### PR TITLE
Add full-system convergence quiescence

### DIFF
--- a/crates/cgka-conformance-simulator/AGENTS.md
+++ b/crates/cgka-conformance-simulator/AGENTS.md
@@ -29,9 +29,14 @@ Read [`README.md`](README.md) for the human framing, [`SCENARIOS.md`](SCENARIOS.
     pending state without adding production engine hooks.
 
 - **Module:** `src/pending_work.rs`
-  - **Role:** Instantaneous strict local-progress observation combining a group-scoped conformance engine snapshot,
-    client-addressed bus queue/delay/mailbox counts, and per-client logical pending entries. It reports blockers for
-    `NoPendingWork`; it does not claim end-to-end delivery or implement virtual-time quiescence waiting.
+  - **Role:** Instantaneous strict local-progress observation plus the adapter-neutral structural progress schema. The
+    structural form adds an opaque token, runnable work, earliest wake, deferred/retry and acknowledgement work,
+    transport state, pass phase/generation, and terminal blockers without serializing protocol identifiers.
+
+- **Module:** `src/quiescence.rs`
+  - **Role:** Bounded virtual-time fixed-point driver. Runner-owned policy decides whether outbound work is accepted and
+    transport is delivered; the driver activates controlled time, runs immediate work, advances exactly to the earliest
+    wake, and records quiescent, blocked, or watchdog-timeout evidence. Limits never define success.
 
 - **Module:** `src/decryptability.rs`
   - **Role:** Serializable active application-message probe results. A
@@ -85,7 +90,9 @@ Read [`README.md`](README.md) for the human framing, [`SCENARIOS.md`](SCENARIOS.
     stream separate from the mutable bus queue: `poll_outbound` returns unresolved transport-ready artifacts
     non-destructively, and `acknowledge_outbound` applies accepted/no-endpoint outcomes to staged commits, independent
     Welcomes, and regenerated queued intents. ScenarioSpec v2 uses the same poll/acknowledgement contract; there is no
-    auto-confirming compatibility lifecycle. Queue/partition mutation is available only through the separately named
+    auto-confirming compatibility lifecycle. The `structural_progress` capability exposes privacy-safe aggregate work,
+    deadlines, pass phase/generation, and terminal state; scenario-owned `await_quiescence` composes it with the existing
+    clock/delivery/publication operations. Queue/partition mutation is available only through the separately named
     `ConvergenceFaultSubject` white-box interface.
 
 - **Module:** `src/vector.rs`

--- a/crates/cgka-conformance-simulator/README.md
+++ b/crates/cgka-conformance-simulator/README.md
@@ -143,11 +143,13 @@ auto-confirmation mode, or second subject publication capability. `ProtocolProfi
 removed lifecycle: it selects the engine's legacy application-profile compatibility through
 `legacy_compatibility_profile()`, but it uses the same explicit outbound contract as `ProtocolProfile::Current`.
 ScenarioSpec v1 is intentionally unsupported after the repository-owned v2 cutover and is rejected before any subject
-action runs. `await_quiescence` composes the subject's structural-progress, virtual-time, delivery, and outbound
-capabilities. Its progress token is diagnostic only: success requires no runnable work, future wake, deferred/retry
-work, publication acknowledgement, transport backlog, scenario-input work, or terminal engine blocker. A zero-delta
-clock activation prevents the legacy far-future harness tick from bypassing virtual deadlines. Iteration, virtual-time,
-and work budgets produce serializable timeout evidence and never redefine unfinished work as quiescent.
+action runs. `await_quiescence` composes structural-progress, virtual-time, and delivery capabilities. It additionally
+requires outbound-publication capability when `policy.outbound` is `accept_all`; manual-publication scenarios retain
+that work as a named blocker without requiring the capability. Its progress token is diagnostic only: success requires
+no runnable work, future wake, deferred/retry work, publication acknowledgement, transport backlog, scenario-input
+work, or terminal engine blocker. Explicit virtual-time activation prevents the legacy far-future harness tick from
+bypassing virtual deadlines. Iteration, virtual-time, and work budgets produce serializable timeout evidence and never
+redefine unfinished work as quiescent.
 
 `probe_bidirectional_decryptability` is the active cryptographic-reachability check. Each named client sends one
 uniquely identified application event through the normal engine and transport path; the runner delivers the resulting

--- a/crates/cgka-conformance-simulator/README.md
+++ b/crates/cgka-conformance-simulator/README.md
@@ -26,6 +26,9 @@ welcomes use NIP-59 gift wraps before the bus delivers them.
 - `ScenarioSpec` — a serializable v2 input contract for deterministic scripted scenarios, including explicit outbound
   acknowledgement and queue
   faults and partitions.
+- `SubjectProgressSnapshot` and `await_quiescence` — a sanitized structural work/deadline contract plus a bounded
+  virtual-time fixed-point driver. It accepts and delivers healthy-path transport according to explicit policy, advances
+  exactly to the earliest subject wake, and records quiescent, blocked, or watchdog-timeout artifacts.
 - `VectorFixture` — portable JSON fixtures pairing runnable scenario input with exact traces or semantic expected
   outcomes.
 - `ScenarioReport` — serializable run artifacts with metadata, expected and observed traces, oracle coverage evidence,
@@ -140,8 +143,11 @@ auto-confirmation mode, or second subject publication capability. `ProtocolProfi
 removed lifecycle: it selects the engine's legacy application-profile compatibility through
 `legacy_compatibility_profile()`, but it uses the same explicit outbound contract as `ProtocolProfile::Current`.
 ScenarioSpec v1 is intentionally unsupported after the repository-owned v2 cutover and is rejected before any subject
-action runs. The simulator does not yet wait for quiescence: structural progress tokens, a fixed-point driver, timeout
-policy, and retry-timer coverage remain in Milestone 1.3.
+action runs. `await_quiescence` composes the subject's structural-progress, virtual-time, delivery, and outbound
+capabilities. Its progress token is diagnostic only: success requires no runnable work, future wake, deferred/retry
+work, publication acknowledgement, transport backlog, scenario-input work, or terminal engine blocker. A zero-delta
+clock activation prevents the legacy far-future harness tick from bypassing virtual deadlines. Iteration, virtual-time,
+and work budgets produce serializable timeout evidence and never redefine unfinished work as quiescent.
 
 `probe_bidirectional_decryptability` is the active cryptographic-reachability check. Each named client sends one
 uniquely identified application event through the normal engine and transport path; the runner delivers the resulting
@@ -227,6 +233,7 @@ recovery without pinning which invite branch wins.
 - `deliver_all`
 - `tick`
 - `advance_time`
+- `await_quiescence`
 - `observe`
 - `observe_exact`
 - `probe_bidirectional_decryptability`

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -452,6 +452,17 @@ These tests keep the simulator machinery honest.
 - `engine_subject_virtual_time_is_shared_while_participant_wakes_are_selected` checks two real durable disband passes:
   a tick at 999 ms settles neither; at 1,000 ms Alice settles while unticked Bob stays live; Bob then settles on a later
   tick without another time advance.
+- `structural_progress_is_stable_sanitized_and_names_publication_work` checks stable tokens for unchanged structure,
+  exact outbound/transport work visibility, and the absence of identifiers and payload fields.
+- `fixed_point_reports_manual_ack_blocker_then_settles`, `fixed_point_advances_exactly_to_engine_wake`, and
+  `fixed_point_names_withheld_transport_without_spinning` check typed publication/withholding blockers and exact
+  virtual-time advancement against real OpenMLS/SQLite subjects.
+- `fixed_point_is_invariant_to_same_horizon_batch_partitioning` delivers the same competing commits in one frozen batch
+  or two completed convergence passes, requires the same semantic canonical result, and diagnoses retention/anchor
+  assumption violations separately from a result mismatch.
+- `unchanged_runnable_work_times_out_without_becoming_quiescent` and
+  `virtual_time_budget_is_a_watchdog_not_a_quiescence_definition` pin terminal timeout artifacts and ensure watchdogs
+  cannot manufacture success.
 - `outbound_poll_is_non_destructive_and_acknowledgement_is_idempotent` checks exact application artifacts, repeatable
   polling, same-outcome acknowledgement replay, transport delivery, and disappearance after resolution;
   `outbound_poll_preserves_emission_order_past_single_digit_handles` guards deterministic ordering under a burst.

--- a/crates/cgka-conformance-simulator/src/bus.rs
+++ b/crates/cgka-conformance-simulator/src/bus.rs
@@ -20,7 +20,7 @@
 //! broadcast welcomes (then the engine's `NotForThisClient` filter kicks
 //! in client-side).
 
-use crate::pending_work::BusPendingWorkSnapshot;
+use crate::pending_work::{BusPendingWorkSnapshot, BusStructuralProgressSnapshot};
 use crate::scenario_input_ledger::ScenarioInputMetadata;
 use cgka_traits::transport::{TransportEnvelope, TransportMessage};
 use cgka_traits::types::{MemberId, MessageId};
@@ -359,6 +359,15 @@ impl TransportBus {
                 .filter(|in_flight| targets_client(&inner.policy, identity, client, in_flight))
                 .count(),
             mailbox_messages: inner.mailboxes.get(&client).map_or(0, Vec::len),
+        }
+    }
+
+    pub(crate) fn structural_progress_snapshot(&self) -> BusStructuralProgressSnapshot {
+        let inner = self.inner.lock().unwrap();
+        BusStructuralProgressSnapshot {
+            queued_messages: inner.queue.len(),
+            delayed_messages: inner.delayed.values().map(Vec::len).sum(),
+            mailbox_messages: inner.mailboxes.values().map(Vec::len).sum(),
         }
     }
 

--- a/crates/cgka-conformance-simulator/src/client.rs
+++ b/crates/cgka-conformance-simulator/src/client.rs
@@ -5,7 +5,7 @@
 use crate::audit_capture::{AuditCapture, CapturingRecorder};
 use crate::bus::{ClientId, TransportBus};
 use crate::decryptability::DecryptabilityProbeSendStatus;
-use crate::pending_work::PendingWorkObservation;
+use crate::pending_work::{ClientStructuralProgress, PendingWorkObservation};
 use crate::scenario_input_ledger::{
     ScenarioInputKind, ScenarioInputLedgerEntry, ScenarioInputMetadata, ScenarioInputTracker,
 };
@@ -1562,6 +1562,24 @@ impl HarnessClient {
             bus_mailbox_messages: bus.mailbox_messages,
             scenario_inputs_pending: self.scenario_input_tracker.pending_count(),
         }
+    }
+
+    pub(crate) fn structural_progress_observation(
+        &self,
+        client: String,
+    ) -> Result<ClientStructuralProgress, EngineError> {
+        Ok(ClientStructuralProgress {
+            client,
+            engine: self
+                .default_group
+                .as_ref()
+                .map(|group_id| {
+                    self.engine()
+                        .conformance_structural_progress_snapshot(group_id)
+                })
+                .transpose()?,
+            scenario_inputs_pending: self.scenario_input_tracker.pending_count(),
+        })
     }
 
     fn next_app_payload(&mut self, payload: Vec<u8>) -> Vec<u8> {

--- a/crates/cgka-conformance-simulator/src/lib.rs
+++ b/crates/cgka-conformance-simulator/src/lib.rs
@@ -89,7 +89,7 @@ pub use subject::{
     ConvergenceFaultSubject, ConvergenceSubject, EngineHarnessSubject, SubjectCapability,
     SubjectCreateGroup, SubjectDescriptor, SubjectError, SubjectInviteMembers,
     SubjectOutboundArtifact, SubjectOutboundKind, SubjectOutboundOutcome, SubjectSendApplication,
-    SubjectUpdateAdminPolicy, SubjectUpdateGroupData, required_capabilities, required_capability,
+    SubjectUpdateAdminPolicy, SubjectUpdateGroupData, required_capabilities,
 };
 pub use vector::{
     AppInvalidationObservation, ApplicationProfileContract, ClientEventCounts, ClientObservation,

--- a/crates/cgka-conformance-simulator/src/lib.rs
+++ b/crates/cgka-conformance-simulator/src/lib.rs
@@ -29,6 +29,7 @@ pub mod oracle;
 mod pending_work;
 pub mod policy_cases;
 pub mod proptest_support;
+mod quiescence;
 pub mod report;
 pub mod scenario;
 mod scenario_input_ledger;
@@ -40,6 +41,7 @@ pub use cgka_engine::conformance_snapshot::{
     ConformanceAppComponent, ConformanceCanonicalStateSnapshot, ConformanceDisbandedGroupSnapshot,
     ConformanceGroupSnapshot, ConformanceLeafCapabilities, ConformanceLeafSnapshot,
     ConformancePendingWorkSnapshot, ConformanceRequiredCapabilities,
+    ConformanceStructuralProgressSnapshot,
 };
 pub use cgka_engine::{canonicalization, convergence, openmls_projection};
 pub use client::{ClientBuilder, HarnessClient, HarnessStorageMode};
@@ -58,7 +60,14 @@ pub use oracle::{
     coverage_matrix_entry, expected_behaviors, property_test_coverage_entries, scenario_stimuli,
     trace_behaviors,
 };
-pub use pending_work::PendingWorkObservation;
+pub use pending_work::{
+    ClientStructuralProgress, PendingWorkObservation, SubjectProgressSnapshot,
+    SubjectTerminalBlocker,
+};
+pub use quiescence::{
+    QuiescenceObservation, QuiescenceOutboundPolicy, QuiescencePolicy, QuiescenceStatus,
+    QuiescenceTransportPolicy, QuiescenceWatchdog, drive_subject_to_quiescence,
+};
 pub use report::{
     ReportArgs, ReportCommand, ReportFailureSummary, ReportInput, ReportRunSummary,
     ScenarioReportSummary, parse_report_command, report_usage, run_report,
@@ -80,7 +89,7 @@ pub use subject::{
     ConvergenceFaultSubject, ConvergenceSubject, EngineHarnessSubject, SubjectCapability,
     SubjectCreateGroup, SubjectDescriptor, SubjectError, SubjectInviteMembers,
     SubjectOutboundArtifact, SubjectOutboundKind, SubjectOutboundOutcome, SubjectSendApplication,
-    SubjectUpdateAdminPolicy, SubjectUpdateGroupData, required_capability,
+    SubjectUpdateAdminPolicy, SubjectUpdateGroupData, required_capabilities, required_capability,
 };
 pub use vector::{
     AppInvalidationObservation, ApplicationProfileContract, ClientEventCounts, ClientObservation,

--- a/crates/cgka-conformance-simulator/src/oracle.rs
+++ b/crates/cgka-conformance-simulator/src/oracle.rs
@@ -3,7 +3,10 @@
 //! The simulator has two jobs: run scenario inputs and explain what behavior
 //! those inputs actually checked. This module keeps that second job explicit.
 
-use crate::{ScenarioReport, ScenarioSpec, ScenarioStep, ScenarioTrace, TraceExpectation};
+use crate::{
+    QuiescenceObservation, ScenarioReport, ScenarioSpec, ScenarioStep, ScenarioTrace,
+    TraceExpectation,
+};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 
@@ -128,10 +131,28 @@ pub fn build_scenario_oracle_report(
     expected_trace: Option<&ScenarioTrace>,
     expected_outcomes: &[TraceExpectation],
     observed_trace: &ScenarioTrace,
+    quiescence_observations: &[QuiescenceObservation],
 ) -> ScenarioOracleReport {
     let stimuli = scenario_stimuli(spec);
-    let oracle_behaviors = expected_behaviors(expected_trace, expected_outcomes);
-    let observed_behaviors = trace_behaviors(observed_trace);
+    let mut oracle_behaviors = expected_behaviors(expected_trace, expected_outcomes);
+    if spec
+        .steps
+        .iter()
+        .any(|step| matches!(step, ScenarioStep::AwaitQuiescence { .. }))
+        && !oracle_behaviors.contains(&OracleBehavior::QuiescenceState)
+    {
+        oracle_behaviors.push(OracleBehavior::QuiescenceState);
+        oracle_behaviors.sort();
+    }
+    let mut observed_behaviors = trace_behaviors(observed_trace);
+    if quiescence_observations
+        .iter()
+        .any(|observation| observation.status.is_quiescent())
+        && !observed_behaviors.contains(&OracleBehavior::QuiescenceState)
+    {
+        observed_behaviors.push(OracleBehavior::QuiescenceState);
+        observed_behaviors.sort();
+    }
     let evidence = behavior_evidence(observed_trace);
 
     let observed_set = observed_behaviors.iter().copied().collect::<BTreeSet<_>>();
@@ -322,6 +343,10 @@ pub fn scenario_stimuli(spec: &ScenarioSpec) -> Vec<ScenarioStimulus> {
                 stimuli.insert(ScenarioStimulus::Restart);
             }
             ScenarioStep::AdvanceTime { .. } => {
+                stimuli.insert(ScenarioStimulus::VirtualTimeAdvance);
+            }
+            ScenarioStep::AwaitQuiescence { .. } => {
+                stimuli.insert(ScenarioStimulus::QuiescenceGate);
                 stimuli.insert(ScenarioStimulus::VirtualTimeAdvance);
             }
             ScenarioStep::DeliverAll

--- a/crates/cgka-conformance-simulator/src/pending_work.rs
+++ b/crates/cgka-conformance-simulator/src/pending_work.rs
@@ -1,16 +1,24 @@
 //! Instantaneous pending-work observations for strict simulator assertions.
 //!
-//! This deliberately does not decide quiescence over time. It captures one
-//! privacy-safe, client-scoped local execution boundary; Milestone 1.3 will
-//! add structural progress tokens and bounded virtual-time fixed-point
-//! evaluation. It does not assert end-to-end delivery of transport objects
-//! that a scenario dropped.
+//! The pending-work form captures one privacy-safe, client-scoped local
+//! execution boundary. The structural form is consumed by the bounded
+//! virtual-time fixed-point driver, but it still does not assert end-to-end
+//! delivery of transport objects that a scenario dropped.
 
-use cgka_engine::conformance_snapshot::ConformancePendingWorkSnapshot;
+use cgka_engine::conformance_snapshot::{
+    ConformancePendingWorkSnapshot, ConformanceStructuralProgressSnapshot,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub(crate) struct BusPendingWorkSnapshot {
+    pub queued_messages: usize,
+    pub delayed_messages: usize,
+    pub mailbox_messages: usize,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct BusStructuralProgressSnapshot {
     pub queued_messages: usize,
     pub delayed_messages: usize,
     pub mailbox_messages: usize,
@@ -50,6 +58,91 @@ impl PendingWorkObservation {
         }
         if self.scenario_inputs_pending > 0 {
             blockers.push("scenario_inputs");
+        }
+        blockers
+    }
+}
+
+/// One participant's sanitized engine scheduling state.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClientStructuralProgress {
+    pub client: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub engine: Option<ConformanceStructuralProgressSnapshot>,
+    pub scenario_inputs_pending: usize,
+}
+
+/// Terminal engine state that cannot be resolved by running or advancing the
+/// subject. The client label is a scenario-local name, never an account id.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SubjectTerminalBlocker {
+    EngineUnrecoverable { client: String },
+}
+
+/// Adapter-neutral structural state consumed by the virtual-time fixed-point
+/// driver. The token is diagnostic and cycle-detection evidence; quiescence is
+/// defined by the explicit work/deadline fields, never token equality alone.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SubjectProgressSnapshot {
+    pub schema_version: String,
+    pub structural_token: String,
+    pub current_monotonic_ms: u64,
+    pub runnable_work: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub earliest_next_wake_monotonic_ms: Option<u64>,
+    pub deferred_retry_work: usize,
+    pub outbound_awaiting_acknowledgement: usize,
+    pub transport_queued_messages: usize,
+    pub transport_delayed_messages: usize,
+    pub transport_mailbox_messages: usize,
+    pub scenario_inputs_pending: usize,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub terminal_blockers: Vec<SubjectTerminalBlocker>,
+    pub clients: Vec<ClientStructuralProgress>,
+}
+
+impl SubjectProgressSnapshot {
+    pub fn is_quiescent(&self) -> bool {
+        self.runnable_work == 0
+            && self.earliest_next_wake_monotonic_ms.is_none()
+            && self.deferred_retry_work == 0
+            && self.outbound_awaiting_acknowledgement == 0
+            && self.transport_queued_messages == 0
+            && self.transport_delayed_messages == 0
+            && self.transport_mailbox_messages == 0
+            && self.scenario_inputs_pending == 0
+            && self.terminal_blockers.is_empty()
+    }
+
+    pub fn blocking_subsystems(&self) -> Vec<&'static str> {
+        let mut blockers = Vec::new();
+        if self.runnable_work > 0 {
+            blockers.push("runnable_work");
+        }
+        if self.earliest_next_wake_monotonic_ms.is_some() {
+            blockers.push("scheduled_wake");
+        }
+        if self.deferred_retry_work > 0 {
+            blockers.push("deferred_retry");
+        }
+        if self.outbound_awaiting_acknowledgement > 0 {
+            blockers.push("outbound_acknowledgement");
+        }
+        if self.transport_queued_messages > 0 {
+            blockers.push("transport_queue");
+        }
+        if self.transport_delayed_messages > 0 {
+            blockers.push("transport_delayed");
+        }
+        if self.transport_mailbox_messages > 0 {
+            blockers.push("transport_mailboxes");
+        }
+        if self.scenario_inputs_pending > 0 {
+            blockers.push("scenario_inputs");
+        }
+        if !self.terminal_blockers.is_empty() {
+            blockers.push("terminal_engine_state");
         }
         blockers
     }

--- a/crates/cgka-conformance-simulator/src/pending_work.rs
+++ b/crates/cgka-conformance-simulator/src/pending_work.rs
@@ -81,13 +81,17 @@ pub enum SubjectTerminalBlocker {
 }
 
 /// Adapter-neutral structural state consumed by the virtual-time fixed-point
-/// driver. The token is diagnostic and cycle-detection evidence; quiescence is
-/// defined by the explicit work/deadline fields, never token equality alone.
+/// driver. The token is diagnostic only; quiescence is defined by the explicit
+/// work/deadline fields, never token equality.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SubjectProgressSnapshot {
     pub schema_version: String,
     pub structural_token: String,
     pub current_monotonic_ms: u64,
+    /// Engine work runnable on the next participant tick.
+    #[serde(default)]
+    pub runnable_engine_work: usize,
+    /// Aggregate runnable work across the engine and subject-owned transport.
     pub runnable_work: usize,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub earliest_next_wake_monotonic_ms: Option<u64>,

--- a/crates/cgka-conformance-simulator/src/quiescence.rs
+++ b/crates/cgka-conformance-simulator/src/quiescence.rs
@@ -107,10 +107,10 @@ pub async fn drive_subject_to_quiescence(
     policy: &QuiescencePolicy,
     step_index: usize,
 ) -> Result<QuiescenceObservation, SubjectError> {
-    // Select the subject's controlled clock before the first participant wake.
-    // A zero delta is semantically inert but prevents legacy harness adapters
-    // from substituting their historical far-future one-shot drain shortcut.
-    subject.advance_time(0).await?;
+    // Select controlled-time behavior before the first participant wake. This
+    // prevents legacy harness adapters from substituting their historical
+    // far-future one-shot drain shortcut without relying on a magic time delta.
+    subject.activate_virtual_time()?;
     let initial = subject.structural_progress()?;
     let started_at = initial.current_monotonic_ms;
     let mut snapshot = initial;
@@ -136,7 +136,7 @@ pub async fn drive_subject_to_quiescence(
         }
         if (snapshot.outbound_awaiting_acknowledgement > 0
             && policy.outbound == QuiescenceOutboundPolicy::Manual)
-            || ((snapshot.transport_queued_messages > 0 || snapshot.transport_mailbox_messages > 0)
+            || (snapshot.transport_queued_messages > 0
                 && policy.transport == QuiescenceTransportPolicy::Manual)
         {
             return Ok(blocked_observation(
@@ -155,16 +155,13 @@ pub async fn drive_subject_to_quiescence(
             ));
         }
 
-        let engine_runnable = snapshot.runnable_work.saturating_sub(
-            snapshot
-                .transport_queued_messages
-                .saturating_add(snapshot.transport_mailbox_messages),
-        );
-        let will_ack = policy.outbound == QuiescenceOutboundPolicy::AcceptAll;
-        let will_deliver = policy.transport == QuiescenceTransportPolicy::DeliverAll;
-        let will_tick = engine_runnable > 0
+        let will_ack = snapshot.outbound_awaiting_acknowledgement > 0
+            && policy.outbound == QuiescenceOutboundPolicy::AcceptAll;
+        let will_deliver = snapshot.transport_queued_messages > 0
+            && policy.transport == QuiescenceTransportPolicy::DeliverAll;
+        let will_tick = snapshot.runnable_engine_work > 0
             || snapshot.transport_mailbox_messages > 0
-            || (snapshot.transport_queued_messages > 0 && will_deliver);
+            || will_deliver;
         let planned_work = (if will_ack {
             snapshot.outbound_awaiting_acknowledgement as u64
         } else {
@@ -176,7 +173,8 @@ pub async fn drive_subject_to_quiescence(
             0
         })
         .saturating_add(if will_tick {
-            engine_runnable
+            snapshot
+                .runnable_engine_work
                 .saturating_add(snapshot.transport_mailbox_messages)
                 .max(1) as u64
         } else {
@@ -193,11 +191,7 @@ pub async fn drive_subject_to_quiescence(
                 snapshot,
             ));
         }
-        let mut attempted_work = 0u64;
-
-        if snapshot.outbound_awaiting_acknowledgement > 0
-            && policy.outbound == QuiescenceOutboundPolicy::AcceptAll
-        {
+        if will_ack {
             for client in clients {
                 for artifact in subject.poll_outbound(client)? {
                     subject
@@ -207,34 +201,20 @@ pub async fn drive_subject_to_quiescence(
                             SubjectOutboundOutcome::Accepted,
                         )
                         .await?;
-                    attempted_work = attempted_work.saturating_add(1);
                 }
             }
         }
 
-        if snapshot.transport_queued_messages > 0
-            && policy.transport == QuiescenceTransportPolicy::DeliverAll
-        {
+        if will_deliver {
             subject.deliver_all()?;
-            attempted_work =
-                attempted_work.saturating_add(snapshot.transport_queued_messages as u64);
         }
 
-        if engine_runnable > 0
-            || snapshot.transport_mailbox_messages > 0
-            || (snapshot.transport_queued_messages > 0
-                && policy.transport == QuiescenceTransportPolicy::DeliverAll)
-        {
+        if will_tick {
             subject.tick(clients).await?;
-            attempted_work = attempted_work.saturating_add(
-                engine_runnable
-                    .saturating_add(snapshot.transport_mailbox_messages)
-                    .max(1) as u64,
-            );
         }
 
-        if attempted_work > 0 {
-            work_units = work_units.saturating_add(attempted_work);
+        if planned_work > 0 {
+            work_units = work_units.saturating_add(planned_work);
             iterations = iterations.saturating_add(1);
             snapshot = subject.structural_progress()?;
             continue;
@@ -386,6 +366,17 @@ mod tests {
 
         async fn tick(&mut self, _clients: &[String]) -> Result<(), SubjectError> {
             self.ticks += 1;
+            if self.snapshot.transport_mailbox_messages > 0 {
+                self.snapshot.runnable_work = self
+                    .snapshot
+                    .runnable_work
+                    .saturating_sub(self.snapshot.transport_mailbox_messages);
+                self.snapshot.transport_mailbox_messages = 0;
+            }
+            Ok(())
+        }
+
+        fn activate_virtual_time(&mut self) -> Result<(), SubjectError> {
             Ok(())
         }
 
@@ -401,6 +392,7 @@ mod tests {
             schema_version: "1".into(),
             structural_token: "unchanged".into(),
             current_monotonic_ms: 0,
+            runnable_engine_work: 1,
             runnable_work: 1,
             earliest_next_wake_monotonic_ms: None,
             deferred_retry_work: 0,
@@ -447,6 +439,7 @@ mod tests {
     #[tokio::test]
     async fn virtual_time_budget_is_a_watchdog_not_a_quiescence_definition() {
         let mut pending = progress();
+        pending.runnable_engine_work = 0;
         pending.runnable_work = 0;
         pending.earliest_next_wake_monotonic_ms = Some(100);
         let mut subject = StuckSubject {
@@ -477,5 +470,84 @@ mod tests {
             Some(100)
         );
         assert!(!result.final_progress.is_quiescent());
+    }
+
+    #[tokio::test]
+    async fn work_unit_budget_covers_immediate_and_scheduled_actions() {
+        let policy = QuiescencePolicy {
+            max_work_units: 0,
+            ..QuiescencePolicy::default()
+        };
+        let mut immediate = StuckSubject {
+            snapshot: progress(),
+            ticks: 0,
+        };
+        let immediate_result =
+            drive_subject_to_quiescence(&mut immediate, &["alice".into()], &policy, 5)
+                .await
+                .expect("immediate work budget produces an artifact");
+        assert!(matches!(
+            immediate_result.status,
+            QuiescenceStatus::TimedOut {
+                watchdog: QuiescenceWatchdog::WorkUnits,
+                ..
+            }
+        ));
+        assert_eq!(immediate.ticks, 0);
+
+        let mut scheduled_progress = progress();
+        scheduled_progress.runnable_engine_work = 0;
+        scheduled_progress.runnable_work = 0;
+        scheduled_progress.earliest_next_wake_monotonic_ms = Some(100);
+        let mut scheduled = StuckSubject {
+            snapshot: scheduled_progress,
+            ticks: 0,
+        };
+        let scheduled_result =
+            drive_subject_to_quiescence(&mut scheduled, &["alice".into()], &policy, 6)
+                .await
+                .expect("scheduled work budget produces an artifact");
+        assert!(matches!(
+            scheduled_result.status,
+            QuiescenceStatus::TimedOut {
+                watchdog: QuiescenceWatchdog::WorkUnits,
+                ..
+            }
+        ));
+        assert_eq!(scheduled.snapshot.current_monotonic_ms, 0);
+        assert_eq!(scheduled.ticks, 0);
+    }
+
+    #[tokio::test]
+    async fn manual_transport_drains_mailboxes_but_blocks_undelivered_queue() {
+        let policy = QuiescencePolicy {
+            transport: QuiescenceTransportPolicy::Manual,
+            ..QuiescencePolicy::default()
+        };
+        let mut mailbox_progress = progress();
+        mailbox_progress.runnable_engine_work = 0;
+        mailbox_progress.transport_mailbox_messages = 1;
+        let mut mailbox = StuckSubject {
+            snapshot: mailbox_progress,
+            ticks: 0,
+        };
+        let settled = drive_subject_to_quiescence(&mut mailbox, &["alice".into()], &policy, 7)
+            .await
+            .expect("post-delivery mailbox can drain under manual transport");
+        assert_eq!(settled.status, QuiescenceStatus::Quiescent);
+        assert_eq!(mailbox.ticks, 1);
+
+        let mut queued_progress = progress();
+        queued_progress.runnable_engine_work = 0;
+        queued_progress.transport_queued_messages = 1;
+        let mut queued = StuckSubject {
+            snapshot: queued_progress,
+            ticks: 0,
+        };
+        let blocked = drive_subject_to_quiescence(&mut queued, &["alice".into()], &policy, 8)
+            .await
+            .expect("undelivered queue is a manual transport blocker");
+        assert!(matches!(blocked.status, QuiescenceStatus::Blocked { .. }));
+        assert_eq!(queued.ticks, 0);
     }
 }

--- a/crates/cgka-conformance-simulator/src/quiescence.rs
+++ b/crates/cgka-conformance-simulator/src/quiescence.rs
@@ -1,0 +1,481 @@
+//! Adapter-neutral virtual-time quiescence driver.
+//!
+//! Quiescence is a structural fixed point: no runnable work, no future wake,
+//! no deferred/retry work, no unresolved publication, and no external or
+//! terminal blocker. Limits are watchdog evidence only and never redefine an
+//! unfinished subject as quiescent.
+
+use crate::{ConvergenceSubject, SubjectError, SubjectOutboundOutcome, SubjectProgressSnapshot};
+use serde::{Deserialize, Serialize};
+
+const fn default_max_iterations() -> u32 {
+    256
+}
+
+const fn default_max_virtual_time_ms() -> u64 {
+    60_000
+}
+
+const fn default_max_work_units() -> u64 {
+    100_000
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QuiescenceOutboundPolicy {
+    #[default]
+    AcceptAll,
+    Manual,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QuiescenceTransportPolicy {
+    #[default]
+    DeliverAll,
+    Manual,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QuiescencePolicy {
+    #[serde(default = "default_max_iterations")]
+    pub max_iterations: u32,
+    #[serde(default = "default_max_virtual_time_ms")]
+    pub max_virtual_time_ms: u64,
+    #[serde(default = "default_max_work_units")]
+    pub max_work_units: u64,
+    #[serde(default)]
+    pub outbound: QuiescenceOutboundPolicy,
+    #[serde(default)]
+    pub transport: QuiescenceTransportPolicy,
+}
+
+impl Default for QuiescencePolicy {
+    fn default() -> Self {
+        Self {
+            max_iterations: default_max_iterations(),
+            max_virtual_time_ms: default_max_virtual_time_ms(),
+            max_work_units: default_max_work_units(),
+            outbound: QuiescenceOutboundPolicy::default(),
+            transport: QuiescenceTransportPolicy::default(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QuiescenceWatchdog {
+    Iterations,
+    VirtualTime,
+    WorkUnits,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum QuiescenceStatus {
+    Quiescent,
+    Blocked {
+        subsystems: Vec<String>,
+    },
+    TimedOut {
+        watchdog: QuiescenceWatchdog,
+        subsystems: Vec<String>,
+    },
+}
+
+impl QuiescenceStatus {
+    pub fn is_quiescent(&self) -> bool {
+        matches!(self, Self::Quiescent)
+    }
+}
+
+/// Serializable terminal artifact for one fixed-point attempt.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QuiescenceObservation {
+    pub step_index: usize,
+    pub policy: QuiescencePolicy,
+    pub status: QuiescenceStatus,
+    pub iterations: u32,
+    pub work_units: u64,
+    pub virtual_time_advanced_ms: u64,
+    pub final_progress: SubjectProgressSnapshot,
+}
+
+pub async fn drive_subject_to_quiescence(
+    subject: &mut dyn ConvergenceSubject,
+    clients: &[String],
+    policy: &QuiescencePolicy,
+    step_index: usize,
+) -> Result<QuiescenceObservation, SubjectError> {
+    // Select the subject's controlled clock before the first participant wake.
+    // A zero delta is semantically inert but prevents legacy harness adapters
+    // from substituting their historical far-future one-shot drain shortcut.
+    subject.advance_time(0).await?;
+    let initial = subject.structural_progress()?;
+    let started_at = initial.current_monotonic_ms;
+    let mut snapshot = initial;
+    let mut iterations = 0u32;
+    let mut work_units = 0u64;
+
+    loop {
+        if snapshot.is_quiescent() {
+            return Ok(observation(
+                step_index,
+                policy,
+                QuiescenceStatus::Quiescent,
+                iterations,
+                work_units,
+                started_at,
+                snapshot,
+            ));
+        }
+        if !snapshot.terminal_blockers.is_empty() {
+            return Ok(blocked_observation(
+                step_index, policy, iterations, work_units, started_at, snapshot,
+            ));
+        }
+        if (snapshot.outbound_awaiting_acknowledgement > 0
+            && policy.outbound == QuiescenceOutboundPolicy::Manual)
+            || ((snapshot.transport_queued_messages > 0 || snapshot.transport_mailbox_messages > 0)
+                && policy.transport == QuiescenceTransportPolicy::Manual)
+        {
+            return Ok(blocked_observation(
+                step_index, policy, iterations, work_units, started_at, snapshot,
+            ));
+        }
+        if iterations >= policy.max_iterations {
+            return Ok(timeout_observation(
+                step_index,
+                policy,
+                QuiescenceWatchdog::Iterations,
+                iterations,
+                work_units,
+                started_at,
+                snapshot,
+            ));
+        }
+
+        let engine_runnable = snapshot.runnable_work.saturating_sub(
+            snapshot
+                .transport_queued_messages
+                .saturating_add(snapshot.transport_mailbox_messages),
+        );
+        let will_ack = policy.outbound == QuiescenceOutboundPolicy::AcceptAll;
+        let will_deliver = policy.transport == QuiescenceTransportPolicy::DeliverAll;
+        let will_tick = engine_runnable > 0
+            || snapshot.transport_mailbox_messages > 0
+            || (snapshot.transport_queued_messages > 0 && will_deliver);
+        let planned_work = (if will_ack {
+            snapshot.outbound_awaiting_acknowledgement as u64
+        } else {
+            0
+        })
+        .saturating_add(if will_deliver {
+            snapshot.transport_queued_messages as u64
+        } else {
+            0
+        })
+        .saturating_add(if will_tick {
+            engine_runnable
+                .saturating_add(snapshot.transport_mailbox_messages)
+                .max(1) as u64
+        } else {
+            0
+        });
+        if planned_work > 0 && work_units.saturating_add(planned_work) > policy.max_work_units {
+            return Ok(timeout_observation(
+                step_index,
+                policy,
+                QuiescenceWatchdog::WorkUnits,
+                iterations,
+                work_units,
+                started_at,
+                snapshot,
+            ));
+        }
+        let mut attempted_work = 0u64;
+
+        if snapshot.outbound_awaiting_acknowledgement > 0
+            && policy.outbound == QuiescenceOutboundPolicy::AcceptAll
+        {
+            for client in clients {
+                for artifact in subject.poll_outbound(client)? {
+                    subject
+                        .acknowledge_outbound(
+                            client,
+                            &artifact.outbound_id,
+                            SubjectOutboundOutcome::Accepted,
+                        )
+                        .await?;
+                    attempted_work = attempted_work.saturating_add(1);
+                }
+            }
+        }
+
+        if snapshot.transport_queued_messages > 0
+            && policy.transport == QuiescenceTransportPolicy::DeliverAll
+        {
+            subject.deliver_all()?;
+            attempted_work =
+                attempted_work.saturating_add(snapshot.transport_queued_messages as u64);
+        }
+
+        if engine_runnable > 0
+            || snapshot.transport_mailbox_messages > 0
+            || (snapshot.transport_queued_messages > 0
+                && policy.transport == QuiescenceTransportPolicy::DeliverAll)
+        {
+            subject.tick(clients).await?;
+            attempted_work = attempted_work.saturating_add(
+                engine_runnable
+                    .saturating_add(snapshot.transport_mailbox_messages)
+                    .max(1) as u64,
+            );
+        }
+
+        if attempted_work > 0 {
+            work_units = work_units.saturating_add(attempted_work);
+            iterations = iterations.saturating_add(1);
+            snapshot = subject.structural_progress()?;
+            continue;
+        }
+
+        if let Some(next_wake) = snapshot.earliest_next_wake_monotonic_ms {
+            let delta = next_wake.saturating_sub(snapshot.current_monotonic_ms);
+            let advanced = snapshot.current_monotonic_ms.saturating_sub(started_at);
+            if advanced.saturating_add(delta) > policy.max_virtual_time_ms {
+                return Ok(timeout_observation(
+                    step_index,
+                    policy,
+                    QuiescenceWatchdog::VirtualTime,
+                    iterations,
+                    work_units,
+                    started_at,
+                    snapshot,
+                ));
+            }
+            if work_units.saturating_add(1) > policy.max_work_units {
+                return Ok(timeout_observation(
+                    step_index,
+                    policy,
+                    QuiescenceWatchdog::WorkUnits,
+                    iterations,
+                    work_units,
+                    started_at,
+                    snapshot,
+                ));
+            }
+            subject.advance_time(delta).await?;
+            subject.tick(clients).await?;
+            iterations = iterations.saturating_add(1);
+            work_units = work_units.saturating_add(1);
+            snapshot = subject.structural_progress()?;
+            continue;
+        }
+
+        return Ok(blocked_observation(
+            step_index, policy, iterations, work_units, started_at, snapshot,
+        ));
+    }
+}
+
+fn observation(
+    step_index: usize,
+    policy: &QuiescencePolicy,
+    status: QuiescenceStatus,
+    iterations: u32,
+    work_units: u64,
+    started_at: u64,
+    final_progress: SubjectProgressSnapshot,
+) -> QuiescenceObservation {
+    QuiescenceObservation {
+        step_index,
+        policy: policy.clone(),
+        status,
+        iterations,
+        work_units,
+        virtual_time_advanced_ms: final_progress
+            .current_monotonic_ms
+            .saturating_sub(started_at),
+        final_progress,
+    }
+}
+
+fn blocked_observation(
+    step_index: usize,
+    policy: &QuiescencePolicy,
+    iterations: u32,
+    work_units: u64,
+    started_at: u64,
+    final_progress: SubjectProgressSnapshot,
+) -> QuiescenceObservation {
+    let subsystems = blocker_names(&final_progress);
+    observation(
+        step_index,
+        policy,
+        QuiescenceStatus::Blocked { subsystems },
+        iterations,
+        work_units,
+        started_at,
+        final_progress,
+    )
+}
+
+fn timeout_observation(
+    step_index: usize,
+    policy: &QuiescencePolicy,
+    watchdog: QuiescenceWatchdog,
+    iterations: u32,
+    work_units: u64,
+    started_at: u64,
+    final_progress: SubjectProgressSnapshot,
+) -> QuiescenceObservation {
+    let subsystems = blocker_names(&final_progress);
+    observation(
+        step_index,
+        policy,
+        QuiescenceStatus::TimedOut {
+            watchdog,
+            subsystems,
+        },
+        iterations,
+        work_units,
+        started_at,
+        final_progress,
+    )
+}
+
+fn blocker_names(snapshot: &SubjectProgressSnapshot) -> Vec<String> {
+    snapshot
+        .blocking_subsystems()
+        .into_iter()
+        .map(str::to_owned)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{SubjectCapability, SubjectDescriptor};
+    use async_trait::async_trait;
+    use std::collections::BTreeSet;
+
+    struct StuckSubject {
+        snapshot: SubjectProgressSnapshot,
+        ticks: usize,
+    }
+
+    #[async_trait]
+    impl ConvergenceSubject for StuckSubject {
+        fn descriptor(&self) -> SubjectDescriptor {
+            SubjectDescriptor {
+                adapter: "stuck".into(),
+                adapter_version: "1".into(),
+                storage_backend: "none".into(),
+                capabilities: BTreeSet::from([
+                    SubjectCapability::StructuralProgress,
+                    SubjectCapability::TransportDelivery,
+                    SubjectCapability::VirtualTime,
+                ]),
+            }
+        }
+
+        fn structural_progress(&mut self) -> Result<SubjectProgressSnapshot, SubjectError> {
+            Ok(self.snapshot.clone())
+        }
+
+        async fn tick(&mut self, _clients: &[String]) -> Result<(), SubjectError> {
+            self.ticks += 1;
+            Ok(())
+        }
+
+        async fn advance_time(&mut self, delta_ms: u64) -> Result<(), SubjectError> {
+            self.snapshot.current_monotonic_ms =
+                self.snapshot.current_monotonic_ms.saturating_add(delta_ms);
+            Ok(())
+        }
+    }
+
+    fn progress() -> SubjectProgressSnapshot {
+        SubjectProgressSnapshot {
+            schema_version: "1".into(),
+            structural_token: "unchanged".into(),
+            current_monotonic_ms: 0,
+            runnable_work: 1,
+            earliest_next_wake_monotonic_ms: None,
+            deferred_retry_work: 0,
+            outbound_awaiting_acknowledgement: 0,
+            transport_queued_messages: 0,
+            transport_delayed_messages: 0,
+            transport_mailbox_messages: 0,
+            scenario_inputs_pending: 0,
+            terminal_blockers: Vec::new(),
+            clients: Vec::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn unchanged_runnable_work_times_out_without_becoming_quiescent() {
+        let mut subject = StuckSubject {
+            snapshot: progress(),
+            ticks: 0,
+        };
+        let result = drive_subject_to_quiescence(
+            &mut subject,
+            &["alice".into()],
+            &QuiescencePolicy {
+                max_iterations: 2,
+                max_work_units: 10,
+                ..QuiescencePolicy::default()
+            },
+            3,
+        )
+        .await
+        .expect("watchdog produces an artifact");
+
+        assert_eq!(subject.ticks, 2);
+        assert!(matches!(
+            result.status,
+            QuiescenceStatus::TimedOut {
+                watchdog: QuiescenceWatchdog::Iterations,
+                ..
+            }
+        ));
+        assert!(!result.final_progress.is_quiescent());
+    }
+
+    #[tokio::test]
+    async fn virtual_time_budget_is_a_watchdog_not_a_quiescence_definition() {
+        let mut pending = progress();
+        pending.runnable_work = 0;
+        pending.earliest_next_wake_monotonic_ms = Some(100);
+        let mut subject = StuckSubject {
+            snapshot: pending,
+            ticks: 0,
+        };
+        let result = drive_subject_to_quiescence(
+            &mut subject,
+            &["alice".into()],
+            &QuiescencePolicy {
+                max_virtual_time_ms: 99,
+                ..QuiescencePolicy::default()
+            },
+            4,
+        )
+        .await
+        .expect("watchdog produces an artifact");
+
+        assert!(matches!(
+            result.status,
+            QuiescenceStatus::TimedOut {
+                watchdog: QuiescenceWatchdog::VirtualTime,
+                ..
+            }
+        ));
+        assert_eq!(
+            result.final_progress.earliest_next_wake_monotonic_ms,
+            Some(100)
+        );
+        assert!(!result.final_progress.is_quiescent());
+    }
+}

--- a/crates/cgka-conformance-simulator/src/report.rs
+++ b/crates/cgka-conformance-simulator/src/report.rs
@@ -445,6 +445,7 @@ mod tests {
             oracle,
             step_log: Vec::new(),
             pending_resolution_observations: Vec::new(),
+            quiescence_observations: Vec::new(),
             recovery_observations: Vec::new(),
             epoch_change_observations: Vec::new(),
             app_invalidation_observations: Vec::new(),

--- a/crates/cgka-conformance-simulator/src/scenario.rs
+++ b/crates/cgka-conformance-simulator/src/scenario.rs
@@ -1379,10 +1379,13 @@ mod tests {
 
     #[test]
     fn queue_fault_steps_require_explicit_white_box_capability() {
-        let capability = crate::required_capability(&ScenarioStep::DropQueued { index: 0 });
+        let capabilities = required_capabilities(&ScenarioStep::DropQueued { index: 0 });
 
-        assert_eq!(capability, SubjectCapability::WhiteBoxTransportQueueFaults);
-        assert!(capability.is_white_box());
+        assert_eq!(
+            capabilities,
+            vec![SubjectCapability::WhiteBoxTransportQueueFaults]
+        );
+        assert!(capabilities[0].is_white_box());
     }
 
     #[test]

--- a/crates/cgka-conformance-simulator/src/scenario.rs
+++ b/crates/cgka-conformance-simulator/src/scenario.rs
@@ -6,11 +6,12 @@
 
 use crate::{
     ConvergenceFaultSubject, ConvergenceSubject, EngineHarnessSubject, ExpectationFailure,
-    HarnessStorageMode, PendingResolutionObservation, ScenarioErrorObservation,
-    ScenarioOracleReport, ScenarioTrace, SubjectCreateGroup, SubjectDescriptor, SubjectError,
-    SubjectInviteMembers, SubjectOutboundArtifact, SubjectOutboundKind, SubjectOutboundOutcome,
-    SubjectSendApplication, SubjectUpdateAdminPolicy, SubjectUpdateGroupData, TraceExpectation,
-    VectorFixture, build_scenario_oracle_report, compare_trace_expectations, required_capability,
+    HarnessStorageMode, PendingResolutionObservation, QuiescenceObservation, QuiescencePolicy,
+    ScenarioErrorObservation, ScenarioOracleReport, ScenarioTrace, SubjectCreateGroup,
+    SubjectDescriptor, SubjectError, SubjectInviteMembers, SubjectOutboundArtifact,
+    SubjectOutboundKind, SubjectOutboundOutcome, SubjectSendApplication, SubjectUpdateAdminPolicy,
+    SubjectUpdateGroupData, TraceExpectation, VectorFixture, build_scenario_oracle_report,
+    compare_trace_expectations, drive_subject_to_quiescence, required_capabilities,
 };
 use cgka_traits::group::ProtocolProfile;
 use serde::{Deserialize, Serialize};
@@ -105,6 +106,13 @@ pub enum ScenarioStep {
     AdvanceTime {
         delta_ms: u64,
     },
+    /// Drive the complete subject to a bounded structural fixed point using
+    /// virtual time. A non-quiescent terminal result is retained in the report
+    /// and fails the scenario invariant.
+    AwaitQuiescence {
+        #[serde(default)]
+        policy: QuiescencePolicy,
+    },
     Observe {
         clients: Vec<String>,
     },
@@ -181,6 +189,7 @@ impl ScenarioStep {
             ScenarioStep::DeliverAll => "deliver_all",
             ScenarioStep::Tick { .. } => "tick",
             ScenarioStep::AdvanceTime { .. } => "advance_time",
+            ScenarioStep::AwaitQuiescence { .. } => "await_quiescence",
             ScenarioStep::Observe { .. } => "observe",
             ScenarioStep::ObserveExact { .. } => "observe_exact",
             ScenarioStep::ProbeBidirectionalDecryptability { .. } => {
@@ -212,6 +221,8 @@ pub struct ScenarioReport {
     pub step_log: Vec<ScenarioStepLogEntry>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub pending_resolution_observations: Vec<PendingResolutionObservation>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub quiescence_observations: Vec<QuiescenceObservation>,
     pub recovery_observations: Vec<crate::ForkRecoveryObservation>,
     pub epoch_change_observations: Vec<EpochChangeReportObservation>,
     pub app_invalidation_observations: Vec<AppInvalidationReportObservation>,
@@ -309,6 +320,7 @@ impl std::error::Error for ScenarioRunError {}
 
 pub async fn run_scenario_spec(spec: &ScenarioSpec) -> Result<ScenarioTrace, ScenarioRunError> {
     let report = run_scenario_report(spec, None).await?;
+    ensure_quiescence_steps_succeeded(&report)?;
     Ok(report
         .observed_trace
         .expect("successful report always includes an observed trace"))
@@ -320,6 +332,7 @@ pub async fn run_scenario_spec_with_subject(
     subject: &mut dyn ConvergenceSubject,
 ) -> Result<ScenarioTrace, ScenarioRunError> {
     let report = run_scenario_report_with_subject(spec, None, Vec::new(), subject).await?;
+    ensure_quiescence_steps_succeeded(&report)?;
     Ok(report
         .observed_trace
         .expect("successful report always includes an observed trace"))
@@ -438,6 +451,7 @@ async fn run_scenario_report_inner(
     let mut decryptability_probes = Vec::new();
     let mut admin_policy_observations = Vec::new();
     let mut error_observations = Vec::new();
+    let mut quiescence_observations = Vec::new();
     let mut step_log = Vec::new();
 
     for (step_index, step) in spec.steps.iter().enumerate() {
@@ -631,6 +645,13 @@ async fn run_scenario_report_inner(
                     .await
                     .map_err(|error| subject_step_error(step_index, error))?;
             }
+            ScenarioStep::AwaitQuiescence { policy } => {
+                quiescence_observations.push(
+                    drive_subject_to_quiescence(subject, &spec.clients, policy, step_index)
+                        .await
+                        .map_err(|error| subject_step_error(step_index, error))?,
+                );
+            }
             ScenarioStep::Observe { clients: labels } => {
                 observations.extend(
                     subject
@@ -753,14 +774,29 @@ async fn run_scenario_report_inner(
             })
         })
         .collect();
-    let expectation_failures =
+    let mut expectation_failures =
         compare_trace_expectations(expected_trace.as_ref(), &expected_outcomes, &observed_trace);
+    for observation in &quiescence_observations {
+        if !observation.status.is_quiescent() {
+            expectation_failures.push(ExpectationFailure {
+                kind: "quiescence_not_reached".into(),
+                message: format!(
+                    "await_quiescence step {} ended as {:?}",
+                    observation.step_index, observation.status
+                ),
+                expected: serde_json::json!({"status": "quiescent"}),
+                actual: serde_json::to_value(observation)
+                    .expect("quiescence observation serializes"),
+            });
+        }
+    }
     let invariant_failures = invariant_failures(&expectation_failures);
     let oracle = build_scenario_oracle_report(
         spec,
         expected_trace.as_ref(),
         &expected_outcomes,
         &observed_trace,
+        &quiescence_observations,
     );
 
     Ok(ScenarioReport {
@@ -780,6 +816,7 @@ async fn run_scenario_report_inner(
         oracle,
         step_log,
         pending_resolution_observations,
+        quiescence_observations,
         recovery_observations,
         epoch_change_observations,
         app_invalidation_observations,
@@ -813,17 +850,18 @@ pub fn validate_scenario_for_subject(
         }
     }
     for (step_index, step) in spec.steps.iter().enumerate() {
-        let capability = required_capability(step);
-        if !descriptor.supports(capability) {
-            return Err(err(
-                step_index,
-                format!(
-                    "subject {} does not support capability {} required by {}",
-                    descriptor.adapter,
-                    capability,
-                    step.kind()
-                ),
-            ));
+        for capability in required_capabilities(step) {
+            if !descriptor.supports(capability) {
+                return Err(err(
+                    step_index,
+                    format!(
+                        "subject {} does not support capability {} required by {}",
+                        descriptor.adapter,
+                        capability,
+                        step.kind()
+                    ),
+                ));
+            }
         }
     }
     Ok(())
@@ -893,6 +931,21 @@ fn invariant_failures(expectation_failures: &[ExpectationFailure]) -> Vec<Invari
             message: failure.message.clone(),
         })
         .collect()
+}
+
+fn ensure_quiescence_steps_succeeded(report: &ScenarioReport) -> Result<(), ScenarioRunError> {
+    let Some(observation) = report
+        .quiescence_observations
+        .iter()
+        .find(|observation| !observation.status.is_quiescent())
+    else {
+        return Ok(());
+    };
+    let artifact = serde_json::to_string(observation).unwrap_or_else(|_| "unserializable".into());
+    Err(ScenarioRunError {
+        step_index: Some(observation.step_index),
+        message: format!("quiescence was not reached: {artifact}"),
+    })
 }
 
 #[cfg(test)]
@@ -1035,8 +1088,298 @@ mod tests {
     }
 
     #[test]
+    fn await_quiescence_is_serializable_and_requires_composed_capabilities() {
+        let step = ScenarioStep::AwaitQuiescence {
+            policy: QuiescencePolicy::default(),
+        };
+        let encoded = serde_json::to_value(&step).expect("quiescence step serializes");
+        assert_eq!(encoded["type"], "await_quiescence");
+        assert_eq!(encoded["policy"]["max_iterations"], 256);
+        assert_eq!(
+            serde_json::from_value::<ScenarioStep>(encoded).expect("quiescence step deserializes"),
+            step
+        );
+        assert_eq!(
+            required_capabilities(&step),
+            vec![
+                SubjectCapability::StructuralProgress,
+                SubjectCapability::VirtualTime,
+                SubjectCapability::TransportDelivery,
+                SubjectCapability::OutboundPublication,
+            ]
+        );
+
+        let manual = ScenarioStep::AwaitQuiescence {
+            policy: QuiescencePolicy {
+                outbound: crate::QuiescenceOutboundPolicy::Manual,
+                ..QuiescencePolicy::default()
+            },
+        };
+        assert!(!required_capabilities(&manual).contains(&SubjectCapability::OutboundPublication));
+    }
+
+    #[tokio::test]
+    async fn await_quiescence_drives_a_real_subject_and_records_the_terminal_artifact() {
+        let spec = ScenarioSpec {
+            name: "await-quiescence-smoke/v1".into(),
+            spec_version: "2".into(),
+            clients: vec!["alice".into(), "bob".into()],
+            steps: vec![
+                ScenarioStep::CreateGroup {
+                    creator: "alice".into(),
+                    name: "quiescence".into(),
+                    invitees: vec!["bob".into()],
+                    required_features: Vec::new(),
+                    initial_admins: None,
+                    pending: "create".into(),
+                },
+                ScenarioStep::AwaitQuiescence {
+                    policy: QuiescencePolicy::default(),
+                },
+                ScenarioStep::ObserveExact {
+                    clients: vec!["alice".into(), "bob".into()],
+                },
+            ],
+        };
+
+        let report = run_scenario_report(&spec, None)
+            .await
+            .expect("real subject scenario runs");
+        assert_eq!(report.quiescence_observations.len(), 1);
+        assert_eq!(
+            report.quiescence_observations[0].status,
+            crate::QuiescenceStatus::Quiescent
+        );
+        assert!(
+            report.quiescence_observations[0]
+                .final_progress
+                .is_quiescent()
+        );
+        assert!(report.expectation_failures.is_empty());
+        assert!(
+            report
+                .oracle
+                .observed_behaviors
+                .contains(&crate::OracleBehavior::QuiescenceState)
+        );
+    }
+
+    #[tokio::test]
+    async fn blocked_quiescence_is_a_report_artifact_and_a_spec_run_error() {
+        let spec = ScenarioSpec {
+            name: "await-quiescence-blocked/v1".into(),
+            spec_version: "2".into(),
+            clients: vec!["alice".into(), "bob".into()],
+            steps: vec![
+                ScenarioStep::CreateGroup {
+                    creator: "alice".into(),
+                    name: "quiescence".into(),
+                    invitees: vec!["bob".into()],
+                    required_features: Vec::new(),
+                    initial_admins: None,
+                    pending: "create".into(),
+                },
+                ScenarioStep::AwaitQuiescence {
+                    policy: QuiescencePolicy::default(),
+                },
+                ScenarioStep::SendAppMessage {
+                    sender: "alice".into(),
+                    payload: "withheld".into(),
+                },
+                ScenarioStep::AcknowledgeOutbound {
+                    client: "alice".into(),
+                    publication: None,
+                    selection: ScenarioOutboundSelection::All,
+                    outcome: SubjectOutboundOutcome::Accepted,
+                },
+                ScenarioStep::DelayQueued {
+                    index: 0,
+                    delayed: "withheld".into(),
+                },
+                ScenarioStep::AwaitQuiescence {
+                    policy: QuiescencePolicy::default(),
+                },
+            ],
+        };
+
+        let report = run_scenario_report(&spec, None)
+            .await
+            .expect("blocked quiescence still produces a report");
+        assert!(matches!(
+            report.quiescence_observations[1].status,
+            crate::QuiescenceStatus::Blocked { .. }
+        ));
+        assert_eq!(
+            report.expectation_failures[0].kind,
+            "quiescence_not_reached"
+        );
+
+        let error = run_scenario_spec(&spec)
+            .await
+            .expect_err("a blocked await step cannot silently succeed");
+        assert_eq!(error.step_index, Some(5));
+        assert!(error.message.contains("transport_delayed"));
+        assert!(error.message.contains("\"status\":\"blocked\""));
+    }
+
+    #[tokio::test]
+    async fn fixed_point_is_invariant_to_same_horizon_batch_partitioning() {
+        fn scenario(split_delivery: bool) -> ScenarioSpec {
+            let clients = vec!["alice".into(), "bob".into(), "carol".into()];
+            let mut steps = vec![
+                ScenarioStep::CreateGroup {
+                    creator: "alice".into(),
+                    name: "batch-partition".into(),
+                    invitees: vec!["bob".into(), "carol".into()],
+                    required_features: Vec::new(),
+                    initial_admins: Some(vec!["bob".into()]),
+                    pending: "create".into(),
+                },
+                ScenarioStep::AwaitQuiescence {
+                    policy: QuiescencePolicy::default(),
+                },
+                ScenarioStep::UpdateGroupData {
+                    client: "alice".into(),
+                    name: "alice branch".into(),
+                    pending: "alice-update".into(),
+                },
+                ScenarioStep::UpdateGroupData {
+                    client: "bob".into(),
+                    name: "bob branch".into(),
+                    pending: "bob-update".into(),
+                },
+                ScenarioStep::accept_publication("alice", "alice-update"),
+                ScenarioStep::accept_publication("bob", "bob-update"),
+            ];
+            if split_delivery {
+                steps.extend([
+                    ScenarioStep::DelayQueued {
+                        index: 1,
+                        delayed: "second-branch".into(),
+                    },
+                    ScenarioStep::DeliverAll,
+                    ScenarioStep::Tick {
+                        clients: clients.clone(),
+                    },
+                    ScenarioStep::AdvanceTime { delta_ms: 1_000 },
+                    ScenarioStep::Tick {
+                        clients: clients.clone(),
+                    },
+                    ScenarioStep::ReleaseDelayed {
+                        delayed: "second-branch".into(),
+                    },
+                ]);
+            }
+            steps.extend([
+                ScenarioStep::DeliverAll,
+                ScenarioStep::Tick {
+                    clients: clients.clone(),
+                },
+                ScenarioStep::AwaitQuiescence {
+                    policy: QuiescencePolicy::default(),
+                },
+                ScenarioStep::ObserveExact {
+                    clients: clients.clone(),
+                },
+            ]);
+            ScenarioSpec {
+                name: if split_delivery {
+                    "same-horizon-split/v1".into()
+                } else {
+                    "same-horizon-batch/v1".into()
+                },
+                spec_version: "2".into(),
+                clients,
+                steps,
+            }
+        }
+
+        let batch = run_scenario_report(&scenario(false), None)
+            .await
+            .expect("batch scenario runs");
+        let split = run_scenario_report(&scenario(true), None)
+            .await
+            .expect("split scenario runs");
+        assert!(batch.expectation_failures.is_empty(), "{batch:#?}");
+        assert!(split.expectation_failures.is_empty(), "{split:#?}");
+
+        let states = |report: &ScenarioReport| {
+            report
+                .observed_trace
+                .as_ref()
+                .expect("trace exists")
+                .observations
+                .iter()
+                .map(|observation| {
+                    observation
+                        .canonical_state
+                        .clone()
+                        .expect("exact state exists")
+                })
+                .collect::<Vec<_>>()
+        };
+        let batch_states = states(&batch);
+        let split_states = states(&split);
+        let retention_assumption_violations = |report: &ScenarioReport| {
+            report
+                .observed_trace
+                .as_ref()
+                .expect("trace exists")
+                .observations
+                .iter()
+                .flat_map(|observation| {
+                    observation
+                        .scenario_input_ledger
+                        .iter()
+                        .filter(|entry| {
+                            entry.expired > 0
+                                || entry.resource_refused > 0
+                                || entry.rejected > 0
+                                || entry.ingest_errors > 0
+                        })
+                        .map(|entry| {
+                            format!(
+                                "{}:{}:{:?}",
+                                observation.client, entry.scenario_id, entry.disposition
+                            )
+                        })
+                })
+                .collect::<Vec<_>>()
+        };
+        assert!(
+            retention_assumption_violations(&batch).is_empty(),
+            "batch retention/anchor assumption violations: {:?}",
+            retention_assumption_violations(&batch)
+        );
+        assert!(
+            retention_assumption_violations(&split).is_empty(),
+            "split retention/anchor assumption violations: {:?}",
+            retention_assumption_violations(&split)
+        );
+        assert!(batch_states.iter().all(|state| state == &batch_states[0]));
+        assert!(split_states.iter().all(|state| state == &split_states[0]));
+        let semantic_result = |state: &crate::ConformanceCanonicalStateSnapshot| match state {
+            crate::ConformanceCanonicalStateSnapshot::Live(snapshot) => (
+                snapshot.epoch,
+                snapshot.group_name.clone(),
+                snapshot.sorted_member_identities_hex.clone(),
+                snapshot.admin_identities_hex.clone(),
+                snapshot.protocol_lifecycle,
+                snapshot.protocol_profile,
+            ),
+            crate::ConformanceCanonicalStateSnapshot::Disbanded(_) => {
+                panic!("metamorphic branch race unexpectedly disbanded")
+            }
+        };
+        assert_eq!(
+            semantic_result(&batch_states[0]),
+            semantic_result(&split_states[0])
+        );
+    }
+
+    #[test]
     fn queue_fault_steps_require_explicit_white_box_capability() {
-        let capability = required_capability(&ScenarioStep::DropQueued { index: 0 });
+        let capability = crate::required_capability(&ScenarioStep::DropQueued { index: 0 });
 
         assert_eq!(capability, SubjectCapability::WhiteBoxTransportQueueFaults);
         assert!(capability.is_white_box());

--- a/crates/cgka-conformance-simulator/src/subject.rs
+++ b/crates/cgka-conformance-simulator/src/subject.rs
@@ -263,6 +263,12 @@ pub trait ConvergenceSubject: Send {
         ))
     }
 
+    /// Select controlled virtual-time behavior without advancing either clock
+    /// domain. This makes the clock-mode transition explicit for adapters.
+    fn activate_virtual_time(&mut self) -> Result<(), SubjectError> {
+        Err(SubjectError::unsupported(SubjectCapability::VirtualTime))
+    }
+
     /// Advance the subject's paired convergence clock without waking a
     /// participant runtime. A later `tick` selects which participants observe
     /// the elapsed deadline.
@@ -356,42 +362,6 @@ pub trait ConvergenceFaultSubject {
     fn clear_partition(&mut self) -> Result<(), SubjectError>;
 }
 
-/// Capability required for one ScenarioSpec v2 step.
-pub fn required_capability(step: &ScenarioStep) -> SubjectCapability {
-    match step {
-        ScenarioStep::CreateGroup { .. }
-        | ScenarioStep::InviteMembers { .. }
-        | ScenarioStep::UpdateGroupData { .. }
-        | ScenarioStep::UpdateAdminPolicy { .. }
-        | ScenarioStep::ExpectUpdateAdminPolicyError { .. }
-        | ScenarioStep::Leave { .. } => SubjectCapability::GroupMutation,
-        ScenarioStep::AcknowledgeOutbound { .. } => SubjectCapability::OutboundPublication,
-        ScenarioStep::SendAppMessage { .. } => SubjectCapability::ApplicationMessaging,
-        ScenarioStep::DeliverAll | ScenarioStep::Tick { .. } => {
-            SubjectCapability::TransportDelivery
-        }
-        ScenarioStep::AdvanceTime { .. } => SubjectCapability::VirtualTime,
-        ScenarioStep::AwaitQuiescence { .. } => SubjectCapability::StructuralProgress,
-        ScenarioStep::Observe { .. } | ScenarioStep::ClearEvents { .. } => {
-            SubjectCapability::EventObservation
-        }
-        ScenarioStep::ObserveExact { .. } => SubjectCapability::ExactConformanceObservation,
-        ScenarioStep::ProbeBidirectionalDecryptability { .. } => {
-            SubjectCapability::ActiveDecryptabilityProbe
-        }
-        ScenarioStep::ObserveAdminPolicy { .. } => SubjectCapability::AdminPolicyObservation,
-        ScenarioStep::RestartClient { .. } => SubjectCapability::CrashReopen,
-        ScenarioStep::DropQueued { .. }
-        | ScenarioStep::DuplicateQueued { .. }
-        | ScenarioStep::DelayQueued { .. }
-        | ScenarioStep::ReleaseDelayed { .. }
-        | ScenarioStep::ReorderQueued { .. } => SubjectCapability::WhiteBoxTransportQueueFaults,
-        ScenarioStep::SetPartition { .. } | ScenarioStep::ClearPartition => {
-            SubjectCapability::WhiteBoxTransportPartition
-        }
-    }
-}
-
 /// Complete capability set used by a scenario step. Most operations need one
 /// capability; fixed-point settling composes progress, time, delivery, and
 /// optionally outbound acknowledgement without moving policy into the subject.
@@ -407,7 +377,38 @@ pub fn required_capabilities(step: &ScenarioStep) -> Vec<SubjectCapability> {
         }
         capabilities
     } else {
-        vec![required_capability(step)]
+        vec![match step {
+            ScenarioStep::CreateGroup { .. }
+            | ScenarioStep::InviteMembers { .. }
+            | ScenarioStep::UpdateGroupData { .. }
+            | ScenarioStep::UpdateAdminPolicy { .. }
+            | ScenarioStep::ExpectUpdateAdminPolicyError { .. }
+            | ScenarioStep::Leave { .. } => SubjectCapability::GroupMutation,
+            ScenarioStep::AcknowledgeOutbound { .. } => SubjectCapability::OutboundPublication,
+            ScenarioStep::SendAppMessage { .. } => SubjectCapability::ApplicationMessaging,
+            ScenarioStep::DeliverAll | ScenarioStep::Tick { .. } => {
+                SubjectCapability::TransportDelivery
+            }
+            ScenarioStep::AdvanceTime { .. } => SubjectCapability::VirtualTime,
+            ScenarioStep::Observe { .. } | ScenarioStep::ClearEvents { .. } => {
+                SubjectCapability::EventObservation
+            }
+            ScenarioStep::ObserveExact { .. } => SubjectCapability::ExactConformanceObservation,
+            ScenarioStep::ProbeBidirectionalDecryptability { .. } => {
+                SubjectCapability::ActiveDecryptabilityProbe
+            }
+            ScenarioStep::ObserveAdminPolicy { .. } => SubjectCapability::AdminPolicyObservation,
+            ScenarioStep::RestartClient { .. } => SubjectCapability::CrashReopen,
+            ScenarioStep::DropQueued { .. }
+            | ScenarioStep::DuplicateQueued { .. }
+            | ScenarioStep::DelayQueued { .. }
+            | ScenarioStep::ReleaseDelayed { .. }
+            | ScenarioStep::ReorderQueued { .. } => SubjectCapability::WhiteBoxTransportQueueFaults,
+            ScenarioStep::SetPartition { .. } | ScenarioStep::ClearPartition => {
+                SubjectCapability::WhiteBoxTransportPartition
+            }
+            ScenarioStep::AwaitQuiescence { .. } => unreachable!("handled above"),
+        }]
     }
 }
 
@@ -740,12 +741,16 @@ impl ConvergenceSubject for EngineHarnessSubject {
         Ok(())
     }
 
-    async fn advance_time(&mut self, delta_ms: u64) -> Result<(), SubjectError> {
-        self.convergence_clock.advance_ms(delta_ms);
+    fn activate_virtual_time(&mut self) -> Result<(), SubjectError> {
         for client in self.clients.values_mut() {
             client.enable_virtual_time_tick();
         }
         Ok(())
+    }
+
+    async fn advance_time(&mut self, delta_ms: u64) -> Result<(), SubjectError> {
+        self.convergence_clock.advance_ms(delta_ms);
+        self.activate_virtual_time()
     }
 
     fn poll_outbound(
@@ -911,6 +916,8 @@ impl ConvergenceSubject for EngineHarnessSubject {
         let labels = self.clients.keys().cloned().collect::<Vec<_>>();
         for label in &labels {
             self.sync_client_outbound(label)?;
+            // Refresh durable message dispositions before counting scenario
+            // inputs that still lack a current or terminal outcome.
             let _ = self.client_mut(label)?.scenario_input_ledger();
         }
 
@@ -976,6 +983,7 @@ impl ConvergenceSubject for EngineHarnessSubject {
             schema_version: "1".into(),
             structural_token: String::new(),
             current_monotonic_ms,
+            runnable_engine_work,
             runnable_work: runnable_engine_work
                 .saturating_add(bus.queued_messages)
                 .saturating_add(bus.mailbox_messages),

--- a/crates/cgka-conformance-simulator/src/subject.rs
+++ b/crates/cgka-conformance-simulator/src/subject.rs
@@ -9,12 +9,12 @@ use crate::client::HarnessPublicationError;
 use crate::{
     BidirectionalDecryptabilityObservation, ClientBuilder, ClientObservation,
     DecryptabilityProbeSendStatus, DirectionalDecryptabilityProbe, HarnessClient,
-    HarnessStorageMode, ScenarioAdminPolicyObservation, ScenarioStep, TransportBus, observe_client,
-    observe_client_exact,
+    HarnessStorageMode, ScenarioAdminPolicyObservation, ScenarioStep, SubjectProgressSnapshot,
+    SubjectTerminalBlocker, TransportBus, observe_client, observe_client_exact,
 };
 use async_trait::async_trait;
-use cgka_engine::ManualConvergenceClock;
 use cgka_engine::feature_registry::FeatureRegistry;
+use cgka_engine::{ConvergenceClock, ManualConvergenceClock};
 use cgka_traits::EngineError;
 use cgka_traits::capabilities::{Capability, CapabilityRequirement, Feature, RequirementLevel};
 use cgka_traits::engine::KeyPackage;
@@ -23,6 +23,7 @@ use cgka_traits::group::ProtocolProfile;
 use cgka_traits::transport::{TransportEnvelope, TransportMessage};
 use cgka_traits::types::{GroupId, MemberId, MessageId};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt;
 use std::sync::Arc;
@@ -41,6 +42,7 @@ pub enum SubjectCapability {
     CrashReopen,
     VirtualTime,
     OutboundPublication,
+    StructuralProgress,
     WhiteBoxTransportQueueFaults,
     WhiteBoxTransportPartition,
     WhiteBoxStorageFaults,
@@ -59,6 +61,7 @@ impl SubjectCapability {
             Self::CrashReopen => "crash_reopen",
             Self::VirtualTime => "virtual_time",
             Self::OutboundPublication => "outbound_publication",
+            Self::StructuralProgress => "structural_progress",
             Self::WhiteBoxTransportQueueFaults => "white_box_transport_queue_faults",
             Self::WhiteBoxTransportPartition => "white_box_transport_partition",
             Self::WhiteBoxStorageFaults => "white_box_storage_faults",
@@ -287,6 +290,12 @@ pub trait ConvergenceSubject: Send {
         ))
     }
 
+    fn structural_progress(&mut self) -> Result<SubjectProgressSnapshot, SubjectError> {
+        Err(SubjectError::unsupported(
+            SubjectCapability::StructuralProgress,
+        ))
+    }
+
     fn observe(&mut self, _clients: &[String]) -> Result<Vec<ClientObservation>, SubjectError> {
         Err(SubjectError::unsupported(
             SubjectCapability::EventObservation,
@@ -362,6 +371,7 @@ pub fn required_capability(step: &ScenarioStep) -> SubjectCapability {
             SubjectCapability::TransportDelivery
         }
         ScenarioStep::AdvanceTime { .. } => SubjectCapability::VirtualTime,
+        ScenarioStep::AwaitQuiescence { .. } => SubjectCapability::StructuralProgress,
         ScenarioStep::Observe { .. } | ScenarioStep::ClearEvents { .. } => {
             SubjectCapability::EventObservation
         }
@@ -379,6 +389,25 @@ pub fn required_capability(step: &ScenarioStep) -> SubjectCapability {
         ScenarioStep::SetPartition { .. } | ScenarioStep::ClearPartition => {
             SubjectCapability::WhiteBoxTransportPartition
         }
+    }
+}
+
+/// Complete capability set used by a scenario step. Most operations need one
+/// capability; fixed-point settling composes progress, time, delivery, and
+/// optionally outbound acknowledgement without moving policy into the subject.
+pub fn required_capabilities(step: &ScenarioStep) -> Vec<SubjectCapability> {
+    if let ScenarioStep::AwaitQuiescence { policy } = step {
+        let mut capabilities = vec![
+            SubjectCapability::StructuralProgress,
+            SubjectCapability::VirtualTime,
+            SubjectCapability::TransportDelivery,
+        ];
+        if policy.outbound == crate::QuiescenceOutboundPolicy::AcceptAll {
+            capabilities.push(SubjectCapability::OutboundPublication);
+        }
+        capabilities
+    } else {
+        vec![required_capability(step)]
     }
 }
 
@@ -442,6 +471,7 @@ impl EngineHarnessSubject {
             SubjectCapability::CrashReopen,
             SubjectCapability::VirtualTime,
             SubjectCapability::OutboundPublication,
+            SubjectCapability::StructuralProgress,
             SubjectCapability::WhiteBoxTransportQueueFaults,
             SubjectCapability::WhiteBoxTransportPartition,
         ]);
@@ -877,6 +907,98 @@ impl ConvergenceSubject for EngineHarnessSubject {
         Ok(())
     }
 
+    fn structural_progress(&mut self) -> Result<SubjectProgressSnapshot, SubjectError> {
+        let labels = self.clients.keys().cloned().collect::<Vec<_>>();
+        for label in &labels {
+            self.sync_client_outbound(label)?;
+            let _ = self.client_mut(label)?.scenario_input_ledger();
+        }
+
+        let clients = labels
+            .iter()
+            .map(|label| {
+                self.client(label)?
+                    .structural_progress_observation(label.clone())
+                    .map_err(|error| {
+                        SubjectError::new("progress_snapshot_failed", observe_engine_error(&error))
+                    })
+            })
+            .collect::<Result<Vec<_>, SubjectError>>()?;
+        let bus = self.bus.structural_progress_snapshot();
+        let current_monotonic_ms = self.convergence_clock.now().monotonic_ms;
+        let outbound_awaiting_acknowledgement = self
+            .outbound_records
+            .values()
+            .filter(|record| record.resolution.is_none())
+            .count();
+        let runnable_engine_work = clients
+            .iter()
+            .filter_map(|client| client.engine.as_ref())
+            .map(|engine| engine.runnable_work)
+            .sum::<usize>();
+        let earliest_next_wake_monotonic_ms = clients
+            .iter()
+            .filter_map(|client| {
+                client
+                    .engine
+                    .as_ref()
+                    .and_then(|engine| engine.earliest_next_wake_monotonic_ms)
+            })
+            .min();
+        let deferred_retry_work = clients
+            .iter()
+            .filter_map(|client| client.engine.as_ref())
+            .map(|engine| {
+                engine
+                    .pending_work
+                    .stored_retryable_messages
+                    .saturating_add(engine.pending_work.stored_transport_deferred_messages)
+            })
+            .sum();
+        let scenario_inputs_pending = clients
+            .iter()
+            .map(|client| client.scenario_inputs_pending)
+            .sum();
+        let terminal_blockers = clients
+            .iter()
+            .filter(|client| {
+                client
+                    .engine
+                    .as_ref()
+                    .is_some_and(|engine| engine.terminal_unrecoverable)
+            })
+            .map(|client| SubjectTerminalBlocker::EngineUnrecoverable {
+                client: client.client.clone(),
+            })
+            .collect();
+
+        let mut snapshot = SubjectProgressSnapshot {
+            schema_version: "1".into(),
+            structural_token: String::new(),
+            current_monotonic_ms,
+            runnable_work: runnable_engine_work
+                .saturating_add(bus.queued_messages)
+                .saturating_add(bus.mailbox_messages),
+            earliest_next_wake_monotonic_ms,
+            deferred_retry_work,
+            outbound_awaiting_acknowledgement,
+            transport_queued_messages: bus.queued_messages,
+            transport_delayed_messages: bus.delayed_messages,
+            transport_mailbox_messages: bus.mailbox_messages,
+            scenario_inputs_pending,
+            terminal_blockers,
+            clients,
+        };
+        let encoded = serde_json::to_vec(&snapshot).map_err(|error| {
+            SubjectError::new(
+                "progress_serialization_failed",
+                format!("serialize structural progress: {error}"),
+            )
+        })?;
+        snapshot.structural_token = hex::encode(Sha256::digest(encoded));
+        Ok(snapshot)
+    }
+
     fn observe(&mut self, clients: &[String]) -> Result<Vec<ClientObservation>, SubjectError> {
         clients
             .iter()
@@ -1183,7 +1305,10 @@ fn observe_engine_error(error: &EngineError) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ConformanceCanonicalStateSnapshot;
+    use crate::{
+        ConformanceCanonicalStateSnapshot, QuiescenceOutboundPolicy, QuiescencePolicy,
+        QuiescenceStatus, drive_subject_to_quiescence,
+    };
 
     async fn create_current_group_and_join(
         subject: &mut EngineHarnessSubject,
@@ -2170,5 +2295,261 @@ mod tests {
                 .canonical_state_snapshot(),
             ConformanceCanonicalStateSnapshot::Disbanded(_)
         ));
+    }
+
+    #[tokio::test]
+    async fn structural_progress_is_stable_sanitized_and_names_publication_work() {
+        let labels = vec!["alice".to_owned(), "bob".to_owned()];
+        let mut subject = EngineHarnessSubject::new(
+            &labels,
+            ProtocolProfile::Current,
+            HarnessStorageMode::InMemorySqlite,
+        )
+        .expect("engine subject constructs");
+        create_current_group_and_join(&mut subject, "alice", &labels[1..]).await;
+
+        let settled = subject.structural_progress().expect("progress snapshot");
+        assert!(settled.is_quiescent(), "settled snapshot: {settled:#?}");
+        assert_eq!(
+            settled.structural_token,
+            subject
+                .structural_progress()
+                .expect("repeat progress snapshot")
+                .structural_token,
+            "unchanged structure must have a stable token"
+        );
+
+        subject
+            .send_application(SubjectSendApplication {
+                action_id: "structural-app",
+                sender: "alice",
+                payload: "pending publication",
+            })
+            .await
+            .expect("application emits outbound work");
+        let pending = subject.structural_progress().expect("pending progress");
+        assert_ne!(pending.structural_token, settled.structural_token);
+        assert_eq!(pending.outbound_awaiting_acknowledgement, 1);
+        assert_eq!(pending.transport_queued_messages, 1);
+
+        let encoded = serde_json::to_string(&pending).expect("progress serializes");
+        for forbidden in [
+            "group_id",
+            "message_id",
+            "account_id",
+            "payload",
+            "ciphertext",
+            "pubkey",
+        ] {
+            assert!(
+                !encoded.contains(forbidden),
+                "progress leaked forbidden field name {forbidden}: {encoded}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn fixed_point_reports_manual_ack_blocker_then_settles() {
+        let labels = vec!["alice".to_owned(), "bob".to_owned()];
+        let mut subject = EngineHarnessSubject::new(
+            &labels,
+            ProtocolProfile::Current,
+            HarnessStorageMode::InMemorySqlite,
+        )
+        .expect("engine subject constructs");
+        create_current_group_and_join(&mut subject, "alice", &labels[1..]).await;
+        subject
+            .send_application(SubjectSendApplication {
+                action_id: "manual-ack-app",
+                sender: "alice",
+                payload: "manual ack",
+            })
+            .await
+            .expect("application emits outbound work");
+
+        let blocked = drive_subject_to_quiescence(
+            &mut subject,
+            &labels,
+            &QuiescencePolicy {
+                outbound: QuiescenceOutboundPolicy::Manual,
+                ..QuiescencePolicy::default()
+            },
+            7,
+        )
+        .await
+        .expect("manual fixed point reports a terminal observation");
+        assert!(matches!(blocked.status, QuiescenceStatus::Blocked { .. }));
+        assert!(
+            blocked
+                .final_progress
+                .blocking_subsystems()
+                .contains(&"outbound_acknowledgement")
+        );
+
+        let settled =
+            drive_subject_to_quiescence(&mut subject, &labels, &QuiescencePolicy::default(), 8)
+                .await
+                .expect("automatic publication and delivery settle");
+        assert_eq!(settled.status, QuiescenceStatus::Quiescent);
+        assert!(settled.final_progress.is_quiescent());
+    }
+
+    #[tokio::test]
+    async fn fixed_point_advances_exactly_to_engine_wake() {
+        let labels = vec!["alice".to_owned()];
+        let mut subject = EngineHarnessSubject::new(
+            &labels,
+            ProtocolProfile::Current,
+            HarnessStorageMode::InMemorySqlite,
+        )
+        .expect("engine subject constructs");
+        create_current_group_and_join(&mut subject, "alice", &[]).await;
+        let alice = subject.client_mut("alice").expect("alice exists");
+        alice.request_disband().await.expect("request disband");
+        alice
+            .advance_convergence()
+            .await
+            .expect("prepare disband commit");
+        for artifact in subject
+            .poll_outbound("alice")
+            .expect("disband publication is pollable")
+        {
+            subject
+                .acknowledge_outbound(
+                    "alice",
+                    &artifact.outbound_id,
+                    SubjectOutboundOutcome::Accepted,
+                )
+                .await
+                .expect("accept disband publication");
+        }
+        subject
+            .client_mut("alice")
+            .expect("alice exists")
+            .advance_convergence()
+            .await
+            .expect("open collecting pass");
+
+        let before = subject.structural_progress().expect("scheduled progress");
+        assert_eq!(before.earliest_next_wake_monotonic_ms, Some(1_000));
+        let settled =
+            drive_subject_to_quiescence(&mut subject, &labels, &QuiescencePolicy::default(), 9)
+                .await
+                .expect("fixed point settles disband");
+        assert_eq!(settled.status, QuiescenceStatus::Quiescent);
+        assert_eq!(
+            settled.virtual_time_advanced_ms, 1_000,
+            "before={before:#?}; settled={settled:#?}"
+        );
+        assert!(matches!(
+            subject
+                .client("alice")
+                .expect("alice exists")
+                .canonical_state_snapshot(),
+            ConformanceCanonicalStateSnapshot::Disbanded(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn structural_wake_rebases_across_restart_without_granting_fresh_time() {
+        let labels = vec!["alice".to_owned()];
+        let mut subject = EngineHarnessSubject::new(
+            &labels,
+            ProtocolProfile::Current,
+            HarnessStorageMode::TempFileBackedSqlite,
+        )
+        .expect("file-backed engine subject constructs");
+        create_current_group_and_join(&mut subject, "alice", &[]).await;
+        let alice = subject.client_mut("alice").expect("alice exists");
+        alice.request_disband().await.expect("request disband");
+        alice
+            .advance_convergence()
+            .await
+            .expect("prepare disband commit");
+        for artifact in subject
+            .poll_outbound("alice")
+            .expect("disband publication is pollable")
+        {
+            subject
+                .acknowledge_outbound(
+                    "alice",
+                    &artifact.outbound_id,
+                    SubjectOutboundOutcome::Accepted,
+                )
+                .await
+                .expect("accept disband publication");
+        }
+        subject
+            .client_mut("alice")
+            .expect("alice exists")
+            .advance_convergence()
+            .await
+            .expect("open collecting pass");
+        subject
+            .advance_time(400)
+            .await
+            .expect("advance partway to cutoff");
+        subject
+            .restart("alice")
+            .expect("restart file-backed client");
+
+        let restarted = subject.structural_progress().expect("restarted progress");
+        assert_eq!(restarted.current_monotonic_ms, 400);
+        assert_eq!(restarted.earliest_next_wake_monotonic_ms, Some(1_000));
+        let settled =
+            drive_subject_to_quiescence(&mut subject, &labels, &QuiescencePolicy::default(), 10)
+                .await
+                .expect("restarted fixed point settles");
+        assert_eq!(settled.status, QuiescenceStatus::Quiescent);
+        assert_eq!(settled.virtual_time_advanced_ms, 600);
+    }
+
+    #[tokio::test]
+    async fn fixed_point_names_withheld_transport_without_spinning() {
+        let labels = vec!["alice".to_owned(), "bob".to_owned()];
+        let mut subject = EngineHarnessSubject::new(
+            &labels,
+            ProtocolProfile::Current,
+            HarnessStorageMode::InMemorySqlite,
+        )
+        .expect("engine subject constructs");
+        create_current_group_and_join(&mut subject, "alice", &labels[1..]).await;
+        subject
+            .send_application(SubjectSendApplication {
+                action_id: "withheld-app",
+                sender: "alice",
+                payload: "withheld",
+            })
+            .await
+            .expect("application emits outbound work");
+        for artifact in subject
+            .poll_outbound("alice")
+            .expect("application is pollable")
+        {
+            subject
+                .acknowledge_outbound(
+                    "alice",
+                    &artifact.outbound_id,
+                    SubjectOutboundOutcome::Accepted,
+                )
+                .await
+                .expect("transport accepted the application");
+        }
+        subject
+            .delay_queued(0, "withheld")
+            .expect("delay queued application");
+
+        let blocked =
+            drive_subject_to_quiescence(&mut subject, &labels, &QuiescencePolicy::default(), 10)
+                .await
+                .expect("withheld transport produces an observation");
+        assert_eq!(blocked.iterations, 0);
+        assert!(matches!(blocked.status, QuiescenceStatus::Blocked { .. }));
+        assert!(
+            blocked
+                .final_progress
+                .blocking_subsystems()
+                .contains(&"transport_delayed")
+        );
     }
 }

--- a/crates/cgka-engine/src/conformance_snapshot.rs
+++ b/crates/cgka-engine/src/conformance_snapshot.rs
@@ -6,11 +6,11 @@
 //! surfaces must not enable or consume this interface.
 
 use cgka_traits::app_components::GroupLifecycleV1;
-use cgka_traits::convergence_pass::ConvergencePassPhase;
+use cgka_traits::convergence_pass::{ConvergencePassPhase, DurableConvergencePass};
 use cgka_traits::engine_state::{EpochState, GroupLifecycleState};
 use cgka_traits::error::EngineError;
 use cgka_traits::group::ProtocolProfile;
-use cgka_traits::message::MessageState;
+use cgka_traits::message::{MessageRecord, MessageState};
 use cgka_traits::storage::{StorageError, StorageProvider};
 use cgka_traits::types::{EpochId, GroupId};
 use openmls::group::MlsGroup;
@@ -392,20 +392,38 @@ pub(crate) fn capture_pending_work_snapshot<S: StorageProvider>(
     group_id: &GroupId,
 ) -> Result<ConformancePendingWorkSnapshot, EngineError> {
     engine.ensure_group_live(group_id)?;
-    let disbanded = engine.storage.disband_tombstone(group_id)?.is_some();
     let epoch_state = engine
         .epoch_manager
         .state(group_id)
         .ok_or_else(|| EngineError::UnknownGroup(group_id.clone()))?;
     let lifecycle = GroupLifecycleState::from(epoch_state);
+    let pass = engine.storage.convergence_pass(group_id)?;
+    let messages = engine.storage.list_messages(group_id, EpochId(0))?;
+    capture_pending_work_snapshot_from(
+        engine,
+        group_id,
+        epoch_state,
+        lifecycle,
+        pass.as_ref(),
+        &messages,
+    )
+}
+
+fn capture_pending_work_snapshot_from<S: StorageProvider>(
+    engine: &crate::Engine<S>,
+    group_id: &GroupId,
+    epoch_state: &EpochState,
+    lifecycle: GroupLifecycleState,
+    pass: Option<&DurableConvergencePass>,
+    messages: &[MessageRecord],
+) -> Result<ConformancePendingWorkSnapshot, EngineError> {
+    let disbanded = engine.storage.disband_tombstone(group_id)?.is_some();
     let recovering_buffered_messages = match epoch_state {
         EpochState::Recovering(recovering) => recovering.buffered().len(),
         _ => 0,
     };
 
-    let pass = engine.storage.convergence_pass(group_id)?;
-    let active_pass = pass.as_ref().filter(|pass| pass.is_active());
-    let messages = engine.storage.list_messages(group_id, EpochId(0))?;
+    let active_pass = pass.filter(|pass| pass.is_active());
     let mut stored_created_messages = 0;
     let mut stored_retryable_messages = 0;
     let mut stored_transport_deferred_messages = 0;
@@ -493,7 +511,6 @@ pub(crate) fn capture_structural_progress_snapshot<S: StorageProvider>(
     group_id: &GroupId,
 ) -> Result<ConformanceStructuralProgressSnapshot, EngineError> {
     engine.ensure_group_live(group_id)?;
-    let pending_work = capture_pending_work_snapshot(engine, group_id)?;
     let epoch_state = engine
         .epoch_manager
         .state(group_id)
@@ -501,24 +518,36 @@ pub(crate) fn capture_structural_progress_snapshot<S: StorageProvider>(
     let lifecycle = GroupLifecycleState::from(epoch_state);
     let current_epoch = engine.epoch_manager.epoch(group_id).unwrap_or_default().0;
     let now = engine.convergence_now();
-    let pass = engine.storage.convergence_pass(group_id)?;
+    let mut pass = engine.storage.convergence_pass(group_id)?;
+    if let Some(active) = pass.as_mut().filter(|pass| pass.is_active()) {
+        let policy = engine
+            .convergence_policy_for_group(group_id)
+            .map_err(|error| {
+                EngineError::Backend(format!("load convergence policy for snapshot: {error}"))
+            })?;
+        crate::distributed_convergence::normalize_convergence_pass_for_runtime(
+            active,
+            &policy,
+            now,
+            engine.convergence_clock_instance_id,
+        );
+    }
+    let messages = engine.storage.list_messages(group_id, EpochId(0))?;
+    let pending_work = capture_pending_work_snapshot_from(
+        engine,
+        group_id,
+        epoch_state,
+        lifecycle,
+        pass.as_ref(),
+        &messages,
+    )?;
 
     let mut runnable_work = 0usize;
     let mut next_wake = None;
     if let Some(active) = pass.as_ref().filter(|pass| pass.is_active()) {
         match active.phase {
             ConvergencePassPhase::Collecting => {
-                let cutoff = if active.clock_instance_id == engine.convergence_clock_instance_id {
-                    active.cutoff_monotonic_ms()
-                } else {
-                    let backwards = now.wall_ms < active.opened_wall_ms;
-                    let remaining = if backwards {
-                        0
-                    } else {
-                        active.cutoff_wall_ms().saturating_sub(now.wall_ms)
-                    };
-                    now.monotonic_ms.saturating_add(remaining)
-                };
+                let cutoff = active.cutoff_monotonic_ms();
                 if cutoff <= now.monotonic_ms {
                     runnable_work = runnable_work.saturating_add(1);
                 } else {
@@ -532,29 +561,31 @@ pub(crate) fn capture_structural_progress_snapshot<S: StorageProvider>(
         }
     }
 
-    let messages = engine.storage.list_messages(group_id, EpochId(0))?;
+    let mut deferred_normalizations = 0usize;
     for record in messages
         .iter()
         .filter(|record| record.state == MessageState::PeelDeferred)
     {
-        let Some(deferred) = record.deferred_peel.as_ref() else {
-            runnable_work = runnable_work.saturating_add(1);
-            continue;
-        };
-        let deadline = if deferred.clock_instance_id == engine.convergence_clock_instance_id {
-            deferred.residence_deadline_monotonic_ms
-        } else {
-            let observed_wall = deferred.wall_high_water_ms.max(now.wall_ms);
-            let remaining = deferred
-                .residence_deadline_wall_ms
-                .saturating_sub(observed_wall);
-            now.monotonic_ms.saturating_add(remaining)
-        };
+        let (deferred, changed) = crate::message_processor::normalized_deferred_peel_lifecycle(
+            record.deferred_peel.as_ref(),
+            now,
+            engine.convergence_clock_instance_id,
+            engine.deferred_peel_residence_ms,
+        );
+        deferred_normalizations = deferred_normalizations.saturating_add(usize::from(changed));
+        let deadline = deferred.residence_deadline_monotonic_ms;
         if deadline <= now.monotonic_ms {
             runnable_work = runnable_work.saturating_add(1);
         } else {
             next_wake = Some(next_wake.map_or(deadline, |current: u64| current.min(deadline)));
         }
+    }
+    if deferred_normalizations > crate::message_processor::MAX_DEFERRED_ROWS_PER_SWEEP {
+        // Runtime maintenance persists lifecycle migrations in bounded slices
+        // and immediately schedules another slice while normalization remains.
+        runnable_work = runnable_work.saturating_add(1);
+        next_wake =
+            Some(next_wake.map_or(now.monotonic_ms, |current| current.min(now.monotonic_ms)));
     }
 
     for scheduled in engine

--- a/crates/cgka-engine/src/conformance_snapshot.rs
+++ b/crates/cgka-engine/src/conformance_snapshot.rs
@@ -6,6 +6,7 @@
 //! surfaces must not enable or consume this interface.
 
 use cgka_traits::app_components::GroupLifecycleV1;
+use cgka_traits::convergence_pass::ConvergencePassPhase;
 use cgka_traits::engine_state::{EpochState, GroupLifecycleState};
 use cgka_traits::error::EngineError;
 use cgka_traits::group::ProtocolProfile;
@@ -153,6 +154,28 @@ impl ConformancePendingWorkSnapshot {
     pub fn is_empty(&self) -> bool {
         self == &Self::default()
     }
+}
+
+/// Sanitized scheduling state used by black-box convergence simulators.
+///
+/// This is a read-only conformance surface. It exposes only aggregate work,
+/// lifecycle phase, durable generation/epoch counters, and virtual-clock
+/// deadlines. Message, member, account, and group identifiers are excluded.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConformanceStructuralProgressSnapshot {
+    pub current_epoch: u64,
+    pub current_monotonic_ms: u64,
+    pub lifecycle: GroupLifecycleState,
+    pub pending_work: ConformancePendingWorkSnapshot,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pass_generation: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pass_phase: Option<ConvergencePassPhase>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub earliest_next_wake_monotonic_ms: Option<u64>,
+    pub runnable_work: usize,
+    #[serde(default)]
+    pub terminal_unrecoverable: bool,
 }
 
 pub(crate) fn capture_group_snapshot<S: StorageProvider>(
@@ -462,6 +485,122 @@ pub(crate) fn capture_pending_work_snapshot<S: StorageProvider>(
             .values()
             .filter(|(queued_group_id, _)| queued_group_id == group_id)
             .count(),
+    })
+}
+
+pub(crate) fn capture_structural_progress_snapshot<S: StorageProvider>(
+    engine: &crate::Engine<S>,
+    group_id: &GroupId,
+) -> Result<ConformanceStructuralProgressSnapshot, EngineError> {
+    engine.ensure_group_live(group_id)?;
+    let pending_work = capture_pending_work_snapshot(engine, group_id)?;
+    let epoch_state = engine
+        .epoch_manager
+        .state(group_id)
+        .ok_or_else(|| EngineError::UnknownGroup(group_id.clone()))?;
+    let lifecycle = GroupLifecycleState::from(epoch_state);
+    let current_epoch = engine.epoch_manager.epoch(group_id).unwrap_or_default().0;
+    let now = engine.convergence_now();
+    let pass = engine.storage.convergence_pass(group_id)?;
+
+    let mut runnable_work = 0usize;
+    let mut next_wake = None;
+    if let Some(active) = pass.as_ref().filter(|pass| pass.is_active()) {
+        match active.phase {
+            ConvergencePassPhase::Collecting => {
+                let cutoff = if active.clock_instance_id == engine.convergence_clock_instance_id {
+                    active.cutoff_monotonic_ms()
+                } else {
+                    let backwards = now.wall_ms < active.opened_wall_ms;
+                    let remaining = if backwards {
+                        0
+                    } else {
+                        active.cutoff_wall_ms().saturating_sub(now.wall_ms)
+                    };
+                    now.monotonic_ms.saturating_add(remaining)
+                };
+                if cutoff <= now.monotonic_ms {
+                    runnable_work = runnable_work.saturating_add(1);
+                } else {
+                    next_wake = Some(cutoff);
+                }
+            }
+            ConvergencePassPhase::Frozen | ConvergencePassPhase::Resolving => {
+                runnable_work = runnable_work.saturating_add(1);
+            }
+            ConvergencePassPhase::Completed => {}
+        }
+    }
+
+    let messages = engine.storage.list_messages(group_id, EpochId(0))?;
+    for record in messages
+        .iter()
+        .filter(|record| record.state == MessageState::PeelDeferred)
+    {
+        let Some(deferred) = record.deferred_peel.as_ref() else {
+            runnable_work = runnable_work.saturating_add(1);
+            continue;
+        };
+        let deadline = if deferred.clock_instance_id == engine.convergence_clock_instance_id {
+            deferred.residence_deadline_monotonic_ms
+        } else {
+            let observed_wall = deferred.wall_high_water_ms.max(now.wall_ms);
+            let remaining = deferred
+                .residence_deadline_wall_ms
+                .saturating_sub(observed_wall);
+            now.monotonic_ms.saturating_add(remaining)
+        };
+        if deadline <= now.monotonic_ms {
+            runnable_work = runnable_work.saturating_add(1);
+        } else {
+            next_wake = Some(next_wake.map_or(deadline, |current: u64| current.min(deadline)));
+        }
+    }
+
+    for scheduled in engine
+        .scheduled_self_remove_auto_commits
+        .values()
+        .filter(|scheduled| scheduled.group_id == *group_id)
+    {
+        if scheduled.due_at_ms <= now.monotonic_ms {
+            runnable_work = runnable_work.saturating_add(1);
+        } else {
+            next_wake = Some(next_wake.map_or(scheduled.due_at_ms, |current: u64| {
+                current.min(scheduled.due_at_ms)
+            }));
+        }
+    }
+
+    let future_scheduled_work = pass
+        .as_ref()
+        .is_some_and(|pass| pass.phase == ConvergencePassPhase::Collecting)
+        || engine
+            .scheduled_self_remove_auto_commits
+            .values()
+            .any(|scheduled| scheduled.group_id == *group_id);
+    if engine.pending_convergence_groups.contains(group_id) && !future_scheduled_work {
+        runnable_work = runnable_work.saturating_add(1);
+    }
+    if pass.is_none() && pending_work.unresolved_convergence_inputs > 0 {
+        runnable_work = runnable_work.saturating_add(1);
+    }
+    runnable_work = runnable_work
+        .saturating_add(pending_work.recovering_buffered_messages)
+        .saturating_add(pending_work.pending_engine_events)
+        .saturating_add(pending_work.pending_auto_publish)
+        .saturating_add(pending_work.pending_auto_proposals)
+        .saturating_add(pending_work.valid_proposal_schedule_signals);
+
+    Ok(ConformanceStructuralProgressSnapshot {
+        current_epoch,
+        current_monotonic_ms: now.monotonic_ms,
+        lifecycle,
+        pending_work,
+        pass_generation: pass.as_ref().map(|pass| pass.generation),
+        pass_phase: pass.as_ref().map(|pass| pass.phase),
+        earliest_next_wake_monotonic_ms: next_wake,
+        runnable_work,
+        terminal_unrecoverable: lifecycle == GroupLifecycleState::Unrecoverable,
     })
 }
 

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -86,6 +86,68 @@ fn storage_projection_error(error: StorageError) -> OpenMlsProjectionError {
     OpenMlsProjectionError::Storage(format!("{error:?}"))
 }
 
+/// Apply the effective process policy and restart rebase used by convergence
+/// scheduling to an already-loaded durable pass.
+///
+/// The policy-override rewrite does not independently request a storage write.
+/// The returned flag names only a restart rebase that the production loader
+/// must persist (including the whole normalized pass); read-only conformance
+/// views consume the same normalized copy without writing it.
+pub(crate) fn normalize_convergence_pass_for_runtime(
+    pass: &mut DurableConvergencePass,
+    policy: &CanonicalizationPolicy,
+    now: ConvergenceTime,
+    convergence_clock_instance_id: u64,
+) -> bool {
+    #[cfg(feature = "test-policy-overrides")]
+    if policy.settlement_quiescence_ms == 0 {
+        // Test harnesses intentionally mutate the otherwise pinned process
+        // policy to make settlement immediate.
+        pass.quiescence_deadline_monotonic_ms = pass
+            .opened_monotonic_ms
+            .saturating_add(policy.settlement_quiescence_ms);
+        pass.absolute_deadline_monotonic_ms = pass
+            .opened_monotonic_ms
+            .saturating_add(policy.max_convergence_pass_ms);
+        pass.quiescence_deadline_wall_ms = pass
+            .opened_wall_ms
+            .saturating_add(policy.settlement_quiescence_ms);
+        pass.absolute_deadline_wall_ms = pass
+            .opened_wall_ms
+            .saturating_add(policy.max_convergence_pass_ms);
+    }
+    #[cfg(not(feature = "test-policy-overrides"))]
+    let _ = policy;
+
+    if pass.phase != ConvergencePassPhase::Collecting
+        || pass.clock_instance_id == convergence_clock_instance_id
+    {
+        return false;
+    }
+
+    // A process-local monotonic deadline cannot survive restart. Rebase every
+    // build from the durable millisecond wall deadlines. A backwards wall jump
+    // fails closed by making the cutoff due immediately.
+    let backwards = now.wall_ms < pass.opened_wall_ms;
+    let quiescence_remaining = if backwards {
+        0
+    } else {
+        pass.quiescence_deadline_wall_ms.saturating_sub(now.wall_ms)
+    };
+    let absolute_remaining = if backwards {
+        0
+    } else {
+        pass.absolute_deadline_wall_ms.saturating_sub(now.wall_ms)
+    };
+    pass.clock_instance_id = convergence_clock_instance_id;
+    pass.opened_monotonic_ms = now
+        .monotonic_ms
+        .saturating_sub(now.wall_ms.saturating_sub(pass.opened_wall_ms));
+    pass.quiescence_deadline_monotonic_ms = now.monotonic_ms.saturating_add(quiescence_remaining);
+    pass.absolute_deadline_monotonic_ms = now.monotonic_ms.saturating_add(absolute_remaining);
+    true
+}
+
 /// Admin pubkeys, avatar component bytes, and message retention snapshotted on
 /// either side of a convergence apply, for unattributed group-state-change diffs.
 type ReorgComponentSnapshot = (Vec<[u8; 32]>, [Option<Vec<u8>>; 2], Option<u64>);
@@ -582,49 +644,12 @@ impl<S: StorageProvider> Engine<S> {
         } else if let Some(mut pass) = previous.clone()
             && pass.is_active()
         {
-            #[cfg(feature = "test-policy-overrides")]
-            if policy.settlement_quiescence_ms == 0 {
-                // Test harnesses intentionally mutate the otherwise pinned
-                // process policy to make settlement immediate.
-                pass.quiescence_deadline_monotonic_ms = pass
-                    .opened_monotonic_ms
-                    .saturating_add(policy.settlement_quiescence_ms);
-                pass.absolute_deadline_monotonic_ms = pass
-                    .opened_monotonic_ms
-                    .saturating_add(policy.max_convergence_pass_ms);
-                pass.quiescence_deadline_wall_ms = pass
-                    .opened_wall_ms
-                    .saturating_add(policy.settlement_quiescence_ms);
-                pass.absolute_deadline_wall_ms = pass
-                    .opened_wall_ms
-                    .saturating_add(policy.max_convergence_pass_ms);
-            }
-            if pass.phase == ConvergencePassPhase::Collecting
-                && pass.clock_instance_id != self.convergence_clock_instance_id
-            {
-                // A process-local monotonic deadline cannot survive restart.
-                // Rebase every build, including policy-override tests, from the
-                // same persisted millisecond wall deadlines. A backwards wall
-                // jump fails closed by making the cutoff due immediately.
-                let backwards = now.wall_ms < pass.opened_wall_ms;
-                let quiescence_remaining = if backwards {
-                    0
-                } else {
-                    pass.quiescence_deadline_wall_ms.saturating_sub(now.wall_ms)
-                };
-                let absolute_remaining = if backwards {
-                    0
-                } else {
-                    pass.absolute_deadline_wall_ms.saturating_sub(now.wall_ms)
-                };
-                pass.clock_instance_id = self.convergence_clock_instance_id;
-                pass.opened_monotonic_ms = now
-                    .monotonic_ms
-                    .saturating_sub(now.wall_ms.saturating_sub(pass.opened_wall_ms));
-                pass.quiescence_deadline_monotonic_ms =
-                    now.monotonic_ms.saturating_add(quiescence_remaining);
-                pass.absolute_deadline_monotonic_ms =
-                    now.monotonic_ms.saturating_add(absolute_remaining);
+            if normalize_convergence_pass_for_runtime(
+                &mut pass,
+                policy,
+                now,
+                self.convergence_clock_instance_id,
+            ) {
                 self.storage
                     .put_convergence_pass(&pass)
                     .map_err(storage_projection_error)?;

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -86,6 +86,31 @@ fn storage_projection_error(error: StorageError) -> OpenMlsProjectionError {
     OpenMlsProjectionError::Storage(format!("{error:?}"))
 }
 
+#[cfg(feature = "test-policy-overrides")]
+fn apply_test_settlement_override(
+    pass: &mut DurableConvergencePass,
+    policy: &CanonicalizationPolicy,
+) {
+    if policy.settlement_quiescence_ms != 0 {
+        return;
+    }
+
+    // Test harnesses intentionally mutate the otherwise pinned process policy
+    // to make settlement immediate.
+    pass.quiescence_deadline_monotonic_ms = pass
+        .opened_monotonic_ms
+        .saturating_add(policy.settlement_quiescence_ms);
+    pass.absolute_deadline_monotonic_ms = pass
+        .opened_monotonic_ms
+        .saturating_add(policy.max_convergence_pass_ms);
+    pass.quiescence_deadline_wall_ms = pass
+        .opened_wall_ms
+        .saturating_add(policy.settlement_quiescence_ms);
+    pass.absolute_deadline_wall_ms = pass
+        .opened_wall_ms
+        .saturating_add(policy.max_convergence_pass_ms);
+}
+
 /// Apply the effective process policy and restart rebase used by convergence
 /// scheduling to an already-loaded durable pass.
 ///
@@ -100,22 +125,7 @@ pub(crate) fn normalize_convergence_pass_for_runtime(
     convergence_clock_instance_id: u64,
 ) -> bool {
     #[cfg(feature = "test-policy-overrides")]
-    if policy.settlement_quiescence_ms == 0 {
-        // Test harnesses intentionally mutate the otherwise pinned process
-        // policy to make settlement immediate.
-        pass.quiescence_deadline_monotonic_ms = pass
-            .opened_monotonic_ms
-            .saturating_add(policy.settlement_quiescence_ms);
-        pass.absolute_deadline_monotonic_ms = pass
-            .opened_monotonic_ms
-            .saturating_add(policy.max_convergence_pass_ms);
-        pass.quiescence_deadline_wall_ms = pass
-            .opened_wall_ms
-            .saturating_add(policy.settlement_quiescence_ms);
-        pass.absolute_deadline_wall_ms = pass
-            .opened_wall_ms
-            .saturating_add(policy.max_convergence_pass_ms);
-    }
+    apply_test_settlement_override(pass, policy);
     #[cfg(not(feature = "test-policy-overrides"))]
     let _ = policy;
 

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -608,6 +608,17 @@ impl<S: StorageProvider> Engine<S> {
         crate::conformance_snapshot::capture_pending_work_snapshot(self, group_id)
     }
 
+    /// Capture sanitized structural work and scheduling state for a black-box
+    /// conformance runner. This read-only surface cannot influence selection.
+    #[cfg(feature = "test-conformance-snapshot")]
+    pub fn conformance_structural_progress_snapshot(
+        &self,
+        group_id: &GroupId,
+    ) -> Result<crate::conformance_snapshot::ConformanceStructuralProgressSnapshot, EngineError>
+    {
+        crate::conformance_snapshot::capture_structural_progress_snapshot(self, group_id)
+    }
+
     /// Read the durable state of one synthetic scenario input under either its
     /// transport or content-derived id.
     ///

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -14,6 +14,8 @@ mod store;
 
 pub(crate) use ingest::avatar_component_snapshot;
 pub(crate) use send::merge_capabilities;
+#[cfg(feature = "test-conformance-snapshot")]
+pub(crate) use store::normalized_deferred_peel_lifecycle;
 
 use crate::convergence_input::{ClassifiedConvergenceInput, ConvergenceInputContext};
 use crate::engine::{Engine, ScheduledSelfRemoveAutoCommit};

--- a/crates/cgka-engine/src/message_processor/store.rs
+++ b/crates/cgka-engine/src/message_processor/store.rs
@@ -13,6 +13,53 @@ use cgka_traits::storage::{LeaveRequest, StorageError, StorageProvider};
 use cgka_traits::transport::TransportMessage;
 use cgka_traits::types::{EpochId, GroupId, MessageId};
 
+/// Return the effective deferred-peel lifecycle for the current clock domain.
+///
+/// This is the single source of truth for legacy-row initialization and
+/// restart rebasing. Runtime maintenance persists the returned value when
+/// `changed` is true; conformance diagnostics use the same normalized copy
+/// without mutating storage.
+pub(crate) fn normalized_deferred_peel_lifecycle(
+    lifecycle: Option<&DeferredPeelLifecycle>,
+    now: crate::convergence_clock::ConvergenceTime,
+    convergence_clock_instance_id: u64,
+    deferred_peel_residence_ms: u64,
+) -> (DeferredPeelLifecycle, bool) {
+    let Some(lifecycle) = lifecycle else {
+        return (
+            DeferredPeelLifecycle {
+                first_observed_wall_ms: now.wall_ms,
+                wall_high_water_ms: now.wall_ms,
+                clock_instance_id: convergence_clock_instance_id,
+                residence_deadline_monotonic_ms: now
+                    .monotonic_ms
+                    .saturating_add(deferred_peel_residence_ms),
+                residence_deadline_wall_ms: now.wall_ms.saturating_add(deferred_peel_residence_ms),
+                distinct_context_attempts: 0,
+                last_context_fingerprint: None,
+            },
+            true,
+        );
+    };
+
+    let mut normalized = lifecycle.clone();
+    if normalized.clock_instance_id == convergence_clock_instance_id {
+        return (normalized, false);
+    }
+
+    // Monotonic values do not survive restart. Preserve elapsed wall
+    // residence through a high-water mark. If wall time moved backwards,
+    // using the prior high water prevents premature expiry.
+    let observed_wall = normalized.wall_high_water_ms.max(now.wall_ms);
+    let remaining = normalized
+        .residence_deadline_wall_ms
+        .saturating_sub(observed_wall);
+    normalized.clock_instance_id = convergence_clock_instance_id;
+    normalized.residence_deadline_monotonic_ms = now.monotonic_ms.saturating_add(remaining);
+    normalized.wall_high_water_ms = observed_wall;
+    (normalized, true)
+}
+
 impl<S: StorageProvider> Engine<S> {
     pub(crate) fn recorded_message_outcome(
         &self,
@@ -413,38 +460,13 @@ impl<S: StorageProvider> Engine<S> {
         let mut persisted = 0usize;
         let mut normalization_pending = false;
         for record in records {
-            let mut changed = false;
-            let lifecycle = record.deferred_peel.get_or_insert_with(|| {
-                changed = true;
-                DeferredPeelLifecycle {
-                    first_observed_wall_ms: now.wall_ms,
-                    wall_high_water_ms: now.wall_ms,
-                    clock_instance_id: self.convergence_clock_instance_id,
-                    residence_deadline_monotonic_ms: now
-                        .monotonic_ms
-                        .saturating_add(self.deferred_peel_residence_ms),
-                    residence_deadline_wall_ms: now
-                        .wall_ms
-                        .saturating_add(self.deferred_peel_residence_ms),
-                    distinct_context_attempts: 0,
-                    last_context_fingerprint: None,
-                }
-            });
-            if lifecycle.clock_instance_id != self.convergence_clock_instance_id {
-                // Monotonic values do not survive restart. Preserve elapsed
-                // wall residence through a high-water mark. If wall time moved
-                // backwards, using the prior high water prevents premature
-                // expiry.
-                let observed_wall = lifecycle.wall_high_water_ms.max(now.wall_ms);
-                let remaining = lifecycle
-                    .residence_deadline_wall_ms
-                    .saturating_sub(observed_wall);
-                lifecycle.clock_instance_id = self.convergence_clock_instance_id;
-                lifecycle.residence_deadline_monotonic_ms =
-                    now.monotonic_ms.saturating_add(remaining);
-                lifecycle.wall_high_water_ms = observed_wall;
-                changed = true;
-            }
+            let (lifecycle, changed) = normalized_deferred_peel_lifecycle(
+                record.deferred_peel.as_ref(),
+                now,
+                self.convergence_clock_instance_id,
+                self.deferred_peel_residence_ms,
+            );
+            record.deferred_peel = Some(lifecycle);
             if changed {
                 if persisted < MAX_DEFERRED_ROWS_PER_SWEEP {
                     self.storage.put_message(record)?;

--- a/crates/cgka-engine/src/message_processor/store.rs
+++ b/crates/cgka-engine/src/message_processor/store.rs
@@ -13,6 +13,24 @@ use cgka_traits::storage::{LeaveRequest, StorageError, StorageProvider};
 use cgka_traits::transport::TransportMessage;
 use cgka_traits::types::{EpochId, GroupId, MessageId};
 
+fn fresh_deferred_peel_lifecycle(
+    now: crate::convergence_clock::ConvergenceTime,
+    convergence_clock_instance_id: u64,
+    deferred_peel_residence_ms: u64,
+) -> DeferredPeelLifecycle {
+    DeferredPeelLifecycle {
+        first_observed_wall_ms: now.wall_ms,
+        wall_high_water_ms: now.wall_ms,
+        clock_instance_id: convergence_clock_instance_id,
+        residence_deadline_monotonic_ms: now
+            .monotonic_ms
+            .saturating_add(deferred_peel_residence_ms),
+        residence_deadline_wall_ms: now.wall_ms.saturating_add(deferred_peel_residence_ms),
+        distinct_context_attempts: 0,
+        last_context_fingerprint: None,
+    }
+}
+
 /// Return the effective deferred-peel lifecycle for the current clock domain.
 ///
 /// This is the single source of truth for legacy-row initialization and
@@ -27,17 +45,11 @@ pub(crate) fn normalized_deferred_peel_lifecycle(
 ) -> (DeferredPeelLifecycle, bool) {
     let Some(lifecycle) = lifecycle else {
         return (
-            DeferredPeelLifecycle {
-                first_observed_wall_ms: now.wall_ms,
-                wall_high_water_ms: now.wall_ms,
-                clock_instance_id: convergence_clock_instance_id,
-                residence_deadline_monotonic_ms: now
-                    .monotonic_ms
-                    .saturating_add(deferred_peel_residence_ms),
-                residence_deadline_wall_ms: now.wall_ms.saturating_add(deferred_peel_residence_ms),
-                distinct_context_attempts: 0,
-                last_context_fingerprint: None,
-            },
+            fresh_deferred_peel_lifecycle(
+                now,
+                convergence_clock_instance_id,
+                deferred_peel_residence_ms,
+            ),
             true,
         );
     };
@@ -372,19 +384,11 @@ impl<S: StorageProvider> Engine<S> {
                 .and_then(|record| record.deferred_peel.clone())
                 .or_else(|| {
                     let now = self.convergence_now();
-                    Some(DeferredPeelLifecycle {
-                        first_observed_wall_ms: now.wall_ms,
-                        wall_high_water_ms: now.wall_ms,
-                        clock_instance_id: self.convergence_clock_instance_id,
-                        residence_deadline_monotonic_ms: now
-                            .monotonic_ms
-                            .saturating_add(self.deferred_peel_residence_ms),
-                        residence_deadline_wall_ms: now
-                            .wall_ms
-                            .saturating_add(self.deferred_peel_residence_ms),
-                        distinct_context_attempts: 0,
-                        last_context_fingerprint: None,
-                    })
+                    Some(fresh_deferred_peel_lifecycle(
+                        now,
+                        self.convergence_clock_instance_id,
+                        self.deferred_peel_residence_ms,
+                    ))
                 })
         } else {
             None

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -4888,6 +4888,88 @@ async fn collecting_pass_restart_preserves_remaining_window_and_backward_clock_f
     );
 }
 
+#[cfg(all(
+    feature = "test-conformance-snapshot",
+    feature = "test-policy-overrides"
+))]
+#[tokio::test]
+async fn conformance_progress_uses_the_schedulers_effective_policy_deadline() {
+    let (mut alice, _alice_storage) = build_client(b"alice");
+    let carol_storage = SqliteAccountStorage::in_memory().unwrap();
+    let clock = ManualConvergenceClock::new(1_000, 10_000);
+    let mut carol =
+        build_client_with_storage_and_clock(b"carol", carol_storage.clone(), clock.clone());
+    let mut david = build_client(b"david").0;
+
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "conformance-effective-deadline".into(),
+            description: "".into(),
+            members: vec![carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    carol
+        .join_welcome(welcome_for(&welcomes, b"carol"))
+        .await
+        .unwrap();
+    carol.drain_events();
+
+    let invite = alice
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![david.fresh_key_package().await.unwrap()],
+        })
+        .await
+        .unwrap();
+    let (commit, _) = evolution(invite);
+    carol
+        .buffer_openmls_convergence_message(&group_id, route(commit, &group_id))
+        .unwrap();
+
+    let persisted = carol_storage
+        .convergence_pass(&group_id)
+        .unwrap()
+        .expect("collecting pass persisted with the original policy");
+    assert_eq!(persisted.cutoff_monotonic_ms(), 2_000);
+    carol
+        .set_convergence_policy(CanonicalizationPolicy {
+            settlement_quiescence_ms: 0,
+            ..CanonicalizationPolicy::default()
+        })
+        .expect("test policy override accepted");
+
+    let snapshot = carol
+        .conformance_structural_progress_snapshot(&group_id)
+        .expect("read-only conformance progress");
+    assert_eq!(snapshot.current_monotonic_ms, 1_000);
+    assert_eq!(snapshot.earliest_next_wake_monotonic_ms, None);
+    assert!(snapshot.runnable_work > 0);
+    assert_eq!(
+        carol_storage
+            .convergence_pass(&group_id)
+            .unwrap()
+            .expect("snapshot does not rewrite storage")
+            .cutoff_monotonic_ms(),
+        2_000
+    );
+    assert_eq!(
+        carol
+            .prepare_convergence_cutoff_delay_ms(&group_id)
+            .expect("production scheduler prepares the same pass"),
+        Some(0)
+    );
+}
+
 #[tokio::test]
 async fn rebuilt_engine_emits_losing_branch_app_invalidation_after_convergence() {
     let (mut alice, _alice_storage) = build_client(b"alice");

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -4941,14 +4941,20 @@ async fn conformance_progress_uses_the_schedulers_effective_policy_deadline() {
         .unwrap()
         .expect("collecting pass persisted with the original policy");
     assert_eq!(persisted.cutoff_monotonic_ms(), 2_000);
-    carol
+    drop(carol);
+    clock.set_wall_ms(10_400);
+    let mut restarted = build_client_with_storage_and_clock(b"carol", carol_storage.clone(), clock);
+    restarted
+        .hydrate_stable_groups_from_storage()
+        .expect("restart hydrates the persisted group");
+    restarted
         .set_convergence_policy(CanonicalizationPolicy {
             settlement_quiescence_ms: 0,
             ..CanonicalizationPolicy::default()
         })
         .expect("test policy override accepted");
 
-    let snapshot = carol
+    let snapshot = restarted
         .conformance_structural_progress_snapshot(&group_id)
         .expect("read-only conformance progress");
     assert_eq!(snapshot.current_monotonic_ms, 1_000);
@@ -4963,11 +4969,28 @@ async fn conformance_progress_uses_the_schedulers_effective_policy_deadline() {
         2_000
     );
     assert_eq!(
-        carol
+        restarted
             .prepare_convergence_cutoff_delay_ms(&group_id)
             .expect("production scheduler prepares the same pass"),
         Some(0)
     );
+    let normalized = carol_storage
+        .convergence_pass(&group_id)
+        .unwrap()
+        .expect("restart rebase persists the normalized pass");
+    assert_eq!(normalized.opened_monotonic_ms, 600);
+    assert_eq!(
+        normalized.quiescence_deadline_wall_ms,
+        normalized.opened_wall_ms
+    );
+    assert_eq!(normalized.quiescence_deadline_monotonic_ms, 1_000);
+    assert_eq!(
+        normalized.absolute_deadline_wall_ms,
+        normalized
+            .opened_wall_ms
+            .saturating_add(V1_MAX_CONVERGENCE_PASS_MS)
+    );
+    assert_eq!(normalized.absolute_deadline_monotonic_ms, 5_600);
 }
 
 #[tokio::test]

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -467,23 +467,23 @@ rate, topology, assertion, and schema work remains owned by Milestone 2.1.
 
 ### 1.3 Full-system quiescence
 
-Status: `in-progress`
+Status: `complete`
 
 - [x] Add an injectable paired monotonic/wall convergence clock and use it for pass deadlines, cutoff decisions, restart
   rebasing, and deterministic engine/harness tests.
 - [x] Expose that clock through the subject-level `virtual_time` capability and portable `advance_time` scenario step;
   route subject `Tick` through the same clock so global time can advance while participant runtimes remain paused.
 
-- [ ] Expose a sanitized structural progress token, runnable work, earliest next wake-up, deferred/retry work, outbound
+- [x] Expose a sanitized structural progress token, runnable work, earliest next wake-up, deferred/retry work, outbound
   work awaiting acknowledgement, and terminal blockers; include inbox, delayed messages, pass phase, and durable
   transitions.
-- [ ] Drive subject operations and scheduled wakes from the shared advancing monotonic/controlled wall clock; do not
+- [x] Drive subject operations and scheduled wakes from the shared advancing monotonic/controlled wall clock; do not
   infer time progress from repeated calls at one synthetic timestamp or wait on real wall time.
-- [ ] Compute a bounded virtual-time fixed point from structural work and the earliest next wake-up. Treat step, time,
+- [x] Compute a bounded virtual-time fixed point from structural work and the earliest next wake-up. Treat step, time,
   and work limits only as watchdog/performance evidence, not as the definition of quiescence.
-- [ ] Report which subsystem prevents quiescence.
-- [ ] Bound quiescence waiting by scenario policy and emit a terminal timeout artifact.
-- [ ] Add controlled metamorphic runs that preserve retained input and horizon eligibility while varying delivery across
+- [x] Report which subsystem prevents quiescence.
+- [x] Bound quiescence waiting by scenario policy and emit a terminal timeout artifact.
+- [x] Add controlled metamorphic runs that preserve retained input and horizon eligibility while varying delivery across
   one frozen batch versus multiple convergence passes; report retention/anchor assumption violations separately.
 
 ### 1.4 Deterministic failure capsules
@@ -501,7 +501,7 @@ Status: `not-started`
 
 - [x] A wrong exact state cannot pass as converged.
 - [x] A normal scenario cannot access engine/storage internals.
-- [ ] Hidden pending work prevents quiescence.
+- [x] Hidden pending work prevents quiescence.
 - [ ] A captured byte-level failure replays with the same outcome.
 - [ ] Targeted semantic mutations are detected.
 - [ ] Every durable fail-closed/non-progress state names a tested repair or terminal user-visible outcome.
@@ -829,3 +829,4 @@ incorrect result.
 | 2026-07-30 | M5 account-device modeling input | Documented a non-normative multi-device design space while deliberately leaving admission, synchronization, and repair choices unresolved; future scenarios must model account-device instances without assuming those candidate semantics | [MDK #1199](https://github.com/marmot-protocol/mdk/pull/1199), merge `aac777f3`; documentation-only |
 | 2026-07-30 | 1.2c / 1.3b subject virtual time | Added a capability-gated `advance_time` scenario operation backed by one shared paired clock across the engine subject; time advancement is a separate failure-free operation and `Tick` selects which participant runtimes observe it, while standalone clients without an injected clock preserve the legacy far-future shortcut | [MDK #1202](https://github.com/marmot-protocol/mdk/pull/1202), merge `1ccc4065`; focused serialization/preflight/dispatch test; two real disband passes remain live at a 999 ms tick, Alice alone settles at 1,000 ms, and Bob settles on a later tick without another time advance; full simulator suite |
 | 2026-08-01 | 1.2d public outbound lifecycle and Scenario IR v2 cutover | Added non-destructive polling of exact transport-ready subject artifacts and typed accepted/no-endpoint acknowledgement; client-scoped pending identities, state-bearing commits, independent Welcomes, definite rollback, regenerated queued intents, scheduled evolution work, duplicate acknowledgement, and exposure refusal retain their distinct semantics without exposing mutable bus queues. Migrated every repository-owned scenario producer to v2 `acknowledge_outbound` operations and removed the compatibility constructor, direct subject pending controls, client lifecycle flag, and silent auto-confirm branches ([MDK #1207](https://github.com/marmot-protocol/mdk/issues/1207)) | Focused subject/runner contract tests; fixed vectors; generated families; incident replay; full simulator suite; `just fast-ci` |
+| 2026-08-01 | 1.3 full-system quiescence | Added privacy-safe structural progress with runnable work, exact virtual deadlines, pass phase/generation, retry/deferred/publication/transport work, and terminal blockers; added runner-owned bounded fixed-point settling with explicit healthy-path publication/delivery policy and serializable blocked/timeout artifacts; added same-horizon batch-partition metamorphic coverage | [MDK #1216](https://github.com/marmot-protocol/mdk/pull/1216); focused real-engine deadline, lost-ack, withheld-transport, watchdog, serialization/privacy, and metamorphic tests; full simulator suite; `just fast-ci` |

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "Convergence Reliability And Simulation Plan"
 created: 2026-07-30
-updated: 2026-07-30
+updated: 2026-08-02
 tags: [marmot, cgka, convergence, simulation, verification, reliability]
 status: working-plan
 ---


### PR DESCRIPTION
## Summary

- add a privacy-safe structural progress snapshot spanning engine work, pass deadlines, deferred retries, publication acknowledgements, transport queues, scenario inputs, and terminal engine state
- add a bounded virtual-time fixed-point driver and ScenarioSpec await_quiescence step with explicit publication and transport policy
- emit quiescent, blocked, and watchdog-timeout artifacts in scenario reports and oracle coverage
- add real-engine deadline, restart, lost-ack, withheld-transport, watchdog, serialization/privacy, and batch-versus-multiple-pass metamorphic coverage
- mark Milestone 1.3 complete in the convergence reliability plan

## Design and risk

The engine change is read-only and available only behind the existing test-conformance-snapshot feature. It exposes sanitized aggregate scheduling state and does not alter branch selection, convergence constants, publication behavior, or production runtime scheduling. Fixed-point policy and all automatic acknowledgement/delivery behavior remain simulator-owned.

Watchdog limits produce timeout evidence only; they cannot turn unfinished work into quiescence. Manual publication or transport policy produces a named blocked result rather than spinning.

## Verification

- cargo test -p cgka-conformance-simulator
- cargo test -p cgka-conformance-simulator --lib
- cargo test -p cgka-engine --features test-policy-overrides,test-conformance-snapshot
- just fast-ci

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added bounded virtual-time settling with configurable watchdog limits.
  - Added structural progress reporting and sanitized diagnostics for pending work, blockers, transport, retries, and scheduling.
  - Added quiescence scenario steps with quiescent, blocked, and timed-out results.
  - Added capability validation for progress tracking, virtual time, transport delivery, and outbound publication.

- **Documentation**
  - Updated simulator and reliability documentation for quiescence, progress reporting, and supported scenario steps.

- **Tests**
  - Added coverage for delivery batching, acknowledgements, delayed transport, wake advancement, blockers, and timeout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->