### PR TITLE
Add deterministic convergence failure capsules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -838,6 +838,7 @@ dependencies = [
  "async-trait",
  "cgka-engine",
  "cgka-traits",
+ "fs-private",
  "hex",
  "marmot-forensics",
  "nostr",

--- a/crates/cgka-conformance-simulator/AGENTS.md
+++ b/crates/cgka-conformance-simulator/AGENTS.md
@@ -38,6 +38,12 @@ Read [`README.md`](README.md) for the human framing, [`SCENARIOS.md`](SCENARIOS.
     transport is delivered; the driver activates controlled time, runs immediate work, advances exactly to the earliest
     wake, and records quiescent, blocked, or watchdog-timeout evidence. Limits never define success.
 
+- **Module:** `src/failure_capsule.rs`
+  - **Role:** Versioned failure fingerprints and capsules, restrictive artifact I/O, synthetic-vector promotion, and
+    exact engine byte replay from a sensitive recipient SQLite/OpenMLS checkpoint. Never put a checkpoint into a
+    `synthetic_shareable` capsule; it contains key material. The wire/schema contract is
+    `schemas/failure-capsule.v1.schema.json`.
+
 - **Module:** `src/decryptability.rs`
   - **Role:** Serializable active application-message probe results. A
     `ProbeBidirectionalDecryptability` scenario step sends one logical event per named client, drains every attached
@@ -107,12 +113,13 @@ Read [`README.md`](README.md) for the human framing, [`SCENARIOS.md`](SCENARIOS.
 
 - **Module:** `src/report.rs`
   - **Role:** Report command parsing and run-summary types (`ReportArgs`, `ReportCommand`, `ReportRunSummary`,
-    `ScenarioReportSummary`, `ReportFailureSummary`) used by the report CLI.
+    `ScenarioReportSummary`, `ReportFailureSummary`) used by the report CLI. Failed reports retain subject-step errors
+    and emit restrictive failure capsules with captured transport artifacts.
 
 - **Module:** `src/bin/cgka-conformance-simulator-report.rs`
   - **Role:** Report writer CLI. Runs generated families or vector fixture files/directories, writes one JSON
-    `ScenarioReport` per scenario plus fixture candidates for generated cases, prints a pass/fail summary, and exits
-    non-zero on expectation failures.
+    `ScenarioReport` per scenario plus fixture candidates and failure capsules, replays checkpoint-bearing capsules,
+    prints a pass/fail summary, and exits non-zero on expectation failures.
 
 - **Module:** `src/bin/cgka-policy-casegen.rs`
   - **Role:** Policy-case generator CLI; reads `formal/tamarin/policy_cases.json` and parses/reasons over the bounded
@@ -164,7 +171,7 @@ group-data fork recovery, rollback plus delayed duplicate app delivery, partitio
 delivery, stable duplicate/delay/reorder queue faults, 20+ client message storms, partitioned large-group delivery
 storms, multi-committer group-data storms, mixed large message/commit storms, and restart plus duplicate delivery
 faults. These cases carry semantic `expected_outcomes`, so report failures point at the broken convergence invariant
-instead of only writing an observation dump. Generator version `3` draws the delivery schedule of the rollback and storm
+instead of only writing an observation dump. Generator version `6` draws the delivery schedule of the rollback and storm
 shapes (arms 2, 6, 7, 8, 9) from the seed, so distinct seeds exercise distinct adversarial orderings; the
 schedule-invariant convergence, rollback, and payload-set expectations stay fixed, so coverage grows with the seed
 without re-pinning vectors.
@@ -260,7 +267,8 @@ Keep these aligned with [`README.md`](README.md), [`SCENARIOS.md`](SCENARIOS.md)
   `UpdateGroupData`, the runner promotes that invitee to an initial admin for the group. Direct harness tests should
   use `create_group_with_admins` explicitly for competing admin commits.
 - **Failure minimization is intentionally conservative.** Generated reports populate `minimized_case` with a greedy
-  step-removal reducer when removable app/delivery noise can be dropped without changing the failure kinds. There is no
+  step-removal reducer when removable app/delivery noise can be dropped without changing the complete stable failure
+  fingerprint. There is no
   domain-specific shrinker yet.
 
 ## Conventions

--- a/crates/cgka-conformance-simulator/AGENTS.md
+++ b/crates/cgka-conformance-simulator/AGENTS.md
@@ -267,8 +267,8 @@ Keep these aligned with [`README.md`](README.md), [`SCENARIOS.md`](SCENARIOS.md)
   `UpdateGroupData`, the runner promotes that invitee to an initial admin for the group. Direct harness tests should
   use `create_group_with_admins` explicitly for competing admin commits.
 - **Failure minimization is intentionally conservative.** Generated reports populate `minimized_case` with a greedy
-  step-removal reducer when removable app/delivery noise can be dropped without changing the complete stable failure
-  fingerprint. There is no
+  step-removal reducer when removable app/delivery noise can be dropped without changing the semantic failure identity
+  (classification, action type, and failure kind). Complete state-digest fingerprints remain diagnostic evidence. There is no
   domain-specific shrinker yet.
 
 ## Conventions

--- a/crates/cgka-conformance-simulator/Cargo.toml
+++ b/crates/cgka-conformance-simulator/Cargo.toml
@@ -15,7 +15,8 @@ conformance-slow = []
 cgka-traits.workspace = true
 cgka-engine = { workspace = true, features = ["test-conformance-snapshot"] }
 marmot-forensics.workspace = true
-storage-sqlite.workspace = true
+storage-sqlite = { workspace = true, features = ["test-conformance-replay"] }
+fs-private.workspace = true
 transport-nostr-peeler.workspace = true
 openmls.workspace = true
 openmls_basic_credential.workspace = true

--- a/crates/cgka-conformance-simulator/README.md
+++ b/crates/cgka-conformance-simulator/README.md
@@ -34,8 +34,8 @@ welcomes use NIP-59 gift wraps before the bus delivers them.
 - `ScenarioReport` — serializable run artifacts with metadata, expected and observed traces, oracle coverage evidence,
   step logs, recoveries, and expectation failures.
 - `FailureCapsuleV1` — a versioned failure artifact containing the scenario, expanded virtual-time schedule, exact
-  policy/constants, report/ledgers/state commitments, captured transport objects, resource counters, and a stable
-  failure fingerprint. An optional sensitive recipient checkpoint enables byte-exact engine replay.
+  policy/constants, report/ledgers/state commitments, a bounded transport-evidence tail with truncation counters, and a
+  stable failure fingerprint. An optional bounded sensitive recipient checkpoint enables byte-exact engine replay.
 - `ConformanceGroupSnapshot` — a feature-gated synthetic-test projection of exact canonical group state: leaf identities
   and capabilities, required/application state, lifecycle/profile/admin state, a GroupContext hash, and the adopted
   domain-separated exporter commitment. Raw exporter material is never serialized.
@@ -343,7 +343,9 @@ the conformance contract clearer.
 
 `run_generated_case_report(case, expected_trace)` adds generated-family metadata: family name, generator version, seed,
 case index, and an optional `minimized_case` field. Failing generated cases run a conservative greedy minimizer that
-removes removable delivery/app steps only when the complete stable failure fingerprint still reproduces. Generated report runs also write
+removes removable delivery/app steps only when the semantic failure identity (classification, action type, and failure
+kind) still reproduces. The complete fingerprint, including the state digest, remains in the capsule for diagnosis.
+Generated report runs also write
 a sibling `*-fixture.v1.json` candidate. Cases with semantic expectations keep those expectations; cases without them
 use the observed trace as an exact expected trace in the candidate. When a failing generated case has a minimized
 reproducer, the fixture candidate uses that minimized scenario.

--- a/crates/cgka-conformance-simulator/README.md
+++ b/crates/cgka-conformance-simulator/README.md
@@ -35,7 +35,8 @@ welcomes use NIP-59 gift wraps before the bus delivers them.
   step logs, recoveries, and expectation failures.
 - `FailureCapsuleV1` — a versioned failure artifact containing the scenario, expanded virtual-time schedule, exact
   policy/constants, report/ledgers/state commitments, a bounded transport-evidence tail with truncation counters, and a
-  stable failure fingerprint. An optional bounded sensitive recipient checkpoint enables byte-exact engine replay.
+  stable failure fingerprint. Explicitly requested byte-exact replay is written to a separately named sensitive sibling
+  capsule so the logical campaign capsule remains portable.
 - `ConformanceGroupSnapshot` — a feature-gated synthetic-test projection of exact canonical group state: leaf identities
   and capabilities, required/application state, lifecycle/profile/admin state, a GroupContext hash, and the adopted
   domain-separated exporter commitment. Raw exporter material is never serialized.
@@ -102,10 +103,11 @@ selected subject adapter, declared capabilities, storage backend, observed trace
 observations, and the mismatched expected/actual JSON. A subject that lacks any capability required by a scenario is
 rejected before the first scenario action executes.
 
-Failed report runs also write `*-failure-capsule.v1.json`. The capsule writer uses owner-only directories and files.
-Synthetic capsules without checkpoints may be reviewed and promoted into portable vectors; real incident material and
-any capsule containing an SQLite/OpenMLS checkpoint must remain `sensitive_local` because the checkpoint contains key
-material. Replay a checkpoint-bearing capsule without regenerating MLS bytes with:
+Failed report runs also write a portable `*-failure-capsule.v1.json`. The capsule writer uses owner-only directories and
+files. Sensitive SQLite/OpenMLS checkpoint capture is off by default because it contains key material and incurs a
+checkpoint export. Pass `--capture-sensitive-replay` to capture only the final planned recipient tick and write a
+separate `*-sensitive-replay-capsule.v1.json`; the portable logical capsule remains eligible for vector promotion.
+Replay the sensitive sibling without regenerating MLS bytes with:
 
 ```sh
 cargo run -p cgka-conformance-simulator --bin cgka-conformance-simulator-report -- \

--- a/crates/cgka-conformance-simulator/README.md
+++ b/crates/cgka-conformance-simulator/README.md
@@ -33,11 +33,14 @@ welcomes use NIP-59 gift wraps before the bus delivers them.
   outcomes.
 - `ScenarioReport` — serializable run artifacts with metadata, expected and observed traces, oracle coverage evidence,
   step logs, recoveries, and expectation failures.
+- `FailureCapsuleV1` — a versioned failure artifact containing the scenario, expanded virtual-time schedule, exact
+  policy/constants, report/ledgers/state commitments, captured transport objects, resource counters, and a stable
+  failure fingerprint. An optional sensitive recipient checkpoint enables byte-exact engine replay.
 - `ConformanceGroupSnapshot` — a feature-gated synthetic-test projection of exact canonical group state: leaf identities
   and capabilities, required/application state, lifecycle/profile/admin state, a GroupContext hash, and the adopted
   domain-separated exporter commitment. Raw exporter material is never serialized.
-- `cgka-conformance-simulator-report` — a small CLI that runs generated scenario families, writes JSON reports, and
-  emits fixture candidates for generated cases.
+- `cgka-conformance-simulator-report` — a small CLI that runs generated scenario families, writes JSON reports and
+  failure capsules, emits fixture candidates for generated cases, and replays capsules that contain byte checkpoints.
 - `proptest_support` — strategies that generate arbitrary typed `SendIntent` sequences for property-based tests.
 
 ## Testing layers
@@ -98,6 +101,19 @@ The report command exits non-zero when any fixture expectation fails. Each repor
 selected subject adapter, declared capabilities, storage backend, observed trace, flattened recovery and epoch
 observations, and the mismatched expected/actual JSON. A subject that lacks any capability required by a scenario is
 rejected before the first scenario action executes.
+
+Failed report runs also write `*-failure-capsule.v1.json`. The capsule writer uses owner-only directories and files.
+Synthetic capsules without checkpoints may be reviewed and promoted into portable vectors; real incident material and
+any capsule containing an SQLite/OpenMLS checkpoint must remain `sensitive_local` because the checkpoint contains key
+material. Replay a checkpoint-bearing capsule without regenerating MLS bytes with:
+
+```sh
+cargo run -p cgka-conformance-simulator --bin cgka-conformance-simulator-report -- \
+  --replay-capsule /private/path/failure-capsule.v1.json
+```
+
+The replay succeeds only when the exact stored recipient state plus captured transport objects reproduce the recorded
+engine fingerprint. Capsule v1's JSON Schema is `schemas/failure-capsule.v1.schema.json`.
 
 ## Exact state oracle
 
@@ -299,7 +315,7 @@ trace includes exactly the selected branch application payload.
 semantic expectations. The generator rotates through invite forks, group-data forks, publish rollback plus delayed app
 duplicates, partition/heal/leave, delayed past-epoch app delivery, stable duplicate/delay/reorder queue faults, 20+
 client message storms, partitioned large-group delivery storms, multi-committer group-data storms, mixed large
-message/commit storms, and restart plus duplicate delivery faults. Generator version `4` draws the delivery schedule of
+message/commit storms, and restart plus duplicate delivery faults. Generator version `6` draws the delivery schedule of
 the rollback and storm shapes from the seed, so distinct seeds exercise distinct adversarial orderings while the
 schedule-invariant convergence, rollback, and payload-set expectations stay fixed. These cases are ordinary
 `ScenarioSpec`s, so the same runner and report path can turn selected generated cases into fixed vectors when that makes
@@ -316,7 +332,8 @@ the conformance contract clearer.
 - `observed_trace` — the trace produced by the scenario runner.
 - `oracle` — scenario stimuli, expected behavior classes, observed behavior classes, evidence counts, and weak-oracle
   warnings.
-- `step_log` — one entry per completed scenario step.
+- `step_log` — one entry per attempted scenario step, including the first typed failure; later planned steps remain
+  visible in a failure capsule's expanded schedule with no status.
 - `pending_resolution_observations` — flattened publish confirmations and rollbacks.
 - `recovery_observations` — flattened fork-recovery events from all client observations.
 - `epoch_change_observations` — flattened `EpochChanged` events from all client observations.
@@ -326,7 +343,7 @@ the conformance contract clearer.
 
 `run_generated_case_report(case, expected_trace)` adds generated-family metadata: family name, generator version, seed,
 case index, and an optional `minimized_case` field. Failing generated cases run a conservative greedy minimizer that
-removes removable delivery/app steps only when the same failure kinds still reproduce. Generated report runs also write
+removes removable delivery/app steps only when the complete stable failure fingerprint still reproduces. Generated report runs also write
 a sibling `*-fixture.v1.json` candidate. Cases with semantic expectations keep those expectations; cases without them
 use the observed trace as an exact expected trace in the candidate. When a failing generated case has a minimized
 reproducer, the fixture candidate uses that minimized scenario.

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -488,8 +488,11 @@ These tests keep the simulator machinery honest.
   after an artifact reached a recipient mailbox;
   `exposed_welcome_prevents_partial_commit_retraction_and_rollback` applies the same rule to the complete
   commit/Welcome publication so a failed rollback cannot partially mutate transport state.
-- `failing_generated_case_records_a_minimized_reproducer` checks that a failing generated case records a smaller
-  reproducer when removable delivery noise is enough to keep the same failure.
+- `failing_generated_case_records_a_minimized_reproducer` checks that semantic failure identity lets a failing
+  generated case remove an entire irrelevant application-message storm even though action indices and the full state
+  digest change.
+- `failed_campaign_capsule_contains_a_replayable_tick_witness` checks that a real report campaign exports a sensitive
+  recipient checkpoint plus exact mailbox bytes and that both the replay API and report CLI reproduce its fingerprint.
 - `tests/generated_policy_cases.rs` checks that Tamarin-derived branch selector cases match the Rust selector across
   candidate orderings.
 

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -328,7 +328,8 @@ These are real simulator scenarios that are still tied to Rust harness details.
 
 - Setup: Bob is already in Alice's group. Alice invites Carol. Carol receives the welcome and the group-message echo
   together.
-- Expected: Carol processes the welcome and treats the pre-join group wrapper as stale peel failure.
+- Expected: Carol processes the welcome and retains the pre-join group wrapper as transport-deferred until it can be
+  peeled or a local resource policy releases it.
 - Reason: the trace format does not yet record stale classifications as portable expectations.
 
 ## Generated Scenario Families
@@ -353,7 +354,7 @@ regression, covers a new semantic edge, or is the smallest readable example of a
 
 ### `convergence-chaos/v1`
 
-- Generator: `generate_convergence_chaos_family` (generator version `4`).
+- Generator: `generate_convergence_chaos_family` (generator version `6`).
 - Setup: the family rotates through the case classes below.
 - Expected: each case carries semantic expectations for convergence, rollback, payload delivery, or recovery, then
   performs a final global drain with exact-state and pending-work assertions.
@@ -428,8 +429,8 @@ regression, covers a new semantic edge, or is the smallest readable example of a
 - Setup: Alice creates a 21-member group. Members send app messages, then eight members race group-data commits.
 - Pressure: large app-message load (seed-driven reorder) followed by a commit storm with a seed-driven duplicate and reorder.
 - Expected: the committers converge at epoch 2 with 21 members and the same branch-sensitive group name (see Chaos Class
-  `8`). Strict oracle coverage currently also reports that the cleared application phase lacks a delivery or
-  invalidation expectation; this is a tracked oracle gap, not an engine-state failure.
+  `8`). The application phase is not cleared: every observed committer must retain the exact seed-ordered payload set
+  addressed to it, so the later commit storm cannot hide a dropped, duplicated, or unaccounted application message.
 
 #### Chaos Class `10`: Restart Delivery Faults
 
@@ -444,7 +445,10 @@ These tests keep the simulator machinery honest.
 
 - `canonical_vector_fixtures_match_generated_traces` checks that every top-level JSON scenario vector still matches its
   expected trace or semantic outcomes.
-- `tests/report_runner.rs` checks CLI parsing, report JSON writing, fixture-candidate writing, and pass/fail summaries.
+- `tests/report_runner.rs` checks CLI parsing, report JSON writing, fixture-candidate and restrictive failure-capsule
+  writing, exact transport capture, and pass/fail summaries.
+- `tests/failure_capsules.rs` checks the v1 schema/round trip, owner-only artifact modes, portable synthetic promotion,
+  and exact recipient-checkpoint plus captured-commit replay. Omitting the captured commit must change the fingerprint.
 - `src/oracle.rs` and `tests/report_runner.rs` check that reports name their stimuli, expected behavior classes,
   observed behavior classes, and weak-oracle warnings.
 - `virtual_time_is_capability_gated_serializable_and_dispatched` checks that `advance_time` round-trips through the

--- a/crates/cgka-conformance-simulator/schemas/failure-capsule.v1.schema.json
+++ b/crates/cgka-conformance-simulator/schemas/failure-capsule.v1.schema.json
@@ -7,8 +7,6 @@
   "required": [
     "schema_version",
     "sensitivity",
-    "original_scenario",
-    "canonical_scenario",
     "seeds",
     "expanded_schedule",
     "binary_version",
@@ -22,8 +20,6 @@
     "sensitivity": {
       "enum": ["synthetic_shareable", "sensitive_local"]
     },
-    "original_scenario": { "$ref": "#/$defs/scenario" },
-    "canonical_scenario": { "$ref": "#/$defs/scenario" },
     "seeds": {
       "type": "object",
       "additionalProperties": { "type": "integer", "minimum": 0 }
@@ -63,6 +59,7 @@
     },
     "captured_transport_artifacts": {
       "type": "array",
+      "maxItems": 256,
       "items": {
         "type": "object",
         "required": ["sequence", "sender", "message"],
@@ -145,8 +142,6 @@
         "checkpoint_monotonic_ms",
         "checkpoint_wall_ms",
         "virtual_time_tick_enabled",
-        "failure_kind",
-        "failing_action_id",
         "expected_fingerprint"
       ],
       "properties": {
@@ -154,13 +149,11 @@
         "identity_seed": { "type": "array", "items": { "type": "integer", "minimum": 0, "maximum": 255 } },
         "protocol_profile": {},
         "group_id": { "type": "array", "items": { "type": "integer", "minimum": 0, "maximum": 255 } },
-        "sensitive_checkpoint": { "type": "array", "items": { "type": "integer", "minimum": 0, "maximum": 255 } },
-        "captured_deliveries": { "type": "array", "items": { "type": "object" } },
+        "sensitive_checkpoint": { "type": "array", "maxItems": 16777216, "items": { "type": "integer", "minimum": 0, "maximum": 255 } },
+        "captured_deliveries": { "type": "array", "maxItems": 256, "items": { "type": "object" } },
         "checkpoint_monotonic_ms": { "type": "integer", "minimum": 0 },
         "checkpoint_wall_ms": { "type": "integer", "minimum": 0 },
         "virtual_time_tick_enabled": { "type": "boolean" },
-        "failure_kind": { "type": "string" },
-        "failing_action_id": { "type": "string" },
         "expected_fingerprint": { "$ref": "#/$defs/fingerprint" }
       }
     }

--- a/crates/cgka-conformance-simulator/schemas/failure-capsule.v1.schema.json
+++ b/crates/cgka-conformance-simulator/schemas/failure-capsule.v1.schema.json
@@ -1,0 +1,168 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/marmot-protocol/mdk/cgka-conformance-simulator/failure-capsule.v1.schema.json",
+  "title": "MDK convergence failure capsule v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "sensitivity",
+    "original_scenario",
+    "canonical_scenario",
+    "seeds",
+    "expanded_schedule",
+    "binary_version",
+    "policy",
+    "report",
+    "resources",
+    "failure"
+  ],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "sensitivity": {
+      "enum": ["synthetic_shareable", "sensitive_local"]
+    },
+    "original_scenario": { "$ref": "#/$defs/scenario" },
+    "canonical_scenario": { "$ref": "#/$defs/scenario" },
+    "seeds": {
+      "type": "object",
+      "additionalProperties": { "type": "integer", "minimum": 0 }
+    },
+    "expanded_schedule": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/expanded_action" }
+    },
+    "adapter": {
+      "oneOf": [{ "type": "null" }, { "type": "object" }]
+    },
+    "binary_version": { "type": "string", "minLength": 1 },
+    "policy": {
+      "type": "object",
+      "required": ["canonicalization", "quiescence_by_action", "engine_constants"],
+      "properties": {
+        "canonicalization": { "type": "object" },
+        "quiescence_by_action": {
+          "type": "object",
+          "additionalProperties": { "type": "object" }
+        },
+        "engine_constants": {
+          "type": "object",
+          "required": ["schema_version", "values"],
+          "properties": {
+            "schema_version": { "const": "1" },
+            "values": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "integer",
+                "minimum": 0
+              }
+            }
+          }
+        }
+      }
+    },
+    "captured_transport_artifacts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["sequence", "sender", "message"],
+        "properties": {
+          "sequence": { "type": "integer", "minimum": 0 },
+          "sender": { "type": "string" },
+          "message": { "type": "object" }
+        }
+      }
+    },
+    "report": { "type": "object" },
+    "resources": {
+      "type": "object",
+      "required": ["counters"],
+      "properties": {
+        "counters": {
+          "type": "object",
+          "additionalProperties": { "type": "integer", "minimum": 0 }
+        }
+      }
+    },
+    "failure": { "$ref": "#/$defs/fingerprint" },
+    "byte_replay": { "$ref": "#/$defs/byte_replay" },
+    "minimized_reproducer": { "$ref": "#/$defs/scenario" }
+  },
+  "$defs": {
+    "scenario": {
+      "type": "object",
+      "required": ["name", "spec_version", "clients", "steps"],
+      "properties": {
+        "name": { "type": "string" },
+        "spec_version": { "const": "2" },
+        "clients": { "type": "array", "items": { "type": "string" } },
+        "steps": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "expanded_action": {
+      "type": "object",
+      "required": ["action_id", "step_index", "action_type", "virtual_time_ms", "status"],
+      "properties": {
+        "action_id": { "type": "string" },
+        "step_index": { "type": "integer", "minimum": 0 },
+        "action_type": { "type": "string" },
+        "virtual_time_ms": { "type": "integer", "minimum": 0 },
+        "status": { "oneOf": [{ "type": "null" }, { "type": "object" }] }
+      }
+    },
+    "fingerprint": {
+      "type": "object",
+      "required": ["version", "digest", "classification", "failure_kind", "normalized_state_digest"],
+      "properties": {
+        "version": { "const": "1" },
+        "digest": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "classification": {
+          "enum": [
+            "converged",
+            "expected_refusal",
+            "retryable_block",
+            "terminal_protocol_failure",
+            "resource_failure",
+            "environment_failure",
+            "timeout",
+            "oracle_violation"
+          ]
+        },
+        "first_failing_action_id": { "type": "string" },
+        "failure_kind": { "type": "string" },
+        "normalized_state_digest": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+      }
+    },
+    "byte_replay": {
+      "type": "object",
+      "required": [
+        "client_label",
+        "identity_seed",
+        "protocol_profile",
+        "group_id",
+        "sensitive_checkpoint",
+        "captured_deliveries",
+        "checkpoint_monotonic_ms",
+        "checkpoint_wall_ms",
+        "virtual_time_tick_enabled",
+        "failure_kind",
+        "failing_action_id",
+        "expected_fingerprint"
+      ],
+      "properties": {
+        "client_label": { "type": "string" },
+        "identity_seed": { "type": "array", "items": { "type": "integer", "minimum": 0, "maximum": 255 } },
+        "protocol_profile": {},
+        "group_id": { "type": "array", "items": { "type": "integer", "minimum": 0, "maximum": 255 } },
+        "sensitive_checkpoint": { "type": "array", "items": { "type": "integer", "minimum": 0, "maximum": 255 } },
+        "captured_deliveries": { "type": "array", "items": { "type": "object" } },
+        "checkpoint_monotonic_ms": { "type": "integer", "minimum": 0 },
+        "checkpoint_wall_ms": { "type": "integer", "minimum": 0 },
+        "virtual_time_tick_enabled": { "type": "boolean" },
+        "failure_kind": { "type": "string" },
+        "failing_action_id": { "type": "string" },
+        "expected_fingerprint": { "$ref": "#/$defs/fingerprint" }
+      }
+    }
+  }
+}

--- a/crates/cgka-conformance-simulator/src/bin/cgka-conformance-simulator-report.rs
+++ b/crates/cgka-conformance-simulator/src/bin/cgka-conformance-simulator-report.rs
@@ -1,6 +1,9 @@
 use std::error::Error;
 
-use cgka_conformance_simulator::{ReportCommand, parse_report_command, report_usage, run_report};
+use cgka_conformance_simulator::{
+    ReportCommand, parse_report_command, read_failure_capsule, replay_engine_bytes, report_usage,
+    run_report,
+};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -11,6 +14,19 @@ async fn main() -> Result<(), Box<dyn Error>> {
             if summary.failed() > 0 {
                 return Err("conformance failures".into());
             }
+            Ok(())
+        }
+        ReportCommand::ReplayCapsule(path) => {
+            let capsule = read_failure_capsule(&path)?;
+            let replay = capsule
+                .byte_replay
+                .as_ref()
+                .ok_or("failure capsule does not contain an engine byte-replay checkpoint")?;
+            let observation = replay_engine_bytes(replay).await?;
+            println!(
+                "REPRODUCED {} at epoch {} ({})",
+                observation.client_label, observation.epoch, observation.fingerprint.digest
+            );
             Ok(())
         }
         ReportCommand::Help => {

--- a/crates/cgka-conformance-simulator/src/bus.rs
+++ b/crates/cgka-conformance-simulator/src/bus.rs
@@ -24,7 +24,7 @@ use crate::pending_work::{BusPendingWorkSnapshot, BusStructuralProgressSnapshot}
 use crate::scenario_input_ledger::ScenarioInputMetadata;
 use cgka_traits::transport::{TransportEnvelope, TransportMessage};
 use cgka_traits::types::{MemberId, MessageId};
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 
 /// Stable id assigned by the bus to every attached client.
@@ -55,6 +55,12 @@ pub(crate) struct OutboundEmission {
     pub msg: TransportMessage,
 }
 
+pub(crate) struct CapturedOutboundWindow {
+    pub observed_objects: u64,
+    pub observed_json_bytes: u64,
+    pub emissions: Vec<(ClientId, OutboundEmission)>,
+}
+
 #[derive(Clone)]
 pub struct TransportBus {
     inner: Arc<Mutex<Inner>>,
@@ -70,6 +76,11 @@ struct Inner {
     /// queue so a black-box subject can expose publication work without
     /// leaking queue indices or fault-injection internals.
     outbound_emissions: HashMap<ClientId, Vec<OutboundEmission>>,
+    /// Bounded forensic evidence, separate from outbound lifecycle state.
+    captured_outbound_tail: VecDeque<(ClientId, OutboundEmission, u64)>,
+    captured_outbound_json_bytes: u64,
+    observed_outbound_objects: u64,
+    observed_outbound_json_bytes: u64,
     policy: DeliveryPolicy,
     /// Per-client pre-delivery buffer.
     mailboxes: HashMap<ClientId, Vec<TransportMessage>>,
@@ -96,6 +107,10 @@ impl TransportBus {
                 next_outbound_sequence: 0,
                 queue: Vec::new(),
                 outbound_emissions: HashMap::new(),
+                captured_outbound_tail: VecDeque::new(),
+                captured_outbound_json_bytes: 0,
+                observed_outbound_objects: 0,
+                observed_outbound_json_bytes: 0,
                 policy,
                 mailboxes: HashMap::new(),
                 partition_allowed: None,
@@ -144,6 +159,32 @@ impl TransportBus {
                     sequence,
                     msg: msg.clone(),
                 });
+            let json_bytes = serde_json::to_vec(&msg).map_or(0, |bytes| bytes.len() as u64);
+            inner.observed_outbound_objects = inner.observed_outbound_objects.saturating_add(1);
+            inner.observed_outbound_json_bytes = inner
+                .observed_outbound_json_bytes
+                .saturating_add(json_bytes);
+            inner.captured_outbound_json_bytes = inner
+                .captured_outbound_json_bytes
+                .saturating_add(json_bytes);
+            inner.captured_outbound_tail.push_back((
+                sender,
+                OutboundEmission {
+                    sequence,
+                    msg: msg.clone(),
+                },
+                json_bytes,
+            ));
+            while inner.captured_outbound_tail.len() > crate::MAX_CAPTURED_TRANSPORT_OBJECTS
+                || inner.captured_outbound_json_bytes > crate::MAX_CAPTURED_TRANSPORT_JSON_BYTES
+            {
+                let Some((_, _, evicted_bytes)) = inner.captured_outbound_tail.pop_front() else {
+                    break;
+                };
+                inner.captured_outbound_json_bytes = inner
+                    .captured_outbound_json_bytes
+                    .saturating_sub(evicted_bytes);
+            }
         }
         inner.queue.push(InFlight { sender, msg });
     }
@@ -162,6 +203,19 @@ impl TransportBus {
             .filter(|emission| after_sequence.is_none_or(|after| emission.sequence > after))
             .cloned()
             .collect()
+    }
+
+    pub(crate) fn captured_outbound_window(&self) -> CapturedOutboundWindow {
+        let inner = self.inner.lock().unwrap();
+        CapturedOutboundWindow {
+            observed_objects: inner.observed_outbound_objects,
+            observed_json_bytes: inner.observed_outbound_json_bytes,
+            emissions: inner
+                .captured_outbound_tail
+                .iter()
+                .map(|(sender, emission, _)| (*sender, emission.clone()))
+                .collect(),
+        }
     }
 
     /// Retract every still-undelivered artifact for one pending publication.
@@ -313,6 +367,16 @@ impl TransportBus {
     pub fn mailbox(&self, client: ClientId) -> Vec<TransportMessage> {
         let mut inner = self.inner.lock().unwrap();
         std::mem::take(inner.mailboxes.get_mut(&client).unwrap())
+    }
+
+    pub(crate) fn mailbox_snapshot(&self, client: ClientId) -> Vec<TransportMessage> {
+        self.inner
+            .lock()
+            .unwrap()
+            .mailboxes
+            .get(&client)
+            .cloned()
+            .unwrap_or_default()
     }
 
     /// Restrict deliveries to a subset of clients (the others are
@@ -510,5 +574,41 @@ fn take_batch(queue: &mut Vec<InFlight>, policy: &DeliveryPolicy, n: usize) -> V
             }
             taken
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cgka_traits::transport::{Timestamp, TransportSource};
+
+    #[test]
+    fn forensic_outbound_capture_is_bounded_at_emission_time() {
+        let bus = TransportBus::ordered();
+        let sender = bus.attach(MemberId::new(vec![1; 32]));
+        bus.capture_outbound_for(sender);
+        for sequence in 0..300_u64 {
+            bus.send(
+                sender,
+                TransportMessage {
+                    id: MessageId::new(sequence.to_be_bytes().to_vec()),
+                    payload: vec![2; 32],
+                    timestamp: Timestamp(sequence),
+                    causal_deps: Vec::new(),
+                    source: TransportSource("test".into()),
+                    envelope: TransportEnvelope::GroupMessage {
+                        transport_group_id: vec![3; 32],
+                    },
+                },
+            );
+        }
+
+        let capture = bus.captured_outbound_window();
+        assert_eq!(capture.observed_objects, 300);
+        assert_eq!(
+            capture.emissions.len(),
+            crate::MAX_CAPTURED_TRANSPORT_OBJECTS
+        );
+        assert!(capture.observed_json_bytes > 0);
     }
 }

--- a/crates/cgka-conformance-simulator/src/client.rs
+++ b/crates/cgka-conformance-simulator/src/client.rs
@@ -478,6 +478,36 @@ impl HarnessClient {
         self.storage_backing.database_path()
     }
 
+    /// Export the sensitive engine/OpenMLS state needed to replay captured
+    /// transport bytes without regenerating MLS messages.
+    pub fn export_conformance_replay_checkpoint(
+        &self,
+        group_id: &GroupId,
+    ) -> Result<Vec<u8>, EngineError> {
+        self.storage()
+            .export_conformance_replay_snapshot(group_id)
+            .map_err(EngineError::Storage)
+    }
+
+    /// Restore a sensitive replay checkpoint and rebuild the engine over it.
+    pub fn restore_conformance_replay_checkpoint(
+        &mut self,
+        group_id: &GroupId,
+        checkpoint: &[u8],
+    ) -> Result<(), EngineError> {
+        self.storage()
+            .import_conformance_replay_snapshot(group_id, checkpoint)
+            .map_err(EngineError::Storage)?;
+        self.default_group = Some(group_id.clone());
+        self.restart();
+        Ok(())
+    }
+
+    /// Deliver one exact captured transport object directly to this client.
+    pub fn inject_captured_transport(&self, message: TransportMessage) {
+        self.bus.inject(self.bus_id, message);
+    }
+
     pub(crate) fn enable_virtual_time_tick(&mut self) {
         self.virtual_time_tick_enabled = true;
     }

--- a/crates/cgka-conformance-simulator/src/client.rs
+++ b/crates/cgka-conformance-simulator/src/client.rs
@@ -1570,7 +1570,10 @@ impl HarnessClient {
         &self,
     ) -> Result<cgka_engine::conformance_snapshot::ConformanceCanonicalStateSnapshot, EngineError>
     {
-        let group_id = self.default_group.clone().expect("group");
+        let group_id = self
+            .default_group
+            .clone()
+            .ok_or_else(|| EngineError::Other("no default group to snapshot".into()))?;
         self.engine()
             .conformance_canonical_state_snapshot(&group_id)
     }

--- a/crates/cgka-conformance-simulator/src/client.rs
+++ b/crates/cgka-conformance-simulator/src/client.rs
@@ -508,6 +508,18 @@ impl HarnessClient {
         self.bus.inject(self.bus_id, message);
     }
 
+    pub(crate) fn replay_group_id(&self) -> Option<&GroupId> {
+        self.default_group.as_ref()
+    }
+
+    pub(crate) fn replay_protocol_profile(&self) -> ProtocolProfile {
+        self.protocol_profile
+    }
+
+    pub(crate) fn replay_uses_virtual_time(&self) -> bool {
+        self.virtual_time_tick_enabled
+    }
+
     pub(crate) fn enable_virtual_time_tick(&mut self) {
         self.virtual_time_tick_enabled = true;
     }
@@ -1550,10 +1562,17 @@ impl HarnessClient {
     pub fn canonical_state_snapshot(
         &self,
     ) -> cgka_engine::conformance_snapshot::ConformanceCanonicalStateSnapshot {
+        self.try_canonical_state_snapshot()
+            .expect("capture canonical state snapshot")
+    }
+
+    pub(crate) fn try_canonical_state_snapshot(
+        &self,
+    ) -> Result<cgka_engine::conformance_snapshot::ConformanceCanonicalStateSnapshot, EngineError>
+    {
         let group_id = self.default_group.clone().expect("group");
         self.engine()
             .conformance_canonical_state_snapshot(&group_id)
-            .expect("capture canonical state snapshot")
     }
 
     pub fn scenario_input_ledger(&mut self) -> Vec<ScenarioInputLedgerEntry> {

--- a/crates/cgka-conformance-simulator/src/failure_capsule.rs
+++ b/crates/cgka-conformance-simulator/src/failure_capsule.rs
@@ -1,0 +1,613 @@
+//! Versioned, replayable failure artifacts for convergence reliability runs.
+//!
+//! A capsule keeps logical scenario/report evidence separate from the opaque
+//! cryptographic checkpoint required for byte-exact MLS replay. Checkpoints are
+//! always sensitive local evidence and must be written with owner-only modes.
+
+use std::collections::BTreeMap;
+use std::error::Error;
+use std::fmt;
+use std::path::Path;
+use std::sync::Arc;
+
+use cgka_engine::ManualConvergenceClock;
+use cgka_engine::canonicalization::CanonicalizationPolicy;
+use cgka_traits::group::ProtocolProfile;
+use cgka_traits::transport::TransportMessage;
+use cgka_traits::types::GroupId;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::{
+    ClientBuilder, ConformanceConstantSnapshot, HarnessStorageMode, QuiescencePolicy,
+    QuiescenceStatus, ScenarioReport, ScenarioSpec, ScenarioStep, ScenarioStepStatus,
+    SubjectDescriptor, TransportBus, conformance_constant_snapshot,
+};
+
+pub const FAILURE_CAPSULE_SCHEMA_VERSION: &str = "1";
+pub const FAILURE_FINGERPRINT_VERSION: &str = "1";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FailureCapsuleSensitivity {
+    SyntheticShareable,
+    SensitiveLocal,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TerminalOutcomeClassification {
+    Converged,
+    ExpectedRefusal,
+    RetryableBlock,
+    TerminalProtocolFailure,
+    ResourceFailure,
+    EnvironmentFailure,
+    Timeout,
+    OracleViolation,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FailureFingerprintV1 {
+    pub version: String,
+    pub digest: String,
+    pub classification: TerminalOutcomeClassification,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_failing_action_id: Option<String>,
+    pub failure_kind: String,
+    pub normalized_state_digest: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExpandedScenarioActionV1 {
+    pub action_id: String,
+    pub step_index: usize,
+    pub action_type: String,
+    /// Virtual monotonic time immediately before this action executes.
+    pub virtual_time_ms: u64,
+    /// `None` means execution stopped before this planned action.
+    pub status: Option<ScenarioStepStatus>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CapturedTransportArtifactV1 {
+    pub sequence: u64,
+    pub sender: String,
+    pub message: TransportMessage,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CapsulePolicySnapshotV1 {
+    pub canonicalization: CanonicalizationPolicy,
+    /// Exact policies selected by each `await_quiescence` action.
+    pub quiescence_by_action: BTreeMap<String, QuiescencePolicy>,
+    pub engine_constants: ConformanceConstantSnapshot,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResourceObservationV1 {
+    pub counters: BTreeMap<String, u64>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EngineByteReplayV1 {
+    pub client_label: String,
+    /// Exact seed passed to `ClientBuilder`; this is not a secret for synthetic
+    /// runs but is still carried only by a sensitive capsule with the checkpoint.
+    pub identity_seed: Vec<u8>,
+    pub protocol_profile: ProtocolProfile,
+    pub group_id: Vec<u8>,
+    /// Opaque serialized SQLite/OpenMLS group checkpoint. Contains key material.
+    pub sensitive_checkpoint: Vec<u8>,
+    pub captured_deliveries: Vec<TransportMessage>,
+    pub checkpoint_monotonic_ms: u64,
+    pub checkpoint_wall_ms: u64,
+    /// Whether the original harness tick used the injected clock rather than
+    /// the legacy far-future settlement shortcut.
+    pub virtual_time_tick_enabled: bool,
+    pub failure_kind: String,
+    pub failing_action_id: String,
+    pub expected_fingerprint: FailureFingerprintV1,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EngineByteReplayObservationV1 {
+    pub client_label: String,
+    pub epoch: u64,
+    pub normalized_state_digest: String,
+    pub fingerprint: FailureFingerprintV1,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FailureCapsuleV1 {
+    pub schema_version: String,
+    pub sensitivity: FailureCapsuleSensitivity,
+    pub original_scenario: ScenarioSpec,
+    pub canonical_scenario: ScenarioSpec,
+    /// Stable named seeds/indices needed to reconstruct generated schedules.
+    pub seeds: BTreeMap<String, u64>,
+    pub expanded_schedule: Vec<ExpandedScenarioActionV1>,
+    pub adapter: Option<SubjectDescriptor>,
+    pub binary_version: String,
+    pub policy: CapsulePolicySnapshotV1,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub captured_transport_artifacts: Vec<CapturedTransportArtifactV1>,
+    pub report: ScenarioReport,
+    pub resources: ResourceObservationV1,
+    pub failure: FailureFingerprintV1,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub byte_replay: Option<EngineByteReplayV1>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub minimized_reproducer: Option<ScenarioSpec>,
+}
+
+#[derive(Debug)]
+pub enum FailureCapsuleError {
+    NoFailure,
+    SensitiveNotPortable,
+    MissingPortableExpectation,
+    InvalidVersion(String),
+    ReplayFingerprintMismatch { expected: String, actual: String },
+    Io(std::io::Error),
+    Json(serde_json::Error),
+    Replay(String),
+}
+
+impl fmt::Display for FailureCapsuleError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NoFailure => f.write_str("cannot create a failure capsule from a passing report"),
+            Self::SensitiveNotPortable => {
+                f.write_str("sensitive failure capsules cannot be promoted to portable vectors")
+            }
+            Self::MissingPortableExpectation => f.write_str(
+                "failure capsule has no intended exact or semantic expectation to preserve",
+            ),
+            Self::InvalidVersion(version) => {
+                write!(f, "unsupported failure capsule version {version}")
+            }
+            Self::ReplayFingerprintMismatch { expected, actual } => write!(
+                f,
+                "byte replay fingerprint mismatch: expected {expected}, got {actual}"
+            ),
+            Self::Io(error) => write!(f, "failure capsule I/O: {error}"),
+            Self::Json(error) => write!(f, "failure capsule JSON: {error}"),
+            Self::Replay(error) => write!(f, "failure capsule replay: {error}"),
+        }
+    }
+}
+
+impl Error for FailureCapsuleError {}
+
+impl From<std::io::Error> for FailureCapsuleError {
+    fn from(error: std::io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+impl From<serde_json::Error> for FailureCapsuleError {
+    fn from(error: serde_json::Error) -> Self {
+        Self::Json(error)
+    }
+}
+
+impl FailureCapsuleV1 {
+    pub fn from_report(
+        report: ScenarioReport,
+        sensitivity: FailureCapsuleSensitivity,
+        captured_transport_artifacts: Vec<CapturedTransportArtifactV1>,
+        byte_replay: Option<EngineByteReplayV1>,
+    ) -> Result<Self, FailureCapsuleError> {
+        let failure = fingerprint_report_failure(&report)?;
+        let mut virtual_time_ms = 0_u64;
+        let expanded_schedule = report
+            .scenario
+            .steps
+            .iter()
+            .enumerate()
+            .map(|(step_index, step)| {
+                let action = ExpandedScenarioActionV1 {
+                    action_id: format!("step-{step_index}:{}", step.kind()),
+                    step_index,
+                    action_type: step.kind().into(),
+                    virtual_time_ms,
+                    status: report
+                        .step_log
+                        .iter()
+                        .find(|entry| entry.step_index == step_index)
+                        .map(|entry| entry.status.clone()),
+                };
+                if let ScenarioStep::AdvanceTime { delta_ms } = step {
+                    virtual_time_ms = virtual_time_ms.saturating_add(*delta_ms);
+                }
+                action
+            })
+            .collect();
+        let quiescence_by_action = report
+            .scenario
+            .steps
+            .iter()
+            .enumerate()
+            .filter_map(|(step_index, step)| match step {
+                ScenarioStep::AwaitQuiescence { policy } => {
+                    Some((format!("step-{step_index}:{}", step.kind()), policy.clone()))
+                }
+                _ => None,
+            })
+            .collect();
+        let minimized_reproducer = report
+            .metadata
+            .generated
+            .as_ref()
+            .and_then(|generated| generated.minimized_case.clone());
+        let seeds = report
+            .metadata
+            .generated
+            .as_ref()
+            .map(|generated| {
+                BTreeMap::from([
+                    ("generator_seed".into(), generated.seed),
+                    ("case_index".into(), generated.case_index),
+                ])
+            })
+            .unwrap_or_default();
+        Ok(Self {
+            schema_version: FAILURE_CAPSULE_SCHEMA_VERSION.into(),
+            sensitivity,
+            original_scenario: report.scenario.clone(),
+            canonical_scenario: report.scenario.clone(),
+            seeds,
+            expanded_schedule,
+            adapter: report.metadata.subject.clone(),
+            binary_version: env!("CARGO_PKG_VERSION").into(),
+            policy: CapsulePolicySnapshotV1 {
+                canonicalization: CanonicalizationPolicy::default(),
+                quiescence_by_action,
+                engine_constants: conformance_constant_snapshot(),
+            },
+            resources: resource_observations(&report, &captured_transport_artifacts),
+            captured_transport_artifacts,
+            report,
+            failure,
+            byte_replay,
+            minimized_reproducer,
+        })
+    }
+
+    pub fn validate(&self) -> Result<(), FailureCapsuleError> {
+        if self.schema_version != FAILURE_CAPSULE_SCHEMA_VERSION {
+            return Err(FailureCapsuleError::InvalidVersion(
+                self.schema_version.clone(),
+            ));
+        }
+        if self.byte_replay.is_some()
+            && self.sensitivity != FailureCapsuleSensitivity::SensitiveLocal
+        {
+            return Err(FailureCapsuleError::Replay(
+                "byte replay checkpoints require sensitive_local classification".into(),
+            ));
+        }
+        let report_fingerprint = fingerprint_report_failure(&self.report)?;
+        if report_fingerprint != self.failure {
+            return Err(FailureCapsuleError::Replay(
+                "failure fingerprint does not match the captured report".into(),
+            ));
+        }
+        if let Some(replay) = &self.byte_replay {
+            let expected = build_fingerprint(
+                replay.expected_fingerprint.classification,
+                Some(replay.failing_action_id.clone()),
+                replay.failure_kind.clone(),
+                replay.expected_fingerprint.normalized_state_digest.clone(),
+            );
+            if expected != replay.expected_fingerprint {
+                return Err(FailureCapsuleError::Replay(
+                    "engine byte-replay fingerprint is internally inconsistent".into(),
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+pub fn write_failure_capsule(
+    path: &Path,
+    capsule: &FailureCapsuleV1,
+) -> Result<(), FailureCapsuleError> {
+    capsule.validate()?;
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        #[cfg(unix)]
+        let _parent_guard = fs_private::prepare_directory_path(
+            parent,
+            fs_private::PRIVATE_DIR_MODE,
+            fs_private::ExistingDirectoryMode::Preserve,
+        )?;
+        #[cfg(not(unix))]
+        fs_private::create_dir_all_private(parent)?;
+    }
+    let bytes = serde_json::to_vec_pretty(capsule)?;
+    fs_private::write_private(path, &bytes)?;
+    Ok(())
+}
+
+pub fn read_failure_capsule(path: &Path) -> Result<FailureCapsuleV1, FailureCapsuleError> {
+    let capsule: FailureCapsuleV1 = serde_json::from_slice(&std::fs::read(path)?)?;
+    capsule.validate()?;
+    Ok(capsule)
+}
+
+/// Convert a reviewed synthetic failure into a portable regression-vector
+/// candidate. Sensitive incident capsules are intentionally ineligible.
+pub fn promote_failure_capsule_to_vector(
+    capsule: &FailureCapsuleV1,
+    conformance_version: impl Into<String>,
+) -> Result<crate::VectorFixture, FailureCapsuleError> {
+    capsule.validate()?;
+    if capsule.sensitivity != FailureCapsuleSensitivity::SyntheticShareable {
+        return Err(FailureCapsuleError::SensitiveNotPortable);
+    }
+    let scenario = capsule
+        .minimized_reproducer
+        .clone()
+        .unwrap_or_else(|| capsule.canonical_scenario.clone());
+    if capsule.report.expected_trace.is_none() && capsule.report.expected_outcomes.is_empty() {
+        return Err(FailureCapsuleError::MissingPortableExpectation);
+    }
+    let mut expected_trace = capsule.report.expected_trace.clone();
+    if let Some(expected_trace) = &mut expected_trace {
+        expected_trace.name = scenario.name.clone();
+    }
+    Ok(crate::VectorFixture {
+        scenario_name: scenario.name.clone(),
+        vector_version: "1".into(),
+        conformance_version: conformance_version.into(),
+        seed: capsule
+            .report
+            .metadata
+            .generated
+            .as_ref()
+            .map(|generated| generated.seed),
+        application_profile: None,
+        scenario,
+        expected_trace,
+        expected_outcomes: capsule.report.expected_outcomes.clone(),
+    })
+}
+
+pub fn fingerprint_report_failure(
+    report: &ScenarioReport,
+) -> Result<FailureFingerprintV1, FailureCapsuleError> {
+    let failed_step_evidence = report
+        .step_log
+        .iter()
+        .filter_map(|step| match &step.status {
+            ScenarioStepStatus::Completed => None,
+            ScenarioStepStatus::Failed { kind, message } => Some((
+                step.step_index,
+                step.step_type.as_str(),
+                kind.as_str(),
+                message.as_str(),
+            )),
+        })
+        .collect::<Vec<_>>();
+    let normalized_state_digest = digest_json(&(
+        &report.observed_trace,
+        &report.quiescence_observations,
+        &report.pending_resolution_observations,
+        &report.epoch_change_observations,
+        &report.app_invalidation_observations,
+        failed_step_evidence,
+    ))?;
+
+    let failed_step = report.step_log.iter().find_map(|step| match &step.status {
+        ScenarioStepStatus::Failed { kind, .. } => Some((
+            TerminalOutcomeClassification::EnvironmentFailure,
+            format!("step-{}:{}", step.step_index, step.step_type),
+            format!("scenario_step_failed:{kind}"),
+        )),
+        ScenarioStepStatus::Completed => None,
+    });
+    let quiescence =
+        report
+            .quiescence_observations
+            .iter()
+            .find_map(|observation| match &observation.status {
+                QuiescenceStatus::Quiescent => None,
+                QuiescenceStatus::Blocked { .. } => Some((
+                    if observation.final_progress.terminal_blockers.is_empty() {
+                        TerminalOutcomeClassification::RetryableBlock
+                    } else {
+                        TerminalOutcomeClassification::TerminalProtocolFailure
+                    },
+                    format!("step-{}:await_quiescence", observation.step_index),
+                    "quiescence_blocked".to_string(),
+                )),
+                QuiescenceStatus::TimedOut { .. } => Some((
+                    TerminalOutcomeClassification::Timeout,
+                    format!("step-{}:await_quiescence", observation.step_index),
+                    "quiescence_timeout".to_string(),
+                )),
+            });
+    let oracle = report
+        .expectation_failures
+        .first()
+        .map(|failure| {
+            (
+                TerminalOutcomeClassification::OracleViolation,
+                "oracle".to_string(),
+                failure.kind.clone(),
+            )
+        })
+        .or_else(|| {
+            report.invariant_failures.first().map(|failure| {
+                (
+                    TerminalOutcomeClassification::OracleViolation,
+                    "oracle".to_string(),
+                    failure.kind.clone(),
+                )
+            })
+        })
+        .or_else(|| {
+            report
+                .oracle
+                .missing_observed_behaviors
+                .first()
+                .map(|behavior| {
+                    (
+                        TerminalOutcomeClassification::OracleViolation,
+                        "oracle".to_string(),
+                        format!("missing_observed_behavior:{behavior:?}"),
+                    )
+                })
+        })
+        .or_else(|| {
+            report.oracle.weak_oracle_warnings.first().map(|warning| {
+                (
+                    TerminalOutcomeClassification::OracleViolation,
+                    "oracle".to_string(),
+                    format!("weak_oracle_warning:{:?}", warning.stimulus),
+                )
+            })
+        });
+    let (classification, action_id, failure_kind) = failed_step
+        .or(quiescence)
+        .or(oracle)
+        .ok_or(FailureCapsuleError::NoFailure)?;
+    Ok(build_fingerprint(
+        classification,
+        Some(action_id),
+        failure_kind,
+        normalized_state_digest,
+    ))
+}
+
+pub async fn replay_engine_bytes(
+    replay: &EngineByteReplayV1,
+) -> Result<EngineByteReplayObservationV1, FailureCapsuleError> {
+    let bus = TransportBus::ordered();
+    let clock =
+        ManualConvergenceClock::new(replay.checkpoint_monotonic_ms, replay.checkpoint_wall_ms);
+    let mut client = ClientBuilder::new(replay.identity_seed.clone())
+        .registry(crate::subject::scenario_registry())
+        .protocol_profile(replay.protocol_profile)
+        .storage_mode(HarnessStorageMode::InMemorySqlite)
+        .convergence_clock(Arc::new(clock))
+        .attach(&bus);
+    let group_id = GroupId::new(replay.group_id.clone());
+    client
+        .restore_conformance_replay_checkpoint(&group_id, &replay.sensitive_checkpoint)
+        .map_err(|error| FailureCapsuleError::Replay(error.to_string()))?;
+    if replay.virtual_time_tick_enabled {
+        client.enable_virtual_time_tick();
+    }
+    for message in &replay.captured_deliveries {
+        client.inject_captured_transport(message.clone());
+    }
+    let outcomes = client.tick().await;
+    if let Some(error) = outcomes.into_iter().find_map(Result::err) {
+        return Err(FailureCapsuleError::Replay(error.to_string()));
+    }
+    let canonical_state = client.canonical_state_snapshot();
+    let normalized_state_digest = digest_json(&canonical_state)?;
+    let fingerprint = build_fingerprint(
+        replay.expected_fingerprint.classification,
+        Some(replay.failing_action_id.clone()),
+        replay.failure_kind.clone(),
+        normalized_state_digest.clone(),
+    );
+    if fingerprint.digest != replay.expected_fingerprint.digest {
+        return Err(FailureCapsuleError::ReplayFingerprintMismatch {
+            expected: replay.expected_fingerprint.digest.clone(),
+            actual: fingerprint.digest,
+        });
+    }
+    Ok(EngineByteReplayObservationV1 {
+        client_label: replay.client_label.clone(),
+        epoch: client.epoch().0,
+        normalized_state_digest,
+        fingerprint,
+    })
+}
+
+pub fn build_fingerprint(
+    classification: TerminalOutcomeClassification,
+    first_failing_action_id: Option<String>,
+    failure_kind: String,
+    normalized_state_digest: String,
+) -> FailureFingerprintV1 {
+    let material = serde_json::to_vec(&(
+        FAILURE_FINGERPRINT_VERSION,
+        classification,
+        &first_failing_action_id,
+        &failure_kind,
+        &normalized_state_digest,
+    ))
+    .expect("failure fingerprint material serializes");
+    FailureFingerprintV1 {
+        version: FAILURE_FINGERPRINT_VERSION.into(),
+        digest: hex::encode(Sha256::digest(material)),
+        classification,
+        first_failing_action_id,
+        failure_kind,
+        normalized_state_digest,
+    }
+}
+
+pub fn digest_json(value: &impl Serialize) -> Result<String, FailureCapsuleError> {
+    Ok(hex::encode(Sha256::digest(serde_json::to_vec(value)?)))
+}
+
+fn resource_observations(
+    report: &ScenarioReport,
+    captured_transport_artifacts: &[CapturedTransportArtifactV1],
+) -> ResourceObservationV1 {
+    let mut counters = BTreeMap::new();
+    counters.insert(
+        "planned_scenario_steps".into(),
+        report.scenario.steps.len() as u64,
+    );
+    counters.insert(
+        "executed_scenario_steps".into(),
+        report.step_log.len() as u64,
+    );
+    counters.insert(
+        "observed_clients".into(),
+        report
+            .observed_trace
+            .as_ref()
+            .map_or(0, |trace| trace.observations.len()) as u64,
+    );
+    counters.insert(
+        "expectation_failures".into(),
+        report.expectation_failures.len() as u64,
+    );
+    counters.insert(
+        "invariant_failures".into(),
+        report.invariant_failures.len() as u64,
+    );
+    counters.insert(
+        "quiescence_iterations".into(),
+        report
+            .quiescence_observations
+            .iter()
+            .map(|observation| observation.iterations as u64)
+            .sum(),
+    );
+    counters.insert(
+        "captured_transport_objects".into(),
+        captured_transport_artifacts.len() as u64,
+    );
+    counters.insert(
+        "captured_transport_json_bytes".into(),
+        captured_transport_artifacts
+            .iter()
+            .map(|artifact| {
+                serde_json::to_vec(&artifact.message).map_or(0, |bytes| bytes.len() as u64)
+            })
+            .sum(),
+    );
+    ResourceObservationV1 { counters }
+}

--- a/crates/cgka-conformance-simulator/src/failure_capsule.rs
+++ b/crates/cgka-conformance-simulator/src/failure_capsule.rs
@@ -21,11 +21,14 @@ use sha2::{Digest, Sha256};
 use crate::{
     ClientBuilder, ConformanceConstantSnapshot, HarnessStorageMode, QuiescencePolicy,
     QuiescenceStatus, ScenarioReport, ScenarioSpec, ScenarioStep, ScenarioStepStatus,
-    SubjectDescriptor, TransportBus, conformance_constant_snapshot,
+    SubjectDescriptor, SubjectFailureCategory, TransportBus, conformance_constant_snapshot,
 };
 
 pub const FAILURE_CAPSULE_SCHEMA_VERSION: &str = "1";
 pub const FAILURE_FINGERPRINT_VERSION: &str = "1";
+pub const MAX_CAPTURED_TRANSPORT_OBJECTS: usize = 256;
+pub const MAX_CAPTURED_TRANSPORT_JSON_BYTES: u64 = 1_048_576;
+pub const MAX_CAPTURED_REPLAY_CHECKPOINT_BYTES: usize = 16 * 1_048_576;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -58,6 +61,32 @@ pub struct FailureFingerprintV1 {
     pub normalized_state_digest: String,
 }
 
+/// Stable semantic identity used by reducers. Unlike the full fingerprint,
+/// this deliberately excludes action indices and observed-state digests that
+/// are expected to change when irrelevant scenario steps are removed.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FailureIdentityV1 {
+    pub classification: TerminalOutcomeClassification,
+    pub failing_action_type: String,
+    pub failure_kind: String,
+}
+
+impl FailureFingerprintV1 {
+    pub fn semantic_identity(&self) -> FailureIdentityV1 {
+        let failing_action_type = self
+            .first_failing_action_id
+            .as_deref()
+            .and_then(|action_id| action_id.split_once(':').map(|(_, kind)| kind))
+            .unwrap_or_else(|| self.first_failing_action_id.as_deref().unwrap_or("unknown"))
+            .to_owned();
+        FailureIdentityV1 {
+            classification: self.classification,
+            failing_action_type,
+            failure_kind: self.failure_kind.clone(),
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ExpandedScenarioActionV1 {
     pub action_id: String,
@@ -74,6 +103,19 @@ pub struct CapturedTransportArtifactV1 {
     pub sequence: u64,
     pub sender: String,
     pub message: TransportMessage,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct CapturedTransportWindowV1 {
+    pub artifacts: Vec<CapturedTransportArtifactV1>,
+    pub observed_objects: u64,
+    pub observed_json_bytes: u64,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ScenarioFailureCaptureV1 {
+    pub transport: CapturedTransportWindowV1,
+    pub byte_replay: Option<EngineByteReplayV1>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -105,8 +147,6 @@ pub struct EngineByteReplayV1 {
     /// Whether the original harness tick used the injected clock rather than
     /// the legacy far-future settlement shortcut.
     pub virtual_time_tick_enabled: bool,
-    pub failure_kind: String,
-    pub failing_action_id: String,
     pub expected_fingerprint: FailureFingerprintV1,
 }
 
@@ -122,8 +162,6 @@ pub struct EngineByteReplayObservationV1 {
 pub struct FailureCapsuleV1 {
     pub schema_version: String,
     pub sensitivity: FailureCapsuleSensitivity,
-    pub original_scenario: ScenarioSpec,
-    pub canonical_scenario: ScenarioSpec,
     /// Stable named seeds/indices needed to reconstruct generated schedules.
     pub seeds: BTreeMap<String, u64>,
     pub expanded_schedule: Vec<ExpandedScenarioActionV1>,
@@ -198,6 +236,27 @@ impl FailureCapsuleV1 {
         captured_transport_artifacts: Vec<CapturedTransportArtifactV1>,
         byte_replay: Option<EngineByteReplayV1>,
     ) -> Result<Self, FailureCapsuleError> {
+        let observed_objects = captured_transport_artifacts.len() as u64;
+        let observed_json_bytes = transport_json_bytes(&captured_transport_artifacts);
+        Self::from_report_capture(
+            report,
+            sensitivity,
+            CapturedTransportWindowV1 {
+                artifacts: captured_transport_artifacts,
+                observed_objects,
+                observed_json_bytes,
+            },
+            byte_replay,
+        )
+    }
+
+    pub fn from_report_capture(
+        report: ScenarioReport,
+        sensitivity: FailureCapsuleSensitivity,
+        captured_transport: CapturedTransportWindowV1,
+        byte_replay: Option<EngineByteReplayV1>,
+    ) -> Result<Self, FailureCapsuleError> {
+        let captured_transport = bound_transport_capture(captured_transport);
         let failure = fingerprint_report_failure(&report)?;
         let mut virtual_time_ms = 0_u64;
         let expanded_schedule = report
@@ -254,8 +313,6 @@ impl FailureCapsuleV1 {
         let capsule = Self {
             schema_version: FAILURE_CAPSULE_SCHEMA_VERSION.into(),
             sensitivity,
-            original_scenario: report.scenario.clone(),
-            canonical_scenario: report.scenario.clone(),
             seeds,
             expanded_schedule,
             adapter: report.metadata.subject.clone(),
@@ -265,8 +322,8 @@ impl FailureCapsuleV1 {
                 quiescence_by_action,
                 engine_constants: conformance_constant_snapshot(),
             },
-            resources: resource_observations(&report, &captured_transport_artifacts),
-            captured_transport_artifacts,
+            resources: resource_observations(&report, &captured_transport),
+            captured_transport_artifacts: captured_transport.artifacts,
             report,
             failure,
             byte_replay,
@@ -296,10 +353,19 @@ impl FailureCapsuleV1 {
             ));
         }
         if let Some(replay) = &self.byte_replay {
+            if replay.sensitive_checkpoint.len() > MAX_CAPTURED_REPLAY_CHECKPOINT_BYTES
+                || replay.captured_deliveries.len() > MAX_CAPTURED_TRANSPORT_OBJECTS
+                || transport_messages_json_bytes(&replay.captured_deliveries)
+                    > MAX_CAPTURED_TRANSPORT_JSON_BYTES
+            {
+                return Err(FailureCapsuleError::Replay(
+                    "engine byte-replay evidence exceeds the capsule resource policy".into(),
+                ));
+            }
             let expected = build_fingerprint(
                 replay.expected_fingerprint.classification,
-                Some(replay.failing_action_id.clone()),
-                replay.failure_kind.clone(),
+                replay.expected_fingerprint.first_failing_action_id.clone(),
+                replay.expected_fingerprint.failure_kind.clone(),
                 replay.expected_fingerprint.normalized_state_digest.clone(),
             );
             if expected != replay.expected_fingerprint {
@@ -354,7 +420,7 @@ pub fn promote_failure_capsule_to_vector(
     let scenario = capsule
         .minimized_reproducer
         .clone()
-        .unwrap_or_else(|| capsule.canonical_scenario.clone());
+        .unwrap_or_else(|| capsule.report.scenario.clone());
     if capsule.report.expected_trace.is_none() && capsule.report.expected_outcomes.is_empty() {
         return Err(FailureCapsuleError::MissingPortableExpectation);
     }
@@ -402,8 +468,19 @@ pub fn fingerprint_report_failure(
     ))?;
 
     let failed_step = report.step_log.iter().find_map(|step| match &step.status {
-        ScenarioStepStatus::Failed { kind, .. } => Some((
-            TerminalOutcomeClassification::EnvironmentFailure,
+        ScenarioStepStatus::Failed { kind, category, .. } => Some((
+            match category {
+                SubjectFailureCategory::ExpectedRefusal => {
+                    TerminalOutcomeClassification::ExpectedRefusal
+                }
+                SubjectFailureCategory::Protocol => {
+                    TerminalOutcomeClassification::TerminalProtocolFailure
+                }
+                SubjectFailureCategory::Resource => TerminalOutcomeClassification::ResourceFailure,
+                SubjectFailureCategory::Environment => {
+                    TerminalOutcomeClassification::EnvironmentFailure
+                }
+            },
             format!("step-{}:{}", step.step_index, step.step_type),
             format!("scenario_step_failed:{kind}"),
         )),
@@ -506,15 +583,26 @@ pub async fn replay_engine_bytes(
         client.inject_captured_transport(message.clone());
     }
     let outcomes = client.tick().await;
-    if let Some(error) = outcomes.into_iter().find_map(Result::err) {
-        return Err(FailureCapsuleError::Replay(error.to_string()));
-    }
+    let actual_error = outcomes.iter().find_map(|outcome| outcome.as_ref().err());
     let canonical_state = client.canonical_state_snapshot();
     let normalized_state_digest = digest_json(&canonical_state)?;
+    let (classification, failure_kind) = actual_error.map_or(
+        (
+            TerminalOutcomeClassification::Converged,
+            "campaign_tick_replay".to_string(),
+        ),
+        |error| {
+            let (category, code) = crate::subject::classify_engine_error(error);
+            (
+                terminal_classification(category),
+                format!("scenario_step_failed:{code}"),
+            )
+        },
+    );
     let fingerprint = build_fingerprint(
-        replay.expected_fingerprint.classification,
-        Some(replay.failing_action_id.clone()),
-        replay.failure_kind.clone(),
+        classification,
+        replay.expected_fingerprint.first_failing_action_id.clone(),
+        failure_kind,
         normalized_state_digest.clone(),
     );
     if fingerprint.digest != replay.expected_fingerprint.digest {
@@ -561,7 +649,7 @@ pub fn digest_json(value: &impl Serialize) -> Result<String, FailureCapsuleError
 
 fn resource_observations(
     report: &ScenarioReport,
-    captured_transport_artifacts: &[CapturedTransportArtifactV1],
+    captured_transport: &CapturedTransportWindowV1,
 ) -> ResourceObservationV1 {
     let mut counters = BTreeMap::new();
     counters.insert(
@@ -596,17 +684,77 @@ fn resource_observations(
             .sum(),
     );
     counters.insert(
-        "captured_transport_objects".into(),
-        captured_transport_artifacts.len() as u64,
+        "transport_objects_observed".into(),
+        captured_transport.observed_objects,
     );
     counters.insert(
-        "captured_transport_json_bytes".into(),
-        captured_transport_artifacts
-            .iter()
-            .map(|artifact| {
-                serde_json::to_vec(&artifact.message).map_or(0, |bytes| bytes.len() as u64)
-            })
-            .sum(),
+        "transport_objects_retained".into(),
+        captured_transport.artifacts.len() as u64,
+    );
+    counters.insert(
+        "transport_objects_dropped".into(),
+        captured_transport
+            .observed_objects
+            .saturating_sub(captured_transport.artifacts.len() as u64),
+    );
+    counters.insert(
+        "transport_json_bytes_observed".into(),
+        captured_transport.observed_json_bytes,
+    );
+    let retained_json_bytes = transport_json_bytes(&captured_transport.artifacts);
+    counters.insert("transport_json_bytes_retained".into(), retained_json_bytes);
+    counters.insert(
+        "transport_json_bytes_dropped".into(),
+        captured_transport
+            .observed_json_bytes
+            .saturating_sub(retained_json_bytes),
     );
     ResourceObservationV1 { counters }
+}
+
+fn transport_json_bytes(artifacts: &[CapturedTransportArtifactV1]) -> u64 {
+    artifacts
+        .iter()
+        .map(|artifact| serde_json::to_vec(&artifact.message).map_or(0, |bytes| bytes.len() as u64))
+        .sum()
+}
+
+fn transport_messages_json_bytes(messages: &[TransportMessage]) -> u64 {
+    messages
+        .iter()
+        .map(|message| serde_json::to_vec(message).map_or(0, |bytes| bytes.len() as u64))
+        .sum()
+}
+
+fn bound_transport_capture(mut capture: CapturedTransportWindowV1) -> CapturedTransportWindowV1 {
+    capture.artifacts.sort_by_key(|artifact| artifact.sequence);
+    let mut retained_bytes = 0_u64;
+    let mut retained = capture
+        .artifacts
+        .into_iter()
+        .rev()
+        .filter(|artifact| {
+            let bytes = serde_json::to_vec(&artifact.message).map_or(0, |bytes| bytes.len() as u64);
+            if retained_bytes.saturating_add(bytes) > MAX_CAPTURED_TRANSPORT_JSON_BYTES {
+                return false;
+            }
+            retained_bytes = retained_bytes.saturating_add(bytes);
+            true
+        })
+        .take(MAX_CAPTURED_TRANSPORT_OBJECTS)
+        .collect::<Vec<_>>();
+    retained.sort_by_key(|artifact| artifact.sequence);
+    capture.artifacts = retained;
+    capture
+}
+
+pub(crate) fn terminal_classification(
+    category: SubjectFailureCategory,
+) -> TerminalOutcomeClassification {
+    match category {
+        SubjectFailureCategory::ExpectedRefusal => TerminalOutcomeClassification::ExpectedRefusal,
+        SubjectFailureCategory::Protocol => TerminalOutcomeClassification::TerminalProtocolFailure,
+        SubjectFailureCategory::Resource => TerminalOutcomeClassification::ResourceFailure,
+        SubjectFailureCategory::Environment => TerminalOutcomeClassification::EnvironmentFailure,
+    }
 }

--- a/crates/cgka-conformance-simulator/src/failure_capsule.rs
+++ b/crates/cgka-conformance-simulator/src/failure_capsule.rs
@@ -4,7 +4,7 @@
 //! cryptographic checkpoint required for byte-exact MLS replay. Checkpoints are
 //! always sensitive local evidence and must be written with owner-only modes.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
 use std::error::Error;
 use std::fmt;
 use std::path::Path;
@@ -584,8 +584,7 @@ pub async fn replay_engine_bytes(
     }
     let outcomes = client.tick().await;
     let actual_error = outcomes.iter().find_map(|outcome| outcome.as_ref().err());
-    let canonical_state = client.canonical_state_snapshot();
-    let normalized_state_digest = digest_json(&canonical_state)?;
+    let normalized_state_digest = replay_state_digest(&client)?;
     let (classification, failure_kind) = actual_error.map_or(
         (
             TerminalOutcomeClassification::Converged,
@@ -617,6 +616,13 @@ pub async fn replay_engine_bytes(
         normalized_state_digest,
         fingerprint,
     })
+}
+
+fn replay_state_digest(client: &crate::HarnessClient) -> Result<String, FailureCapsuleError> {
+    let canonical_state = client
+        .try_canonical_state_snapshot()
+        .map_err(|error| FailureCapsuleError::Replay(error.to_string()))?;
+    digest_json(&canonical_state)
 }
 
 pub fn build_fingerprint(
@@ -728,24 +734,30 @@ fn transport_messages_json_bytes(messages: &[TransportMessage]) -> u64 {
 
 fn bound_transport_capture(mut capture: CapturedTransportWindowV1) -> CapturedTransportWindowV1 {
     capture.artifacts.sort_by_key(|artifact| artifact.sequence);
-    let mut retained_bytes = 0_u64;
-    let mut retained = capture
-        .artifacts
-        .into_iter()
-        .rev()
-        .filter(|artifact| {
-            let bytes = serde_json::to_vec(&artifact.message).map_or(0, |bytes| bytes.len() as u64);
-            if retained_bytes.saturating_add(bytes) > MAX_CAPTURED_TRANSPORT_JSON_BYTES {
-                return false;
-            }
-            retained_bytes = retained_bytes.saturating_add(bytes);
-            true
-        })
-        .take(MAX_CAPTURED_TRANSPORT_OBJECTS)
-        .collect::<Vec<_>>();
-    retained.sort_by_key(|artifact| artifact.sequence);
-    capture.artifacts = retained;
+    // The bus already enforces these limits while recording emissions. This
+    // defensive pass handles externally assembled captures with the identical
+    // policy: evict from the front until the retained evidence is one
+    // contiguous newest tail under both limits.
+    let mut retained = VecDeque::from(capture.artifacts);
+    let mut retained_bytes = retained
+        .iter()
+        .map(|artifact| transport_message_json_bytes(&artifact.message))
+        .sum::<u64>();
+    while retained.len() > MAX_CAPTURED_TRANSPORT_OBJECTS
+        || retained_bytes > MAX_CAPTURED_TRANSPORT_JSON_BYTES
+    {
+        let Some(dropped) = retained.pop_front() else {
+            break;
+        };
+        retained_bytes =
+            retained_bytes.saturating_sub(transport_message_json_bytes(&dropped.message));
+    }
+    capture.artifacts = retained.into();
     capture
+}
+
+fn transport_message_json_bytes(message: &TransportMessage) -> u64 {
+    serde_json::to_vec(message).map_or(0, |bytes| bytes.len() as u64)
 }
 
 pub(crate) fn terminal_classification(
@@ -756,5 +768,23 @@ pub(crate) fn terminal_classification(
         SubjectFailureCategory::Protocol => TerminalOutcomeClassification::TerminalProtocolFailure,
         SubjectFailureCategory::Resource => TerminalOutcomeClassification::ResourceFailure,
         SubjectFailureCategory::Environment => TerminalOutcomeClassification::EnvironmentFailure,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn replay_state_digest_returns_an_error_when_no_group_can_be_snapshotted() {
+        let bus = TransportBus::ordered();
+        let client = ClientBuilder::new(vec![7; 32])
+            .registry(crate::subject::engine_harness_feature_registry())
+            .attach(&bus);
+
+        assert!(matches!(
+            replay_state_digest(&client),
+            Err(FailureCapsuleError::Replay(_))
+        ));
     }
 }

--- a/crates/cgka-conformance-simulator/src/failure_capsule.rs
+++ b/crates/cgka-conformance-simulator/src/failure_capsule.rs
@@ -251,7 +251,7 @@ impl FailureCapsuleV1 {
                 ])
             })
             .unwrap_or_default();
-        Ok(Self {
+        let capsule = Self {
             schema_version: FAILURE_CAPSULE_SCHEMA_VERSION.into(),
             sensitivity,
             original_scenario: report.scenario.clone(),
@@ -271,7 +271,9 @@ impl FailureCapsuleV1 {
             failure,
             byte_replay,
             minimized_reproducer,
-        })
+        };
+        capsule.validate()?;
+        Ok(capsule)
     }
 
     pub fn validate(&self) -> Result<(), FailureCapsuleError> {
@@ -385,12 +387,9 @@ pub fn fingerprint_report_failure(
         .iter()
         .filter_map(|step| match &step.status {
             ScenarioStepStatus::Completed => None,
-            ScenarioStepStatus::Failed { kind, message } => Some((
-                step.step_index,
-                step.step_type.as_str(),
-                kind.as_str(),
-                message.as_str(),
-            )),
+            ScenarioStepStatus::Failed { kind, .. } => {
+                Some((step.step_index, step.step_type.as_str(), kind.as_str()))
+            }
         })
         .collect::<Vec<_>>();
     let normalized_state_digest = digest_json(&(
@@ -491,7 +490,7 @@ pub async fn replay_engine_bytes(
     let clock =
         ManualConvergenceClock::new(replay.checkpoint_monotonic_ms, replay.checkpoint_wall_ms);
     let mut client = ClientBuilder::new(replay.identity_seed.clone())
-        .registry(crate::subject::scenario_registry())
+        .registry(crate::subject::engine_harness_feature_registry())
         .protocol_profile(replay.protocol_profile)
         .storage_mode(HarnessStorageMode::InMemorySqlite)
         .convergence_clock(Arc::new(clock))

--- a/crates/cgka-conformance-simulator/src/family.rs
+++ b/crates/cgka-conformance-simulator/src/family.rs
@@ -4,10 +4,10 @@
 //! to replay or promote a generated case into a fixed vector.
 
 use crate::{
-    CapturedTransportArtifactV1, FailureFingerprintV1, GeneratedScenarioMetadata,
-    HarnessStorageMode, ScenarioOutboundSelection, ScenarioReport, ScenarioRunError, ScenarioSpec,
-    ScenarioStep, ScenarioTrace, SubjectOutboundOutcome, TraceExpectation, VectorFixture,
-    fingerprint_report_failure, run_scenario_report_with_outcomes_and_capture,
+    GeneratedScenarioMetadata, HarnessStorageMode, ScenarioOutboundSelection, ScenarioReport,
+    ScenarioRunError, ScenarioSpec, ScenarioStep, ScenarioTrace, SubjectOutboundOutcome,
+    TraceExpectation, VectorFixture, fingerprint_report_failure,
+    run_scenario_report_with_outcomes_and_capture,
     run_scenario_report_with_outcomes_and_storage_mode,
 };
 use rand::rngs::StdRng;
@@ -118,8 +118,14 @@ pub async fn run_generated_case_report_with_storage_mode(
     expected_trace: Option<ScenarioTrace>,
     storage_mode: HarnessStorageMode,
 ) -> Result<ScenarioReport, ScenarioRunError> {
-    let (report, _) =
-        run_generated_case_report_with_capture(case, expected_trace, storage_mode).await?;
+    let mut report = run_scenario_report_with_outcomes_and_storage_mode(
+        &case.scenario,
+        expected_trace.clone(),
+        case.expected_outcomes.clone(),
+        storage_mode,
+    )
+    .await?;
+    add_generated_metadata(case, expected_trace.as_ref(), &mut report, storage_mode).await;
     Ok(report)
 }
 
@@ -129,16 +135,26 @@ pub async fn run_generated_case_report_with_capture(
     case: &GeneratedScenarioCase,
     expected_trace: Option<ScenarioTrace>,
     storage_mode: HarnessStorageMode,
-) -> Result<(ScenarioReport, Vec<CapturedTransportArtifactV1>), ScenarioRunError> {
-    let (mut report, captured_transport_artifacts) = run_scenario_report_with_outcomes_and_capture(
+) -> Result<(ScenarioReport, crate::ScenarioFailureCaptureV1), ScenarioRunError> {
+    let (mut report, failure_capture) = run_scenario_report_with_outcomes_and_capture(
         &case.scenario,
         expected_trace.clone(),
         case.expected_outcomes.clone(),
         storage_mode,
     )
     .await?;
-    let minimized_case = if fingerprint_report_failure(&report).is_ok() {
-        minimize_failing_case(case, expected_trace.as_ref(), &report, storage_mode).await
+    add_generated_metadata(case, expected_trace.as_ref(), &mut report, storage_mode).await;
+    Ok((report, failure_capture))
+}
+
+async fn add_generated_metadata(
+    case: &GeneratedScenarioCase,
+    expected_trace: Option<&ScenarioTrace>,
+    report: &mut ScenarioReport,
+    storage_mode: HarnessStorageMode,
+) {
+    let minimized_case = if fingerprint_report_failure(report).is_ok() {
+        minimize_failing_case(case, expected_trace, report, storage_mode).await
     } else {
         None
     };
@@ -149,7 +165,6 @@ pub async fn run_generated_case_report_with_capture(
         case_index: case.case_index,
         minimized_case,
     });
-    Ok((report, captured_transport_artifacts))
 }
 
 async fn minimize_failing_case(
@@ -158,7 +173,9 @@ async fn minimize_failing_case(
     failing_report: &ScenarioReport,
     storage_mode: HarnessStorageMode,
 ) -> Option<ScenarioSpec> {
-    let target_fingerprint = fingerprint_report_failure(failing_report).ok()?;
+    let target_identity = fingerprint_report_failure(failing_report)
+        .ok()?
+        .semantic_identity();
 
     let mut candidate = case.scenario.clone();
     let mut changed = false;
@@ -175,7 +192,7 @@ async fn minimize_failing_case(
             &trial,
             expected_trace.cloned(),
             case.expected_outcomes.clone(),
-            &target_fingerprint,
+            &target_identity,
             storage_mode,
         )
         .await
@@ -194,7 +211,7 @@ async fn reproduces_failure(
     scenario: &ScenarioSpec,
     expected_trace: Option<ScenarioTrace>,
     expected_outcomes: Vec<TraceExpectation>,
-    target_fingerprint: &FailureFingerprintV1,
+    target_identity: &crate::FailureIdentityV1,
     storage_mode: HarnessStorageMode,
 ) -> bool {
     match run_scenario_report_with_outcomes_and_storage_mode(
@@ -206,7 +223,7 @@ async fn reproduces_failure(
     .await
     {
         Ok(report) => fingerprint_report_failure(&report)
-            .is_ok_and(|fingerprint| fingerprint == *target_fingerprint),
+            .is_ok_and(|fingerprint| fingerprint.semantic_identity() == *target_identity),
         Err(_) => false,
     }
 }

--- a/crates/cgka-conformance-simulator/src/family.rs
+++ b/crates/cgka-conformance-simulator/src/family.rs
@@ -4,9 +4,11 @@
 //! to replay or promote a generated case into a fixed vector.
 
 use crate::{
-    GeneratedScenarioMetadata, HarnessStorageMode, ScenarioOutboundSelection, ScenarioReport,
-    ScenarioRunError, ScenarioSpec, ScenarioStep, ScenarioTrace, SubjectOutboundOutcome,
-    TraceExpectation, VectorFixture, run_scenario_report_with_outcomes_and_storage_mode,
+    CapturedTransportArtifactV1, FailureFingerprintV1, GeneratedScenarioMetadata,
+    HarnessStorageMode, ScenarioOutboundSelection, ScenarioReport, ScenarioRunError, ScenarioSpec,
+    ScenarioStep, ScenarioTrace, SubjectOutboundOutcome, TraceExpectation, VectorFixture,
+    fingerprint_report_failure, run_scenario_report_with_outcomes_and_capture,
+    run_scenario_report_with_outcomes_and_storage_mode,
 };
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
@@ -89,7 +91,7 @@ pub fn generate_convergence_chaos_family(seed: u64, cases: usize) -> Vec<Generat
         add_strict_reliability_oracle(&mut scenario, &mut expected_outcomes);
         out.push(GeneratedScenarioCase {
             family_name: "convergence-chaos/v1".into(),
-            generator_version: "5".into(),
+            generator_version: "6".into(),
             seed,
             case_index: case_index as u64,
             scenario,
@@ -116,17 +118,29 @@ pub async fn run_generated_case_report_with_storage_mode(
     expected_trace: Option<ScenarioTrace>,
     storage_mode: HarnessStorageMode,
 ) -> Result<ScenarioReport, ScenarioRunError> {
-    let mut report = run_scenario_report_with_outcomes_and_storage_mode(
+    let (report, _) =
+        run_generated_case_report_with_capture(case, expected_trace, storage_mode).await?;
+    Ok(report)
+}
+
+/// Generated-case runner that retains exact wire artifacts for a failure
+/// capsule while keeping the ordinary report API unchanged.
+pub async fn run_generated_case_report_with_capture(
+    case: &GeneratedScenarioCase,
+    expected_trace: Option<ScenarioTrace>,
+    storage_mode: HarnessStorageMode,
+) -> Result<(ScenarioReport, Vec<CapturedTransportArtifactV1>), ScenarioRunError> {
+    let (mut report, captured_transport_artifacts) = run_scenario_report_with_outcomes_and_capture(
         &case.scenario,
         expected_trace.clone(),
         case.expected_outcomes.clone(),
         storage_mode,
     )
     .await?;
-    let minimized_case = if report.expectation_failures.is_empty() {
-        None
-    } else {
+    let minimized_case = if fingerprint_report_failure(&report).is_ok() {
         minimize_failing_case(case, expected_trace.as_ref(), &report, storage_mode).await
+    } else {
+        None
     };
     report.metadata.generated = Some(GeneratedScenarioMetadata {
         family_name: case.family_name.clone(),
@@ -135,7 +149,7 @@ pub async fn run_generated_case_report_with_storage_mode(
         case_index: case.case_index,
         minimized_case,
     });
-    Ok(report)
+    Ok((report, captured_transport_artifacts))
 }
 
 async fn minimize_failing_case(
@@ -144,10 +158,7 @@ async fn minimize_failing_case(
     failing_report: &ScenarioReport,
     storage_mode: HarnessStorageMode,
 ) -> Option<ScenarioSpec> {
-    let target_failures = failure_kinds(failing_report);
-    if target_failures.is_empty() {
-        return None;
-    }
+    let target_fingerprint = fingerprint_report_failure(failing_report).ok()?;
 
     let mut candidate = case.scenario.clone();
     let mut changed = false;
@@ -164,7 +175,7 @@ async fn minimize_failing_case(
             &trial,
             expected_trace.cloned(),
             case.expected_outcomes.clone(),
-            &target_failures,
+            &target_fingerprint,
             storage_mode,
         )
         .await
@@ -183,7 +194,7 @@ async fn reproduces_failure(
     scenario: &ScenarioSpec,
     expected_trace: Option<ScenarioTrace>,
     expected_outcomes: Vec<TraceExpectation>,
-    target_failures: &BTreeSet<String>,
+    target_fingerprint: &FailureFingerprintV1,
     storage_mode: HarnessStorageMode,
 ) -> bool {
     match run_scenario_report_with_outcomes_and_storage_mode(
@@ -194,17 +205,10 @@ async fn reproduces_failure(
     )
     .await
     {
-        Ok(report) => target_failures.is_subset(&failure_kinds(&report)),
+        Ok(report) => fingerprint_report_failure(&report)
+            .is_ok_and(|fingerprint| fingerprint == *target_fingerprint),
         Err(_) => false,
     }
-}
-
-fn failure_kinds(report: &ScenarioReport) -> BTreeSet<String> {
-    report
-        .expectation_failures
-        .iter()
-        .map(|failure| failure.kind.clone())
-        .collect()
 }
 
 fn is_minimizer_removable(step: &ScenarioStep) -> bool {
@@ -735,27 +739,30 @@ fn convergence_chaos_large_mixed_message_commit_storm(
     let invitees = clients[1..].to_vec();
     let senders = clients[1..].to_vec();
     let committers = clients[..8].to_vec();
+    let sender_payloads = senders
+        .iter()
+        .map(|sender| (sender.clone(), format!("{sender}:mixed-storm:{case_index}")))
+        .collect::<Vec<_>>();
     let mut steps = large_group_setup(
         format!("large-mixed-message-commit-storm-{case_index}"),
         clients.clone(),
         invitees,
     );
 
-    for sender in &senders {
+    for (sender, payload) in &sender_payloads {
         steps.push(ScenarioStep::SendAppMessage {
             sender: sender.clone(),
-            payload: format!("{sender}:mixed-storm:{case_index}"),
+            payload: payload.clone(),
         });
     }
-    // Vary the message-phase schedule from the seed. These events are cleared
-    // before the observed commit storm, so the schedule changes engine input
-    // ordering without affecting the pinned expectations.
+    // Vary the message-phase schedule from the seed and preserve those events
+    // through the commit storm so the oracle checks both workload phases.
+    let message_order = shuffled_order(rng, senders.len());
     steps.push(ScenarioStep::ReorderQueued {
-        order: shuffled_order(rng, senders.len()),
+        order: message_order.clone(),
     });
     steps.push(ScenarioStep::DeliverAll);
     steps.push(tick_vec(clients.clone()));
-    steps.push(clear_vec(clients.clone()));
 
     for committer in &committers {
         steps.push(ScenarioStep::UpdateGroupData {
@@ -794,10 +801,18 @@ fn convergence_chaos_large_mixed_message_commit_storm(
     ];
     for (offset, committer) in committers.iter().enumerate() {
         expected.push(confirmed(
-            37 + offset,
+            36 + offset,
             committer,
             &format!("{committer}-mixed-update"),
         ));
+        let received_payloads = message_order
+            .iter()
+            .filter_map(|index| {
+                let (sender, payload) = &sender_payloads[*index];
+                (sender != committer).then(|| payload.clone())
+            })
+            .collect();
+        expected.push(client_state(committer, 2, 21, received_payloads));
     }
     (scenario, expected)
 }

--- a/crates/cgka-conformance-simulator/src/family.rs
+++ b/crates/cgka-conformance-simulator/src/family.rs
@@ -135,12 +135,14 @@ pub async fn run_generated_case_report_with_capture(
     case: &GeneratedScenarioCase,
     expected_trace: Option<ScenarioTrace>,
     storage_mode: HarnessStorageMode,
+    capture_sensitive_replay: bool,
 ) -> Result<(ScenarioReport, crate::ScenarioFailureCaptureV1), ScenarioRunError> {
     let (mut report, failure_capture) = run_scenario_report_with_outcomes_and_capture(
         &case.scenario,
         expected_trace.clone(),
         case.expected_outcomes.clone(),
         storage_mode,
+        capture_sensitive_replay,
     )
     .await?;
     add_generated_metadata(case, expected_trace.as_ref(), &mut report, storage_mode).await;

--- a/crates/cgka-conformance-simulator/src/lib.rs
+++ b/crates/cgka-conformance-simulator/src/lib.rs
@@ -100,7 +100,8 @@ pub use subject::{
     ConvergenceFaultSubject, ConvergenceSubject, EngineHarnessSubject, SubjectCapability,
     SubjectCreateGroup, SubjectDescriptor, SubjectError, SubjectInviteMembers,
     SubjectOutboundArtifact, SubjectOutboundKind, SubjectOutboundOutcome, SubjectSendApplication,
-    SubjectUpdateAdminPolicy, SubjectUpdateGroupData, required_capabilities,
+    SubjectUpdateAdminPolicy, SubjectUpdateGroupData, engine_harness_feature_registry,
+    required_capabilities,
 };
 pub use vector::{
     AppInvalidationObservation, ApplicationProfileContract, ClientEventCounts, ClientObservation,

--- a/crates/cgka-conformance-simulator/src/lib.rs
+++ b/crates/cgka-conformance-simulator/src/lib.rs
@@ -51,12 +51,15 @@ pub use decryptability::{
     DirectionalDecryptabilityProbe,
 };
 pub use failure_capsule::{
-    CapsulePolicySnapshotV1, CapturedTransportArtifactV1, EngineByteReplayObservationV1,
-    EngineByteReplayV1, ExpandedScenarioActionV1, FAILURE_CAPSULE_SCHEMA_VERSION,
-    FAILURE_FINGERPRINT_VERSION, FailureCapsuleError, FailureCapsuleSensitivity, FailureCapsuleV1,
-    FailureFingerprintV1, ResourceObservationV1, TerminalOutcomeClassification, build_fingerprint,
-    digest_json, fingerprint_report_failure, promote_failure_capsule_to_vector,
-    read_failure_capsule, replay_engine_bytes, write_failure_capsule,
+    CapsulePolicySnapshotV1, CapturedTransportArtifactV1, CapturedTransportWindowV1,
+    EngineByteReplayObservationV1, EngineByteReplayV1, ExpandedScenarioActionV1,
+    FAILURE_CAPSULE_SCHEMA_VERSION, FAILURE_FINGERPRINT_VERSION, FailureCapsuleError,
+    FailureCapsuleSensitivity, FailureCapsuleV1, FailureFingerprintV1, FailureIdentityV1,
+    MAX_CAPTURED_REPLAY_CHECKPOINT_BYTES, MAX_CAPTURED_TRANSPORT_JSON_BYTES,
+    MAX_CAPTURED_TRANSPORT_OBJECTS, ResourceObservationV1, ScenarioFailureCaptureV1,
+    TerminalOutcomeClassification, build_fingerprint, digest_json, fingerprint_report_failure,
+    promote_failure_capsule_to_vector, read_failure_capsule, replay_engine_bytes,
+    write_failure_capsule,
 };
 pub use family::{
     GeneratedScenarioCase, generate_convergence_chaos_family,
@@ -98,10 +101,10 @@ pub use scenario_input_ledger::{
 };
 pub use subject::{
     ConvergenceFaultSubject, ConvergenceSubject, EngineHarnessSubject, SubjectCapability,
-    SubjectCreateGroup, SubjectDescriptor, SubjectError, SubjectInviteMembers,
-    SubjectOutboundArtifact, SubjectOutboundKind, SubjectOutboundOutcome, SubjectSendApplication,
-    SubjectUpdateAdminPolicy, SubjectUpdateGroupData, engine_harness_feature_registry,
-    required_capabilities,
+    SubjectCreateGroup, SubjectDescriptor, SubjectError, SubjectFailureCategory,
+    SubjectInviteMembers, SubjectOutboundArtifact, SubjectOutboundKind, SubjectOutboundOutcome,
+    SubjectSendApplication, SubjectUpdateAdminPolicy, SubjectUpdateGroupData,
+    engine_harness_feature_registry, required_capabilities,
 };
 pub use vector::{
     AppInvalidationObservation, ApplicationProfileContract, ClientEventCounts, ClientObservation,

--- a/crates/cgka-conformance-simulator/src/lib.rs
+++ b/crates/cgka-conformance-simulator/src/lib.rs
@@ -24,6 +24,7 @@ mod audit_capture;
 pub mod bus;
 pub mod client;
 mod decryptability;
+mod failure_capsule;
 pub mod family;
 pub mod oracle;
 mod pending_work;
@@ -38,10 +39,10 @@ pub mod vector;
 
 pub use bus::{ClientId, DeliveryPolicy, TransportBus};
 pub use cgka_engine::conformance_snapshot::{
-    ConformanceAppComponent, ConformanceCanonicalStateSnapshot, ConformanceDisbandedGroupSnapshot,
-    ConformanceGroupSnapshot, ConformanceLeafCapabilities, ConformanceLeafSnapshot,
-    ConformancePendingWorkSnapshot, ConformanceRequiredCapabilities,
-    ConformanceStructuralProgressSnapshot,
+    ConformanceAppComponent, ConformanceCanonicalStateSnapshot, ConformanceConstantSnapshot,
+    ConformanceDisbandedGroupSnapshot, ConformanceGroupSnapshot, ConformanceLeafCapabilities,
+    ConformanceLeafSnapshot, ConformancePendingWorkSnapshot, ConformanceRequiredCapabilities,
+    ConformanceStructuralProgressSnapshot, conformance_constant_snapshot,
 };
 pub use cgka_engine::{canonicalization, convergence, openmls_projection};
 pub use client::{ClientBuilder, HarnessClient, HarnessStorageMode};
@@ -49,10 +50,19 @@ pub use decryptability::{
     BidirectionalDecryptabilityObservation, DecryptabilityProbeSendStatus,
     DirectionalDecryptabilityProbe,
 };
+pub use failure_capsule::{
+    CapsulePolicySnapshotV1, CapturedTransportArtifactV1, EngineByteReplayObservationV1,
+    EngineByteReplayV1, ExpandedScenarioActionV1, FAILURE_CAPSULE_SCHEMA_VERSION,
+    FAILURE_FINGERPRINT_VERSION, FailureCapsuleError, FailureCapsuleSensitivity, FailureCapsuleV1,
+    FailureFingerprintV1, ResourceObservationV1, TerminalOutcomeClassification, build_fingerprint,
+    digest_json, fingerprint_report_failure, promote_failure_capsule_to_vector,
+    read_failure_capsule, replay_engine_bytes, write_failure_capsule,
+};
 pub use family::{
     GeneratedScenarioCase, generate_convergence_chaos_family,
     generate_convergence_e2e_delivery_family, generate_send_leave_family,
-    run_generated_case_report, run_generated_case_report_with_storage_mode,
+    run_generated_case_report, run_generated_case_report_with_capture,
+    run_generated_case_report_with_storage_mode,
 };
 pub use oracle::{
     BehaviorEvidenceSummary, CoverageMatrixEntry, OracleBehavior, OracleCoverageWarning,
@@ -77,10 +87,11 @@ pub use scenario::{
     InvariantFailure, ScenarioOutboundSelection, ScenarioReport, ScenarioReportMetadata,
     ScenarioRunError, ScenarioSpec, ScenarioStep, ScenarioStepLogEntry, ScenarioStepStatus,
     VectorFixtureMetadata, run_scenario_report, run_scenario_report_with_outcomes,
+    run_scenario_report_with_outcomes_and_capture,
     run_scenario_report_with_outcomes_and_storage_mode, run_scenario_report_with_storage_mode,
     run_scenario_report_with_subject, run_scenario_spec, run_scenario_spec_with_subject,
-    run_vector_fixture_report, run_vector_fixture_report_with_storage_mode,
-    validate_scenario_for_subject,
+    run_vector_fixture_report, run_vector_fixture_report_with_capture,
+    run_vector_fixture_report_with_storage_mode, validate_scenario_for_subject,
 };
 pub use scenario_input_ledger::{
     ScenarioInputDisposition, ScenarioInputKind, ScenarioInputLedgerEntry,

--- a/crates/cgka-conformance-simulator/src/report.rs
+++ b/crates/cgka-conformance-simulator/src/report.rs
@@ -123,7 +123,7 @@ fn scenario_report_failures(
         .iter()
         .filter_map(|step| match &step.status {
             crate::ScenarioStepStatus::Completed => None,
-            crate::ScenarioStepStatus::Failed { kind, message } => Some(ReportFailureSummary {
+            crate::ScenarioStepStatus::Failed { kind, message, .. } => Some(ReportFailureSummary {
                 kind: format!("scenario_step_failed:{kind}"),
                 message: format!("step {} ({}): {message}", step.step_index, step.step_type),
             }),
@@ -228,7 +228,7 @@ async fn run_generated_family_reports(
 
     let mut summaries = Vec::with_capacity(cases.len());
     for case in cases {
-        let (report, captured_transport_artifacts) =
+        let (report, failure_capture) =
             run_generated_case_report_with_capture(&case, None, storage_mode).await?;
         let output = out.join(format!(
             "{}-seed-{}-case-{}.json",
@@ -258,9 +258,9 @@ async fn run_generated_family_reports(
                 case.seed,
                 case.case_index
             ));
-            Some(write_synthetic_failure_capsule(
+            Some(write_report_failure_capsule(
                 &report,
-                captured_transport_artifacts,
+                failure_capture_for(&failures, failure_capture),
                 path,
             )?)
         };
@@ -312,7 +312,7 @@ async fn run_vector_fixture_reports(
     let mut summaries = Vec::with_capacity(fixture_paths.len());
     for path in fixture_paths {
         let fixture: VectorFixture = serde_json::from_str(&std::fs::read_to_string(&path)?)?;
-        let (report, captured_transport_artifacts) =
+        let (report, failure_capture) =
             run_vector_fixture_report_with_capture(&fixture, storage_mode).await?;
         let output = out.join(format!(
             "{}-report.json",
@@ -330,9 +330,9 @@ async fn run_vector_fixture_reports(
                 "{}-failure-capsule.v1.json",
                 fixture.scenario_name.replace('/', "-")
             ));
-            Some(write_synthetic_failure_capsule(
+            Some(write_report_failure_capsule(
                 &report,
-                captured_transport_artifacts,
+                failure_capture_for(&failures, failure_capture),
                 path,
             )?)
         };
@@ -351,16 +351,35 @@ async fn run_vector_fixture_reports(
     Ok(summaries)
 }
 
-fn write_synthetic_failure_capsule(
+fn failure_capture_for(
+    failures: &[ReportFailureSummary],
+    capture: crate::ScenarioFailureCaptureV1,
+) -> crate::ScenarioFailureCaptureV1 {
+    if failures
+        .iter()
+        .all(|failure| failure.kind == "weak_oracle_warning")
+    {
+        crate::ScenarioFailureCaptureV1::default()
+    } else {
+        capture
+    }
+}
+
+fn write_report_failure_capsule(
     report: &ScenarioReport,
-    captured_transport_artifacts: Vec<crate::CapturedTransportArtifactV1>,
+    capture: crate::ScenarioFailureCaptureV1,
     path: PathBuf,
 ) -> Result<PathBuf, Box<dyn Error>> {
-    let capsule = FailureCapsuleV1::from_report(
+    let sensitivity = if capture.byte_replay.is_some() {
+        FailureCapsuleSensitivity::SensitiveLocal
+    } else {
+        FailureCapsuleSensitivity::SyntheticShareable
+    };
+    let capsule = FailureCapsuleV1::from_report_capture(
         report.clone(),
-        FailureCapsuleSensitivity::SyntheticShareable,
-        captured_transport_artifacts,
-        None,
+        sensitivity,
+        capture.transport,
+        capture.byte_replay,
     )?;
     write_failure_capsule(&path, &capsule)?;
     Ok(path)
@@ -601,6 +620,7 @@ mod tests {
             step_type: "tick".into(),
             status: crate::ScenarioStepStatus::Failed {
                 kind: "backend".into(),
+                category: crate::SubjectFailureCategory::Resource,
                 message: "convergence replay budget exceeded".into(),
             },
         });

--- a/crates/cgka-conformance-simulator/src/report.rs
+++ b/crates/cgka-conformance-simulator/src/report.rs
@@ -15,6 +15,8 @@ pub struct ReportArgs {
     pub out: PathBuf,
     pub strict_oracle: bool,
     pub storage_mode: HarnessStorageMode,
+    /// Explicit opt-in because replay checkpoints contain MLS key material.
+    pub capture_sensitive_replay: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -90,6 +92,9 @@ impl ReportRunSummary {
             if let Some(capsule) = &scenario.failure_capsule {
                 lines.push(format!("  capsule: {}", capsule.display()));
             }
+            if let Some(capsule) = &scenario.replay_capsule {
+                lines.push(format!("  sensitive replay: {}", capsule.display()));
+            }
         }
         lines.push(format!("Reports: {}", self.out.display()));
         lines.join("\n")
@@ -102,6 +107,7 @@ pub struct ScenarioReportSummary {
     pub source: String,
     pub output: PathBuf,
     pub failure_capsule: Option<PathBuf>,
+    pub replay_capsule: Option<PathBuf>,
     pub expectation_count: usize,
     pub failure_count: usize,
     pub failures: Vec<ReportFailureSummary>,
@@ -190,12 +196,19 @@ pub async fn run_report(args: &ReportArgs) -> Result<ReportRunSummary, Box<dyn E
                 &args.out,
                 args.strict_oracle,
                 args.storage_mode,
+                args.capture_sensitive_replay,
             )
             .await?
         }
         ReportInput::VectorFixtures { paths } => {
-            run_vector_fixture_reports(paths, &args.out, args.strict_oracle, args.storage_mode)
-                .await?
+            run_vector_fixture_reports(
+                paths,
+                &args.out,
+                args.strict_oracle,
+                args.storage_mode,
+                args.capture_sensitive_replay,
+            )
+            .await?
         }
     };
 
@@ -218,6 +231,7 @@ async fn run_generated_family_reports(
     out: &Path,
     strict_oracle: bool,
     storage_mode: HarnessStorageMode,
+    capture_sensitive_replay: bool,
 ) -> Result<Vec<ScenarioReportSummary>, Box<dyn Error>> {
     let cases = match family {
         "send-leave/v1" => generate_send_leave_family(seed, cases),
@@ -228,8 +242,13 @@ async fn run_generated_family_reports(
 
     let mut summaries = Vec::with_capacity(cases.len());
     for case in cases {
-        let (report, failure_capture) =
-            run_generated_case_report_with_capture(&case, None, storage_mode).await?;
+        let (report, failure_capture) = run_generated_case_report_with_capture(
+            &case,
+            None,
+            storage_mode,
+            capture_sensitive_replay,
+        )
+        .await?;
         let output = out.join(format!(
             "{}-seed-{}-case-{}.json",
             case.family_name.replace('/', "-"),
@@ -249,26 +268,34 @@ async fn run_generated_family_reports(
         let coverage = coverage_matrix_entry(source.clone(), &report);
         let failures = scenario_report_failures(&report, strict_oracle);
         let failure_count = failures.len();
-        let failure_capsule = if failures.is_empty() {
-            None
+        let failure_capsules = if failures.is_empty() {
+            WrittenFailureCapsules::default()
         } else {
-            let path = out.join(format!(
+            let portable_path = out.join(format!(
                 "{}-seed-{}-case-{}-failure-capsule.v1.json",
                 case.family_name.replace('/', "-"),
                 case.seed,
                 case.case_index
             ));
-            Some(write_report_failure_capsule(
+            let replay_path = out.join(format!(
+                "{}-seed-{}-case-{}-sensitive-replay-capsule.v1.json",
+                case.family_name.replace('/', "-"),
+                case.seed,
+                case.case_index
+            ));
+            write_report_failure_capsules(
                 &report,
                 failure_capture_for(&failures, failure_capture),
-                path,
-            )?)
+                portable_path,
+                replay_path,
+            )?
         };
         summaries.push(ScenarioReportSummary {
             scenario_name: report.metadata.scenario_name.clone(),
             source,
             output,
-            failure_capsule,
+            failure_capsule: failure_capsules.portable,
+            replay_capsule: failure_capsules.replay,
             expectation_count: report.expected_trace.iter().count()
                 + report.expected_outcomes.len(),
             failure_count,
@@ -307,13 +334,18 @@ async fn run_vector_fixture_reports(
     out: &Path,
     strict_oracle: bool,
     storage_mode: HarnessStorageMode,
+    capture_sensitive_replay: bool,
 ) -> Result<Vec<ScenarioReportSummary>, Box<dyn Error>> {
     let fixture_paths = collect_vector_fixture_paths(paths)?;
     let mut summaries = Vec::with_capacity(fixture_paths.len());
     for path in fixture_paths {
         let fixture: VectorFixture = serde_json::from_str(&std::fs::read_to_string(&path)?)?;
-        let (report, failure_capture) =
-            run_vector_fixture_report_with_capture(&fixture, storage_mode).await?;
+        let (report, failure_capture) = run_vector_fixture_report_with_capture(
+            &fixture,
+            storage_mode,
+            capture_sensitive_replay,
+        )
+        .await?;
         let output = out.join(format!(
             "{}-report.json",
             fixture.scenario_name.replace('/', "-")
@@ -323,24 +355,30 @@ async fn run_vector_fixture_reports(
         let coverage = coverage_matrix_entry(source.clone(), &report);
         let failures = scenario_report_failures(&report, strict_oracle);
         let failure_count = failures.len();
-        let failure_capsule = if failures.is_empty() {
-            None
+        let failure_capsules = if failures.is_empty() {
+            WrittenFailureCapsules::default()
         } else {
-            let path = out.join(format!(
+            let portable_path = out.join(format!(
                 "{}-failure-capsule.v1.json",
                 fixture.scenario_name.replace('/', "-")
             ));
-            Some(write_report_failure_capsule(
+            let replay_path = out.join(format!(
+                "{}-sensitive-replay-capsule.v1.json",
+                fixture.scenario_name.replace('/', "-")
+            ));
+            write_report_failure_capsules(
                 &report,
                 failure_capture_for(&failures, failure_capture),
-                path,
-            )?)
+                portable_path,
+                replay_path,
+            )?
         };
         summaries.push(ScenarioReportSummary {
             scenario_name: fixture.scenario_name.clone(),
             source,
             output,
-            failure_capsule,
+            failure_capsule: failure_capsules.portable,
+            replay_capsule: failure_capsules.replay,
             expectation_count: fixture.expected_trace.iter().count()
                 + fixture.expected_outcomes.len(),
             failure_count,
@@ -365,24 +403,43 @@ fn failure_capture_for(
     }
 }
 
-fn write_report_failure_capsule(
+#[derive(Default)]
+struct WrittenFailureCapsules {
+    portable: Option<PathBuf>,
+    replay: Option<PathBuf>,
+}
+
+fn write_report_failure_capsules(
     report: &ScenarioReport,
     capture: crate::ScenarioFailureCaptureV1,
-    path: PathBuf,
-) -> Result<PathBuf, Box<dyn Error>> {
-    let sensitivity = if capture.byte_replay.is_some() {
-        FailureCapsuleSensitivity::SensitiveLocal
-    } else {
-        FailureCapsuleSensitivity::SyntheticShareable
-    };
-    let capsule = FailureCapsuleV1::from_report_capture(
+    portable_path: PathBuf,
+    replay_path: PathBuf,
+) -> Result<WrittenFailureCapsules, Box<dyn Error>> {
+    let portable_capsule = FailureCapsuleV1::from_report_capture(
         report.clone(),
-        sensitivity,
+        FailureCapsuleSensitivity::SyntheticShareable,
         capture.transport,
-        capture.byte_replay,
+        None,
     )?;
-    write_failure_capsule(&path, &capsule)?;
-    Ok(path)
+    write_failure_capsule(&portable_path, &portable_capsule)?;
+
+    let replay = if let Some(byte_replay) = capture.byte_replay {
+        let replay_capsule = FailureCapsuleV1::from_report(
+            report.clone(),
+            FailureCapsuleSensitivity::SensitiveLocal,
+            Vec::new(),
+            Some(byte_replay),
+        )?;
+        write_failure_capsule(&replay_path, &replay_capsule)?;
+        Some(replay_path)
+    } else {
+        None
+    };
+
+    Ok(WrittenFailureCapsules {
+        portable: Some(portable_path),
+        replay,
+    })
 }
 
 fn collect_vector_fixture_paths(paths: &[PathBuf]) -> Result<Vec<PathBuf>, Box<dyn Error>> {
@@ -454,6 +511,7 @@ pub fn parse_report_command(
     let mut strict_oracle = true;
     let mut storage_mode = None;
     let mut replay_capsule = None;
+    let mut capture_sensitive_replay = false;
     let mut scenario_input_selected = false;
 
     let mut args = args.into_iter();
@@ -478,6 +536,7 @@ pub fn parse_report_command(
             "--replay-capsule" => {
                 replay_capsule = Some(PathBuf::from(next_value(&mut args, "--replay-capsule")?));
             }
+            "--capture-sensitive-replay" => capture_sensitive_replay = true,
             "--out" => out = PathBuf::from(next_value(&mut args, "--out")?),
             "--storage" => {
                 storage_mode = Some(HarnessStorageMode::parse(&next_value(
@@ -493,8 +552,10 @@ pub fn parse_report_command(
     }
 
     if let Some(path) = replay_capsule {
-        if scenario_input_selected {
-            return Err("--replay-capsule cannot be combined with family/vector inputs".into());
+        if scenario_input_selected || capture_sensitive_replay {
+            return Err(
+                "--replay-capsule cannot be combined with scenario or capture inputs".into(),
+            );
         }
         return Ok(ReportCommand::ReplayCapsule(path));
     }
@@ -514,6 +575,7 @@ pub fn parse_report_command(
         out,
         strict_oracle,
         storage_mode: storage_mode.unwrap_or_else(HarnessStorageMode::from_env),
+        capture_sensitive_replay,
     }))
 }
 
@@ -526,7 +588,7 @@ fn next_value(
 }
 
 pub fn report_usage() -> &'static str {
-    "Usage: cgka-conformance-simulator-report [--replay-capsule FILE | --vectors FILE_OR_DIR ... | --family send-leave/v1|convergence-e2e-delivery/v1|convergence-chaos/v1 --seed N --cases N] [--out DIR] [--storage memory|file] [--strict-oracle|--allow-weak-oracle]"
+    "Usage: cgka-conformance-simulator-report [--replay-capsule FILE | --vectors FILE_OR_DIR ... | --family send-leave/v1|convergence-e2e-delivery/v1|convergence-chaos/v1 --seed N --cases N] [--out DIR] [--storage memory|file] [--strict-oracle|--allow-weak-oracle] [--capture-sensitive-replay]"
 }
 
 #[cfg(test)]

--- a/crates/cgka-conformance-simulator/src/report.rs
+++ b/crates/cgka-conformance-simulator/src/report.rs
@@ -2,10 +2,11 @@ use std::error::Error;
 use std::path::{Path, PathBuf};
 
 use crate::{
-    CoverageMatrixEntry, GeneratedScenarioCase, HarnessStorageMode, ScenarioReport, VectorFixture,
-    coverage_matrix_entry, generate_convergence_chaos_family,
-    generate_convergence_e2e_delivery_family, generate_send_leave_family,
-    run_generated_case_report_with_storage_mode, run_vector_fixture_report_with_storage_mode,
+    CoverageMatrixEntry, FailureCapsuleSensitivity, FailureCapsuleV1, GeneratedScenarioCase,
+    HarnessStorageMode, ScenarioReport, VectorFixture, coverage_matrix_entry,
+    generate_convergence_chaos_family, generate_convergence_e2e_delivery_family,
+    generate_send_leave_family, run_generated_case_report_with_capture,
+    run_vector_fixture_report_with_capture, write_failure_capsule,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -31,6 +32,7 @@ pub enum ReportInput {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ReportCommand {
     Run(ReportArgs),
+    ReplayCapsule(PathBuf),
     Help,
 }
 
@@ -85,6 +87,9 @@ impl ReportRunSummary {
             for failure in &scenario.failures {
                 lines.push(format!("  - {}: {}", failure.kind, failure.message));
             }
+            if let Some(capsule) = &scenario.failure_capsule {
+                lines.push(format!("  capsule: {}", capsule.display()));
+            }
         }
         lines.push(format!("Reports: {}", self.out.display()));
         lines.join("\n")
@@ -96,6 +101,7 @@ pub struct ScenarioReportSummary {
     pub scenario_name: String,
     pub source: String,
     pub output: PathBuf,
+    pub failure_capsule: Option<PathBuf>,
     pub expectation_count: usize,
     pub failure_count: usize,
     pub failures: Vec<ReportFailureSummary>,
@@ -113,12 +119,24 @@ fn scenario_report_failures(
     strict_oracle: bool,
 ) -> Vec<ReportFailureSummary> {
     let mut failures = report
-        .expectation_failures
+        .step_log
         .iter()
-        .map(|failure| ReportFailureSummary {
-            kind: failure.kind.clone(),
-            message: failure.message.clone(),
+        .filter_map(|step| match &step.status {
+            crate::ScenarioStepStatus::Completed => None,
+            crate::ScenarioStepStatus::Failed { kind, message } => Some(ReportFailureSummary {
+                kind: format!("scenario_step_failed:{kind}"),
+                message: format!("step {} ({}): {message}", step.step_index, step.step_type),
+            }),
         })
+        .chain(
+            report
+                .expectation_failures
+                .iter()
+                .map(|failure| ReportFailureSummary {
+                    kind: failure.kind.clone(),
+                    message: failure.message.clone(),
+                }),
+        )
         .collect::<Vec<_>>();
 
     if !strict_oracle {
@@ -150,7 +168,14 @@ fn scenario_report_failures(
 }
 
 pub async fn run_report(args: &ReportArgs) -> Result<ReportRunSummary, Box<dyn Error>> {
-    std::fs::create_dir_all(&args.out)?;
+    #[cfg(unix)]
+    let _output_dir_guard = fs_private::prepare_directory_path(
+        &args.out,
+        fs_private::PRIVATE_DIR_MODE,
+        fs_private::ExistingDirectoryMode::Preserve,
+    )?;
+    #[cfg(not(unix))]
+    fs_private::create_dir_all_private(&args.out)?;
 
     let scenarios = match &args.input {
         ReportInput::GeneratedFamily {
@@ -203,7 +228,8 @@ async fn run_generated_family_reports(
 
     let mut summaries = Vec::with_capacity(cases.len());
     for case in cases {
-        let report = run_generated_case_report_with_storage_mode(&case, None, storage_mode).await?;
+        let (report, captured_transport_artifacts) =
+            run_generated_case_report_with_capture(&case, None, storage_mode).await?;
         let output = out.join(format!(
             "{}-seed-{}-case-{}.json",
             case.family_name.replace('/', "-"),
@@ -223,10 +249,29 @@ async fn run_generated_family_reports(
         let coverage = coverage_matrix_entry(source.clone(), &report);
         let failures = scenario_report_failures(&report, strict_oracle);
         let failure_count = failures.len();
+        let failure_capsule = if failures.is_empty() {
+            None
+        } else {
+            let path = out.join(format!(
+                "{}-seed-{}-case-{}-failure-capsule.v1.json",
+                case.family_name.replace('/', "-"),
+                case.seed,
+                case.case_index
+            ));
+            let capsule = FailureCapsuleV1::from_report(
+                report.clone(),
+                FailureCapsuleSensitivity::SyntheticShareable,
+                captured_transport_artifacts,
+                None,
+            )?;
+            write_failure_capsule(&path, &capsule)?;
+            Some(path)
+        };
         summaries.push(ScenarioReportSummary {
             scenario_name: report.metadata.scenario_name.clone(),
             source,
             output,
+            failure_capsule,
             expectation_count: report.expected_trace.iter().count()
                 + report.expected_outcomes.len(),
             failure_count,
@@ -270,7 +315,8 @@ async fn run_vector_fixture_reports(
     let mut summaries = Vec::with_capacity(fixture_paths.len());
     for path in fixture_paths {
         let fixture: VectorFixture = serde_json::from_str(&std::fs::read_to_string(&path)?)?;
-        let report = run_vector_fixture_report_with_storage_mode(&fixture, storage_mode).await?;
+        let (report, captured_transport_artifacts) =
+            run_vector_fixture_report_with_capture(&fixture, storage_mode).await?;
         let output = out.join(format!(
             "{}-report.json",
             fixture.scenario_name.replace('/', "-")
@@ -280,10 +326,27 @@ async fn run_vector_fixture_reports(
         let coverage = coverage_matrix_entry(source.clone(), &report);
         let failures = scenario_report_failures(&report, strict_oracle);
         let failure_count = failures.len();
+        let failure_capsule = if failures.is_empty() {
+            None
+        } else {
+            let path = out.join(format!(
+                "{}-failure-capsule.v1.json",
+                fixture.scenario_name.replace('/', "-")
+            ));
+            let capsule = FailureCapsuleV1::from_report(
+                report.clone(),
+                FailureCapsuleSensitivity::SyntheticShareable,
+                captured_transport_artifacts,
+                None,
+            )?;
+            write_failure_capsule(&path, &capsule)?;
+            Some(path)
+        };
         summaries.push(ScenarioReportSummary {
             scenario_name: fixture.scenario_name.clone(),
             source,
             output,
+            failure_capsule,
             expectation_count: fixture.expected_trace.iter().count()
                 + fixture.expected_outcomes.len(),
             failure_count,
@@ -362,14 +425,31 @@ pub fn parse_report_command(
     let mut out = PathBuf::from("target/cgka-conformance-simulator-reports");
     let mut strict_oracle = true;
     let mut storage_mode = None;
+    let mut replay_capsule = None;
+    let mut scenario_input_selected = false;
 
     let mut args = args.into_iter();
     while let Some(arg) = args.next() {
         match arg.as_str() {
-            "--family" => family = next_value(&mut args, "--family")?,
-            "--seed" => seed = next_value(&mut args, "--seed")?.parse()?,
-            "--cases" => cases = next_value(&mut args, "--cases")?.parse()?,
-            "--vectors" => vectors.push(PathBuf::from(next_value(&mut args, "--vectors")?)),
+            "--family" => {
+                scenario_input_selected = true;
+                family = next_value(&mut args, "--family")?;
+            }
+            "--seed" => {
+                scenario_input_selected = true;
+                seed = next_value(&mut args, "--seed")?.parse()?;
+            }
+            "--cases" => {
+                scenario_input_selected = true;
+                cases = next_value(&mut args, "--cases")?.parse()?;
+            }
+            "--vectors" => {
+                scenario_input_selected = true;
+                vectors.push(PathBuf::from(next_value(&mut args, "--vectors")?));
+            }
+            "--replay-capsule" => {
+                replay_capsule = Some(PathBuf::from(next_value(&mut args, "--replay-capsule")?));
+            }
             "--out" => out = PathBuf::from(next_value(&mut args, "--out")?),
             "--storage" => {
                 storage_mode = Some(HarnessStorageMode::parse(&next_value(
@@ -382,6 +462,13 @@ pub fn parse_report_command(
             "--help" | "-h" => return Ok(ReportCommand::Help),
             other => return Err(format!("unknown argument {other}").into()),
         }
+    }
+
+    if let Some(path) = replay_capsule {
+        if scenario_input_selected {
+            return Err("--replay-capsule cannot be combined with family/vector inputs".into());
+        }
+        return Ok(ReportCommand::ReplayCapsule(path));
     }
 
     let input = if vectors.is_empty() {
@@ -411,7 +498,7 @@ fn next_value(
 }
 
 pub fn report_usage() -> &'static str {
-    "Usage: cgka-conformance-simulator-report [--vectors FILE_OR_DIR ... | --family send-leave/v1|convergence-e2e-delivery/v1|convergence-chaos/v1 --seed N --cases N] [--out DIR] [--storage memory|file] [--strict-oracle|--allow-weak-oracle]"
+    "Usage: cgka-conformance-simulator-report [--replay-capsule FILE | --vectors FILE_OR_DIR ... | --family send-leave/v1|convergence-e2e-delivery/v1|convergence-chaos/v1 --seed N --cases N] [--out DIR] [--storage memory|file] [--strict-oracle|--allow-weak-oracle]"
 }
 
 #[cfg(test)]
@@ -488,5 +575,31 @@ mod tests {
                 .iter()
                 .any(|failure| failure.kind == "missing_observed_behavior")
         );
+    }
+
+    #[test]
+    fn scenario_report_failures_include_subject_step_failures() {
+        let mut report = report_with_oracle(ScenarioOracleReport {
+            stimuli: Vec::new(),
+            oracle_behaviors: Vec::new(),
+            observed_behaviors: Vec::new(),
+            missing_observed_behaviors: Vec::new(),
+            evidence: BehaviorEvidenceSummary::default(),
+            weak_oracle_warnings: Vec::new(),
+        });
+        report.step_log.push(crate::ScenarioStepLogEntry {
+            step_index: 4,
+            step_type: "tick".into(),
+            status: crate::ScenarioStepStatus::Failed {
+                kind: "backend".into(),
+                message: "convergence replay budget exceeded".into(),
+            },
+        });
+
+        let failures = scenario_report_failures(&report, false);
+
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].kind, "scenario_step_failed:backend");
+        assert!(failures[0].message.contains("replay budget exceeded"));
     }
 }

--- a/crates/cgka-conformance-simulator/src/report.rs
+++ b/crates/cgka-conformance-simulator/src/report.rs
@@ -258,14 +258,11 @@ async fn run_generated_family_reports(
                 case.seed,
                 case.case_index
             ));
-            let capsule = FailureCapsuleV1::from_report(
-                report.clone(),
-                FailureCapsuleSensitivity::SyntheticShareable,
+            Some(write_synthetic_failure_capsule(
+                &report,
                 captured_transport_artifacts,
-                None,
-            )?;
-            write_failure_capsule(&path, &capsule)?;
-            Some(path)
+                path,
+            )?)
         };
         summaries.push(ScenarioReportSummary {
             scenario_name: report.metadata.scenario_name.clone(),
@@ -333,14 +330,11 @@ async fn run_vector_fixture_reports(
                 "{}-failure-capsule.v1.json",
                 fixture.scenario_name.replace('/', "-")
             ));
-            let capsule = FailureCapsuleV1::from_report(
-                report.clone(),
-                FailureCapsuleSensitivity::SyntheticShareable,
+            Some(write_synthetic_failure_capsule(
+                &report,
                 captured_transport_artifacts,
-                None,
-            )?;
-            write_failure_capsule(&path, &capsule)?;
-            Some(path)
+                path,
+            )?)
         };
         summaries.push(ScenarioReportSummary {
             scenario_name: fixture.scenario_name.clone(),
@@ -355,6 +349,21 @@ async fn run_vector_fixture_reports(
         });
     }
     Ok(summaries)
+}
+
+fn write_synthetic_failure_capsule(
+    report: &ScenarioReport,
+    captured_transport_artifacts: Vec<crate::CapturedTransportArtifactV1>,
+    path: PathBuf,
+) -> Result<PathBuf, Box<dyn Error>> {
+    let capsule = FailureCapsuleV1::from_report(
+        report.clone(),
+        FailureCapsuleSensitivity::SyntheticShareable,
+        captured_transport_artifacts,
+        None,
+    )?;
+    write_failure_capsule(&path, &capsule)?;
+    Ok(path)
 }
 
 fn collect_vector_fixture_paths(paths: &[PathBuf]) -> Result<Vec<PathBuf>, Box<dyn Error>> {

--- a/crates/cgka-conformance-simulator/src/scenario.rs
+++ b/crates/cgka-conformance-simulator/src/scenario.rs
@@ -397,19 +397,22 @@ pub async fn run_scenario_report_with_outcomes_and_storage_mode(
     run_scenario_report_inner(spec, expected_trace, expected_outcomes, None, &mut subject).await
 }
 
-/// Run the in-process engine subject and retain a bounded exact-transport tail
-/// plus the latest bounded recipient-tick checkpoint. Callers must treat the
-/// checkpoint as sensitive even when campaigns use synthetic keys.
+/// Run the in-process engine subject and retain a bounded exact-transport tail.
+/// When explicitly requested, also capture the final planned recipient tick;
+/// callers must treat that checkpoint as sensitive even with synthetic keys.
 pub async fn run_scenario_report_with_outcomes_and_capture(
     spec: &ScenarioSpec,
     expected_trace: Option<ScenarioTrace>,
     expected_outcomes: Vec<TraceExpectation>,
     storage_mode: HarnessStorageMode,
+    capture_sensitive_replay: bool,
 ) -> Result<(ScenarioReport, crate::ScenarioFailureCaptureV1), ScenarioRunError> {
     let mut subject =
         EngineHarnessSubject::new(&spec.clients, ProtocolProfile::Legacy, storage_mode)
             .map_err(subject_setup_error)?;
-    subject.enable_failure_replay_capture();
+    if capture_sensitive_replay && let Some(recipient_tick) = final_planned_recipient_tick(spec) {
+        subject.capture_failure_replay_at_tick(recipient_tick);
+    }
     let report =
         run_scenario_report_inner(spec, expected_trace, expected_outcomes, None, &mut subject)
             .await?;
@@ -464,16 +467,21 @@ pub async fn run_vector_fixture_report_with_storage_mode(
 }
 
 /// Vector runner variant used by the report CLI when it must emit exact wire
-/// evidence alongside a failing report.
+/// evidence and, by explicit opt-in, a final recipient-tick checkpoint.
 pub async fn run_vector_fixture_report_with_capture(
     fixture: &VectorFixture,
     storage_mode: HarnessStorageMode,
+    capture_sensitive_replay: bool,
 ) -> Result<(ScenarioReport, crate::ScenarioFailureCaptureV1), ScenarioRunError> {
     let protocol_profile = fixture_protocol_profile(fixture)?;
     let mut subject =
         EngineHarnessSubject::new(&fixture.scenario.clients, protocol_profile, storage_mode)
             .map_err(subject_setup_error)?;
-    subject.enable_failure_replay_capture();
+    if capture_sensitive_replay
+        && let Some(recipient_tick) = final_planned_recipient_tick(&fixture.scenario)
+    {
+        subject.capture_failure_replay_at_tick(recipient_tick);
+    }
     let report = run_scenario_report_inner(
         &fixture.scenario,
         fixture.expected_trace.clone(),
@@ -494,6 +502,17 @@ pub async fn run_vector_fixture_report_with_capture(
             byte_replay: subject.byte_replay_capture(),
         },
     ))
+}
+
+fn final_planned_recipient_tick(spec: &ScenarioSpec) -> Option<usize> {
+    spec.steps
+        .iter()
+        .filter_map(|step| match step {
+            ScenarioStep::Tick { clients } => Some(clients.len()),
+            _ => None,
+        })
+        .sum::<usize>()
+        .checked_sub(1)
 }
 
 fn fixture_protocol_profile(fixture: &VectorFixture) -> Result<ProtocolProfile, ScenarioRunError> {
@@ -1620,6 +1639,26 @@ mod tests {
 
         assert_eq!(error.step_index, None);
         assert!(error.message.contains("unsupported ScenarioSpec version 1"));
+    }
+
+    #[test]
+    fn sensitive_replay_targets_only_the_final_planned_recipient_tick() {
+        let spec = ScenarioSpec {
+            name: "replay-target".to_owned(),
+            spec_version: "2".to_owned(),
+            clients: vec!["alice".to_owned(), "bob".to_owned()],
+            steps: vec![
+                ScenarioStep::Tick {
+                    clients: vec!["alice".to_owned()],
+                },
+                ScenarioStep::DeliverAll,
+                ScenarioStep::Tick {
+                    clients: vec!["alice".to_owned(), "bob".to_owned()],
+                },
+            ],
+        };
+
+        assert_eq!(final_planned_recipient_tick(&spec), Some(2));
     }
 
     #[tokio::test]

--- a/crates/cgka-conformance-simulator/src/scenario.rs
+++ b/crates/cgka-conformance-simulator/src/scenario.rs
@@ -5,13 +5,15 @@
 //! their observed trace to exact or semantic fixture expectations.
 
 use crate::{
-    ConvergenceFaultSubject, ConvergenceSubject, EngineHarnessSubject, ExpectationFailure,
-    HarnessStorageMode, PendingResolutionObservation, QuiescenceObservation, QuiescencePolicy,
-    ScenarioErrorObservation, ScenarioOracleReport, ScenarioTrace, SubjectCreateGroup,
-    SubjectDescriptor, SubjectError, SubjectInviteMembers, SubjectOutboundArtifact,
-    SubjectOutboundKind, SubjectOutboundOutcome, SubjectSendApplication, SubjectUpdateAdminPolicy,
-    SubjectUpdateGroupData, TraceExpectation, VectorFixture, build_scenario_oracle_report,
-    compare_trace_expectations, drive_subject_to_quiescence, required_capabilities,
+    BidirectionalDecryptabilityObservation, ClientObservation, ConvergenceFaultSubject,
+    ConvergenceSubject, EngineHarnessSubject, ExpectationFailure, HarnessStorageMode,
+    PendingResolutionObservation, QuiescenceObservation, QuiescencePolicy,
+    ScenarioAdminPolicyObservation, ScenarioErrorObservation, ScenarioOracleReport, ScenarioTrace,
+    SubjectCreateGroup, SubjectDescriptor, SubjectError, SubjectFailureCategory,
+    SubjectInviteMembers, SubjectOutboundArtifact, SubjectOutboundKind, SubjectOutboundOutcome,
+    SubjectSendApplication, SubjectUpdateAdminPolicy, SubjectUpdateGroupData, TraceExpectation,
+    VectorFixture, build_scenario_oracle_report, compare_trace_expectations,
+    drive_subject_to_quiescence, required_capabilities,
 };
 use cgka_traits::group::ProtocolProfile;
 use serde::{Deserialize, Serialize};
@@ -289,6 +291,8 @@ pub enum ScenarioStepStatus {
     Failed {
         #[serde(default = "default_step_failure_kind")]
         kind: String,
+        #[serde(default)]
+        category: SubjectFailureCategory,
         message: String,
     },
 }
@@ -313,6 +317,7 @@ pub struct InvariantFailure {
 pub struct ScenarioRunError {
     pub step_index: Option<usize>,
     pub kind: String,
+    pub category: SubjectFailureCategory,
     pub message: String,
 }
 
@@ -392,22 +397,29 @@ pub async fn run_scenario_report_with_outcomes_and_storage_mode(
     run_scenario_report_inner(spec, expected_trace, expected_outcomes, None, &mut subject).await
 }
 
-/// Run the in-process engine subject and retain the exact transport artifacts
-/// needed for a failure capsule. Callers must treat the returned artifacts as
-/// potentially sensitive even though synthetic campaigns use synthetic keys.
+/// Run the in-process engine subject and retain a bounded exact-transport tail
+/// plus the latest bounded recipient-tick checkpoint. Callers must treat the
+/// checkpoint as sensitive even when campaigns use synthetic keys.
 pub async fn run_scenario_report_with_outcomes_and_capture(
     spec: &ScenarioSpec,
     expected_trace: Option<ScenarioTrace>,
     expected_outcomes: Vec<TraceExpectation>,
     storage_mode: HarnessStorageMode,
-) -> Result<(ScenarioReport, Vec<crate::CapturedTransportArtifactV1>), ScenarioRunError> {
+) -> Result<(ScenarioReport, crate::ScenarioFailureCaptureV1), ScenarioRunError> {
     let mut subject =
         EngineHarnessSubject::new(&spec.clients, ProtocolProfile::Legacy, storage_mode)
             .map_err(subject_setup_error)?;
+    subject.enable_failure_replay_capture();
     let report =
         run_scenario_report_inner(spec, expected_trace, expected_outcomes, None, &mut subject)
             .await?;
-    Ok((report, subject.captured_transport_artifacts()))
+    Ok((
+        report,
+        crate::ScenarioFailureCaptureV1 {
+            transport: subject.captured_transport_window(),
+            byte_replay: subject.byte_replay_capture(),
+        },
+    ))
 }
 
 /// Build a complete report using an explicitly supplied adapter.
@@ -432,8 +444,23 @@ pub async fn run_vector_fixture_report_with_storage_mode(
     fixture: &VectorFixture,
     storage_mode: HarnessStorageMode,
 ) -> Result<ScenarioReport, ScenarioRunError> {
-    let (report, _) = run_vector_fixture_report_with_capture(fixture, storage_mode).await?;
-    Ok(report)
+    let protocol_profile = fixture_protocol_profile(fixture)?;
+    let mut subject =
+        EngineHarnessSubject::new(&fixture.scenario.clients, protocol_profile, storage_mode)
+            .map_err(subject_setup_error)?;
+    run_scenario_report_inner(
+        &fixture.scenario,
+        fixture.expected_trace.clone(),
+        fixture.expected_outcomes.clone(),
+        Some(VectorFixtureMetadata {
+            scenario_name: fixture.scenario_name.clone(),
+            vector_version: fixture.vector_version.clone(),
+            conformance_version: fixture.conformance_version.clone(),
+            seed: fixture.seed,
+        }),
+        &mut subject,
+    )
+    .await
 }
 
 /// Vector runner variant used by the report CLI when it must emit exact wire
@@ -441,25 +468,12 @@ pub async fn run_vector_fixture_report_with_storage_mode(
 pub async fn run_vector_fixture_report_with_capture(
     fixture: &VectorFixture,
     storage_mode: HarnessStorageMode,
-) -> Result<(ScenarioReport, Vec<crate::CapturedTransportArtifactV1>), ScenarioRunError> {
-    let protocol_profile = match fixture
-        .application_profile
-        .as_ref()
-        .map(|profile| profile.name.as_str())
-    {
-        None | Some("legacy") => ProtocolProfile::Legacy,
-        Some("current") => ProtocolProfile::Current,
-        Some(name) => {
-            return Err(ScenarioRunError {
-                step_index: None,
-                kind: "unsupported_application_profile".into(),
-                message: format!("unsupported application profile {name}"),
-            });
-        }
-    };
+) -> Result<(ScenarioReport, crate::ScenarioFailureCaptureV1), ScenarioRunError> {
+    let protocol_profile = fixture_protocol_profile(fixture)?;
     let mut subject =
         EngineHarnessSubject::new(&fixture.scenario.clients, protocol_profile, storage_mode)
             .map_err(subject_setup_error)?;
+    subject.enable_failure_replay_capture();
     let report = run_scenario_report_inner(
         &fixture.scenario,
         fixture.expected_trace.clone(),
@@ -473,7 +487,334 @@ pub async fn run_vector_fixture_report_with_capture(
         &mut subject,
     )
     .await?;
-    Ok((report, subject.captured_transport_artifacts()))
+    Ok((
+        report,
+        crate::ScenarioFailureCaptureV1 {
+            transport: subject.captured_transport_window(),
+            byte_replay: subject.byte_replay_capture(),
+        },
+    ))
+}
+
+fn fixture_protocol_profile(fixture: &VectorFixture) -> Result<ProtocolProfile, ScenarioRunError> {
+    Ok(
+        match fixture
+            .application_profile
+            .as_ref()
+            .map(|profile| profile.name.as_str())
+        {
+            None | Some("legacy") => ProtocolProfile::Legacy,
+            Some("current") => ProtocolProfile::Current,
+            Some(name) => {
+                return Err(ScenarioRunError {
+                    step_index: None,
+                    kind: "unsupported_application_profile".into(),
+                    category: SubjectFailureCategory::Environment,
+                    message: format!("unsupported application profile {name}"),
+                });
+            }
+        },
+    )
+}
+
+#[derive(Default)]
+struct ScenarioStepOutputs {
+    pending_resolutions: Vec<PendingResolutionObservation>,
+    observations: Vec<ClientObservation>,
+    decryptability_probes: Vec<BidirectionalDecryptabilityObservation>,
+    admin_policy_observations: Vec<ScenarioAdminPolicyObservation>,
+    error_observations: Vec<ScenarioErrorObservation>,
+    quiescence_observations: Vec<QuiescenceObservation>,
+}
+
+async fn execute_scenario_step(
+    spec: &ScenarioSpec,
+    step_index: usize,
+    step: &ScenarioStep,
+    subject: &mut dyn ConvergenceSubject,
+    outputs: &mut ScenarioStepOutputs,
+) -> Result<(), ScenarioRunError> {
+    let action_id = scenario_input_id(step_index, step);
+    let ScenarioStepOutputs {
+        pending_resolutions,
+        observations,
+        decryptability_probes,
+        admin_policy_observations,
+        error_observations,
+        quiescence_observations,
+    } = outputs;
+    match step {
+        ScenarioStep::CreateGroup {
+            creator,
+            name,
+            invitees,
+            required_features,
+            initial_admins,
+            pending,
+        } => {
+            let initial_admin_labels = initial_admins
+                .clone()
+                .unwrap_or_else(|| scenario_initial_admins(spec, step_index, invitees));
+            subject
+                .create_group(SubjectCreateGroup {
+                    creator,
+                    name,
+                    invitees,
+                    required_features,
+                    initial_admins: &initial_admin_labels,
+                    pending,
+                })
+                .await
+                .map_err(|error| subject_step_error(step_index, error))?;
+        }
+        ScenarioStep::InviteMembers {
+            inviter,
+            invitees,
+            pending,
+        } => {
+            subject
+                .invite_members(SubjectInviteMembers {
+                    action_id: &action_id,
+                    inviter,
+                    invitees,
+                    pending,
+                })
+                .await
+                .map_err(|error| subject_step_error(step_index, error))?;
+        }
+        ScenarioStep::UpdateGroupData {
+            client,
+            name,
+            pending,
+        } => {
+            subject
+                .update_group_data(SubjectUpdateGroupData {
+                    action_id: &action_id,
+                    client,
+                    name,
+                    pending,
+                })
+                .await
+                .map_err(|error| subject_step_error(step_index, error))?;
+        }
+        ScenarioStep::UpdateAdminPolicy {
+            client,
+            admins,
+            pending,
+        } => {
+            subject
+                .update_admin_policy(SubjectUpdateAdminPolicy {
+                    action_id: Some(&action_id),
+                    client,
+                    admins,
+                    pending: Some(pending),
+                })
+                .await
+                .map_err(|error| {
+                    let mut failure = subject_step_error(step_index, error);
+                    failure.message = format!(
+                        "update_admin_policy unexpectedly failed: {}",
+                        failure.message
+                    );
+                    failure
+                })?;
+        }
+        ScenarioStep::ExpectUpdateAdminPolicyError {
+            client,
+            admins,
+            error,
+        } => {
+            let client_label = client.clone();
+            match subject
+                .update_admin_policy(SubjectUpdateAdminPolicy {
+                    action_id: None,
+                    client,
+                    admins,
+                    pending: None,
+                })
+                .await
+            {
+                Ok(_) => {
+                    return Err(err(
+                        step_index,
+                        format!("update_admin_policy unexpectedly succeeded; expected {error}"),
+                    ));
+                }
+                Err(actual) => {
+                    if &actual.code != error {
+                        return Err(err(
+                            step_index,
+                            format!(
+                                "update_admin_policy failed with {}; expected {error}",
+                                actual.code
+                            ),
+                        ));
+                    }
+                    error_observations.push(ScenarioErrorObservation {
+                        step_index,
+                        client: client_label,
+                        operation: "update_admin_policy".into(),
+                        error: actual.code,
+                    });
+                }
+            }
+        }
+        ScenarioStep::AcknowledgeOutbound {
+            client,
+            publication,
+            selection,
+            outcome,
+        } => {
+            let client_label = client.clone();
+            let artifacts = subject
+                .poll_outbound(client)
+                .map_err(|error| subject_step_error(step_index, error))?
+                .into_iter()
+                .filter(|artifact| {
+                    publication.as_ref().is_none_or(|publication| {
+                        artifact.publication.as_ref() == Some(publication)
+                    }) && selection.matches(artifact)
+                })
+                .collect::<Vec<_>>();
+            if artifacts.is_empty() && publication.is_some() {
+                return Err(err(
+                    step_index,
+                    format!(
+                        "no unresolved outbound artifacts matched client {client}, publication {publication:?}, selection {selection:?}"
+                    ),
+                ));
+            }
+            for artifact in artifacts {
+                subject
+                    .acknowledge_outbound(client, &artifact.outbound_id, *outcome)
+                    .await
+                    .map_err(|error| subject_step_error(step_index, error))?;
+            }
+            if let Some(publication) = publication {
+                pending_resolutions.push(PendingResolutionObservation {
+                    step_index,
+                    client: client_label,
+                    pending: publication.clone(),
+                    resolution: match outcome {
+                        SubjectOutboundOutcome::Accepted => "confirmed",
+                        SubjectOutboundOutcome::ReachedNoEndpoint => "rolled_back",
+                    }
+                    .into(),
+                });
+            }
+        }
+        ScenarioStep::SendAppMessage { sender, payload } => {
+            subject
+                .send_application(SubjectSendApplication {
+                    action_id: &action_id,
+                    sender,
+                    payload,
+                })
+                .await
+                .map_err(|error| subject_step_error(step_index, error))?;
+        }
+        ScenarioStep::Leave { client } => {
+            subject
+                .leave(&action_id, client)
+                .await
+                .map_err(|error| subject_step_error(step_index, error))?;
+        }
+        ScenarioStep::DeliverAll => subject
+            .deliver_all()
+            .map_err(|error| subject_step_error(step_index, error))?,
+        ScenarioStep::Tick { clients: labels } => {
+            subject
+                .tick(labels)
+                .await
+                .map_err(|error| subject_step_error(step_index, error))?;
+        }
+        ScenarioStep::AdvanceTime { delta_ms } => {
+            subject
+                .advance_time(*delta_ms)
+                .await
+                .map_err(|error| subject_step_error(step_index, error))?;
+        }
+        ScenarioStep::AwaitQuiescence { policy } => {
+            quiescence_observations.push(
+                drive_subject_to_quiescence(subject, &spec.clients, policy, step_index)
+                    .await
+                    .map_err(|error| subject_step_error(step_index, error))?,
+            );
+        }
+        ScenarioStep::Observe { clients: labels } => {
+            observations.extend(
+                subject
+                    .observe(labels)
+                    .map_err(|error| subject_step_error(step_index, error))?,
+            );
+        }
+        ScenarioStep::ObserveExact { clients: labels } => {
+            observations.extend(
+                subject
+                    .observe_exact(labels)
+                    .map_err(|error| subject_step_error(step_index, error))?,
+            );
+        }
+        ScenarioStep::ProbeBidirectionalDecryptability { clients: labels } => {
+            decryptability_probes.push(
+                subject
+                    .probe_bidirectional_decryptability(labels, step_index)
+                    .await
+                    .map_err(|error| subject_step_error(step_index, error))?,
+            );
+        }
+        ScenarioStep::ObserveAdminPolicy { clients: labels } => {
+            admin_policy_observations.extend(
+                subject
+                    .observe_admin_policy(labels)
+                    .map_err(|error| subject_step_error(step_index, error))?,
+            );
+        }
+        ScenarioStep::ClearEvents { clients: labels } => {
+            subject
+                .clear_events(labels)
+                .map_err(|error| subject_step_error(step_index, error))?;
+        }
+        ScenarioStep::DropQueued { index } => {
+            subject_faults(subject, step_index)?
+                .drop_queued(*index)
+                .map_err(|error| subject_step_error(step_index, error))?;
+        }
+        ScenarioStep::DuplicateQueued { index } => {
+            subject_faults(subject, step_index)?
+                .duplicate_queued(*index)
+                .map_err(|error| subject_step_error(step_index, error))?;
+        }
+        ScenarioStep::DelayQueued { index, delayed } => {
+            subject_faults(subject, step_index)?
+                .delay_queued(*index, delayed)
+                .map_err(|error| subject_step_error(step_index, error))?;
+        }
+        ScenarioStep::ReleaseDelayed { delayed } => {
+            subject_faults(subject, step_index)?
+                .release_delayed(delayed)
+                .map_err(|error| subject_step_error(step_index, error))?;
+        }
+        ScenarioStep::ReorderQueued { order } => {
+            subject_faults(subject, step_index)?
+                .reorder_queued(order)
+                .map_err(|error| subject_step_error(step_index, error))?;
+        }
+        ScenarioStep::SetPartition { allow } => {
+            subject_faults(subject, step_index)?
+                .set_partition(allow)
+                .map_err(|error| subject_step_error(step_index, error))?;
+        }
+        ScenarioStep::ClearPartition => subject_faults(subject, step_index)?
+            .clear_partition()
+            .map_err(|error| subject_step_error(step_index, error))?,
+        ScenarioStep::RestartClient { client } => {
+            subject
+                .restart(client)
+                .map_err(|error| subject_step_error(step_index, error))?;
+        }
+    }
+    Ok::<(), ScenarioRunError>(())
 }
 
 async fn run_scenario_report_inner(
@@ -485,295 +826,19 @@ async fn run_scenario_report_inner(
 ) -> Result<ScenarioReport, ScenarioRunError> {
     let descriptor = subject.descriptor();
     validate_scenario_for_subject(spec, &descriptor)?;
-    let mut pending_resolutions = Vec::new();
-    let mut observations = Vec::new();
-    let mut decryptability_probes = Vec::new();
-    let mut admin_policy_observations = Vec::new();
-    let mut error_observations = Vec::new();
-    let mut quiescence_observations = Vec::new();
+    let mut outputs = ScenarioStepOutputs::default();
     let mut step_log = Vec::new();
 
     for (step_index, step) in spec.steps.iter().enumerate() {
-        let action_id = scenario_input_id(step_index, step);
-        let step_result = async {
-            match step {
-            ScenarioStep::CreateGroup {
-                creator,
-                name,
-                invitees,
-                required_features,
-                initial_admins,
-                pending,
-            } => {
-                let initial_admin_labels = initial_admins
-                    .clone()
-                    .unwrap_or_else(|| scenario_initial_admins(spec, step_index, invitees));
-                subject
-                    .create_group(SubjectCreateGroup {
-                        creator,
-                        name,
-                        invitees,
-                        required_features,
-                        initial_admins: &initial_admin_labels,
-                        pending,
-                    })
-                    .await
-                    .map_err(|error| subject_step_error(step_index, error))?;
-            }
-            ScenarioStep::InviteMembers {
-                inviter,
-                invitees,
-                pending,
-            } => {
-                subject
-                    .invite_members(SubjectInviteMembers {
-                        action_id: &action_id,
-                        inviter,
-                        invitees,
-                        pending,
-                    })
-                    .await
-                    .map_err(|error| subject_step_error(step_index, error))?;
-            }
-            ScenarioStep::UpdateGroupData {
-                client,
-                name,
-                pending,
-            } => {
-                subject
-                    .update_group_data(SubjectUpdateGroupData {
-                        action_id: &action_id,
-                        client,
-                        name,
-                        pending,
-                    })
-                    .await
-                    .map_err(|error| subject_step_error(step_index, error))?;
-            }
-            ScenarioStep::UpdateAdminPolicy {
-                client,
-                admins,
-                pending,
-            } => {
-                subject
-                    .update_admin_policy(SubjectUpdateAdminPolicy {
-                        action_id: Some(&action_id),
-                        client,
-                        admins,
-                        pending: Some(pending),
-                    })
-                    .await
-                    .map_err(|error| {
-                        err(
-                            step_index,
-                            format!("update_admin_policy unexpectedly failed: {error}"),
-                        )
-                    })?;
-            }
-            ScenarioStep::ExpectUpdateAdminPolicyError {
-                client,
-                admins,
-                error,
-            } => {
-                let client_label = client.clone();
-                match subject
-                    .update_admin_policy(SubjectUpdateAdminPolicy {
-                        action_id: None,
-                        client,
-                        admins,
-                        pending: None,
-                    })
-                    .await
-                {
-                    Ok(_) => {
-                        return Err(err(
-                            step_index,
-                            format!("update_admin_policy unexpectedly succeeded; expected {error}"),
-                        ));
-                    }
-                    Err(actual) => {
-                        if &actual.code != error {
-                            return Err(err(
-                                step_index,
-                                format!(
-                                    "update_admin_policy failed with {}; expected {error}",
-                                    actual.code
-                                ),
-                            ));
-                        }
-                        error_observations.push(ScenarioErrorObservation {
-                            step_index,
-                            client: client_label,
-                            operation: "update_admin_policy".into(),
-                            error: actual.code,
-                        });
-                    }
-                }
-            }
-            ScenarioStep::AcknowledgeOutbound {
-                client,
-                publication,
-                selection,
-                outcome,
-            } => {
-                let client_label = client.clone();
-                let artifacts = subject
-                    .poll_outbound(client)
-                    .map_err(|error| subject_step_error(step_index, error))?
-                    .into_iter()
-                    .filter(|artifact| {
-                        publication.as_ref().is_none_or(|publication| {
-                            artifact.publication.as_ref() == Some(publication)
-                        }) && selection.matches(artifact)
-                    })
-                    .collect::<Vec<_>>();
-                if artifacts.is_empty() && publication.is_some() {
-                    return Err(err(
-                        step_index,
-                        format!(
-                            "no unresolved outbound artifacts matched client {client}, publication {publication:?}, selection {selection:?}"
-                        ),
-                    ));
-                }
-                for artifact in artifacts {
-                    subject
-                        .acknowledge_outbound(client, &artifact.outbound_id, *outcome)
-                        .await
-                        .map_err(|error| subject_step_error(step_index, error))?;
-                }
-                if let Some(publication) = publication {
-                    pending_resolutions.push(PendingResolutionObservation {
-                        step_index,
-                        client: client_label,
-                        pending: publication.clone(),
-                        resolution: match outcome {
-                            SubjectOutboundOutcome::Accepted => "confirmed",
-                            SubjectOutboundOutcome::ReachedNoEndpoint => "rolled_back",
-                        }
-                        .into(),
-                    });
-                }
-            }
-            ScenarioStep::SendAppMessage { sender, payload } => {
-                subject
-                    .send_application(SubjectSendApplication {
-                        action_id: &action_id,
-                        sender,
-                        payload,
-                    })
-                    .await
-                    .map_err(|error| subject_step_error(step_index, error))?;
-            }
-            ScenarioStep::Leave { client } => {
-                subject
-                    .leave(&action_id, client)
-                    .await
-                    .map_err(|error| subject_step_error(step_index, error))?;
-            }
-            ScenarioStep::DeliverAll => subject
-                .deliver_all()
-                .map_err(|error| subject_step_error(step_index, error))?,
-            ScenarioStep::Tick { clients: labels } => {
-                subject
-                    .tick(labels)
-                    .await
-                    .map_err(|error| subject_step_error(step_index, error))?;
-            }
-            ScenarioStep::AdvanceTime { delta_ms } => {
-                subject
-                    .advance_time(*delta_ms)
-                    .await
-                    .map_err(|error| subject_step_error(step_index, error))?;
-            }
-            ScenarioStep::AwaitQuiescence { policy } => {
-                quiescence_observations.push(
-                    drive_subject_to_quiescence(subject, &spec.clients, policy, step_index)
-                        .await
-                        .map_err(|error| subject_step_error(step_index, error))?,
-                );
-            }
-            ScenarioStep::Observe { clients: labels } => {
-                observations.extend(
-                    subject
-                        .observe(labels)
-                        .map_err(|error| subject_step_error(step_index, error))?,
-                );
-            }
-            ScenarioStep::ObserveExact { clients: labels } => {
-                observations.extend(
-                    subject
-                        .observe_exact(labels)
-                        .map_err(|error| subject_step_error(step_index, error))?,
-                );
-            }
-            ScenarioStep::ProbeBidirectionalDecryptability { clients: labels } => {
-                decryptability_probes.push(
-                    subject
-                        .probe_bidirectional_decryptability(labels, step_index)
-                        .await
-                        .map_err(|error| subject_step_error(step_index, error))?,
-                );
-            }
-            ScenarioStep::ObserveAdminPolicy { clients: labels } => {
-                admin_policy_observations.extend(
-                    subject
-                        .observe_admin_policy(labels)
-                        .map_err(|error| subject_step_error(step_index, error))?,
-                );
-            }
-            ScenarioStep::ClearEvents { clients: labels } => {
-                subject
-                    .clear_events(labels)
-                    .map_err(|error| subject_step_error(step_index, error))?;
-            }
-            ScenarioStep::DropQueued { index } => {
-                subject_faults(subject, step_index)?
-                    .drop_queued(*index)
-                    .map_err(|error| subject_step_error(step_index, error))?;
-            }
-            ScenarioStep::DuplicateQueued { index } => {
-                subject_faults(subject, step_index)?
-                    .duplicate_queued(*index)
-                    .map_err(|error| subject_step_error(step_index, error))?;
-            }
-            ScenarioStep::DelayQueued { index, delayed } => {
-                subject_faults(subject, step_index)?
-                    .delay_queued(*index, delayed)
-                    .map_err(|error| subject_step_error(step_index, error))?;
-            }
-            ScenarioStep::ReleaseDelayed { delayed } => {
-                subject_faults(subject, step_index)?
-                    .release_delayed(delayed)
-                    .map_err(|error| subject_step_error(step_index, error))?;
-            }
-            ScenarioStep::ReorderQueued { order } => {
-                subject_faults(subject, step_index)?
-                    .reorder_queued(order)
-                    .map_err(|error| subject_step_error(step_index, error))?;
-            }
-            ScenarioStep::SetPartition { allow } => {
-                subject_faults(subject, step_index)?
-                    .set_partition(allow)
-                    .map_err(|error| subject_step_error(step_index, error))?;
-            }
-            ScenarioStep::ClearPartition => subject_faults(subject, step_index)?
-                .clear_partition()
-                .map_err(|error| subject_step_error(step_index, error))?,
-                ScenarioStep::RestartClient { client } => {
-                    subject
-                        .restart(client)
-                        .map_err(|error| subject_step_error(step_index, error))?;
-                }
-            }
-            Ok::<(), ScenarioRunError>(())
-        }
-        .await;
+        let step_result =
+            execute_scenario_step(spec, step_index, step, subject, &mut outputs).await;
         if let Err(error) = step_result {
             step_log.push(ScenarioStepLogEntry {
                 step_index,
                 step_type: step.kind().into(),
                 status: ScenarioStepStatus::Failed {
                     kind: error.kind,
+                    category: error.category,
                     message: error.message,
                 },
             });
@@ -785,6 +850,15 @@ async fn run_scenario_report_inner(
             status: ScenarioStepStatus::Completed,
         });
     }
+
+    let ScenarioStepOutputs {
+        pending_resolutions,
+        observations,
+        decryptability_probes,
+        admin_policy_observations,
+        error_observations,
+        quiescence_observations,
+    } = outputs;
 
     let observed_trace = ScenarioTrace {
         name: spec.name.clone(),
@@ -892,6 +966,7 @@ pub fn validate_scenario_for_subject(
         return Err(ScenarioRunError {
             step_index: None,
             kind: "unsupported_scenario_version".into(),
+            category: SubjectFailureCategory::Environment,
             message: format!("unsupported ScenarioSpec version {}", spec.spec_version),
         });
     }
@@ -901,6 +976,7 @@ pub fn validate_scenario_for_subject(
             return Err(ScenarioRunError {
                 step_index: None,
                 kind: "duplicate_client".into(),
+                category: SubjectFailureCategory::Environment,
                 message: format!("duplicate client label {label}"),
             });
         }
@@ -965,6 +1041,7 @@ fn err(step_index: usize, message: String) -> ScenarioRunError {
     ScenarioRunError {
         step_index: Some(step_index),
         kind: "scenario_error".into(),
+        category: SubjectFailureCategory::Environment,
         message,
     }
 }
@@ -974,6 +1051,7 @@ fn subject_setup_error(error: SubjectError) -> ScenarioRunError {
     ScenarioRunError {
         step_index: None,
         kind: error.code,
+        category: error.category,
         message,
     }
 }
@@ -982,6 +1060,7 @@ fn subject_step_error(step_index: usize, error: SubjectError) -> ScenarioRunErro
     ScenarioRunError {
         step_index: Some(step_index),
         kind: error.code,
+        category: error.category,
         message: error.message,
     }
 }
@@ -1002,12 +1081,18 @@ fn ensure_execution_succeeded(report: &ScenarioReport) -> Result<(), ScenarioRun
         .iter()
         .find(|step| !step.status.is_completed())
     {
-        let ScenarioStepStatus::Failed { kind, message } = &step.status else {
+        let ScenarioStepStatus::Failed {
+            kind,
+            category,
+            message,
+        } = &step.status
+        else {
             unreachable!("non-completed step must be failed")
         };
         return Err(ScenarioRunError {
             step_index: Some(step.step_index),
             kind: kind.clone(),
+            category: *category,
             message: message.clone(),
         });
     }
@@ -1022,6 +1107,7 @@ fn ensure_execution_succeeded(report: &ScenarioReport) -> Result<(), ScenarioRun
     Err(ScenarioRunError {
         step_index: Some(observation.step_index),
         kind: "quiescence_not_reached".into(),
+        category: SubjectFailureCategory::Protocol,
         message: format!("quiescence was not reached: {artifact}"),
     })
 }
@@ -1342,6 +1428,7 @@ mod tests {
             status,
             ScenarioStepStatus::Failed {
                 kind: "scenario_step_failed".into(),
+                category: SubjectFailureCategory::Environment,
                 message: "legacy report".into(),
             }
         );

--- a/crates/cgka-conformance-simulator/src/scenario.rs
+++ b/crates/cgka-conformance-simulator/src/scenario.rs
@@ -286,7 +286,15 @@ pub struct ScenarioStepLogEntry {
 #[serde(tag = "status", rename_all = "snake_case")]
 pub enum ScenarioStepStatus {
     Completed,
-    Failed { message: String },
+    Failed {
+        #[serde(default = "default_step_failure_kind")]
+        kind: String,
+        message: String,
+    },
+}
+
+fn default_step_failure_kind() -> String {
+    "scenario_step_failed".into()
 }
 
 impl ScenarioStepStatus {
@@ -304,6 +312,7 @@ pub struct InvariantFailure {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ScenarioRunError {
     pub step_index: Option<usize>,
+    pub kind: String,
     pub message: String,
 }
 
@@ -320,7 +329,7 @@ impl std::error::Error for ScenarioRunError {}
 
 pub async fn run_scenario_spec(spec: &ScenarioSpec) -> Result<ScenarioTrace, ScenarioRunError> {
     let report = run_scenario_report(spec, None).await?;
-    ensure_quiescence_steps_succeeded(&report)?;
+    ensure_execution_succeeded(&report)?;
     Ok(report
         .observed_trace
         .expect("successful report always includes an observed trace"))
@@ -332,7 +341,7 @@ pub async fn run_scenario_spec_with_subject(
     subject: &mut dyn ConvergenceSubject,
 ) -> Result<ScenarioTrace, ScenarioRunError> {
     let report = run_scenario_report_with_subject(spec, None, Vec::new(), subject).await?;
-    ensure_quiescence_steps_succeeded(&report)?;
+    ensure_execution_succeeded(&report)?;
     Ok(report
         .observed_trace
         .expect("successful report always includes an observed trace"))
@@ -383,6 +392,24 @@ pub async fn run_scenario_report_with_outcomes_and_storage_mode(
     run_scenario_report_inner(spec, expected_trace, expected_outcomes, None, &mut subject).await
 }
 
+/// Run the in-process engine subject and retain the exact transport artifacts
+/// needed for a failure capsule. Callers must treat the returned artifacts as
+/// potentially sensitive even though synthetic campaigns use synthetic keys.
+pub async fn run_scenario_report_with_outcomes_and_capture(
+    spec: &ScenarioSpec,
+    expected_trace: Option<ScenarioTrace>,
+    expected_outcomes: Vec<TraceExpectation>,
+    storage_mode: HarnessStorageMode,
+) -> Result<(ScenarioReport, Vec<crate::CapturedTransportArtifactV1>), ScenarioRunError> {
+    let mut subject =
+        EngineHarnessSubject::new(&spec.clients, ProtocolProfile::Legacy, storage_mode)
+            .map_err(subject_setup_error)?;
+    let report =
+        run_scenario_report_inner(spec, expected_trace, expected_outcomes, None, &mut subject)
+            .await?;
+    Ok((report, subject.captured_transport_artifacts()))
+}
+
 /// Build a complete report using an explicitly supplied adapter.
 ///
 /// Capability validation runs before the subject receives any action.
@@ -415,6 +442,7 @@ pub async fn run_vector_fixture_report_with_storage_mode(
         Some(name) => {
             return Err(ScenarioRunError {
                 step_index: None,
+                kind: "unsupported_application_profile".into(),
                 message: format!("unsupported application profile {name}"),
             });
         }
@@ -437,6 +465,46 @@ pub async fn run_vector_fixture_report_with_storage_mode(
     .await
 }
 
+/// Vector runner variant used by the report CLI when it must emit exact wire
+/// evidence alongside a failing report.
+pub async fn run_vector_fixture_report_with_capture(
+    fixture: &VectorFixture,
+    storage_mode: HarnessStorageMode,
+) -> Result<(ScenarioReport, Vec<crate::CapturedTransportArtifactV1>), ScenarioRunError> {
+    let protocol_profile = match fixture
+        .application_profile
+        .as_ref()
+        .map(|profile| profile.name.as_str())
+    {
+        None | Some("legacy") => ProtocolProfile::Legacy,
+        Some("current") => ProtocolProfile::Current,
+        Some(name) => {
+            return Err(ScenarioRunError {
+                step_index: None,
+                kind: "unsupported_application_profile".into(),
+                message: format!("unsupported application profile {name}"),
+            });
+        }
+    };
+    let mut subject =
+        EngineHarnessSubject::new(&fixture.scenario.clients, protocol_profile, storage_mode)
+            .map_err(subject_setup_error)?;
+    let report = run_scenario_report_inner(
+        &fixture.scenario,
+        fixture.expected_trace.clone(),
+        fixture.expected_outcomes.clone(),
+        Some(VectorFixtureMetadata {
+            scenario_name: fixture.scenario_name.clone(),
+            vector_version: fixture.vector_version.clone(),
+            conformance_version: fixture.conformance_version.clone(),
+            seed: fixture.seed,
+        }),
+        &mut subject,
+    )
+    .await?;
+    Ok((report, subject.captured_transport_artifacts()))
+}
+
 async fn run_scenario_report_inner(
     spec: &ScenarioSpec,
     expected_trace: Option<ScenarioTrace>,
@@ -456,7 +524,8 @@ async fn run_scenario_report_inner(
 
     for (step_index, step) in spec.steps.iter().enumerate() {
         let action_id = scenario_input_id(step_index, step);
-        match step {
+        let step_result = async {
+            match step {
             ScenarioStep::CreateGroup {
                 creator,
                 name,
@@ -719,11 +788,25 @@ async fn run_scenario_report_inner(
             ScenarioStep::ClearPartition => subject_faults(subject, step_index)?
                 .clear_partition()
                 .map_err(|error| subject_step_error(step_index, error))?,
-            ScenarioStep::RestartClient { client } => {
-                subject
-                    .restart(client)
-                    .map_err(|error| subject_step_error(step_index, error))?;
+                ScenarioStep::RestartClient { client } => {
+                    subject
+                        .restart(client)
+                        .map_err(|error| subject_step_error(step_index, error))?;
+                }
             }
+            Ok::<(), ScenarioRunError>(())
+        }
+        .await;
+        if let Err(error) = step_result {
+            step_log.push(ScenarioStepLogEntry {
+                step_index,
+                step_type: step.kind().into(),
+                status: ScenarioStepStatus::Failed {
+                    kind: error.kind,
+                    message: error.message,
+                },
+            });
+            break;
         }
         step_log.push(ScenarioStepLogEntry {
             step_index,
@@ -837,6 +920,7 @@ pub fn validate_scenario_for_subject(
     if spec.spec_version != "2" {
         return Err(ScenarioRunError {
             step_index: None,
+            kind: "unsupported_scenario_version".into(),
             message: format!("unsupported ScenarioSpec version {}", spec.spec_version),
         });
     }
@@ -845,6 +929,7 @@ pub fn validate_scenario_for_subject(
         if !clients.insert(label) {
             return Err(ScenarioRunError {
                 step_index: None,
+                kind: "duplicate_client".into(),
                 message: format!("duplicate client label {label}"),
             });
         }
@@ -908,19 +993,26 @@ fn subject_faults(
 fn err(step_index: usize, message: String) -> ScenarioRunError {
     ScenarioRunError {
         step_index: Some(step_index),
+        kind: "scenario_error".into(),
         message,
     }
 }
 
 fn subject_setup_error(error: SubjectError) -> ScenarioRunError {
+    let message = error.to_string();
     ScenarioRunError {
         step_index: None,
-        message: error.to_string(),
+        kind: error.code,
+        message,
     }
 }
 
 fn subject_step_error(step_index: usize, error: SubjectError) -> ScenarioRunError {
-    err(step_index, error.to_string())
+    ScenarioRunError {
+        step_index: Some(step_index),
+        kind: error.code,
+        message: error.message,
+    }
 }
 
 fn invariant_failures(expectation_failures: &[ExpectationFailure]) -> Vec<InvariantFailure> {
@@ -933,7 +1025,21 @@ fn invariant_failures(expectation_failures: &[ExpectationFailure]) -> Vec<Invari
         .collect()
 }
 
-fn ensure_quiescence_steps_succeeded(report: &ScenarioReport) -> Result<(), ScenarioRunError> {
+fn ensure_execution_succeeded(report: &ScenarioReport) -> Result<(), ScenarioRunError> {
+    if let Some(step) = report
+        .step_log
+        .iter()
+        .find(|step| !step.status.is_completed())
+    {
+        let ScenarioStepStatus::Failed { kind, message } = &step.status else {
+            unreachable!("non-completed step must be failed")
+        };
+        return Err(ScenarioRunError {
+            step_index: Some(step.step_index),
+            kind: kind.clone(),
+            message: message.clone(),
+        });
+    }
     let Some(observation) = report
         .quiescence_observations
         .iter()
@@ -944,6 +1050,7 @@ fn ensure_quiescence_steps_succeeded(report: &ScenarioReport) -> Result<(), Scen
     let artifact = serde_json::to_string(observation).unwrap_or_else(|_| "unserializable".into());
     Err(ScenarioRunError {
         step_index: Some(observation.step_index),
+        kind: "quiescence_not_reached".into(),
         message: format!("quiescence was not reached: {artifact}"),
     })
 }
@@ -1220,6 +1327,53 @@ mod tests {
         assert_eq!(error.step_index, Some(5));
         assert!(error.message.contains("transport_delayed"));
         assert!(error.message.contains("\"status\":\"blocked\""));
+    }
+
+    #[tokio::test]
+    async fn subject_step_failure_is_a_report_artifact_and_a_spec_run_error() {
+        let spec = ScenarioSpec {
+            name: "step-failure-artifact/v1".into(),
+            spec_version: "2".into(),
+            clients: vec!["alice".into()],
+            steps: vec![ScenarioStep::AcknowledgeOutbound {
+                client: "alice".into(),
+                publication: Some("missing-publication".into()),
+                selection: ScenarioOutboundSelection::All,
+                outcome: SubjectOutboundOutcome::Accepted,
+            }],
+        };
+
+        let report = run_scenario_report(&spec, None)
+            .await
+            .expect("execution failures remain reportable");
+        assert!(matches!(
+            &report.step_log[0].status,
+            ScenarioStepStatus::Failed { message, .. } if message.contains("no unresolved outbound")
+        ));
+        assert!(report.observed_trace.is_some());
+
+        let error = run_scenario_spec(&spec)
+            .await
+            .expect_err("trace-only execution still reports the failed step");
+        assert_eq!(error.step_index, Some(0));
+        assert!(error.message.contains("no unresolved outbound"));
+    }
+
+    #[test]
+    fn legacy_failed_step_status_defaults_its_failure_kind() {
+        let status: ScenarioStepStatus = serde_json::from_value(serde_json::json!({
+            "status": "failed",
+            "message": "legacy report"
+        }))
+        .expect("legacy failed status remains readable");
+
+        assert_eq!(
+            status,
+            ScenarioStepStatus::Failed {
+                kind: "scenario_step_failed".into(),
+                message: "legacy report".into(),
+            }
+        );
     }
 
     #[tokio::test]

--- a/crates/cgka-conformance-simulator/src/scenario.rs
+++ b/crates/cgka-conformance-simulator/src/scenario.rs
@@ -432,37 +432,8 @@ pub async fn run_vector_fixture_report_with_storage_mode(
     fixture: &VectorFixture,
     storage_mode: HarnessStorageMode,
 ) -> Result<ScenarioReport, ScenarioRunError> {
-    let protocol_profile = match fixture
-        .application_profile
-        .as_ref()
-        .map(|profile| profile.name.as_str())
-    {
-        None | Some("legacy") => ProtocolProfile::Legacy,
-        Some("current") => ProtocolProfile::Current,
-        Some(name) => {
-            return Err(ScenarioRunError {
-                step_index: None,
-                kind: "unsupported_application_profile".into(),
-                message: format!("unsupported application profile {name}"),
-            });
-        }
-    };
-    let mut subject =
-        EngineHarnessSubject::new(&fixture.scenario.clients, protocol_profile, storage_mode)
-            .map_err(subject_setup_error)?;
-    run_scenario_report_inner(
-        &fixture.scenario,
-        fixture.expected_trace.clone(),
-        fixture.expected_outcomes.clone(),
-        Some(VectorFixtureMetadata {
-            scenario_name: fixture.scenario_name.clone(),
-            vector_version: fixture.vector_version.clone(),
-            conformance_version: fixture.conformance_version.clone(),
-            seed: fixture.seed,
-        }),
-        &mut subject,
-    )
-    .await
+    let (report, _) = run_vector_fixture_report_with_capture(fixture, storage_mode).await?;
+    Ok(report)
 }
 
 /// Vector runner variant used by the report CLI when it must emit exact wire

--- a/crates/cgka-conformance-simulator/src/subject.rs
+++ b/crates/cgka-conformance-simulator/src/subject.rs
@@ -498,6 +498,27 @@ impl EngineHarnessSubject {
             .ok_or_else(|| SubjectError::new("unknown_client", format!("unknown client {label}")))
     }
 
+    /// Exact transport artifacts emitted during this subject run. Payloads are
+    /// retained only for explicit failure-capsule capture.
+    pub fn captured_transport_artifacts(&self) -> Vec<crate::CapturedTransportArtifactV1> {
+        let mut artifacts = self
+            .clients
+            .iter()
+            .flat_map(|(label, client)| {
+                self.bus
+                    .outbound_since(client.bus_id, None)
+                    .into_iter()
+                    .map(|emission| crate::CapturedTransportArtifactV1 {
+                        sequence: emission.sequence,
+                        sender: label.clone(),
+                        message: emission.msg,
+                    })
+            })
+            .collect::<Vec<_>>();
+        artifacts.sort_by_key(|artifact| artifact.sequence);
+        artifacts
+    }
+
     fn client_mut(&mut self, label: &str) -> Result<&mut HarnessClient, SubjectError> {
         self.clients
             .get_mut(label)
@@ -736,7 +757,7 @@ impl ConvergenceSubject for EngineHarnessSubject {
 
     async fn tick(&mut self, clients: &[String]) -> Result<(), SubjectError> {
         for label in clients {
-            self.client_mut(label)?.tick().await;
+            ensure_tick_succeeded(self.client_mut(label)?.tick().await)?;
         }
         Ok(())
     }
@@ -1228,7 +1249,7 @@ fn required_features_from_names(names: &[String]) -> Result<Vec<Feature>, Subjec
         .collect()
 }
 
-fn scenario_registry() -> FeatureRegistry {
+pub(crate) fn scenario_registry() -> FeatureRegistry {
     let mut registry = FeatureRegistry::new();
     registry.register(
         Feature("self-remove"),
@@ -1262,6 +1283,15 @@ fn outbound_sequence(outbound_id: &str) -> Result<u64, SubjectError> {
 
 fn subject_engine_error(error: EngineError) -> SubjectError {
     SubjectError::new(observe_engine_error(&error), error.to_string())
+}
+
+fn ensure_tick_succeeded(
+    outcomes: Vec<Result<cgka_traits::ingest::IngestOutcome, EngineError>>,
+) -> Result<(), SubjectError> {
+    match outcomes.into_iter().find_map(Result::err) {
+        Some(error) => Err(subject_engine_error(error)),
+        None => Ok(()),
+    }
 }
 
 fn subject_publication_error(error: HarnessPublicationError) -> SubjectError {
@@ -1355,6 +1385,16 @@ mod tests {
             .tick(invitees)
             .await
             .expect("invitees ingest founding welcomes");
+    }
+
+    #[test]
+    fn engine_subject_tick_surfaces_engine_failures() {
+        let error = ensure_tick_succeeded(vec![Err(EngineError::Backend(
+            "converge buffered group: injected failure".into(),
+        ))])
+        .expect_err("tick must not discard the engine failure");
+        assert_eq!(error.code, "backend");
+        assert!(error.message.contains("converge buffered group"));
     }
 
     #[tokio::test]

--- a/crates/cgka-conformance-simulator/src/subject.rs
+++ b/crates/cgka-conformance-simulator/src/subject.rs
@@ -7,10 +7,11 @@
 
 use crate::client::HarnessPublicationError;
 use crate::{
-    BidirectionalDecryptabilityObservation, ClientBuilder, ClientObservation,
-    DecryptabilityProbeSendStatus, DirectionalDecryptabilityProbe, HarnessClient,
-    HarnessStorageMode, ScenarioAdminPolicyObservation, ScenarioStep, SubjectProgressSnapshot,
-    SubjectTerminalBlocker, TransportBus, observe_client, observe_client_exact,
+    BidirectionalDecryptabilityObservation, CapturedTransportArtifactV1, CapturedTransportWindowV1,
+    ClientBuilder, ClientObservation, DecryptabilityProbeSendStatus,
+    DirectionalDecryptabilityProbe, EngineByteReplayV1, HarnessClient, HarnessStorageMode,
+    ScenarioAdminPolicyObservation, ScenarioStep, SubjectProgressSnapshot, SubjectTerminalBlocker,
+    TransportBus, observe_client, observe_client_exact,
 };
 use async_trait::async_trait;
 use cgka_engine::feature_registry::FeatureRegistry;
@@ -100,10 +101,21 @@ impl SubjectDescriptor {
 }
 
 /// Adapter-level failure with a normalized code suitable for expectations.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SubjectFailureCategory {
+    ExpectedRefusal,
+    Protocol,
+    Resource,
+    #[default]
+    Environment,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SubjectError {
     pub code: String,
     pub message: String,
+    pub category: SubjectFailureCategory,
 }
 
 impl SubjectError {
@@ -111,6 +123,19 @@ impl SubjectError {
         Self {
             code: code.into(),
             message: message.into(),
+            category: SubjectFailureCategory::Environment,
+        }
+    }
+
+    pub fn classified(
+        category: SubjectFailureCategory,
+        code: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            code: code.into(),
+            message: message.into(),
+            category,
         }
     }
 
@@ -421,6 +446,8 @@ pub struct EngineHarnessSubject {
     convergence_clock: ManualConvergenceClock,
     outbound_cursors: HashMap<String, u64>,
     outbound_records: BTreeMap<u64, EngineSubjectOutboundRecord>,
+    replay_capture_enabled: bool,
+    last_byte_replay: Option<EngineByteReplayV1>,
 }
 
 #[derive(Clone)]
@@ -435,6 +462,18 @@ struct EngineSubjectOutboundRecord {
     pending: Option<PendingStateRef>,
     queued_intent: Option<(GroupId, MessageId)>,
     resolution: Option<SubjectOutboundOutcome>,
+}
+
+struct PendingByteReplay {
+    client_label: String,
+    identity_seed: Vec<u8>,
+    protocol_profile: ProtocolProfile,
+    group_id: Vec<u8>,
+    sensitive_checkpoint: Vec<u8>,
+    captured_deliveries: Vec<TransportMessage>,
+    checkpoint_monotonic_ms: u64,
+    checkpoint_wall_ms: u64,
+    virtual_time_tick_enabled: bool,
 }
 
 impl EngineHarnessSubject {
@@ -489,6 +528,8 @@ impl EngineHarnessSubject {
             convergence_clock,
             outbound_cursors: HashMap::new(),
             outbound_records: BTreeMap::new(),
+            replay_capture_enabled: false,
+            last_byte_replay: None,
         })
     }
 
@@ -498,25 +539,123 @@ impl EngineHarnessSubject {
             .ok_or_else(|| SubjectError::new("unknown_client", format!("unknown client {label}")))
     }
 
-    /// Exact transport artifacts emitted during this subject run. Payloads are
-    /// retained only for explicit failure-capsule capture.
-    pub fn captured_transport_artifacts(&self) -> Vec<crate::CapturedTransportArtifactV1> {
-        let mut artifacts = self
+    /// Bounded tail of exact transport artifacts emitted during this subject
+    /// run, plus totals that make truncation explicit.
+    pub fn captured_transport_window(&self) -> CapturedTransportWindowV1 {
+        let capture = self.bus.captured_outbound_window();
+        let labels_by_bus_id = self
             .clients
             .iter()
-            .flat_map(|(label, client)| {
-                self.bus
-                    .outbound_since(client.bus_id, None)
-                    .into_iter()
-                    .map(|emission| crate::CapturedTransportArtifactV1 {
-                        sequence: emission.sequence,
-                        sender: label.clone(),
-                        message: emission.msg,
-                    })
+            .map(|(label, client)| (client.bus_id, label))
+            .collect::<HashMap<_, _>>();
+        let artifacts = capture
+            .emissions
+            .into_iter()
+            .filter_map(|(sender, emission)| {
+                Some(CapturedTransportArtifactV1 {
+                    sequence: emission.sequence,
+                    sender: labels_by_bus_id.get(&sender)?.to_string(),
+                    message: emission.msg,
+                })
             })
-            .collect::<Vec<_>>();
-        artifacts.sort_by_key(|artifact| artifact.sequence);
-        artifacts
+            .collect();
+        CapturedTransportWindowV1 {
+            artifacts,
+            observed_objects: capture.observed_objects,
+            observed_json_bytes: capture.observed_json_bytes,
+        }
+    }
+
+    pub fn captured_transport_artifacts(&self) -> Vec<CapturedTransportArtifactV1> {
+        self.captured_transport_window().artifacts
+    }
+
+    pub fn byte_replay_capture(&self) -> Option<EngineByteReplayV1> {
+        self.last_byte_replay.clone()
+    }
+
+    pub fn enable_failure_replay_capture(&mut self) {
+        self.replay_capture_enabled = true;
+    }
+
+    fn prepare_byte_replay(&self, label: &str) -> Option<PendingByteReplay> {
+        if !self.replay_capture_enabled {
+            return None;
+        }
+        let client = self.clients.get(label)?;
+        let group_id = client.replay_group_id()?.clone();
+        let sensitive_checkpoint = client
+            .export_conformance_replay_checkpoint(&group_id)
+            .ok()?;
+        if sensitive_checkpoint.len() > crate::MAX_CAPTURED_REPLAY_CHECKPOINT_BYTES {
+            return None;
+        }
+        let captured_deliveries = self.bus.mailbox_snapshot(client.bus_id);
+        let captured_delivery_bytes = captured_deliveries
+            .iter()
+            .map(|message| serde_json::to_vec(message).map_or(0, |bytes| bytes.len() as u64))
+            .sum::<u64>();
+        if captured_deliveries.len() > crate::MAX_CAPTURED_TRANSPORT_OBJECTS
+            || captured_delivery_bytes > crate::MAX_CAPTURED_TRANSPORT_JSON_BYTES
+        {
+            return None;
+        }
+        let now = self.convergence_clock.now();
+        Some(PendingByteReplay {
+            client_label: label.to_owned(),
+            identity_seed: pad32(label.as_bytes()),
+            protocol_profile: client.replay_protocol_profile(),
+            group_id: group_id.as_slice().to_vec(),
+            sensitive_checkpoint,
+            captured_deliveries,
+            checkpoint_monotonic_ms: now.monotonic_ms,
+            checkpoint_wall_ms: now.wall_ms,
+            virtual_time_tick_enabled: client.replay_uses_virtual_time(),
+        })
+    }
+
+    fn complete_byte_replay(
+        &self,
+        pending: PendingByteReplay,
+        outcomes: &[Result<cgka_traits::ingest::IngestOutcome, EngineError>],
+    ) -> Option<EngineByteReplayV1> {
+        let client = self.clients.get(&pending.client_label)?;
+        let canonical_state = client.try_canonical_state_snapshot().ok()?;
+        let normalized_state_digest = crate::digest_json(&canonical_state).ok()?;
+        let (classification, failure_kind) = outcomes
+            .iter()
+            .find_map(|outcome| outcome.as_ref().err())
+            .map_or(
+                (
+                    crate::TerminalOutcomeClassification::Converged,
+                    "campaign_tick_replay".to_string(),
+                ),
+                |error| {
+                    let (category, code) = classify_engine_error(error);
+                    (
+                        crate::failure_capsule::terminal_classification(category),
+                        format!("scenario_step_failed:{code}"),
+                    )
+                },
+            );
+        let expected_fingerprint = crate::build_fingerprint(
+            classification,
+            Some("campaign_tick".into()),
+            failure_kind,
+            normalized_state_digest,
+        );
+        Some(EngineByteReplayV1 {
+            client_label: pending.client_label,
+            identity_seed: pending.identity_seed,
+            protocol_profile: pending.protocol_profile,
+            group_id: pending.group_id,
+            sensitive_checkpoint: pending.sensitive_checkpoint,
+            captured_deliveries: pending.captured_deliveries,
+            checkpoint_monotonic_ms: pending.checkpoint_monotonic_ms,
+            checkpoint_wall_ms: pending.checkpoint_wall_ms,
+            virtual_time_tick_enabled: pending.virtual_time_tick_enabled,
+            expected_fingerprint,
+        })
     }
 
     fn client_mut(&mut self, label: &str) -> Result<&mut HarnessClient, SubjectError> {
@@ -757,7 +896,14 @@ impl ConvergenceSubject for EngineHarnessSubject {
 
     async fn tick(&mut self, clients: &[String]) -> Result<(), SubjectError> {
         for label in clients {
-            ensure_tick_succeeded(self.client_mut(label)?.tick().await)?;
+            let pending_replay = self.prepare_byte_replay(label);
+            let outcomes = self.client_mut(label)?.tick().await;
+            if let Some(pending_replay) = pending_replay
+                && let Some(replay) = self.complete_byte_replay(pending_replay, &outcomes)
+            {
+                self.last_byte_replay = Some(replay);
+            }
+            ensure_tick_succeeded(outcomes)?;
         }
         Ok(())
     }
@@ -1285,8 +1431,39 @@ fn outbound_sequence(outbound_id: &str) -> Result<u64, SubjectError> {
         })
 }
 
+pub(crate) fn classify_engine_error(error: &EngineError) -> (SubjectFailureCategory, String) {
+    let category = match error {
+        EngineError::Backend(_) | EngineError::Storage(_) => SubjectFailureCategory::Resource,
+        EngineError::InvalidTransition(_)
+        | EngineError::Other(_)
+        | EngineError::Peeler(_)
+        | EngineError::ForkedEpoch { .. }
+        | EngineError::UnknownPending => SubjectFailureCategory::Protocol,
+        EngineError::NotGroupAdmin { .. }
+        | EngineError::AdminCannotSelfRemove { .. }
+        | EngineError::AdminDepletion { .. }
+        | EngineError::LeaveAlreadyRequested { .. }
+        | EngineError::Serialize(_)
+        | EngineError::InvalidWelcome
+        | EngineError::WelcomeAlreadyProcessed
+        | EngineError::UnknownGroup(_)
+        | EngineError::UnknownMember { .. }
+        | EngineError::NotAMember { .. }
+        | EngineError::MissingRequiredCapabilities { .. }
+        | EngineError::DisbandingUnsupportedMembers { .. }
+        | EngineError::DisbandingNotEnabled { .. }
+        | EngineError::InvalidCredentialIdentity(_)
+        | EngineError::InvalidAccountIdentityProof(_)
+        | EngineError::InvalidKeyPackageLifetime { .. }
+        | EngineError::UnsupportedCiphersuite { .. }
+        | EngineError::InvalidAppMessagePayload(_) => SubjectFailureCategory::ExpectedRefusal,
+    };
+    (category, observe_engine_error(error))
+}
+
 fn subject_engine_error(error: EngineError) -> SubjectError {
-    SubjectError::new(observe_engine_error(&error), error.to_string())
+    let (category, code) = classify_engine_error(&error);
+    SubjectError::classified(category, code, error.to_string())
 }
 
 fn ensure_tick_succeeded(
@@ -1398,6 +1575,7 @@ mod tests {
         ))])
         .expect_err("tick must not discard the engine failure");
         assert_eq!(error.code, "backend");
+        assert_eq!(error.category, SubjectFailureCategory::Resource);
         assert!(error.message.contains("converge buffered group"));
     }
 

--- a/crates/cgka-conformance-simulator/src/subject.rs
+++ b/crates/cgka-conformance-simulator/src/subject.rs
@@ -454,7 +454,7 @@ impl EngineHarnessSubject {
                 ));
             }
             let builder = ClientBuilder::new(pad32(label.as_bytes()))
-                .registry(scenario_registry())
+                .registry(engine_harness_feature_registry())
                 .protocol_profile(protocol_profile)
                 .storage_mode(storage_mode)
                 .convergence_clock(Arc::new(convergence_clock.clone()));
@@ -1249,7 +1249,11 @@ fn required_features_from_names(names: &[String]) -> Result<Vec<Feature>, Subjec
         .collect()
 }
 
-pub(crate) fn scenario_registry() -> FeatureRegistry {
+/// Returns the feature registry used by the production-shaped engine harness.
+///
+/// Exact replay tests use this helper so their client capabilities cannot drift
+/// from the clients constructed by [`EngineHarnessSubject`].
+pub fn engine_harness_feature_registry() -> FeatureRegistry {
     let mut registry = FeatureRegistry::new();
     registry.register(
         Feature("self-remove"),

--- a/crates/cgka-conformance-simulator/src/subject.rs
+++ b/crates/cgka-conformance-simulator/src/subject.rs
@@ -446,7 +446,8 @@ pub struct EngineHarnessSubject {
     convergence_clock: ManualConvergenceClock,
     outbound_cursors: HashMap<String, u64>,
     outbound_records: BTreeMap<u64, EngineSubjectOutboundRecord>,
-    replay_capture_enabled: bool,
+    replay_capture_target_tick: Option<usize>,
+    observed_recipient_ticks: usize,
     last_byte_replay: Option<EngineByteReplayV1>,
 }
 
@@ -528,7 +529,8 @@ impl EngineHarnessSubject {
             convergence_clock,
             outbound_cursors: HashMap::new(),
             outbound_records: BTreeMap::new(),
-            replay_capture_enabled: false,
+            replay_capture_target_tick: None,
+            observed_recipient_ticks: 0,
             last_byte_replay: None,
         })
     }
@@ -574,14 +576,14 @@ impl EngineHarnessSubject {
         self.last_byte_replay.clone()
     }
 
-    pub fn enable_failure_replay_capture(&mut self) {
-        self.replay_capture_enabled = true;
+    /// Capture one explicitly selected recipient tick. Campaign callers choose
+    /// the final planned tick so checkpoint export is paid at most once rather
+    /// than once per client on every tick step.
+    pub fn capture_failure_replay_at_tick(&mut self, recipient_tick: usize) {
+        self.replay_capture_target_tick = Some(recipient_tick);
     }
 
     fn prepare_byte_replay(&self, label: &str) -> Option<PendingByteReplay> {
-        if !self.replay_capture_enabled {
-            return None;
-        }
         let client = self.clients.get(label)?;
         let group_id = client.replay_group_id()?.clone();
         let sensitive_checkpoint = client
@@ -896,7 +898,11 @@ impl ConvergenceSubject for EngineHarnessSubject {
 
     async fn tick(&mut self, clients: &[String]) -> Result<(), SubjectError> {
         for label in clients {
-            let pending_replay = self.prepare_byte_replay(label);
+            let recipient_tick = self.observed_recipient_ticks;
+            self.observed_recipient_ticks = self.observed_recipient_ticks.saturating_add(1);
+            let pending_replay = (self.replay_capture_target_tick == Some(recipient_tick))
+                .then(|| self.prepare_byte_replay(label))
+                .flatten();
             let outcomes = self.client_mut(label)?.tick().await;
             if let Some(pending_replay) = pending_replay
                 && let Some(replay) = self.complete_byte_replay(pending_replay, &outcomes)
@@ -1438,12 +1444,12 @@ pub(crate) fn classify_engine_error(error: &EngineError) -> (SubjectFailureCateg
         | EngineError::Other(_)
         | EngineError::Peeler(_)
         | EngineError::ForkedEpoch { .. }
-        | EngineError::UnknownPending => SubjectFailureCategory::Protocol,
+        | EngineError::UnknownPending
+        | EngineError::Serialize(_) => SubjectFailureCategory::Protocol,
         EngineError::NotGroupAdmin { .. }
         | EngineError::AdminCannotSelfRemove { .. }
         | EngineError::AdminDepletion { .. }
         | EngineError::LeaveAlreadyRequested { .. }
-        | EngineError::Serialize(_)
         | EngineError::InvalidWelcome
         | EngineError::WelcomeAlreadyProcessed
         | EngineError::UnknownGroup(_)
@@ -1577,6 +1583,14 @@ mod tests {
         assert_eq!(error.code, "backend");
         assert_eq!(error.category, SubjectFailureCategory::Resource);
         assert!(error.message.contains("converge buffered group"));
+    }
+
+    #[test]
+    fn serialization_failures_are_not_classified_as_expected_refusals() {
+        let (category, code) =
+            classify_engine_error(&EngineError::Serialize("malformed internal state".into()));
+        assert_eq!(category, SubjectFailureCategory::Protocol);
+        assert_eq!(code, "invalid_admin_policy");
     }
 
     #[tokio::test]

--- a/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
+++ b/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
@@ -1856,7 +1856,7 @@ async fn strict_chaos_boundary_retires_pre_join_opaque_resource_work() {
 
 #[tokio::test]
 async fn failing_generated_case_records_a_minimized_reproducer() {
-    let scenario = ScenarioSpec {
+    let mut scenario = ScenarioSpec {
         name: "convergence-chaos/minimizer-smoke/v1".into(),
         spec_version: "2".into(),
         clients: vec!["alice".into(), "bob".into()],
@@ -1877,19 +1877,23 @@ async fn failing_generated_case_records_a_minimized_reproducer() {
             ScenarioStep::ClearEvents {
                 clients: vec!["alice".into(), "bob".into()],
             },
-            ScenarioStep::SendAppMessage {
-                sender: "bob".into(),
-                payload: "irrelevant noise".into(),
-            },
-            ScenarioStep::DeliverAll,
-            ScenarioStep::Tick {
-                clients: vec!["alice".into()],
-            },
-            ScenarioStep::Observe {
-                clients: vec!["alice".into()],
-            },
         ],
     };
+    for index in 0..24 {
+        scenario.steps.push(ScenarioStep::SendAppMessage {
+            sender: "bob".into(),
+            payload: format!("irrelevant storm message {index}"),
+        });
+    }
+    scenario.steps.extend([
+        ScenarioStep::DeliverAll,
+        ScenarioStep::Tick {
+            clients: vec!["alice".into()],
+        },
+        ScenarioStep::Observe {
+            clients: vec!["alice".into()],
+        },
+    ]);
     let case = GeneratedScenarioCase {
         family_name: "convergence-chaos/v1".into(),
         generator_version: "1".into(),
@@ -1920,6 +1924,13 @@ async fn failing_generated_case_records_a_minimized_reproducer() {
     assert!(
         minimized.steps.len() < case.scenario.steps.len(),
         "minimized case should remove irrelevant delivery noise"
+    );
+    assert!(
+        minimized
+            .steps
+            .iter()
+            .all(|step| !matches!(step, ScenarioStep::SendAppMessage { .. })),
+        "semantic failure identity should let the reducer remove the entire application-message storm"
     );
     let minimized_report =
         run_scenario_report_with_outcomes(minimized, None, case.expected_outcomes.clone())

--- a/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
+++ b/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
@@ -1681,7 +1681,7 @@ async fn convergence_chaos_family_generates_specs_with_semantic_expectations() {
 
     for (case_index, case) in cases.iter().enumerate() {
         assert_eq!(case.family_name, "convergence-chaos/v1");
-        assert_eq!(case.generator_version, "5");
+        assert_eq!(case.generator_version, "6");
         assert_eq!(case.seed, 123);
         assert_eq!(case.case_index, case_index as u64);
     }

--- a/crates/cgka-conformance-simulator/tests/failure_capsules.rs
+++ b/crates/cgka-conformance-simulator/tests/failure_capsules.rs
@@ -1,0 +1,297 @@
+use std::fs;
+
+use cgka_conformance_simulator::TraceExpectation;
+use cgka_conformance_simulator::VectorMismatch;
+use cgka_conformance_simulator::{
+    CapturedTransportArtifactV1, ClientBuilder, EngineByteReplayV1, FailureCapsuleError,
+    FailureCapsuleSensitivity, FailureCapsuleV1, TerminalOutcomeClassification, TransportBus,
+    build_fingerprint, digest_json, promote_failure_capsule_to_vector, read_failure_capsule,
+    replay_engine_bytes, run_scenario_report, write_failure_capsule,
+};
+use cgka_conformance_simulator::{ScenarioSpec, ScenarioStep};
+use cgka_engine::feature_registry::FeatureRegistry;
+use cgka_traits::group::ProtocolProfile;
+use cgka_traits::{Capability, CapabilityRequirement, Feature, RequirementLevel};
+
+fn pad32(name: &[u8]) -> Vec<u8> {
+    let mut out = vec![0_u8; 32];
+    out[..name.len()].copy_from_slice(name);
+    out
+}
+
+fn scenario_registry() -> FeatureRegistry {
+    let mut registry = FeatureRegistry::new();
+    registry.register(
+        Feature("self-remove"),
+        CapabilityRequirement {
+            requires: Capability::Proposal(10),
+            level: RequirementLevel::Required,
+            description: "MIP-03",
+        },
+    );
+    registry
+}
+
+#[tokio::test]
+async fn exact_captured_commit_replays_from_sensitive_checkpoint() {
+    let bus = TransportBus::ordered();
+    let mut alice = ClientBuilder::new(pad32(b"alice"))
+        .registry(scenario_registry())
+        .attach(&bus);
+    let mut bob = ClientBuilder::new(pad32(b"bob"))
+        .registry(scenario_registry())
+        .attach(&bus);
+    let bob_key_package = bob.fresh_key_package().await;
+    let (group_id, create) = alice
+        .create_group("byte-replay", vec![bob_key_package], vec![])
+        .await;
+    alice.confirm(create).await;
+    bus.deliver_all();
+    assert!(bob.tick().await.into_iter().all(|outcome| outcome.is_ok()));
+
+    let checkpoint = bob
+        .export_conformance_replay_checkpoint(&group_id)
+        .expect("export recipient checkpoint");
+    let update = alice.update_group_data("captured branch").await;
+    let captured_deliveries = bus.queued_messages();
+    assert_eq!(captured_deliveries.len(), 1);
+    alice.confirm(update).await;
+    bus.deliver_all();
+    assert!(bob.tick().await.into_iter().all(|outcome| outcome.is_ok()));
+
+    let normalized_state_digest =
+        digest_json(&bob.canonical_state_snapshot()).expect("digest canonical state");
+    let expected_fingerprint = build_fingerprint(
+        TerminalOutcomeClassification::OracleViolation,
+        Some("step-6:tick".into()),
+        "captured_commit_state".into(),
+        normalized_state_digest,
+    );
+    let replay = EngineByteReplayV1 {
+        client_label: "bob".into(),
+        identity_seed: pad32(b"bob"),
+        protocol_profile: ProtocolProfile::Legacy,
+        group_id: group_id.as_slice().to_vec(),
+        sensitive_checkpoint: checkpoint,
+        captured_deliveries,
+        checkpoint_monotonic_ms: 0,
+        checkpoint_wall_ms: 0,
+        virtual_time_tick_enabled: false,
+        failure_kind: "captured_commit_state".into(),
+        failing_action_id: "step-6:tick".into(),
+        expected_fingerprint: expected_fingerprint.clone(),
+    };
+
+    let debug_bus = TransportBus::ordered();
+    let mut debug_bob = ClientBuilder::new(pad32(b"bob"))
+        .registry(scenario_registry())
+        .attach(&debug_bus);
+    debug_bob
+        .restore_conformance_replay_checkpoint(&group_id, &replay.sensitive_checkpoint)
+        .expect("restore debug checkpoint");
+    for message in &replay.captured_deliveries {
+        debug_bob.inject_captured_transport(message.clone());
+    }
+    assert!(
+        debug_bob
+            .tick()
+            .await
+            .into_iter()
+            .all(|outcome| outcome.is_ok())
+    );
+    assert_eq!(
+        debug_bob.canonical_state_snapshot(),
+        bob.canonical_state_snapshot(),
+        "checkpoint plus captured transport must recreate exact state"
+    );
+
+    let mut capsule_report = run_scenario_report(
+        &ScenarioSpec {
+            name: "captured-byte-replay/v1".into(),
+            spec_version: "2".into(),
+            clients: Vec::new(),
+            steps: Vec::new(),
+        },
+        None,
+    )
+    .await
+    .expect("capsule report");
+    capsule_report.expectation_failures.push(VectorMismatch {
+        kind: "captured_commit_state".into(),
+        message: "captured byte-level sentinel".into(),
+        expected: serde_json::json!({"epoch": 1}),
+        actual: serde_json::json!({"epoch": 2}),
+    });
+    let capsule = FailureCapsuleV1::from_report(
+        capsule_report,
+        FailureCapsuleSensitivity::SensitiveLocal,
+        vec![CapturedTransportArtifactV1 {
+            sequence: 0,
+            sender: "alice".into(),
+            message: replay.captured_deliveries[0].clone(),
+        }],
+        Some(replay.clone()),
+    )
+    .expect("build byte replay capsule");
+    let dir = tempfile::tempdir().expect("capsule directory");
+    let capsule_path = dir.path().join("captured-byte-replay.v1.json");
+    write_failure_capsule(&capsule_path, &capsule).expect("write byte replay capsule");
+    let restored_capsule = read_failure_capsule(&capsule_path).expect("read byte replay capsule");
+    let observation = replay_engine_bytes(
+        restored_capsule
+            .byte_replay
+            .as_ref()
+            .expect("capsule contains byte replay"),
+    )
+    .await
+    .expect("exact bytes reproduce the state fingerprint");
+    assert_eq!(observation.epoch, 2);
+    assert_eq!(observation.fingerprint, expected_fingerprint);
+
+    let mut missing_input = replay;
+    missing_input.captured_deliveries.clear();
+    let error = replay_engine_bytes(&missing_input)
+        .await
+        .expect_err("removing captured bytes must change the outcome");
+    assert!(error.to_string().contains("fingerprint mismatch"));
+}
+
+#[tokio::test]
+async fn capsule_round_trip_records_schedule_policy_and_resources() {
+    let scenario = ScenarioSpec {
+        name: "failure-capsule-contract/v1".into(),
+        spec_version: "2".into(),
+        clients: vec!["alice".into(), "bob".into()],
+        steps: vec![
+            ScenarioStep::CreateGroup {
+                creator: "alice".into(),
+                name: "capsule".into(),
+                invitees: vec!["bob".into()],
+                required_features: vec![],
+                initial_admins: None,
+                pending: "create".into(),
+            },
+            ScenarioStep::AcknowledgeOutbound {
+                client: "alice".into(),
+                publication: Some("create".into()),
+                selection: cgka_conformance_simulator::ScenarioOutboundSelection::All,
+                outcome: cgka_conformance_simulator::SubjectOutboundOutcome::Accepted,
+            },
+            ScenarioStep::AdvanceTime { delta_ms: 250 },
+            ScenarioStep::DeliverAll,
+            ScenarioStep::Tick {
+                clients: vec!["bob".into()],
+            },
+            ScenarioStep::ObserveExact {
+                clients: vec!["alice".into(), "bob".into()],
+            },
+        ],
+    };
+    let mut report = run_scenario_report(&scenario, None)
+        .await
+        .expect("scenario report");
+    report
+        .expected_outcomes
+        .push(TraceExpectation::ClientState {
+            client: "alice".into(),
+            epoch: 999,
+            member_count: 2,
+            received_payloads: None,
+            added_members: None,
+            removed_members: None,
+        });
+    report.expectation_failures.push(VectorMismatch {
+        kind: "sentinel_state_mismatch".into(),
+        message: "intentional capsule sentinel".into(),
+        expected: serde_json::json!({"epoch": 999}),
+        actual: serde_json::json!({"epoch": 1}),
+    });
+    let capsule = FailureCapsuleV1::from_report(
+        report,
+        FailureCapsuleSensitivity::SyntheticShareable,
+        Vec::new(),
+        None,
+    )
+    .expect("build capsule");
+
+    assert_eq!(capsule.schema_version, "1");
+    assert_eq!(capsule.expanded_schedule[2].virtual_time_ms, 0);
+    assert_eq!(capsule.expanded_schedule[3].virtual_time_ms, 250);
+    assert_eq!(capsule.failure.failure_kind, "sentinel_state_mismatch");
+    assert_eq!(capsule.resources.counters["planned_scenario_steps"], 6);
+    assert_eq!(capsule.resources.counters["executed_scenario_steps"], 6);
+
+    let schema: serde_json::Value =
+        serde_json::from_str(include_str!("../schemas/failure-capsule.v1.schema.json"))
+            .expect("failure capsule schema parses");
+    let encoded = serde_json::to_value(&capsule).expect("capsule serializes");
+    for required in schema["required"].as_array().expect("required fields") {
+        let required = required.as_str().expect("required field is a string");
+        assert!(
+            encoded.get(required).is_some(),
+            "missing required {required}"
+        );
+    }
+    let promoted = promote_failure_capsule_to_vector(&capsule, "test")
+        .expect("synthetic capsule promotes to a vector candidate");
+    assert_eq!(promoted.scenario, capsule.canonical_scenario);
+    assert_eq!(promoted.expected_trace, capsule.report.expected_trace);
+    assert_eq!(promoted.expected_outcomes, capsule.report.expected_outcomes);
+
+    let mut expectationless = capsule.clone();
+    expectationless.report.expected_trace = None;
+    expectationless.report.expected_outcomes.clear();
+    assert!(matches!(
+        promote_failure_capsule_to_vector(&expectationless, "test"),
+        Err(FailureCapsuleError::MissingPortableExpectation)
+    ));
+
+    let mut incorrectly_shareable = capsule.clone();
+    incorrectly_shareable.byte_replay = Some(EngineByteReplayV1 {
+        client_label: "alice".into(),
+        identity_seed: pad32(b"alice"),
+        protocol_profile: ProtocolProfile::Legacy,
+        group_id: vec![1],
+        sensitive_checkpoint: vec![1],
+        captured_deliveries: Vec::new(),
+        checkpoint_monotonic_ms: 0,
+        checkpoint_wall_ms: 0,
+        virtual_time_tick_enabled: false,
+        failure_kind: incorrectly_shareable.failure.failure_kind.clone(),
+        failing_action_id: "oracle".into(),
+        expected_fingerprint: incorrectly_shareable.failure.clone(),
+    });
+    assert!(
+        incorrectly_shareable.validate().is_err(),
+        "a capsule containing key material must be sensitive_local"
+    );
+
+    let dir = tempfile::tempdir().expect("temporary capsule directory");
+    let path = dir
+        .path()
+        .join("sensitive-capsules")
+        .join("failure-capsule.v1.json");
+    write_failure_capsule(&path, &capsule).expect("write private capsule");
+    assert_eq!(read_failure_capsule(&path).expect("read capsule"), capsule);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        assert_eq!(
+            fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+        assert_eq!(
+            fs::metadata(path.parent().unwrap())
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o700
+        );
+    }
+
+    let mut unsupported = capsule;
+    unsupported.schema_version = "2".into();
+    assert!(unsupported.validate().is_err());
+}

--- a/crates/cgka-conformance-simulator/tests/failure_capsules.rs
+++ b/crates/cgka-conformance-simulator/tests/failure_capsules.rs
@@ -4,10 +4,10 @@ use cgka_conformance_simulator::TraceExpectation;
 use cgka_conformance_simulator::VectorMismatch;
 use cgka_conformance_simulator::{
     CapturedTransportArtifactV1, ClientBuilder, EngineByteReplayV1, FailureCapsuleError,
-    FailureCapsuleSensitivity, FailureCapsuleV1, TerminalOutcomeClassification, TransportBus,
-    build_fingerprint, digest_json, engine_harness_feature_registry, fingerprint_report_failure,
-    promote_failure_capsule_to_vector, read_failure_capsule, replay_engine_bytes,
-    run_scenario_report, write_failure_capsule,
+    FailureCapsuleSensitivity, FailureCapsuleV1, MAX_CAPTURED_TRANSPORT_JSON_BYTES,
+    TerminalOutcomeClassification, TransportBus, build_fingerprint, digest_json,
+    engine_harness_feature_registry, fingerprint_report_failure, promote_failure_capsule_to_vector,
+    read_failure_capsule, replay_engine_bytes, run_scenario_report, write_failure_capsule,
 };
 use cgka_conformance_simulator::{ScenarioSpec, ScenarioStep};
 use cgka_traits::group::ProtocolProfile;
@@ -325,6 +325,28 @@ async fn capsule_round_trip_records_schedule_policy_and_resources() {
         300
     );
     assert_eq!(bounded.resources.counters["transport_objects_dropped"], 44);
+    assert_eq!(bounded.captured_transport_artifacts[0].sequence, 44);
+    assert_eq!(bounded.captured_transport_artifacts[255].sequence, 299);
+
+    let mut too_large = template.clone();
+    too_large.sequence = 1;
+    too_large.message.payload = vec![0; MAX_CAPTURED_TRANSPORT_JSON_BYTES as usize + 1];
+    let contiguous_tail = FailureCapsuleV1::from_report(
+        first_failed_report.clone(),
+        FailureCapsuleSensitivity::SyntheticShareable,
+        vec![
+            template.clone(),
+            too_large,
+            CapturedTransportArtifactV1 {
+                sequence: 2,
+                ..template.clone()
+            },
+        ],
+        None,
+    )
+    .expect("oversized middle artifact is evicted with the older prefix");
+    assert_eq!(contiguous_tail.captured_transport_artifacts.len(), 1);
+    assert_eq!(contiguous_tail.captured_transport_artifacts[0].sequence, 2);
 
     let dir = tempfile::tempdir().expect("temporary capsule directory");
     let path = dir

--- a/crates/cgka-conformance-simulator/tests/failure_capsules.rs
+++ b/crates/cgka-conformance-simulator/tests/failure_capsules.rs
@@ -11,6 +11,8 @@ use cgka_conformance_simulator::{
 };
 use cgka_conformance_simulator::{ScenarioSpec, ScenarioStep};
 use cgka_traits::group::ProtocolProfile;
+use cgka_traits::transport::{Timestamp, TransportEnvelope, TransportMessage, TransportSource};
+use cgka_traits::types::MessageId;
 
 fn pad32(name: &[u8]) -> Vec<u8> {
     let mut out = vec![0_u8; 32];
@@ -48,9 +50,9 @@ async fn exact_captured_commit_replays_from_sensitive_checkpoint() {
     let normalized_state_digest =
         digest_json(&bob.canonical_state_snapshot()).expect("digest canonical state");
     let expected_fingerprint = build_fingerprint(
-        TerminalOutcomeClassification::OracleViolation,
-        Some("step-6:tick".into()),
-        "captured_commit_state".into(),
+        TerminalOutcomeClassification::Converged,
+        Some("campaign_tick".into()),
+        "campaign_tick_replay".into(),
         normalized_state_digest,
     );
     let replay = EngineByteReplayV1 {
@@ -63,8 +65,6 @@ async fn exact_captured_commit_replays_from_sensitive_checkpoint() {
         checkpoint_monotonic_ms: 0,
         checkpoint_wall_ms: 0,
         virtual_time_tick_enabled: false,
-        failure_kind: "captured_commit_state".into(),
-        failing_action_id: "step-6:tick".into(),
         expected_fingerprint: expected_fingerprint.clone(),
     };
 
@@ -220,7 +220,7 @@ async fn capsule_round_trip_records_schedule_policy_and_resources() {
     }
     let promoted = promote_failure_capsule_to_vector(&capsule, "test")
         .expect("synthetic capsule promotes to a vector candidate");
-    assert_eq!(promoted.scenario, capsule.canonical_scenario);
+    assert_eq!(promoted.scenario, capsule.report.scenario);
     assert_eq!(promoted.expected_trace, capsule.report.expected_trace);
     assert_eq!(promoted.expected_outcomes, capsule.report.expected_outcomes);
 
@@ -243,8 +243,6 @@ async fn capsule_round_trip_records_schedule_policy_and_resources() {
         checkpoint_monotonic_ms: 0,
         checkpoint_wall_ms: 0,
         virtual_time_tick_enabled: false,
-        failure_kind: incorrectly_shareable.failure.failure_kind.clone(),
-        failing_action_id: "oracle".into(),
         expected_fingerprint: incorrectly_shareable.failure.clone(),
     });
     assert!(
@@ -270,6 +268,7 @@ async fn capsule_round_trip_records_schedule_policy_and_resources() {
             step_type: "tick".into(),
             status: cgka_conformance_simulator::ScenarioStepStatus::Failed {
                 kind: "backend".into(),
+                category: cgka_conformance_simulator::SubjectFailureCategory::Resource,
                 message: "backend error at /tmp/first.sqlite".into(),
             },
         });
@@ -285,6 +284,47 @@ async fn capsule_round_trip_records_schedule_policy_and_resources() {
         fingerprint_report_failure(&second_failed_report).expect("second fingerprint"),
         "free-form backend text must not affect the stable failure fingerprint"
     );
+    let resource_fingerprint =
+        fingerprint_report_failure(&first_failed_report).expect("resource fingerprint");
+    assert_eq!(
+        resource_fingerprint.classification,
+        TerminalOutcomeClassification::ResourceFailure,
+        "typed subject provenance must not collapse engine/storage failures into environment noise"
+    );
+
+    let template = CapturedTransportArtifactV1 {
+        sequence: 0,
+        sender: "alice".into(),
+        message: TransportMessage {
+            id: MessageId::new(vec![7; 32]),
+            payload: vec![8; 32],
+            timestamp: Timestamp(1),
+            causal_deps: Vec::new(),
+            source: TransportSource("test".into()),
+            envelope: TransportEnvelope::GroupMessage {
+                transport_group_id: vec![9; 32],
+            },
+        },
+    };
+    let oversized_capture = (0..300)
+        .map(|sequence| CapturedTransportArtifactV1 {
+            sequence,
+            ..template.clone()
+        })
+        .collect::<Vec<_>>();
+    let bounded = FailureCapsuleV1::from_report(
+        first_failed_report.clone(),
+        FailureCapsuleSensitivity::SyntheticShareable,
+        oversized_capture,
+        None,
+    )
+    .expect("oversized evidence is bounded during capsule construction");
+    assert_eq!(bounded.captured_transport_artifacts.len(), 256);
+    assert_eq!(
+        bounded.resources.counters["transport_objects_observed"],
+        300
+    );
+    assert_eq!(bounded.resources.counters["transport_objects_dropped"], 44);
 
     let dir = tempfile::tempdir().expect("temporary capsule directory");
     let path = dir

--- a/crates/cgka-conformance-simulator/tests/failure_capsules.rs
+++ b/crates/cgka-conformance-simulator/tests/failure_capsules.rs
@@ -5,13 +5,12 @@ use cgka_conformance_simulator::VectorMismatch;
 use cgka_conformance_simulator::{
     CapturedTransportArtifactV1, ClientBuilder, EngineByteReplayV1, FailureCapsuleError,
     FailureCapsuleSensitivity, FailureCapsuleV1, TerminalOutcomeClassification, TransportBus,
-    build_fingerprint, digest_json, promote_failure_capsule_to_vector, read_failure_capsule,
-    replay_engine_bytes, run_scenario_report, write_failure_capsule,
+    build_fingerprint, digest_json, engine_harness_feature_registry, fingerprint_report_failure,
+    promote_failure_capsule_to_vector, read_failure_capsule, replay_engine_bytes,
+    run_scenario_report, write_failure_capsule,
 };
 use cgka_conformance_simulator::{ScenarioSpec, ScenarioStep};
-use cgka_engine::feature_registry::FeatureRegistry;
 use cgka_traits::group::ProtocolProfile;
-use cgka_traits::{Capability, CapabilityRequirement, Feature, RequirementLevel};
 
 fn pad32(name: &[u8]) -> Vec<u8> {
     let mut out = vec![0_u8; 32];
@@ -19,27 +18,14 @@ fn pad32(name: &[u8]) -> Vec<u8> {
     out
 }
 
-fn scenario_registry() -> FeatureRegistry {
-    let mut registry = FeatureRegistry::new();
-    registry.register(
-        Feature("self-remove"),
-        CapabilityRequirement {
-            requires: Capability::Proposal(10),
-            level: RequirementLevel::Required,
-            description: "MIP-03",
-        },
-    );
-    registry
-}
-
 #[tokio::test]
 async fn exact_captured_commit_replays_from_sensitive_checkpoint() {
     let bus = TransportBus::ordered();
     let mut alice = ClientBuilder::new(pad32(b"alice"))
-        .registry(scenario_registry())
+        .registry(engine_harness_feature_registry())
         .attach(&bus);
     let mut bob = ClientBuilder::new(pad32(b"bob"))
-        .registry(scenario_registry())
+        .registry(engine_harness_feature_registry())
         .attach(&bus);
     let bob_key_package = bob.fresh_key_package().await;
     let (group_id, create) = alice
@@ -84,7 +70,7 @@ async fn exact_captured_commit_replays_from_sensitive_checkpoint() {
 
     let debug_bus = TransportBus::ordered();
     let mut debug_bob = ClientBuilder::new(pad32(b"bob"))
-        .registry(scenario_registry())
+        .registry(engine_harness_feature_registry())
         .attach(&debug_bus);
     debug_bob
         .restore_conformance_replay_checkpoint(&group_id, &replay.sensitive_checkpoint)
@@ -264,6 +250,40 @@ async fn capsule_round_trip_records_schedule_policy_and_resources() {
     assert!(
         incorrectly_shareable.validate().is_err(),
         "a capsule containing key material must be sensitive_local"
+    );
+    assert!(
+        FailureCapsuleV1::from_report(
+            capsule.report.clone(),
+            FailureCapsuleSensitivity::SyntheticShareable,
+            Vec::new(),
+            incorrectly_shareable.byte_replay.clone(),
+        )
+        .is_err(),
+        "construction must reject a shareable capsule containing key material"
+    );
+
+    let mut first_failed_report = capsule.report.clone();
+    first_failed_report
+        .step_log
+        .push(cgka_conformance_simulator::ScenarioStepLogEntry {
+            step_index: 7,
+            step_type: "tick".into(),
+            status: cgka_conformance_simulator::ScenarioStepStatus::Failed {
+                kind: "backend".into(),
+                message: "backend error at /tmp/first.sqlite".into(),
+            },
+        });
+    let mut second_failed_report = first_failed_report.clone();
+    let cgka_conformance_simulator::ScenarioStepStatus::Failed { message, .. } =
+        &mut second_failed_report.step_log.last_mut().unwrap().status
+    else {
+        unreachable!("the appended step is failed");
+    };
+    *message = "backend error at /different/host/second.sqlite".into();
+    assert_eq!(
+        fingerprint_report_failure(&first_failed_report).expect("first fingerprint"),
+        fingerprint_report_failure(&second_failed_report).expect("second fingerprint"),
+        "free-form backend text must not affect the stable failure fingerprint"
     );
 
     let dir = tempfile::tempdir().expect("temporary capsule directory");

--- a/crates/cgka-conformance-simulator/tests/report_runner.rs
+++ b/crates/cgka-conformance-simulator/tests/report_runner.rs
@@ -132,6 +132,19 @@ fn parse_help_returns_help_command() {
 }
 
 #[test]
+fn parse_replay_capsule_command() {
+    let command = parse_report_command([
+        "--replay-capsule".into(),
+        "target/failure-capsule.v1.json".into(),
+    ])
+    .expect("replay capsule args parse");
+    assert_eq!(
+        command,
+        ReportCommand::ReplayCapsule(PathBuf::from("target/failure-capsule.v1.json"))
+    );
+}
+
+#[test]
 fn parse_rejects_unknown_argument() {
     let err = parse_report_command(["--wat".into()]).expect_err("unknown arg errors");
     assert!(err.to_string().contains("unknown argument --wat"));
@@ -276,6 +289,21 @@ async fn report_runner_strict_oracle_counts_weak_warnings_as_failures() {
             .failures
             .iter()
             .any(|failure| failure.kind == "weak_oracle_warning")
+    );
+    let capsule_path = summary.scenarios[0]
+        .failure_capsule
+        .as_ref()
+        .expect("strict failure emits a capsule");
+    assert!(capsule_path.exists());
+    let capsule: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(capsule_path).expect("read capsule"))
+            .expect("capsule JSON parses");
+    assert_eq!(capsule["schema_version"], "1");
+    assert_eq!(capsule["failure"]["classification"], "oracle_violation");
+    assert!(
+        capsule["captured_transport_artifacts"]
+            .as_array()
+            .is_some_and(|artifacts| !artifacts.is_empty())
     );
 
     fs::remove_dir_all(out_dir).expect("clean output dir");

--- a/crates/cgka-conformance-simulator/tests/report_runner.rs
+++ b/crates/cgka-conformance-simulator/tests/report_runner.rs
@@ -145,6 +145,18 @@ fn parse_replay_capsule_command() {
 }
 
 #[test]
+fn parse_replay_capsule_rejects_scenario_inputs() {
+    let error = parse_report_command([
+        "--replay-capsule".into(),
+        "target/failure-capsule.v1.json".into(),
+        "--family".into(),
+        "send-leave/v1".into(),
+    ])
+    .expect_err("replay capsule must not combine with family inputs");
+    assert!(error.to_string().contains("--replay-capsule"));
+}
+
+#[test]
 fn parse_rejects_unknown_argument() {
     let err = parse_report_command(["--wat".into()]).expect_err("unknown arg errors");
     assert!(err.to_string().contains("unknown argument --wat"));

--- a/crates/cgka-conformance-simulator/tests/report_runner.rs
+++ b/crates/cgka-conformance-simulator/tests/report_runner.rs
@@ -3,8 +3,8 @@ use std::path::PathBuf;
 
 use cgka_conformance_simulator::{
     FailureCapsuleSensitivity, HarnessStorageMode, OracleBehavior, ReportArgs, ReportCommand,
-    ReportInput, ScenarioStimulus, parse_report_command, property_test_coverage_entries,
-    read_failure_capsule, replay_engine_bytes, run_report,
+    ReportInput, ScenarioStimulus, parse_report_command, promote_failure_capsule_to_vector,
+    property_test_coverage_entries, read_failure_capsule, replay_engine_bytes, run_report,
 };
 
 #[test]
@@ -21,6 +21,7 @@ fn parse_defaults_to_send_leave_family() {
             out: PathBuf::from("target/cgka-conformance-simulator-reports"),
             strict_oracle: true,
             storage_mode: HarnessStorageMode::InMemorySqlite,
+            capture_sensitive_replay: false,
         })
     );
 }
@@ -50,6 +51,7 @@ fn parse_custom_report_args() {
             out: PathBuf::from("target/custom"),
             strict_oracle: true,
             storage_mode: HarnessStorageMode::InMemorySqlite,
+            capture_sensitive_replay: false,
         })
     );
 }
@@ -62,6 +64,16 @@ fn explicit_storage_flag_overrides_environment_default() {
         panic!("expected run command");
     };
     assert_eq!(args.storage_mode, HarnessStorageMode::TempFileBackedSqlite);
+}
+
+#[test]
+fn sensitive_replay_capture_requires_an_explicit_flag() {
+    let ReportCommand::Run(args) =
+        parse_report_command(["--capture-sensitive-replay".into()]).expect("capture flag parses")
+    else {
+        panic!("expected run command");
+    };
+    assert!(args.capture_sensitive_replay);
 }
 
 #[test]
@@ -83,6 +95,7 @@ fn parse_vector_fixture_report_args() {
             out: PathBuf::from("target/vector-reports"),
             strict_oracle: true,
             storage_mode: HarnessStorageMode::InMemorySqlite,
+            capture_sensitive_replay: false,
         })
     );
 }
@@ -107,6 +120,7 @@ fn parse_strict_oracle_report_args() {
             out: PathBuf::from("target/cgka-conformance-simulator-reports"),
             strict_oracle: true,
             storage_mode: HarnessStorageMode::InMemorySqlite,
+            capture_sensitive_replay: false,
         })
     );
 }
@@ -223,6 +237,7 @@ async fn report_runner_writes_send_leave_json_reports() {
         out: out_dir.clone(),
         strict_oracle: false,
         storage_mode: HarnessStorageMode::InMemorySqlite,
+        capture_sensitive_replay: false,
     })
     .await
     .expect("runner writes reports");
@@ -291,6 +306,7 @@ async fn report_runner_strict_oracle_counts_weak_warnings_as_failures() {
         out: out_dir.clone(),
         strict_oracle: true,
         storage_mode: HarnessStorageMode::InMemorySqlite,
+        capture_sensitive_replay: false,
     })
     .await
     .expect("strict runner writes reports");
@@ -315,6 +331,7 @@ async fn report_runner_strict_oracle_counts_weak_warnings_as_failures() {
     assert_eq!(capsule["failure"]["classification"], "oracle_violation");
     assert!(capsule.get("captured_transport_artifacts").is_none());
     assert!(capsule.get("byte_replay").is_none());
+    assert!(summary.scenarios[0].replay_capsule.is_none());
 
     fs::remove_dir_all(out_dir).expect("clean output dir");
 }
@@ -338,6 +355,7 @@ async fn report_runner_writes_convergence_delivery_json_reports() {
         out: out_dir.clone(),
         strict_oracle: false,
         storage_mode: HarnessStorageMode::InMemorySqlite,
+        capture_sensitive_replay: false,
     })
     .await
     .expect("runner writes convergence delivery reports");
@@ -390,6 +408,7 @@ async fn report_runner_writes_convergence_chaos_reports_and_fixture_candidates()
         out: out_dir.clone(),
         strict_oracle: false,
         storage_mode: HarnessStorageMode::InMemorySqlite,
+        capture_sensitive_replay: false,
     })
     .await
     .expect("runner writes convergence chaos reports");
@@ -481,6 +500,7 @@ async fn report_runner_writes_vector_fixture_reports_and_summary() {
         out: out_dir.clone(),
         strict_oracle: false,
         storage_mode: HarnessStorageMode::InMemorySqlite,
+        capture_sensitive_replay: false,
     })
     .await
     .expect("runner writes vector reports");
@@ -542,6 +562,7 @@ async fn failed_campaign_capsule_contains_a_replayable_tick_witness() {
         out: out_dir,
         strict_oracle: false,
         storage_mode: HarnessStorageMode::InMemorySqlite,
+        capture_sensitive_replay: true,
     })
     .await
     .expect("failing campaign reports");
@@ -553,9 +574,29 @@ async fn failed_campaign_capsule_contains_a_replayable_tick_witness() {
     let capsule = read_failure_capsule(capsule_path).expect("campaign capsule reads");
     assert_eq!(
         capsule.sensitivity,
+        FailureCapsuleSensitivity::SyntheticShareable
+    );
+    assert!(capsule.byte_replay.is_none());
+    promote_failure_capsule_to_vector(&capsule, "test")
+        .expect("the logical campaign capsule remains portable");
+
+    let replay_capsule_path = summary.scenarios[0]
+        .replay_capsule
+        .as_ref()
+        .expect("explicit replay capture writes a separate sibling");
+    assert!(
+        replay_capsule_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.contains("sensitive-replay-capsule"))
+    );
+    let replay_capsule =
+        read_failure_capsule(replay_capsule_path).expect("sensitive replay capsule reads");
+    assert_eq!(
+        replay_capsule.sensitivity,
         FailureCapsuleSensitivity::SensitiveLocal
     );
-    let replay = capsule
+    let replay = replay_capsule
         .byte_replay
         .as_ref()
         .expect("campaign exports its last real recipient tick");
@@ -564,7 +605,10 @@ async fn failed_campaign_capsule_contains_a_replayable_tick_witness() {
         .expect("campaign-produced tick witness replays exactly");
 
     let cli = std::process::Command::new(env!("CARGO_BIN_EXE_cgka-conformance-simulator-report"))
-        .args(["--replay-capsule", &capsule_path.display().to_string()])
+        .args([
+            "--replay-capsule",
+            &replay_capsule_path.display().to_string(),
+        ])
         .output()
         .expect("replay CLI runs");
     assert!(

--- a/crates/cgka-conformance-simulator/tests/report_runner.rs
+++ b/crates/cgka-conformance-simulator/tests/report_runner.rs
@@ -2,8 +2,9 @@ use std::fs;
 use std::path::PathBuf;
 
 use cgka_conformance_simulator::{
-    HarnessStorageMode, OracleBehavior, ReportArgs, ReportCommand, ReportInput, ScenarioStimulus,
-    parse_report_command, property_test_coverage_entries, run_report,
+    FailureCapsuleSensitivity, HarnessStorageMode, OracleBehavior, ReportArgs, ReportCommand,
+    ReportInput, ScenarioStimulus, parse_report_command, property_test_coverage_entries,
+    read_failure_capsule, replay_engine_bytes, run_report,
 };
 
 #[test]
@@ -312,11 +313,8 @@ async fn report_runner_strict_oracle_counts_weak_warnings_as_failures() {
             .expect("capsule JSON parses");
     assert_eq!(capsule["schema_version"], "1");
     assert_eq!(capsule["failure"]["classification"], "oracle_violation");
-    assert!(
-        capsule["captured_transport_artifacts"]
-            .as_array()
-            .is_some_and(|artifacts| !artifacts.is_empty())
-    );
+    assert!(capsule.get("captured_transport_artifacts").is_none());
+    assert!(capsule.get("byte_replay").is_none());
 
     fs::remove_dir_all(out_dir).expect("clean output dir");
 }
@@ -516,4 +514,62 @@ async fn report_runner_writes_vector_fixture_reports_and_summary() {
     );
 
     fs::remove_dir_all(out_dir).expect("clean output dir");
+}
+
+#[tokio::test]
+async fn failed_campaign_capsule_contains_a_replayable_tick_witness() {
+    let temp = tempfile::tempdir().expect("campaign temp directory");
+    let fixture_path = temp.path().join("failing-message-exchange.v1.json");
+    let out_dir = temp.path().join("reports");
+    let mut fixture: serde_json::Value = serde_json::from_str(include_str!(
+        "../vectors/three-client-message-exchange.v1.json"
+    ))
+    .expect("fixture parses");
+    fixture["scenario_name"] = "campaign-byte-replay/v1".into();
+    fixture["scenario"]["name"] = "campaign-byte-replay/v1".into();
+    fixture["expected_trace"]["name"] = "campaign-byte-replay/v1".into();
+    fixture["expected_trace"]["observations"][0]["member_count"] = 99.into();
+    fs::write(
+        &fixture_path,
+        serde_json::to_vec_pretty(&fixture).expect("fixture serializes"),
+    )
+    .expect("fixture writes");
+
+    let summary = run_report(&ReportArgs {
+        input: ReportInput::VectorFixtures {
+            paths: vec![fixture_path],
+        },
+        out: out_dir,
+        strict_oracle: false,
+        storage_mode: HarnessStorageMode::InMemorySqlite,
+    })
+    .await
+    .expect("failing campaign reports");
+    assert_eq!(summary.failed(), 1);
+    let capsule_path = summary.scenarios[0]
+        .failure_capsule
+        .as_ref()
+        .expect("failure capsule path");
+    let capsule = read_failure_capsule(capsule_path).expect("campaign capsule reads");
+    assert_eq!(
+        capsule.sensitivity,
+        FailureCapsuleSensitivity::SensitiveLocal
+    );
+    let replay = capsule
+        .byte_replay
+        .as_ref()
+        .expect("campaign exports its last real recipient tick");
+    replay_engine_bytes(replay)
+        .await
+        .expect("campaign-produced tick witness replays exactly");
+
+    let cli = std::process::Command::new(env!("CARGO_BIN_EXE_cgka-conformance-simulator-report"))
+        .args(["--replay-capsule", &capsule_path.display().to_string()])
+        .output()
+        .expect("replay CLI runs");
+    assert!(
+        cli.status.success(),
+        "replay CLI failed: {}",
+        String::from_utf8_lossy(&cli.stderr)
+    );
 }

--- a/crates/cgka-engine/src/conformance_snapshot.rs
+++ b/crates/cgka-engine/src/conformance_snapshot.rs
@@ -5,6 +5,8 @@
 //! never the exporter secret itself. Production telemetry and application
 //! surfaces must not enable or consume this interface.
 
+use std::collections::BTreeMap;
+
 use cgka_traits::app_components::GroupLifecycleV1;
 use cgka_traits::convergence_pass::{ConvergencePassPhase, DurableConvergencePass};
 use cgka_traits::engine_state::{EpochState, GroupLifecycleState};
@@ -22,6 +24,94 @@ use openmls_traits::types::VerifiableCiphersuite;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tls_codec::Serialize as _;
+
+/// Machine-readable snapshot of the convergence constants owned by the engine
+/// adapter. Keys are the stable ledger identifiers from the reliability plan.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConformanceConstantSnapshot {
+    pub schema_version: String,
+    pub values: BTreeMap<String, u64>,
+}
+
+/// Capture the exact engine-owned values needed to reproduce and interpret a
+/// conformance failure. App-runtime scheduler constants belong to later
+/// adapters and are deliberately not invented here.
+pub fn conformance_constant_snapshot() -> ConformanceConstantSnapshot {
+    let mut values = BTreeMap::new();
+    values.insert(
+        "P1.max_rewind_commits".into(),
+        crate::convergence::V1_MAX_REWIND_COMMITS,
+    );
+    values.insert(
+        "P2.app_message_past_epoch_limit".into(),
+        crate::canonicalization::V1_APP_MESSAGE_PAST_EPOCH_LIMIT,
+    );
+    values.insert(
+        "P3.max_past_epochs".into(),
+        crate::wire_format::DEFAULT_MAX_PAST_EPOCHS as u64,
+    );
+    values.insert(
+        "P4.settlement_quiescence_ms".into(),
+        crate::canonicalization::V1_SETTLEMENT_QUIESCENCE_MS,
+    );
+    values.insert(
+        "P5.max_convergence_pass_ms".into(),
+        crate::canonicalization::V1_MAX_CONVERGENCE_PASS_MS,
+    );
+    values.insert(
+        "P6.witness_quorum_senders_per_epoch".into(),
+        crate::convergence::V1_WITNESS_QUORUM_SENDERS_PER_EPOCH as u64,
+    );
+    values.insert(
+        "P7.witness_quorum_epochs".into(),
+        crate::convergence::V1_WITNESS_QUORUM_EPOCHS as u64,
+    );
+    values.insert(
+        "P8.max_witness_override_depth".into(),
+        crate::convergence::V1_MAX_WITNESS_OVERRIDE_DEPTH,
+    );
+    values.insert(
+        "E1.max_convergence_reprocessing_passes".into(),
+        crate::message_processor::MAX_CONVERGENCE_REPROCESSING_PASSES as u64,
+    );
+    values.insert(
+        "E2.max_deferred_peel_attempts".into(),
+        crate::message_processor::MAX_DEFERRED_PEEL_ATTEMPTS as u64,
+    );
+    values.insert(
+        "E3.max_peel_deferred_rows_per_group".into(),
+        crate::message_processor::MAX_PEEL_DEFERRED_ROWS_PER_GROUP as u64,
+    );
+    values.insert(
+        "E4.max_deferred_rows_per_sweep".into(),
+        crate::message_processor::MAX_DEFERRED_ROWS_PER_SWEEP as u64,
+    );
+    values.insert(
+        "E5.candidate_replay_budget_slack".into(),
+        crate::openmls_projection::CANDIDATE_REPLAY_BUDGET_SLACK,
+    );
+    values.insert(
+        "E6.candidate_replay_budget_floor".into(),
+        crate::openmls_projection::CANDIDATE_REPLAY_BUDGET_FLOOR,
+    );
+    values.insert(
+        "E7.self_remove_auto_commit_jitter_min_ms".into(),
+        crate::message_processor::SELF_REMOVE_AUTO_COMMIT_JITTER_MIN_MS,
+    );
+    values.insert(
+        "E7.self_remove_auto_commit_jitter_max_ms".into(),
+        crate::message_processor::SELF_REMOVE_AUTO_COMMIT_JITTER_MIN_MS
+            + crate::message_processor::SELF_REMOVE_AUTO_COMMIT_JITTER_SPAN_MS,
+    );
+    values.insert(
+        "E8.max_deferred_peel_residence_ms".into(),
+        crate::message_processor::MAX_DEFERRED_PEEL_RESIDENCE_MS,
+    );
+    ConformanceConstantSnapshot {
+        schema_version: "1".into(),
+        values,
+    }
+}
 
 /// MLS-Exporter label adopted by Marmot's conformance-state contract.
 pub const CONFORMANCE_EXPORTER_LABEL: &str = "marmot";
@@ -698,6 +788,34 @@ mod tests {
             CONFORMANCE_COMMITMENT_DOMAIN,
             b"marmot-convergence-conformance-v1"
         );
+    }
+
+    #[test]
+    fn constant_snapshot_pins_every_engine_owned_reliability_constant() {
+        let snapshot = conformance_constant_snapshot();
+        assert_eq!(snapshot.schema_version, "1");
+        assert_eq!(snapshot.values.len(), 17);
+        for key in [
+            "P1.max_rewind_commits",
+            "P2.app_message_past_epoch_limit",
+            "P3.max_past_epochs",
+            "P4.settlement_quiescence_ms",
+            "P5.max_convergence_pass_ms",
+            "P6.witness_quorum_senders_per_epoch",
+            "P7.witness_quorum_epochs",
+            "P8.max_witness_override_depth",
+            "E1.max_convergence_reprocessing_passes",
+            "E2.max_deferred_peel_attempts",
+            "E3.max_peel_deferred_rows_per_group",
+            "E4.max_deferred_rows_per_sweep",
+            "E5.candidate_replay_budget_slack",
+            "E6.candidate_replay_budget_floor",
+            "E7.self_remove_auto_commit_jitter_min_ms",
+            "E7.self_remove_auto_commit_jitter_max_ms",
+            "E8.max_deferred_peel_residence_ms",
+        ] {
+            assert!(snapshot.values.contains_key(key), "missing {key}");
+        }
     }
 
     #[test]

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -32,9 +32,9 @@ use cgka_traits::transport::{TransportEnvelope, TransportMessage};
 use cgka_traits::types::{EpochId, GroupId, MemberId, MessageId};
 use sha2::{Digest, Sha256};
 
-const MAX_CONVERGENCE_REPROCESSING_PASSES: usize = 16;
-const SELF_REMOVE_AUTO_COMMIT_JITTER_MIN_MS: u64 = 10;
-const SELF_REMOVE_AUTO_COMMIT_JITTER_SPAN_MS: u64 = 40;
+pub(crate) const MAX_CONVERGENCE_REPROCESSING_PASSES: usize = 16;
+pub(crate) const SELF_REMOVE_AUTO_COMMIT_JITTER_MIN_MS: u64 = 10;
+pub(crate) const SELF_REMOVE_AUTO_COMMIT_JITTER_SPAN_MS: u64 = 40;
 
 /// Retry budget for a `PeelDeferred` row (mdk#339). Each unit is one
 /// actual re-peel attempt under a *changed* peel context (the fingerprint

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -171,9 +171,9 @@ struct ReplayBudget {
 /// Multiplicative slack over the linear `commits × (max_rewind_commits + 1)` probe estimate.
 /// Generous enough that legitimate forks never trip the budget; small enough that pathological
 /// `B^D` branching fails closed well before it materializes.
-const CANDIDATE_REPLAY_BUDGET_SLACK: u64 = 4;
+pub(crate) const CANDIDATE_REPLAY_BUDGET_SLACK: u64 = 4;
 /// Floor so tiny passes (few commits, shallow rewind) always have headroom.
-const CANDIDATE_REPLAY_BUDGET_FLOOR: u64 = 32;
+pub(crate) const CANDIDATE_REPLAY_BUDGET_FLOOR: u64 = 32;
 
 impl ReplayBudget {
     fn new(limit: u64) -> Self {

--- a/crates/storage-sqlite/Cargo.toml
+++ b/crates/storage-sqlite/Cargo.toml
@@ -24,3 +24,4 @@ tempfile.workspace = true
 
 [features]
 extensions-draft = ["openmls_traits/extensions-draft"]
+test-conformance-replay = []

--- a/crates/storage-sqlite/src/connection.rs
+++ b/crates/storage-sqlite/src/connection.rs
@@ -443,6 +443,27 @@ impl SqliteSynchronous {
 }
 
 impl SqliteAccountStorage {
+    /// Export one group's convergence/OpenMLS state, including any durable
+    /// convergence pass, for a sensitive test-only replay capsule.
+    #[cfg(feature = "test-conformance-replay")]
+    pub fn export_conformance_replay_snapshot(
+        &self,
+        group_id: &cgka_traits::types::GroupId,
+    ) -> StorageResult<Vec<u8>> {
+        crate::storage::snapshots::export_replay(self, group_id)
+    }
+
+    /// Restore a sensitive test-only conformance replay snapshot into this
+    /// account-device database.
+    #[cfg(feature = "test-conformance-replay")]
+    pub fn import_conformance_replay_snapshot(
+        &self,
+        group_id: &cgka_traits::types::GroupId,
+        snapshot: &[u8],
+    ) -> StorageResult<()> {
+        crate::storage::snapshots::import_replay(self, group_id, snapshot)
+    }
+
     pub fn in_memory() -> StorageResult<Self> {
         Self::in_memory_with_options(SqliteStorageOptions::default())
     }

--- a/crates/storage-sqlite/src/storage/mod.rs
+++ b/crates/storage-sqlite/src/storage/mod.rs
@@ -13,7 +13,7 @@ mod maintenance;
 mod member_validation_cache;
 mod messages;
 mod outbound;
-mod snapshots;
+pub(crate) mod snapshots;
 mod welcomes;
 
 #[cfg(test)]

--- a/crates/storage-sqlite/src/storage/snapshots.rs
+++ b/crates/storage-sqlite/src/storage/snapshots.rs
@@ -35,6 +35,23 @@ pub(super) fn release(
     lifecycle::release(store, group_id, name)
 }
 
+#[cfg(feature = "test-conformance-replay")]
+pub(crate) fn export_replay(
+    store: &SqliteAccountStorage,
+    group_id: &GroupId,
+) -> StorageResult<Vec<u8>> {
+    capture::export(store, group_id)
+}
+
+#[cfg(feature = "test-conformance-replay")]
+pub(crate) fn import_replay(
+    store: &SqliteAccountStorage,
+    group_id: &GroupId,
+    snapshot: &[u8],
+) -> StorageResult<()> {
+    restore::import(store, group_id, snapshot)
+}
+
 #[cfg(test)]
 mod tests {
     use crate::SqliteAccountStorage;
@@ -245,6 +262,79 @@ mod tests {
         assert!(matches!(
             store.rollback_group_to_snapshot(&g1.id, "a-before"),
             Err(StorageError::SnapshotMissing(_))
+        ));
+    }
+
+    #[cfg(feature = "test-conformance-replay")]
+    #[test]
+    fn conformance_replay_snapshot_round_trips_into_a_fresh_database() {
+        use cgka_traits::convergence_pass::{
+            ConvergenceCutoffCause, ConvergencePassMember, ConvergencePassMemberRole,
+            ConvergencePassPhase, DurableConvergencePass,
+        };
+        use cgka_traits::storage::ConvergencePassStorage;
+
+        let source = SqliteAccountStorage::in_memory().unwrap();
+        let group = sample_group(gid(1), 3, 2);
+        source.put_group(&group).unwrap();
+        source
+            .put_message(&sample_message(mid(7), group.id.clone(), 3))
+            .unwrap();
+        let mls_group_id = openmls::group::GroupId::from_slice(group.id.as_slice());
+        source
+            .mls_storage()
+            .write_group_state(&mls_group_id, &TestGroupState(b"captured-state".to_vec()))
+            .unwrap();
+        let pass = DurableConvergencePass {
+            group_id: group.id.clone(),
+            generation: 9,
+            phase: ConvergencePassPhase::Frozen,
+            base_epoch: EpochId(3),
+            clock_instance_id: 42,
+            opened_monotonic_ms: 100,
+            quiescence_deadline_monotonic_ms: 1_100,
+            absolute_deadline_monotonic_ms: 5_100,
+            opened_wall_ms: 200,
+            quiescence_deadline_wall_ms: 1_200,
+            absolute_deadline_wall_ms: 5_200,
+            members: vec![ConvergencePassMember {
+                message_id: mid(7),
+                payload_digest: [8; 32],
+                role: ConvergencePassMemberRole::CommitEdge,
+                source_epoch: 3,
+            }],
+            frozen_at_wall_ms: Some(1_200),
+            cutoff_cause: Some(ConvergenceCutoffCause::Quiescence),
+            fairness_slot_available: false,
+        };
+        source.put_convergence_pass(&pass).unwrap();
+
+        let snapshot = source
+            .export_conformance_replay_snapshot(&group.id)
+            .unwrap();
+        let restored = SqliteAccountStorage::in_memory().unwrap();
+        restored
+            .import_conformance_replay_snapshot(&group.id, &snapshot)
+            .unwrap();
+
+        assert_eq!(restored.get_group(&group.id).unwrap(), group);
+        assert_eq!(
+            restored
+                .list_messages(&group.id, cgka_traits::types::EpochId(0))
+                .unwrap(),
+            source
+                .list_messages(&group.id, cgka_traits::types::EpochId(0))
+                .unwrap()
+        );
+        let state: Option<TestGroupState> =
+            restored.mls_storage().group_state(&mls_group_id).unwrap();
+        assert_eq!(state, Some(TestGroupState(b"captured-state".to_vec())));
+        assert_eq!(restored.convergence_pass(&group.id).unwrap(), Some(pass));
+
+        assert!(matches!(
+            restored.import_conformance_replay_snapshot(&gid(2), &snapshot),
+            Err(StorageError::Serialization(message))
+                if message == "conformance replay snapshot group id mismatch"
         ));
     }
 }

--- a/crates/storage-sqlite/src/storage/snapshots/capture.rs
+++ b/crates/storage-sqlite/src/storage/snapshots/capture.rs
@@ -1,9 +1,9 @@
-#[cfg(feature = "test-conformance-replay")]
-use super::rows::ReplaySnapshot;
 use super::rows::{
     MemberCapabilitiesSnapshot, OpenMlsValueSnapshot, OrderedMessage, OrderedQueuedOutbound,
     Snapshot,
 };
+#[cfg(feature = "test-conformance-replay")]
+use super::rows::{REPLAY_SNAPSHOT_VERSION, ReplaySnapshot};
 use crate::openmls_storage::mls_group_key;
 use crate::{
     SqliteAccountStorage, SqliteResultExt, connection::retry_on_busy, deserialize, serialize,
@@ -92,7 +92,7 @@ pub(super) fn export(store: &SqliteAccountStorage, group_id: &GroupId) -> Storag
         .map(|record| deserialize(&record))
         .transpose()?;
     serialize(&ReplaySnapshot {
-        version: 1,
+        version: REPLAY_SNAPSHOT_VERSION,
         group: capture_snapshot(&conn, group_id)?,
         convergence_pass,
     })

--- a/crates/storage-sqlite/src/storage/snapshots/capture.rs
+++ b/crates/storage-sqlite/src/storage/snapshots/capture.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "test-conformance-replay")]
+use super::rows::ReplaySnapshot;
 use super::rows::{
     MemberCapabilitiesSnapshot, OpenMlsValueSnapshot, OrderedMessage, OrderedQueuedOutbound,
     Snapshot,
@@ -36,6 +38,17 @@ fn create_on_connection(
     group_id: &GroupId,
     name: &str,
 ) -> StorageResult<()> {
+    let snapshot = capture_snapshot(conn, group_id)?;
+    conn.execute(
+        "INSERT OR REPLACE INTO cgka_group_snapshots (group_id, name, snapshot)
+             VALUES (?1, ?2, ?3)",
+        params![group_id.as_slice(), name, serialize(&snapshot)?],
+    )
+    .storage()?;
+    Ok(())
+}
+
+fn capture_snapshot(conn: &rusqlite::Connection, group_id: &GroupId) -> StorageResult<Snapshot> {
     let mls_group_key = mls_group_key(group_id)?;
     let group_blob: Vec<u8> = conn
         .query_row(
@@ -54,7 +67,7 @@ fn create_on_connection(
     let validated_tree_marker = validated_tree_marker(conn, group_id)?;
     let openmls_values = openmls_values(conn, &mls_group_key)?;
 
-    let snapshot = Snapshot {
+    Ok(Snapshot {
         group,
         messages,
         queued_outbound,
@@ -62,14 +75,27 @@ fn create_on_connection(
         convergence_policy,
         validated_tree_marker,
         openmls_values,
-    };
-    conn.execute(
-        "INSERT OR REPLACE INTO cgka_group_snapshots (group_id, name, snapshot)
-             VALUES (?1, ?2, ?3)",
-        params![group_id.as_slice(), name, serialize(&snapshot)?],
-    )
-    .storage()?;
-    Ok(())
+    })
+}
+
+#[cfg(feature = "test-conformance-replay")]
+pub(super) fn export(store: &SqliteAccountStorage, group_id: &GroupId) -> StorageResult<Vec<u8>> {
+    let conn = store.lock()?;
+    let convergence_pass = conn
+        .query_row(
+            "SELECT record FROM cgka_convergence_passes WHERE group_id = ?1",
+            params![group_id.as_slice()],
+            |row| row.get::<_, Vec<u8>>(0),
+        )
+        .optional()
+        .storage()?
+        .map(|record| deserialize(&record))
+        .transpose()?;
+    serialize(&ReplaySnapshot {
+        version: 1,
+        group: capture_snapshot(&conn, group_id)?,
+        convergence_pass,
+    })
 }
 
 fn messages(tx: &rusqlite::Connection, group_id: &GroupId) -> StorageResult<Vec<OrderedMessage>> {

--- a/crates/storage-sqlite/src/storage/snapshots/restore.rs
+++ b/crates/storage-sqlite/src/storage/snapshots/restore.rs
@@ -1,9 +1,9 @@
-#[cfg(feature = "test-conformance-replay")]
-use super::rows::ReplaySnapshot;
 use super::rows::{
     MemberCapabilitiesSnapshot, OpenMlsValueSnapshot, OrderedMessage, OrderedQueuedOutbound,
     Snapshot,
 };
+#[cfg(feature = "test-conformance-replay")]
+use super::rows::{REPLAY_SNAPSHOT_VERSION, ReplaySnapshot};
 use crate::openmls_storage::mls_group_key;
 use crate::{
     SqliteAccountStorage, SqliteResultExt, connection::retry_on_busy, created_at_to_i64,
@@ -72,7 +72,7 @@ pub(super) fn import(
     snapshot_blob: &[u8],
 ) -> StorageResult<()> {
     let snapshot: ReplaySnapshot = deserialize(snapshot_blob)?;
-    if snapshot.version != 1 {
+    if snapshot.version != REPLAY_SNAPSHOT_VERSION {
         return Err(StorageError::Serialization(format!(
             "unsupported conformance replay snapshot version {}",
             snapshot.version

--- a/crates/storage-sqlite/src/storage/snapshots/restore.rs
+++ b/crates/storage-sqlite/src/storage/snapshots/restore.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "test-conformance-replay")]
+use super::rows::ReplaySnapshot;
 use super::rows::{
     MemberCapabilitiesSnapshot, OpenMlsValueSnapshot, OrderedMessage, OrderedQueuedOutbound,
     Snapshot,
@@ -60,15 +62,74 @@ fn rollback_snapshot(
         .storage()?
         .ok_or_else(|| StorageError::SnapshotMissing(name.to_string()))?;
     let snapshot: Snapshot = deserialize(&snapshot_blob)?;
+    restore_snapshot(conn, group_id, &snapshot, mls_group_key)
+}
 
+#[cfg(feature = "test-conformance-replay")]
+pub(super) fn import(
+    store: &SqliteAccountStorage,
+    group_id: &GroupId,
+    snapshot_blob: &[u8],
+) -> StorageResult<()> {
+    let snapshot: ReplaySnapshot = deserialize(snapshot_blob)?;
+    if snapshot.version != 1 {
+        return Err(StorageError::Serialization(format!(
+            "unsupported conformance replay snapshot version {}",
+            snapshot.version
+        )));
+    }
+    if snapshot.group.group.id != *group_id {
+        return Err(StorageError::Serialization(
+            "conformance replay snapshot group id mismatch".to_string(),
+        ));
+    }
+    retry_on_busy(|| {
+        let mls_group_key = mls_group_key(group_id)?;
+        let mut conn = store.lock()?;
+        let tx = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .storage()?;
+        restore_snapshot(&tx, group_id, &snapshot.group, &mls_group_key)?;
+        convergence_pass(&tx, group_id, snapshot.convergence_pass.as_ref())?;
+        tx.commit().storage()?;
+        Ok(())
+    })
+}
+
+#[cfg(feature = "test-conformance-replay")]
+fn convergence_pass(
+    conn: &rusqlite::Connection,
+    group_id: &GroupId,
+    pass: Option<&cgka_traits::convergence_pass::DurableConvergencePass>,
+) -> StorageResult<()> {
+    conn.execute(
+        "DELETE FROM cgka_convergence_passes WHERE group_id = ?1",
+        params![group_id.as_slice()],
+    )
+    .storage()?;
+    if let Some(pass) = pass {
+        conn.execute(
+            "INSERT INTO cgka_convergence_passes (group_id, record) VALUES (?1, ?2)",
+            params![group_id.as_slice(), serialize(pass)?],
+        )
+        .storage()?;
+    }
+    Ok(())
+}
+
+fn restore_snapshot(
+    conn: &rusqlite::Connection,
+    group_id: &GroupId,
+    snapshot: &Snapshot,
+    mls_group_key: &[u8],
+) -> StorageResult<()> {
     group(conn, group_id, &snapshot.group)?;
     messages(conn, group_id, &snapshot.messages)?;
     queued_outbound(conn, group_id, &snapshot.queued_outbound)?;
     member_capabilities(conn, group_id, &snapshot.member_caps)?;
     convergence_policy(conn, group_id, snapshot.convergence_policy.as_deref())?;
     validated_tree_marker(conn, group_id, snapshot.validated_tree_marker.as_deref())?;
-    openmls_values(conn, mls_group_key, &snapshot.openmls_values)?;
-    Ok(())
+    openmls_values(conn, mls_group_key, &snapshot.openmls_values)
 }
 
 fn group(conn: &rusqlite::Connection, group_id: &GroupId, group: &Group) -> StorageResult<()> {

--- a/crates/storage-sqlite/src/storage/snapshots/rows.rs
+++ b/crates/storage-sqlite/src/storage/snapshots/rows.rs
@@ -25,6 +25,9 @@ pub(super) struct Snapshot {
 /// has different semantics and must reconstruct the scheduler state as well as
 /// the group/OpenMLS state that it governs.
 #[cfg(feature = "test-conformance-replay")]
+pub(super) const REPLAY_SNAPSHOT_VERSION: u32 = 1;
+
+#[cfg(feature = "test-conformance-replay")]
 #[derive(Serialize, Deserialize)]
 pub(super) struct ReplaySnapshot {
     pub(super) version: u32,

--- a/crates/storage-sqlite/src/storage/snapshots/rows.rs
+++ b/crates/storage-sqlite/src/storage/snapshots/rows.rs
@@ -1,4 +1,6 @@
 use cgka_traits::capabilities::GroupCapabilities;
+#[cfg(feature = "test-conformance-replay")]
+use cgka_traits::convergence_pass::DurableConvergencePass;
 use cgka_traits::group::Group;
 use cgka_traits::message::MessageRecord;
 use cgka_traits::storage::QueuedOutboundIntent;
@@ -14,6 +16,20 @@ pub(super) struct Snapshot {
     pub(super) convergence_policy: Option<Vec<u8>>,
     pub(super) validated_tree_marker: Option<Vec<u8>>,
     pub(super) openmls_values: Vec<OpenMlsValueSnapshot>,
+}
+
+/// Test-only envelope for byte-exact convergence replay.
+///
+/// Ordinary epoch rollback deliberately excludes the durable convergence pass:
+/// a rollback must not silently rewind the pass scheduler. A replay checkpoint
+/// has different semantics and must reconstruct the scheduler state as well as
+/// the group/OpenMLS state that it governs.
+#[cfg(feature = "test-conformance-replay")]
+#[derive(Serialize, Deserialize)]
+pub(super) struct ReplaySnapshot {
+    pub(super) version: u32,
+    pub(super) group: Snapshot,
+    pub(super) convergence_pass: Option<DurableConvergencePass>,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -499,25 +499,27 @@ Status: `complete`
 - [x] Promote minimized synthetic failures into portable vectors when they define durable behavior.
 
 Capsule v1 is the local `failure_capsule.rs` data contract plus
-`schemas/failure-capsule.v1.schema.json`. Report campaigns automatically emit a capsule for failed steps, oracle
-violations, weak-oracle failures, and quiescence failures. A capsule records the complete report (including exact state,
+`schemas/failure-capsule.v1.schema.json`. Report campaigns automatically emit a portable logical capsule for failed
+steps, oracle violations, weak-oracle failures, and quiescence failures. A capsule records the complete report (including exact state,
 input ledgers, and output observations), generated seed metadata, a virtual-time-expanded action schedule, exact
 quiescence policies, the engine constant snapshot, adapter/binary versions, and bounded resource counters. Failure
 evidence retains at most the newest 256 transport objects and 1 MiB of serialized transport data while recording
 observed, retained, and dropped object/byte counts. A warning-only strict-oracle capsule retains no wire bytes or key
-material. Byte replay uses the same delivery limits and a 16 MiB checkpoint ceiling; an oversized tick is skipped while
-the previous bounded witness remains available. Stable full fingerprints combine a normalized terminal classification, first failing action, failure kind,
+material. Byte replay uses the same delivery limits and a 16 MiB checkpoint ceiling; an oversized selected tick is
+skipped. Stable full fingerprints combine a normalized terminal classification, first failing action, failure kind,
 and observed-state digest. The reducer instead preserves semantic failure identity (classification, action type, and
 failure kind), so removing irrelevant steps is not defeated by shifted action indices or a changed trace digest.
 
-The optional engine byte-replay payload is deliberately separate from logical scenario replay. During a real report
-campaign, the engine adapter records the most recent recipient tick (or the tick that fails): its pre-input
-SQLite/OpenMLS checkpoint, including any active durable convergence pass, the exact mailbox `TransportMessage`
-objects, and the resulting typed engine fingerprint. Replay therefore never asks OpenMLS to regenerate a commit.
-Ordinary epoch rollback snapshots intentionally do not rewind pass scheduling; only this replay envelope carries that
-additional state. The checkpoint contains key material: validation rejects it unless the capsule is
-`sensitive_local`, and the writer creates directories/files with owner-only modes. The report CLI accepts
-`--replay-capsule FILE` and verifies the captured engine fingerprint. `promote_failure_capsule_to_vector` accepts only
+The optional engine byte-replay payload is deliberately separate from logical scenario replay. Sensitive capture is
+off by default and requires `--capture-sensitive-replay`. The engine adapter then exports at most one checkpoint, for
+the final planned recipient tick, rather than serializing every client database before every tick. Its pre-input
+SQLite/OpenMLS checkpoint includes any active durable convergence pass, the exact mailbox `TransportMessage` objects,
+and the resulting typed engine fingerprint. The report runner keeps the logical capsule `synthetic_shareable` and
+writes the checkpoint to a separately named `sensitive_local` sibling; if execution stops before the selected tick, no
+replay sibling is emitted. Replay therefore never asks OpenMLS to regenerate a commit. Ordinary epoch rollback
+snapshots intentionally do not rewind pass scheduling; only this replay envelope carries that additional state. The
+checkpoint contains key material, and the writer creates directories/files with owner-only modes. The report CLI
+accepts `--replay-capsule FILE` and verifies the captured engine fingerprint. `promote_failure_capsule_to_vector` accepts only
 `synthetic_shareable` capsules, preserves the intended exact or semantic expectation rather than the buggy observed
 trace, and uses the fingerprint-preserving minimized scenario when present. It refuses capsules without a portable
 expectation.

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -115,7 +115,7 @@ The baseline is useful scaffolding, but it is not yet the target reliability lab
 | Milestone | Outcome | Status | Exit gate |
 | --- | --- | --- | --- |
 | 0. Assurance foundation | Guarantees, assumptions, constants, and formal gate are explicit | complete | Every constant is classified; formal warnings fail CI; protocol decisions are named |
-| 1. Trustworthy engine black box | Exact oracle, public subject boundary, full quiescence, replay capsules | in-progress | Known semantic mutations fail and captured failures replay |
+| 1. Trustworthy engine black box | Exact oracle, public subject boundary, full quiescence, replay capsules | complete | Known semantic mutations fail and captured failures replay |
 | 2. Scenario IR and retained relays | One adapter-neutral DSL/IR plus realistic offline/history sync | not-started | One compiled case runs against reference, engine, and retained-relay adapters |
 | 3. Adversarial campaigns | Sustained real-world workloads, resource sweeps, incident import | not-started | Headline workload families produce bounded, diagnosable results |
 | 4. Independent verification | Reference model, liveness model, mutation adequacy, protocol decision gate | not-started | Model and tests detect seeded policy/lifecycle defects |
@@ -435,9 +435,9 @@ point hid. Two are resolved without weakening the oracle:
 The remaining engine-state failure was closed by durably bounding opaque local transport residence: after controlled
 virtual time, the pre-join object is released as `resource_refused`, exact-ID redelivery remains eligible, and the
 strict scenario-input/pending-work boundary settles without claiming a protocol stale reason. Report campaigns run the
-complete strict expectations by default. Strict coverage still flags the mixed large storm because its application
-phase is cleared before any delivery-or-invalidation expectation accounts for it; that is a separate oracle coverage
-gap.
+complete strict expectations by default. The mixed large storm now retains its application phase through the
+interleaved commit storm and pins each observed recipient's ordered payload set, so commit convergence cannot hide
+dropped or duplicated application traffic.
 
 ### 1.2 Public subject boundary
 
@@ -488,23 +488,66 @@ Status: `complete`
 
 ### 1.4 Deterministic failure capsules
 
-Status: `not-started`
+Status: `complete`
 
-- [ ] Define a versioned capsule schema.
-- [ ] Save original scenario, canonical IR, seeds, expanded schedule, policy/constant snapshot, adapter/binary versions,
+- [x] Define a versioned capsule schema.
+- [x] Save original scenario, canonical IR, seeds, expanded schedule, policy/constant snapshot, adapter/binary versions,
   captured wire bytes, virtual time, scenario-input/output ledger, state commitments, and resource measurements.
-- [ ] Replay a capsule without regenerating MLS bytes.
-- [ ] Keep real incident artifacts local and restrictive-by-construction.
-- [ ] Promote minimized synthetic failures into portable vectors when they define durable behavior.
+- [x] Replay a capsule without regenerating MLS bytes.
+- [x] Keep real incident artifacts local and restrictive-by-construction.
+- [x] Promote minimized synthetic failures into portable vectors when they define durable behavior.
+
+Capsule v1 is the local `failure_capsule.rs` data contract plus
+`schemas/failure-capsule.v1.schema.json`. Report campaigns automatically emit a capsule for failed steps, oracle
+violations, weak-oracle failures, and quiescence failures. A capsule records the complete report (including exact state,
+input ledgers, and output observations), generated seed metadata, a virtual-time-expanded action schedule, exact
+quiescence policies, the engine constant snapshot, adapter/binary versions, transport objects, and bounded resource
+counters. Stable fingerprints combine a normalized terminal classification, first failing action, failure kind, and
+observed-state digest; the reducer accepts a candidate only when that full fingerprint is preserved.
+
+The optional engine byte-replay payload is deliberately separate from logical scenario replay. It contains a
+recipient's pre-input SQLite/OpenMLS checkpoint, including any active durable convergence pass, and the exact captured
+`TransportMessage` objects, so replay never asks OpenMLS to regenerate a commit. Ordinary epoch rollback snapshots
+intentionally do not rewind pass scheduling; only this test-only replay envelope carries that additional state. The
+checkpoint contains key material: validation rejects it unless the capsule is
+`sensitive_local`, and the writer creates directories/files with owner-only modes. The report CLI accepts
+`--replay-capsule FILE` and verifies the captured engine fingerprint. `promote_failure_capsule_to_vector` accepts only
+`synthetic_shareable` capsules, preserves the intended exact or semantic expectation rather than the buggy observed
+trace, and uses the fingerprint-preserving minimized scenario when present. It refuses capsules without a portable
+expectation.
 
 ### Milestone 1 Exit Gate
 
 - [x] A wrong exact state cannot pass as converged.
 - [x] A normal scenario cannot access engine/storage internals.
 - [x] Hidden pending work prevents quiescence.
-- [ ] A captured byte-level failure replays with the same outcome.
-- [ ] Targeted semantic mutations are detected.
-- [ ] Every durable fail-closed/non-progress state names a tested repair or terminal user-visible outcome.
+- [x] A captured byte-level failure replays with the same outcome.
+- [x] Targeted semantic mutations are detected.
+- [x] Every durable fail-closed/non-progress state names a tested repair or terminal user-visible outcome.
+
+The Milestone 1 mutation sentinels deliberately alter member identity, exporter commitment, input-ledger disposition,
+pending-work state, a directed decryptability edge, and the captured byte delivery set. The exact-state, ledger,
+pending-work, decryptability, and replay-fingerprint oracles reject each mutation. This is the minimum oracle-adequacy
+gate; Milestone 4.3 still owns a broad implementation mutation campaign.
+
+Durable non-progress/fail-closed outcome inventory:
+
+| Durable state/disposition | Named recovery or terminal outcome | Current test evidence |
+| --- | --- | --- |
+| `PendingPublish` / unresolved outbound | Transport acknowledgement commits it; `ReachedNoEndpoint` atomically retracts artifacts and rolls back; a crash reopens stranded pending state | `definite_publish_failure_retracts_commit_before_local_rollback`; `reopen_after_crash_during_publish_recovers_stranded_pending_commit` |
+| `Merging` / `Recovering` / active pass | Scheduled convergence drains runnable work; inherited stale passes are discarded and reseeded at the current tip | `stale_pass_base_epoch_reopens_at_the_current_tip_instead_of_halting`; `frozen_stale_pass_base_epoch_reopens_at_the_current_tip_instead_of_halting` |
+| `Retryable` message | Dependency arrival or rollback replays it; an invalid replay retires terminally | `future_epoch_app_message_stays_deferred_until_commit_arrives`; `buffered_retryable_peer_message_is_retired_terminal_after_replay` |
+| `PeelDeferred` transport | Changed peel context retries it; capacity/retry/residence exhaustion emits typed `resource_refused`, releases the row, and preserves exact-ID redelivery | `deferred_peel_retries_after_epoch_advance`; `deferred_peel_retry_budget_refuses_without_terminal_dedup`; `deferred_peel_residence_survives_restart_and_backward_clock`; `peel_deferred_rows_capped_per_group_under_flood` |
+| `ConvergenceDeferred` input | Later dependency/evidence makes it eligible; falling below retained history terminally expires/invalidates it; it does not itself hold the scheduler open | `commit_with_missing_parent_is_deferred`; `deferred_commit_ages_out_when_it_falls_below_retained_anchor`; `future_epoch_app_message_stays_deferred_until_commit_arrives` |
+| Durable queued outbound intent | The scheduler regenerates and drains it; restart re-arms it; group removal terminally discards it | `trait_advance_convergence_drains_queued_outbound_intent`; `restart_schedules_groups_with_durable_queued_intents`; `drain_on_removed_copy_discards_queued_intents_without_error` |
+| Hydration quarantine | Access/send/convergence are visibly refused; verified retry or authenticated rejoin repairs and replays retained input | `quarantined_group_rejects_valid_inbound_commit_on_do_ingest`; `retry_recovers_a_transiently_quarantined_group`; `rejoin_welcome_replays_and_retires_quarantine_retained_input` |
+| `Unrecoverable` | Structural progress exposes a terminal blocker and the engine emits `GroupUnrecoverable`; verified replacement Welcome repairs it | `unrecoverable_halt_survives_engine_restart_until_verified_repair`; quiescence terminal-blocker tests |
+| `Disbanded`, removed/self-evicted, `Failed`, or `EpochInvalidated` | Terminal state/disposition is explicit and cannot masquerade as pending work; disband retains an authenticated shared tombstone | `exact_oracle_projects_terminal_disband_tombstone_across_restart`; `deferred_peel_self_evicted_row_stays_failed_not_swept_processed`; losing-branch invalidation tests |
+
+Typed operation failures such as `ReplayBudgetExceeded`, invalid policy, serialization, and storage failure remain
+fail-closed and cannot return a partial candidate. They do not add another durable lifecycle/disposition: the capsule
+records the failed step and the durable state already covered by this inventory. Milestone 3.1 still owns end-to-end
+resource-exhaustion and recovery campaigns for those error sources.
 
 ## Milestone 2: Scenario IR And Retained Relays
 
@@ -830,3 +873,4 @@ incorrect result.
 | 2026-07-30 | 1.2c / 1.3b subject virtual time | Added a capability-gated `advance_time` scenario operation backed by one shared paired clock across the engine subject; time advancement is a separate failure-free operation and `Tick` selects which participant runtimes observe it, while standalone clients without an injected clock preserve the legacy far-future shortcut | [MDK #1202](https://github.com/marmot-protocol/mdk/pull/1202), merge `1ccc4065`; focused serialization/preflight/dispatch test; two real disband passes remain live at a 999 ms tick, Alice alone settles at 1,000 ms, and Bob settles on a later tick without another time advance; full simulator suite |
 | 2026-08-01 | 1.2d public outbound lifecycle and Scenario IR v2 cutover | Added non-destructive polling of exact transport-ready subject artifacts and typed accepted/no-endpoint acknowledgement; client-scoped pending identities, state-bearing commits, independent Welcomes, definite rollback, regenerated queued intents, scheduled evolution work, duplicate acknowledgement, and exposure refusal retain their distinct semantics without exposing mutable bus queues. Migrated every repository-owned scenario producer to v2 `acknowledge_outbound` operations and removed the compatibility constructor, direct subject pending controls, client lifecycle flag, and silent auto-confirm branches ([MDK #1207](https://github.com/marmot-protocol/mdk/issues/1207)) | Focused subject/runner contract tests; fixed vectors; generated families; incident replay; full simulator suite; `just fast-ci` |
 | 2026-08-01 | 1.3 full-system quiescence | Added privacy-safe structural progress with runnable work, exact virtual deadlines, pass phase/generation, retry/deferred/publication/transport work, and terminal blockers; added runner-owned bounded fixed-point settling with explicit healthy-path publication/delivery policy and serializable blocked/timeout artifacts; added same-horizon batch-partition metamorphic coverage | [MDK #1216](https://github.com/marmot-protocol/mdk/pull/1216); focused real-engine deadline, lost-ack, withheld-transport, watchdog, serialization/privacy, and metamorphic tests; full simulator suite; `just fast-ci` |
+| 2026-08-02 | 1.4 deterministic failure capsules and Milestone 1 exit | Added versioned restrictive failure capsules, full-fingerprint minimization, exact recipient-state plus captured-transport replay, CLI replay, portable synthetic-vector promotion, failed-step report retention, a constant snapshot, and mixed-storm application assertions; completed the mutation-sentinel and durable-outcome inventories | `failure_capsules`; `report_runner`; `subject_step_failure_is_a_report_artifact_and_a_spec_run_error`; `convergence_chaos_family_generates_specs_with_semantic_expectations`; storage snapshot round-trip; full simulator/storage suites; `just fast-ci` |

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -491,8 +491,9 @@ Status: `complete`
 Status: `complete`
 
 - [x] Define a versioned capsule schema.
-- [x] Save original scenario, canonical IR, seeds, expanded schedule, policy/constant snapshot, adapter/binary versions,
-  captured wire bytes, virtual time, scenario-input/output ledger, state commitments, and resource measurements.
+- [x] Save the report's single authoritative scenario, seeds, expanded schedule, policy/constant snapshot,
+  adapter/binary versions, a bounded tail of captured wire bytes, virtual time, scenario-input/output ledger, state
+  commitments, and resource measurements.
 - [x] Replay a capsule without regenerating MLS bytes.
 - [x] Keep real incident artifacts local and restrictive-by-construction.
 - [x] Promote minimized synthetic failures into portable vectors when they define durable behavior.
@@ -501,15 +502,20 @@ Capsule v1 is the local `failure_capsule.rs` data contract plus
 `schemas/failure-capsule.v1.schema.json`. Report campaigns automatically emit a capsule for failed steps, oracle
 violations, weak-oracle failures, and quiescence failures. A capsule records the complete report (including exact state,
 input ledgers, and output observations), generated seed metadata, a virtual-time-expanded action schedule, exact
-quiescence policies, the engine constant snapshot, adapter/binary versions, transport objects, and bounded resource
-counters. Stable fingerprints combine a normalized terminal classification, first failing action, failure kind, and
-observed-state digest; the reducer accepts a candidate only when that full fingerprint is preserved.
+quiescence policies, the engine constant snapshot, adapter/binary versions, and bounded resource counters. Failure
+evidence retains at most the newest 256 transport objects and 1 MiB of serialized transport data while recording
+observed, retained, and dropped object/byte counts. A warning-only strict-oracle capsule retains no wire bytes or key
+material. Byte replay uses the same delivery limits and a 16 MiB checkpoint ceiling; an oversized tick is skipped while
+the previous bounded witness remains available. Stable full fingerprints combine a normalized terminal classification, first failing action, failure kind,
+and observed-state digest. The reducer instead preserves semantic failure identity (classification, action type, and
+failure kind), so removing irrelevant steps is not defeated by shifted action indices or a changed trace digest.
 
-The optional engine byte-replay payload is deliberately separate from logical scenario replay. It contains a
-recipient's pre-input SQLite/OpenMLS checkpoint, including any active durable convergence pass, and the exact captured
-`TransportMessage` objects, so replay never asks OpenMLS to regenerate a commit. Ordinary epoch rollback snapshots
-intentionally do not rewind pass scheduling; only this test-only replay envelope carries that additional state. The
-checkpoint contains key material: validation rejects it unless the capsule is
+The optional engine byte-replay payload is deliberately separate from logical scenario replay. During a real report
+campaign, the engine adapter records the most recent recipient tick (or the tick that fails): its pre-input
+SQLite/OpenMLS checkpoint, including any active durable convergence pass, the exact mailbox `TransportMessage`
+objects, and the resulting typed engine fingerprint. Replay therefore never asks OpenMLS to regenerate a commit.
+Ordinary epoch rollback snapshots intentionally do not rewind pass scheduling; only this replay envelope carries that
+additional state. The checkpoint contains key material: validation rejects it unless the capsule is
 `sensitive_local`, and the writer creates directories/files with owner-only modes. The report CLI accepts
 `--replay-capsule FILE` and verifies the captured engine fingerprint. `promote_failure_capsule_to_vector` accepts only
 `synthetic_shareable` capsules, preserves the intended exact or semantic expectation rather than the buggy observed
@@ -525,10 +531,15 @@ expectation.
 - [x] Targeted semantic mutations are detected.
 - [x] Every durable fail-closed/non-progress state names a tested repair or terminal user-visible outcome.
 
-The Milestone 1 mutation sentinels deliberately alter member identity, exporter commitment, input-ledger disposition,
-pending-work state, a directed decryptability edge, and the captured byte delivery set. The exact-state, ledger,
-pending-work, decryptability, and replay-fingerprint oracles reject each mutation. This is the minimum oracle-adequacy
-gate; Milestone 4.3 still owns a broad implementation mutation campaign.
+The Milestone 1 mutation sentinels deliberately alter member identity
+(`exact_equivalence_rejects_same_count_with_different_member_identities`), exporter commitment
+(`exact_equivalence_rejects_different_exporter_commitments`), input-ledger disposition
+(`scenario_input_ledger_expectation_is_exact`), pending-work state
+(`no_pending_work_requires_an_empty_exact_progress_snapshot`), a directed decryptability edge
+(`bidirectional_decryptability_requires_every_directed_edge`), and the captured byte delivery set
+(`exact_captured_commit_replays_from_sensitive_checkpoint`). The campaign producer and CLI path are pinned by
+`failed_campaign_capsule_contains_a_replayable_tick_witness`. This is the minimum oracle-adequacy gate; Milestone 4.3
+still owns a broad implementation mutation campaign.
 
 Durable non-progress/fail-closed outcome inventory:
 
@@ -873,4 +884,4 @@ incorrect result.
 | 2026-07-30 | 1.2c / 1.3b subject virtual time | Added a capability-gated `advance_time` scenario operation backed by one shared paired clock across the engine subject; time advancement is a separate failure-free operation and `Tick` selects which participant runtimes observe it, while standalone clients without an injected clock preserve the legacy far-future shortcut | [MDK #1202](https://github.com/marmot-protocol/mdk/pull/1202), merge `1ccc4065`; focused serialization/preflight/dispatch test; two real disband passes remain live at a 999 ms tick, Alice alone settles at 1,000 ms, and Bob settles on a later tick without another time advance; full simulator suite |
 | 2026-08-01 | 1.2d public outbound lifecycle and Scenario IR v2 cutover | Added non-destructive polling of exact transport-ready subject artifacts and typed accepted/no-endpoint acknowledgement; client-scoped pending identities, state-bearing commits, independent Welcomes, definite rollback, regenerated queued intents, scheduled evolution work, duplicate acknowledgement, and exposure refusal retain their distinct semantics without exposing mutable bus queues. Migrated every repository-owned scenario producer to v2 `acknowledge_outbound` operations and removed the compatibility constructor, direct subject pending controls, client lifecycle flag, and silent auto-confirm branches ([MDK #1207](https://github.com/marmot-protocol/mdk/issues/1207)) | Focused subject/runner contract tests; fixed vectors; generated families; incident replay; full simulator suite; `just fast-ci` |
 | 2026-08-01 | 1.3 full-system quiescence | Added privacy-safe structural progress with runnable work, exact virtual deadlines, pass phase/generation, retry/deferred/publication/transport work, and terminal blockers; added runner-owned bounded fixed-point settling with explicit healthy-path publication/delivery policy and serializable blocked/timeout artifacts; added same-horizon batch-partition metamorphic coverage | [MDK #1216](https://github.com/marmot-protocol/mdk/pull/1216); focused real-engine deadline, lost-ack, withheld-transport, watchdog, serialization/privacy, and metamorphic tests; full simulator suite; `just fast-ci` |
-| 2026-08-02 | 1.4 deterministic failure capsules and Milestone 1 exit | Added versioned restrictive failure capsules, full-fingerprint minimization, exact recipient-state plus captured-transport replay, CLI replay, portable synthetic-vector promotion, failed-step report retention, a constant snapshot, and mixed-storm application assertions; completed the mutation-sentinel and durable-outcome inventories | `failure_capsules`; `report_runner`; `subject_step_failure_is_a_report_artifact_and_a_spec_run_error`; `convergence_chaos_family_generates_specs_with_semantic_expectations`; storage snapshot round-trip; full simulator/storage suites; `just fast-ci` |
+| 2026-08-02 | 1.4 deterministic failure capsules and Milestone 1 exit | Added versioned restrictive failure capsules, semantic-identity minimization, typed protocol/resource/environment failure provenance, bounded transport evidence with truncation accounting, campaign-produced recipient checkpoints, exact recipient-state plus captured-transport and CLI replay, portable checkpoint-free vector promotion, failed-step report retention, a constant snapshot, and mixed-storm application assertions; completed the named mutation-sentinel and durable-outcome inventories | `failure_capsules`; `report_runner`; `failed_campaign_capsule_contains_a_replayable_tick_witness`; `failing_generated_case_records_a_minimized_reproducer`; `subject_step_failure_is_a_report_artifact_and_a_spec_run_error`; `convergence_chaos_family_generates_specs_with_semantic_expectations`; storage snapshot round-trip; full simulator/storage suites; `just fast-ci` |


### PR DESCRIPTION
## What changed

- add a versioned convergence failure-capsule schema with stable fingerprints, expanded schedules, exact policies/constants, resource counters, report evidence, and restrictive artifact writes
- retain exact emitted transport objects and add optional sensitive SQLite/OpenMLS byte replay, including active durable convergence-pass state and paired virtual-clock values
- make engine-subject tick failures typed report artifacts instead of silently discarding `EngineError`s
- minimize generated failures only when the complete fingerprint is preserved, and promote only synthetic capsules that retain the original intended expectation
- expose a machine-readable snapshot of the engine-owned convergence constants without changing their values or selection behavior
- strengthen the mixed large-group storm so application delivery remains asserted across the subsequent commit storm
- complete the Milestone 1.4 and Milestone 1 exit tracking/evidence in the reliability plan

## Why

Milestone 1 needs the in-process engine simulator to recognize incorrect results and preserve enough evidence to explain and reproduce them before broader relay, app-runtime, process, and VM campaigns build on it. Previously, generated failures lacked one stable artifact, engine tick errors could be discarded by the subject adapter, and a portable promotion could accidentally bless the observed bad output.

## Runtime impact and risk

Normal convergence behavior is unchanged. Production engine changes are limited to a conformance-only constant snapshot and crate-private visibility for existing constants; their values and call sites are unchanged. SQLite replay export/import is behind the `test-conformance-replay` feature used by the simulator. Ordinary production group snapshot/rollback semantics still exclude convergence-pass scheduling state; only the sensitive test replay envelope restores it.

Automatically emitted synthetic capsules contain logical reports and exact synthetic transport artifacts. Byte-level replay additionally requires an explicitly constructed `sensitive_local` capsule with the recipient checkpoint; those checkpoints contain key material and are written owner-only.

## Verification

- `cargo test -p storage-sqlite --features test-conformance-replay` — 309 passed
- `cargo test -p cgka-conformance-simulator` — full suite green, including 41 canonical scenarios, 11 property tests, 16 report-runner tests, and exact failure-capsule replay
- `just fast-ci`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added versioned failure capsules with reports, transport artifacts, fingerprints, and optional replay checkpoints.
  * Added CLI replay support with reproduced-failure verification.
  * Added structured failure reporting and captured transport details.
  * Added promotion of eligible synthetic failures to portable vector fixtures.
  * Added durable replay snapshots and a published capsule schema.

* **Bug Fixes**
  * Failure minimization now preserves complete failure fingerprints.
  * Scenario execution surfaces failed steps and engine errors.
  * Mixed storm scenarios retain and validate application messages through commits.

* **Documentation**
  * Updated simulator guides, scenarios, and reliability planning documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->