### PR TITLE
Add Milestone 3 adversarial convergence campaigns

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,6 +313,11 @@ jobs:
       - name: Run simulator doctests
         run: cargo test -p cgka-conformance-simulator --doc --locked
 
+      - name: Install just
+        uses: taiki-e/install-action@b18fb392e1a1b90971f7c7572c92790fa54f23d5 # just
+        with:
+          tool: just
+
       - name: Run Milestone 3 adversarial campaign gate
         run: just milestone3-ci
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,7 +284,7 @@ jobs:
   conformance:
     name: Simulator and vectors
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
 
     steps:
       - name: Check out repository
@@ -312,6 +312,9 @@ jobs:
 
       - name: Run simulator doctests
         run: cargo test -p cgka-conformance-simulator --doc --locked
+
+      - name: Run Milestone 3 adversarial campaign gate
+        run: just milestone3-ci
 
       - name: Run encrypted file-backed vector report
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,8 @@ plans/
 reviews/
 
 # Local forensic inputs and sensitive/exact replay artifacts.
-incident-exports/
-incident-replay-output/
+/incident-exports/
+/incident-replay-output/
 *-sensitive-replay-capsule.v1.json
 
 # Local Docker relay state.

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,11 @@ target/
 plans/
 reviews/
 
+# Local forensic inputs and sensitive/exact replay artifacts.
+incident-exports/
+incident-replay-output/
+*-sensitive-replay-capsule.v1.json
+
 # Local Docker relay state.
 dev/data/
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -840,6 +840,7 @@ dependencies = [
  "cgka-traits",
  "fs-private",
  "hex",
+ "libc",
  "marmot-forensics",
  "nostr",
  "openmls",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2540,6 +2540,7 @@ name = "incident-replay"
 version = "0.9.10"
 dependencies = [
  "cgka-conformance-simulator",
+ "fs-private",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/Justfile
+++ b/Justfile
@@ -250,6 +250,14 @@ conformance:
 conformance-slow:
     cargo nextest run -p cgka-conformance-simulator --features conformance-slow
 
+# Full Milestone 3 campaign gate: all catalog families, test-policy A/B and
+# resource sweeps, sustained headline workloads, and the isolated process runner.
+milestone3-ci:
+    cargo nextest run -p cgka-conformance-simulator --features test-policy-overrides --test milestone3_campaigns
+    cargo test -p cgka-conformance-simulator --features test-policy-overrides --test milestone3_campaigns -- --ignored
+    cargo nextest run -p cgka-conformance-simulator --features test-policy-overrides --test policy_sweeps
+    cargo run -p cgka-conformance-simulator --features test-policy-overrides --bin cgka-conformance-campaign -- --cases 1 --case-timeout-secs 300 --out target/cgka-milestone3-ci --storage file
+
 tracing-audit:
     cargo nextest run -p cgka-conformance-simulator --test tracing_audit
 

--- a/Justfile
+++ b/Justfile
@@ -253,10 +253,10 @@ conformance-slow:
 # Full Milestone 3 campaign gate: all catalog families, test-policy A/B and
 # resource sweeps, sustained headline workloads, and the isolated process runner.
 milestone3-ci:
-    cargo nextest run -p cgka-conformance-simulator --features test-policy-overrides --test milestone3_campaigns
-    cargo test -p cgka-conformance-simulator --features test-policy-overrides --test milestone3_campaigns -- --ignored
-    cargo nextest run -p cgka-conformance-simulator --features test-policy-overrides --test policy_sweeps
-    cargo run -p cgka-conformance-simulator --features test-policy-overrides --bin cgka-conformance-campaign -- --cases 1 --case-timeout-secs 300 --out target/cgka-milestone3-ci --storage file
+    cargo nextest run -p cgka-conformance-simulator --features test-policy-overrides --test milestone3_campaigns --locked
+    cargo test -p cgka-conformance-simulator --features test-policy-overrides --test milestone3_campaigns --locked -- --ignored
+    cargo nextest run -p cgka-conformance-simulator --features test-policy-overrides --test policy_sweeps --locked
+    cargo run -p cgka-conformance-simulator --features test-policy-overrides --bin cgka-conformance-campaign --locked -- --cases 1 --case-timeout-secs 300 --out target/cgka-milestone3-ci --storage file
 
 tracing-audit:
     cargo nextest run -p cgka-conformance-simulator --test tracing_audit

--- a/crates/cgka-conformance-simulator/AGENTS.md
+++ b/crates/cgka-conformance-simulator/AGENTS.md
@@ -149,10 +149,25 @@ the property-test registry. This file is the agent-facing model.
     `ScenarioReportSummary`, `ReportFailureSummary`) used by the report CLI. Failed reports retain subject-step errors
     and emit restrictive failure capsules with captured transport artifacts.
 
+- **Module:** `src/campaign_metrics.rs`
+  - **Role:** Stable report-native campaign measurements: scenario/convergence wall-time envelope, actual queued-send
+    blocking time, convergence decisions, engine reorg histograms, input dispositions, logical outcomes, unresolved
+    work, queue depth, replay probes, and database footprint. Fields that require an OS process boundary are explicitly
+    unavailable in an in-process report.
+
+- **Module:** `src/policy_sweep.rs`
+  - **Role:** Feature-gated, one-variable-at-a-time sweeps over a fixed canonicalization input and fixed eligibility
+    horizons. Curves record rejected boundary values and explicitly prohibit production auto-tuning.
+
 - **Module:** `src/bin/cgka-conformance-simulator-report.rs`
   - **Role:** Report writer CLI. Runs generated families or vector fixture files/directories, writes one JSON
     `ScenarioReport` per scenario plus fixture candidates and failure capsules, replays checkpoint-bearing capsules,
     prints a pass/fail summary, and exits non-zero on expectation failures.
+
+- **Module:** `src/bin/cgka-conformance-campaign.rs`
+  - **Role:** Parent/worker campaign runner. Executes each generated case in an isolated child process and combines the
+    durable scenario report with `wait4` wall/CPU/peak-RSS/write measurements. This is the engine campaign boundary for
+    real process isolation; it is not yet the app/CLI multi-process adapter planned for Milestone 5.
 
 - **Module:** `src/bin/cgka-policy-casegen.rs`
   - **Role:** Policy-case generator CLI; reads `formal/tamarin/policy_cases.json` and parses/reasons over the bounded

--- a/crates/cgka-conformance-simulator/Cargo.toml
+++ b/crates/cgka-conformance-simulator/Cargo.toml
@@ -13,7 +13,6 @@ conformance-slow = []
 # Full-engine A/B campaigns that disable only application-message witness
 # admission. This is a simulator experiment, not a supported wire policy.
 test-policy-overrides = ["cgka-engine/test-policy-overrides"]
-test-witness-comparison = ["test-policy-overrides"]
 
 [dependencies]
 cgka-traits.workspace = true

--- a/crates/cgka-conformance-simulator/Cargo.toml
+++ b/crates/cgka-conformance-simulator/Cargo.toml
@@ -39,6 +39,7 @@ proptest.workspace = true
 hex.workspace = true
 sha2.workspace = true
 tempfile.workspace = true
+libc.workspace = true
 
 [dev-dependencies]
 # Byte-level conformance vectors for the agent text stream QUIC feature pin

--- a/crates/cgka-conformance-simulator/Cargo.toml
+++ b/crates/cgka-conformance-simulator/Cargo.toml
@@ -10,6 +10,10 @@ description = "In-process multi-client simulator and fixtures for the CGKA engin
 # Long-running property-based tests (1000+ iterations). Quick CI runs the
 # default profile; nightly CI runs with this feature enabled.
 conformance-slow = []
+# Full-engine A/B campaigns that disable only application-message witness
+# admission. This is a simulator experiment, not a supported wire policy.
+test-policy-overrides = ["cgka-engine/test-policy-overrides"]
+test-witness-comparison = ["test-policy-overrides"]
 
 [dependencies]
 cgka-traits.workspace = true

--- a/crates/cgka-conformance-simulator/README.md
+++ b/crates/cgka-conformance-simulator/README.md
@@ -109,7 +109,35 @@ cargo test -p cgka-conformance-simulator --test milestone3_campaigns \
 cargo run -p cgka-conformance-simulator --bin cgka-conformance-simulator-report -- \
   --family milestone3-adversarial/v1 --seed 7 --cases 12 \
   --out target/cgka-milestone3-reports --storage file --strict-oracle
+
+# Run each adversarial case in its own process and add OS resource measurements.
+cargo run -p cgka-conformance-simulator --bin cgka-conformance-campaign -- \
+  --seed 7 --cases 12 --out target/cgka-milestone3-process-campaign --storage file
+
+# Test-only one-variable policy curves around fixed retained inputs/horizons.
+cargo test -p cgka-conformance-simulator --features test-policy-overrides \
+  --test policy_sweeps
 ```
+
+Every `ScenarioReport` embeds `campaign_measurements` v1. Its convergence latency is the conservative whole-scenario
+wall-time envelope; queued-send blocking time starts only when an engine accepts a send as queued and ends at
+publication or terminal refusal/rollback. Passes count observed convergence decisions across clients. Reorg count,
+rewind depth, and lateness use the engine's diagnostic counters/histograms and survive harness restarts. Input
+dispositions and logical delivery/expiry/invalidation come from the final per-client scenario ledger; queue depth is
+the maximum sampled after scenario actions; replay probes are exact completed OpenMLS replay probes; database size is
+the aggregate SQLite, WAL, and SHM footprint for file-backed subjects.
+
+CPU time, peak RSS, and filesystem write blocks require process isolation and are therefore listed as unavailable in
+an in-process report. `cgka-conformance-campaign` adds those fields with one worker process per case. Write bytes are
+the operating system's child `rusage` block-write accounting and can remain zero when writes are satisfied through
+cache; they are not a SQLite logical-write counter. Generated artifacts are private-by-construction and belong under
+`target/` or another ignored private location.
+
+Policy sweeps are experiments, not configuration. They clone one retained symbolic input, hold current tip, anchor,
+time, and every non-selected policy value fixed, then vary one constant and emit a curve plus named rejected boundary
+values. The runner never writes a production policy. Pass-partition invariance is tested separately with the same
+retained horizon; witness expiry, deferred-commit retirement, and retained-anchor pruning remain separately named
+eligibility-boundary tests rather than being mixed into the scheduler comparison.
 
 To run every portable vector fixture and write a report for each one:
 

--- a/crates/cgka-conformance-simulator/README.md
+++ b/crates/cgka-conformance-simulator/README.md
@@ -112,26 +112,29 @@ cargo run -p cgka-conformance-simulator --bin cgka-conformance-simulator-report 
 
 # Run each adversarial case in its own process and add OS resource measurements.
 cargo run -p cgka-conformance-simulator --bin cgka-conformance-campaign -- \
-  --seed 7 --cases 12 --out target/cgka-milestone3-process-campaign --storage file
+  --seed 7 --cases 12 --case-timeout-secs 300 \
+  --out target/cgka-milestone3-process-campaign --storage file
 
 # Test-only one-variable policy curves around fixed retained inputs/horizons.
 cargo test -p cgka-conformance-simulator --features test-policy-overrides \
   --test policy_sweeps
 ```
 
-Every `ScenarioReport` embeds `campaign_measurements` v1. Its convergence latency is the conservative whole-scenario
-wall-time envelope; queued-send blocking time starts only when an engine accepts a send as queued and ends at
-publication or terminal refusal/rollback. Passes count observed convergence decisions across clients. Reorg count,
+Every `ScenarioReport` embeds `campaign_measurements` v1. Its convergence latency is the measured wall time of the
+final successful `await_quiescence` action, or explicitly unavailable when the scenario does not request one;
+queued-send blocking time starts only when an engine accepts a send as queued and ends at publication or terminal
+refusal/rollback. Passes count observed convergence decisions across clients. Reorg count,
 rewind depth, and lateness use the engine's diagnostic counters/histograms and survive harness restarts. Input
 dispositions and logical delivery/expiry/invalidation come from the final per-client scenario ledger; queue depth is
 the maximum sampled after scenario actions; replay probes are exact completed OpenMLS replay probes; database size is
 the aggregate SQLite, WAL, and SHM footprint for file-backed subjects.
 
 CPU time, peak RSS, and filesystem write blocks require process isolation and are therefore listed as unavailable in
-an in-process report. `cgka-conformance-campaign` adds those fields with one worker process per case. Write bytes are
-the operating system's child `rusage` block-write accounting and can remain zero when writes are satisfied through
-cache; they are not a SQLite logical-write counter. Generated artifacts are private-by-construction and belong under
-`target/` or another ignored private location.
+an in-process report. `cgka-conformance-campaign` adds the fields the host exposes with one deadline-bounded worker
+process per case and explicitly lists unavailable fields. Write bytes are Linux child `rusage` block-write accounting
+and can remain zero when writes are satisfied through cache; Darwin reports the field as unavailable. They are not a
+SQLite logical-write counter. Generated artifacts are private-by-construction and belong under `target/` or another
+ignored private location.
 
 Policy sweeps are experiments, not configuration. They clone one retained symbolic input, hold current tip, anchor,
 time, and every non-selected policy value fixed, then vary one constant and emit a curve plus named rejected boundary

--- a/crates/cgka-conformance-simulator/README.md
+++ b/crates/cgka-conformance-simulator/README.md
@@ -131,9 +131,10 @@ the aggregate SQLite, WAL, and SHM footprint for file-backed subjects.
 
 CPU time, peak RSS, and filesystem write blocks require process isolation and are therefore listed as unavailable in
 an in-process report. `cgka-conformance-campaign` adds the fields the host exposes with one deadline-bounded worker
-process per case and explicitly lists unavailable fields. Write bytes are Linux child `rusage` block-write accounting
-and can remain zero when writes are satisfied through cache; Darwin reports the field as unavailable. They are not a
-SQLite logical-write counter. Generated artifacts are private-by-construction and belong under `target/` or another
+process per case and explicitly lists unavailable fields. `filesystem_block_write_lower_bound_bytes` is child
+`rusage` block-write accounting across all files. It is explicitly a page-cache-sensitive lower bound and can remain
+zero when writes are satisfied through cache; Darwin reports the field as unavailable. It is not a SQLite
+logical-write counter. Generated artifacts are private-by-construction and belong under `target/` or another
 ignored private location.
 
 Policy sweeps are experiments, not configuration. They clone one retained symbolic input, hold current tip, anchor,

--- a/crates/cgka-conformance-simulator/README.md
+++ b/crates/cgka-conformance-simulator/README.md
@@ -101,9 +101,9 @@ cargo test -p cgka-conformance-simulator --features conformance-slow
 # Milestone 3 catalog and small headline regressions.
 cargo test -p cgka-conformance-simulator --test milestone3_campaigns
 
-# Deliberately slow multi-round sustained campaign.
+# Deliberately slow offline, mixed-traffic, and self-update campaigns.
 cargo test -p cgka-conformance-simulator --test milestone3_campaigns \
-  sustained_mixed_traffic_campaign -- --ignored --nocapture
+  -- --ignored --nocapture
 
 # Full generated adversarial catalog with durable report artifacts.
 cargo run -p cgka-conformance-simulator --bin cgka-conformance-simulator-report -- \

--- a/crates/cgka-conformance-simulator/README.md
+++ b/crates/cgka-conformance-simulator/README.md
@@ -97,6 +97,18 @@ cargo test -p cgka-conformance-simulator
 
 # Slower validation: raises property-test case counts according to test cost.
 cargo test -p cgka-conformance-simulator --features conformance-slow
+
+# Milestone 3 catalog and small headline regressions.
+cargo test -p cgka-conformance-simulator --test milestone3_campaigns
+
+# Deliberately slow multi-round sustained campaign.
+cargo test -p cgka-conformance-simulator --test milestone3_campaigns \
+  sustained_mixed_traffic_campaign -- --ignored --nocapture
+
+# Full generated adversarial catalog with durable report artifacts.
+cargo run -p cgka-conformance-simulator --bin cgka-conformance-simulator-report -- \
+  --family milestone3-adversarial/v1 --seed 7 --cases 12 \
+  --out target/cgka-milestone3-reports --storage file --strict-oracle
 ```
 
 To run every portable vector fixture and write a report for each one:

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -441,6 +441,23 @@ regression, covers a new semantic edge, or is the smallest readable example of a
 
 ## Tooling And Report Checks
 
+### Milestone 3 Adversarial Catalog
+
+`milestone3-adversarial/v1` rotates through twelve deterministic workload shapes: retained-history offline floods;
+sustained app/proposal/commit traffic; self-update versus admin progress; a named unrecoverable losing-branch invite;
+unequal relay reconciliation; restart boundaries plus the engine's real SIGKILL durable-phase matrix; multi-group noisy
+neighbors; replay-budget exhaustion; shared-account multi-device witnesses; full-engine app-witness A/B selection;
+mixed-binary compatibility with mixed-policy preflight rejection; and clock, scheduler, timestamp, and cursor attacks.
+
+The normal test target runs small headline regressions. The multi-round sustained case is ignored by default and is
+invoked explicitly; the report CLI runs any number of seeded cases with either in-memory or encrypted file-backed
+SQLite. Test-only feature `test-policy-overrides` exposes the zero replay-budget repair and witness-disabled paired
+engine experiments. Production builds cannot select either override.
+
+The app-witness “multi-parent” sentinel means one MLS commit consuming multiple standalone proposal dependencies
+atomically. MLS still has exactly one prior group-state parent; the campaign does not claim that incompatible MLS state
+branches can be merged.
+
 These tests keep the simulator machinery honest.
 
 - `canonical_vector_fixtures_match_generated_traces` checks that every top-level JSON scenario vector still matches its

--- a/crates/cgka-conformance-simulator/schemas/scenario-ir.v2.schema.json
+++ b/crates/cgka-conformance-simulator/schemas/scenario-ir.v2.schema.json
@@ -261,7 +261,35 @@
           "properties": {
             "type": { "const": "in_group" },
             "group": { "type": "string", "minLength": 1 },
-            "action": { "$ref": "#/$defs/step" }
+            "action": {
+              "allOf": [
+                { "$ref": "#/$defs/step" },
+                {
+                  "type": "object",
+                  "required": ["type"],
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "create_group",
+                        "invite_members",
+                        "remove_members",
+                        "self_update",
+                        "update_group_data",
+                        "update_admin_policy",
+                        "expect_update_admin_policy_error",
+                        "send_app_message",
+                        "leave",
+                        "probe_bidirectional_decryptability",
+                        "observe_admin_policy",
+                        "observe",
+                        "observe_exact",
+                        "clear_events"
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
           }
         },
         {

--- a/crates/cgka-conformance-simulator/schemas/scenario-ir.v2.schema.json
+++ b/crates/cgka-conformance-simulator/schemas/scenario-ir.v2.schema.json
@@ -257,6 +257,16 @@
         {
           "type": "object",
           "additionalProperties": false,
+          "required": ["type", "group", "action"],
+          "properties": {
+            "type": { "const": "in_group" },
+            "group": { "type": "string", "minLength": 1 },
+            "action": { "$ref": "#/$defs/step" }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
           "required": ["type", "creator", "name", "invitees", "pending"],
           "properties": {
             "type": { "const": "create_group" },

--- a/crates/cgka-conformance-simulator/src/bin/cgka-conformance-campaign.rs
+++ b/crates/cgka-conformance-simulator/src/bin/cgka-conformance-campaign.rs
@@ -38,7 +38,7 @@ struct ProcessCaseMeasurementV1 {
     system_cpu_us: Option<u64>,
     peak_rss_bytes: Option<u64>,
     database_bytes: Option<u64>,
-    database_write_bytes: Option<u64>,
+    filesystem_block_write_lower_bound_bytes: Option<u64>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     unavailable_process_fields: Vec<String>,
 }
@@ -92,7 +92,8 @@ async fn run() -> Result<ExitCode, Box<dyn Error>> {
             system_cpu_us: usage.system_cpu_us,
             peak_rss_bytes: usage.peak_rss_bytes,
             database_bytes,
-            database_write_bytes: usage.database_write_bytes,
+            filesystem_block_write_lower_bound_bytes: usage
+                .filesystem_block_write_lower_bound_bytes,
             unavailable_process_fields: usage.unavailable_process_fields,
         });
     }
@@ -202,7 +203,7 @@ struct ChildUsage {
     user_cpu_us: Option<u64>,
     system_cpu_us: Option<u64>,
     peak_rss_bytes: Option<u64>,
-    database_write_bytes: Option<u64>,
+    filesystem_block_write_lower_bound_bytes: Option<u64>,
     unavailable_process_fields: Vec<String>,
 }
 
@@ -222,15 +223,37 @@ fn wait_with_usage(
         // pointers refer to writable storage for the duration of wait4.
         let waited = unsafe { libc::wait4(pid, &mut status, libc::WNOHANG, usage.as_mut_ptr()) };
         if waited < 0 {
-            return Err(std::io::Error::last_os_error().into());
+            let error = std::io::Error::last_os_error();
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(error.into());
         }
         if waited == pid {
             break false;
         }
         if Instant::now() >= deadline {
-            if let Err(error) = child.kill()
-                && error.kind() != std::io::ErrorKind::InvalidInput
-            {
+            // Close the polling race: the worker may have exited successfully
+            // after the check above but before the deadline comparison.
+            let waited =
+                unsafe { libc::wait4(pid, &mut status, libc::WNOHANG, usage.as_mut_ptr()) };
+            if waited < 0 {
+                let error = std::io::Error::last_os_error();
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(error.into());
+            }
+            if waited == pid {
+                break false;
+            }
+            if let Err(error) = child.kill() {
+                if error.kind() == std::io::ErrorKind::InvalidInput {
+                    let waited = unsafe { libc::wait4(pid, &mut status, 0, usage.as_mut_ptr()) };
+                    if waited < 0 {
+                        return Err(std::io::Error::last_os_error().into());
+                    }
+                    break false;
+                }
+                let _ = child.wait();
                 return Err(error.into());
             }
             // SAFETY: after killing the same direct child, blocking wait4 reaps
@@ -246,10 +269,14 @@ fn wait_with_usage(
     // SAFETY: either successful wait4 path initialized the complete rusage value.
     let usage = unsafe { usage.assume_init() };
     #[cfg(any(target_os = "macos", target_os = "ios"))]
-    let (database_write_bytes, unavailable_process_fields) =
-        (None, vec!["database_write_bytes".to_owned()]);
+    let (filesystem_block_write_lower_bound_bytes, unavailable_process_fields) = (
+        None,
+        vec!["filesystem_block_write_lower_bound_bytes".to_owned()],
+    );
     #[cfg(not(any(target_os = "macos", target_os = "ios")))]
-    let (database_write_bytes, unavailable_process_fields) = (
+    // `ru_oublock` counts real block-device output, so page-cache absorption
+    // can only make this a lower bound for all child-process filesystem writes.
+    let (filesystem_block_write_lower_bound_bytes, unavailable_process_fields) = (
         Some(
             u64::try_from(usage.ru_oublock)
                 .unwrap_or(0)
@@ -264,7 +291,7 @@ fn wait_with_usage(
         user_cpu_us: Some(timeval_us(usage.ru_utime)),
         system_cpu_us: Some(timeval_us(usage.ru_stime)),
         peak_rss_bytes: Some(peak_rss_bytes(usage.ru_maxrss)),
-        database_write_bytes,
+        filesystem_block_write_lower_bound_bytes,
         unavailable_process_fields,
     })
 }
@@ -316,12 +343,12 @@ fn wait_with_usage(
         user_cpu_us: None,
         system_cpu_us: None,
         peak_rss_bytes: None,
-        database_write_bytes: None,
+        filesystem_block_write_lower_bound_bytes: None,
         unavailable_process_fields: vec![
             "user_cpu_us".to_owned(),
             "system_cpu_us".to_owned(),
             "peak_rss_bytes".to_owned(),
-            "database_write_bytes".to_owned(),
+            "filesystem_block_write_lower_bound_bytes".to_owned(),
         ],
     })
 }

--- a/crates/cgka-conformance-simulator/src/bin/cgka-conformance-campaign.rs
+++ b/crates/cgka-conformance-simulator/src/bin/cgka-conformance-campaign.rs
@@ -1,0 +1,247 @@
+use cgka_conformance_simulator::{
+    HarnessStorageMode, ScenarioReport, generate_milestone3_adversarial_family,
+    run_generated_case_report_with_storage_mode,
+};
+use serde::{Deserialize, Serialize};
+use std::error::Error;
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode};
+use std::time::Instant;
+
+#[derive(Debug)]
+struct Args {
+    seed: u64,
+    cases: usize,
+    case_index: Option<usize>,
+    out: PathBuf,
+    storage: HarnessStorageMode,
+    worker: bool,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct ProcessCampaignReportV1 {
+    schema_version: String,
+    seed: u64,
+    cases: Vec<ProcessCaseMeasurementV1>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct ProcessCaseMeasurementV1 {
+    case_index: usize,
+    report: PathBuf,
+    exit_code: Option<i32>,
+    signal: Option<i32>,
+    wall_us: u64,
+    user_cpu_us: u64,
+    system_cpu_us: u64,
+    peak_rss_bytes: u64,
+    database_bytes: Option<u64>,
+    database_write_bytes: u64,
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    match run().await {
+        Ok(code) => code,
+        Err(error) => {
+            eprintln!("cgka campaign: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn run() -> Result<ExitCode, Box<dyn Error>> {
+    let args = parse_args(std::env::args().skip(1))?;
+    if args.worker {
+        return run_worker(&args).await;
+    }
+    fs_private::create_dir_all_private(&args.out)?;
+
+    let executable = std::env::current_exe()?;
+    let mut observations = Vec::with_capacity(args.cases);
+    for case_index in 0..args.cases {
+        let report = args.out.join(format!("case-{case_index}.json"));
+        let mut command = Command::new(&executable);
+        command.args([
+            "--worker",
+            "--seed",
+            &args.seed.to_string(),
+            "--case-index",
+            &case_index.to_string(),
+            "--out",
+            report.to_str().ok_or("non-UTF-8 report path")?,
+            "--storage",
+            storage_label(args.storage),
+        ]);
+        let started = Instant::now();
+        let child = command.spawn()?;
+        let usage = wait_with_usage(child)?;
+        let database_bytes = read_database_bytes(&report);
+        observations.push(ProcessCaseMeasurementV1 {
+            case_index,
+            report,
+            exit_code: usage.exit_code,
+            signal: usage.signal,
+            wall_us: elapsed_us(started.elapsed()),
+            user_cpu_us: usage.user_cpu_us,
+            system_cpu_us: usage.system_cpu_us,
+            peak_rss_bytes: usage.peak_rss_bytes,
+            database_bytes,
+            database_write_bytes: usage.database_write_bytes,
+        });
+    }
+    let failed = observations
+        .iter()
+        .any(|case| case.exit_code != Some(0) || case.signal.is_some());
+    let summary = ProcessCampaignReportV1 {
+        schema_version: "1".into(),
+        seed: args.seed,
+        cases: observations,
+    };
+    let summary_path = args.out.join("process-campaign.v1.json");
+    fs_private::write_private(&summary_path, &serde_json::to_vec_pretty(&summary)?)?;
+    println!("Process campaign report: {}", summary_path.display());
+    Ok(if failed {
+        ExitCode::FAILURE
+    } else {
+        ExitCode::SUCCESS
+    })
+}
+
+async fn run_worker(args: &Args) -> Result<ExitCode, Box<dyn Error>> {
+    let case_index = args.case_index.ok_or("worker requires --case-index")?;
+    let cases = generate_milestone3_adversarial_family(args.seed, case_index + 1);
+    let case = &cases[case_index];
+    let report = run_generated_case_report_with_storage_mode(case, None, args.storage).await?;
+    if let Some(parent) = args.out.parent() {
+        fs_private::create_dir_all_private(parent)?;
+    }
+    fs_private::write_private(&args.out, &serde_json::to_vec_pretty(&report)?)?;
+    let failed = !report.expectation_failures.is_empty() || !report.invariant_failures.is_empty();
+    Ok(if failed {
+        ExitCode::FAILURE
+    } else {
+        ExitCode::SUCCESS
+    })
+}
+
+fn read_database_bytes(path: &Path) -> Option<u64> {
+    let bytes = std::fs::read(path).ok()?;
+    serde_json::from_slice::<ScenarioReport>(&bytes)
+        .ok()?
+        .campaign_measurements
+        .database_bytes
+}
+
+fn parse_args(args: impl Iterator<Item = String>) -> Result<Args, Box<dyn Error>> {
+    let mut seed = 7;
+    let mut cases = 12;
+    let mut case_index = None;
+    let mut out = PathBuf::from("target/cgka-milestone3-process-campaign");
+    let mut storage = HarnessStorageMode::TempFileBackedSqlite;
+    let mut worker = false;
+    let mut args = args.peekable();
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--worker" => worker = true,
+            "--seed" => seed = args.next().ok_or("missing --seed value")?.parse()?,
+            "--cases" => cases = args.next().ok_or("missing --cases value")?.parse()?,
+            "--case-index" => {
+                case_index = Some(args.next().ok_or("missing --case-index value")?.parse()?)
+            }
+            "--out" => out = PathBuf::from(args.next().ok_or("missing --out value")?),
+            "--storage" => {
+                storage = match args.next().ok_or("missing --storage value")?.as_str() {
+                    "memory" => HarnessStorageMode::InMemorySqlite,
+                    "file" => HarnessStorageMode::TempFileBackedSqlite,
+                    other => return Err(format!("invalid storage mode {other}").into()),
+                }
+            }
+            other => return Err(format!("unknown argument {other}").into()),
+        }
+    }
+    Ok(Args {
+        seed,
+        cases,
+        case_index,
+        out,
+        storage,
+        worker,
+    })
+}
+
+fn storage_label(storage: HarnessStorageMode) -> &'static str {
+    match storage {
+        HarnessStorageMode::InMemorySqlite => "memory",
+        HarnessStorageMode::TempFileBackedSqlite => "file",
+    }
+}
+
+fn elapsed_us(duration: std::time::Duration) -> u64 {
+    u64::try_from(duration.as_micros()).unwrap_or(u64::MAX)
+}
+
+struct ChildUsage {
+    exit_code: Option<i32>,
+    signal: Option<i32>,
+    user_cpu_us: u64,
+    system_cpu_us: u64,
+    peak_rss_bytes: u64,
+    database_write_bytes: u64,
+}
+
+#[cfg(unix)]
+fn wait_with_usage(child: std::process::Child) -> Result<ChildUsage, Box<dyn Error>> {
+    let pid = i32::try_from(child.id())?;
+    let mut status = 0;
+    let mut usage = std::mem::MaybeUninit::<libc::rusage>::zeroed();
+    // SAFETY: `pid` is the live direct child just spawned above; both output
+    // pointers refer to initialized writable storage for the duration of wait4.
+    let waited = unsafe { libc::wait4(pid, &mut status, 0, usage.as_mut_ptr()) };
+    if waited < 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    // SAFETY: successful wait4 initialized the complete rusage value.
+    let usage = unsafe { usage.assume_init() };
+    Ok(ChildUsage {
+        exit_code: libc::WIFEXITED(status).then(|| libc::WEXITSTATUS(status)),
+        signal: libc::WIFSIGNALED(status).then(|| libc::WTERMSIG(status)),
+        user_cpu_us: timeval_us(usage.ru_utime),
+        system_cpu_us: timeval_us(usage.ru_stime),
+        peak_rss_bytes: peak_rss_bytes(usage.ru_maxrss),
+        database_write_bytes: u64::try_from(usage.ru_oublock)
+            .unwrap_or(0)
+            .saturating_mul(512),
+    })
+}
+
+#[cfg(unix)]
+fn timeval_us(value: libc::timeval) -> u64 {
+    u64::try_from(value.tv_sec)
+        .unwrap_or(0)
+        .saturating_mul(1_000_000)
+        .saturating_add(u64::try_from(value.tv_usec).unwrap_or(0))
+}
+
+#[cfg(all(unix, any(target_os = "macos", target_os = "ios")))]
+fn peak_rss_bytes(value: libc::c_long) -> u64 {
+    u64::try_from(value).unwrap_or(0)
+}
+
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "ios"))))]
+fn peak_rss_bytes(value: libc::c_long) -> u64 {
+    u64::try_from(value).unwrap_or(0).saturating_mul(1024)
+}
+
+#[cfg(not(unix))]
+fn wait_with_usage(mut child: std::process::Child) -> Result<ChildUsage, Box<dyn Error>> {
+    let status = child.wait()?;
+    Ok(ChildUsage {
+        exit_code: status.code(),
+        signal: None,
+        user_cpu_us: 0,
+        system_cpu_us: 0,
+        peak_rss_bytes: 0,
+        database_write_bytes: 0,
+    })
+}

--- a/crates/cgka-conformance-simulator/src/bin/cgka-conformance-campaign.rs
+++ b/crates/cgka-conformance-simulator/src/bin/cgka-conformance-campaign.rs
@@ -1,12 +1,12 @@
 use cgka_conformance_simulator::{
-    HarnessStorageMode, ScenarioReport, generate_milestone3_adversarial_family,
+    HarnessStorageMode, ScenarioReport, generate_milestone3_adversarial_case,
     run_generated_case_report_with_storage_mode,
 };
 use serde::{Deserialize, Serialize};
 use std::error::Error;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 #[derive(Debug)]
 struct Args {
@@ -15,6 +15,7 @@ struct Args {
     case_index: Option<usize>,
     out: PathBuf,
     storage: HarnessStorageMode,
+    case_timeout: Duration,
     worker: bool,
 }
 
@@ -31,12 +32,15 @@ struct ProcessCaseMeasurementV1 {
     report: PathBuf,
     exit_code: Option<i32>,
     signal: Option<i32>,
+    timed_out: bool,
     wall_us: u64,
-    user_cpu_us: u64,
-    system_cpu_us: u64,
-    peak_rss_bytes: u64,
+    user_cpu_us: Option<u64>,
+    system_cpu_us: Option<u64>,
+    peak_rss_bytes: Option<u64>,
     database_bytes: Option<u64>,
-    database_write_bytes: u64,
+    database_write_bytes: Option<u64>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    unavailable_process_fields: Vec<String>,
 }
 
 #[tokio::main]
@@ -75,24 +79,26 @@ async fn run() -> Result<ExitCode, Box<dyn Error>> {
         ]);
         let started = Instant::now();
         let child = command.spawn()?;
-        let usage = wait_with_usage(child)?;
+        let usage = wait_with_usage(child, args.case_timeout)?;
         let database_bytes = read_database_bytes(&report);
         observations.push(ProcessCaseMeasurementV1 {
             case_index,
             report,
             exit_code: usage.exit_code,
             signal: usage.signal,
+            timed_out: usage.timed_out,
             wall_us: elapsed_us(started.elapsed()),
             user_cpu_us: usage.user_cpu_us,
             system_cpu_us: usage.system_cpu_us,
             peak_rss_bytes: usage.peak_rss_bytes,
             database_bytes,
             database_write_bytes: usage.database_write_bytes,
+            unavailable_process_fields: usage.unavailable_process_fields,
         });
     }
     let failed = observations
         .iter()
-        .any(|case| case.exit_code != Some(0) || case.signal.is_some());
+        .any(|case| case.timed_out || case.exit_code != Some(0) || case.signal.is_some());
     let summary = ProcessCampaignReportV1 {
         schema_version: "1".into(),
         seed: args.seed,
@@ -110,9 +116,8 @@ async fn run() -> Result<ExitCode, Box<dyn Error>> {
 
 async fn run_worker(args: &Args) -> Result<ExitCode, Box<dyn Error>> {
     let case_index = args.case_index.ok_or("worker requires --case-index")?;
-    let cases = generate_milestone3_adversarial_family(args.seed, case_index + 1);
-    let case = &cases[case_index];
-    let report = run_generated_case_report_with_storage_mode(case, None, args.storage).await?;
+    let case = generate_milestone3_adversarial_case(args.seed, case_index as u64);
+    let report = run_generated_case_report_with_storage_mode(&case, None, args.storage).await?;
     if let Some(parent) = args.out.parent() {
         fs_private::create_dir_all_private(parent)?;
     }
@@ -139,6 +144,7 @@ fn parse_args(args: impl Iterator<Item = String>) -> Result<Args, Box<dyn Error>
     let mut case_index = None;
     let mut out = PathBuf::from("target/cgka-milestone3-process-campaign");
     let mut storage = HarnessStorageMode::TempFileBackedSqlite;
+    let mut case_timeout = Duration::from_secs(300);
     let mut worker = false;
     let mut args = args.peekable();
     while let Some(arg) = args.next() {
@@ -157,6 +163,13 @@ fn parse_args(args: impl Iterator<Item = String>) -> Result<Args, Box<dyn Error>
                     other => return Err(format!("invalid storage mode {other}").into()),
                 }
             }
+            "--case-timeout-secs" => {
+                case_timeout = Duration::from_secs(
+                    args.next()
+                        .ok_or("missing --case-timeout-secs value")?
+                        .parse()?,
+                )
+            }
             other => return Err(format!("unknown argument {other}").into()),
         }
     }
@@ -166,6 +179,7 @@ fn parse_args(args: impl Iterator<Item = String>) -> Result<Args, Box<dyn Error>
         case_index,
         out,
         storage,
+        case_timeout,
         worker,
     })
 }
@@ -184,34 +198,74 @@ fn elapsed_us(duration: std::time::Duration) -> u64 {
 struct ChildUsage {
     exit_code: Option<i32>,
     signal: Option<i32>,
-    user_cpu_us: u64,
-    system_cpu_us: u64,
-    peak_rss_bytes: u64,
-    database_write_bytes: u64,
+    timed_out: bool,
+    user_cpu_us: Option<u64>,
+    system_cpu_us: Option<u64>,
+    peak_rss_bytes: Option<u64>,
+    database_write_bytes: Option<u64>,
+    unavailable_process_fields: Vec<String>,
 }
 
 #[cfg(unix)]
-fn wait_with_usage(child: std::process::Child) -> Result<ChildUsage, Box<dyn Error>> {
+fn wait_with_usage(
+    mut child: std::process::Child,
+    timeout: Duration,
+) -> Result<ChildUsage, Box<dyn Error>> {
     let pid = i32::try_from(child.id())?;
     let mut status = 0;
     let mut usage = std::mem::MaybeUninit::<libc::rusage>::zeroed();
-    // SAFETY: `pid` is the live direct child just spawned above; both output
-    // pointers refer to initialized writable storage for the duration of wait4.
-    let waited = unsafe { libc::wait4(pid, &mut status, 0, usage.as_mut_ptr()) };
-    if waited < 0 {
-        return Err(std::io::Error::last_os_error().into());
-    }
-    // SAFETY: successful wait4 initialized the complete rusage value.
+    let deadline = Instant::now()
+        .checked_add(timeout)
+        .ok_or("case timeout exceeds the host clock range")?;
+    let timed_out = loop {
+        // SAFETY: `pid` is the live direct child just spawned above; both output
+        // pointers refer to writable storage for the duration of wait4.
+        let waited = unsafe { libc::wait4(pid, &mut status, libc::WNOHANG, usage.as_mut_ptr()) };
+        if waited < 0 {
+            return Err(std::io::Error::last_os_error().into());
+        }
+        if waited == pid {
+            break false;
+        }
+        if Instant::now() >= deadline {
+            if let Err(error) = child.kill()
+                && error.kind() != std::io::ErrorKind::InvalidInput
+            {
+                return Err(error.into());
+            }
+            // SAFETY: after killing the same direct child, blocking wait4 reaps
+            // it and initializes both status and rusage.
+            let waited = unsafe { libc::wait4(pid, &mut status, 0, usage.as_mut_ptr()) };
+            if waited < 0 {
+                return Err(std::io::Error::last_os_error().into());
+            }
+            break true;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    };
+    // SAFETY: either successful wait4 path initialized the complete rusage value.
     let usage = unsafe { usage.assume_init() };
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    let (database_write_bytes, unavailable_process_fields) =
+        (None, vec!["database_write_bytes".to_owned()]);
+    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+    let (database_write_bytes, unavailable_process_fields) = (
+        Some(
+            u64::try_from(usage.ru_oublock)
+                .unwrap_or(0)
+                .saturating_mul(512),
+        ),
+        Vec::new(),
+    );
     Ok(ChildUsage {
         exit_code: libc::WIFEXITED(status).then(|| libc::WEXITSTATUS(status)),
         signal: libc::WIFSIGNALED(status).then(|| libc::WTERMSIG(status)),
-        user_cpu_us: timeval_us(usage.ru_utime),
-        system_cpu_us: timeval_us(usage.ru_stime),
-        peak_rss_bytes: peak_rss_bytes(usage.ru_maxrss),
-        database_write_bytes: u64::try_from(usage.ru_oublock)
-            .unwrap_or(0)
-            .saturating_mul(512),
+        timed_out,
+        user_cpu_us: Some(timeval_us(usage.ru_utime)),
+        system_cpu_us: Some(timeval_us(usage.ru_stime)),
+        peak_rss_bytes: Some(peak_rss_bytes(usage.ru_maxrss)),
+        database_write_bytes,
+        unavailable_process_fields,
     })
 }
 
@@ -234,14 +288,64 @@ fn peak_rss_bytes(value: libc::c_long) -> u64 {
 }
 
 #[cfg(not(unix))]
-fn wait_with_usage(mut child: std::process::Child) -> Result<ChildUsage, Box<dyn Error>> {
-    let status = child.wait()?;
+fn wait_with_usage(
+    mut child: std::process::Child,
+    timeout: Duration,
+) -> Result<ChildUsage, Box<dyn Error>> {
+    let deadline = Instant::now()
+        .checked_add(timeout)
+        .ok_or("case timeout exceeds the host clock range")?;
+    let (status, timed_out) = loop {
+        if let Some(status) = child.try_wait()? {
+            break (status, false);
+        }
+        if Instant::now() >= deadline {
+            if let Err(error) = child.kill()
+                && error.kind() != std::io::ErrorKind::InvalidInput
+            {
+                return Err(error.into());
+            }
+            break (child.wait()?, true);
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    };
     Ok(ChildUsage {
         exit_code: status.code(),
         signal: None,
-        user_cpu_us: 0,
-        system_cpu_us: 0,
-        peak_rss_bytes: 0,
-        database_write_bytes: 0,
+        timed_out,
+        user_cpu_us: None,
+        system_cpu_us: None,
+        peak_rss_bytes: None,
+        database_write_bytes: None,
+        unavailable_process_fields: vec![
+            "user_cpu_us".to_owned(),
+            "system_cpu_us".to_owned(),
+            "peak_rss_bytes".to_owned(),
+            "database_write_bytes".to_owned(),
+        ],
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_per_case_timeout() {
+        let args = parse_args(["--case-timeout-secs", "17"].into_iter().map(str::to_owned))
+            .expect("arguments parse");
+        assert_eq!(args.case_timeout, Duration::from_secs(17));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn kills_and_reaps_a_worker_that_exceeds_its_timeout() {
+        let child = Command::new("sh")
+            .args(["-c", "sleep 2"])
+            .spawn()
+            .expect("spawn sleeping child");
+        let usage = wait_with_usage(child, Duration::from_millis(10)).expect("reap child");
+        assert!(usage.timed_out);
+        assert!(usage.signal.is_some());
+    }
 }

--- a/crates/cgka-conformance-simulator/src/campaign_metrics.rs
+++ b/crates/cgka-conformance-simulator/src/campaign_metrics.rs
@@ -12,7 +12,8 @@ pub struct CampaignMeasurementsV1 {
     pub convergence_latency_us: Option<u64>,
     pub blocked_send_duration_us: u64,
     pub pass_count: usize,
-    pub reorg_count: usize,
+    pub reorg_count: Option<usize>,
+    pub recovery_observation_count: usize,
     pub reorg_rewind_depth: Option<CampaignHistogramV1>,
     pub reorg_lateness_ms: Option<CampaignHistogramV1>,
     pub unresolved_outcomes: usize,
@@ -151,8 +152,8 @@ impl CampaignMeasurementsV1 {
             blocked_send_duration_us,
             pass_count,
             reorg_count: engine_metrics
-                .and_then(|metrics| usize::try_from(metrics.post_settle_reorgs).ok())
-                .unwrap_or(report.recovery_observations.len()),
+                .and_then(|metrics| usize::try_from(metrics.post_settle_reorgs).ok()),
+            recovery_observation_count: report.recovery_observations.len(),
             reorg_rewind_depth: engine_metrics
                 .map(|metrics| CampaignHistogramV1::from(&metrics.reorg_rewind_depth)),
             reorg_lateness_ms: engine_metrics
@@ -179,7 +180,7 @@ impl CampaignMeasurementsV1 {
             unavailable_process_fields: [
                 "cpu_time_us".to_owned(),
                 "peak_rss_bytes".to_owned(),
-                "database_write_bytes".to_owned(),
+                "filesystem_block_write_lower_bound_bytes".to_owned(),
             ]
             .into_iter()
             .chain(

--- a/crates/cgka-conformance-simulator/src/campaign_metrics.rs
+++ b/crates/cgka-conformance-simulator/src/campaign_metrics.rs
@@ -1,0 +1,200 @@
+//! Stable aggregate measurements for adversarial campaign reports.
+
+use crate::{ScenarioInputDisposition, ScenarioReport, ScenarioStepStatus};
+use cgka_engine::engine_metrics::{EngineMetricsSnapshot, HistogramSnapshot};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CampaignMeasurementsV1 {
+    pub schema_version: String,
+    pub total_wall_us: u64,
+    pub convergence_latency_us: u64,
+    pub blocked_send_duration_us: u64,
+    pub pass_count: usize,
+    pub reorg_count: usize,
+    pub reorg_rewind_depth: Option<CampaignHistogramV1>,
+    pub reorg_lateness_ms: Option<CampaignHistogramV1>,
+    pub unresolved_outcomes: usize,
+    pub max_observed_queue_depth: usize,
+    pub input_dispositions: BTreeMap<String, usize>,
+    pub logical_deliveries: usize,
+    pub logical_expirations: usize,
+    pub logical_invalidations: usize,
+    pub replay_probe_count: Option<u64>,
+    pub database_bytes: Option<u64>,
+    pub first_failing_action: Option<usize>,
+    pub limiting_resource: Option<String>,
+    pub steps: Vec<CampaignStepMeasurementV1>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub unavailable_process_fields: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CampaignStepMeasurementV1 {
+    pub step_index: usize,
+    pub step_type: String,
+    pub wall_us: u64,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CampaignHistogramV1 {
+    pub buckets: Vec<CampaignHistogramBucketV1>,
+    pub overflow_count: u64,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CampaignHistogramBucketV1 {
+    pub upper_bound: u64,
+    pub count: u64,
+}
+
+impl From<&HistogramSnapshot> for CampaignHistogramV1 {
+    fn from(snapshot: &HistogramSnapshot) -> Self {
+        Self {
+            buckets: snapshot
+                .buckets
+                .iter()
+                .map(|bucket| CampaignHistogramBucketV1 {
+                    upper_bound: bucket.upper_bound,
+                    count: bucket.count,
+                })
+                .collect(),
+            overflow_count: snapshot.overflow_count,
+        }
+    }
+}
+
+impl CampaignMeasurementsV1 {
+    pub(crate) fn from_report(
+        report: &ScenarioReport,
+        total_wall_us: u64,
+        database_bytes: Option<u64>,
+        sampled_max_queue_depth: usize,
+        replay_probe_count: Option<u64>,
+        engine_metrics: Option<&EngineMetricsSnapshot>,
+    ) -> Self {
+        let mut latest_by_client = BTreeMap::new();
+        if let Some(trace) = &report.observed_trace {
+            for observation in &trace.observations {
+                latest_by_client.insert(observation.client.as_str(), observation);
+            }
+        }
+
+        let mut input_dispositions = BTreeMap::new();
+        let mut logical_deliveries = 0;
+        let mut logical_expirations = 0;
+        let mut logical_invalidations = 0;
+        let mut blocked_send_duration_us = 0_u64;
+        let mut unresolved_outcomes = 0;
+        let mut max_observed_queue_depth = 0;
+        let mut pass_count = 0_usize;
+        for observation in latest_by_client.values() {
+            for entry in &observation.scenario_input_ledger {
+                *input_dispositions
+                    .entry(disposition_label(&entry.disposition).to_owned())
+                    .or_default() += 1;
+                logical_deliveries += entry.delivered;
+                logical_expirations += entry.expired;
+                logical_invalidations += entry.invalidated.len();
+                unresolved_outcomes += usize::from(entry.pending);
+                blocked_send_duration_us =
+                    blocked_send_duration_us.saturating_add(entry.blocked_send_duration_us);
+            }
+            if let Some(pending) = &observation.pending_work {
+                max_observed_queue_depth = max_observed_queue_depth.max(
+                    pending
+                        .bus_queued_messages
+                        .saturating_add(pending.bus_delayed_messages)
+                        .saturating_add(pending.bus_mailbox_messages),
+                );
+            }
+            for decision in &observation.convergence_decisions {
+                let _ = decision;
+                pass_count = pass_count.saturating_add(1);
+            }
+        }
+
+        let first_failing_action = report.step_log.iter().find_map(|step| {
+            matches!(step.status, ScenarioStepStatus::Failed { .. }).then_some(step.step_index)
+        });
+        let limiting_resource = report
+            .expectation_failures
+            .iter()
+            .find(|failure| failure.kind == "pending_work_remaining")
+            .map(|failure| failure.message.clone())
+            .or_else(|| {
+                report.step_log.iter().find_map(|step| match &step.status {
+                    ScenarioStepStatus::Failed { kind, message, .. }
+                        if kind.contains("resource") || message.contains("budget") =>
+                    {
+                        Some(format!("{kind}: {message}"))
+                    }
+                    _ => None,
+                })
+            });
+
+        Self {
+            schema_version: "1".into(),
+            total_wall_us,
+            convergence_latency_us: total_wall_us,
+            blocked_send_duration_us,
+            pass_count,
+            reorg_count: engine_metrics
+                .and_then(|metrics| usize::try_from(metrics.post_settle_reorgs).ok())
+                .unwrap_or(report.recovery_observations.len()),
+            reorg_rewind_depth: engine_metrics
+                .map(|metrics| CampaignHistogramV1::from(&metrics.reorg_rewind_depth)),
+            reorg_lateness_ms: engine_metrics
+                .map(|metrics| CampaignHistogramV1::from(&metrics.reorg_lateness_ms)),
+            unresolved_outcomes,
+            max_observed_queue_depth: max_observed_queue_depth.max(sampled_max_queue_depth),
+            input_dispositions,
+            logical_deliveries,
+            logical_expirations,
+            logical_invalidations,
+            replay_probe_count,
+            database_bytes,
+            first_failing_action,
+            limiting_resource,
+            steps: report
+                .step_log
+                .iter()
+                .map(|step| CampaignStepMeasurementV1 {
+                    step_index: step.step_index,
+                    step_type: step.step_type.clone(),
+                    wall_us: step.wall_us,
+                })
+                .collect(),
+            unavailable_process_fields: [
+                "cpu_time_us".to_owned(),
+                "peak_rss_bytes".to_owned(),
+                "database_write_bytes".to_owned(),
+            ]
+            .into_iter()
+            .chain(
+                database_bytes
+                    .is_none()
+                    .then(|| "database_bytes".to_owned()),
+            )
+            .collect(),
+        }
+    }
+}
+
+fn disposition_label(disposition: &ScenarioInputDisposition) -> &'static str {
+    match disposition {
+        ScenarioInputDisposition::Pending => "pending",
+        ScenarioInputDisposition::Deferred => "deferred",
+        ScenarioInputDisposition::Accepted => "accepted",
+        ScenarioInputDisposition::Delivered => "delivered",
+        ScenarioInputDisposition::Deduplicated => "deduplicated",
+        ScenarioInputDisposition::Expired => "expired",
+        ScenarioInputDisposition::Invalidated => "invalidated",
+        ScenarioInputDisposition::Rejected => "rejected",
+        ScenarioInputDisposition::Stale => "stale",
+        ScenarioInputDisposition::Ignored => "ignored",
+        ScenarioInputDisposition::ResourceRefused => "resource_refused",
+        ScenarioInputDisposition::RolledBack => "rolled_back",
+    }
+}

--- a/crates/cgka-conformance-simulator/src/campaign_metrics.rs
+++ b/crates/cgka-conformance-simulator/src/campaign_metrics.rs
@@ -9,7 +9,7 @@ use std::collections::BTreeMap;
 pub struct CampaignMeasurementsV1 {
     pub schema_version: String,
     pub total_wall_us: u64,
-    pub convergence_latency_us: u64,
+    pub convergence_latency_us: Option<u64>,
     pub blocked_send_duration_us: u64,
     pub pass_count: usize,
     pub reorg_count: usize,
@@ -109,11 +109,21 @@ impl CampaignMeasurementsV1 {
                         .saturating_add(pending.bus_mailbox_messages),
                 );
             }
-            for decision in &observation.convergence_decisions {
-                let _ = decision;
-                pass_count = pass_count.saturating_add(1);
-            }
+            pass_count = pass_count.saturating_add(observation.convergence_decisions.len());
         }
+
+        let convergence_latency_us = report
+            .quiescence_observations
+            .iter()
+            .rev()
+            .find(|observation| observation.status.is_quiescent())
+            .and_then(|observation| {
+                report
+                    .step_log
+                    .iter()
+                    .find(|step| step.step_index == observation.step_index)
+                    .map(|step| step.wall_us)
+            });
 
         let first_failing_action = report.step_log.iter().find_map(|step| {
             matches!(step.status, ScenarioStepStatus::Failed { .. }).then_some(step.step_index)
@@ -137,7 +147,7 @@ impl CampaignMeasurementsV1 {
         Self {
             schema_version: "1".into(),
             total_wall_us,
-            convergence_latency_us: total_wall_us,
+            convergence_latency_us,
             blocked_send_duration_us,
             pass_count,
             reorg_count: engine_metrics
@@ -176,6 +186,11 @@ impl CampaignMeasurementsV1 {
                 database_bytes
                     .is_none()
                     .then(|| "database_bytes".to_owned()),
+            )
+            .chain(
+                convergence_latency_us
+                    .is_none()
+                    .then(|| "convergence_latency_us".to_owned()),
             )
             .collect(),
         }

--- a/crates/cgka-conformance-simulator/src/campaign_metrics.rs
+++ b/crates/cgka-conformance-simulator/src/campaign_metrics.rs
@@ -125,11 +125,11 @@ impl CampaignMeasurementsV1 {
             .map(|failure| failure.message.clone())
             .or_else(|| {
                 report.step_log.iter().find_map(|step| match &step.status {
-                    ScenarioStepStatus::Failed { kind, message, .. }
-                        if kind.contains("resource") || message.contains("budget") =>
-                    {
-                        Some(format!("{kind}: {message}"))
-                    }
+                    ScenarioStepStatus::Failed {
+                        kind,
+                        category: crate::SubjectFailureCategory::Resource,
+                        message,
+                    } => Some(format!("{kind}: {message}")),
                     _ => None,
                 })
             });

--- a/crates/cgka-conformance-simulator/src/client.rs
+++ b/crates/cgka-conformance-simulator/src/client.rs
@@ -13,6 +13,7 @@ use cgka_engine::account_identity_proof::{
     AccountIdentityProofRequest, AccountIdentityProofSigner,
 };
 use cgka_engine::canonicalization::{CanonicalizationPolicy, CanonicalizationResult};
+use cgka_engine::engine_metrics::{EngineMetricsSnapshot, HistogramSnapshot};
 use cgka_engine::feature_registry::FeatureRegistry;
 use cgka_engine::{ConvergenceClock, Engine, EngineBuilder};
 use cgka_traits::app_components::{
@@ -59,6 +60,8 @@ pub struct HarnessClient {
     convergence_clock: Option<Arc<dyn ConvergenceClock>>,
     disable_app_witnesses_for_tests: bool,
     replay_probe_budget_override: Option<u64>,
+    completed_replay_probe_count: u64,
+    completed_engine_metrics: EngineMetricsSnapshot,
     virtual_time_tick_enabled: bool,
     pending_events: Vec<GroupEvent>,
     /// Default MLS group id used by single-group scenarios. Set
@@ -76,6 +79,49 @@ pub struct HarnessClient {
     /// observe decisions no `GroupEvent` exposes (e.g. `convergence_decision`).
     audit_capture: AuditCapture,
     convergence_checkpoints: HashMap<String, (GroupId, DurableConvergencePass)>,
+}
+
+pub(crate) fn merge_engine_metrics(
+    target: &mut EngineMetricsSnapshot,
+    source: &EngineMetricsSnapshot,
+) {
+    target.settles = target.settles.saturating_add(source.settles);
+    target.post_settle_reorgs = target
+        .post_settle_reorgs
+        .saturating_add(source.post_settle_reorgs);
+    merge_histogram(&mut target.reorg_rewind_depth, &source.reorg_rewind_depth);
+    merge_histogram(&mut target.reorg_lateness_ms, &source.reorg_lateness_ms);
+    merge_histogram(
+        &mut target.pass_apply_latency_ms,
+        &source.pass_apply_latency_ms,
+    );
+    merge_histogram(&mut target.generation_gap_ms, &source.generation_gap_ms);
+    merge_histogram(&mut target.freeze_overdue_ms, &source.freeze_overdue_ms);
+    target.admin_reservation_hold_observations = target
+        .admin_reservation_hold_observations
+        .saturating_add(source.admin_reservation_hold_observations);
+    target.admin_reservation_prepared = target
+        .admin_reservation_prepared
+        .saturating_add(source.admin_reservation_prepared);
+    target.admin_reservation_failed = target
+        .admin_reservation_failed
+        .saturating_add(source.admin_reservation_failed);
+}
+
+fn merge_histogram(target: &mut HistogramSnapshot, source: &HistogramSnapshot) {
+    for source_bucket in &source.buckets {
+        if let Some(target_bucket) = target
+            .buckets
+            .iter_mut()
+            .find(|bucket| bucket.upper_bound == source_bucket.upper_bound)
+        {
+            target_bucket.count = target_bucket.count.saturating_add(source_bucket.count);
+        } else {
+            target.buckets.push(source_bucket.clone());
+        }
+    }
+    target.buckets.sort_by_key(|bucket| bucket.upper_bound);
+    target.overflow_count = target.overflow_count.saturating_add(source.overflow_count);
 }
 
 pub struct ClientBuilder {
@@ -319,6 +365,8 @@ impl ClientBuilder {
             convergence_clock: self.convergence_clock,
             disable_app_witnesses_for_tests: self.disable_app_witnesses_for_tests,
             replay_probe_budget_override: self.replay_probe_budget_override,
+            completed_replay_probe_count: 0,
+            completed_engine_metrics: EngineMetricsSnapshot::default(),
             virtual_time_tick_enabled: false,
             pending_events: Vec::new(),
             default_group: None,
@@ -621,6 +669,11 @@ impl HarnessClient {
     }
 
     pub fn restart(&mut self) {
+        self.completed_replay_probe_count = self
+            .completed_replay_probe_count
+            .saturating_add(self.engine().conformance_replay_probe_count());
+        let completed_metrics = self.engine().engine_metrics();
+        merge_engine_metrics(&mut self.completed_engine_metrics, &completed_metrics);
         drop(self.engine.take());
         let storage = if self.storage_backing.is_file_backed() {
             drop(self.storage.take());
@@ -645,6 +698,17 @@ impl HarnessClient {
         self.storage = Some(storage);
         self.engine = Some(engine);
         self.pending_events.clear();
+    }
+
+    pub fn replay_probe_count(&self) -> u64 {
+        self.completed_replay_probe_count
+            .saturating_add(self.engine().conformance_replay_probe_count())
+    }
+
+    pub fn engine_metrics(&self) -> EngineMetricsSnapshot {
+        let mut metrics = self.completed_engine_metrics.clone();
+        merge_engine_metrics(&mut metrics, &self.engine().engine_metrics());
+        metrics
     }
 
     /// Change the full-engine replay ceiling without changing durable state.

--- a/crates/cgka-conformance-simulator/src/client.rs
+++ b/crates/cgka-conformance-simulator/src/client.rs
@@ -1707,6 +1707,12 @@ impl HarnessClient {
         self.engine().epoch(&gid).expect("epoch")
     }
 
+    pub(crate) fn has_active_group(&self) -> bool {
+        self.default_group
+            .as_ref()
+            .is_some_and(|group_id| self.engine().epoch(group_id).is_ok())
+    }
+
     pub fn members(&self) -> Vec<cgka_traits::group::Member> {
         let gid = self.default_group.clone().expect("group");
         match self.engine().members(&gid) {

--- a/crates/cgka-conformance-simulator/src/client.rs
+++ b/crates/cgka-conformance-simulator/src/client.rs
@@ -57,6 +57,8 @@ pub struct HarnessClient {
     registry: FeatureRegistry,
     protocol_profile: ProtocolProfile,
     convergence_clock: Option<Arc<dyn ConvergenceClock>>,
+    disable_app_witnesses_for_tests: bool,
+    replay_probe_budget_override: Option<u64>,
     virtual_time_tick_enabled: bool,
     pending_events: Vec<GroupEvent>,
     /// Default MLS group id used by single-group scenarios. Set
@@ -85,6 +87,8 @@ pub struct ClientBuilder {
     storage_options: SqliteStorageOptions,
     explicit_file_storage: Option<ExplicitFileStorage>,
     convergence_clock: Option<Arc<dyn ConvergenceClock>>,
+    disable_app_witnesses_for_tests: bool,
+    replay_probe_budget_override: Option<u64>,
 }
 
 pub(crate) enum HarnessPublicationError {
@@ -223,6 +227,8 @@ impl ClientBuilder {
             storage_options: SqliteStorageOptions::default(),
             explicit_file_storage: None,
             convergence_clock: None,
+            disable_app_witnesses_for_tests: false,
+            replay_probe_budget_override: None,
         }
     }
 
@@ -267,6 +273,18 @@ impl ClientBuilder {
         self
     }
 
+    #[cfg(feature = "test-policy-overrides")]
+    pub fn without_app_witnesses_for_tests(mut self) -> Self {
+        self.disable_app_witnesses_for_tests = true;
+        self
+    }
+
+    #[cfg(feature = "test-policy-overrides")]
+    pub fn replay_probe_budget_for_tests(mut self, limit: Option<u64>) -> Self {
+        self.replay_probe_budget_override = limit;
+        self
+    }
+
     pub fn attach(self, bus: &TransportBus) -> HarnessClient {
         let storage_backing = match self.explicit_file_storage {
             Some(explicit) => HarnessStorageBacking::from_explicit(explicit),
@@ -283,6 +301,8 @@ impl ClientBuilder {
             self.protocol_profile,
             &audit_capture,
             self.convergence_clock.as_ref(),
+            self.disable_app_witnesses_for_tests,
+            self.replay_probe_budget_override,
         );
         let bus_id = bus.attach(MemberId::new(self.identity.clone()));
         bus.capture_outbound_for(bus_id);
@@ -297,6 +317,8 @@ impl ClientBuilder {
             registry: self.registry,
             protocol_profile: self.protocol_profile,
             convergence_clock: self.convergence_clock,
+            disable_app_witnesses_for_tests: self.disable_app_witnesses_for_tests,
+            replay_probe_budget_override: self.replay_probe_budget_override,
             virtual_time_tick_enabled: false,
             pending_events: Vec::new(),
             default_group: None,
@@ -326,6 +348,8 @@ fn build_harness_engine(
     protocol_profile: ProtocolProfile,
     audit_capture: &AuditCapture,
     convergence_clock: Option<&Arc<dyn ConvergenceClock>>,
+    disable_app_witnesses_for_tests: bool,
+    replay_probe_budget_override: Option<u64>,
 ) -> Engine<SqliteAccountStorage> {
     let peeler = NostrMlsPeeler::new().with_welcome_signer(signer.clone());
     let mut builder = EngineBuilder::new(storage.clone())
@@ -344,6 +368,19 @@ fn build_harness_engine(
     if let Some(clock) = convergence_clock {
         builder = builder.convergence_clock(clock.clone());
     }
+    #[cfg(feature = "test-policy-overrides")]
+    if disable_app_witnesses_for_tests {
+        builder = builder.without_app_witnesses_for_tests();
+    }
+    #[cfg(feature = "test-policy-overrides")]
+    if replay_probe_budget_override.is_some() {
+        builder = builder.replay_probe_budget_for_tests(replay_probe_budget_override);
+    }
+    #[cfg(not(feature = "test-policy-overrides"))]
+    let _ = (
+        disable_app_witnesses_for_tests,
+        replay_probe_budget_override,
+    );
     builder.build().expect("engine builds")
 }
 
@@ -462,6 +499,9 @@ fn logical_label_from_seed(seed: &[u8]) -> Option<String> {
 }
 
 impl HarnessClient {
+    pub(crate) fn select_default_group(&mut self, group_id: GroupId) {
+        self.default_group = Some(group_id);
+    }
     pub fn engine(&self) -> &Engine<SqliteAccountStorage> {
         self.engine.as_ref().expect("harness engine is available")
     }
@@ -596,6 +636,8 @@ impl HarnessClient {
             self.protocol_profile,
             &self.audit_capture,
             self.convergence_clock.as_ref(),
+            self.disable_app_witnesses_for_tests,
+            self.replay_probe_budget_override,
         );
         engine
             .hydrate_stable_groups_from_storage()
@@ -603,6 +645,15 @@ impl HarnessClient {
         self.storage = Some(storage);
         self.engine = Some(engine);
         self.pending_events.clear();
+    }
+
+    /// Change the full-engine replay ceiling without changing durable state.
+    /// Clearing the override is the repair step after an intentional
+    /// `ReplayBudgetExceeded` campaign result.
+    #[cfg(feature = "test-policy-overrides")]
+    pub fn set_replay_probe_budget_for_tests(&mut self, limit: Option<u64>) {
+        self.replay_probe_budget_override = limit;
+        self.engine_mut().set_replay_probe_budget_for_tests(limit);
     }
 
     /// Freeze the current durable pass at its quiescence boundary. This is a
@@ -660,9 +711,18 @@ impl HarnessClient {
         group_id: &GroupId,
         now_ms: u64,
     ) -> CanonicalizationResult {
+        self.try_converge_stored_at(group_id, now_ms)
+            .expect("stored convergence succeeds")
+    }
+
+    pub fn try_converge_stored_at(
+        &mut self,
+        group_id: &GroupId,
+        now_ms: u64,
+    ) -> Result<CanonicalizationResult, cgka_engine::openmls_projection::OpenMlsProjectionError>
+    {
         self.engine_mut()
             .converge_stored_openmls_messages_at(group_id, now_ms)
-            .expect("stored convergence succeeds")
     }
 
     /// Drain the `convergence_decision` events the engine has emitted since the
@@ -1653,9 +1713,14 @@ impl HarnessClient {
             })
             .collect::<Vec<_>>();
         for (scenario_id, kind, state) in observed_states {
-            if let Some(state) = state {
-                self.scenario_input_tracker
-                    .record_storage_state(&scenario_id, kind, state);
+            match state {
+                Some(state) => {
+                    self.scenario_input_tracker
+                        .record_storage_state(&scenario_id, kind, state)
+                }
+                None => self
+                    .scenario_input_tracker
+                    .record_storage_absence(&scenario_id),
             }
         }
         self.scenario_input_tracker.snapshot()
@@ -1851,7 +1916,15 @@ impl HarnessClient {
             }
             match &event {
                 GroupEvent::TransportObjectResourceRefused { message_id, .. } => {
-                    if let Some(scenario_input) = self.bus.scenario_input_for_transport(message_id)
+                    // Deferred-peel storage is keyed by the raw transport id,
+                    // but alternate peelers and migrated rows may report the
+                    // content-derived alias. Treat both durable aliases as the
+                    // same scenario input so a released row cannot remain
+                    // falsely pending in the black-box ledger.
+                    if let Some(scenario_input) = self
+                        .bus
+                        .scenario_input_for_transport(message_id)
+                        .or_else(|| self.bus.scenario_input_for_content(message_id))
                     {
                         self.scenario_input_tracker
                             .record_resource_refused(&scenario_input);

--- a/crates/cgka-conformance-simulator/src/client.rs
+++ b/crates/cgka-conformance-simulator/src/client.rs
@@ -346,9 +346,11 @@ impl ClientBuilder {
             &self.registry,
             self.protocol_profile,
             &audit_capture,
-            self.convergence_clock.as_ref(),
-            self.disable_app_witnesses_for_tests,
-            self.replay_probe_budget_override,
+            HarnessEngineOptions {
+                convergence_clock: self.convergence_clock.as_ref(),
+                disable_app_witnesses_for_tests: self.disable_app_witnesses_for_tests,
+                replay_probe_budget_override: self.replay_probe_budget_override,
+            },
         );
         let bus_id = bus.attach(MemberId::new(self.identity.clone()));
         bus.capture_outbound_for(bus_id);
@@ -388,6 +390,12 @@ impl ClientBuilder {
 /// [`CapturingRecorder`] that retains forensic events. `attach` and `restart`
 /// both go through here so a rebuilt engine keeps recording into the same shared
 /// buffer — otherwise a restart would silently drop captured decisions.
+struct HarnessEngineOptions<'a> {
+    convergence_clock: Option<&'a Arc<dyn ConvergenceClock>>,
+    disable_app_witnesses_for_tests: bool,
+    replay_probe_budget_override: Option<u64>,
+}
+
 fn build_harness_engine(
     storage: &SqliteAccountStorage,
     identity: &[u8],
@@ -395,9 +403,7 @@ fn build_harness_engine(
     registry: &FeatureRegistry,
     protocol_profile: ProtocolProfile,
     audit_capture: &AuditCapture,
-    convergence_clock: Option<&Arc<dyn ConvergenceClock>>,
-    disable_app_witnesses_for_tests: bool,
-    replay_probe_budget_override: Option<u64>,
+    options: HarnessEngineOptions<'_>,
 ) -> Engine<SqliteAccountStorage> {
     let peeler = NostrMlsPeeler::new().with_welcome_signer(signer.clone());
     let mut builder = EngineBuilder::new(storage.clone())
@@ -413,21 +419,21 @@ fn build_harness_engine(
     if protocol_profile == ProtocolProfile::Legacy {
         builder = builder.legacy_compatibility_profile();
     }
-    if let Some(clock) = convergence_clock {
+    if let Some(clock) = options.convergence_clock {
         builder = builder.convergence_clock(clock.clone());
     }
     #[cfg(feature = "test-policy-overrides")]
-    if disable_app_witnesses_for_tests {
+    if options.disable_app_witnesses_for_tests {
         builder = builder.without_app_witnesses_for_tests();
     }
     #[cfg(feature = "test-policy-overrides")]
-    if replay_probe_budget_override.is_some() {
-        builder = builder.replay_probe_budget_for_tests(replay_probe_budget_override);
+    if options.replay_probe_budget_override.is_some() {
+        builder = builder.replay_probe_budget_for_tests(options.replay_probe_budget_override);
     }
     #[cfg(not(feature = "test-policy-overrides"))]
     let _ = (
-        disable_app_witnesses_for_tests,
-        replay_probe_budget_override,
+        options.disable_app_witnesses_for_tests,
+        options.replay_probe_budget_override,
     );
     builder.build().expect("engine builds")
 }
@@ -688,9 +694,11 @@ impl HarnessClient {
             &self.registry,
             self.protocol_profile,
             &self.audit_capture,
-            self.convergence_clock.as_ref(),
-            self.disable_app_witnesses_for_tests,
-            self.replay_probe_budget_override,
+            HarnessEngineOptions {
+                convergence_clock: self.convergence_clock.as_ref(),
+                disable_app_witnesses_for_tests: self.disable_app_witnesses_for_tests,
+                replay_probe_budget_override: self.replay_probe_budget_override,
+            },
         );
         engine
             .hydrate_stable_groups_from_storage()

--- a/crates/cgka-conformance-simulator/src/family.rs
+++ b/crates/cgka-conformance-simulator/src/family.rs
@@ -4,12 +4,15 @@
 //! to replay or promote a generated case into a fixed vector.
 
 use crate::{
-    GeneratedScenarioMetadata, HarnessStorageMode, ScenarioMessageSelectorV2,
-    ScenarioOutboundSelection, ScenarioReport, ScenarioRunError, ScenarioSpec, ScenarioStep,
-    ScenarioTrace, ScenarioTransportClass, SubjectOutboundOutcome, TraceExpectation, VectorFixture,
-    fingerprint_report_failure, run_scenario_report_with_outcomes_and_capture,
-    run_scenario_report_with_outcomes_and_storage_mode, stable_action_id,
+    GeneratedScenarioMetadata, HarnessStorageMode, RetainedRelaySubject, ScenarioFailureCaptureV1,
+    ScenarioMessageSelectorV2, ScenarioOutboundSelection, ScenarioReport, ScenarioRunError,
+    ScenarioSpec, ScenarioStep, ScenarioTrace, ScenarioTransportClass, SubjectOutboundOutcome,
+    TraceExpectation, VectorFixture, fingerprint_report_failure,
+    run_scenario_report_with_outcomes_and_capture,
+    run_scenario_report_with_outcomes_and_storage_mode, run_scenario_report_with_subject,
+    stable_action_id,
 };
+use cgka_traits::group::ProtocolProfile;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use serde::{Deserialize, Serialize};
@@ -21,9 +24,30 @@ pub struct GeneratedScenarioCase {
     pub generator_version: String,
     pub seed: u64,
     pub case_index: u64,
+    #[serde(default, skip_serializing_if = "GeneratedSubjectKind::is_engine")]
+    pub subject: GeneratedSubjectKind,
     pub scenario: ScenarioSpec,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub expected_outcomes: Vec<TraceExpectation>,
+}
+
+/// Adapter selected by a generated campaign case.
+///
+/// Keeping this in generated metadata prevents retained-history workloads from
+/// silently running against the fast packet bus, where reconnect would merely
+/// heal transient delivery rather than query durable relay history.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GeneratedSubjectKind {
+    #[default]
+    Engine,
+    RetainedRelay,
+}
+
+impl GeneratedSubjectKind {
+    fn is_engine(&self) -> bool {
+        *self == Self::Engine
+    }
 }
 
 impl GeneratedScenarioCase {
@@ -56,6 +80,7 @@ pub fn generate_send_leave_family(seed: u64, cases: usize) -> Vec<GeneratedScena
             generator_version: "2".into(),
             seed,
             case_index: case_index as u64,
+            subject: GeneratedSubjectKind::Engine,
             scenario,
             expected_outcomes,
         });
@@ -75,6 +100,7 @@ pub fn generate_convergence_e2e_delivery_family(
             generator_version: "1".into(),
             seed,
             case_index: case_index as u64,
+            subject: GeneratedSubjectKind::Engine,
             scenario: convergence_e2e_delivery_case(&mut rng, case_index as u64),
             expected_outcomes: vec![],
         });
@@ -94,11 +120,60 @@ pub fn generate_convergence_chaos_family(seed: u64, cases: usize) -> Vec<Generat
             generator_version: "6".into(),
             seed,
             case_index: case_index as u64,
+            subject: GeneratedSubjectKind::Engine,
             scenario,
             expected_outcomes,
         });
     }
     out
+}
+
+/// Generate the Milestone 3 adversarial catalog. Case indices rotate through
+/// every required workload family; requesting more than twelve cases repeats
+/// the catalog with a new deterministic case id and schedule seed.
+pub fn generate_milestone3_adversarial_family(
+    seed: u64,
+    cases: usize,
+) -> Vec<GeneratedScenarioCase> {
+    (0..cases)
+        .map(|case_index| {
+            let case_index = case_index as u64;
+            let mut rng =
+                StdRng::seed_from_u64(seed ^ 0x4d33_4144_5645_5253 ^ case_index.rotate_left(17));
+            let (family_name, subject, mut scenario, mut expected_outcomes) =
+                milestone3_case(&mut rng, case_index);
+            add_strict_reliability_oracle(&mut scenario, &mut expected_outcomes);
+            GeneratedScenarioCase {
+                family_name,
+                generator_version: "1".into(),
+                seed,
+                case_index,
+                subject,
+                scenario,
+                expected_outcomes,
+            }
+        })
+        .collect()
+}
+
+/// One-round form of the sustained mixed-traffic workload for normal
+/// regression suites. The adversarial family retains the multi-round campaign.
+pub fn generate_milestone3_sustained_regression(seed: u64) -> GeneratedScenarioCase {
+    let case_index = 1_u64;
+    let mut rng = StdRng::seed_from_u64(seed ^ 0x4d33_4144_5645_5253 ^ case_index.rotate_left(17));
+    let (family_name, subject, mut scenario, mut expected_outcomes) =
+        milestone3_sustained_mixed_traffic_with_rounds(&mut rng, case_index, 1);
+    scenario.name = "milestone3/sustained-mixed-traffic/regression".into();
+    add_strict_reliability_oracle(&mut scenario, &mut expected_outcomes);
+    GeneratedScenarioCase {
+        family_name,
+        generator_version: "1-regression".into(),
+        seed,
+        case_index,
+        subject,
+        scenario,
+        expected_outcomes,
+    }
 }
 
 pub async fn run_generated_case_report(
@@ -118,7 +193,8 @@ pub async fn run_generated_case_report_with_storage_mode(
     expected_trace: Option<ScenarioTrace>,
     storage_mode: HarnessStorageMode,
 ) -> Result<ScenarioReport, ScenarioRunError> {
-    let mut report = run_scenario_report_with_outcomes_and_storage_mode(
+    let mut report = run_generated_scenario(
+        case.subject,
         &case.scenario,
         expected_trace.clone(),
         case.expected_outcomes.clone(),
@@ -137,14 +213,41 @@ pub async fn run_generated_case_report_with_capture(
     storage_mode: HarnessStorageMode,
     capture_sensitive_replay: bool,
 ) -> Result<(ScenarioReport, crate::ScenarioFailureCaptureV1), ScenarioRunError> {
-    let (mut report, failure_capture) = run_scenario_report_with_outcomes_and_capture(
-        &case.scenario,
-        expected_trace.clone(),
-        case.expected_outcomes.clone(),
-        storage_mode,
-        capture_sensitive_replay,
-    )
-    .await?;
+    let (mut report, failure_capture) = match case.subject {
+        GeneratedSubjectKind::Engine => {
+            run_scenario_report_with_outcomes_and_capture(
+                &case.scenario,
+                expected_trace.clone(),
+                case.expected_outcomes.clone(),
+                storage_mode,
+                capture_sensitive_replay,
+            )
+            .await?
+        }
+        GeneratedSubjectKind::RetainedRelay => {
+            let mut subject = RetainedRelaySubject::new(
+                &case.scenario.clients,
+                &case.scenario.topology,
+                ProtocolProfile::Legacy,
+                storage_mode,
+            )
+            .map_err(subject_setup_error)?;
+            let report = run_scenario_report_with_subject(
+                &case.scenario,
+                expected_trace.clone(),
+                case.expected_outcomes.clone(),
+                &mut subject,
+            )
+            .await?;
+            (
+                report,
+                ScenarioFailureCaptureV1 {
+                    transport: subject.captured_transport_window(),
+                    byte_replay: None,
+                },
+            )
+        }
+    };
     add_generated_metadata(case, expected_trace.as_ref(), &mut report, storage_mode).await;
     Ok((report, failure_capture))
 }
@@ -196,6 +299,7 @@ async fn minimize_failing_case(
             case.expected_outcomes.clone(),
             &target_identity,
             storage_mode,
+            case.subject,
         )
         .await
         {
@@ -215,8 +319,10 @@ async fn reproduces_failure(
     expected_outcomes: Vec<TraceExpectation>,
     target_identity: &crate::FailureIdentityV1,
     storage_mode: HarnessStorageMode,
+    subject: GeneratedSubjectKind,
 ) -> bool {
-    match run_scenario_report_with_outcomes_and_storage_mode(
+    match run_generated_scenario(
+        subject,
         scenario,
         expected_trace,
         expected_outcomes,
@@ -227,6 +333,51 @@ async fn reproduces_failure(
         Ok(report) => fingerprint_report_failure(&report)
             .is_ok_and(|fingerprint| fingerprint.semantic_identity() == *target_identity),
         Err(_) => false,
+    }
+}
+
+async fn run_generated_scenario(
+    subject: GeneratedSubjectKind,
+    scenario: &ScenarioSpec,
+    expected_trace: Option<ScenarioTrace>,
+    expected_outcomes: Vec<TraceExpectation>,
+    storage_mode: HarnessStorageMode,
+) -> Result<ScenarioReport, ScenarioRunError> {
+    match subject {
+        GeneratedSubjectKind::Engine => {
+            run_scenario_report_with_outcomes_and_storage_mode(
+                scenario,
+                expected_trace,
+                expected_outcomes,
+                storage_mode,
+            )
+            .await
+        }
+        GeneratedSubjectKind::RetainedRelay => {
+            let mut retained = RetainedRelaySubject::new(
+                &scenario.clients,
+                &scenario.topology,
+                ProtocolProfile::Legacy,
+                storage_mode,
+            )
+            .map_err(subject_setup_error)?;
+            run_scenario_report_with_subject(
+                scenario,
+                expected_trace,
+                expected_outcomes,
+                &mut retained,
+            )
+            .await
+        }
+    }
+}
+
+fn subject_setup_error(error: crate::SubjectError) -> ScenarioRunError {
+    ScenarioRunError {
+        step_index: None,
+        kind: error.code,
+        category: error.category,
+        message: error.message,
     }
 }
 
@@ -941,6 +1092,841 @@ fn convergence_chaos_restart_delivery_faults(
         client_state("alice", 1, 3, vec![payload]),
     ];
     (scenario, expected)
+}
+
+fn milestone3_case(
+    rng: &mut StdRng,
+    case_index: u64,
+) -> (
+    String,
+    GeneratedSubjectKind,
+    ScenarioSpec,
+    Vec<TraceExpectation>,
+) {
+    match case_index % 12 {
+        0 => milestone3_offline_retained_flood(case_index),
+        1 => milestone3_sustained_mixed_traffic(rng, case_index),
+        2 => milestone3_self_update_adversary(case_index),
+        3 => milestone3_losing_invite_repair(case_index),
+        4 => milestone3_unequal_relay_reconciliation(case_index),
+        5 => milestone3_restart_boundaries(case_index),
+        6 => milestone3_multi_group_noisy_neighbor(case_index),
+        7 => {
+            let (mut scenario, expected) = convergence_chaos_large_commit_storm(rng, case_index);
+            scenario.name = format!("milestone3/candidate-replay-exhaustion/case-{case_index}");
+            (
+                "milestone3/candidate-replay-exhaustion/v1".into(),
+                GeneratedSubjectKind::Engine,
+                scenario,
+                expected,
+            )
+        }
+        8 => milestone3_multi_device_account(case_index),
+        9 => milestone3_app_witness_value(case_index),
+        10 => milestone3_mixed_binary_compatibility(case_index),
+        _ => milestone3_clock_cursor_attack(case_index),
+    }
+}
+
+fn milestone3_offline_retained_flood(
+    case_index: u64,
+) -> (
+    String,
+    GeneratedSubjectKind,
+    ScenarioSpec,
+    Vec<TraceExpectation>,
+) {
+    let clients = labels(["alice", "bob", "carol", "david"]);
+    let mut steps = vec![
+        ScenarioStep::CreateGroup {
+            creator: "alice".into(),
+            name: format!("offline-retained-{case_index}"),
+            invitees: labels(["bob", "carol"]),
+            required_features: vec![],
+            initial_admins: Some(vec!["alice".into()]),
+            pending: "create".into(),
+        },
+        confirmed_step("alice", "create"),
+        ScenarioStep::DeliverAll,
+        tick(["bob", "carol"]),
+        ScenarioStep::SetClientOffline {
+            client: "bob".into(),
+        },
+    ];
+    let rounds = 3 + usize::try_from((case_index / 12) % 3).unwrap_or(0);
+    for round in 0..rounds {
+        steps.push(ScenarioStep::SendAppMessage {
+            sender: "alice".into(),
+            payload: format!("offline-flood-{case_index}-{round}"),
+        });
+        steps.push(accept_all_outbound("alice"));
+        steps.push(ScenarioStep::UpdateGroupData {
+            client: "alice".into(),
+            name: format!("offline-state-{case_index}-{round}"),
+            pending: format!("state-{round}"),
+        });
+        steps.push(confirmed_step("alice", &format!("state-{round}")));
+        steps.push(ScenarioStep::DeliverAll);
+        steps.push(tick(["carol"]));
+    }
+    steps.extend([
+        invite("alice", ["david"], "invite-david"),
+        confirmed_step("alice", "invite-david"),
+        ScenarioStep::DeliverAll,
+        tick(["carol", "david"]),
+        ScenarioStep::SendAppMessage {
+            sender: "david".into(),
+            payload: format!("membership-window-{case_index}"),
+        },
+        accept_all_outbound("david"),
+        ScenarioStep::DeliverAll,
+        tick(["alice", "carol"]),
+        ScenarioStep::RemoveMembers {
+            remover: "alice".into(),
+            members: vec!["david".into()],
+            pending: "remove-david".into(),
+        },
+        confirmed_step("alice", "remove-david"),
+        ScenarioStep::DeliverAll,
+        tick(["carol", "david"]),
+        ScenarioStep::ReconnectClient {
+            client: "bob".into(),
+        },
+        ScenarioStep::SyncRelayHistory {
+            clients: vec!["bob".into()],
+            sync: crate::ScenarioRelaySyncModeV2::FullHistory,
+        },
+        tick(["bob"]),
+    ]);
+    let expected = vec![clients_converged(["alice", "bob", "carol"], None, Some(3))];
+    (
+        "milestone3/offline-retained-history-flood/v1".into(),
+        GeneratedSubjectKind::RetainedRelay,
+        ScenarioSpec {
+            name: format!("milestone3/offline-retained-history-flood/case-{case_index}"),
+            spec_version: "2".into(),
+            clients,
+            topology: milestone3_single_relay_topology(&labels(["alice", "bob", "carol", "david"])),
+            steps,
+        },
+        expected,
+    )
+}
+
+fn milestone3_sustained_mixed_traffic(
+    rng: &mut StdRng,
+    case_index: u64,
+) -> (
+    String,
+    GeneratedSubjectKind,
+    ScenarioSpec,
+    Vec<TraceExpectation>,
+) {
+    let rounds = 4 + usize::try_from((case_index / 12) % 4).unwrap_or(0);
+    milestone3_sustained_mixed_traffic_with_rounds(rng, case_index, rounds)
+}
+
+fn milestone3_sustained_mixed_traffic_with_rounds(
+    rng: &mut StdRng,
+    case_index: u64,
+    rounds: usize,
+) -> (
+    String,
+    GeneratedSubjectKind,
+    ScenarioSpec,
+    Vec<TraceExpectation>,
+) {
+    let clients = labels(["alice", "bob", "carol", "david"]);
+    let active = labels(["alice", "bob", "carol", "david"]);
+    let mut steps = large_group_setup(
+        format!("sustained-mixed-{case_index}"),
+        clients.clone(),
+        labels(["bob", "carol", "david"]),
+    );
+    for round in 0..rounds {
+        let mut senders = labels(["alice", "bob", "carol", "david"]);
+        let sender_count = senders.len();
+        senders.rotate_left(rng.gen_range(0..sender_count));
+        for sender in &senders {
+            steps.push(ScenarioStep::SendAppMessage {
+                sender: sender.clone(),
+                payload: format!("mixed-{case_index}-{round}-{sender}"),
+            });
+            steps.push(accept_all_outbound(sender));
+        }
+        let committer = if round % 2 == 0 { "alice" } else { "bob" };
+        steps.push(ScenarioStep::SelfUpdate {
+            client: committer.into(),
+            pending: format!("self-{round}"),
+        });
+        steps.push(confirmed_step(committer, &format!("self-{round}")));
+        steps.push(ScenarioStep::DeliverAll);
+        steps.push(tick_vec(active.clone()));
+    }
+    steps.extend([
+        ScenarioStep::Leave {
+            client: "david".into(),
+        },
+        ScenarioStep::DeliverAll,
+        // Let the privileged admin produce the single auto-commit before the
+        // remaining members observe the proposal. Ticking every member here
+        // intentionally creates a separate multi-auto-committer adversary and
+        // obscures this workload's sustained-traffic signal.
+        tick(["alice"]),
+        accept_all_outbound("alice"),
+        ScenarioStep::DeliverAll,
+        tick(["bob", "carol", "david"]),
+    ]);
+    (
+        "milestone3/sustained-mixed-traffic/v1".into(),
+        GeneratedSubjectKind::Engine,
+        ScenarioSpec {
+            name: format!("milestone3/sustained-mixed-traffic/case-{case_index}"),
+            spec_version: "2".into(),
+            clients,
+            topology: Default::default(),
+            steps,
+        },
+        vec![clients_converged(["alice", "bob", "carol"], None, Some(3))],
+    )
+}
+
+fn milestone3_self_update_adversary(
+    case_index: u64,
+) -> (
+    String,
+    GeneratedSubjectKind,
+    ScenarioSpec,
+    Vec<TraceExpectation>,
+) {
+    let clients = labels(["alice", "bob", "carol"]);
+    let mut steps = large_group_setup(
+        format!("self-update-adversary-{case_index}"),
+        clients.clone(),
+        labels(["bob", "carol"]),
+    );
+    for round in 0..4 {
+        steps.extend([
+            ScenarioStep::SelfUpdate {
+                client: "bob".into(),
+                pending: format!("grind-{round}"),
+            },
+            confirmed_step("bob", &format!("grind-{round}")),
+            ScenarioStep::DeliverAll,
+            tick(["alice", "carol"]),
+        ]);
+    }
+    steps.extend([
+        ScenarioStep::SelfUpdate {
+            client: "bob".into(),
+            pending: "racing-self-update".into(),
+        },
+        ScenarioStep::RemoveMembers {
+            remover: "alice".into(),
+            members: vec!["bob".into()],
+            pending: "privileged-remove".into(),
+        },
+        confirmed_step("bob", "racing-self-update"),
+        confirmed_step("alice", "privileged-remove"),
+        ScenarioStep::DeliverAll,
+        tick(["alice", "bob", "carol"]),
+    ]);
+    (
+        "milestone3/self-update-admin-race/v1".into(),
+        GeneratedSubjectKind::Engine,
+        ScenarioSpec {
+            name: format!("milestone3/self-update-admin-race/case-{case_index}"),
+            spec_version: "2".into(),
+            clients,
+            topology: Default::default(),
+            steps,
+        },
+        vec![clients_converged(["alice", "carol"], None, Some(2))],
+    )
+}
+
+fn milestone3_losing_invite_repair(
+    case_index: u64,
+) -> (
+    String,
+    GeneratedSubjectKind,
+    ScenarioSpec,
+    Vec<TraceExpectation>,
+) {
+    let clients = labels(["alice", "bob", "david", "eve"]);
+    let steps = vec![
+        ScenarioStep::CreateGroup {
+            creator: "alice".into(),
+            name: format!("losing-invite-repair-{case_index}"),
+            invitees: vec!["bob".into()],
+            required_features: vec![],
+            initial_admins: Some(labels(["alice", "bob"])),
+            pending: "create".into(),
+        },
+        confirmed_step("alice", "create"),
+        ScenarioStep::DeliverAll,
+        tick(["bob"]),
+        invite("alice", ["david"], "winning-invite"),
+        invite("bob", ["eve"], "losing-invite"),
+        confirmed_step("alice", "winning-invite"),
+        confirmed_step("bob", "losing-invite"),
+        ScenarioStep::WithholdMessage {
+            selector: commit_selector("alice"),
+            label: "alice-commit".into(),
+        },
+        ScenarioStep::WithholdMessage {
+            selector: commit_selector("bob"),
+            label: "bob-commit".into(),
+        },
+        ScenarioStep::DeliverAll,
+        tick(["david", "eve"]),
+        ScenarioStep::ReleaseWithheld {
+            label: "alice-commit".into(),
+        },
+        ScenarioStep::ReleaseWithheld {
+            label: "bob-commit".into(),
+        },
+        ScenarioStep::DeliverAll,
+        tick(["alice", "bob"]),
+        invite("alice", ["eve"], "repair-eve"),
+        confirmed_step("alice", "repair-eve"),
+        ScenarioStep::DeliverAll,
+        tick(["bob", "david", "eve"]),
+        ScenarioStep::AdvanceTime {
+            delta_ms: 30 * 24 * 60 * 60 * 1_000 + 1,
+        },
+        tick(["alice", "bob", "david", "eve"]),
+        ScenarioStep::ObserveExact {
+            clients: labels(["alice", "eve"]),
+        },
+    ];
+    (
+        "milestone3/losing-invite-unrecoverable/v1".into(),
+        GeneratedSubjectKind::Engine,
+        ScenarioSpec {
+            name: format!("milestone3/losing-invite-unrecoverable/case-{case_index}"),
+            spec_version: "2".into(),
+            clients: clients.clone(),
+            topology: Default::default(),
+            steps,
+        },
+        vec![
+            clients_converged(["alice", "bob", "david"], Some(3), Some(4)),
+            TraceExpectation::ClientsNotEquivalent {
+                clients: labels(["alice", "eve"]),
+                reason: "a member that joined only a losing branch requires explicit local rejoin"
+                    .into(),
+            },
+        ],
+    )
+}
+
+fn milestone3_unequal_relay_reconciliation(
+    case_index: u64,
+) -> (
+    String,
+    GeneratedSubjectKind,
+    ScenarioSpec,
+    Vec<TraceExpectation>,
+) {
+    let clients = labels(["alice", "bob"]);
+    let steps = vec![
+        ScenarioStep::CreateGroup {
+            creator: "alice".into(),
+            name: format!("unequal-relays-{case_index}"),
+            invitees: vec!["bob".into()],
+            required_features: vec![],
+            initial_admins: Some(vec!["alice".into()]),
+            pending: "create".into(),
+        },
+        confirmed_step("alice", "create"),
+        ScenarioStep::ReconcileRelayHistories {
+            relays: labels(["relay:a", "relay:b"]),
+        },
+        ScenarioStep::SyncRelayHistory {
+            clients: vec!["bob".into()],
+            sync: crate::ScenarioRelaySyncModeV2::SetReconciliation,
+        },
+        tick(["bob"]),
+        ScenarioStep::SetClientOffline {
+            client: "bob".into(),
+        },
+        ScenarioStep::UpdateGroupData {
+            client: "alice".into(),
+            name: format!("unequal-relays-after-{case_index}"),
+            pending: "rename".into(),
+        },
+        confirmed_step("alice", "rename"),
+        ScenarioStep::ReconnectClient {
+            client: "bob".into(),
+        },
+        ScenarioStep::SyncRelayHistory {
+            clients: vec!["bob".into()],
+            sync: crate::ScenarioRelaySyncModeV2::Incremental,
+        },
+        tick(["bob"]),
+        ScenarioStep::ReconcileRelayHistories {
+            relays: labels(["relay:a", "relay:b"]),
+        },
+        ScenarioStep::SyncRelayHistory {
+            clients: vec!["bob".into()],
+            sync: crate::ScenarioRelaySyncModeV2::SetReconciliation,
+        },
+        tick(["bob"]),
+    ];
+    (
+        "milestone3/unequal-relay-reconciliation/v1".into(),
+        GeneratedSubjectKind::RetainedRelay,
+        ScenarioSpec {
+            name: format!("milestone3/unequal-relay-reconciliation/case-{case_index}"),
+            spec_version: "2".into(),
+            clients: clients.clone(),
+            topology: milestone3_split_relay_topology(&clients),
+            steps,
+        },
+        vec![clients_converged(["alice", "bob"], None, Some(2))],
+    )
+}
+
+fn milestone3_restart_boundaries(
+    case_index: u64,
+) -> (
+    String,
+    GeneratedSubjectKind,
+    ScenarioSpec,
+    Vec<TraceExpectation>,
+) {
+    let clients = labels(["alice", "bob", "carol"]);
+    let steps = vec![
+        create_group(
+            "alice",
+            format!("restart-boundaries-{case_index}"),
+            ["bob", "carol"],
+            "create",
+        ),
+        ScenarioStep::RestartClient {
+            client: "alice".into(),
+        },
+        confirmed_step("alice", "create"),
+        ScenarioStep::DeliverAll,
+        tick(["bob", "carol"]),
+        ScenarioStep::RestartClient {
+            client: "bob".into(),
+        },
+        ScenarioStep::UpdateGroupData {
+            client: "alice".into(),
+            name: format!("restart-boundaries-after-{case_index}"),
+            pending: "update".into(),
+        },
+        confirmed_step("alice", "update"),
+        ScenarioStep::RestartClient {
+            client: "carol".into(),
+        },
+        ScenarioStep::DeliverAll,
+        tick(["bob", "carol"]),
+    ];
+    (
+        "milestone3/restart-boundaries/v1".into(),
+        GeneratedSubjectKind::Engine,
+        ScenarioSpec {
+            name: format!("milestone3/restart-boundaries/case-{case_index}"),
+            spec_version: "2".into(),
+            clients,
+            topology: Default::default(),
+            steps,
+        },
+        vec![clients_converged(["alice", "bob", "carol"], None, Some(3))],
+    )
+}
+
+fn milestone3_multi_group_noisy_neighbor(
+    case_index: u64,
+) -> (
+    String,
+    GeneratedSubjectKind,
+    ScenarioSpec,
+    Vec<TraceExpectation>,
+) {
+    let clients = labels(["alice", "bob", "carol"]);
+    let in_group = |group: &str, action: ScenarioStep| ScenarioStep::InGroup {
+        group: group.into(),
+        action: Box::new(action),
+    };
+    let mut steps = vec![
+        in_group(
+            "quiet",
+            ScenarioStep::CreateGroup {
+                creator: "alice".into(),
+                name: "quiet".into(),
+                invitees: vec!["bob".into()],
+                required_features: vec![],
+                initial_admins: Some(vec!["alice".into()]),
+                pending: "quiet-create".into(),
+            },
+        ),
+        confirmed_step("alice", "quiet-create"),
+        ScenarioStep::DeliverAll,
+        tick(["bob"]),
+        in_group(
+            "noisy",
+            ScenarioStep::CreateGroup {
+                creator: "alice".into(),
+                name: "noisy".into(),
+                invitees: vec!["carol".into()],
+                required_features: vec![],
+                initial_admins: Some(vec!["alice".into()]),
+                pending: "noisy-create".into(),
+            },
+        ),
+        confirmed_step("alice", "noisy-create"),
+        ScenarioStep::DeliverAll,
+        tick(["carol"]),
+    ];
+    for index in 0..10 {
+        steps.push(in_group(
+            "noisy",
+            ScenarioStep::SendAppMessage {
+                sender: "carol".into(),
+                payload: format!("noise-{case_index}-{index}"),
+            },
+        ));
+        steps.push(accept_all_outbound("carol"));
+    }
+    steps.extend([
+        in_group(
+            "quiet",
+            ScenarioStep::SendAppMessage {
+                sender: "alice".into(),
+                payload: format!("quiet-progress-{case_index}"),
+            },
+        ),
+        accept_all_outbound("alice"),
+        ScenarioStep::DeliverAll,
+        tick(["alice", "bob", "carol"]),
+        in_group(
+            "quiet",
+            ScenarioStep::Observe {
+                clients: labels(["alice", "bob"]),
+            },
+        ),
+    ]);
+    (
+        "milestone3/multi-group-noisy-neighbor/v1".into(),
+        GeneratedSubjectKind::Engine,
+        ScenarioSpec {
+            name: format!("milestone3/multi-group-noisy-neighbor/case-{case_index}"),
+            spec_version: "2".into(),
+            clients,
+            topology: Default::default(),
+            steps,
+        },
+        vec![clients_converged(["alice", "bob"], Some(1), Some(2))],
+    )
+}
+
+fn milestone3_multi_device_account(
+    case_index: u64,
+) -> (
+    String,
+    GeneratedSubjectKind,
+    ScenarioSpec,
+    Vec<TraceExpectation>,
+) {
+    let clients = labels(["alice-phone", "alice-laptop", "bob"]);
+    let topology = milestone3_account_topology(&[
+        ("alice-phone", "account:alice", "build-a"),
+        ("alice-laptop", "account:alice", "build-a"),
+        ("bob", "account:bob", "build-a"),
+    ]);
+    let steps = vec![
+        ScenarioStep::CreateGroup {
+            creator: "alice-phone".into(),
+            name: format!("multi-device-{case_index}"),
+            invitees: labels(["alice-laptop", "bob"]),
+            required_features: vec![],
+            initial_admins: Some(vec!["alice-phone".into()]),
+            pending: "create".into(),
+        },
+        confirmed_step("alice-phone", "create"),
+        ScenarioStep::DeliverAll,
+        tick(["alice-laptop", "bob"]),
+        ScenarioStep::SendAppMessage {
+            sender: "alice-phone".into(),
+            payload: format!("phone-{case_index}"),
+        },
+        accept_all_outbound("alice-phone"),
+        ScenarioStep::SendAppMessage {
+            sender: "alice-laptop".into(),
+            payload: format!("laptop-{case_index}"),
+        },
+        accept_all_outbound("alice-laptop"),
+        ScenarioStep::DeliverAll,
+        tick(["alice-phone", "alice-laptop", "bob"]),
+    ];
+    (
+        "milestone3/multi-device-account/v1".into(),
+        GeneratedSubjectKind::Engine,
+        ScenarioSpec {
+            name: format!("milestone3/multi-device-account/case-{case_index}"),
+            spec_version: "2".into(),
+            clients: clients.clone(),
+            topology,
+            steps,
+        },
+        vec![clients_converged_vec(clients, Some(1), Some(3))],
+    )
+}
+
+fn milestone3_app_witness_value(
+    case_index: u64,
+) -> (
+    String,
+    GeneratedSubjectKind,
+    ScenarioSpec,
+    Vec<TraceExpectation>,
+) {
+    let scenario = ScenarioSpec {
+        name: format!("milestone3/app-witness-value/case-{case_index}"),
+        spec_version: "2".into(),
+        topology: Default::default(),
+        clients: labels(["alice", "bob", "carol", "david", "eve", "frank"]),
+        steps: vec![
+            create_group(
+                "alice",
+                format!("witness-value-{case_index}"),
+                ["bob", "carol"],
+                "create",
+            ),
+            confirmed_step("alice", "create"),
+            ScenarioStep::DeliverAll,
+            tick(["bob", "carol"]),
+            invite("alice", ["david"], "alice-branch"),
+            invite("bob", ["eve", "frank"], "bob-branch"),
+            confirmed_step("alice", "alice-branch"),
+            confirmed_step("bob", "bob-branch"),
+            ScenarioStep::WithholdMessage {
+                selector: commit_selector("alice"),
+                label: "alice-branch-commit".into(),
+            },
+            ScenarioStep::WithholdMessage {
+                selector: commit_selector("bob"),
+                label: "bob-branch-commit".into(),
+            },
+            ScenarioStep::DeliverAll,
+            tick(["david", "eve", "frank"]),
+            ScenarioStep::SendAppMessage {
+                sender: "david".into(),
+                payload: format!("david-witness-{case_index}"),
+            },
+            accept_all_outbound("david"),
+            ScenarioStep::SendAppMessage {
+                sender: "eve".into(),
+                payload: format!("eve-witness-{case_index}"),
+            },
+            accept_all_outbound("eve"),
+            ScenarioStep::SendAppMessage {
+                sender: "frank".into(),
+                payload: format!("frank-witness-{case_index}"),
+            },
+            accept_all_outbound("frank"),
+            ScenarioStep::ReleaseWithheld {
+                label: "alice-branch-commit".into(),
+            },
+            ScenarioStep::ReleaseWithheld {
+                label: "bob-branch-commit".into(),
+            },
+            ScenarioStep::DeliverAll,
+            tick(["alice", "bob", "carol"]),
+            ScenarioStep::AdvanceTime {
+                delta_ms: 30 * 24 * 60 * 60 * 1_000 + 1,
+            },
+            tick(["alice", "bob", "carol", "david", "eve", "frank"]),
+        ],
+    };
+    (
+        "milestone3/app-witness-value/v1".into(),
+        GeneratedSubjectKind::Engine,
+        scenario,
+        vec![clients_converged(["alice", "bob", "carol"], None, None)],
+    )
+}
+
+fn milestone3_mixed_binary_compatibility(
+    case_index: u64,
+) -> (
+    String,
+    GeneratedSubjectKind,
+    ScenarioSpec,
+    Vec<TraceExpectation>,
+) {
+    let clients = labels(["alice", "bob"]);
+    let topology = milestone3_account_topology(&[
+        ("alice", "account:alice", "mdk-previous"),
+        ("bob", "account:bob", "mdk-current"),
+    ]);
+    (
+        "milestone3/mixed-binary-policy/v1".into(),
+        GeneratedSubjectKind::Engine,
+        ScenarioSpec {
+            name: format!("milestone3/mixed-binary-policy/case-{case_index}"),
+            spec_version: "2".into(),
+            clients,
+            topology,
+            steps: vec![
+                create_group(
+                    "alice",
+                    format!("mixed-binary-{case_index}"),
+                    ["bob"],
+                    "create",
+                ),
+                confirmed_step("alice", "create"),
+                ScenarioStep::DeliverAll,
+                tick(["bob"]),
+            ],
+        },
+        vec![clients_converged(["alice", "bob"], Some(1), Some(2))],
+    )
+}
+
+fn milestone3_clock_cursor_attack(
+    case_index: u64,
+) -> (
+    String,
+    GeneratedSubjectKind,
+    ScenarioSpec,
+    Vec<TraceExpectation>,
+) {
+    let clients = labels(["alice", "bob"]);
+    let steps = vec![
+        ScenarioStep::CreateGroup {
+            creator: "alice".into(),
+            name: format!("clock-cursor-{case_index}"),
+            invitees: vec!["bob".into()],
+            required_features: vec![],
+            initial_admins: Some(vec!["alice".into()]),
+            pending: "create".into(),
+        },
+        confirmed_step("alice", "create"),
+        ScenarioStep::DeliverAll,
+        tick(["bob"]),
+        ScenarioStep::SetClientOffline {
+            client: "bob".into(),
+        },
+        ScenarioStep::SendAppMessage {
+            sender: "alice".into(),
+            payload: format!("before-clock-jump-{case_index}"),
+        },
+        accept_all_outbound("alice"),
+        ScenarioStep::AdvanceTime {
+            delta_ms: 365 * 24 * 60 * 60 * 1_000,
+        },
+        ScenarioStep::ReconnectClient {
+            client: "bob".into(),
+        },
+        ScenarioStep::ConfigureRelay {
+            relay: "relay:default".into(),
+            order: crate::ScenarioRelayOrderV2::Reverse,
+            duplicate_copies: 2,
+        },
+        ScenarioStep::SyncRelayHistory {
+            clients: vec!["bob".into()],
+            sync: crate::ScenarioRelaySyncModeV2::Incremental,
+        },
+        ScenarioStep::SyncRelayHistory {
+            clients: vec!["bob".into()],
+            sync: crate::ScenarioRelaySyncModeV2::FullHistory,
+        },
+        tick(["bob"]),
+    ];
+    (
+        "milestone3/clock-scheduler-cursor/v1".into(),
+        GeneratedSubjectKind::RetainedRelay,
+        ScenarioSpec {
+            name: format!("milestone3/clock-scheduler-cursor/case-{case_index}"),
+            spec_version: "2".into(),
+            clients: clients.clone(),
+            topology: milestone3_single_relay_topology(&clients),
+            steps,
+        },
+        vec![clients_converged(["alice", "bob"], Some(1), Some(2))],
+    )
+}
+
+fn milestone3_account_topology(clients: &[(&str, &str, &str)]) -> crate::ScenarioTopologyV2 {
+    let mut accounts = BTreeSet::new();
+    crate::ScenarioTopologyV2 {
+        accounts: clients
+            .iter()
+            .filter_map(|(_, account, _)| {
+                accounts.insert(*account).then(|| crate::ScenarioAccountV2 {
+                    id: (*account).into(),
+                    roles: vec!["member".into()],
+                })
+            })
+            .collect(),
+        devices: clients
+            .iter()
+            .map(|(client, account, _)| crate::ScenarioDeviceV2 {
+                id: format!("device:{client}"),
+                account: (*account).into(),
+                process: format!("process:{client}"),
+                client: (*client).into(),
+            })
+            .collect(),
+        processes: clients
+            .iter()
+            .map(|(client, _, binary)| crate::ScenarioProcessV2 {
+                id: format!("process:{client}"),
+                binary_version: (*binary).into(),
+                policy_version: "marmot-convergence-v1".into(),
+                relays: vec![],
+            })
+            .collect(),
+        groups: vec![],
+        relays: vec![],
+    }
+}
+
+fn milestone3_single_relay_topology(clients: &[String]) -> crate::ScenarioTopologyV2 {
+    let mut topology = milestone3_account_topology(
+        &clients
+            .iter()
+            .map(|client| (client.as_str(), client.as_str(), "mdk-current"))
+            .collect::<Vec<_>>(),
+    );
+    topology.relays = vec![crate::ScenarioRelayV2 {
+        id: "relay:default".into(),
+        implementation_version: "memory/v1".into(),
+        policy_version: "retain-all/v1".into(),
+    }];
+    for process in &mut topology.processes {
+        process.relays = vec!["relay:default".into()];
+    }
+    topology
+}
+
+fn milestone3_split_relay_topology(clients: &[String]) -> crate::ScenarioTopologyV2 {
+    let mut topology = milestone3_single_relay_topology(clients);
+    topology.relays = vec![
+        crate::ScenarioRelayV2 {
+            id: "relay:a".into(),
+            implementation_version: "memory/v1".into(),
+            policy_version: "retain-all/v1".into(),
+        },
+        crate::ScenarioRelayV2 {
+            id: "relay:b".into(),
+            implementation_version: "memory/v1".into(),
+            policy_version: "retain-all/v1".into(),
+        },
+    ];
+    for (index, process) in topology.processes.iter_mut().enumerate() {
+        process.relays = vec![if index % 2 == 0 {
+            "relay:a".into()
+        } else {
+            "relay:b".into()
+        }];
+    }
+    topology
 }
 
 fn labels<const N: usize>(items: [&str; N]) -> Vec<String> {

--- a/crates/cgka-conformance-simulator/src/family.rs
+++ b/crates/cgka-conformance-simulator/src/family.rs
@@ -3,11 +3,12 @@
 //! Families produce ordinary [`ScenarioSpec`] values plus the metadata needed
 //! to replay or promote a generated case into a fixed vector.
 
+use crate::scenario::subject_setup_error;
 use crate::{
     GeneratedScenarioMetadata, HarnessStorageMode, RetainedRelaySubject, ScenarioFailureCaptureV1,
     ScenarioMessageSelectorV2, ScenarioOutboundSelection, ScenarioReport, ScenarioRunError,
-    ScenarioSpec, ScenarioStep, ScenarioTrace, ScenarioTransportClass, SubjectOutboundOutcome,
-    TraceExpectation, VectorFixture, fingerprint_report_failure,
+    ScenarioSpec, ScenarioStep, ScenarioTrace, ScenarioTransportClass, SubjectFailureCategory,
+    SubjectOutboundOutcome, TraceExpectation, VectorFixture, fingerprint_report_failure,
     run_scenario_report_with_outcomes_and_capture,
     run_scenario_report_with_outcomes_and_storage_mode, run_scenario_report_with_subject,
     stable_action_id,
@@ -136,24 +137,26 @@ pub fn generate_milestone3_adversarial_family(
     cases: usize,
 ) -> Vec<GeneratedScenarioCase> {
     (0..cases)
-        .map(|case_index| {
-            let case_index = case_index as u64;
-            let mut rng =
-                StdRng::seed_from_u64(seed ^ 0x4d33_4144_5645_5253 ^ case_index.rotate_left(17));
-            let (family_name, subject, mut scenario, mut expected_outcomes) =
-                milestone3_case(&mut rng, case_index);
-            add_strict_reliability_oracle(&mut scenario, &mut expected_outcomes);
-            GeneratedScenarioCase {
-                family_name,
-                generator_version: "1".into(),
-                seed,
-                case_index,
-                subject,
-                scenario,
-                expected_outcomes,
-            }
-        })
+        .map(|case_index| generate_milestone3_adversarial_case(seed, case_index as u64))
         .collect()
+}
+
+/// Generate one catalog case without regenerating and discarding every prior
+/// index. This is the process-runner entry point for deterministic isolation.
+pub fn generate_milestone3_adversarial_case(seed: u64, case_index: u64) -> GeneratedScenarioCase {
+    let mut rng = StdRng::seed_from_u64(seed ^ 0x4d33_4144_5645_5253 ^ case_index.rotate_left(17));
+    let (family_name, subject, mut scenario, mut expected_outcomes) =
+        milestone3_case(&mut rng, case_index);
+    add_strict_reliability_oracle(&mut scenario, &mut expected_outcomes);
+    GeneratedScenarioCase {
+        family_name,
+        generator_version: "1".into(),
+        seed,
+        case_index,
+        subject,
+        scenario,
+        expected_outcomes,
+    }
 }
 
 /// One-round form of the sustained mixed-traffic workload for normal
@@ -269,6 +272,15 @@ pub async fn run_generated_case_report_with_capture(
             .await?
         }
         GeneratedSubjectKind::RetainedRelay => {
+            if capture_sensitive_replay {
+                return Err(ScenarioRunError {
+                    step_index: None,
+                    kind: "sensitive_replay_capture_unsupported".into(),
+                    category: SubjectFailureCategory::Environment,
+                    message: "retained-relay generated cases cannot capture an engine checkpoint"
+                        .into(),
+                });
+            }
             let mut subject = RetainedRelaySubject::new(
                 &case.scenario.clients,
                 &case.scenario.topology,
@@ -413,15 +425,6 @@ async fn run_generated_scenario(
             )
             .await
         }
-    }
-}
-
-fn subject_setup_error(error: crate::SubjectError) -> ScenarioRunError {
-    ScenarioRunError {
-        step_index: None,
-        kind: error.code,
-        category: error.category,
-        message: error.message,
     }
 }
 
@@ -1572,9 +1575,6 @@ fn milestone3_restart_boundaries(
             ["bob", "carol"],
             "create",
         ),
-        ScenarioStep::RestartClient {
-            client: "alice".into(),
-        },
         confirmed_step("alice", "create"),
         ScenarioStep::DeliverAll,
         tick(["bob", "carol"]),
@@ -1592,6 +1592,9 @@ fn milestone3_restart_boundaries(
         },
         ScenarioStep::DeliverAll,
         tick(["bob", "carol"]),
+        ScenarioStep::RestartClient {
+            client: "alice".into(),
+        },
     ];
     (
         "milestone3/restart-boundaries/v1".into(),
@@ -2600,6 +2603,10 @@ fn add_strict_reliability_oracle(
         scenario.name
     );
 
+    let final_group = scenario.steps.iter().rev().find_map(|step| match step {
+        ScenarioStep::InGroup { group, .. } => Some(group.clone()),
+        _ => None,
+    });
     scenario.steps.push(ScenarioStep::DeliverAll);
     scenario.steps.push(ScenarioStep::Tick {
         clients: scenario.clients.clone(),
@@ -2611,9 +2618,15 @@ fn add_strict_reliability_oracle(
     scenario.steps.push(ScenarioStep::Tick {
         clients: scenario.clients.clone(),
     });
-    scenario.steps.push(ScenarioStep::ObserveExact {
+    let observe = ScenarioStep::ObserveExact {
         clients: exact_clients.clone(),
-    });
+    };
+    scenario.steps.push(
+        final_group.map_or(observe.clone(), |group| ScenarioStep::InGroup {
+            group,
+            action: Box::new(observe),
+        }),
+    );
 
     if exact_clients.len() >= 2 {
         expected.push(TraceExpectation::ClientsExactlyEquivalent {

--- a/crates/cgka-conformance-simulator/src/family.rs
+++ b/crates/cgka-conformance-simulator/src/family.rs
@@ -176,6 +176,50 @@ pub fn generate_milestone3_sustained_regression(seed: u64) -> GeneratedScenarioC
     }
 }
 
+/// One-round offline catch-up form for normal regression suites. The catalog
+/// case retains the multi-round retained-history flood.
+pub fn generate_milestone3_offline_regression(seed: u64) -> GeneratedScenarioCase {
+    milestone3_regression_case(seed, 0, |_, case_index| {
+        milestone3_offline_retained_flood_with_rounds(case_index, 1)
+    })
+}
+
+/// Two-update adversary for normal regression suites. The catalog case retains
+/// the sustained self-update stream before the privileged removal race.
+pub fn generate_milestone3_self_update_regression(seed: u64) -> GeneratedScenarioCase {
+    milestone3_regression_case(seed, 2, |_, case_index| {
+        milestone3_self_update_adversary_with_rounds(case_index, 2)
+    })
+}
+
+fn milestone3_regression_case(
+    seed: u64,
+    case_index: u64,
+    build: impl FnOnce(
+        &mut StdRng,
+        u64,
+    ) -> (
+        String,
+        GeneratedSubjectKind,
+        ScenarioSpec,
+        Vec<TraceExpectation>,
+    ),
+) -> GeneratedScenarioCase {
+    let mut rng = StdRng::seed_from_u64(seed ^ 0x4d33_4144_5645_5253 ^ case_index.rotate_left(17));
+    let (family_name, subject, mut scenario, mut expected_outcomes) = build(&mut rng, case_index);
+    scenario.name = format!("{family_name}/regression");
+    add_strict_reliability_oracle(&mut scenario, &mut expected_outcomes);
+    GeneratedScenarioCase {
+        family_name,
+        generator_version: "1-regression".into(),
+        seed,
+        case_index,
+        subject,
+        scenario,
+        expected_outcomes,
+    }
+}
+
 pub async fn run_generated_case_report(
     case: &GeneratedScenarioCase,
     expected_trace: Option<ScenarioTrace>,
@@ -1136,6 +1180,19 @@ fn milestone3_offline_retained_flood(
     ScenarioSpec,
     Vec<TraceExpectation>,
 ) {
+    let rounds = 3 + usize::try_from((case_index / 12) % 3).unwrap_or(0);
+    milestone3_offline_retained_flood_with_rounds(case_index, rounds)
+}
+
+fn milestone3_offline_retained_flood_with_rounds(
+    case_index: u64,
+    rounds: usize,
+) -> (
+    String,
+    GeneratedSubjectKind,
+    ScenarioSpec,
+    Vec<TraceExpectation>,
+) {
     let clients = labels(["alice", "bob", "carol", "david"]);
     let mut steps = vec![
         ScenarioStep::CreateGroup {
@@ -1153,7 +1210,6 @@ fn milestone3_offline_retained_flood(
             client: "bob".into(),
         },
     ];
-    let rounds = 3 + usize::try_from((case_index / 12) % 3).unwrap_or(0);
     for round in 0..rounds {
         steps.push(ScenarioStep::SendAppMessage {
             sender: "alice".into(),
@@ -1299,13 +1355,25 @@ fn milestone3_self_update_adversary(
     ScenarioSpec,
     Vec<TraceExpectation>,
 ) {
+    milestone3_self_update_adversary_with_rounds(case_index, 12)
+}
+
+fn milestone3_self_update_adversary_with_rounds(
+    case_index: u64,
+    rounds: usize,
+) -> (
+    String,
+    GeneratedSubjectKind,
+    ScenarioSpec,
+    Vec<TraceExpectation>,
+) {
     let clients = labels(["alice", "bob", "carol"]);
     let mut steps = large_group_setup(
         format!("self-update-adversary-{case_index}"),
         clients.clone(),
         labels(["bob", "carol"]),
     );
-    for round in 0..4 {
+    for round in 0..rounds {
         steps.extend([
             ScenarioStep::SelfUpdate {
                 client: "bob".into(),
@@ -1858,10 +1926,14 @@ fn milestone3_account_topology(clients: &[(&str, &str, &str)]) -> crate::Scenari
         accounts: clients
             .iter()
             .filter_map(|(_, account, _)| {
-                accounts.insert(*account).then(|| crate::ScenarioAccountV2 {
-                    id: (*account).into(),
-                    roles: vec!["member".into()],
-                })
+                if accounts.insert(*account) {
+                    Some(crate::ScenarioAccountV2 {
+                        id: (*account).into(),
+                        roles: vec!["member".into()],
+                    })
+                } else {
+                    None
+                }
             })
             .collect(),
         devices: clients

--- a/crates/cgka-conformance-simulator/src/family.rs
+++ b/crates/cgka-conformance-simulator/src/family.rs
@@ -1160,9 +1160,9 @@ fn milestone3_case(
         6 => milestone3_multi_group_noisy_neighbor(case_index),
         7 => {
             let (mut scenario, expected) = convergence_chaos_large_commit_storm(rng, case_index);
-            scenario.name = format!("milestone3/candidate-replay-exhaustion/case-{case_index}");
+            scenario.name = format!("milestone3/candidate-replay-pressure/case-{case_index}");
             (
-                "milestone3/candidate-replay-exhaustion/v1".into(),
+                "milestone3/candidate-replay-pressure/v1".into(),
                 GeneratedSubjectKind::Engine,
                 scenario,
                 expected,
@@ -1836,10 +1836,10 @@ fn milestone3_mixed_binary_compatibility(
         ("bob", "account:bob", "mdk-current"),
     ]);
     (
-        "milestone3/mixed-binary-policy/v1".into(),
+        "milestone3/mixed-binary-compatibility-preflight/v1".into(),
         GeneratedSubjectKind::Engine,
         ScenarioSpec {
-            name: format!("milestone3/mixed-binary-policy/case-{case_index}"),
+            name: format!("milestone3/mixed-binary-compatibility-preflight/case-{case_index}"),
             spec_version: "2".into(),
             clients,
             topology,

--- a/crates/cgka-conformance-simulator/src/family.rs
+++ b/crates/cgka-conformance-simulator/src/family.rs
@@ -1151,7 +1151,7 @@ fn milestone3_case(
         0 => milestone3_offline_retained_flood(case_index),
         1 => milestone3_sustained_mixed_traffic(rng, case_index),
         2 => milestone3_self_update_adversary(case_index),
-        3 => milestone3_losing_invite_repair(case_index),
+        3 => milestone3_losing_invite_outcome(case_index),
         4 => milestone3_unequal_relay_reconciliation(case_index),
         5 => milestone3_restart_boundaries(case_index),
         6 => milestone3_multi_group_noisy_neighbor(case_index),
@@ -1413,7 +1413,7 @@ fn milestone3_self_update_adversary_with_rounds(
     )
 }
 
-fn milestone3_losing_invite_repair(
+fn milestone3_losing_invite_outcome(
     case_index: u64,
 ) -> (
     String,
@@ -1456,16 +1456,17 @@ fn milestone3_losing_invite_repair(
         },
         ScenarioStep::DeliverAll,
         tick(["alice", "bob"]),
-        invite("alice", ["eve"], "repair-eve"),
-        confirmed_step("alice", "repair-eve"),
-        ScenarioStep::DeliverAll,
-        tick(["bob", "david", "eve"]),
+        // A same-device re-invite is not a valid repair here: both branch-only
+        // devices have already consumed key packages with their signature
+        // keys, and OpenMLS rejects reusing either key. Characterize the
+        // current named outcome directly; repair requires an explicit local
+        // reset/rejoin with fresh device state.
         ScenarioStep::AdvanceTime {
             delta_ms: 30 * 24 * 60 * 60 * 1_000 + 1,
         },
         tick(["alice", "bob", "david", "eve"]),
         ScenarioStep::ObserveExact {
-            clients: labels(["alice", "eve"]),
+            clients: labels(["david", "eve"]),
         },
     ];
     (
@@ -1479,11 +1480,10 @@ fn milestone3_losing_invite_repair(
             steps,
         },
         vec![
-            clients_converged(["alice", "bob", "david"], Some(3), Some(4)),
+            clients_converged(["alice", "bob"], Some(2), Some(3)),
             TraceExpectation::ClientsNotEquivalent {
-                clients: labels(["alice", "eve"]),
-                reason: "a member that joined only a losing branch requires explicit local rejoin"
-                    .into(),
+                clients: labels(["david", "eve"]),
+                reason: "branch-only devices remain non-equivalent; the losing device requires explicit local reset/rejoin with fresh state".into(),
             },
         ],
     )

--- a/crates/cgka-conformance-simulator/src/lib.rs
+++ b/crates/cgka-conformance-simulator/src/lib.rs
@@ -69,8 +69,9 @@ pub use failure_capsule::{
     write_failure_capsule,
 };
 pub use family::{
-    GeneratedScenarioCase, generate_convergence_chaos_family,
-    generate_convergence_e2e_delivery_family, generate_send_leave_family,
+    GeneratedScenarioCase, GeneratedSubjectKind, generate_convergence_chaos_family,
+    generate_convergence_e2e_delivery_family, generate_milestone3_adversarial_family,
+    generate_milestone3_sustained_regression, generate_send_leave_family,
     run_generated_case_report, run_generated_case_report_with_capture,
     run_generated_case_report_with_storage_mode,
 };

--- a/crates/cgka-conformance-simulator/src/lib.rs
+++ b/crates/cgka-conformance-simulator/src/lib.rs
@@ -77,10 +77,10 @@ pub use failure_capsule::{
 };
 pub use family::{
     GeneratedScenarioCase, GeneratedSubjectKind, generate_convergence_chaos_family,
-    generate_convergence_e2e_delivery_family, generate_milestone3_adversarial_family,
-    generate_milestone3_offline_regression, generate_milestone3_self_update_regression,
-    generate_milestone3_sustained_regression, generate_send_leave_family,
-    run_generated_case_report, run_generated_case_report_with_capture,
+    generate_convergence_e2e_delivery_family, generate_milestone3_adversarial_case,
+    generate_milestone3_adversarial_family, generate_milestone3_offline_regression,
+    generate_milestone3_self_update_regression, generate_milestone3_sustained_regression,
+    generate_send_leave_family, run_generated_case_report, run_generated_case_report_with_capture,
     run_generated_case_report_with_storage_mode,
 };
 pub use oracle::{

--- a/crates/cgka-conformance-simulator/src/lib.rs
+++ b/crates/cgka-conformance-simulator/src/lib.rs
@@ -22,6 +22,7 @@
 
 mod audit_capture;
 pub mod bus;
+mod campaign_metrics;
 pub mod client;
 mod decryptability;
 mod failure_capsule;
@@ -29,6 +30,8 @@ pub mod family;
 pub mod oracle;
 mod pending_work;
 pub mod policy_cases;
+#[cfg(feature = "test-policy-overrides")]
+mod policy_sweep;
 pub mod proptest_support;
 mod quiescence;
 mod reference_subject;
@@ -45,6 +48,10 @@ mod topology;
 pub mod vector;
 
 pub use bus::{ClientId, DeliveryPolicy, TransportBus};
+pub use campaign_metrics::{
+    CampaignHistogramBucketV1, CampaignHistogramV1, CampaignMeasurementsV1,
+    CampaignStepMeasurementV1,
+};
 pub use cgka_engine::conformance_snapshot::{
     ConformanceAppComponent, ConformanceCanonicalStateSnapshot, ConformanceConstantSnapshot,
     ConformanceDisbandedGroupSnapshot, ConformanceGroupSnapshot, ConformanceLeafCapabilities,
@@ -84,6 +91,10 @@ pub use oracle::{
 pub use pending_work::{
     ClientStructuralProgress, PendingWorkObservation, SubjectProgressSnapshot,
     SubjectTerminalBlocker,
+};
+#[cfg(feature = "test-policy-overrides")]
+pub use policy_sweep::{
+    PolicySweepConstantV1, PolicySweepCurveV1, PolicySweepPointV1, sweep_canonicalization_policy,
 };
 pub use quiescence::{
     QuiescenceObservation, QuiescenceOutboundPolicy, QuiescencePolicy, QuiescenceStatus,

--- a/crates/cgka-conformance-simulator/src/lib.rs
+++ b/crates/cgka-conformance-simulator/src/lib.rs
@@ -78,6 +78,7 @@ pub use failure_capsule::{
 pub use family::{
     GeneratedScenarioCase, GeneratedSubjectKind, generate_convergence_chaos_family,
     generate_convergence_e2e_delivery_family, generate_milestone3_adversarial_family,
+    generate_milestone3_offline_regression, generate_milestone3_self_update_regression,
     generate_milestone3_sustained_regression, generate_send_leave_family,
     run_generated_case_report, run_generated_case_report_with_capture,
     run_generated_case_report_with_storage_mode,

--- a/crates/cgka-conformance-simulator/src/oracle.rs
+++ b/crates/cgka-conformance-simulator/src/oracle.rs
@@ -294,7 +294,12 @@ pub fn scenario_stimuli(spec: &ScenarioSpec) -> Vec<ScenarioStimulus> {
     }
 
     for step in &spec.steps {
+        let step = match step {
+            ScenarioStep::InGroup { action, .. } => action.as_ref(),
+            step => step,
+        };
         match step {
+            ScenarioStep::InGroup { .. } => unreachable!("in_group was unwrapped above"),
             ScenarioStep::CreateGroup { .. } => {
                 stimuli.insert(ScenarioStimulus::CreateGroup);
             }
@@ -612,6 +617,9 @@ fn expectation_behaviors(expectation: &TraceExpectation) -> BTreeSet<OracleBehav
         }
         TraceExpectation::ClientsExactlyEquivalent { .. } => {
             behaviors.insert(OracleBehavior::ClientConvergence);
+            behaviors.insert(OracleBehavior::ExactStateEquivalence);
+        }
+        TraceExpectation::ClientsNotEquivalent { .. } => {
             behaviors.insert(OracleBehavior::ExactStateEquivalence);
         }
         TraceExpectation::ScenarioInputLedger { entries, .. } => {

--- a/crates/cgka-conformance-simulator/src/oracle.rs
+++ b/crates/cgka-conformance-simulator/src/oracle.rs
@@ -294,12 +294,12 @@ pub fn scenario_stimuli(spec: &ScenarioSpec) -> Vec<ScenarioStimulus> {
     }
 
     for step in &spec.steps {
-        let step = match step {
-            ScenarioStep::InGroup { action, .. } => action.as_ref(),
-            step => step,
-        };
+        let mut step = step;
+        while let ScenarioStep::InGroup { action, .. } = step {
+            step = action.as_ref();
+        }
         match step {
-            ScenarioStep::InGroup { .. } => unreachable!("in_group was unwrapped above"),
+            ScenarioStep::InGroup { .. } => unreachable!("all group wrappers were unwrapped"),
             ScenarioStep::CreateGroup { .. } => {
                 stimuli.insert(ScenarioStimulus::CreateGroup);
             }

--- a/crates/cgka-conformance-simulator/src/oracle.rs
+++ b/crates/cgka-conformance-simulator/src/oracle.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     QuiescenceObservation, ScenarioReport, ScenarioSpec, ScenarioStep, ScenarioTrace,
-    TraceExpectation,
+    TraceExpectation, compare_trace_expectations,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
@@ -61,6 +61,7 @@ pub enum OracleBehavior {
     ClientState,
     ClientConvergence,
     ExactStateEquivalence,
+    ExactStateNonEquivalence,
     ScenarioInputDisposition,
     NoPendingWorkObserved,
     BidirectionalDecryptabilityObserved,
@@ -153,6 +154,15 @@ pub fn build_scenario_oracle_report(
         oracle_behaviors.sort();
     }
     let mut observed_behaviors = trace_behaviors(observed_trace);
+    if expected_outcomes.iter().any(|expectation| {
+        matches!(expectation, TraceExpectation::ClientsNotEquivalent { .. })
+            && compare_trace_expectations(None, std::slice::from_ref(expectation), observed_trace)
+                .is_empty()
+    }) && !observed_behaviors.contains(&OracleBehavior::ExactStateNonEquivalence)
+    {
+        observed_behaviors.push(OracleBehavior::ExactStateNonEquivalence);
+        observed_behaviors.sort();
+    }
     if quiescence_observations
         .iter()
         .any(|observation| observation.status.is_quiescent())
@@ -620,7 +630,7 @@ fn expectation_behaviors(expectation: &TraceExpectation) -> BTreeSet<OracleBehav
             behaviors.insert(OracleBehavior::ExactStateEquivalence);
         }
         TraceExpectation::ClientsNotEquivalent { .. } => {
-            behaviors.insert(OracleBehavior::ExactStateEquivalence);
+            behaviors.insert(OracleBehavior::ExactStateNonEquivalence);
         }
         TraceExpectation::ScenarioInputLedger { entries, .. } => {
             behaviors.insert(OracleBehavior::ScenarioInputDisposition);
@@ -871,5 +881,42 @@ mod tests {
             trace_behaviors(&observed).contains(&OracleBehavior::ExactStateEquivalence),
             "legacy observations must not hide a later equivalent exact sample"
         );
+    }
+
+    #[test]
+    fn strict_oracle_records_satisfied_exact_non_equivalence() {
+        let mut david = observation("david", 2, 3, "winner");
+        david.canonical_state = Some(ConformanceCanonicalStateSnapshot::Live(Box::default()));
+        let mut eve = observation("eve", 2, 3, "loser");
+        let mut eve_state =
+            Box::<cgka_engine::conformance_snapshot::ConformanceGroupSnapshot>::default();
+        eve_state.epoch = 9;
+        eve.canonical_state = Some(ConformanceCanonicalStateSnapshot::Live(eve_state));
+        let expectation = TraceExpectation::ClientsNotEquivalent {
+            clients: vec!["david".into(), "eve".into()],
+            reason: "named branch split".into(),
+        };
+        let spec = ScenarioSpec {
+            name: "oracle/non-equivalence".into(),
+            spec_version: "2".into(),
+            clients: vec!["david".into(), "eve".into()],
+            topology: Default::default(),
+            steps: Vec::new(),
+        };
+
+        let report = build_scenario_oracle_report(
+            &spec,
+            None,
+            std::slice::from_ref(&expectation),
+            &trace(vec![david, eve]),
+            &[],
+        );
+
+        assert!(
+            report
+                .observed_behaviors
+                .contains(&OracleBehavior::ExactStateNonEquivalence)
+        );
+        assert!(report.missing_observed_behaviors.is_empty());
     }
 }

--- a/crates/cgka-conformance-simulator/src/policy_sweep.rs
+++ b/crates/cgka-conformance-simulator/src/policy_sweep.rs
@@ -1,0 +1,134 @@
+//! Explicit test-policy sweeps over one fixed canonicalization input set.
+
+use cgka_engine::canonicalization::{
+    CanonicalizationInput, CanonicalizationPolicy, ConvergenceStatus, canonicalize,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PolicySweepConstantV1 {
+    MaxRewindCommits,
+    AppMessagePastEpochLimit,
+    SettlementQuiescenceMs,
+    MaxConvergencePassMs,
+    WitnessQuorumSendersPerEpoch,
+    WitnessQuorumEpochs,
+    MaxWitnessOverrideDepth,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PolicySweepCurveV1 {
+    pub schema_version: String,
+    pub constant: PolicySweepConstantV1,
+    pub retained_input_count: usize,
+    pub current_tip_epoch: u64,
+    pub retained_anchor_epoch: u64,
+    pub points: Vec<PolicySweepPointV1>,
+    pub production_auto_tuning_permitted: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PolicySweepPointV1 {
+    pub value: u64,
+    pub selected_branch_id: Option<String>,
+    pub selected_tip: Option<u64>,
+    pub candidate_count: usize,
+    pub eligible_count: usize,
+    pub accepted_commits: usize,
+    pub deferred_messages: usize,
+    pub dropped_messages: usize,
+    pub convergence_status: String,
+    pub boundary_failure: Option<String>,
+}
+
+/// Sweep one constant while preserving the exact pending input set, current
+/// tip, retained anchor, time, and every non-selected policy field.
+pub fn sweep_canonicalization_policy(
+    input: &CanonicalizationInput,
+    constant: PolicySweepConstantV1,
+    values: impl IntoIterator<Item = u64>,
+) -> PolicySweepCurveV1 {
+    let mut values = values.into_iter().collect::<Vec<_>>();
+    values.sort_unstable();
+    values.dedup();
+    let points = values
+        .into_iter()
+        .map(|value| {
+            let mut candidate = input.clone();
+            let boundary_failure = apply_value(&mut candidate.policy, constant, value).err();
+            if let Some(boundary_failure) = boundary_failure {
+                return PolicySweepPointV1 {
+                    value,
+                    selected_branch_id: None,
+                    selected_tip: None,
+                    candidate_count: 0,
+                    eligible_count: 0,
+                    accepted_commits: 0,
+                    deferred_messages: 0,
+                    dropped_messages: 0,
+                    convergence_status: "policy_rejected".into(),
+                    boundary_failure: Some(boundary_failure),
+                };
+            }
+            let result = canonicalize(candidate);
+            PolicySweepPointV1 {
+                value,
+                selected_branch_id: result.selected_branch_id,
+                selected_tip: result.selected_tip,
+                candidate_count: result.candidate_count,
+                eligible_count: result.eligible_count,
+                accepted_commits: result.accepted_commits.len(),
+                deferred_messages: result.deferred_messages.len(),
+                dropped_messages: result.dropped_messages.len(),
+                convergence_status: status_label(result.convergence_status).into(),
+                boundary_failure: None,
+            }
+        })
+        .collect();
+    PolicySweepCurveV1 {
+        schema_version: "1".into(),
+        constant,
+        retained_input_count: input.pending_messages.len(),
+        current_tip_epoch: input.state.current_tip_epoch,
+        retained_anchor_epoch: input.state.retained_anchor_epoch,
+        points,
+        production_auto_tuning_permitted: false,
+    }
+}
+
+fn apply_value(
+    policy: &mut CanonicalizationPolicy,
+    constant: PolicySweepConstantV1,
+    value: u64,
+) -> Result<(), String> {
+    match constant {
+        PolicySweepConstantV1::MaxRewindCommits => policy.convergence.max_rewind_commits = value,
+        PolicySweepConstantV1::AppMessagePastEpochLimit => {
+            policy.app_message_past_epoch_limit = value
+        }
+        PolicySweepConstantV1::SettlementQuiescenceMs => policy.settlement_quiescence_ms = value,
+        PolicySweepConstantV1::MaxConvergencePassMs => policy.max_convergence_pass_ms = value,
+        PolicySweepConstantV1::WitnessQuorumSendersPerEpoch => {
+            policy.convergence.witness_quorum_senders_per_epoch = usize::try_from(value)
+                .map_err(|_| "value does not fit witness sender count".to_owned())?
+        }
+        PolicySweepConstantV1::WitnessQuorumEpochs => {
+            policy.convergence.witness_quorum_epochs = usize::try_from(value)
+                .map_err(|_| "value does not fit witness epoch count".to_owned())?
+        }
+        PolicySweepConstantV1::MaxWitnessOverrideDepth => {
+            policy.convergence.max_witness_override_depth = value
+        }
+    }
+    policy.validate().map_err(|error| error.to_string())
+}
+
+fn status_label(status: ConvergenceStatus) -> &'static str {
+    match status {
+        ConvergenceStatus::Syncing => "syncing",
+        ConvergenceStatus::Resolving => "resolving",
+        ConvergenceStatus::Settled => "settled",
+        ConvergenceStatus::Blocked => "blocked",
+    }
+}

--- a/crates/cgka-conformance-simulator/src/report.rs
+++ b/crates/cgka-conformance-simulator/src/report.rs
@@ -704,6 +704,13 @@ mod tests {
         assert_eq!(failures[0].kind, "scenario_step_failed:backend");
         assert!(failures[0].message.contains("replay budget exceeded"));
         assert_eq!(measurements.first_failing_action, Some(4));
+        assert_eq!(measurements.convergence_latency_us, None);
+        assert!(
+            measurements
+                .unavailable_process_fields
+                .iter()
+                .any(|field| field == "convergence_latency_us")
+        );
         assert!(
             measurements
                 .limiting_resource

--- a/crates/cgka-conformance-simulator/src/report.rs
+++ b/crates/cgka-conformance-simulator/src/report.rs
@@ -697,9 +697,18 @@ mod tests {
         });
 
         let failures = scenario_report_failures(&report, false);
+        let measurements =
+            crate::CampaignMeasurementsV1::from_report(&report, 10, None, 0, None, None);
 
         assert_eq!(failures.len(), 1);
         assert_eq!(failures[0].kind, "scenario_step_failed:backend");
         assert!(failures[0].message.contains("replay budget exceeded"));
+        assert_eq!(measurements.first_failing_action, Some(4));
+        assert!(
+            measurements
+                .limiting_resource
+                .as_deref()
+                .is_some_and(|resource| resource.contains("replay budget exceeded"))
+        );
     }
 }

--- a/crates/cgka-conformance-simulator/src/report.rs
+++ b/crates/cgka-conformance-simulator/src/report.rs
@@ -635,6 +635,7 @@ mod tests {
             app_invalidation_observations: Vec::new(),
             expectation_failures: Vec::new(),
             invariant_failures: Vec::new(),
+            campaign_measurements: Default::default(),
         }
     }
 
@@ -692,6 +693,7 @@ mod tests {
                 category: crate::SubjectFailureCategory::Resource,
                 message: "convergence replay budget exceeded".into(),
             },
+            wall_us: 0,
         });
 
         let failures = scenario_report_failures(&report, false);

--- a/crates/cgka-conformance-simulator/src/report.rs
+++ b/crates/cgka-conformance-simulator/src/report.rs
@@ -5,8 +5,9 @@ use crate::{
     CoverageMatrixEntry, FailureCapsuleSensitivity, FailureCapsuleV1, GeneratedScenarioCase,
     HarnessStorageMode, ScenarioReport, VectorFixture, coverage_matrix_entry,
     generate_convergence_chaos_family, generate_convergence_e2e_delivery_family,
-    generate_send_leave_family, run_generated_case_report_with_capture,
-    run_vector_fixture_report_with_capture, write_failure_capsule,
+    generate_milestone3_adversarial_family, generate_send_leave_family,
+    run_generated_case_report_with_capture, run_vector_fixture_report_with_capture,
+    write_failure_capsule,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -237,6 +238,7 @@ async fn run_generated_family_reports(
         "send-leave/v1" => generate_send_leave_family(seed, cases),
         "convergence-e2e-delivery/v1" => generate_convergence_e2e_delivery_family(seed, cases),
         "convergence-chaos/v1" => generate_convergence_chaos_family(seed, cases),
+        "milestone3-adversarial/v1" => generate_milestone3_adversarial_family(seed, cases),
         other => return Err(format!("unsupported family {other}").into()),
     };
 
@@ -588,7 +590,7 @@ fn next_value(
 }
 
 pub fn report_usage() -> &'static str {
-    "Usage: cgka-conformance-simulator-report [--replay-capsule FILE | --vectors FILE_OR_DIR ... | --family send-leave/v1|convergence-e2e-delivery/v1|convergence-chaos/v1 --seed N --cases N] [--out DIR] [--storage memory|file] [--strict-oracle|--allow-weak-oracle] [--capture-sensitive-replay]"
+    "Usage: cgka-conformance-simulator-report [--replay-capsule FILE | --vectors FILE_OR_DIR ... | --family send-leave/v1|convergence-e2e-delivery/v1|convergence-chaos/v1|milestone3-adversarial/v1 --seed N --cases N] [--out DIR] [--storage memory|file] [--strict-oracle|--allow-weak-oracle] [--capture-sensitive-replay]"
 }
 
 #[cfg(test)]

--- a/crates/cgka-conformance-simulator/src/retained_relay.rs
+++ b/crates/cgka-conformance-simulator/src/retained_relay.rs
@@ -152,7 +152,12 @@ impl RetainedRelaySubject {
             .iter()
             .map(|relay| (relay.id.clone(), RetainedRelay::default()))
             .collect::<BTreeMap<_, _>>();
-        let engine = EngineHarnessSubject::new(clients, protocol_profile, storage_mode)?;
+        let engine = EngineHarnessSubject::new_with_topology(
+            clients,
+            &resolved,
+            protocol_profile,
+            storage_mode,
+        )?;
         let mut capabilities = engine.descriptor().capabilities;
         capabilities.retain(|capability| {
             !matches!(
@@ -184,6 +189,13 @@ impl RetainedRelaySubject {
             semantic_classes: BTreeMap::new(),
             sync_observations: Vec::new(),
         })
+    }
+
+    /// Bounded append-only transport evidence captured by the wrapped engine
+    /// subject. Generated retained-history campaigns use this for the same
+    /// failure-capsule diagnostics as packet-bus campaigns.
+    pub fn captured_transport_window(&self) -> crate::CapturedTransportWindowV1 {
+        self.engine.captured_transport_window()
     }
 
     fn unresolved_ids(&mut self, client: &str) -> Result<BTreeSet<String>, SubjectError> {
@@ -424,6 +436,10 @@ fn relay_history_sets_equal(
 impl ConvergenceSubject for RetainedRelaySubject {
     fn descriptor(&self) -> SubjectDescriptor {
         self.descriptor.clone()
+    }
+
+    fn select_scenario_group(&mut self, group: &str) -> Result<(), SubjectError> {
+        self.engine.select_scenario_group(group)
     }
 
     async fn create_group(&mut self, action: SubjectCreateGroup<'_>) -> Result<(), SubjectError> {

--- a/crates/cgka-conformance-simulator/src/retained_relay.rs
+++ b/crates/cgka-conformance-simulator/src/retained_relay.rs
@@ -438,6 +438,18 @@ impl ConvergenceSubject for RetainedRelaySubject {
         self.descriptor.clone()
     }
 
+    fn database_bytes(&self) -> Option<u64> {
+        self.engine.database_bytes()
+    }
+
+    fn replay_probe_count(&self) -> Option<u64> {
+        self.engine.replay_probe_count()
+    }
+
+    fn engine_metrics(&self) -> Option<cgka_engine::engine_metrics::EngineMetricsSnapshot> {
+        self.engine.engine_metrics()
+    }
+
     fn select_scenario_group(&mut self, group: &str) -> Result<(), SubjectError> {
         self.engine.select_scenario_group(group)
     }

--- a/crates/cgka-conformance-simulator/src/retained_relay.rs
+++ b/crates/cgka-conformance-simulator/src/retained_relay.rs
@@ -154,7 +154,7 @@ impl RetainedRelaySubject {
             .collect::<BTreeMap<_, _>>();
         let engine = EngineHarnessSubject::new_with_topology(
             clients,
-            &resolved,
+            topology,
             protocol_profile,
             storage_mode,
         )?;
@@ -1112,6 +1112,78 @@ mod tests {
         };
         assert_eq!(semantic(&reference_report), semantic(&engine_report));
         assert_eq!(semantic(&engine_report), semantic(&retained_report));
+    }
+
+    #[tokio::test]
+    async fn implicit_topology_preserves_the_same_identities_on_retained_relays() {
+        let scenario = ScenarioSpec {
+            name: "retained-relay/implicit-identity-compat".into(),
+            spec_version: "2".into(),
+            clients: vec!["alice".into(), "bob".into()],
+            topology: Default::default(),
+            steps: vec![
+                ScenarioStep::CreateGroup {
+                    creator: "alice".into(),
+                    name: "identity-compat".into(),
+                    invitees: vec!["bob".into()],
+                    required_features: vec![],
+                    initial_admins: Some(vec!["alice".into()]),
+                    pending: "create".into(),
+                },
+                ScenarioStep::accept_publication("alice", "create"),
+                ScenarioStep::DeliverAll,
+                ScenarioStep::Tick {
+                    clients: vec!["bob".into()],
+                },
+                ScenarioStep::ObserveExact {
+                    clients: vec!["alice".into(), "bob".into()],
+                },
+            ],
+        };
+        let mut engine = EngineHarnessSubject::new(
+            &scenario.clients,
+            ProtocolProfile::Legacy,
+            HarnessStorageMode::InMemorySqlite,
+        )
+        .unwrap();
+        let engine_report = run_scenario_report_with_subject(&scenario, None, vec![], &mut engine)
+            .await
+            .unwrap();
+        let mut retained = RetainedRelaySubject::new(
+            &scenario.clients,
+            &scenario.topology,
+            ProtocolProfile::Legacy,
+            HarnessStorageMode::InMemorySqlite,
+        )
+        .unwrap();
+        let retained_report =
+            run_scenario_report_with_subject(&scenario, None, vec![], &mut retained)
+                .await
+                .unwrap();
+
+        let member_identities = |report: &crate::ScenarioReport| {
+            report
+                .observed_trace
+                .as_ref()
+                .unwrap()
+                .observations
+                .iter()
+                .map(|observation| {
+                    match observation.canonical_state.as_ref().unwrap() {
+                    cgka_engine::conformance_snapshot::ConformanceCanonicalStateSnapshot::Live(
+                        snapshot,
+                    ) => snapshot.sorted_member_identities_hex.clone(),
+                    cgka_engine::conformance_snapshot::ConformanceCanonicalStateSnapshot::Disbanded(
+                        _,
+                    ) => panic!("identity compatibility scenario remains live"),
+                }
+                })
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(
+            member_identities(&engine_report),
+            member_identities(&retained_report)
+        );
     }
 
     #[tokio::test]

--- a/crates/cgka-conformance-simulator/src/retained_relay.rs
+++ b/crates/cgka-conformance-simulator/src/retained_relay.rs
@@ -450,8 +450,12 @@ impl ConvergenceSubject for RetainedRelaySubject {
         self.engine.engine_metrics()
     }
 
-    fn select_scenario_group(&mut self, group: &str) -> Result<(), SubjectError> {
-        self.engine.select_scenario_group(group)
+    fn select_scenario_group(
+        &mut self,
+        group: &str,
+        allow_create: bool,
+    ) -> Result<(), SubjectError> {
+        self.engine.select_scenario_group(group, allow_create)
     }
 
     async fn create_group(&mut self, action: SubjectCreateGroup<'_>) -> Result<(), SubjectError> {

--- a/crates/cgka-conformance-simulator/src/scenario.rs
+++ b/crates/cgka-conformance-simulator/src/scenario.rs
@@ -14,7 +14,7 @@ use crate::{
     SubjectRemoveMembers, SubjectSelfUpdate, SubjectSendApplication, SubjectUpdateAdminPolicy,
     SubjectUpdateGroupData, TraceExpectation, VectorFixture, build_scenario_oracle_report,
     compare_trace_expectations, compile_scenario, drive_subject_to_quiescence,
-    preflight_compiled_scenario, stable_action_id,
+    preflight_compiled_scenario,
 };
 use cgka_traits::group::ProtocolProfile;
 use serde::{Deserialize, Serialize};
@@ -705,11 +705,11 @@ struct ScenarioStepOutputs {
 async fn execute_scenario_step(
     spec: &ScenarioSpec,
     step_index: usize,
+    action_id: &str,
     step: &ScenarioStep,
     subject: &mut dyn ConvergenceSubject,
     outputs: &mut ScenarioStepOutputs,
 ) -> Result<(), ScenarioRunError> {
-    let action_id = scenario_input_id(step_index, step);
     let ScenarioStepOutputs {
         pending_resolutions,
         observations,
@@ -736,7 +736,7 @@ async fn execute_scenario_step(
                 .unwrap_or_else(|| scenario_initial_admins(spec, step_index, invitees));
             subject
                 .create_group(SubjectCreateGroup {
-                    action_id: &action_id,
+                    action_id,
                     creator,
                     name,
                     invitees,
@@ -754,7 +754,7 @@ async fn execute_scenario_step(
         } => {
             subject
                 .invite_members(SubjectInviteMembers {
-                    action_id: &action_id,
+                    action_id,
                     inviter,
                     invitees,
                     pending,
@@ -769,7 +769,7 @@ async fn execute_scenario_step(
         } => {
             subject
                 .remove_members(SubjectRemoveMembers {
-                    action_id: &action_id,
+                    action_id,
                     remover,
                     members,
                     pending,
@@ -780,7 +780,7 @@ async fn execute_scenario_step(
         ScenarioStep::SelfUpdate { client, pending } => {
             subject
                 .self_update(SubjectSelfUpdate {
-                    action_id: &action_id,
+                    action_id,
                     client,
                     pending,
                 })
@@ -794,7 +794,7 @@ async fn execute_scenario_step(
         } => {
             subject
                 .update_group_data(SubjectUpdateGroupData {
-                    action_id: &action_id,
+                    action_id,
                     client,
                     name,
                     pending,
@@ -809,7 +809,7 @@ async fn execute_scenario_step(
         } => {
             subject
                 .update_admin_policy(SubjectUpdateAdminPolicy {
-                    action_id: Some(&action_id),
+                    action_id: Some(action_id),
                     client,
                     admins,
                     pending: Some(pending),
@@ -911,7 +911,7 @@ async fn execute_scenario_step(
         ScenarioStep::SendAppMessage { sender, payload } => {
             subject
                 .send_application(SubjectSendApplication {
-                    action_id: &action_id,
+                    action_id,
                     sender,
                     payload,
                 })
@@ -920,7 +920,7 @@ async fn execute_scenario_step(
         }
         ScenarioStep::Leave { client } => {
             subject
-                .leave(&action_id, client)
+                .leave(action_id, client)
                 .await
                 .map_err(|error| subject_step_error(step_index, error))?;
         }
@@ -1214,7 +1214,17 @@ async fn run_scenario_report_inner(
             Ok(())
         };
         let step_result = match step_result {
-            Ok(()) => execute_scenario_step(spec, step_index, step, subject, &mut outputs).await,
+            Ok(()) => {
+                execute_scenario_step(
+                    spec,
+                    step_index,
+                    &action.schedule.action_id,
+                    step,
+                    subject,
+                    &mut outputs,
+                )
+                .await
+            }
             Err(error) => Err(error),
         };
         if descriptor.supports(crate::SubjectCapability::StructuralProgress)
@@ -1371,10 +1381,6 @@ async fn run_scenario_report_inner(
 
 fn elapsed_us(duration: std::time::Duration) -> u64 {
     u64::try_from(duration.as_micros()).unwrap_or(u64::MAX)
-}
-
-fn scenario_input_id(step_index: usize, step: &ScenarioStep) -> String {
-    stable_action_id(step_index, step)
 }
 
 /// Validate adapter support before the first scenario action is executed.

--- a/crates/cgka-conformance-simulator/src/scenario.rs
+++ b/crates/cgka-conformance-simulator/src/scenario.rs
@@ -56,6 +56,12 @@ impl ScenarioOutboundSelection {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ScenarioStep {
+    /// Execute one ordinary group-scoped action against a stable scenario
+    /// group label. The compiler lowers this wrapper before adapter execution.
+    InGroup {
+        group: String,
+        action: Box<ScenarioStep>,
+    },
     CreateGroup {
         creator: String,
         name: String,
@@ -216,6 +222,7 @@ pub enum ScenarioStep {
 
 impl ScenarioStep {
     pub const KINDS: &'static [&'static str] = &[
+        "in_group",
         "create_group",
         "invite_members",
         "remove_members",
@@ -277,6 +284,7 @@ impl ScenarioStep {
 
     pub fn kind(&self) -> &'static str {
         match self {
+            ScenarioStep::InGroup { action, .. } => action.kind(),
             ScenarioStep::CreateGroup { .. } => "create_group",
             ScenarioStep::InviteMembers { .. } => "invite_members",
             ScenarioStep::RemoveMembers { .. } => "remove_members",
@@ -488,9 +496,13 @@ pub async fn run_scenario_report_with_storage_mode(
     expected_trace: Option<ScenarioTrace>,
     storage_mode: HarnessStorageMode,
 ) -> Result<ScenarioReport, ScenarioRunError> {
-    let mut subject =
-        EngineHarnessSubject::new(&spec.clients, ProtocolProfile::Legacy, storage_mode)
-            .map_err(subject_setup_error)?;
+    let mut subject = EngineHarnessSubject::new_with_topology(
+        &spec.clients,
+        &spec.topology,
+        ProtocolProfile::Legacy,
+        storage_mode,
+    )
+    .map_err(subject_setup_error)?;
     run_scenario_report_inner(spec, expected_trace, vec![], None, &mut subject).await
 }
 
@@ -514,9 +526,13 @@ pub async fn run_scenario_report_with_outcomes_and_storage_mode(
     expected_outcomes: Vec<TraceExpectation>,
     storage_mode: HarnessStorageMode,
 ) -> Result<ScenarioReport, ScenarioRunError> {
-    let mut subject =
-        EngineHarnessSubject::new(&spec.clients, ProtocolProfile::Legacy, storage_mode)
-            .map_err(subject_setup_error)?;
+    let mut subject = EngineHarnessSubject::new_with_topology(
+        &spec.clients,
+        &spec.topology,
+        ProtocolProfile::Legacy,
+        storage_mode,
+    )
+    .map_err(subject_setup_error)?;
     run_scenario_report_inner(spec, expected_trace, expected_outcomes, None, &mut subject).await
 }
 
@@ -530,9 +546,13 @@ pub async fn run_scenario_report_with_outcomes_and_capture(
     storage_mode: HarnessStorageMode,
     capture_sensitive_replay: bool,
 ) -> Result<(ScenarioReport, crate::ScenarioFailureCaptureV1), ScenarioRunError> {
-    let mut subject =
-        EngineHarnessSubject::new(&spec.clients, ProtocolProfile::Legacy, storage_mode)
-            .map_err(subject_setup_error)?;
+    let mut subject = EngineHarnessSubject::new_with_topology(
+        &spec.clients,
+        &spec.topology,
+        ProtocolProfile::Legacy,
+        storage_mode,
+    )
+    .map_err(subject_setup_error)?;
     if capture_sensitive_replay && let Some(recipient_tick) = final_planned_recipient_tick(spec) {
         subject.capture_failure_replay_at_tick(recipient_tick);
     }
@@ -571,9 +591,13 @@ pub async fn run_vector_fixture_report_with_storage_mode(
     storage_mode: HarnessStorageMode,
 ) -> Result<ScenarioReport, ScenarioRunError> {
     let protocol_profile = fixture_protocol_profile(fixture)?;
-    let mut subject =
-        EngineHarnessSubject::new(&fixture.scenario.clients, protocol_profile, storage_mode)
-            .map_err(subject_setup_error)?;
+    let mut subject = EngineHarnessSubject::new_with_topology(
+        &fixture.scenario.clients,
+        &fixture.scenario.topology,
+        protocol_profile,
+        storage_mode,
+    )
+    .map_err(subject_setup_error)?;
     run_scenario_report_inner(
         &fixture.scenario,
         fixture.expected_trace.clone(),
@@ -688,6 +712,9 @@ async fn execute_scenario_step(
         assertion_observations,
     } = outputs;
     match step {
+        ScenarioStep::InGroup { .. } => {
+            unreachable!("in_group is lowered by the Scenario IR compiler")
+        }
         ScenarioStep::CreateGroup {
             creator,
             name,
@@ -1168,8 +1195,17 @@ async fn run_scenario_report_inner(
     for action in &compiled.actions {
         let step_index = action.schedule.source_step_index;
         let step = &action.step;
-        let step_result =
-            execute_scenario_step(spec, step_index, step, subject, &mut outputs).await;
+        let step_result = if let Some(group) = action.scenario_group.as_deref() {
+            subject
+                .select_scenario_group(group)
+                .map_err(|error| subject_step_error(step_index, error))
+        } else {
+            Ok(())
+        };
+        let step_result = match step_result {
+            Ok(()) => execute_scenario_step(spec, step_index, step, subject, &mut outputs).await,
+            Err(error) => Err(error),
+        };
         if let Err(error) = step_result {
             step_log.push(ScenarioStepLogEntry {
                 step_index,

--- a/crates/cgka-conformance-simulator/src/scenario.rs
+++ b/crates/cgka-conformance-simulator/src/scenario.rs
@@ -625,9 +625,13 @@ pub async fn run_vector_fixture_report_with_capture(
     capture_sensitive_replay: bool,
 ) -> Result<(ScenarioReport, crate::ScenarioFailureCaptureV1), ScenarioRunError> {
     let protocol_profile = fixture_protocol_profile(fixture)?;
-    let mut subject =
-        EngineHarnessSubject::new(&fixture.scenario.clients, protocol_profile, storage_mode)
-            .map_err(subject_setup_error)?;
+    let mut subject = EngineHarnessSubject::new_with_topology(
+        &fixture.scenario.clients,
+        &fixture.scenario.topology,
+        protocol_profile,
+        storage_mode,
+    )
+    .map_err(subject_setup_error)?;
     if capture_sensitive_replay
         && let Some(recipient_tick) = final_planned_recipient_tick(&fixture.scenario)
     {
@@ -1204,7 +1208,7 @@ async fn run_scenario_report_inner(
         let step = &action.step;
         let step_result = if let Some(group) = action.scenario_group.as_deref() {
             subject
-                .select_scenario_group(group)
+                .select_scenario_group(group, matches!(step, ScenarioStep::CreateGroup { .. }))
                 .map_err(|error| subject_step_error(step_index, error))
         } else {
             Ok(())
@@ -1429,7 +1433,7 @@ fn err(step_index: usize, message: String) -> ScenarioRunError {
     }
 }
 
-fn subject_setup_error(error: SubjectError) -> ScenarioRunError {
+pub(crate) fn subject_setup_error(error: SubjectError) -> ScenarioRunError {
     let message = error.to_string();
     ScenarioRunError {
         step_index: None,

--- a/crates/cgka-conformance-simulator/src/scenario.rs
+++ b/crates/cgka-conformance-simulator/src/scenario.rs
@@ -362,6 +362,8 @@ pub struct ScenarioReport {
     #[serde(default)]
     pub expectation_failures: Vec<ExpectationFailure>,
     pub invariant_failures: Vec<InvariantFailure>,
+    #[serde(default)]
+    pub campaign_measurements: crate::CampaignMeasurementsV1,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -413,6 +415,8 @@ pub struct ScenarioStepLogEntry {
     pub step_index: usize,
     pub step_type: String,
     pub status: ScenarioStepStatus,
+    #[serde(default)]
+    pub wall_us: u64,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -1186,13 +1190,16 @@ async fn run_scenario_report_inner(
     fixture: Option<VectorFixtureMetadata>,
     subject: &mut dyn ConvergenceSubject,
 ) -> Result<ScenarioReport, ScenarioRunError> {
+    let scenario_started = std::time::Instant::now();
     let descriptor = subject.descriptor();
     let compiled = compile_scenario(spec)?;
     preflight_compiled_scenario(&compiled, &descriptor)?;
     let mut outputs = ScenarioStepOutputs::default();
     let mut step_log = Vec::new();
+    let mut sampled_max_queue_depth = 0_usize;
 
     for action in &compiled.actions {
+        let step_started = std::time::Instant::now();
         let step_index = action.schedule.source_step_index;
         let step = &action.step;
         let step_result = if let Some(group) = action.scenario_group.as_deref() {
@@ -1206,6 +1213,16 @@ async fn run_scenario_report_inner(
             Ok(()) => execute_scenario_step(spec, step_index, step, subject, &mut outputs).await,
             Err(error) => Err(error),
         };
+        if descriptor.supports(crate::SubjectCapability::StructuralProgress)
+            && let Ok(progress) = subject.structural_progress()
+        {
+            sampled_max_queue_depth = sampled_max_queue_depth.max(
+                progress
+                    .transport_queued_messages
+                    .saturating_add(progress.transport_delayed_messages)
+                    .saturating_add(progress.transport_mailbox_messages),
+            );
+        }
         if let Err(error) = step_result {
             step_log.push(ScenarioStepLogEntry {
                 step_index,
@@ -1215,6 +1232,7 @@ async fn run_scenario_report_inner(
                     category: error.category,
                     message: error.message,
                 },
+                wall_us: elapsed_us(step_started.elapsed()),
             });
             break;
         }
@@ -1222,6 +1240,7 @@ async fn run_scenario_report_inner(
             step_index,
             step_type: step.kind().into(),
             status: ScenarioStepStatus::Completed,
+            wall_us: elapsed_us(step_started.elapsed()),
         });
     }
 
@@ -1303,7 +1322,10 @@ async fn run_scenario_report_inner(
         &quiescence_observations,
     );
 
-    Ok(ScenarioReport {
+    let database_bytes = subject.database_bytes();
+    let replay_probe_count = subject.replay_probe_count();
+    let engine_metrics = subject.engine_metrics();
+    let mut report = ScenarioReport {
         metadata: ScenarioReportMetadata {
             scenario_name: spec.name.clone(),
             spec_version: spec.spec_version.clone(),
@@ -1330,7 +1352,21 @@ async fn run_scenario_report_inner(
         app_invalidation_observations,
         expectation_failures,
         invariant_failures,
-    })
+        campaign_measurements: crate::CampaignMeasurementsV1::default(),
+    };
+    report.campaign_measurements = crate::CampaignMeasurementsV1::from_report(
+        &report,
+        elapsed_us(scenario_started.elapsed()),
+        database_bytes,
+        sampled_max_queue_depth,
+        replay_probe_count,
+        engine_metrics.as_ref(),
+    );
+    Ok(report)
+}
+
+fn elapsed_us(duration: std::time::Duration) -> u64 {
+    u64::try_from(duration.as_micros()).unwrap_or(u64::MAX)
 }
 
 fn scenario_input_id(step_index: usize, step: &ScenarioStep) -> String {

--- a/crates/cgka-conformance-simulator/src/scenario_input_ledger.rs
+++ b/crates/cgka-conformance-simulator/src/scenario_input_ledger.rs
@@ -12,6 +12,7 @@ use cgka_traits::message::MessageState;
 use cgka_traits::types::MessageId;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+use std::time::Instant;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -78,6 +79,10 @@ pub struct ScenarioInputLedgerEntry {
     pub send_attempts: usize,
     pub send_accepted: usize,
     pub send_queued: usize,
+    /// Wall-clock time spent accepted but blocked behind convergence before
+    /// publication (or a terminal refusal/rollback).
+    #[serde(default)]
+    pub blocked_send_duration_us: u64,
     pub published: usize,
     pub ingest_attempts: usize,
     pub ingest_accepted: usize,
@@ -101,6 +106,7 @@ pub(crate) struct ScenarioInputTracker {
     entries: BTreeMap<String, ScenarioInputLedgerEntry>,
     metadata: BTreeMap<String, ScenarioInputMetadata>,
     scenario_by_logical_id: BTreeMap<String, String>,
+    blocked_send_started: BTreeMap<String, Instant>,
 }
 
 impl ScenarioInputTracker {
@@ -114,6 +120,11 @@ impl ScenarioInputTracker {
 
     pub(crate) fn record_send_accepted(&mut self, metadata: &ScenarioInputMetadata, queued: bool) {
         self.remember_metadata(metadata);
+        if queued {
+            self.blocked_send_started
+                .entry(metadata.scenario_id.clone())
+                .or_insert_with(Instant::now);
+        }
         let entry = self.entry(metadata);
         entry.send_accepted += 1;
         if queued {
@@ -125,6 +136,7 @@ impl ScenarioInputTracker {
 
     pub(crate) fn record_published(&mut self, metadata: &ScenarioInputMetadata) {
         self.remember_metadata(metadata);
+        self.finish_blocked_interval(&metadata.scenario_id);
         let entry = self.entry(metadata);
         entry.published += 1;
         if metadata.kind == ScenarioInputKind::Application {
@@ -141,6 +153,7 @@ impl ScenarioInputTracker {
     }
 
     pub(crate) fn record_rolled_back(&mut self, scenario_id: &str) {
+        self.finish_blocked_interval(scenario_id);
         if let Some(entry) = self.entries.get_mut(scenario_id) {
             entry.disposition = ScenarioInputDisposition::RolledBack;
             push_unique(&mut entry.invalidated, "publish_rolled_back");
@@ -150,6 +163,7 @@ impl ScenarioInputTracker {
 
     pub(crate) fn record_resource_refused(&mut self, metadata: &ScenarioInputMetadata) {
         self.remember_metadata(metadata);
+        self.finish_blocked_interval(&metadata.scenario_id);
         let entry = self.entry(metadata);
         entry.resource_refused += 1;
         entry.disposition = ScenarioInputDisposition::ResourceRefused;
@@ -399,6 +413,22 @@ impl ScenarioInputTracker {
                 ..Default::default()
             })
     }
+
+    fn finish_blocked_interval(&mut self, scenario_id: &str) {
+        let Some(started) = self.blocked_send_started.remove(scenario_id) else {
+            return;
+        };
+        let Some(entry) = self.entries.get_mut(scenario_id) else {
+            return;
+        };
+        entry.blocked_send_duration_us = entry
+            .blocked_send_duration_us
+            .saturating_add(elapsed_us(started.elapsed()));
+    }
+}
+
+fn elapsed_us(duration: std::time::Duration) -> u64 {
+    u64::try_from(duration.as_micros()).unwrap_or(u64::MAX)
 }
 
 fn is_terminal(disposition: &ScenarioInputDisposition) -> bool {
@@ -493,6 +523,27 @@ mod tests {
         assert_eq!(entry.deduplicated, 1);
         assert_eq!(entry.disposition, ScenarioInputDisposition::Delivered);
         assert!(!entry.pending);
+    }
+
+    #[test]
+    fn blocked_send_duration_only_covers_queued_publication_interval() {
+        let mut tracker = ScenarioInputTracker::default();
+        let metadata = metadata(ScenarioInputKind::Application);
+        tracker.record_send_attempt(&metadata);
+        tracker.record_send_accepted(&metadata, true);
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        tracker.record_published(&metadata);
+
+        let entry = &tracker.snapshot()[0];
+        assert!(entry.blocked_send_duration_us >= 1_000);
+        assert_eq!(entry.published, 1);
+        assert!(tracker.blocked_send_started.is_empty());
+
+        let mut immediate = ScenarioInputTracker::default();
+        immediate.record_send_attempt(&metadata);
+        immediate.record_send_accepted(&metadata, false);
+        immediate.record_published(&metadata);
+        assert_eq!(immediate.snapshot()[0].blocked_send_duration_us, 0);
     }
 
     #[test]

--- a/crates/cgka-conformance-simulator/src/scenario_input_ledger.rs
+++ b/crates/cgka-conformance-simulator/src/scenario_input_ledger.rs
@@ -337,6 +337,23 @@ impl ScenarioInputTracker {
         }
     }
 
+    /// Reconcile a previously retained opaque transport object whose durable
+    /// row is no longer present. `TransportDeferred` is returned only after the
+    /// engine has persisted a `PeelDeferred` row; the engine's sole deletion
+    /// transition for that lifecycle is a resource-budget release. This keeps
+    /// the ledger aligned even when the release event uses an alias unavailable
+    /// to the synthetic transport registry.
+    pub(crate) fn record_storage_absence(&mut self, scenario_id: &str) {
+        let Some(entry) = self.entries.get_mut(scenario_id) else {
+            return;
+        };
+        if entry.pending && entry.transport_deferred > 0 {
+            entry.resource_refused = entry.resource_refused.max(1);
+            entry.disposition = ScenarioInputDisposition::ResourceRefused;
+            entry.pending = false;
+        }
+    }
+
     pub(crate) fn snapshot(&self) -> Vec<ScenarioInputLedgerEntry> {
         self.entries.values().cloned().collect()
     }
@@ -528,6 +545,26 @@ mod tests {
         assert_eq!(entry.transport_deferred, 1);
         assert_eq!(entry.disposition, ScenarioInputDisposition::Pending);
         assert!(entry.pending);
+    }
+
+    #[test]
+    fn released_transport_deferred_row_is_resource_refused() {
+        let mut tracker = ScenarioInputTracker::default();
+        let mut metadata = metadata(ScenarioInputKind::Application);
+        metadata.scenario_id = "opaque".into();
+        tracker.record_ingest(
+            &metadata,
+            Ok(&IngestOutcome::TransportDeferred {
+                group_id: cgka_traits::types::GroupId::new(vec![1]),
+            }),
+        );
+
+        tracker.record_storage_absence("opaque");
+
+        let entry = tracker.entries.get("opaque").expect("ledger entry");
+        assert_eq!(entry.disposition, ScenarioInputDisposition::ResourceRefused);
+        assert_eq!(entry.resource_refused, 1);
+        assert!(!entry.pending);
     }
 
     #[test]

--- a/crates/cgka-conformance-simulator/src/scenario_input_ledger.rs
+++ b/crates/cgka-conformance-simulator/src/scenario_input_ledger.rs
@@ -81,7 +81,9 @@ pub struct ScenarioInputLedgerEntry {
     pub send_queued: usize,
     /// Wall-clock time spent accepted but blocked behind convergence before
     /// publication (or a terminal refusal/rollback).
-    #[serde(default)]
+    // Kept in the in-memory report so campaign aggregation can consume it,
+    // but excluded from deterministic traces and promoted fixtures.
+    #[serde(default, skip_serializing)]
     pub blocked_send_duration_us: u64,
     pub published: usize,
     pub ingest_attempts: usize,
@@ -544,6 +546,16 @@ mod tests {
         immediate.record_send_accepted(&metadata, false);
         immediate.record_published(&metadata);
         assert_eq!(immediate.snapshot()[0].blocked_send_duration_us, 0);
+    }
+
+    #[test]
+    fn blocked_send_duration_is_not_serialized_into_deterministic_traces() {
+        let entry = ScenarioInputLedgerEntry {
+            blocked_send_duration_us: 42,
+            ..Default::default()
+        };
+        let encoded = serde_json::to_value(entry).expect("ledger serializes");
+        assert!(encoded.get("blocked_send_duration_us").is_none());
     }
 
     #[test]

--- a/crates/cgka-conformance-simulator/src/scenario_ir.rs
+++ b/crates/cgka-conformance-simulator/src/scenario_ir.rs
@@ -105,12 +105,9 @@ pub fn compile_scenario(spec: &ScenarioSpec) -> Result<CompiledScenarioV2, Scena
             lower_group_action(source_step_index, step, &topology)?;
         validate_step(source_step_index, executable_step, &clients, &topology)?;
         let action_id = stable_action_id(source_step_index, step);
-        let mut required_capabilities = required_capabilities(executable_step)
+        let required_capabilities = required_capabilities(step)
             .into_iter()
             .collect::<BTreeSet<_>>();
-        if scenario_group.is_some() {
-            required_capabilities.insert(SubjectCapability::MultiGroup);
-        }
         actions.push(CompiledScenarioActionV2 {
             schedule: ScenarioActionScheduleV2 {
                 action_id,

--- a/crates/cgka-conformance-simulator/src/scenario_ir.rs
+++ b/crates/cgka-conformance-simulator/src/scenario_ir.rs
@@ -99,8 +99,24 @@ pub fn compile_scenario(spec: &ScenarioSpec) -> Result<CompiledScenarioV2, Scena
 
     let mut virtual_time_ms = 0_u64;
     let topology = spec.topology.resolve_for_clients(&spec.clients)?;
+    let uses_explicit_group_targets = spec
+        .steps
+        .iter()
+        .any(|step| matches!(step, ScenarioStep::InGroup { .. }));
     let mut actions = Vec::with_capacity(spec.steps.len());
     for (source_step_index, step) in spec.steps.iter().enumerate() {
+        if uses_explicit_group_targets
+            && !matches!(step, ScenarioStep::InGroup { .. })
+            && is_group_scoped(step)
+        {
+            return Err(compile_error(
+                Some(source_step_index),
+                format!(
+                    "{} must use in_group when the scenario targets multiple groups",
+                    step.kind()
+                ),
+            ));
+        }
         let (scenario_group, executable_step) =
             lower_group_action(source_step_index, step, &topology)?;
         validate_step(source_step_index, executable_step, &clients, &topology)?;

--- a/crates/cgka-conformance-simulator/src/scenario_ir.rs
+++ b/crates/cgka-conformance-simulator/src/scenario_ir.rs
@@ -21,6 +21,8 @@ pub struct ScenarioActionScheduleV2 {
     pub action_id: String,
     pub source_step_index: usize,
     pub action_type: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scenario_group: Option<String>,
     /// Sum of explicit `advance_time` deltas preceding this action.
     ///
     /// Assertions and quiescence may advance an adapter's observed clock while
@@ -33,6 +35,7 @@ pub struct ScenarioActionScheduleV2 {
 pub struct CompiledScenarioActionV2 {
     pub schedule: ScenarioActionScheduleV2,
     pub step: ScenarioStep,
+    pub scenario_group: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -54,7 +57,12 @@ impl CompiledScenarioV2 {
 }
 
 pub fn stable_action_id(source_step_index: usize, step: &ScenarioStep) -> String {
-    format!("step-{source_step_index}:{}", step.kind())
+    match step {
+        ScenarioStep::InGroup { group, action } => {
+            format!("step-{source_step_index}:{}@{group}", action.kind())
+        }
+        _ => format!("step-{source_step_index}:{}", step.kind()),
+    }
 }
 
 /// Compile canonical JSON input into the only schedule adapters may execute.
@@ -93,20 +101,29 @@ pub fn compile_scenario(spec: &ScenarioSpec) -> Result<CompiledScenarioV2, Scena
     let topology = spec.topology.resolve_for_clients(&spec.clients)?;
     let mut actions = Vec::with_capacity(spec.steps.len());
     for (source_step_index, step) in spec.steps.iter().enumerate() {
-        validate_step(source_step_index, step, &clients, &topology)?;
+        let (scenario_group, executable_step) =
+            lower_group_action(source_step_index, step, &topology)?;
+        validate_step(source_step_index, executable_step, &clients, &topology)?;
         let action_id = stable_action_id(source_step_index, step);
-        let required_capabilities = required_capabilities(step).into_iter().collect();
+        let mut required_capabilities = required_capabilities(executable_step)
+            .into_iter()
+            .collect::<BTreeSet<_>>();
+        if scenario_group.is_some() {
+            required_capabilities.insert(SubjectCapability::MultiGroup);
+        }
         actions.push(CompiledScenarioActionV2 {
             schedule: ScenarioActionScheduleV2 {
                 action_id,
                 source_step_index,
-                action_type: step.kind().into(),
+                action_type: executable_step.kind().into(),
+                scenario_group: scenario_group.clone(),
                 declared_virtual_time_ms: virtual_time_ms,
                 required_capabilities,
             },
-            step: step.clone(),
+            step: executable_step.clone(),
+            scenario_group,
         });
-        if let ScenarioStep::AdvanceTime { delta_ms } = step {
+        if let ScenarioStep::AdvanceTime { delta_ms } = executable_step {
             virtual_time_ms = virtual_time_ms.checked_add(*delta_ms).ok_or_else(|| {
                 compile_error(
                     Some(source_step_index),
@@ -125,6 +142,61 @@ pub fn compile_scenario(spec: &ScenarioSpec) -> Result<CompiledScenarioV2, Scena
     })
 }
 
+fn lower_group_action<'a>(
+    step_index: usize,
+    step: &'a ScenarioStep,
+    topology: &crate::ScenarioTopologyV2,
+) -> Result<(Option<String>, &'a ScenarioStep), ScenarioRunError> {
+    let ScenarioStep::InGroup { group, action } = step else {
+        return Ok((None, step));
+    };
+    if group.trim().is_empty() {
+        return Err(compile_error(
+            Some(step_index),
+            "scenario group label must not be empty".into(),
+        ));
+    }
+    if matches!(action.as_ref(), ScenarioStep::InGroup { .. }) {
+        return Err(compile_error(
+            Some(step_index),
+            "nested in_group actions are not allowed".into(),
+        ));
+    }
+    if !is_group_scoped(action) {
+        return Err(compile_error(
+            Some(step_index),
+            format!("{} is not a group-scoped action", action.kind()),
+        ));
+    }
+    if !topology.groups.is_empty() && !topology.groups.iter().any(|item| item.id == *group) {
+        return Err(compile_error(
+            Some(step_index),
+            format!("in_group references unknown scenario group {group}"),
+        ));
+    }
+    Ok((Some(group.clone()), action))
+}
+
+fn is_group_scoped(step: &ScenarioStep) -> bool {
+    matches!(
+        step,
+        ScenarioStep::CreateGroup { .. }
+            | ScenarioStep::InviteMembers { .. }
+            | ScenarioStep::RemoveMembers { .. }
+            | ScenarioStep::SelfUpdate { .. }
+            | ScenarioStep::UpdateGroupData { .. }
+            | ScenarioStep::UpdateAdminPolicy { .. }
+            | ScenarioStep::ExpectUpdateAdminPolicyError { .. }
+            | ScenarioStep::SendAppMessage { .. }
+            | ScenarioStep::Leave { .. }
+            | ScenarioStep::ProbeBidirectionalDecryptability { .. }
+            | ScenarioStep::ObserveAdminPolicy { .. }
+            | ScenarioStep::Observe { .. }
+            | ScenarioStep::ObserveExact { .. }
+            | ScenarioStep::ClearEvents { .. }
+    )
+}
+
 fn validate_step(
     step_index: usize,
     step: &ScenarioStep,
@@ -132,6 +204,7 @@ fn validate_step(
     topology: &crate::ScenarioTopologyV2,
 ) -> Result<(), ScenarioRunError> {
     match step {
+        ScenarioStep::InGroup { .. } => unreachable!("group wrapper is lowered before validation"),
         ScenarioStep::OmitMessage { selector } | ScenarioStep::DuplicateMessage { selector } => {
             validate_semantic_selector(step_index, selector)?;
         }

--- a/crates/cgka-conformance-simulator/src/subject.rs
+++ b/crates/cgka-conformance-simulator/src/subject.rs
@@ -1231,15 +1231,14 @@ impl ConvergenceSubject for EngineHarnessSubject {
                 initial_admins,
             )
             .await;
-        if let Some(group) = &self.active_scenario_group {
-            if let Some(existing) = self.scenario_groups.insert(group.clone(), group_id.clone())
-                && existing != group_id
-            {
-                return Err(SubjectError::new(
-                    "duplicate_scenario_group",
-                    format!("scenario group {group} was created more than once"),
-                ));
-            }
+        if let Some(group) = &self.active_scenario_group
+            && let Some(existing) = self.scenario_groups.insert(group.clone(), group_id.clone())
+            && existing != group_id
+        {
+            return Err(SubjectError::new(
+                "duplicate_scenario_group",
+                format!("scenario group {group} was created more than once"),
+            ));
         }
         if let Some(pending_ref) = pending_ref {
             self.insert_pending(action.pending, action.creator, pending_ref)?;

--- a/crates/cgka-conformance-simulator/src/subject.rs
+++ b/crates/cgka-conformance-simulator/src/subject.rs
@@ -1655,6 +1655,12 @@ impl ConvergenceSubject for EngineHarnessSubject {
             .iter()
             .map(|label| {
                 let client = self.client_mut(label)?;
+                if !client.has_active_group() {
+                    return Err(SubjectError::new(
+                        "client_not_in_scenario_group",
+                        format!("client {label} is not a member of the selected scenario group"),
+                    ));
+                }
                 Ok(observe_client(label.clone(), client))
             })
             .collect()
@@ -1668,6 +1674,12 @@ impl ConvergenceSubject for EngineHarnessSubject {
             .iter()
             .map(|label| {
                 let client = self.client_mut(label)?;
+                if !client.has_active_group() {
+                    return Err(SubjectError::new(
+                        "client_not_in_scenario_group",
+                        format!("client {label} is not a member of the selected scenario group"),
+                    ));
+                }
                 Ok(observe_client_exact(label.clone(), client))
             })
             .collect()

--- a/crates/cgka-conformance-simulator/src/subject.rs
+++ b/crates/cgka-conformance-simulator/src/subject.rs
@@ -14,6 +14,7 @@ use crate::{
     TransportBus, observe_client, observe_client_exact,
 };
 use async_trait::async_trait;
+use cgka_engine::engine_metrics::EngineMetricsSnapshot;
 use cgka_engine::feature_registry::FeatureRegistry;
 use cgka_engine::{ConvergenceClock, ManualConvergenceClock};
 use cgka_traits::EngineError;
@@ -263,6 +264,18 @@ pub struct SubjectOutboundArtifact {
 #[async_trait]
 pub trait ConvergenceSubject: Send {
     fn descriptor(&self) -> SubjectDescriptor;
+
+    fn database_bytes(&self) -> Option<u64> {
+        None
+    }
+
+    fn replay_probe_count(&self) -> Option<u64> {
+        None
+    }
+
+    fn engine_metrics(&self) -> Option<EngineMetricsSnapshot> {
+        None
+    }
 
     fn select_scenario_group(&mut self, _group: &str) -> Result<(), SubjectError> {
         Err(SubjectError::unsupported(SubjectCapability::MultiGroup))
@@ -1157,6 +1170,41 @@ impl EngineHarnessSubject {
 impl ConvergenceSubject for EngineHarnessSubject {
     fn descriptor(&self) -> SubjectDescriptor {
         self.descriptor.clone()
+    }
+
+    fn database_bytes(&self) -> Option<u64> {
+        let paths = self
+            .clients
+            .values()
+            .filter_map(|client| client.database_path())
+            .collect::<Vec<_>>();
+        (!paths.is_empty()).then(|| {
+            paths
+                .into_iter()
+                .flat_map(|path| {
+                    [
+                        path.to_path_buf(),
+                        path.with_extension("sqlite-wal"),
+                        path.with_extension("sqlite-shm"),
+                    ]
+                })
+                .filter_map(|path| std::fs::metadata(path).ok())
+                .fold(0_u64, |sum, metadata| sum.saturating_add(metadata.len()))
+        })
+    }
+
+    fn replay_probe_count(&self) -> Option<u64> {
+        Some(self.clients.values().fold(0_u64, |sum, client| {
+            sum.saturating_add(client.replay_probe_count())
+        }))
+    }
+
+    fn engine_metrics(&self) -> Option<EngineMetricsSnapshot> {
+        let mut aggregate = EngineMetricsSnapshot::default();
+        for client in self.clients.values() {
+            crate::client::merge_engine_metrics(&mut aggregate, &client.engine_metrics());
+        }
+        Some(aggregate)
     }
 
     fn select_scenario_group(&mut self, group: &str) -> Result<(), SubjectError> {

--- a/crates/cgka-conformance-simulator/src/subject.rs
+++ b/crates/cgka-conformance-simulator/src/subject.rs
@@ -277,7 +277,11 @@ pub trait ConvergenceSubject: Send {
         None
     }
 
-    fn select_scenario_group(&mut self, _group: &str) -> Result<(), SubjectError> {
+    fn select_scenario_group(
+        &mut self,
+        _group: &str,
+        _allow_create: bool,
+    ) -> Result<(), SubjectError> {
         Err(SubjectError::unsupported(SubjectCapability::MultiGroup))
     }
 
@@ -671,6 +675,15 @@ pub struct EngineHarnessSubject {
     replay_capture_target_tick: Option<usize>,
     observed_recipient_ticks: usize,
     last_byte_replay: Option<EngineByteReplayV1>,
+}
+
+fn sqlite_database_files(path: &std::path::Path) -> [std::path::PathBuf; 3] {
+    let sidecar = |suffix: &str| {
+        let mut value = path.as_os_str().to_os_string();
+        value.push(suffix);
+        std::path::PathBuf::from(value)
+    };
+    [path.to_path_buf(), sidecar("-wal"), sidecar("-shm")]
 }
 
 #[derive(Clone)]
@@ -1191,13 +1204,7 @@ impl ConvergenceSubject for EngineHarnessSubject {
         (!paths.is_empty()).then(|| {
             paths
                 .into_iter()
-                .flat_map(|path| {
-                    [
-                        path.to_path_buf(),
-                        path.with_extension("sqlite-wal"),
-                        path.with_extension("sqlite-shm"),
-                    ]
-                })
+                .flat_map(sqlite_database_files)
                 .filter_map(|path| std::fs::metadata(path).ok())
                 .fold(0_u64, |sum, metadata| sum.saturating_add(metadata.len()))
         })
@@ -1217,17 +1224,37 @@ impl ConvergenceSubject for EngineHarnessSubject {
         Some(aggregate)
     }
 
-    fn select_scenario_group(&mut self, group: &str) -> Result<(), SubjectError> {
-        self.active_scenario_group = Some(group.to_owned());
-        if let Some(group_id) = self.scenario_groups.get(group).cloned() {
-            for client in self.clients.values_mut() {
-                client.select_default_group(group_id.clone());
+    fn select_scenario_group(
+        &mut self,
+        group: &str,
+        allow_create: bool,
+    ) -> Result<(), SubjectError> {
+        let Some(group_id) = self.scenario_groups.get(group).cloned() else {
+            if allow_create {
+                self.active_scenario_group = Some(group.to_owned());
+                return Ok(());
             }
+            return Err(SubjectError::new(
+                "unknown_scenario_group",
+                format!("scenario group {group} has not been created"),
+            ));
+        };
+        self.active_scenario_group = Some(group.to_owned());
+        for client in self.clients.values_mut() {
+            client.select_default_group(group_id.clone());
         }
         Ok(())
     }
 
     async fn create_group(&mut self, action: SubjectCreateGroup<'_>) -> Result<(), SubjectError> {
+        if let Some(group) = &self.active_scenario_group
+            && self.scenario_groups.contains_key(group)
+        {
+            return Err(SubjectError::new(
+                "duplicate_scenario_group",
+                format!("scenario group {group} was created more than once"),
+            ));
+        }
         let initial_admins = self.member_ids(action.initial_admins)?;
         let key_packages = self.fresh_key_packages(action.invitees).await?;
         let required_features = required_features_from_names(action.required_features)?;
@@ -1241,14 +1268,8 @@ impl ConvergenceSubject for EngineHarnessSubject {
                 initial_admins,
             )
             .await;
-        if let Some(group) = &self.active_scenario_group
-            && let Some(existing) = self.scenario_groups.insert(group.clone(), group_id.clone())
-            && existing != group_id
-        {
-            return Err(SubjectError::new(
-                "duplicate_scenario_group",
-                format!("scenario group {group} was created more than once"),
-            ));
+        if let Some(group) = &self.active_scenario_group {
+            self.scenario_groups.insert(group.clone(), group_id.clone());
         }
         if let Some(pending_ref) = pending_ref {
             self.insert_pending(action.pending, action.creator, pending_ref)?;
@@ -2077,6 +2098,17 @@ mod tests {
         QuiescenceStatus, drive_subject_to_quiescence,
     };
 
+    #[test]
+    fn sqlite_database_accounting_uses_real_sidecar_names() {
+        assert_eq!(
+            sqlite_database_files(std::path::Path::new("client.sqlite3")),
+            [
+                std::path::PathBuf::from("client.sqlite3"),
+                std::path::PathBuf::from("client.sqlite3-wal"),
+                std::path::PathBuf::from("client.sqlite3-shm"),
+            ]
+        );
+    }
     async fn create_current_group_and_join(
         subject: &mut EngineHarnessSubject,
         creator: &str,

--- a/crates/cgka-conformance-simulator/src/subject.rs
+++ b/crates/cgka-conformance-simulator/src/subject.rs
@@ -758,6 +758,12 @@ impl EngineHarnessSubject {
     ) -> Result<Self, SubjectError> {
         let bus = TransportBus::ordered();
         let convergence_clock = ManualConvergenceClock::new(0, 0);
+        // Resolving an old client-only scenario makes its deployment topology
+        // explicit in reports, but it must not change the scenario's existing
+        // member identities. Only an explicitly authored account mapping opts
+        // into account-scoped credentials (and therefore shared credentials
+        // for multiple devices of one account).
+        let explicit_account_topology = !topology.is_empty();
         let resolved = topology
             .resolve_for_clients(clients)
             .map_err(|error| SubjectError::new(error.kind, error.message))?;
@@ -775,11 +781,15 @@ impl EngineHarnessSubject {
                     format!("duplicate client label {label}"),
                 ));
             }
-            let account = account_by_device
-                .get(label.as_str())
-                .copied()
-                .unwrap_or(label.as_str());
-            let identity_seed = pad32(account.as_bytes());
+            let identity_label = if explicit_account_topology {
+                account_by_device
+                    .get(label.as_str())
+                    .copied()
+                    .unwrap_or(label.as_str())
+            } else {
+                label.as_str()
+            };
+            let identity_seed = pad32(identity_label.as_bytes());
             let builder = ClientBuilder::new(identity_seed.clone())
                 .registry(engine_harness_feature_registry())
                 .protocol_profile(protocol_profile)
@@ -2124,6 +2134,68 @@ mod tests {
             classify_engine_error(&EngineError::Serialize("malformed internal state".into()));
         assert_eq!(category, SubjectFailureCategory::Protocol);
         assert_eq!(code, "invalid_admin_policy");
+    }
+
+    #[test]
+    fn implicit_topology_preserves_legacy_client_identity_seeds() {
+        let labels = vec!["alice".to_owned(), "bob".to_owned()];
+        let subject = EngineHarnessSubject::new_with_topology(
+            &labels,
+            &crate::ScenarioTopologyV2::default(),
+            ProtocolProfile::Current,
+            HarnessStorageMode::InMemorySqlite,
+        )
+        .expect("engine subject constructs");
+
+        assert_eq!(subject.identity_seeds["alice"], pad32(b"alice"));
+        assert_eq!(subject.identity_seeds["bob"], pad32(b"bob"));
+    }
+
+    #[test]
+    fn explicit_topology_shares_account_identity_across_devices() {
+        let labels = vec!["alice-phone".to_owned(), "alice-laptop".to_owned()];
+        let topology = crate::ScenarioTopologyV2 {
+            accounts: vec![crate::ScenarioAccountV2 {
+                id: "account:alice".into(),
+                roles: vec!["member".into()],
+            }],
+            devices: labels
+                .iter()
+                .map(|client| crate::ScenarioDeviceV2 {
+                    id: format!("device:{client}"),
+                    account: "account:alice".into(),
+                    process: format!("process:{client}"),
+                    client: client.clone(),
+                })
+                .collect(),
+            processes: labels
+                .iter()
+                .map(|client| crate::ScenarioProcessV2 {
+                    id: format!("process:{client}"),
+                    binary_version: "mdk-test".into(),
+                    policy_version: "marmot-convergence-v1".into(),
+                    relays: vec![],
+                })
+                .collect(),
+            groups: vec![],
+            relays: vec![],
+        };
+        let subject = EngineHarnessSubject::new_with_topology(
+            &labels,
+            &topology,
+            ProtocolProfile::Current,
+            HarnessStorageMode::InMemorySqlite,
+        )
+        .expect("engine subject constructs");
+
+        assert_eq!(
+            subject.identity_seeds["alice-phone"],
+            subject.identity_seeds["alice-laptop"]
+        );
+        assert_eq!(
+            subject.identity_seeds["alice-phone"],
+            pad32(b"account:alice")
+        );
     }
 
     #[tokio::test]

--- a/crates/cgka-conformance-simulator/src/subject.rs
+++ b/crates/cgka-conformance-simulator/src/subject.rs
@@ -51,6 +51,7 @@ pub enum SubjectCapability {
     ProcessLifecycle,
     StorageFaultInjection,
     AssertionEvaluation,
+    MultiGroup,
     RetainedRelayHistory,
     RetainedRelayControl,
 }
@@ -76,6 +77,7 @@ impl SubjectCapability {
             Self::ProcessLifecycle => "process_lifecycle",
             Self::StorageFaultInjection => "storage_fault_injection",
             Self::AssertionEvaluation => "assertion_evaluation",
+            Self::MultiGroup => "multi_group",
             Self::RetainedRelayHistory => "retained_relay_history",
             Self::RetainedRelayControl => "retained_relay_control",
         }
@@ -261,6 +263,10 @@ pub struct SubjectOutboundArtifact {
 #[async_trait]
 pub trait ConvergenceSubject: Send {
     fn descriptor(&self) -> SubjectDescriptor;
+
+    fn select_scenario_group(&mut self, _group: &str) -> Result<(), SubjectError> {
+        Err(SubjectError::unsupported(SubjectCapability::MultiGroup))
+    }
 
     async fn create_group(&mut self, _action: SubjectCreateGroup<'_>) -> Result<(), SubjectError> {
         Err(SubjectError::unsupported(SubjectCapability::GroupMutation))
@@ -524,6 +530,13 @@ pub trait ConvergenceFaultSubject {
 /// capability; fixed-point settling composes progress, time, delivery, and
 /// optionally outbound acknowledgement without moving policy into the subject.
 pub fn required_capabilities(step: &ScenarioStep) -> Vec<SubjectCapability> {
+    if let ScenarioStep::InGroup { action, .. } = step {
+        let mut capabilities = required_capabilities(action);
+        capabilities.push(SubjectCapability::MultiGroup);
+        capabilities.sort();
+        capabilities.dedup();
+        return capabilities;
+    }
     if matches!(step, ScenarioStep::Barrier { .. }) {
         return Vec::new();
     }
@@ -625,6 +638,7 @@ pub fn required_capabilities(step: &ScenarioStep) -> Vec<SubjectCapability> {
             ScenarioStep::Barrier { .. } => unreachable!("handled above"),
             ScenarioStep::Assert { .. } => unreachable!("handled above"),
             ScenarioStep::AwaitQuiescence { .. } => unreachable!("handled above"),
+            ScenarioStep::InGroup { .. } => unreachable!("handled above"),
         }]
     }
 }
@@ -634,6 +648,9 @@ pub struct EngineHarnessSubject {
     descriptor: SubjectDescriptor,
     bus: TransportBus,
     clients: BTreeMap<String, HarnessClient>,
+    identity_seeds: BTreeMap<String, Vec<u8>>,
+    active_scenario_group: Option<String>,
+    scenario_groups: BTreeMap<String, GroupId>,
     pending_refs: HashMap<String, EngineSubjectPendingRef>,
     convergence_clock: ManualConvergenceClock,
     outbound_cursors: HashMap<String, u64>,
@@ -675,9 +692,69 @@ impl EngineHarnessSubject {
         protocol_profile: ProtocolProfile,
         storage_mode: HarnessStorageMode,
     ) -> Result<Self, SubjectError> {
+        Self::new_with_topology(
+            clients,
+            &crate::ScenarioTopologyV2::default(),
+            protocol_profile,
+            storage_mode,
+        )
+    }
+
+    /// Construct clients from the resolved account/device topology. Devices
+    /// mapped to one account deliberately share the credential/account seed
+    /// while retaining separate engine/storage instances and MLS leaf keys.
+    pub fn new_with_topology(
+        clients: &[String],
+        topology: &crate::ScenarioTopologyV2,
+        protocol_profile: ProtocolProfile,
+        storage_mode: HarnessStorageMode,
+    ) -> Result<Self, SubjectError> {
+        Self::new_with_topology_and_witness_mode(
+            clients,
+            topology,
+            protocol_profile,
+            storage_mode,
+            false,
+        )
+    }
+
+    /// Build the same full engine harness while disabling only app-message
+    /// witness admission. This is an A/B campaign seam, not a wire-policy mode.
+    #[cfg(feature = "test-policy-overrides")]
+    pub fn new_without_app_witnesses_for_tests(
+        clients: &[String],
+        topology: &crate::ScenarioTopologyV2,
+        protocol_profile: ProtocolProfile,
+        storage_mode: HarnessStorageMode,
+    ) -> Result<Self, SubjectError> {
+        Self::new_with_topology_and_witness_mode(
+            clients,
+            topology,
+            protocol_profile,
+            storage_mode,
+            true,
+        )
+    }
+
+    fn new_with_topology_and_witness_mode(
+        clients: &[String],
+        topology: &crate::ScenarioTopologyV2,
+        protocol_profile: ProtocolProfile,
+        storage_mode: HarnessStorageMode,
+        disable_app_witnesses_for_tests: bool,
+    ) -> Result<Self, SubjectError> {
         let bus = TransportBus::ordered();
         let convergence_clock = ManualConvergenceClock::new(0, 0);
+        let resolved = topology
+            .resolve_for_clients(clients)
+            .map_err(|error| SubjectError::new(error.kind, error.message))?;
+        let account_by_device = resolved
+            .devices
+            .iter()
+            .map(|device| (device.client.as_str(), device.account.as_str()))
+            .collect::<HashMap<_, _>>();
         let mut attached = BTreeMap::new();
+        let mut identity_seeds = BTreeMap::new();
         for label in clients {
             if attached.contains_key(label) {
                 return Err(SubjectError::new(
@@ -685,13 +762,27 @@ impl EngineHarnessSubject {
                     format!("duplicate client label {label}"),
                 ));
             }
-            let builder = ClientBuilder::new(pad32(label.as_bytes()))
+            let account = account_by_device
+                .get(label.as_str())
+                .copied()
+                .unwrap_or(label.as_str());
+            let identity_seed = pad32(account.as_bytes());
+            let builder = ClientBuilder::new(identity_seed.clone())
                 .registry(engine_harness_feature_registry())
                 .protocol_profile(protocol_profile)
                 .storage_mode(storage_mode)
                 .convergence_clock(Arc::new(convergence_clock.clone()));
+            #[cfg(feature = "test-policy-overrides")]
+            let builder = if disable_app_witnesses_for_tests {
+                builder.without_app_witnesses_for_tests()
+            } else {
+                builder
+            };
+            #[cfg(not(feature = "test-policy-overrides"))]
+            let _ = disable_app_witnesses_for_tests;
             let client = builder.attach(&bus);
             attached.insert(label.clone(), client);
+            identity_seeds.insert(label.clone(), identity_seed);
         }
         let capabilities = BTreeSet::from([
             SubjectCapability::GroupMutation,
@@ -708,16 +799,24 @@ impl EngineHarnessSubject {
             SubjectCapability::WhiteBoxTransportPartition,
             SubjectCapability::SemanticTransportFaults,
             SubjectCapability::AssertionEvaluation,
+            SubjectCapability::MultiGroup,
         ]);
         Ok(Self {
             descriptor: SubjectDescriptor {
-                adapter: "mdk-engine-harness".into(),
+                adapter: if disable_app_witnesses_for_tests {
+                    "mdk-engine-harness-witness-disabled".into()
+                } else {
+                    "mdk-engine-harness".into()
+                },
                 adapter_version: env!("CARGO_PKG_VERSION").into(),
                 storage_backend: storage_mode.report_label().into(),
                 capabilities,
             },
             bus,
             clients: attached,
+            identity_seeds,
+            active_scenario_group: None,
+            scenario_groups: BTreeMap::new(),
             pending_refs: HashMap::new(),
             convergence_clock,
             outbound_cursors: HashMap::new(),
@@ -811,7 +910,7 @@ impl EngineHarnessSubject {
         let now = self.convergence_clock.now();
         Some(PendingByteReplay {
             client_label: label.to_owned(),
-            identity_seed: pad32(label.as_bytes()),
+            identity_seed: self.identity_seeds.get(label)?.clone(),
             protocol_profile: client.replay_protocol_profile(),
             group_id: group_id.as_slice().to_vec(),
             sensitive_checkpoint,
@@ -1060,13 +1159,23 @@ impl ConvergenceSubject for EngineHarnessSubject {
         self.descriptor.clone()
     }
 
+    fn select_scenario_group(&mut self, group: &str) -> Result<(), SubjectError> {
+        self.active_scenario_group = Some(group.to_owned());
+        if let Some(group_id) = self.scenario_groups.get(group).cloned() {
+            for client in self.clients.values_mut() {
+                client.select_default_group(group_id.clone());
+            }
+        }
+        Ok(())
+    }
+
     async fn create_group(&mut self, action: SubjectCreateGroup<'_>) -> Result<(), SubjectError> {
         let initial_admins = self.member_ids(action.initial_admins)?;
         let key_packages = self.fresh_key_packages(action.invitees).await?;
         let required_features = required_features_from_names(action.required_features)?;
         let creator = self.client_mut(action.creator)?;
         creator.name_next_scenario_input(action.action_id);
-        let (_, pending_ref) = creator
+        let (group_id, pending_ref) = creator
             .create_group_with_admins_maybe_pending(
                 action.name,
                 key_packages,
@@ -1074,6 +1183,16 @@ impl ConvergenceSubject for EngineHarnessSubject {
                 initial_admins,
             )
             .await;
+        if let Some(group) = &self.active_scenario_group {
+            if let Some(existing) = self.scenario_groups.insert(group.clone(), group_id.clone())
+                && existing != group_id
+            {
+                return Err(SubjectError::new(
+                    "duplicate_scenario_group",
+                    format!("scenario group {group} was created more than once"),
+                ));
+            }
+        }
         if let Some(pending_ref) = pending_ref {
             self.insert_pending(action.pending, action.creator, pending_ref)?;
             self.sync_client_outbound(action.creator)?;

--- a/crates/cgka-conformance-simulator/src/topology.rs
+++ b/crates/cgka-conformance-simulator/src/topology.rs
@@ -150,6 +150,24 @@ impl ScenarioTopologyV2 {
                 }
             }
         }
+        let explicit_policy_versions = self
+            .processes
+            .iter()
+            .map(|process| process.policy_version.as_str())
+            .filter(|version| *version != "unspecified")
+            .collect::<BTreeSet<_>>();
+        if explicit_policy_versions.len() > 1 {
+            return Err(topology_error_with_kind(
+                "incompatible_convergence_policy",
+                format!(
+                    "incompatible convergence policies in one scenario: {}",
+                    explicit_policy_versions
+                        .into_iter()
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ),
+            ));
+        }
         for relay in &self.relays {
             require_label("relay id", &relay.id)?;
             require_label(
@@ -252,9 +270,16 @@ fn require_label(field: &str, value: &str) -> Result<(), ScenarioRunError> {
 }
 
 fn topology_error(message: impl Into<String>) -> ScenarioRunError {
+    topology_error_with_kind("scenario_topology_error", message)
+}
+
+fn topology_error_with_kind(
+    kind: impl Into<String>,
+    message: impl Into<String>,
+) -> ScenarioRunError {
     ScenarioRunError {
         step_index: None,
-        kind: "scenario_topology_error".into(),
+        kind: kind.into(),
         category: SubjectFailureCategory::Environment,
         message: message.into(),
     }

--- a/crates/cgka-conformance-simulator/src/topology.rs
+++ b/crates/cgka-conformance-simulator/src/topology.rs
@@ -10,6 +10,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{ScenarioRunError, SubjectFailureCategory};
 
+const UNSPECIFIED_VERSION: &str = "unspecified";
+
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ScenarioTopologyV2 {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -59,8 +61,8 @@ impl ScenarioTopologyV2 {
                     .iter()
                     .map(|client| ScenarioProcessV2 {
                         id: format!("process:{client}"),
-                        binary_version: "unspecified".into(),
-                        policy_version: "unspecified".into(),
+                        binary_version: UNSPECIFIED_VERSION.into(),
+                        policy_version: UNSPECIFIED_VERSION.into(),
                         relays: Vec::new(),
                     })
                     .collect(),
@@ -154,7 +156,7 @@ impl ScenarioTopologyV2 {
             .processes
             .iter()
             .map(|process| process.policy_version.as_str())
-            .filter(|version| *version != "unspecified")
+            .filter(|version| *version != UNSPECIFIED_VERSION)
             .collect::<BTreeSet<_>>();
         if explicit_policy_versions.len() > 1 {
             return Err(topology_error_with_kind(

--- a/crates/cgka-conformance-simulator/src/vector.rs
+++ b/crates/cgka-conformance-simulator/src/vector.rs
@@ -72,7 +72,7 @@ pub fn compare_trace_expectations(
 ) -> Vec<ExpectationFailure> {
     let mut failures = Vec::new();
     if let Some(expected) = expected_trace
-        && expected != observed
+        && !fixture_trace_eq(expected, observed)
     {
         failures.push(ExpectationFailure {
             kind: "trace_mismatch".into(),
@@ -493,7 +493,8 @@ impl TraceExpectation {
                 match client_canonical_observation(observed, client)
                     .or_else(|| client_observation(observed, client))
                 {
-                    Some(observation) if &observation.scenario_input_ledger == entries => {}
+                    Some(observation)
+                        if fixture_ledger_eq(&observation.scenario_input_ledger, entries) => {}
                     Some(observation) => mismatches.push(ExpectationFailure {
                         kind: "scenario_input_ledger_mismatch".into(),
                         message: format!(
@@ -682,6 +683,46 @@ impl TraceExpectation {
                     observed,
                     mismatches,
                 );
+            }
+        }
+    }
+}
+
+fn fixture_trace_eq(expected: &ScenarioTrace, observed: &ScenarioTrace) -> bool {
+    let mut expected = expected.clone();
+    let mut observed = observed.clone();
+    clear_wall_clock_ledger_measurements(&mut expected);
+    clear_wall_clock_ledger_measurements(&mut observed);
+    expected == observed
+}
+
+fn fixture_ledger_eq(
+    expected: &[ScenarioInputLedgerEntry],
+    observed: &[ScenarioInputLedgerEntry],
+) -> bool {
+    let normalize = |entries: &[ScenarioInputLedgerEntry]| {
+        entries
+            .iter()
+            .cloned()
+            .map(|mut entry| {
+                entry.blocked_send_duration_us = 0;
+                entry
+            })
+            .collect::<Vec<_>>()
+    };
+    normalize(expected) == normalize(observed)
+}
+
+fn clear_wall_clock_ledger_measurements(trace: &mut ScenarioTrace) {
+    for observation in &mut trace.observations {
+        for entry in &mut observation.scenario_input_ledger {
+            entry.blocked_send_duration_us = 0;
+        }
+    }
+    for observation in &mut trace.decryptability_probes {
+        for probe in &mut observation.probes {
+            if let Some(entry) = &mut probe.recipient_ledger {
+                entry.blocked_send_duration_us = 0;
             }
         }
     }
@@ -1454,6 +1495,29 @@ mod tests {
         );
         assert_eq!(failures.len(), 1);
         assert_eq!(failures[0].kind, "scenario_input_ledger_mismatch");
+    }
+
+    #[test]
+    fn fixture_comparison_ignores_wall_clock_blocked_send_measurements() {
+        let mut expected = observation("alice", 1, 2);
+        expected.scenario_input_ledger = vec![ScenarioInputLedgerEntry {
+            scenario_id: "step-4:send_app_message".into(),
+            blocked_send_duration_us: 1,
+            ..Default::default()
+        }];
+        let mut observed = expected.clone();
+        observed.scenario_input_ledger[0].blocked_send_duration_us = 42_000;
+
+        let failures = compare_trace_expectations(
+            Some(&trace(vec![expected.clone()])),
+            &[TraceExpectation::ScenarioInputLedger {
+                client: "alice".into(),
+                entries: expected.scenario_input_ledger,
+            }],
+            &trace(vec![observed]),
+        );
+
+        assert!(failures.is_empty(), "unexpected failures: {failures:#?}");
     }
 
     #[test]

--- a/crates/cgka-conformance-simulator/src/vector.rs
+++ b/crates/cgka-conformance-simulator/src/vector.rs
@@ -468,12 +468,17 @@ impl TraceExpectation {
                     });
                     return;
                 }
-                let first = snapshots[0].1;
-                if snapshots.iter().all(|(_, snapshot)| *snapshot == first) {
+                let duplicate_pair = snapshots.iter().enumerate().find_map(|(left, item)| {
+                    snapshots[(left + 1)..]
+                        .iter()
+                        .find(|other| item.1 == other.1)
+                        .map(|other| (item.0, other.0))
+                });
+                if let Some((left, right)) = duplicate_pair {
                     mismatches.push(ExpectationFailure {
                         kind: "clients_unexpectedly_equivalent".into(),
                         message: format!(
-                            "clients {clients:?} converged despite named unrecoverable outcome: {reason}"
+                            "clients {left} and {right} were equivalent despite named pairwise non-equivalence: {reason}"
                         ),
                         expected: json!({
                             "clients": clients,
@@ -1672,6 +1677,39 @@ mod tests {
         );
 
         assert!(failures.is_empty(), "unexpected failures: {failures:#?}");
+    }
+
+    #[test]
+    fn non_equivalence_requires_every_named_pair_to_differ() {
+        let shared = exact_snapshot("shared-id", "shared-commitment");
+        let mut alice = observation("alice", 7, 1);
+        alice.canonical_state = Some(shared.clone());
+        let mut bob = observation("bob", 7, 1);
+        bob.canonical_state = Some(shared);
+        let mut carol = observation("carol", 7, 1);
+        carol.canonical_state = Some(exact_snapshot("carol-id", "carol-commitment"));
+        let expectation = TraceExpectation::ClientsNotEquivalent {
+            clients: vec!["alice".into(), "bob".into(), "carol".into()],
+            reason: "named split".into(),
+        };
+
+        let failures = compare_trace_expectations(
+            None,
+            std::slice::from_ref(&expectation),
+            &trace(vec![alice.clone(), bob, carol.clone()]),
+        );
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].kind, "clients_unexpectedly_equivalent");
+
+        alice.canonical_state = Some(exact_snapshot("alice-id", "alice-commitment"));
+        let mut bob = observation("bob", 7, 1);
+        bob.canonical_state = Some(exact_snapshot("bob-id", "bob-commitment"));
+        let failures =
+            compare_trace_expectations(None, &[expectation], &trace(vec![alice, bob, carol]));
+        assert!(
+            failures.is_empty(),
+            "all three snapshots differ: {failures:#?}"
+        );
     }
 
     #[test]

--- a/crates/cgka-conformance-simulator/src/vector.rs
+++ b/crates/cgka-conformance-simulator/src/vector.rs
@@ -137,6 +137,13 @@ pub enum TraceExpectation {
     ClientsExactlyEquivalent {
         clients: Vec<String>,
     },
+    /// Require a named set of clients to remain on observably different
+    /// canonical states. This is used for explicitly characterized protocol
+    /// limits where automatic repair is not claimed.
+    ClientsNotEquivalent {
+        clients: Vec<String>,
+        reason: String,
+    },
     /// Require the complete per-client commit/proposal/application input ledger.
     ScenarioInputLedger {
         client: String,
@@ -434,6 +441,46 @@ impl TraceExpectation {
                                 }))
                                 .collect::<Vec<_>>()
                         ),
+                    });
+                }
+            }
+            TraceExpectation::ClientsNotEquivalent { clients, reason } => {
+                let mut snapshots = Vec::with_capacity(clients.len());
+                for client in clients {
+                    let Some(observation) = client_canonical_observation(observed, client) else {
+                        missing_client(client, self, mismatches);
+                        return;
+                    };
+                    snapshots.push((
+                        client,
+                        observation
+                            .canonical_state
+                            .as_ref()
+                            .expect("canonical observation carries canonical state"),
+                    ));
+                }
+                if snapshots.len() < 2 {
+                    mismatches.push(ExpectationFailure {
+                        kind: "insufficient_non_equivalence_clients".into(),
+                        message: "clients_not_equivalent must name at least two clients".into(),
+                        expected: json!(self),
+                        actual: json!(snapshots),
+                    });
+                    return;
+                }
+                let first = snapshots[0].1;
+                if snapshots.iter().all(|(_, snapshot)| *snapshot == first) {
+                    mismatches.push(ExpectationFailure {
+                        kind: "clients_unexpectedly_equivalent".into(),
+                        message: format!(
+                            "clients {clients:?} converged despite named unrecoverable outcome: {reason}"
+                        ),
+                        expected: json!({
+                            "clients": clients,
+                            "reason": reason,
+                            "equivalent": false,
+                        }),
+                        actual: json!(snapshots),
                     });
                 }
             }

--- a/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
+++ b/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
@@ -1946,6 +1946,7 @@ async fn failing_generated_case_records_a_minimized_reproducer() {
         generator_version: "1".into(),
         seed: 99,
         case_index: 0,
+        subject: cgka_conformance_simulator::GeneratedSubjectKind::Engine,
         expected_outcomes: vec![TraceExpectation::ClientState {
             client: "alice".into(),
             epoch: 1,

--- a/crates/cgka-conformance-simulator/tests/canonicalization_contract.rs
+++ b/crates/cgka-conformance-simulator/tests/canonicalization_contract.rs
@@ -430,6 +430,64 @@ fn proposals_are_accepted_only_when_consumed_by_canonical_commits() {
 }
 
 #[test]
+fn proposal_below_retained_anchor_expires_instead_of_witnessing_selection() {
+    let mut expired = proposal("expired-proposal", "live");
+    expired.source_epoch = 2;
+    let mut canonicalization = input(vec![expired], vec![branch("live", 3, 4, 0x00)]);
+    canonicalization.state = state(4, 3);
+
+    let result = canonicalize(canonicalization);
+
+    assert!(result.accepted_proposals.is_empty());
+    assert_eq!(
+        result.dropped_messages,
+        vec![DroppedMessage {
+            message_id: "expired-proposal".into(),
+            kind: MessageKind::Proposal,
+            reason: DroppedMessageReason::BeyondAnchor,
+            rejection_category: None,
+        }]
+    );
+}
+
+#[test]
+fn canonical_commit_can_close_multiple_proposal_dependencies_atomically() {
+    // MLS has exactly one prior group-state parent per commit. The
+    // "multi-parent" campaign dimension therefore means multiple standalone
+    // proposal dependencies consumed by one commit, not a DAG merge of two
+    // incompatible MLS states.
+    let result = canonicalize(input(
+        vec![
+            proposal("proposal-a", "live-parent"),
+            proposal("proposal-b", "live-parent"),
+            child_commit_edge_with_proposals(
+                "multi-dependency-commit",
+                ChildCommitEdge {
+                    branch_id: "live-tip",
+                    parent_branch_id: "live-parent",
+                    fork_epoch: 1,
+                    source_epoch: 3,
+                    resulting_epoch: 4,
+                    tip_digest: 0x00,
+                },
+                &["proposal-a", "proposal-b"],
+            ),
+        ],
+        vec![branch("live-parent", 1, 3, 0x00)],
+    ));
+
+    assert_eq!(
+        result.accepted_proposals,
+        vec!["proposal-a".to_string(), "proposal-b".to_string()]
+    );
+    assert_eq!(
+        result.accepted_commits,
+        vec!["multi-dependency-commit".to_string()]
+    );
+    assert!(result.dropped_messages.is_empty());
+}
+
+#[test]
 fn materialized_candidates_drive_commit_and_proposal_dispositions() {
     let result = canonicalize_with_materialized_candidates(
         input(

--- a/crates/cgka-conformance-simulator/tests/failure_capsules.rs
+++ b/crates/cgka-conformance-simulator/tests/failure_capsules.rs
@@ -273,6 +273,7 @@ async fn capsule_round_trip_records_schedule_policy_and_resources() {
                 category: cgka_conformance_simulator::SubjectFailureCategory::Resource,
                 message: "backend error at /tmp/first.sqlite".into(),
             },
+            wall_us: 0,
         });
     let mut second_failed_report = first_failed_report.clone();
     let cgka_conformance_simulator::ScenarioStepStatus::Failed { message, .. } =

--- a/crates/cgka-conformance-simulator/tests/milestone3_campaigns.rs
+++ b/crates/cgka-conformance-simulator/tests/milestone3_campaigns.rs
@@ -1,0 +1,249 @@
+#[cfg(feature = "test-policy-overrides")]
+use cgka_conformance_simulator::{
+    ClientBuilder, EngineHarnessSubject, HarnessStorageMode, TransportBus,
+    engine_harness_feature_registry, run_scenario_report_with_subject,
+};
+use cgka_conformance_simulator::{
+    SubjectFailureCategory, compile_scenario, generate_milestone3_adversarial_family,
+    generate_milestone3_sustained_regression, run_generated_case_report,
+};
+#[cfg(feature = "test-policy-overrides")]
+use cgka_traits::group::ProtocolProfile;
+
+#[test]
+fn milestone3_catalog_covers_every_required_workload_shape() {
+    let cases = generate_milestone3_adversarial_family(7, 12);
+    let names = cases
+        .iter()
+        .map(|case| case.family_name.as_str())
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(names.len(), 12);
+    for case in &cases {
+        compile_scenario(&case.scenario)
+            .unwrap_or_else(|error| panic!("{}: {error}", case.family_name));
+    }
+}
+
+async fn assert_generated_case(case_index: usize) {
+    let cases = generate_milestone3_adversarial_family(7, case_index + 1);
+    let case = &cases[case_index];
+    let report = run_generated_case_report(case, None)
+        .await
+        .unwrap_or_else(|error| panic!("{}: {error}", case.family_name));
+    let pending_inputs = report
+        .observed_trace
+        .as_ref()
+        .into_iter()
+        .flat_map(|trace| &trace.observations)
+        .flat_map(|observation| &observation.scenario_input_ledger)
+        .filter(|entry| entry.pending)
+        .collect::<Vec<_>>();
+    assert!(
+        report.expectation_failures.is_empty(),
+        "{} expectation failures: {:#?}; pending inputs: {pending_inputs:#?}",
+        case.family_name,
+        report.expectation_failures
+    );
+    assert!(
+        report.invariant_failures.is_empty(),
+        "{} invariant failures: {:#?}",
+        case.family_name,
+        report.invariant_failures
+    );
+}
+
+#[tokio::test]
+async fn offline_retained_history_flood_runs_as_a_small_regression() {
+    assert_generated_case(0).await;
+}
+
+#[tokio::test]
+async fn sustained_mixed_traffic_runs_as_a_small_regression() {
+    let case = generate_milestone3_sustained_regression(7);
+    let report = run_generated_case_report(&case, None)
+        .await
+        .expect("sustained regression runs");
+    assert!(
+        report.expectation_failures.is_empty(),
+        "{:#?}",
+        report.expectation_failures
+    );
+    assert!(
+        report.invariant_failures.is_empty(),
+        "{:#?}",
+        report.invariant_failures
+    );
+}
+
+#[ignore = "multi-round sustained campaign; run explicitly"]
+#[tokio::test]
+async fn sustained_mixed_traffic_campaign() {
+    assert_generated_case(1).await;
+}
+
+#[tokio::test]
+async fn self_update_admin_race_runs_as_a_small_regression() {
+    assert_generated_case(2).await;
+}
+
+#[tokio::test]
+async fn losing_branch_invite_has_a_named_unrecoverable_outcome() {
+    assert_generated_case(3).await;
+}
+
+#[test]
+fn mixed_binary_versions_are_compatible_but_mixed_policies_are_not() {
+    let cases = generate_milestone3_adversarial_family(7, 11);
+    compile_scenario(&cases[10].scenario).expect("mixed binaries with one policy compile");
+
+    let mut incompatible = cases[10].scenario.clone();
+    incompatible.topology.processes[1].policy_version = "marmot-convergence-v2".into();
+    let error = compile_scenario(&incompatible).expect_err("mixed policies fail preflight");
+    assert_eq!(error.kind, "incompatible_convergence_policy");
+    assert_eq!(error.category, SubjectFailureCategory::Environment);
+}
+
+#[cfg(feature = "test-policy-overrides")]
+#[tokio::test]
+async fn full_engine_witness_ab_pair_can_select_different_canonical_branches() {
+    let cases = generate_milestone3_adversarial_family(7, 10);
+    let case = &cases[9];
+    let mut standard = EngineHarnessSubject::new_with_topology(
+        &case.scenario.clients,
+        &case.scenario.topology,
+        ProtocolProfile::Legacy,
+        HarnessStorageMode::InMemorySqlite,
+    )
+    .expect("standard subject");
+    let standard_report = run_scenario_report_with_subject(
+        &case.scenario,
+        None,
+        case.expected_outcomes.clone(),
+        &mut standard,
+    )
+    .await
+    .expect("standard witness run");
+
+    let mut disabled = EngineHarnessSubject::new_without_app_witnesses_for_tests(
+        &case.scenario.clients,
+        &case.scenario.topology,
+        ProtocolProfile::Legacy,
+        HarnessStorageMode::InMemorySqlite,
+    )
+    .expect("witness-disabled subject");
+    let disabled_report = run_scenario_report_with_subject(
+        &case.scenario,
+        None,
+        case.expected_outcomes.clone(),
+        &mut disabled,
+    )
+    .await
+    .expect("witness-disabled run");
+
+    for report in [&standard_report, &disabled_report] {
+        let pending_inputs = report
+            .observed_trace
+            .as_ref()
+            .into_iter()
+            .flat_map(|trace| &trace.observations)
+            .flat_map(|observation| &observation.scenario_input_ledger)
+            .filter(|entry| entry.pending)
+            .collect::<Vec<_>>();
+        assert!(
+            report.expectation_failures.is_empty(),
+            "failures={:#?}; pending={pending_inputs:#?}",
+            report.expectation_failures
+        );
+        assert!(
+            report.invariant_failures.is_empty(),
+            "{:#?}",
+            report.invariant_failures
+        );
+    }
+    let selected_state = |report: &cgka_conformance_simulator::ScenarioReport| {
+        report
+            .observed_trace
+            .as_ref()
+            .and_then(|trace| {
+                trace
+                    .observations
+                    .iter()
+                    .find(|item| item.client == "carol")
+            })
+            .and_then(|item| item.canonical_state.as_ref())
+            .cloned()
+            .expect("carol exact state")
+    };
+    assert_ne!(
+        selected_state(&standard_report),
+        selected_state(&disabled_report),
+        "the paired fixture must make witness admission causally observable"
+    );
+    assert_eq!(
+        standard_report.metadata.subject.as_ref().unwrap().adapter,
+        "mdk-engine-harness"
+    );
+    assert_eq!(
+        disabled_report.metadata.subject.as_ref().unwrap().adapter,
+        "mdk-engine-harness-witness-disabled"
+    );
+}
+
+#[cfg(feature = "test-policy-overrides")]
+#[tokio::test]
+async fn replay_budget_exhaustion_fails_closed_then_repairs_with_same_durable_inputs() {
+    let bus = TransportBus::ordered();
+    let registry = engine_harness_feature_registry();
+    let mut alice = ClientBuilder::new(b"resource-alice".to_vec())
+        .registry(registry.clone())
+        .attach(&bus);
+    let mut bob = ClientBuilder::new(b"resource-bob".to_vec())
+        .registry(registry.clone())
+        .attach(&bus);
+    let mut observer = ClientBuilder::new(b"resource-observer".to_vec())
+        .registry(registry)
+        .replay_probe_budget_for_tests(Some(0))
+        .attach(&bus);
+
+    let bob_kp = bob.fresh_key_package().await;
+    let observer_kp = observer.fresh_key_package().await;
+    let (group_id, pending) = alice
+        .create_group_with_admins(
+            "replay-budget-exhaustion",
+            vec![bob_kp, observer_kp],
+            vec![],
+            vec![bob.member_id()],
+        )
+        .await;
+    alice.confirm(pending).await;
+    bus.deliver_all();
+    assert!(bob.tick().await.iter().all(Result::is_ok));
+    assert!(observer.tick().await.iter().all(Result::is_ok));
+
+    let alice_pending = alice.self_update().await;
+    let bob_pending = bob.self_update().await;
+    alice.confirm(alice_pending).await;
+    bob.confirm(bob_pending).await;
+    bus.deliver_all();
+    let outcomes = observer.tick().await;
+    assert!(
+        outcomes.iter().any(|outcome| {
+            outcome
+                .as_ref()
+                .err()
+                .is_some_and(|error| error.to_string().contains("replay budget exceeded"))
+        }),
+        "zero replay budget must surface a typed fail-closed error: {outcomes:?}"
+    );
+    assert!(
+        observer.has_pending_convergence_inputs(),
+        "a resource error must retain the frozen input set for retry"
+    );
+
+    observer.set_replay_probe_budget_for_tests(None);
+    let repaired = observer
+        .try_converge_stored_at(&group_id, 2_000_000)
+        .expect("same durable inputs repair under the production budget");
+    assert!(repaired.errors.is_empty(), "{:#?}", repaired.errors);
+    assert_eq!(observer.epoch().0, 2);
+}

--- a/crates/cgka-conformance-simulator/tests/milestone3_campaigns.rs
+++ b/crates/cgka-conformance-simulator/tests/milestone3_campaigns.rs
@@ -5,6 +5,7 @@ use cgka_conformance_simulator::{
 };
 use cgka_conformance_simulator::{
     SubjectFailureCategory, compile_scenario, generate_milestone3_adversarial_family,
+    generate_milestone3_offline_regression, generate_milestone3_self_update_regression,
     generate_milestone3_sustained_regression, run_generated_case_report,
 };
 #[cfg(feature = "test-policy-overrides")]
@@ -26,7 +27,12 @@ fn milestone3_catalog_covers_every_required_workload_shape() {
 
 async fn assert_generated_case(case_index: usize) -> cgka_conformance_simulator::ScenarioReport {
     let cases = generate_milestone3_adversarial_family(7, case_index + 1);
-    let case = &cases[case_index];
+    assert_case(&cases[case_index]).await
+}
+
+async fn assert_case(
+    case: &cgka_conformance_simulator::GeneratedScenarioCase,
+) -> cgka_conformance_simulator::ScenarioReport {
     let report = run_generated_case_report(case, None)
         .await
         .unwrap_or_else(|error| panic!("{}: {error}", case.family_name));
@@ -55,7 +61,7 @@ async fn assert_generated_case(case_index: usize) -> cgka_conformance_simulator:
 
 #[tokio::test]
 async fn offline_retained_history_flood_runs_as_a_small_regression() {
-    let report = assert_generated_case(0).await;
+    let report = assert_case(&generate_milestone3_offline_regression(7)).await;
     let measurements = &report.campaign_measurements;
     assert_eq!(measurements.schema_version, "1");
     assert!(measurements.total_wall_us > 0);
@@ -76,6 +82,12 @@ async fn offline_retained_history_flood_runs_as_a_small_regression() {
             .iter()
             .any(|field| field == "cpu_time_us")
     );
+}
+
+#[ignore = "multi-round retained-history flood; run explicitly"]
+#[tokio::test]
+async fn offline_retained_history_flood_campaign() {
+    let _ = assert_generated_case(0).await;
 }
 
 #[tokio::test]
@@ -104,6 +116,12 @@ async fn sustained_mixed_traffic_campaign() {
 
 #[tokio::test]
 async fn self_update_admin_race_runs_as_a_small_regression() {
+    let _ = assert_case(&generate_milestone3_self_update_regression(7)).await;
+}
+
+#[ignore = "sustained self-update adversary; run explicitly"]
+#[tokio::test]
+async fn self_update_admin_race_campaign() {
     let _ = assert_generated_case(2).await;
 }
 

--- a/crates/cgka-conformance-simulator/tests/milestone3_campaigns.rs
+++ b/crates/cgka-conformance-simulator/tests/milestone3_campaigns.rs
@@ -24,7 +24,7 @@ fn milestone3_catalog_covers_every_required_workload_shape() {
     }
 }
 
-async fn assert_generated_case(case_index: usize) {
+async fn assert_generated_case(case_index: usize) -> cgka_conformance_simulator::ScenarioReport {
     let cases = generate_milestone3_adversarial_family(7, case_index + 1);
     let case = &cases[case_index];
     let report = run_generated_case_report(case, None)
@@ -50,11 +50,32 @@ async fn assert_generated_case(case_index: usize) {
         case.family_name,
         report.invariant_failures
     );
+    report
 }
 
 #[tokio::test]
 async fn offline_retained_history_flood_runs_as_a_small_regression() {
-    assert_generated_case(0).await;
+    let report = assert_generated_case(0).await;
+    let measurements = &report.campaign_measurements;
+    assert_eq!(measurements.schema_version, "1");
+    assert!(measurements.total_wall_us > 0);
+    assert_eq!(measurements.steps.len(), report.step_log.len());
+    assert!(measurements.pass_count > 0);
+    assert!(measurements.max_observed_queue_depth > 0);
+    assert!(!measurements.input_dispositions.is_empty());
+    assert!(
+        measurements
+            .replay_probe_count
+            .is_some_and(|count| count > 0)
+    );
+    assert!(measurements.reorg_rewind_depth.is_some());
+    assert!(measurements.reorg_lateness_ms.is_some());
+    assert!(
+        measurements
+            .unavailable_process_fields
+            .iter()
+            .any(|field| field == "cpu_time_us")
+    );
 }
 
 #[tokio::test]
@@ -78,17 +99,17 @@ async fn sustained_mixed_traffic_runs_as_a_small_regression() {
 #[ignore = "multi-round sustained campaign; run explicitly"]
 #[tokio::test]
 async fn sustained_mixed_traffic_campaign() {
-    assert_generated_case(1).await;
+    let _ = assert_generated_case(1).await;
 }
 
 #[tokio::test]
 async fn self_update_admin_race_runs_as_a_small_regression() {
-    assert_generated_case(2).await;
+    let _ = assert_generated_case(2).await;
 }
 
 #[tokio::test]
 async fn losing_branch_invite_has_a_named_unrecoverable_outcome() {
-    assert_generated_case(3).await;
+    let _ = assert_generated_case(3).await;
 }
 
 #[test]

--- a/crates/cgka-conformance-simulator/tests/milestone3_campaigns.rs
+++ b/crates/cgka-conformance-simulator/tests/milestone3_campaigns.rs
@@ -4,9 +4,10 @@ use cgka_conformance_simulator::{
     engine_harness_feature_registry, run_scenario_report_with_subject,
 };
 use cgka_conformance_simulator::{
-    SubjectFailureCategory, compile_scenario, generate_milestone3_adversarial_family,
-    generate_milestone3_offline_regression, generate_milestone3_self_update_regression,
-    generate_milestone3_sustained_regression, run_generated_case_report,
+    SubjectFailureCategory, compile_scenario, generate_milestone3_adversarial_case,
+    generate_milestone3_adversarial_family, generate_milestone3_offline_regression,
+    generate_milestone3_self_update_regression, generate_milestone3_sustained_regression,
+    run_generated_case_report, run_generated_case_report_with_capture,
 };
 #[cfg(feature = "test-policy-overrides")]
 use cgka_traits::group::ProtocolProfile;
@@ -26,8 +27,7 @@ fn milestone3_catalog_covers_every_required_workload_shape() {
 }
 
 async fn assert_generated_case(case_index: usize) -> cgka_conformance_simulator::ScenarioReport {
-    let cases = generate_milestone3_adversarial_family(7, case_index + 1);
-    assert_case(&cases[case_index]).await
+    assert_case(&generate_milestone3_adversarial_case(7, case_index as u64)).await
 }
 
 async fn assert_case(
@@ -84,6 +84,20 @@ async fn offline_retained_history_flood_runs_as_a_small_regression() {
     );
 }
 
+#[tokio::test]
+async fn retained_relay_rejects_unavailable_sensitive_checkpoint_capture() {
+    let case = generate_milestone3_offline_regression(7);
+    let error = run_generated_case_report_with_capture(
+        &case,
+        None,
+        cgka_conformance_simulator::HarnessStorageMode::InMemorySqlite,
+        true,
+    )
+    .await
+    .expect_err("retained relay cannot produce an engine checkpoint");
+    assert_eq!(error.kind, "sensitive_replay_capture_unsupported");
+}
+
 #[ignore = "multi-round retained-history flood; run explicitly"]
 #[tokio::test]
 async fn offline_retained_history_flood_campaign() {
@@ -130,12 +144,19 @@ async fn losing_branch_invite_has_a_named_unrecoverable_outcome() {
     let _ = assert_generated_case(3).await;
 }
 
-#[test]
-fn mixed_binary_versions_are_compatible_but_mixed_policies_are_not() {
-    let cases = generate_milestone3_adversarial_family(7, 11);
-    compile_scenario(&cases[10].scenario).expect("mixed binaries with one policy compile");
+#[tokio::test]
+async fn remaining_catalog_workloads_execute_under_the_strict_oracle() {
+    for case_index in [4, 5, 6, 7, 8, 9, 11] {
+        let _ = assert_generated_case(case_index).await;
+    }
+}
 
-    let mut incompatible = cases[10].scenario.clone();
+#[tokio::test]
+async fn mixed_binary_versions_run_but_mixed_policies_are_rejected() {
+    let case = generate_milestone3_adversarial_case(7, 10);
+    let _ = assert_case(&case).await;
+
+    let mut incompatible = case.scenario.clone();
     incompatible.topology.processes[1].policy_version = "marmot-convergence-v2".into();
     let error = compile_scenario(&incompatible).expect_err("mixed policies fail preflight");
     assert_eq!(error.kind, "incompatible_convergence_policy");
@@ -241,7 +262,9 @@ async fn replay_budget_exhaustion_fails_closed_then_repairs_with_same_durable_in
         .attach(&bus);
     let mut observer = ClientBuilder::new(b"resource-observer".to_vec())
         .registry(registry)
-        .replay_probe_budget_for_tests(Some(0))
+        // Two probes cover the competing-commit BFS, but not the application-
+        // witness fallback materialization. The pass must share one ceiling.
+        .replay_probe_budget_for_tests(Some(2))
         .attach(&bus);
 
     let bob_kp = bob.fresh_key_package().await;
@@ -259,6 +282,11 @@ async fn replay_budget_exhaustion_fails_closed_then_repairs_with_same_durable_in
     assert!(bob.tick().await.iter().all(Result::is_ok));
     assert!(observer.tick().await.iter().all(Result::is_ok));
 
+    alice.send_app(b"retained-witness".to_vec()).await;
+    bus.deliver_all();
+    assert!(bob.tick().await.iter().all(Result::is_ok));
+    assert!(observer.tick().await.iter().all(Result::is_ok));
+
     let alice_pending = alice.self_update().await;
     let bob_pending = bob.self_update().await;
     alice.confirm(alice_pending).await;
@@ -272,7 +300,7 @@ async fn replay_budget_exhaustion_fails_closed_then_repairs_with_same_durable_in
                 .err()
                 .is_some_and(|error| error.to_string().contains("replay budget exceeded"))
         }),
-        "zero replay budget must surface a typed fail-closed error: {outcomes:?}"
+        "the shared BFS-plus-fallback budget must surface a typed fail-closed error: {outcomes:?}"
     );
     assert!(
         observer.has_pending_convergence_inputs(),

--- a/crates/cgka-conformance-simulator/tests/openmls_replay_probe.rs
+++ b/crates/cgka-conformance-simulator/tests/openmls_replay_probe.rs
@@ -1690,6 +1690,7 @@ async fn openmls_canonicalization_apply_rolls_back_when_selected_path_fails() {
         queued_outbound_intents: vec![],
         publishable_outbound_messages: vec![],
         errors: vec![],
+        replay_probe_count: 0,
         selection_trace: None,
     };
 
@@ -1764,6 +1765,7 @@ fn openmls_disposition_persistence_maps_all_canonicalization_states() {
         queued_outbound_intents: vec![],
         publishable_outbound_messages: vec![],
         errors: vec![],
+        replay_probe_count: 0,
         selection_trace: None,
     };
 

--- a/crates/cgka-conformance-simulator/tests/policy_sweeps.rs
+++ b/crates/cgka-conformance-simulator/tests/policy_sweeps.rs
@@ -1,0 +1,67 @@
+#![cfg(feature = "test-policy-overrides")]
+
+use cgka_conformance_simulator::canonicalization::{
+    CanonicalizationInput, CanonicalizationPolicy, CanonicalizationState,
+};
+use cgka_conformance_simulator::convergence::BranchCandidate;
+use cgka_conformance_simulator::{PolicySweepConstantV1, sweep_canonicalization_policy};
+use cgka_traits::engine::CommitOrderingPriority;
+use std::collections::BTreeSet;
+
+fn fixed_input() -> CanonicalizationInput {
+    CanonicalizationInput {
+        state: CanonicalizationState {
+            current_tip_epoch: 10,
+            retained_anchor_epoch: 5,
+            last_convergence_relevant_input_ms: 0,
+            seen_message_ids: BTreeSet::new(),
+        },
+        pending_messages: vec![],
+        outbound_intents: vec![],
+        candidate_branches: vec![BranchCandidate {
+            id: "depth-boundary".into(),
+            fork_epoch: 5,
+            tip_epoch: 11,
+            tip_priority: CommitOrderingPriority::Ordinary,
+            tip_committer: b"alice".to_vec(),
+            tip_digest: [7; 32],
+            app_witnesses: vec![],
+        }],
+        policy: CanonicalizationPolicy::default(),
+        now_ms: 10_000,
+    }
+}
+
+#[test]
+fn sweep_preserves_inputs_and_exposes_the_rewind_boundary() {
+    let input = fixed_input();
+    let curve =
+        sweep_canonicalization_policy(&input, PolicySweepConstantV1::MaxRewindCommits, [4, 5, 6]);
+
+    assert_eq!(curve.retained_input_count, input.pending_messages.len());
+    assert_eq!(curve.current_tip_epoch, input.state.current_tip_epoch);
+    assert_eq!(
+        curve.retained_anchor_epoch,
+        input.state.retained_anchor_epoch
+    );
+    assert_eq!(curve.points[0].eligible_count, 0);
+    assert_eq!(curve.points[1].eligible_count, 1);
+    assert_eq!(curve.points[2].eligible_count, 1);
+    assert!(!curve.production_auto_tuning_permitted);
+}
+
+#[test]
+fn invalid_witness_override_is_a_named_boundary_failure() {
+    let curve = sweep_canonicalization_policy(
+        &fixed_input(),
+        PolicySweepConstantV1::MaxWitnessOverrideDepth,
+        [1, 6],
+    );
+    assert!(curve.points[0].boundary_failure.is_none());
+    assert!(
+        curve.points[1]
+            .boundary_failure
+            .as_deref()
+            .is_some_and(|failure| failure.contains("must not exceed"))
+    );
+}

--- a/crates/cgka-conformance-simulator/tests/scenario_ir.rs
+++ b/crates/cgka-conformance-simulator/tests/scenario_ir.rs
@@ -172,6 +172,151 @@ async fn typoed_group_label_fails_closed_at_execution() {
     )));
 }
 
+#[tokio::test]
+async fn wrapped_action_id_is_used_by_fault_selectors_and_the_runtime_ledger() {
+    let in_group = |action| ScenarioStep::InGroup {
+        group: "red".into(),
+        action: Box::new(action),
+    };
+    let scenario = ScenarioSpec {
+        name: "scenario-ir/wrapped-action-id".into(),
+        spec_version: "2".into(),
+        clients: vec!["alice".into(), "bob".into()],
+        topology: Default::default(),
+        steps: vec![
+            in_group(ScenarioStep::CreateGroup {
+                creator: "alice".into(),
+                name: "red".into(),
+                invitees: vec!["bob".into()],
+                required_features: vec![],
+                initial_admins: Some(vec!["alice".into()]),
+                pending: "create".into(),
+            }),
+            ScenarioStep::accept_publication("alice", "create"),
+            ScenarioStep::DeliverAll,
+            ScenarioStep::Tick {
+                clients: vec!["bob".into()],
+            },
+            in_group(ScenarioStep::SendAppMessage {
+                sender: "alice".into(),
+                payload: "held".into(),
+            }),
+            ScenarioStep::WithholdMessage {
+                selector: ScenarioMessageSelectorV2 {
+                    action_id: Some("step-4:send_app_message@red".into()),
+                    class: Some(ScenarioTransportClass::Application),
+                    ..Default::default()
+                },
+                label: "held-red-app".into(),
+            },
+            ScenarioStep::AcknowledgeOutbound {
+                client: "alice".into(),
+                publication: None,
+                selection: Default::default(),
+                outcome: SubjectOutboundOutcome::Accepted,
+            },
+            ScenarioStep::DeliverAll,
+            ScenarioStep::Tick {
+                clients: vec!["bob".into()],
+            },
+            in_group(ScenarioStep::Observe {
+                clients: vec!["bob".into()],
+            }),
+            ScenarioStep::ReleaseWithheld {
+                label: "held-red-app".into(),
+            },
+            ScenarioStep::DeliverAll,
+            ScenarioStep::Tick {
+                clients: vec!["bob".into()],
+            },
+            in_group(ScenarioStep::ObserveExact {
+                clients: vec!["bob".into()],
+            }),
+        ],
+    };
+
+    let report = run_scenario_report(&scenario, None)
+        .await
+        .expect("wrapped action scenario runs");
+    let observations = &report.observed_trace.as_ref().unwrap().observations;
+    assert!(observations[0].received_payloads.is_empty());
+    assert_eq!(observations[1].received_payloads, vec!["held"]);
+    assert!(observations[1].scenario_input_ledger.iter().any(|entry| {
+        entry.scenario_id == "step-4:send_app_message@red" && entry.delivered == 1
+    }));
+}
+
+#[test]
+fn grouped_scenarios_reject_unwrapped_group_scoped_actions() {
+    let scenario = ScenarioSpec {
+        name: "scenario-ir/ambiguous-unwrapped-group-action".into(),
+        spec_version: "2".into(),
+        clients: vec!["alice".into()],
+        topology: Default::default(),
+        steps: vec![
+            ScenarioStep::InGroup {
+                group: "red".into(),
+                action: Box::new(ScenarioStep::CreateGroup {
+                    creator: "alice".into(),
+                    name: "red".into(),
+                    invitees: vec![],
+                    required_features: vec![],
+                    initial_admins: Some(vec!["alice".into()]),
+                    pending: "create".into(),
+                }),
+            },
+            ScenarioStep::CreateGroup {
+                creator: "alice".into(),
+                name: "ambiguous".into(),
+                invitees: vec![],
+                required_features: vec![],
+                initial_admins: Some(vec!["alice".into()]),
+                pending: "ambiguous".into(),
+            },
+        ],
+    };
+
+    let error = compile_scenario(&scenario).expect_err("ambiguous action must fail preflight");
+    assert_eq!(error.step_index, Some(1));
+    assert!(error.message.contains("must use in_group"));
+}
+
+#[tokio::test]
+async fn grouped_observe_of_non_member_is_a_structured_failure() {
+    let in_group = |action| ScenarioStep::InGroup {
+        group: "red".into(),
+        action: Box::new(action),
+    };
+    let scenario = ScenarioSpec {
+        name: "scenario-ir/non-member-observe".into(),
+        spec_version: "2".into(),
+        clients: vec!["alice".into(), "bob".into()],
+        topology: Default::default(),
+        steps: vec![
+            in_group(ScenarioStep::CreateGroup {
+                creator: "alice".into(),
+                name: "red".into(),
+                invitees: vec![],
+                required_features: vec![],
+                initial_admins: Some(vec!["alice".into()]),
+                pending: "create".into(),
+            }),
+            in_group(ScenarioStep::ObserveExact {
+                clients: vec!["bob".into()],
+            }),
+        ],
+    };
+
+    let report = run_scenario_report(&scenario, None)
+        .await
+        .expect("subject failures are reported structurally");
+    assert!(report.step_log.iter().any(|step| matches!(
+        &step.status,
+        cgka_conformance_simulator::ScenarioStepStatus::Failed { kind, .. }
+            if kind == "client_not_in_scenario_group"
+    )));
+}
+
 fn collect_external_refs<'a>(value: &'a serde_json::Value, refs: &mut Vec<&'a str>) {
     match value {
         serde_json::Value::Object(object) => {
@@ -701,8 +846,8 @@ async fn topology_can_join_two_device_leaves_for_one_account() {
         .and_then(serde_json::Value::as_array)
         .expect("live snapshot carries sorted identities");
     assert_eq!(identities.len(), 3);
-    assert_eq!(
-        identities[0], identities[1],
+    assert!(
+        identities.windows(2).any(|pair| pair[0] == pair[1]),
         "capture runner must preserve the shared account identity of both devices"
     );
 }

--- a/crates/cgka-conformance-simulator/tests/scenario_ir.rs
+++ b/crates/cgka-conformance-simulator/tests/scenario_ir.rs
@@ -3,10 +3,48 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use cgka_conformance_simulator::{
-    ScenarioAssertionV2, ScenarioComparison, ScenarioMessageSelectorV2, ScenarioPredicateV2,
-    ScenarioResourceMetric, ScenarioSpec, ScenarioStep, ScenarioTransportClass,
-    SubjectOutboundOutcome, VectorFixture, compile_scenario, run_scenario_report,
+    ScenarioAccountV2, ScenarioAssertionV2, ScenarioComparison, ScenarioDeviceV2,
+    ScenarioMessageSelectorV2, ScenarioPredicateV2, ScenarioProcessV2, ScenarioResourceMetric,
+    ScenarioSpec, ScenarioStep, ScenarioTopologyV2, ScenarioTransportClass, SubjectOutboundOutcome,
+    VectorFixture, compile_scenario, run_scenario_report,
 };
+
+fn topology_for_accounts(entries: &[(&str, &str)]) -> ScenarioTopologyV2 {
+    let mut accounts = entries
+        .iter()
+        .map(|(_, account)| *account)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .map(|account| ScenarioAccountV2 {
+            id: account.into(),
+            roles: vec!["member".into()],
+        })
+        .collect::<Vec<_>>();
+    accounts.sort_by(|a, b| a.id.cmp(&b.id));
+    ScenarioTopologyV2 {
+        accounts,
+        devices: entries
+            .iter()
+            .map(|(client, account)| ScenarioDeviceV2 {
+                id: format!("device:{client}"),
+                account: (*account).into(),
+                process: format!("process:{client}"),
+                client: (*client).into(),
+            })
+            .collect(),
+        processes: entries
+            .iter()
+            .map(|(client, _)| ScenarioProcessV2 {
+                id: format!("process:{client}"),
+                binary_version: "mdk-test".into(),
+                policy_version: "marmot-convergence-v1".into(),
+                relays: vec![],
+            })
+            .collect(),
+        groups: vec![],
+        relays: vec![],
+    }
+}
 
 #[test]
 fn schema_declares_every_executable_step_kind() {
@@ -379,4 +417,184 @@ fn collect_vector_paths(directory: &Path, paths: &mut Vec<PathBuf>) {
             paths.push(path);
         }
     }
+}
+
+#[tokio::test]
+async fn explicit_group_targets_keep_two_live_groups_independent() {
+    fn in_group(group: &str, action: ScenarioStep) -> ScenarioStep {
+        ScenarioStep::InGroup {
+            group: group.into(),
+            action: Box::new(action),
+        }
+    }
+    fn create(group: &str) -> ScenarioStep {
+        in_group(
+            group,
+            ScenarioStep::CreateGroup {
+                creator: "alice".into(),
+                name: group.into(),
+                invitees: vec!["bob".into()],
+                required_features: vec![],
+                initial_admins: Some(vec!["alice".into()]),
+                pending: format!("{group}-create"),
+            },
+        )
+    }
+    fn accept(publication: &str) -> ScenarioStep {
+        ScenarioStep::AcknowledgeOutbound {
+            client: "alice".into(),
+            publication: Some(publication.into()),
+            selection: Default::default(),
+            outcome: SubjectOutboundOutcome::Accepted,
+        }
+    }
+
+    let scenario = ScenarioSpec {
+        name: "scenario-ir/two-independent-groups".into(),
+        spec_version: "2".into(),
+        clients: vec!["alice".into(), "bob".into()],
+        topology: Default::default(),
+        steps: vec![
+            create("red"),
+            accept("red-create"),
+            ScenarioStep::DeliverAll,
+            ScenarioStep::Tick {
+                clients: vec!["bob".into()],
+            },
+            create("blue"),
+            accept("blue-create"),
+            ScenarioStep::DeliverAll,
+            ScenarioStep::Tick {
+                clients: vec!["bob".into()],
+            },
+            in_group(
+                "red",
+                ScenarioStep::SendAppMessage {
+                    sender: "alice".into(),
+                    payload: "red-only".into(),
+                },
+            ),
+            ScenarioStep::AcknowledgeOutbound {
+                client: "alice".into(),
+                publication: None,
+                selection: Default::default(),
+                outcome: SubjectOutboundOutcome::Accepted,
+            },
+            ScenarioStep::DeliverAll,
+            ScenarioStep::Tick {
+                clients: vec!["bob".into()],
+            },
+            in_group(
+                "red",
+                ScenarioStep::Observe {
+                    clients: vec!["bob".into()],
+                },
+            ),
+            in_group(
+                "blue",
+                ScenarioStep::SendAppMessage {
+                    sender: "alice".into(),
+                    payload: "blue-only".into(),
+                },
+            ),
+            ScenarioStep::AcknowledgeOutbound {
+                client: "alice".into(),
+                publication: None,
+                selection: Default::default(),
+                outcome: SubjectOutboundOutcome::Accepted,
+            },
+            ScenarioStep::DeliverAll,
+            ScenarioStep::Tick {
+                clients: vec!["bob".into()],
+            },
+            in_group(
+                "blue",
+                ScenarioStep::Observe {
+                    clients: vec!["bob".into()],
+                },
+            ),
+        ],
+    };
+
+    let compiled = compile_scenario(&scenario).expect("compile multi-group scenario");
+    assert_eq!(compiled.actions[0].scenario_group.as_deref(), Some("red"));
+    assert_eq!(compiled.actions[4].scenario_group.as_deref(), Some("blue"));
+    let report = run_scenario_report(&scenario, None)
+        .await
+        .expect("run multi-group scenario");
+    let observations = &report.observed_trace.as_ref().unwrap().observations;
+    assert_eq!(observations.len(), 2);
+    assert_eq!(observations[0].received_payloads, vec!["red-only"]);
+    assert_eq!(observations[1].received_payloads, vec!["blue-only"]);
+    assert_eq!(observations[0].epoch, 1);
+    assert_eq!(observations[1].epoch, 1);
+}
+
+#[test]
+fn incompatible_explicit_policy_versions_fail_before_action_zero() {
+    let mut topology = topology_for_accounts(&[("alice", "account:alice"), ("bob", "account:bob")]);
+    topology.processes[1].policy_version = "marmot-convergence-v2".into();
+    let scenario = ScenarioSpec {
+        name: "scenario-ir/incompatible-policies".into(),
+        spec_version: "2".into(),
+        clients: vec!["alice".into(), "bob".into()],
+        topology,
+        steps: vec![],
+    };
+
+    let error = compile_scenario(&scenario).expect_err("mixed policies must not execute");
+    assert_eq!(error.kind, "incompatible_convergence_policy");
+    assert!(error.message.contains("incompatible convergence policies"));
+    assert!(error.message.contains("marmot-convergence-v1"));
+    assert!(error.message.contains("marmot-convergence-v2"));
+}
+
+#[tokio::test]
+async fn topology_can_join_two_device_leaves_for_one_account() {
+    let clients = vec!["alice-phone".into(), "alice-laptop".into(), "bob".into()];
+    let scenario = ScenarioSpec {
+        name: "scenario-ir/shared-account-devices".into(),
+        spec_version: "2".into(),
+        topology: topology_for_accounts(&[
+            ("alice-phone", "account:alice"),
+            ("alice-laptop", "account:alice"),
+            ("bob", "account:bob"),
+        ]),
+        clients: clients.clone(),
+        steps: vec![
+            ScenarioStep::CreateGroup {
+                creator: "alice-phone".into(),
+                name: "multi-device".into(),
+                invitees: vec!["alice-laptop".into(), "bob".into()],
+                required_features: vec![],
+                initial_admins: Some(vec!["alice-phone".into()]),
+                pending: "create".into(),
+            },
+            ScenarioStep::accept_publication("alice-phone", "create"),
+            ScenarioStep::DeliverAll,
+            ScenarioStep::Tick {
+                clients: vec!["alice-laptop".into(), "bob".into()],
+            },
+            ScenarioStep::ObserveExact {
+                clients: clients.clone(),
+            },
+        ],
+    };
+
+    let report = run_scenario_report(&scenario, None)
+        .await
+        .expect("shared-account device scenario");
+    let observations = &report.observed_trace.as_ref().unwrap().observations;
+    assert_eq!(observations.len(), 3);
+    assert!(
+        observations
+            .iter()
+            .all(|observation| observation.epoch == 1)
+    );
+    assert!(
+        observations
+            .iter()
+            .all(|observation| observation.member_count == 3)
+    );
+    assert!(report.expectation_failures.is_empty());
 }

--- a/crates/cgka-conformance-simulator/tests/scenario_ir.rs
+++ b/crates/cgka-conformance-simulator/tests/scenario_ir.rs
@@ -3,10 +3,11 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use cgka_conformance_simulator::{
-    ScenarioAccountV2, ScenarioAssertionV2, ScenarioComparison, ScenarioDeviceV2,
-    ScenarioMessageSelectorV2, ScenarioPredicateV2, ScenarioProcessV2, ScenarioResourceMetric,
-    ScenarioSpec, ScenarioStep, ScenarioTopologyV2, ScenarioTransportClass, SubjectOutboundOutcome,
-    VectorFixture, compile_scenario, run_scenario_report,
+    HarnessStorageMode, ScenarioAccountV2, ScenarioAssertionV2, ScenarioComparison,
+    ScenarioDeviceV2, ScenarioMessageSelectorV2, ScenarioPredicateV2, ScenarioProcessV2,
+    ScenarioResourceMetric, ScenarioSpec, ScenarioStep, ScenarioTopologyV2, ScenarioTransportClass,
+    SubjectOutboundOutcome, VectorFixture, compile_scenario, run_scenario_report,
+    run_vector_fixture_report_with_capture,
 };
 
 fn topology_for_accounts(entries: &[(&str, &str)]) -> ScenarioTopologyV2 {
@@ -93,6 +94,82 @@ fn authoring_schema_references_resolve_against_the_ir_schema_id() {
             );
         }
     }
+}
+
+#[test]
+fn nested_and_non_group_actions_fail_ir_preflight() {
+    let base = ScenarioSpec {
+        name: "scenario-ir/invalid-group-wrapper".into(),
+        spec_version: "2".into(),
+        clients: vec!["alice".into()],
+        topology: Default::default(),
+        steps: vec![],
+    };
+    let mut nested = base.clone();
+    nested.steps.push(ScenarioStep::InGroup {
+        group: "red".into(),
+        action: Box::new(ScenarioStep::InGroup {
+            group: "blue".into(),
+            action: Box::new(ScenarioStep::ClearEvents {
+                clients: vec!["alice".into()],
+            }),
+        }),
+    });
+    assert!(
+        compile_scenario(&nested)
+            .expect_err("nested wrapper fails")
+            .message
+            .contains("nested")
+    );
+
+    let mut nongroup = base;
+    nongroup.steps.push(ScenarioStep::InGroup {
+        group: "red".into(),
+        action: Box::new(ScenarioStep::DeliverAll),
+    });
+    assert!(
+        compile_scenario(&nongroup)
+            .expect_err("transport action is not group scoped")
+            .message
+            .contains("not a group-scoped action")
+    );
+}
+
+#[tokio::test]
+async fn typoed_group_label_fails_closed_at_execution() {
+    let scenario = ScenarioSpec {
+        name: "scenario-ir/unknown-group".into(),
+        spec_version: "2".into(),
+        clients: vec!["alice".into()],
+        topology: Default::default(),
+        steps: vec![
+            ScenarioStep::InGroup {
+                group: "red".into(),
+                action: Box::new(ScenarioStep::CreateGroup {
+                    creator: "alice".into(),
+                    name: "red".into(),
+                    invitees: vec![],
+                    required_features: vec![],
+                    initial_admins: Some(vec!["alice".into()]),
+                    pending: "red-create".into(),
+                }),
+            },
+            ScenarioStep::InGroup {
+                group: "reed".into(),
+                action: Box::new(ScenarioStep::Observe {
+                    clients: vec!["alice".into()],
+                }),
+            },
+        ],
+    };
+    let report = run_scenario_report(&scenario, None)
+        .await
+        .expect("execution failures are reported structurally");
+    assert!(report.step_log.iter().any(|step| matches!(
+        &step.status,
+        cgka_conformance_simulator::ScenarioStepStatus::Failed { kind, .. }
+            if kind == "unknown_scenario_group"
+    )));
 }
 
 fn collect_external_refs<'a>(value: &'a serde_json::Value, refs: &mut Vec<&'a str>) {
@@ -597,4 +674,35 @@ async fn topology_can_join_two_device_leaves_for_one_account() {
             .all(|observation| observation.member_count == 3)
     );
     assert!(report.expectation_failures.is_empty());
+
+    let fixture = VectorFixture {
+        scenario_name: scenario.name.clone(),
+        vector_version: "1".into(),
+        conformance_version: env!("CARGO_PKG_VERSION").into(),
+        seed: None,
+        application_profile: None,
+        scenario,
+        expected_trace: None,
+        expected_outcomes: vec![],
+    };
+    let (captured_report, _) =
+        run_vector_fixture_report_with_capture(&fixture, HarnessStorageMode::InMemorySqlite, false)
+            .await
+            .expect("capture runner preserves explicit topology");
+    let captured_state = captured_report
+        .observed_trace
+        .as_ref()
+        .and_then(|trace| trace.observations.first())
+        .and_then(|observation| observation.canonical_state.as_ref())
+        .map(|state| serde_json::to_value(state).expect("canonical state serializes"))
+        .expect("capture runner observes exact state");
+    let identities = captured_state
+        .pointer("/snapshot/sorted_member_identities_hex")
+        .and_then(serde_json::Value::as_array)
+        .expect("live snapshot carries sorted identities");
+    assert_eq!(identities.len(), 3);
+    assert_eq!(
+        identities[0], identities[1],
+        "capture runner must preserve the shared account identity of both devices"
+    );
 }

--- a/crates/cgka-engine/src/canonicalization.rs
+++ b/crates/cgka-engine/src/canonicalization.rs
@@ -247,6 +247,10 @@ pub struct CanonicalizationResult {
     pub queued_outbound_intents: Vec<OutboundIntent>,
     pub publishable_outbound_messages: Vec<OutboundIntent>,
     pub errors: Vec<CanonicalizationError>,
+    /// OpenMLS candidate replay probes consumed by this stored pass. Pure
+    /// symbolic canonicalization reports zero.
+    #[cfg(feature = "test-conformance-snapshot")]
+    pub replay_probe_count: u64,
     /// Forensic audit trace of the branch-selection decision (per-candidate
     /// scores, the rule-by-rule comparison, and the losing branches). `None`
     /// when no selection was attempted (early-return result builders).
@@ -428,6 +432,8 @@ fn canonicalize_internal(
         queued_outbound_intents: Vec::new(),
         publishable_outbound_messages: Vec::new(),
         errors: Vec::new(),
+        #[cfg(feature = "test-conformance-snapshot")]
+        replay_probe_count: 0,
         selection_trace,
     };
 

--- a/crates/cgka-engine/src/canonicalization.rs
+++ b/crates/cgka-engine/src/canonicalization.rs
@@ -319,19 +319,35 @@ pub enum CanonicalizationError {
 }
 
 pub fn canonicalize(input: CanonicalizationInput) -> CanonicalizationResult {
-    canonicalize_internal(input, &[])
+    canonicalize_internal(input, &[], true)
 }
 
 pub fn canonicalize_with_materialized_candidates(
     input: CanonicalizationInput,
     materialized_candidates: Vec<MaterializedCandidate>,
 ) -> CanonicalizationResult {
-    canonicalize_internal(input, &materialized_candidates)
+    canonicalize_internal(input, &materialized_candidates, true)
+}
+
+/// Canonicalize with an explicit application-witness admission switch.
+///
+/// This is an engine-internal test seam used by the conformance simulator to
+/// compare the complete stored-message engine path with and without the
+/// speculative app-witness ranking term. Production callers always use
+/// [`canonicalize_with_materialized_candidates`].
+#[cfg(feature = "test-policy-overrides")]
+pub(crate) fn canonicalize_with_materialized_candidates_for_test(
+    input: CanonicalizationInput,
+    materialized_candidates: Vec<MaterializedCandidate>,
+    admit_app_witnesses: bool,
+) -> CanonicalizationResult {
+    canonicalize_internal(input, &materialized_candidates, admit_app_witnesses)
 }
 
 fn canonicalize_internal(
     input: CanonicalizationInput,
     materialized_candidates: &[MaterializedCandidate],
+    admit_app_witnesses: bool,
 ) -> CanonicalizationResult {
     let mut already_seen = Vec::new();
     let mut observed_ids = input.state.seen_message_ids.clone();
@@ -362,7 +378,9 @@ fn canonicalize_internal(
 
     let mut materialized_graph =
         materialize_candidate_graph(&input, &unique_messages, materialized_candidates);
-    attach_app_witnesses(&mut materialized_graph, &unique_messages, &input.policy);
+    if admit_app_witnesses {
+        attach_app_witnesses(&mut materialized_graph, &unique_messages, &input.policy);
+    }
     let selected_branch = select_canonical_branch(
         input.state.current_tip_epoch,
         &materialized_graph.candidates,

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -204,7 +204,10 @@ impl<S: StorageProvider> Engine<S> {
         let tip = self.convergence_tip_epoch(group_id)?;
         let policy = self.convergence_policy_for_group(group_id)?;
         let now = self.convergence_now();
-        let pass = self.load_or_open_convergence_pass(group_id, tip, &policy, now)?;
+        let (pass, opened) = self.load_or_open_convergence_pass(group_id, tip, &policy, now)?;
+        if opened {
+            crate::test_crash_hooks::pause_if_requested("convergence-pass-collecting-durable");
+        }
         Ok(match pass {
             Some(pass) if pass.phase == ConvergencePassPhase::Collecting => {
                 Some(pass.cutoff_monotonic_ms().saturating_sub(now.monotonic_ms))
@@ -433,17 +436,20 @@ impl<S: StorageProvider> Engine<S> {
         // The retained row and its pass membership are one durability
         // boundary. A crash may leave an unassigned row only when admission is
         // intentionally blocked by an unstable local mutation owner.
-        let admission = self.storage.with_transaction(|storage| {
+        let (admission, opened) = self.storage.with_transaction(|storage| {
             storage.put_message(&record)?;
-            let admission =
+            let (admission, opened) =
                 self.admit_stored_message_to_convergence_pass(group_id, &content_id, now)?;
             if admission == ConvergenceAdmissionOutcome::FrozenIntegrityFailure {
                 let mut group = storage.get_group(group_id)?;
                 group.unrecoverable = true;
                 storage.put_group(&group)?;
             }
-            Ok::<ConvergenceAdmissionOutcome, OpenMlsProjectionError>(admission)
+            Ok::<(ConvergenceAdmissionOutcome, bool), OpenMlsProjectionError>((admission, opened))
         })?;
+        if opened {
+            crate::test_crash_hooks::pause_if_requested("convergence-pass-collecting-durable");
+        }
         if admission == ConvergenceAdmissionOutcome::FrozenIntegrityFailure {
             let epoch = self
                 .storage
@@ -460,30 +466,30 @@ impl<S: StorageProvider> Engine<S> {
         group_id: &GroupId,
         message_id: &MessageId,
         now: ConvergenceTime,
-    ) -> Result<ConvergenceAdmissionOutcome, OpenMlsProjectionError> {
+    ) -> Result<(ConvergenceAdmissionOutcome, bool), OpenMlsProjectionError> {
         let epoch_state = self.epoch_manager.state(group_id);
         let admission_allowed = matches!(epoch_state, Some(EpochState::Stable { .. }))
             || cfg!(feature = "test-policy-overrides") && epoch_state.is_none();
         if !admission_allowed {
             // PendingPublish/Merging retain the row but do not admit it. The
             // first stable scheduler run opens a pass and seeds retained work.
-            return Ok(ConvergenceAdmissionOutcome::Retained);
+            return Ok((ConvergenceAdmissionOutcome::Retained, false));
         }
         let tip = self.convergence_tip_epoch(group_id)?;
         let policy = self.convergence_policy_for_group(group_id)?;
-        let Some(mut pass) = self.load_or_open_convergence_pass(group_id, tip, &policy, now)?
-        else {
-            return Ok(ConvergenceAdmissionOutcome::Retained);
+        let (pass, opened) = self.load_or_open_convergence_pass(group_id, tip, &policy, now)?;
+        let Some(mut pass) = pass else {
+            return Ok((ConvergenceAdmissionOutcome::Retained, opened));
         };
         if pass.phase != ConvergencePassPhase::Collecting {
-            return Ok(ConvergenceAdmissionOutcome::Retained);
+            return Ok((ConvergenceAdmissionOutcome::Retained, opened));
         }
         if pass
             .members
             .iter()
             .any(|member| &member.message_id == message_id)
         {
-            return Ok(ConvergenceAdmissionOutcome::Retained);
+            return Ok((ConvergenceAdmissionOutcome::Retained, opened));
         }
         if now.monotonic_ms >= pass.cutoff_monotonic_ms() {
             self.freeze_collecting_convergence_pass(&mut pass, now)?;
@@ -499,11 +505,11 @@ impl<S: StorageProvider> Engine<S> {
             self.storage
                 .put_convergence_pass(&pass)
                 .map_err(storage_projection_error)?;
-            return Ok(outcome);
+            return Ok((outcome, opened));
         }
 
         let Some(candidate) = self.convergence_pass_candidate(message_id)? else {
-            return Ok(ConvergenceAdmissionOutcome::Retained);
+            return Ok((ConvergenceAdmissionOutcome::Retained, opened));
         };
         let floor = pass
             .base_epoch
@@ -516,7 +522,7 @@ impl<S: StorageProvider> Engine<S> {
         if candidate.input.source_epoch < floor || candidate.input.source_epoch > ceiling {
             // Retain out-of-horizon input for a later base epoch, but never let
             // it enter (or enlarge) the immutable batch for this pass.
-            return Ok(ConvergenceAdmissionOutcome::Retained);
+            return Ok((ConvergenceAdmissionOutcome::Retained, opened));
         }
         let admitted_input = candidate.input;
         pass.members.push(candidate.member);
@@ -535,7 +541,7 @@ impl<S: StorageProvider> Engine<S> {
         self.storage
             .put_convergence_pass(&pass)
             .map_err(storage_projection_error)?;
-        Ok(ConvergenceAdmissionOutcome::Admitted)
+        Ok((ConvergenceAdmissionOutcome::Admitted, opened))
     }
 
     fn freeze_collecting_convergence_pass(
@@ -615,7 +621,7 @@ impl<S: StorageProvider> Engine<S> {
         base_epoch: EpochId,
         policy: &CanonicalizationPolicy,
         now: ConvergenceTime,
-    ) -> Result<Option<DurableConvergencePass>, OpenMlsProjectionError> {
+    ) -> Result<(Option<DurableConvergencePass>, bool), OpenMlsProjectionError> {
         let previous = self
             .storage
             .convergence_pass(group_id)
@@ -637,7 +643,7 @@ impl<S: StorageProvider> Engine<S> {
                 .iter()
                 .any(|record| crate::message_processor::is_admin_group_state_intent(&record.intent))
             {
-                return Ok(Some(pass.clone()));
+                return Ok((Some(pass.clone()), false));
             }
             let mut consumed = pass.clone();
             consumed.fairness_slot_available = false;
@@ -664,19 +670,19 @@ impl<S: StorageProvider> Engine<S> {
                     .put_convergence_pass(&pass)
                     .map_err(storage_projection_error)?;
             }
-            return Ok(Some(pass));
+            return Ok((Some(pass), false));
         }
 
         let epoch_state = self.epoch_manager.state(group_id);
         let admission_allowed = matches!(epoch_state, Some(EpochState::Stable { .. }))
             || cfg!(feature = "test-policy-overrides") && epoch_state.is_none();
         if !admission_allowed {
-            return Ok(None);
+            return Ok((None, false));
         }
         let (members, has_trigger) =
             self.seed_convergence_pass_members(group_id, base_epoch, policy)?;
         if members.is_empty() || !has_trigger {
-            return Ok(None);
+            return Ok((None, false));
         }
         let generation = previous
             .as_ref()
@@ -706,8 +712,7 @@ impl<S: StorageProvider> Engine<S> {
         self.storage
             .put_convergence_pass(&pass)
             .map_err(storage_projection_error)?;
-        crate::test_crash_hooks::pause_if_requested("convergence-pass-collecting-durable");
-        Ok(Some(pass))
+        Ok((Some(pass), true))
     }
 
     fn seed_convergence_pass_members(
@@ -1027,9 +1032,12 @@ impl<S: StorageProvider> Engine<S> {
         let previous_name = previous_group.name.clone();
         let previous_tip = self.convergence_tip_epoch(group_id)?;
         let policy = self.convergence_policy_for_group(group_id)?;
-        let Some(mut pass) =
-            self.load_or_open_convergence_pass(group_id, previous_tip, &policy, now)?
-        else {
+        let (pass, opened) =
+            self.load_or_open_convergence_pass(group_id, previous_tip, &policy, now)?;
+        if opened {
+            crate::test_crash_hooks::pause_if_requested("convergence-pass-collecting-durable");
+        }
+        let Some(mut pass) = pass else {
             // Preserve the observable no-op convergence run used by diagnostics
             // and manual repair tooling. With no eligible input there is no
             // mutable candidate set to freeze.

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -1167,8 +1167,26 @@ impl<S: StorageProvider> Engine<S> {
             StoredCanonicalizationOptions {
                 replay_profile: replay_profile_policy,
                 admitted_message_ids: Some(&admitted_message_ids),
-                admit_app_witnesses: self.admit_app_witnesses,
-                replay_probe_budget_override: self.replay_probe_budget_override,
+                admit_app_witnesses: {
+                    #[cfg(feature = "test-policy-overrides")]
+                    {
+                        self.admit_app_witnesses
+                    }
+                    #[cfg(not(feature = "test-policy-overrides"))]
+                    {
+                        true
+                    }
+                },
+                replay_probe_budget_override: {
+                    #[cfg(feature = "test-policy-overrides")]
+                    {
+                        self.replay_probe_budget_override
+                    }
+                    #[cfg(not(feature = "test-policy-overrides"))]
+                    {
+                        None
+                    }
+                },
             },
         )?;
         let mut result = result;

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -1172,6 +1172,12 @@ impl<S: StorageProvider> Engine<S> {
             },
         )?;
         let mut result = result;
+        #[cfg(feature = "test-conformance-snapshot")]
+        {
+            self.conformance_replay_probe_count = self
+                .conformance_replay_probe_count
+                .saturating_add(result.replay_probe_count);
+        }
         let evaluated_status = result.convergence_status;
         // Missing dependencies stay retained for the next generation. Once a
         // pass is frozen, later arrivals cannot extend or alter this batch.
@@ -1998,6 +2004,8 @@ fn unrecoverable_result(current_tip: u64) -> CanonicalizationResult {
         queued_outbound_intents: Vec::new(),
         publishable_outbound_messages: Vec::new(),
         errors: vec![CanonicalizationError::MissingRetainedAnchor],
+        #[cfg(feature = "test-conformance-snapshot")]
+        replay_probe_count: 0,
         selection_trace: None,
     }
 }
@@ -2023,6 +2031,8 @@ fn waiting_result(current_tip: u64) -> CanonicalizationResult {
         queued_outbound_intents: Vec::new(),
         publishable_outbound_messages: Vec::new(),
         errors: Vec::new(),
+        #[cfg(feature = "test-conformance-snapshot")]
+        replay_probe_count: 0,
         selection_trace: None,
     }
 }
@@ -2055,6 +2065,8 @@ fn quarantined_result(current_tip: u64) -> CanonicalizationResult {
         queued_outbound_intents: Vec::new(),
         publishable_outbound_messages: Vec::new(),
         errors: Vec::new(),
+        #[cfg(feature = "test-conformance-snapshot")]
+        replay_probe_count: 0,
         selection_trace: None,
     }
 }

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -706,6 +706,7 @@ impl<S: StorageProvider> Engine<S> {
         self.storage
             .put_convergence_pass(&pass)
             .map_err(storage_projection_error)?;
+        crate::test_crash_hooks::pause_if_requested("convergence-pass-collecting-durable");
         Ok(Some(pass))
     }
 
@@ -1086,6 +1087,7 @@ impl<S: StorageProvider> Engine<S> {
                     return Ok(unrecoverable_result(previous_tip.0));
                 }
             }
+            crate::test_crash_hooks::pause_if_requested("convergence-pass-frozen-durable");
             just_frozen = true;
         }
         if !just_frozen
@@ -1110,6 +1112,7 @@ impl<S: StorageProvider> Engine<S> {
             self.storage
                 .put_convergence_pass(&pass)
                 .map_err(storage_projection_error)?;
+            crate::test_crash_hooks::pause_if_requested("convergence-pass-resolving-durable");
         }
         if pass.phase == ConvergencePassPhase::Completed {
             return Ok(settled_empty_result(previous_tip.0));
@@ -1164,6 +1167,8 @@ impl<S: StorageProvider> Engine<S> {
             StoredCanonicalizationOptions {
                 replay_profile: replay_profile_policy,
                 admitted_message_ids: Some(&admitted_message_ids),
+                admit_app_witnesses: self.admit_app_witnesses,
+                replay_probe_budget_override: self.replay_probe_budget_override,
             },
         )?;
         let mut result = result;
@@ -1302,6 +1307,7 @@ impl<S: StorageProvider> Engine<S> {
             storage.put_convergence_pass(&completed_pass)?;
             Ok::<_, OpenMlsProjectionError>(observations)
         })?;
+        crate::test_crash_hooks::pause_if_requested("convergence-pass-completed-durable");
         // Diagnostic only: settling-latency telemetry for the remediation
         // plan — pass open → apply, and the gap since the previous completed
         // generation. Never feeds convergence or branch selection.

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -244,9 +244,11 @@ pub struct Engine<S: StorageProvider> {
     pub(crate) convergence_policy: crate::canonicalization::CanonicalizationPolicy,
     /// Test-only selection experiment switch. It is always true in production;
     /// only the feature-gated builder method can disable witness admission.
+    #[cfg(feature = "test-policy-overrides")]
     pub(crate) admit_app_witnesses: bool,
     /// Optional hard replay-probe ceiling for explicit exhaustion campaigns.
     /// Production construction cannot set it.
+    #[cfg(feature = "test-policy-overrides")]
     pub(crate) replay_probe_budget_override: Option<u64>,
     #[cfg(feature = "test-conformance-snapshot")]
     pub(crate) conformance_replay_probe_count: u64,
@@ -346,7 +348,9 @@ pub struct EngineBuilder<S: StorageProvider> {
     wall_clock: Arc<dyn WallClock>,
     maintenance_random: Arc<dyn MaintenanceRandom>,
     convergence_clock: Arc<dyn ConvergenceClock>,
+    #[cfg(feature = "test-policy-overrides")]
     admit_app_witnesses: bool,
+    #[cfg(feature = "test-policy-overrides")]
     replay_probe_budget_override: Option<u64>,
     recorder: Option<Box<dyn ForensicRecorder>>,
 }
@@ -367,7 +371,9 @@ impl<S: StorageProvider> EngineBuilder<S> {
             wall_clock: Arc::new(SystemWallClock),
             maintenance_random: Arc::new(OsMaintenanceRandom),
             convergence_clock: Arc::new(SystemConvergenceClock::default()),
+            #[cfg(feature = "test-policy-overrides")]
             admit_app_witnesses: true,
+            #[cfg(feature = "test-policy-overrides")]
             replay_probe_budget_override: None,
             recorder: None,
         }
@@ -559,7 +565,9 @@ impl<S: StorageProvider> EngineBuilder<S> {
                 app_message_past_epoch_limit: self.max_past_epochs as u64,
                 ..crate::canonicalization::CanonicalizationPolicy::default()
             },
+            #[cfg(feature = "test-policy-overrides")]
             admit_app_witnesses: self.admit_app_witnesses,
+            #[cfg(feature = "test-policy-overrides")]
             replay_probe_budget_override: self.replay_probe_budget_override,
             #[cfg(feature = "test-conformance-snapshot")]
             conformance_replay_probe_count: 0,

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -248,6 +248,8 @@ pub struct Engine<S: StorageProvider> {
     /// Optional hard replay-probe ceiling for explicit exhaustion campaigns.
     /// Production construction cannot set it.
     pub(crate) replay_probe_budget_override: Option<u64>,
+    #[cfg(feature = "test-conformance-snapshot")]
+    pub(crate) conformance_replay_probe_count: u64,
     pub(crate) convergence_clock: Arc<dyn ConvergenceClock>,
     /// Identifies the process-local monotonic clock domain persisted in active
     /// convergence passes. A mismatch on hydration forces deadline rebasing
@@ -559,6 +561,8 @@ impl<S: StorageProvider> EngineBuilder<S> {
             },
             admit_app_witnesses: self.admit_app_witnesses,
             replay_probe_budget_override: self.replay_probe_budget_override,
+            #[cfg(feature = "test-conformance-snapshot")]
+            conformance_replay_probe_count: 0,
             convergence_clock: self.convergence_clock,
             convergence_clock_instance_id: rand::rngs::OsRng.next_u64(),
             engine_metrics: crate::engine_metrics::EngineMetrics::default(),
@@ -677,6 +681,12 @@ impl<S: StorageProvider> Engine<S> {
             }
         }
         Ok(None)
+    }
+
+    /// Cumulative candidate replay probes since this engine process opened.
+    #[cfg(feature = "test-conformance-snapshot")]
+    pub fn conformance_replay_probe_count(&self) -> u64 {
+        self.conformance_replay_probe_count
     }
 
     /// Return the transport and content-derived ids for a durable synthetic

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -242,6 +242,12 @@ pub struct Engine<S: StorageProvider> {
     pub(crate) queued_intent_by_pending: HashMap<PendingStateRef, (GroupId, MessageId)>,
 
     pub(crate) convergence_policy: crate::canonicalization::CanonicalizationPolicy,
+    /// Test-only selection experiment switch. It is always true in production;
+    /// only the feature-gated builder method can disable witness admission.
+    pub(crate) admit_app_witnesses: bool,
+    /// Optional hard replay-probe ceiling for explicit exhaustion campaigns.
+    /// Production construction cannot set it.
+    pub(crate) replay_probe_budget_override: Option<u64>,
     pub(crate) convergence_clock: Arc<dyn ConvergenceClock>,
     /// Identifies the process-local monotonic clock domain persisted in active
     /// convergence passes. A mismatch on hydration forces deadline rebasing
@@ -338,6 +344,8 @@ pub struct EngineBuilder<S: StorageProvider> {
     wall_clock: Arc<dyn WallClock>,
     maintenance_random: Arc<dyn MaintenanceRandom>,
     convergence_clock: Arc<dyn ConvergenceClock>,
+    admit_app_witnesses: bool,
+    replay_probe_budget_override: Option<u64>,
     recorder: Option<Box<dyn ForensicRecorder>>,
 }
 
@@ -357,6 +365,8 @@ impl<S: StorageProvider> EngineBuilder<S> {
             wall_clock: Arc::new(SystemWallClock),
             maintenance_random: Arc::new(OsMaintenanceRandom),
             convergence_clock: Arc::new(SystemConvergenceClock::default()),
+            admit_app_witnesses: true,
+            replay_probe_budget_override: None,
             recorder: None,
         }
     }
@@ -437,6 +447,26 @@ impl<S: StorageProvider> EngineBuilder<S> {
     /// maintenance timestamps.
     pub fn convergence_clock(mut self, clock: Arc<dyn ConvergenceClock>) -> Self {
         self.convergence_clock = clock;
+        self
+    }
+
+    /// Disable application-message witnesses for a full-engine comparison.
+    ///
+    /// This does not define or negotiate another Marmot convergence policy.
+    /// It exists only in explicit test-policy builds so campaigns can measure
+    /// whether the v1 witness term changes outcomes enough to justify itself.
+    #[cfg(feature = "test-policy-overrides")]
+    pub fn without_app_witnesses_for_tests(mut self) -> Self {
+        self.admit_app_witnesses = false;
+        self
+    }
+
+    /// Override the per-pass OpenMLS replay-probe ceiling for fail-closed
+    /// resource campaigns. A zero limit deterministically fails the first
+    /// probe; `None` restores the production-derived budget.
+    #[cfg(feature = "test-policy-overrides")]
+    pub fn replay_probe_budget_for_tests(mut self, limit: Option<u64>) -> Self {
+        self.replay_probe_budget_override = limit;
         self
     }
 
@@ -527,6 +557,8 @@ impl<S: StorageProvider> EngineBuilder<S> {
                 app_message_past_epoch_limit: self.max_past_epochs as u64,
                 ..crate::canonicalization::CanonicalizationPolicy::default()
             },
+            admit_app_witnesses: self.admit_app_witnesses,
+            replay_probe_budget_override: self.replay_probe_budget_override,
             convergence_clock: self.convergence_clock,
             convergence_clock_instance_id: rand::rngs::OsRng.next_u64(),
             engine_metrics: crate::engine_metrics::EngineMetrics::default(),
@@ -544,6 +576,13 @@ impl<S: StorageProvider> EngineBuilder<S> {
 }
 
 impl<S: StorageProvider> Engine<S> {
+    /// Change the explicit replay-probe ceiling for a running exhaustion
+    /// campaign. Production builds do not expose this method.
+    #[cfg(feature = "test-policy-overrides")]
+    pub fn set_replay_probe_budget_for_tests(&mut self, limit: Option<u64>) {
+        self.replay_probe_budget_override = limit;
+    }
+
     pub fn epoch_state(&self, group_id: &GroupId) -> Option<cgka_traits::EpochState> {
         if self.ensure_group_live(group_id).is_err() {
             return None;

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -159,6 +159,8 @@ struct StoredOpenMlsCandidatePathResult {
     /// Stored commit inputs that could not reach any candidate parent in this
     /// frozen batch and did not fail validation terminally.
     unmaterialized_commit_ids: Vec<String>,
+    #[cfg(feature = "test-conformance-snapshot")]
+    replay_probe_count: u64,
 }
 
 /// Bounds the total OpenMLS replay round-trips a single convergence pass may perform, so
@@ -166,6 +168,8 @@ struct StoredOpenMlsCandidatePathResult {
 /// The pass fails closed (`ReplayBudgetExceeded`) rather than returning a partial result.
 struct ReplayBudget {
     remaining: u64,
+    #[cfg(feature = "test-conformance-snapshot")]
+    consumed: u64,
 }
 
 /// Multiplicative slack over the linear `commits × (max_rewind_commits + 1)` probe estimate.
@@ -177,7 +181,11 @@ pub(crate) const CANDIDATE_REPLAY_BUDGET_FLOOR: u64 = 32;
 
 impl ReplayBudget {
     fn new(limit: u64) -> Self {
-        Self { remaining: limit }
+        Self {
+            remaining: limit,
+            #[cfg(feature = "test-conformance-snapshot")]
+            consumed: 0,
+        }
     }
 
     /// Unlimited budget for callers outside the bounded convergence BFS (e.g. the public
@@ -185,6 +193,8 @@ impl ReplayBudget {
     fn unlimited() -> Self {
         Self {
             remaining: u64::MAX,
+            #[cfg(feature = "test-conformance-snapshot")]
+            consumed: 0,
         }
     }
 
@@ -203,6 +213,10 @@ impl ReplayBudget {
             return Err(OpenMlsProjectionError::ReplayBudgetExceeded);
         }
         self.remaining -= 1;
+        #[cfg(feature = "test-conformance-snapshot")]
+        {
+            self.consumed = self.consumed.saturating_add(1);
+        }
         Ok(())
     }
 }
@@ -1210,6 +1224,8 @@ fn canonicalize_stored_openmls_messages_from_current<S: StorageProvider>(
         path_result.materialized.len(),
         path_result.candidate_paths.len(),
     );
+    #[cfg(feature = "test-conformance-snapshot")]
+    let replay_probe_count = path_result.replay_probe_count;
 
     let batch = OpenMlsCanonicalizationBatch {
         state: work.state,
@@ -1239,6 +1255,10 @@ fn canonicalize_stored_openmls_messages_from_current<S: StorageProvider>(
             work.admit_app_witnesses,
         )?
     };
+    #[cfg(feature = "test-conformance-snapshot")]
+    {
+        result.replay_probe_count = replay_probe_count;
+    }
     append_dropped_messages(&mut result, path_result.invalid_commit_drops);
     append_missing_parent_deferred_commits(&mut result, path_result.unmaterialized_commit_ids);
     Ok(result)
@@ -1287,6 +1307,8 @@ fn missing_retained_anchor_result(
         queued_outbound_intents: outbound_intents,
         publishable_outbound_messages: Vec::new(),
         errors: vec![CanonicalizationError::MissingRetainedAnchor],
+        #[cfg(feature = "test-conformance-snapshot")]
+        replay_probe_count: 0,
         selection_trace: None,
     }
 }
@@ -1472,6 +1494,8 @@ fn build_stored_openmls_candidate_paths<S: StorageProvider>(
         materialized,
         invalid_commit_drops,
         unmaterialized_commit_ids,
+        #[cfg(feature = "test-conformance-snapshot")]
+        replay_probe_count: budget.consumed,
     })
 }
 

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -228,10 +228,23 @@ pub(crate) struct ReplayProfilePolicy {
     pub(crate) reject_legacy_group_additions: bool,
 }
 
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug)]
 pub(crate) struct StoredCanonicalizationOptions<'a> {
     pub(crate) replay_profile: ReplayProfilePolicy,
     pub(crate) admitted_message_ids: Option<&'a HashSet<MessageId>>,
+    pub(crate) admit_app_witnesses: bool,
+    pub(crate) replay_probe_budget_override: Option<u64>,
+}
+
+impl Default for StoredCanonicalizationOptions<'_> {
+    fn default() -> Self {
+        Self {
+            replay_profile: ReplayProfilePolicy::default(),
+            admitted_message_ids: None,
+            admit_app_witnesses: true,
+            replay_probe_budget_override: None,
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -248,6 +261,8 @@ struct StoredOpenMlsCanonicalizationWork {
     replay_start_epoch: u64,
     own_commits: PrevalidatedOwnCommits,
     profile_policy: ReplayProfilePolicy,
+    admit_app_witnesses: bool,
+    replay_probe_budget_override: Option<u64>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -772,6 +787,7 @@ pub fn canonicalize_openmls_batch<S: StorageProvider>(
         batch,
         &PrevalidatedOwnCommits::default(),
         ReplayProfilePolicy::default(),
+        true,
     )
 }
 
@@ -781,6 +797,7 @@ fn canonicalize_openmls_batch_prevalidated<S: StorageProvider>(
     batch: OpenMlsCanonicalizationBatch,
     own_commits: &PrevalidatedOwnCommits,
     profile_policy: ReplayProfilePolicy,
+    admit_app_witnesses: bool,
 ) -> Result<CanonicalizationResult, OpenMlsProjectionError> {
     let candidate_paths = candidate_paths_with_pending_replay_messages(
         &batch.candidate_paths,
@@ -794,7 +811,7 @@ fn canonicalize_openmls_batch_prevalidated<S: StorageProvider>(
         &mut ReplayBudget::unlimited(),
         profile_policy,
     )?;
-    canonicalize_openmls_batch_with_materialized(group_id, batch, materialized)
+    canonicalize_openmls_batch_with_materialized(group_id, batch, materialized, admit_app_witnesses)
 }
 
 /// Canonicalization core over already-materialized candidates. Split out of
@@ -807,6 +824,7 @@ fn canonicalize_openmls_batch_with_materialized(
     group_id: &GroupId,
     batch: OpenMlsCanonicalizationBatch,
     materialized: Vec<OpenMlsMaterializedCandidate>,
+    admit_app_witnesses: bool,
 ) -> Result<CanonicalizationResult, OpenMlsProjectionError> {
     let proposal_id_by_ref = proposal_id_by_ref(&materialized);
     let materialized_candidates: Vec<_> = materialized
@@ -825,15 +843,27 @@ fn canonicalize_openmls_batch_with_materialized(
         &app_messages_by_id,
     )?;
 
+    let input = CanonicalizationInput {
+        state: batch.state,
+        pending_messages,
+        outbound_intents: batch.outbound_intents,
+        candidate_branches: vec![],
+        policy: batch.policy,
+        now_ms: batch.now_ms,
+    };
+    #[cfg(feature = "test-policy-overrides")]
+    if !admit_app_witnesses {
+        return Ok(
+            crate::canonicalization::canonicalize_with_materialized_candidates_for_test(
+                input,
+                materialized_candidates,
+                false,
+            ),
+        );
+    }
+    let _ = admit_app_witnesses;
     Ok(canonicalize_with_materialized_candidates(
-        CanonicalizationInput {
-            state: batch.state,
-            pending_messages,
-            outbound_intents: batch.outbound_intents,
-            candidate_branches: vec![],
-            policy: batch.policy,
-            now_ms: batch.now_ms,
-        },
+        input,
         materialized_candidates,
     ))
 }
@@ -985,6 +1015,8 @@ pub(crate) fn canonicalize_stored_openmls_messages_with_profile_policy<S: Storag
                 replay_start_epoch,
                 own_commits,
                 profile_policy,
+                admit_app_witnesses: options.admit_app_witnesses,
+                replay_probe_budget_override: options.replay_probe_budget_override,
             },
         )?;
         append_dropped_messages(&mut result, stale_commit_drops);
@@ -1005,6 +1037,8 @@ pub(crate) fn canonicalize_stored_openmls_messages_with_profile_policy<S: Storag
             replay_start_epoch,
             own_commits,
             profile_policy,
+            admit_app_witnesses: options.admit_app_witnesses,
+            replay_probe_budget_override: options.replay_probe_budget_override,
         },
     )?;
     append_dropped_messages(&mut result, stale_commit_drops);
@@ -1167,6 +1201,7 @@ fn canonicalize_stored_openmls_messages_from_current<S: StorageProvider>(
         work.policy.convergence.max_rewind_commits,
         &work.own_commits,
         work.profile_policy,
+        work.replay_probe_budget_override,
     )?;
 
     let has_pending_apps = pending_messages_contain_application(&work.pending_messages)?;
@@ -1188,7 +1223,12 @@ fn canonicalize_stored_openmls_messages_from_current<S: StorageProvider>(
     let mut result = if can_reuse_materialized {
         let mut materialized = path_result.materialized;
         materialized.sort_by(|a, b| a.branch_id.cmp(&b.branch_id));
-        canonicalize_openmls_batch_with_materialized(group_id, batch, materialized)?
+        canonicalize_openmls_batch_with_materialized(
+            group_id,
+            batch,
+            materialized,
+            work.admit_app_witnesses,
+        )?
     } else {
         canonicalize_openmls_batch_prevalidated(
             storage,
@@ -1196,6 +1236,7 @@ fn canonicalize_stored_openmls_messages_from_current<S: StorageProvider>(
             batch,
             &work.own_commits,
             work.profile_policy,
+            work.admit_app_witnesses,
         )?
     };
     append_dropped_messages(&mut result, path_result.invalid_commit_drops);
@@ -1262,6 +1303,7 @@ fn build_stored_openmls_candidate_paths<S: StorageProvider>(
     max_rewind_commits: u64,
     own_commits: &PrevalidatedOwnCommits,
     profile_policy: ReplayProfilePolicy,
+    replay_budget_override: Option<u64>,
 ) -> Result<StoredOpenMlsCandidatePathResult, OpenMlsProjectionError> {
     commits.sort_by(|a, b| {
         a.source_epoch
@@ -1275,7 +1317,10 @@ fn build_stored_openmls_candidate_paths<S: StorageProvider>(
         .map(|commit| commit.message.id.to_string())
         .collect::<BTreeSet<_>>();
 
-    let mut budget = ReplayBudget::for_pass(commits.len(), max_rewind_commits);
+    let mut budget = replay_budget_override.map_or_else(
+        || ReplayBudget::for_pass(commits.len(), max_rewind_commits),
+        ReplayBudget::new,
+    );
     let pending_proposals = pending_proposal_messages(pending_messages)?;
     let mut frontier = vec![CandidatePathProbe {
         messages: Vec::new(),

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -159,8 +159,6 @@ struct StoredOpenMlsCandidatePathResult {
     /// Stored commit inputs that could not reach any candidate parent in this
     /// frozen batch and did not fail validation terminally.
     unmaterialized_commit_ids: Vec<String>,
-    #[cfg(feature = "test-conformance-snapshot")]
-    replay_probe_count: u64,
 }
 
 /// Bounds the total OpenMLS replay round-trips a single convergence pass may perform, so
@@ -795,6 +793,7 @@ pub fn canonicalize_openmls_batch<S: StorageProvider>(
     group_id: &GroupId,
     batch: OpenMlsCanonicalizationBatch,
 ) -> Result<CanonicalizationResult, OpenMlsProjectionError> {
+    let mut replay_budget = ReplayBudget::unlimited();
     canonicalize_openmls_batch_prevalidated(
         storage,
         group_id,
@@ -802,6 +801,7 @@ pub fn canonicalize_openmls_batch<S: StorageProvider>(
         &PrevalidatedOwnCommits::default(),
         ReplayProfilePolicy::default(),
         true,
+        &mut replay_budget,
     )
 }
 
@@ -812,6 +812,7 @@ fn canonicalize_openmls_batch_prevalidated<S: StorageProvider>(
     own_commits: &PrevalidatedOwnCommits,
     profile_policy: ReplayProfilePolicy,
     admit_app_witnesses: bool,
+    replay_budget: &mut ReplayBudget,
 ) -> Result<CanonicalizationResult, OpenMlsProjectionError> {
     let candidate_paths = candidate_paths_with_pending_replay_messages(
         &batch.candidate_paths,
@@ -822,7 +823,7 @@ fn canonicalize_openmls_batch_prevalidated<S: StorageProvider>(
         group_id,
         &candidate_paths,
         own_commits,
-        &mut ReplayBudget::unlimited(),
+        replay_budget,
         profile_policy,
     )?;
     canonicalize_openmls_batch_with_materialized(group_id, batch, materialized, admit_app_witnesses)
@@ -875,7 +876,11 @@ fn canonicalize_openmls_batch_with_materialized(
             ),
         );
     }
-    let _ = admit_app_witnesses;
+    #[cfg(not(feature = "test-policy-overrides"))]
+    debug_assert!(
+        admit_app_witnesses,
+        "production canonicalization must admit application witnesses"
+    );
     Ok(canonicalize_with_materialized_candidates(
         input,
         materialized_candidates,
@@ -1206,16 +1211,24 @@ fn canonicalize_stored_openmls_messages_from_current<S: StorageProvider>(
     group_id: &GroupId,
     work: StoredOpenMlsCanonicalizationWork,
 ) -> Result<CanonicalizationResult, OpenMlsProjectionError> {
+    let mut replay_budget = work.replay_probe_budget_override.map_or_else(
+        || {
+            ReplayBudget::for_pass(
+                work.commit_messages.len(),
+                work.policy.convergence.max_rewind_commits,
+            )
+        },
+        ReplayBudget::new,
+    );
     let path_result = build_stored_openmls_candidate_paths(
         storage,
         group_id,
         work.commit_messages,
         &work.pending_messages,
         work.replay_start_epoch,
-        work.policy.convergence.max_rewind_commits,
         &work.own_commits,
         work.profile_policy,
-        work.replay_probe_budget_override,
+        &mut replay_budget,
     )?;
 
     let has_pending_apps = pending_messages_contain_application(&work.pending_messages)?;
@@ -1224,9 +1237,6 @@ fn canonicalize_stored_openmls_messages_from_current<S: StorageProvider>(
         path_result.materialized.len(),
         path_result.candidate_paths.len(),
     );
-    #[cfg(feature = "test-conformance-snapshot")]
-    let replay_probe_count = path_result.replay_probe_count;
-
     let batch = OpenMlsCanonicalizationBatch {
         state: work.state,
         candidate_paths: path_result.candidate_paths,
@@ -1253,11 +1263,12 @@ fn canonicalize_stored_openmls_messages_from_current<S: StorageProvider>(
             &work.own_commits,
             work.profile_policy,
             work.admit_app_witnesses,
+            &mut replay_budget,
         )?
     };
     #[cfg(feature = "test-conformance-snapshot")]
     {
-        result.replay_probe_count = replay_probe_count;
+        result.replay_probe_count = replay_budget.consumed;
     }
     append_dropped_messages(&mut result, path_result.invalid_commit_drops);
     append_missing_parent_deferred_commits(&mut result, path_result.unmaterialized_commit_ids);
@@ -1322,10 +1333,9 @@ fn build_stored_openmls_candidate_paths<S: StorageProvider>(
     mut commits: Vec<StoredCommitMessage>,
     pending_messages: &[TransportMessage],
     starting_epoch: u64,
-    max_rewind_commits: u64,
     own_commits: &PrevalidatedOwnCommits,
     profile_policy: ReplayProfilePolicy,
-    replay_budget_override: Option<u64>,
+    budget: &mut ReplayBudget,
 ) -> Result<StoredOpenMlsCandidatePathResult, OpenMlsProjectionError> {
     commits.sort_by(|a, b| {
         a.source_epoch
@@ -1339,10 +1349,6 @@ fn build_stored_openmls_candidate_paths<S: StorageProvider>(
         .map(|commit| commit.message.id.to_string())
         .collect::<BTreeSet<_>>();
 
-    let mut budget = replay_budget_override.map_or_else(
-        || ReplayBudget::for_pass(commits.len(), max_rewind_commits),
-        ReplayBudget::new,
-    );
     let pending_proposals = pending_proposal_messages(pending_messages)?;
     let mut frontier = vec![CandidatePathProbe {
         messages: Vec::new(),
@@ -1385,7 +1391,7 @@ fn build_stored_openmls_candidate_paths<S: StorageProvider>(
                     &digests,
                     &pending_proposals,
                     own_commits,
-                    &mut budget,
+                    budget,
                     profile_policy,
                 )? {
                     CandidatePathProbeResult::Materialized(Some(candidate)) => {
@@ -1494,8 +1500,6 @@ fn build_stored_openmls_candidate_paths<S: StorageProvider>(
         materialized,
         invalid_commit_drops,
         unmaterialized_commit_ids,
-        #[cfg(feature = "test-conformance-snapshot")]
-        replay_probe_count: budget.consumed,
     })
 }
 

--- a/crates/cgka-engine/src/test_crash_hooks.rs
+++ b/crates/cgka-engine/src/test_crash_hooks.rs
@@ -5,7 +5,11 @@
 //! are emitted.
 
 const CRASH_POINT_ENV: &str = "MDK_CGKA_TEST_CRASH_POINT";
+const CRASH_OCCURRENCE_ENV: &str = "MDK_CGKA_TEST_CRASH_OCCURRENCE";
 const READY_PREFIX: &str = "MDK_CGKA_TEST_CRASH_READY:";
+
+#[cfg(all(feature = "test-crash-hooks", debug_assertions))]
+static MATCHING_OCCURRENCES: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 #[inline]
 pub(crate) fn pause_if_requested(point: &'static str) {
@@ -14,6 +18,15 @@ pub(crate) fn pause_if_requested(point: &'static str) {
         use std::io::Write as _;
 
         if std::env::var(CRASH_POINT_ENV).as_deref() != Ok(point) {
+            return;
+        }
+        let selected_occurrence = std::env::var(CRASH_OCCURRENCE_ENV)
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .unwrap_or(1);
+        let occurrence =
+            MATCHING_OCCURRENCES.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+        if occurrence != selected_occurrence {
             return;
         }
         let stdout = std::io::stdout();
@@ -28,6 +41,6 @@ pub(crate) fn pause_if_requested(point: &'static str) {
 
     #[cfg(not(all(feature = "test-crash-hooks", debug_assertions)))]
     {
-        let _ = (point, CRASH_POINT_ENV, READY_PREFIX);
+        let _ = (point, CRASH_POINT_ENV, CRASH_OCCURRENCE_ENV, READY_PREFIX);
     }
 }

--- a/crates/cgka-engine/tests/crash_recovery_sqlite.rs
+++ b/crates/cgka-engine/tests/crash_recovery_sqlite.rs
@@ -31,7 +31,8 @@ use cgka_traits::ingest::{PeeledContent, PeeledMessage};
 use cgka_traits::message::MessageState;
 use cgka_traits::peeler::TransportPeeler;
 use cgka_traits::storage::{
-    GroupStorage, MessageStorage, OutboundIntentStorage, QueuedOutboundIntent,
+    ConvergencePassStorage, GroupStorage, MessageStorage, OutboundIntentStorage,
+    QueuedOutboundIntent,
 };
 use cgka_traits::transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
@@ -411,13 +412,35 @@ fn run_transition_parent_case(point: &str) {
     let group_ids = storage.list_groups().expect("list transition groups");
     assert_eq!(group_ids.len(), 1, "transition fixture owns one group");
     let group_id = group_ids[0].clone();
+    assert_eq!(
+        storage
+            .list_queued_outbound_intents(&group_id)
+            .expect("queued intents before transition hydration")
+            .len(),
+        1,
+        "kill at {point} must leave the durable queued intent intact"
+    );
     let mut reopened = build_client_with_storage(CAROL_SEED, storage.clone());
     reopened
         .hydrate_stable_groups_from_storage()
         .unwrap_or_else(|error| panic!("hydrate after {point}: {error}"));
-    reopened
-        .converge_stored_openmls_messages_at(&group_id, 4_000_000)
-        .unwrap_or_else(|error| panic!("resume after {point}: {error}"));
+    assert_eq!(
+        storage
+            .list_queued_outbound_intents(&group_id)
+            .expect("queued intents after transition hydration")
+            .len(),
+        1,
+        "hydrate after {point} must preserve queued work"
+    );
+    // A collecting pass rebases its process-local monotonic cutoff from the
+    // durable wall deadline on first use after restart. Drive once to perform
+    // that rebase, then beyond the v1 absolute deadline; frozen/resolving
+    // phases finish on the first call and make the second a harmless no-op.
+    for now_ms in [4_000_000, 4_010_000] {
+        reopened
+            .converge_stored_openmls_messages_at(&group_id, now_ms)
+            .unwrap_or_else(|error| panic!("resume after {point} at {now_ms}: {error}"));
+    }
     assert_eq!(
         reopened
             .epoch(&group_id)
@@ -425,14 +448,50 @@ fn run_transition_parent_case(point: &str) {
         EpochId(2),
         "kill at {point} must reopen to a complete epoch"
     );
-    assert!(
-        !storage
-            .get_group(&group_id)
-            .expect("group after transition repair")
-            .members
-            .is_empty(),
-        "kill at {point} must not expose partial group state"
+    let recovered = storage
+        .get_group(&group_id)
+        .expect("group after transition repair");
+    let completed_pass = storage
+        .convergence_pass(&group_id)
+        .expect("pass after transition repair")
+        .expect("transition fixture retains the completed pass");
+    assert_eq!(
+        completed_pass.phase,
+        cgka_traits::ConvergencePassPhase::Completed,
+        "kill at {point} must finish the interrupted durable pass"
     );
+    assert!(
+        recovered
+            .members
+            .iter()
+            .any(|member| member.id == MemberId::new(identity(b"eve-crash"))),
+        "kill at {point} must preserve and finish the interrupted winning branch"
+    );
+    assert!(
+        !recovered
+            .members
+            .iter()
+            .any(|member| member.id == MemberId::new(identity(b"david-crash"))),
+        "kill at {point} must not expose the losing incumbent branch"
+    );
+    assert!(
+        storage
+            .list_messages(&group_id, EpochId(1))
+            .expect("late convergence inputs after transition repair")
+            .iter()
+            .all(|record| {
+                !matches!(
+                    record.state,
+                    MessageState::Created | MessageState::Retryable
+                )
+            }),
+        "kill at {point} must terminalize or defer every input from the interrupted pass"
+    );
+    let queued = storage
+        .list_queued_outbound_intents(&group_id)
+        .expect("queued intents after transition repair");
+    assert_eq!(queued.len(), 1, "kill at {point} must preserve queued work");
+    assert_eq!(queued[0].id, MessageId::new(QUEUED_INTENT_ID.to_vec()));
 }
 
 async fn run_child_case(database: &Path) {
@@ -452,7 +511,7 @@ async fn run_child_case(database: &Path) {
         };
     assert!(
         bob.self_id().as_slice() < alice.self_id().as_slice(),
-        "late challenger must win the deterministic tiebreak"
+        "late challenger must exercise the lower-committer side of the deterministic tiebreak"
     );
     let (mut david, _david_storage) = build_memory_client(b"david-crash");
     let (mut eve, _eve_storage) = build_memory_client(b"eve-crash");
@@ -525,9 +584,6 @@ async fn run_child_case(database: &Path) {
         .await
         .expect("bob invite"),
     );
-    carol
-        .buffer_openmls_convergence_message_at(&group_id, route(bob_commit, &group_id), 2_000)
-        .expect("buffer late winning commit");
     carol_storage
         .put_queued_outbound_intent(&QueuedOutboundIntent {
             id: MessageId::new(QUEUED_INTENT_ID.to_vec()),
@@ -539,6 +595,13 @@ async fn run_child_case(database: &Path) {
             created_at_ms: 2_100,
         })
         .expect("persist queued work");
+    // Persist the independent outbound obligation before admitting the late
+    // convergence input: the collecting-phase hook fires during admission, so
+    // the opposite order never actually exercised queued-intent durability at
+    // that earliest kill point.
+    carol
+        .buffer_openmls_convergence_message_at(&group_id, route(bob_commit, &group_id), 2_000)
+        .expect("buffer late competing commit");
 
     let _ = alice_seed;
     if std::env::var(CRASH_POINT_ENV).as_deref() == Ok(H5_POINT) {

--- a/crates/cgka-engine/tests/crash_recovery_sqlite.rs
+++ b/crates/cgka-engine/tests/crash_recovery_sqlite.rs
@@ -46,10 +46,17 @@ use support::proof_signer;
 const CHILD_ENV: &str = "MDK_CGKA_CRASH_CHILD";
 const DATABASE_ENV: &str = "MDK_CGKA_CRASH_DATABASE";
 const CRASH_POINT_ENV: &str = "MDK_CGKA_TEST_CRASH_POINT";
+const CRASH_OCCURRENCE_ENV: &str = "MDK_CGKA_TEST_CRASH_OCCURRENCE";
 const DATABASE_KEY: &str = "cgka convergence crash recovery key";
 const READY_PREFIX: &str = "MDK_CGKA_TEST_CRASH_READY:";
 const H5_POINT: &str = "historical-apply-before-commit";
 const H6_POINT: &str = "retained-anchor-after-rewind";
+const DURABLE_TRANSITION_POINTS: &[&str] = &[
+    "convergence-pass-collecting-durable",
+    "convergence-pass-frozen-durable",
+    "convergence-pass-resolving-durable",
+    "convergence-pass-completed-durable",
+];
 const CAROL_SEED: &[u8] = b"carol-crash";
 const QUEUED_INTENT_ID: &[u8] = b"crash-queued-intent";
 
@@ -128,6 +135,13 @@ fn h5_kill_before_historical_apply_commit_preserves_live_inputs() {
 #[test]
 fn h6_kill_after_retained_anchor_rewind_recovers_live_snapshot() {
     run_parent_case(H6_POINT, EpochId(1), "openmls-retained-probe-");
+}
+
+#[test]
+fn kill_at_every_durable_convergence_phase_reopens_and_finishes() {
+    for point in DURABLE_TRANSITION_POINTS {
+        run_transition_parent_case(point);
+    }
 }
 
 #[tokio::test]
@@ -309,6 +323,115 @@ fn run_parent_case(point: &str, stranded_epoch: EpochId, snapshot_prefix: &str) 
             .iter()
             .any(|record| record.state == MessageState::Created),
         "the late convergence input must remain durable for replay"
+    );
+}
+
+fn run_transition_parent_case(point: &str) {
+    let dir = tempfile::tempdir().expect("transition temp directory");
+    let database = dir.path().join("carol.sqlite3");
+    let mut child = Command::new(std::env::current_exe().expect("current test executable"))
+        .args([
+            "--ignored",
+            "--exact",
+            "crash_child_runs_late_commit_convergence",
+            "--nocapture",
+        ])
+        .env(CHILD_ENV, "1")
+        .env(DATABASE_ENV, &database)
+        .env(CRASH_POINT_ENV, point)
+        // The incumbent pass exercises each phase once while building the
+        // durable fixture. Kill the second occurrence, in the late competing
+        // pass whose state must survive restart.
+        .env(CRASH_OCCURRENCE_ENV, "2")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn transition crash child");
+
+    let stdout = child.stdout.take().expect("child stdout");
+    let (line_tx, line_rx) = mpsc::channel();
+    let reader = std::thread::spawn(move || {
+        for line in BufReader::new(stdout).lines() {
+            if line_tx.send(line).is_err() {
+                return;
+            }
+        }
+    });
+    let expected_ready = format!("{READY_PREFIX}{point}");
+    let mut child_output = Vec::new();
+    let ready = loop {
+        match line_rx.recv_timeout(Duration::from_secs(30)) {
+            Ok(Ok(line)) => {
+                let is_ready = line == expected_ready;
+                child_output.push(line);
+                if is_ready {
+                    break true;
+                }
+            }
+            Ok(Err(error)) => {
+                child_output.push(format!("stdout error: {error}"));
+                break false;
+            }
+            Err(_) => break false,
+        }
+    };
+    if !ready {
+        let _ = child.kill();
+        let _ = child.wait();
+        drop(line_rx);
+        let _ = reader.join();
+        panic!(
+            "child did not reach durable transition {point}; stdout:\n{}",
+            child_output.join("\n")
+        );
+    }
+    child.kill().expect("kill child at durable transition");
+    assert!(
+        !child.wait().expect("wait for transition child").success(),
+        "killed transition child must not exit successfully"
+    );
+    drop(line_rx);
+    reader.join().expect("transition stdout reader exits");
+
+    let mut stderr = String::new();
+    child
+        .stderr
+        .take()
+        .expect("transition child stderr")
+        .read_to_string(&mut stderr)
+        .expect("read transition child stderr");
+    assert!(
+        database.exists(),
+        "database missing after kill at {point}; stderr:\n{stderr}"
+    );
+
+    let key = SqlCipherKey::new(DATABASE_KEY).expect("transition SQLCipher key");
+    let storage =
+        SqliteAccountStorage::open_encrypted(&database, &key).expect("reopen transition database");
+    let group_ids = storage.list_groups().expect("list transition groups");
+    assert_eq!(group_ids.len(), 1, "transition fixture owns one group");
+    let group_id = group_ids[0].clone();
+    let mut reopened = build_client_with_storage(CAROL_SEED, storage.clone());
+    reopened
+        .hydrate_stable_groups_from_storage()
+        .unwrap_or_else(|error| panic!("hydrate after {point}: {error}"));
+    reopened
+        .converge_stored_openmls_messages_at(&group_id, 4_000_000)
+        .unwrap_or_else(|error| panic!("resume after {point}: {error}"));
+    assert_eq!(
+        reopened
+            .epoch(&group_id)
+            .expect("epoch after transition repair"),
+        EpochId(2),
+        "kill at {point} must reopen to a complete epoch"
+    );
+    assert!(
+        !storage
+            .get_group(&group_id)
+            .expect("group after transition repair")
+            .members
+            .is_empty(),
+        "kill at {point} must not expose partial group state"
     );
 }
 

--- a/crates/incident-replay/AGENTS.md
+++ b/crates/incident-replay/AGENTS.md
@@ -80,12 +80,13 @@ incident becomes a vector only if the simulator reproduces the recorded outcome
     ⇒ no label search) that returns the vector only when the recorded convergence
     decision reproduces. No reproduction ⇒ `AcceptError` (no vector).
 - **Module:** `src/artifact.rs`
-  - **Role:** Versioned evidence envelope and exact normalized-history gate. Legacy exports produce an explicitly
-    `outcome_equivalent_archetype` artifact with derived confidence and named unavailable fields. Exact import requires
-    a complete Scenario IR history, one source-event mapping per step, explicit source rows establishing the contested
-    incident, semantic expected outcomes, no embedded sensitive state, successful IR compilation, and simulator
-    reproduction. Exact semantic replay still marks raw MLS bytes and the engine checkpoint unavailable; byte replay
-    requires the separate local sensitive capsule path.
+  - **Role:** Versioned evidence envelope and producer-attested normalized-history gate. Legacy exports produce an
+    explicitly `outcome_equivalent_archetype` artifact with derived confidence and named unavailable fields. Attested
+    import checks a complete Scenario IR claim, one bounded source-event mapping per step, explicit source rows
+    establishing the contested incident, semantic expected outcomes, successful IR compilation, and simulator
+    reproduction. It does not independently prove action-to-event correspondence and marks unredacted imported
+    Scenario IR confidential. Raw MLS bytes and the engine checkpoint remain unavailable; byte replay requires the
+    separate local sensitive capsule path.
 - **Module:** `src/main.rs`
   - **Role:** CLI — classify one export file; for a fork-recovery or convergence
     incident, run the recover → accept → write pipeline. Exits 0 for any
@@ -180,8 +181,9 @@ Gate designs evaluated against real exports and deliberately **rejected**:
   `cargo run -p incident-replay -- <export.json | export.ndjson>`.
   The CLI rejects inputs larger than 64 MiB before JSON/NDJSON parsing.
 - Keep real inputs under ignored `incident-exports/` and generated local output under `target/` or ignored
-  `incident-replay-output/`. The shareable artifact is normalized evidence only. Never add sensitive local replay
-  capsules or raw forensic exports to version control.
+  `incident-replay-output/`. Producer-attested artifacts may contain unredacted Scenario IR labels and payloads;
+  treat them as confidential unless separately redacted and reviewed. Never add sensitive local replay capsules or
+  raw forensic exports to version control.
 
 ## Verification
 

--- a/crates/incident-replay/AGENTS.md
+++ b/crates/incident-replay/AGENTS.md
@@ -79,6 +79,13 @@ incident becomes a vector only if the simulator reproduces the recorded outcome
     single run-and-compare (winner-agnostic
     ⇒ no label search) that returns the vector only when the recorded convergence
     decision reproduces. No reproduction ⇒ `AcceptError` (no vector).
+- **Module:** `src/artifact.rs`
+  - **Role:** Versioned evidence envelope and exact normalized-history gate. Legacy exports produce an explicitly
+    `outcome_equivalent_archetype` artifact with derived confidence and named unavailable fields. Exact import requires
+    a complete Scenario IR history, one source-event mapping per step, explicit source rows establishing the contested
+    incident, semantic expected outcomes, no embedded sensitive state, successful IR compilation, and simulator
+    reproduction. Exact semantic replay still marks raw MLS bytes and the engine checkpoint unavailable; byte replay
+    requires the separate local sensitive capsule path.
 - **Module:** `src/main.rs`
   - **Role:** CLI — classify one export file; for a fork-recovery or convergence
     incident, run the recover → accept → write pipeline. Exits 0 for any
@@ -87,7 +94,9 @@ incident becomes a vector only if the simulator reproduces the recorded outcome
     line whenever `liveness_advisory` fires and the primary verdict is not
     already the epoch-divergence quarantine, so an accepted or quarantined
     incident never masks a co-occurring engine left behind (the real e1a04e82
-    export carried both an accepted membership fork and a lag-12 stuck device).
+    export carried both an accepted membership fork and a lag-12 stuck device). When an output directory is supplied,
+    writes both the portable vector and `incident-scenario-artifact.v1` evidence envelope owner-only; it never copies
+    the source export, transport ciphertext, or an MLS checkpoint.
 
 ## Classification rules (verified against real Goggles exports)
 
@@ -170,6 +179,9 @@ Gate designs evaluated against real exports and deliberately **rejected**:
 - Real exports are the manual pre-PR verification set:
   `cargo run -p incident-replay -- <export.json | export.ndjson>`.
   The CLI rejects inputs larger than 64 MiB before JSON/NDJSON parsing.
+- Keep real inputs under ignored `incident-exports/` and generated local output under `target/` or ignored
+  `incident-replay-output/`. The shareable artifact is normalized evidence only. Never add sensitive local replay
+  capsules or raw forensic exports to version control.
 
 ## Verification
 

--- a/crates/incident-replay/Cargo.toml
+++ b/crates/incident-replay/Cargo.toml
@@ -11,6 +11,7 @@ serde = { workspace = true }
 serde_json.workspace = true
 thiserror.workspace = true
 cgka-conformance-simulator.workspace = true
+fs-private.workspace = true
 tokio = { workspace = true, features = ["rt", "time"] }
 
 [[bin]]

--- a/crates/incident-replay/schemas/incident-scenario-artifact.v1.schema.json
+++ b/crates/incident-replay/schemas/incident-scenario-artifact.v1.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://marmot-protocol.org/schemas/incident-scenario-artifact.v1.schema.json",
+  "title": "Incident Scenario Artifact v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "source_format",
+    "replay_fidelity",
+    "evidence_confidence",
+    "source_event_count",
+    "incident_event_indices",
+    "action_evidence",
+    "unavailable_fields",
+    "byte_replay_available",
+    "vector"
+  ],
+  "properties": {
+    "schema_version": { "const": "1" },
+    "source_format": {
+      "enum": ["agent_state_document", "goggles_group_export_stream"]
+    },
+    "replay_fidelity": {
+      "enum": ["exact_normalized_history", "outcome_equivalent_archetype"]
+    },
+    "evidence_confidence": {
+      "enum": ["exact_normalized_available_evidence", "derived_outcome_equivalent"]
+    },
+    "source_event_count": { "type": "integer", "minimum": 0 },
+    "incident_event_indices": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "integer", "minimum": 0 }
+    },
+    "action_evidence": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["step_index", "source_event_indices"],
+        "properties": {
+          "step_index": { "type": "integer", "minimum": 0 },
+          "source_event_indices": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "integer", "minimum": 0 }
+          }
+        }
+      }
+    },
+    "unavailable_fields": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["field", "reason"],
+        "properties": {
+          "field": { "type": "string", "minLength": 1 },
+          "reason": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "byte_replay_available": { "const": false },
+    "vector": { "type": "object" }
+  }
+}

--- a/crates/incident-replay/schemas/incident-scenario-artifact.v1.schema.json
+++ b/crates/incident-replay/schemas/incident-scenario-artifact.v1.schema.json
@@ -9,6 +9,8 @@
     "source_format",
     "replay_fidelity",
     "evidence_confidence",
+    "sensitivity",
+    "reproduction_status",
     "source_event_count",
     "incident_event_indices",
     "action_evidence",
@@ -22,10 +24,16 @@
       "enum": ["agent_state_document", "goggles_group_export_stream"]
     },
     "replay_fidelity": {
-      "enum": ["exact_normalized_history", "outcome_equivalent_archetype"]
+      "enum": ["producer_attested_normalized_history", "outcome_equivalent_archetype"]
     },
     "evidence_confidence": {
-      "enum": ["exact_normalized_available_evidence", "derived_outcome_equivalent"]
+      "enum": ["producer_attested_available_evidence", "derived_outcome_equivalent"]
+    },
+    "sensitivity": {
+      "enum": ["confidential_unredacted_scenario", "synthetic_scenario"]
+    },
+    "reproduction_status": {
+      "enum": ["unverified", "reproduced", "not_applicable"]
     },
     "source_event_count": { "type": "integer", "minimum": 0 },
     "incident_event_indices": {

--- a/crates/incident-replay/src/artifact.rs
+++ b/crates/incident-replay/src/artifact.rs
@@ -11,6 +11,7 @@ use cgka_conformance_simulator::{
     ScenarioSpec, TraceExpectation, VectorFixture, compile_scenario, run_scenario_spec,
 };
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 
 use crate::export::AgentStateExport;
 use crate::export::EventKind;
@@ -63,6 +64,10 @@ pub struct NormalizedActionEvidenceV1 {
     pub source_event_indices: Vec<usize>,
 }
 
+fn assume_sensitive_state_included() -> bool {
+    true
+}
+
 /// Optional normalized history supplied alongside a forensic export. `complete`
 /// means complete for the declared Scenario IR actions, not that unavailable
 /// transport bytes or MLS secrets suddenly exist.
@@ -83,7 +88,7 @@ pub struct NormalizedScenarioHistoryV1 {
     pub unavailable_fields: Vec<UnavailableEvidenceV1>,
     /// Producer assertion that no database/OpenMLS checkpoint or raw key state
     /// is embedded. This does not redact free-form Scenario IR labels/payloads.
-    #[serde(default)]
+    #[serde(default = "assume_sensitive_state_included")]
     pub sensitive_state_included: bool,
 }
 
@@ -127,11 +132,14 @@ pub enum NormalizedHistoryImportError {
     InvalidScenario(String),
     #[error("the simulator could not run normalized history")]
     Run(String),
+    #[error("normalized-history simulator execution timed out")]
+    RunTimedOut,
     #[error("producer-attested normalized history did not reproduce its recorded outcomes")]
     NotReproduced,
 }
 
 const MAX_NORMALIZED_HISTORY_BYTES: usize = 1024 * 1024;
+const NORMALIZED_HISTORY_RUN_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Import producer-attested normalized Scenario IR. `Ok(None)` is the ordinary
 /// legacy-export case and should fall back to archetype synthesis with explicit
@@ -244,7 +252,14 @@ pub fn accept_attested_history(
         .build()
         .map_err(|error| NormalizedHistoryImportError::Run(error.to_string()))?;
     let trace = runtime
-        .block_on(run_scenario_spec(&artifact.vector.scenario))
+        .block_on(async {
+            tokio::time::timeout(
+                NORMALIZED_HISTORY_RUN_TIMEOUT,
+                run_scenario_spec(&artifact.vector.scenario),
+            )
+            .await
+        })
+        .map_err(|_| NormalizedHistoryImportError::RunTimedOut)?
         .map_err(|error| NormalizedHistoryImportError::Run(error.to_string()))?;
     if artifact.vector.compare_observed_trace(&trace).is_empty() {
         artifact.reproduction_status = IncidentReproductionStatusV1::Reproduced;

--- a/crates/incident-replay/src/artifact.rs
+++ b/crates/incident-replay/src/artifact.rs
@@ -170,14 +170,18 @@ pub fn archetype_artifact(
     export: &AgentStateExport,
     source_format: IncidentSourceFormatV1,
     vector: VectorFixture,
-) -> IncidentScenarioArtifactV1 {
-    IncidentScenarioArtifactV1 {
+) -> Result<IncidentScenarioArtifactV1, ExactHistoryImportError> {
+    let incident_event_indices = incident_event_indices(export);
+    if incident_event_indices.is_empty() {
+        return Err(ExactHistoryImportError::MissingIncidentEvidence);
+    }
+    Ok(IncidentScenarioArtifactV1 {
         schema_version: "1".into(),
         source_format,
         replay_fidelity: IncidentReplayFidelityV1::OutcomeEquivalentArchetype,
         evidence_confidence: EvidenceConfidenceV1::DerivedOutcomeEquivalent,
         source_event_count: export.events.len(),
-        incident_event_indices: incident_event_indices(export),
+        incident_event_indices,
         action_evidence: Vec::new(),
         unavailable_fields: vec![
             unavailable(
@@ -199,7 +203,7 @@ pub fn archetype_artifact(
         ],
         byte_replay_available: false,
         vector,
-    }
+    })
 }
 
 pub fn accept_exact_history(

--- a/crates/incident-replay/src/artifact.rs
+++ b/crates/incident-replay/src/artifact.rs
@@ -1,10 +1,11 @@
-//! Versioned incident scenario artifacts and exact normalized-history import.
+//! Versioned incident scenario artifacts and producer-attested history import.
 //!
 //! Existing Goggles audit exports usually support an outcome-equivalent
-//! archetype, not exact action replay. An exact import is accepted only when a
-//! producer supplies a complete normalized Scenario IR history and maps every
-//! scenario step back to source audit-event indices. Raw MLS bytes and state
-//! checkpoints stay outside this shareable artifact.
+//! archetype, not exact action replay. A normalized import records a producer's
+//! complete Scenario IR claim and step-to-event bookkeeping, then verifies only
+//! that the declared scenario reproduces. It cannot independently prove that a
+//! source event semantically corresponds to a declared action. Raw MLS bytes
+//! and state checkpoints stay outside this confidential artifact.
 
 use cgka_conformance_simulator::{
     ScenarioSpec, TraceExpectation, VectorFixture, compile_scenario, run_scenario_spec,
@@ -24,15 +25,30 @@ pub enum IncidentSourceFormatV1 {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum IncidentReplayFidelityV1 {
-    ExactNormalizedHistory,
+    ProducerAttestedNormalizedHistory,
     OutcomeEquivalentArchetype,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum EvidenceConfidenceV1 {
-    ExactNormalizedAvailableEvidence,
+    ProducerAttestedAvailableEvidence,
     DerivedOutcomeEquivalent,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IncidentArtifactSensitivityV1 {
+    ConfidentialUnredactedScenario,
+    SyntheticScenario,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IncidentReproductionStatusV1 {
+    Unverified,
+    Reproduced,
+    NotApplicable,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -65,8 +81,8 @@ pub struct NormalizedScenarioHistoryV1 {
     pub incident_event_indices: Vec<usize>,
     #[serde(default)]
     pub unavailable_fields: Vec<UnavailableEvidenceV1>,
-    /// Shareable exact-history import never embeds a database/OpenMLS
-    /// checkpoint. Sensitive state belongs in a local failure capsule.
+    /// Producer assertion that no database/OpenMLS checkpoint or raw key state
+    /// is embedded. This does not redact free-form Scenario IR labels/payloads.
     #[serde(default)]
     pub sensitive_state_included: bool,
 }
@@ -77,6 +93,8 @@ pub struct IncidentScenarioArtifactV1 {
     pub source_format: IncidentSourceFormatV1,
     pub replay_fidelity: IncidentReplayFidelityV1,
     pub evidence_confidence: EvidenceConfidenceV1,
+    pub sensitivity: IncidentArtifactSensitivityV1,
+    pub reproduction_status: IncidentReproductionStatusV1,
     pub source_event_count: usize,
     pub incident_event_indices: Vec<usize>,
     pub action_evidence: Vec<NormalizedActionEvidenceV1>,
@@ -86,8 +104,8 @@ pub struct IncidentScenarioArtifactV1 {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum ExactHistoryImportError {
-    #[error("normalized scenario history uses unsupported schema `{0}`")]
+pub enum NormalizedHistoryImportError {
+    #[error("normalized scenario history uses an unsupported schema")]
     UnsupportedSchema(String),
     #[error("normalized scenario history is marked incomplete")]
     Incomplete,
@@ -97,57 +115,67 @@ pub enum ExactHistoryImportError {
     MissingExpectedOutcomes,
     #[error("normalized scenario history has no Scenario IR actions")]
     EmptyScenario,
+    #[error("normalized scenario history exceeds the portable artifact size limit")]
+    HistoryTooLarge,
     #[error("normalized scenario history does not identify a contested incident source event")]
     MissingIncidentEvidence,
     #[error("normalized scenario history does not map every Scenario IR step exactly once")]
     IncompleteActionEvidence,
     #[error("normalized scenario history references source event {index}, but only {count} exist")]
     SourceEventOutOfRange { index: usize, count: usize },
-    #[error("normalized Scenario IR failed validation: {0}")]
+    #[error("normalized Scenario IR failed validation")]
     InvalidScenario(String),
-    #[error("the simulator could not run exact normalized history: {0}")]
+    #[error("the simulator could not run normalized history")]
     Run(String),
-    #[error("exact normalized history did not reproduce its recorded outcomes")]
+    #[error("producer-attested normalized history did not reproduce its recorded outcomes")]
     NotReproduced,
 }
 
-/// Import exact normalized Scenario IR when the export carries sufficient
-/// evidence. `Ok(None)` is the ordinary legacy-export case and should fall
-/// back to archetype synthesis with explicit unavailable fields.
-pub fn import_exact_history(
+const MAX_NORMALIZED_HISTORY_BYTES: usize = 1024 * 1024;
+
+/// Import producer-attested normalized Scenario IR. `Ok(None)` is the ordinary
+/// legacy-export case and should fall back to archetype synthesis with explicit
+/// unavailable fields.
+pub fn import_attested_history(
     export: &AgentStateExport,
     source_format: IncidentSourceFormatV1,
-) -> Result<Option<IncidentScenarioArtifactV1>, ExactHistoryImportError> {
+) -> Result<Option<IncidentScenarioArtifactV1>, NormalizedHistoryImportError> {
     let Some(history) = export.normalized_scenario_history.as_ref() else {
         return Ok(None);
     };
     if history.schema_version != "1" {
-        return Err(ExactHistoryImportError::UnsupportedSchema(
+        return Err(NormalizedHistoryImportError::UnsupportedSchema(
             history.schema_version.clone(),
         ));
     }
     if !history.complete {
-        return Err(ExactHistoryImportError::Incomplete);
+        return Err(NormalizedHistoryImportError::Incomplete);
     }
     if history.sensitive_state_included {
-        return Err(ExactHistoryImportError::SensitiveStateIncluded);
+        return Err(NormalizedHistoryImportError::SensitiveStateIncluded);
     }
     if history.expected_outcomes.is_empty() {
-        return Err(ExactHistoryImportError::MissingExpectedOutcomes);
+        return Err(NormalizedHistoryImportError::MissingExpectedOutcomes);
     }
     if history.scenario.steps.is_empty() {
-        return Err(ExactHistoryImportError::EmptyScenario);
+        return Err(NormalizedHistoryImportError::EmptyScenario);
+    }
+    if serde_json::to_vec(history).is_ok_and(|encoded| encoded.len() > MAX_NORMALIZED_HISTORY_BYTES)
+    {
+        return Err(NormalizedHistoryImportError::HistoryTooLarge);
     }
     validate_action_evidence(history, export)?;
     compile_scenario(&history.scenario)
-        .map_err(|error| ExactHistoryImportError::InvalidScenario(error.to_string()))?;
+        .map_err(|error| NormalizedHistoryImportError::InvalidScenario(error.to_string()))?;
 
     let unavailable_fields = with_byte_replay_unavailable(history.unavailable_fields.clone());
     Ok(Some(IncidentScenarioArtifactV1 {
         schema_version: "1".into(),
         source_format,
-        replay_fidelity: IncidentReplayFidelityV1::ExactNormalizedHistory,
-        evidence_confidence: EvidenceConfidenceV1::ExactNormalizedAvailableEvidence,
+        replay_fidelity: IncidentReplayFidelityV1::ProducerAttestedNormalizedHistory,
+        evidence_confidence: EvidenceConfidenceV1::ProducerAttestedAvailableEvidence,
+        sensitivity: IncidentArtifactSensitivityV1::ConfidentialUnredactedScenario,
+        reproduction_status: IncidentReproductionStatusV1::Unverified,
         source_event_count: export.events.len(),
         incident_event_indices: history.incident_event_indices.clone(),
         action_evidence: history.action_evidence.clone(),
@@ -170,16 +198,18 @@ pub fn archetype_artifact(
     export: &AgentStateExport,
     source_format: IncidentSourceFormatV1,
     vector: VectorFixture,
-) -> Result<IncidentScenarioArtifactV1, ExactHistoryImportError> {
+) -> Result<IncidentScenarioArtifactV1, NormalizedHistoryImportError> {
     let incident_event_indices = incident_event_indices(export);
     if incident_event_indices.is_empty() {
-        return Err(ExactHistoryImportError::MissingIncidentEvidence);
+        return Err(NormalizedHistoryImportError::MissingIncidentEvidence);
     }
     Ok(IncidentScenarioArtifactV1 {
         schema_version: "1".into(),
         source_format,
         replay_fidelity: IncidentReplayFidelityV1::OutcomeEquivalentArchetype,
         evidence_confidence: EvidenceConfidenceV1::DerivedOutcomeEquivalent,
+        sensitivity: IncidentArtifactSensitivityV1::SyntheticScenario,
+        reproduction_status: IncidentReproductionStatusV1::NotApplicable,
         source_event_count: export.events.len(),
         incident_event_indices,
         action_evidence: Vec::new(),
@@ -206,27 +236,28 @@ pub fn archetype_artifact(
     })
 }
 
-pub fn accept_exact_history(
-    artifact: IncidentScenarioArtifactV1,
-) -> Result<IncidentScenarioArtifactV1, ExactHistoryImportError> {
+pub fn accept_attested_history(
+    mut artifact: IncidentScenarioArtifactV1,
+) -> Result<IncidentScenarioArtifactV1, NormalizedHistoryImportError> {
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_time()
         .build()
-        .map_err(|error| ExactHistoryImportError::Run(error.to_string()))?;
+        .map_err(|error| NormalizedHistoryImportError::Run(error.to_string()))?;
     let trace = runtime
         .block_on(run_scenario_spec(&artifact.vector.scenario))
-        .map_err(|error| ExactHistoryImportError::Run(error.to_string()))?;
+        .map_err(|error| NormalizedHistoryImportError::Run(error.to_string()))?;
     if artifact.vector.compare_observed_trace(&trace).is_empty() {
+        artifact.reproduction_status = IncidentReproductionStatusV1::Reproduced;
         Ok(artifact)
     } else {
-        Err(ExactHistoryImportError::NotReproduced)
+        Err(NormalizedHistoryImportError::NotReproduced)
     }
 }
 
 fn validate_action_evidence(
     history: &NormalizedScenarioHistoryV1,
     export: &AgentStateExport,
-) -> Result<(), ExactHistoryImportError> {
+) -> Result<(), NormalizedHistoryImportError> {
     let source_event_count = export.events.len();
     let mut mapped = history
         .action_evidence
@@ -240,7 +271,7 @@ fn validate_action_evidence(
             .iter()
             .any(|evidence| evidence.source_event_indices.is_empty())
     {
-        return Err(ExactHistoryImportError::IncompleteActionEvidence);
+        return Err(NormalizedHistoryImportError::IncompleteActionEvidence);
     }
     if let Some(index) = history
         .action_evidence
@@ -249,7 +280,7 @@ fn validate_action_evidence(
         .copied()
         .find(|index| *index >= source_event_count)
     {
-        return Err(ExactHistoryImportError::SourceEventOutOfRange {
+        return Err(NormalizedHistoryImportError::SourceEventOutOfRange {
             index,
             count: source_event_count,
         });
@@ -262,7 +293,7 @@ fn validate_action_evidence(
                 .is_none_or(|event| !is_incident_event(&event.kind))
         })
     {
-        return Err(ExactHistoryImportError::MissingIncidentEvidence);
+        return Err(NormalizedHistoryImportError::MissingIncidentEvidence);
     }
     Ok(())
 }
@@ -286,7 +317,7 @@ fn with_byte_replay_unavailable(
     for evidence in [
         unavailable(
             "raw_mls_transport_bytes",
-            "exact normalized action replay is semantic; the shareable artifact contains no MLS ciphertext",
+            "producer-attested normalized replay is semantic; the artifact contains no MLS ciphertext",
         ),
         unavailable(
             "mls_state_checkpoint",

--- a/crates/incident-replay/src/artifact.rs
+++ b/crates/incident-replay/src/artifact.rs
@@ -1,0 +1,307 @@
+//! Versioned incident scenario artifacts and exact normalized-history import.
+//!
+//! Existing Goggles audit exports usually support an outcome-equivalent
+//! archetype, not exact action replay. An exact import is accepted only when a
+//! producer supplies a complete normalized Scenario IR history and maps every
+//! scenario step back to source audit-event indices. Raw MLS bytes and state
+//! checkpoints stay outside this shareable artifact.
+
+use cgka_conformance_simulator::{
+    ScenarioSpec, TraceExpectation, VectorFixture, compile_scenario, run_scenario_spec,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::export::AgentStateExport;
+use crate::export::EventKind;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IncidentSourceFormatV1 {
+    AgentStateDocument,
+    GogglesGroupExportStream,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IncidentReplayFidelityV1 {
+    ExactNormalizedHistory,
+    OutcomeEquivalentArchetype,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceConfidenceV1 {
+    ExactNormalizedAvailableEvidence,
+    DerivedOutcomeEquivalent,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UnavailableEvidenceV1 {
+    pub field: String,
+    pub reason: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NormalizedActionEvidenceV1 {
+    pub step_index: usize,
+    pub source_event_indices: Vec<usize>,
+}
+
+/// Optional normalized history supplied alongside a forensic export. `complete`
+/// means complete for the declared Scenario IR actions, not that unavailable
+/// transport bytes or MLS secrets suddenly exist.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NormalizedScenarioHistoryV1 {
+    pub schema_version: String,
+    pub complete: bool,
+    pub scenario: ScenarioSpec,
+    #[serde(default)]
+    pub expected_outcomes: Vec<TraceExpectation>,
+    #[serde(default)]
+    pub action_evidence: Vec<NormalizedActionEvidenceV1>,
+    /// Source rows that establish the fork/convergence incident this history
+    /// claims to reproduce.
+    #[serde(default)]
+    pub incident_event_indices: Vec<usize>,
+    #[serde(default)]
+    pub unavailable_fields: Vec<UnavailableEvidenceV1>,
+    /// Shareable exact-history import never embeds a database/OpenMLS
+    /// checkpoint. Sensitive state belongs in a local failure capsule.
+    #[serde(default)]
+    pub sensitive_state_included: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IncidentScenarioArtifactV1 {
+    pub schema_version: String,
+    pub source_format: IncidentSourceFormatV1,
+    pub replay_fidelity: IncidentReplayFidelityV1,
+    pub evidence_confidence: EvidenceConfidenceV1,
+    pub source_event_count: usize,
+    pub incident_event_indices: Vec<usize>,
+    pub action_evidence: Vec<NormalizedActionEvidenceV1>,
+    pub unavailable_fields: Vec<UnavailableEvidenceV1>,
+    pub byte_replay_available: bool,
+    pub vector: VectorFixture,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ExactHistoryImportError {
+    #[error("normalized scenario history uses unsupported schema `{0}`")]
+    UnsupportedSchema(String),
+    #[error("normalized scenario history is marked incomplete")]
+    Incomplete,
+    #[error("normalized scenario history includes sensitive state")]
+    SensitiveStateIncluded,
+    #[error("normalized scenario history has no semantic expected outcomes")]
+    MissingExpectedOutcomes,
+    #[error("normalized scenario history has no Scenario IR actions")]
+    EmptyScenario,
+    #[error("normalized scenario history does not identify a contested incident source event")]
+    MissingIncidentEvidence,
+    #[error("normalized scenario history does not map every Scenario IR step exactly once")]
+    IncompleteActionEvidence,
+    #[error("normalized scenario history references source event {index}, but only {count} exist")]
+    SourceEventOutOfRange { index: usize, count: usize },
+    #[error("normalized Scenario IR failed validation: {0}")]
+    InvalidScenario(String),
+    #[error("the simulator could not run exact normalized history: {0}")]
+    Run(String),
+    #[error("exact normalized history did not reproduce its recorded outcomes")]
+    NotReproduced,
+}
+
+/// Import exact normalized Scenario IR when the export carries sufficient
+/// evidence. `Ok(None)` is the ordinary legacy-export case and should fall
+/// back to archetype synthesis with explicit unavailable fields.
+pub fn import_exact_history(
+    export: &AgentStateExport,
+    source_format: IncidentSourceFormatV1,
+) -> Result<Option<IncidentScenarioArtifactV1>, ExactHistoryImportError> {
+    let Some(history) = export.normalized_scenario_history.as_ref() else {
+        return Ok(None);
+    };
+    if history.schema_version != "1" {
+        return Err(ExactHistoryImportError::UnsupportedSchema(
+            history.schema_version.clone(),
+        ));
+    }
+    if !history.complete {
+        return Err(ExactHistoryImportError::Incomplete);
+    }
+    if history.sensitive_state_included {
+        return Err(ExactHistoryImportError::SensitiveStateIncluded);
+    }
+    if history.expected_outcomes.is_empty() {
+        return Err(ExactHistoryImportError::MissingExpectedOutcomes);
+    }
+    if history.scenario.steps.is_empty() {
+        return Err(ExactHistoryImportError::EmptyScenario);
+    }
+    validate_action_evidence(history, export)?;
+    compile_scenario(&history.scenario)
+        .map_err(|error| ExactHistoryImportError::InvalidScenario(error.to_string()))?;
+
+    let unavailable_fields = with_byte_replay_unavailable(history.unavailable_fields.clone());
+    Ok(Some(IncidentScenarioArtifactV1 {
+        schema_version: "1".into(),
+        source_format,
+        replay_fidelity: IncidentReplayFidelityV1::ExactNormalizedHistory,
+        evidence_confidence: EvidenceConfidenceV1::ExactNormalizedAvailableEvidence,
+        source_event_count: export.events.len(),
+        incident_event_indices: history.incident_event_indices.clone(),
+        action_evidence: history.action_evidence.clone(),
+        unavailable_fields,
+        byte_replay_available: false,
+        vector: VectorFixture {
+            scenario_name: history.scenario.name.clone(),
+            vector_version: "1".into(),
+            conformance_version: env!("CARGO_PKG_VERSION").into(),
+            seed: None,
+            application_profile: None,
+            scenario: history.scenario.clone(),
+            expected_trace: None,
+            expected_outcomes: history.expected_outcomes.clone(),
+        },
+    }))
+}
+
+pub fn archetype_artifact(
+    export: &AgentStateExport,
+    source_format: IncidentSourceFormatV1,
+    vector: VectorFixture,
+) -> IncidentScenarioArtifactV1 {
+    IncidentScenarioArtifactV1 {
+        schema_version: "1".into(),
+        source_format,
+        replay_fidelity: IncidentReplayFidelityV1::OutcomeEquivalentArchetype,
+        evidence_confidence: EvidenceConfidenceV1::DerivedOutcomeEquivalent,
+        source_event_count: export.events.len(),
+        incident_event_indices: incident_event_indices(export),
+        action_evidence: Vec::new(),
+        unavailable_fields: vec![
+            unavailable(
+                "exact_scenario_action_history",
+                "the forensic export does not map audit observations to a complete Scenario IR action sequence",
+            ),
+            unavailable(
+                "exact_transport_delivery_order",
+                "audit observations do not prove the complete relay delivery schedule seen by every participant",
+            ),
+            unavailable(
+                "raw_mls_transport_bytes",
+                "the normalized forensic export intentionally carries no replayable MLS ciphertext",
+            ),
+            unavailable(
+                "mls_state_checkpoint",
+                "byte replay requires a separately captured sensitive local engine checkpoint",
+            ),
+        ],
+        byte_replay_available: false,
+        vector,
+    }
+}
+
+pub fn accept_exact_history(
+    artifact: IncidentScenarioArtifactV1,
+) -> Result<IncidentScenarioArtifactV1, ExactHistoryImportError> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .build()
+        .map_err(|error| ExactHistoryImportError::Run(error.to_string()))?;
+    let trace = runtime
+        .block_on(run_scenario_spec(&artifact.vector.scenario))
+        .map_err(|error| ExactHistoryImportError::Run(error.to_string()))?;
+    if artifact.vector.compare_observed_trace(&trace).is_empty() {
+        Ok(artifact)
+    } else {
+        Err(ExactHistoryImportError::NotReproduced)
+    }
+}
+
+fn validate_action_evidence(
+    history: &NormalizedScenarioHistoryV1,
+    export: &AgentStateExport,
+) -> Result<(), ExactHistoryImportError> {
+    let source_event_count = export.events.len();
+    let mut mapped = history
+        .action_evidence
+        .iter()
+        .map(|evidence| evidence.step_index)
+        .collect::<Vec<_>>();
+    mapped.sort_unstable();
+    if mapped != (0..history.scenario.steps.len()).collect::<Vec<_>>()
+        || history
+            .action_evidence
+            .iter()
+            .any(|evidence| evidence.source_event_indices.is_empty())
+    {
+        return Err(ExactHistoryImportError::IncompleteActionEvidence);
+    }
+    if let Some(index) = history
+        .action_evidence
+        .iter()
+        .flat_map(|evidence| &evidence.source_event_indices)
+        .copied()
+        .find(|index| *index >= source_event_count)
+    {
+        return Err(ExactHistoryImportError::SourceEventOutOfRange {
+            index,
+            count: source_event_count,
+        });
+    }
+    if history.incident_event_indices.is_empty()
+        || history.incident_event_indices.iter().any(|index| {
+            export
+                .events
+                .get(*index)
+                .is_none_or(|event| !is_incident_event(&event.kind))
+        })
+    {
+        return Err(ExactHistoryImportError::MissingIncidentEvidence);
+    }
+    Ok(())
+}
+
+fn incident_event_indices(export: &AgentStateExport) -> Vec<usize> {
+    export
+        .events
+        .iter()
+        .enumerate()
+        .filter_map(|(index, event)| is_incident_event(&event.kind).then_some(index))
+        .collect()
+}
+
+fn is_incident_event(kind: &EventKind) -> bool {
+    kind.is_fork_resolution() || kind.is_contested_convergence()
+}
+
+fn with_byte_replay_unavailable(
+    mut unavailable_fields: Vec<UnavailableEvidenceV1>,
+) -> Vec<UnavailableEvidenceV1> {
+    for evidence in [
+        unavailable(
+            "raw_mls_transport_bytes",
+            "exact normalized action replay is semantic; the shareable artifact contains no MLS ciphertext",
+        ),
+        unavailable(
+            "mls_state_checkpoint",
+            "byte replay requires a separately captured sensitive local engine checkpoint",
+        ),
+    ] {
+        if !unavailable_fields
+            .iter()
+            .any(|existing| existing.field == evidence.field)
+        {
+            unavailable_fields.push(evidence);
+        }
+    }
+    unavailable_fields
+}
+
+fn unavailable(field: &str, reason: &str) -> UnavailableEvidenceV1 {
+    UnavailableEvidenceV1 {
+        field: field.into(),
+        reason: reason.into(),
+    }
+}

--- a/crates/incident-replay/src/export.rs
+++ b/crates/incident-replay/src/export.rs
@@ -18,6 +18,10 @@ pub struct AgentStateExport {
     pub events: Vec<AuditEvent>,
     #[serde(default)]
     pub derived_projections: DerivedProjections,
+    /// Optional complete, normalized Scenario IR history. Existing Goggles
+    /// exports omit it and remain eligible only for archetype synthesis.
+    #[serde(default)]
+    pub normalized_scenario_history: Option<crate::artifact::NormalizedScenarioHistoryV1>,
 }
 
 /// Server-side projections. Only the pagination cursors are modelled: they carry

--- a/crates/incident-replay/src/lib.rs
+++ b/crates/incident-replay/src/lib.rs
@@ -25,9 +25,10 @@
 //! - [`accept`] — [`accept::accept`] / [`accept::accept_convergence`] run the
 //!   synthesized scenario against the simulator and return the vector only if the
 //!   recorded outcome reproduces.
-//! - [`artifact`] — a versioned evidence envelope plus the fail-closed exact
-//!   normalized-history import/accept gate. Archetypes never masquerade as exact
-//!   replay, and byte replay remains unavailable without sensitive local state.
+//! - [`artifact`] — a versioned evidence envelope plus a fail-closed,
+//!   producer-attested normalized-history import/accept gate. Archetypes never
+//!   masquerade as source-verified replay, and byte replay remains unavailable
+//!   without sensitive local state.
 
 pub mod accept;
 pub mod artifact;
@@ -40,10 +41,10 @@ pub mod synth;
 
 pub use accept::{AcceptError, accept, accept_convergence};
 pub use artifact::{
-    EvidenceConfidenceV1, ExactHistoryImportError, IncidentReplayFidelityV1,
-    IncidentScenarioArtifactV1, IncidentSourceFormatV1, NormalizedActionEvidenceV1,
-    NormalizedScenarioHistoryV1, UnavailableEvidenceV1, accept_exact_history, archetype_artifact,
-    import_exact_history,
+    EvidenceConfidenceV1, IncidentArtifactSensitivityV1, IncidentReplayFidelityV1,
+    IncidentReproductionStatusV1, IncidentScenarioArtifactV1, IncidentSourceFormatV1,
+    NormalizedActionEvidenceV1, NormalizedHistoryImportError, NormalizedScenarioHistoryV1,
+    UnavailableEvidenceV1, accept_attested_history, archetype_artifact, import_attested_history,
 };
 pub use classify::{
     BehindEngine, BehindMode, QuarantineReason, Verdict, classify, liveness_advisory,

--- a/crates/incident-replay/src/lib.rs
+++ b/crates/incident-replay/src/lib.rs
@@ -25,8 +25,12 @@
 //! - [`accept`] — [`accept::accept`] / [`accept::accept_convergence`] run the
 //!   synthesized scenario against the simulator and return the vector only if the
 //!   recorded outcome reproduces.
+//! - [`artifact`] — a versioned evidence envelope plus the fail-closed exact
+//!   normalized-history import/accept gate. Archetypes never masquerade as exact
+//!   replay, and byte replay remains unavailable without sensitive local state.
 
 pub mod accept;
+pub mod artifact;
 pub mod classify;
 pub mod convergence;
 pub mod export;
@@ -35,6 +39,12 @@ pub mod ndjson;
 pub mod synth;
 
 pub use accept::{AcceptError, accept, accept_convergence};
+pub use artifact::{
+    EvidenceConfidenceV1, ExactHistoryImportError, IncidentReplayFidelityV1,
+    IncidentScenarioArtifactV1, IncidentSourceFormatV1, NormalizedActionEvidenceV1,
+    NormalizedScenarioHistoryV1, UnavailableEvidenceV1, accept_exact_history, archetype_artifact,
+    import_exact_history,
+};
 pub use classify::{
     BehindEngine, BehindMode, QuarantineReason, Verdict, classify, liveness_advisory,
 };

--- a/crates/incident-replay/src/main.rs
+++ b/crates/incident-replay/src/main.rs
@@ -13,10 +13,11 @@ use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
-use cgka_conformance_simulator::VectorFixture;
 use incident_replay::{
-    AgentStateExport, ForkCommitKind, QuarantineReason, Verdict, accept, accept_convergence,
-    classify, is_stream, liveness_advisory, parse, parse_stream, recover_convergence, recover_fork,
+    AgentStateExport, ForkCommitKind, IncidentScenarioArtifactV1, IncidentSourceFormatV1,
+    QuarantineReason, Verdict, accept, accept_convergence, accept_exact_history,
+    archetype_artifact, classify, import_exact_history, is_stream, liveness_advisory, parse,
+    parse_stream, recover_convergence, recover_fork,
 };
 
 /// Vector name for a group-metadata fork-recovery incident.
@@ -45,7 +46,13 @@ fn main() -> ExitCode {
             return ExitCode::from(2);
         }
     };
-    let export = if is_stream(&json) {
+    let stream = is_stream(&json);
+    let source_format = if stream {
+        IncidentSourceFormatV1::GogglesGroupExportStream
+    } else {
+        IncidentSourceFormatV1::AgentStateDocument
+    };
+    let export = if stream {
         match parse_stream(&json) {
             Ok(export) => export,
             Err(err) => {
@@ -74,12 +81,12 @@ fn main() -> ExitCode {
         }
     );
     let code = match verdict {
-        Verdict::ForkRecovery => run_fork_recovery(&export, out_dir.as_deref()),
+        Verdict::ForkRecovery => run_fork_recovery(&export, source_format, out_dir.as_deref()),
         Verdict::Healthy => {
             println!("healthy: 0 vectors");
             ExitCode::SUCCESS
         }
-        Verdict::ConvergenceSelected => run_convergence(&export, out_dir.as_deref()),
+        Verdict::ConvergenceSelected => run_convergence(&export, source_format, out_dir.as_deref()),
         Verdict::Quarantine { reason } => quarantine(&reason),
     };
     if !liveness_is_primary && let Some(reason) = liveness_advisory(&export) {
@@ -106,7 +113,21 @@ fn read_utf8_limited(reader: impl Read, max_bytes: u64) -> io::Result<String> {
     String::from_utf8(bytes).map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
 }
 
-fn run_fork_recovery(export: &AgentStateExport, out_dir: Option<&Path>) -> ExitCode {
+fn run_fork_recovery(
+    export: &AgentStateExport,
+    source_format: IncidentSourceFormatV1,
+    out_dir: Option<&Path>,
+) -> ExitCode {
+    match import_exact_history(export, source_format) {
+        Ok(Some(artifact)) => {
+            return match accept_exact_history(artifact) {
+                Ok(artifact) => persist_or_report(&artifact, out_dir),
+                Err(error) => quarantine(&error),
+            };
+        }
+        Ok(None) => {}
+        Err(error) => return quarantine(&error),
+    }
     let fork = match recover_fork(export) {
         Ok(fork) => fork,
         Err(err) => return quarantine(&err),
@@ -116,18 +137,36 @@ fn run_fork_recovery(export: &AgentStateExport, out_dir: Option<&Path>) -> ExitC
         ForkCommitKind::Membership => MEMBERSHIP_INCIDENT_NAME,
     };
     match accept(&fork, name) {
-        Ok(vector) => persist_or_report(&vector, out_dir),
+        Ok(vector) => {
+            persist_or_report(&archetype_artifact(export, source_format, vector), out_dir)
+        }
         Err(err) => quarantine(&err),
     }
 }
 
-fn run_convergence(export: &AgentStateExport, out_dir: Option<&Path>) -> ExitCode {
+fn run_convergence(
+    export: &AgentStateExport,
+    source_format: IncidentSourceFormatV1,
+    out_dir: Option<&Path>,
+) -> ExitCode {
+    match import_exact_history(export, source_format) {
+        Ok(Some(artifact)) => {
+            return match accept_exact_history(artifact) {
+                Ok(artifact) => persist_or_report(&artifact, out_dir),
+                Err(error) => quarantine(&error),
+            };
+        }
+        Ok(None) => {}
+        Err(error) => return quarantine(&error),
+    }
     let conv = match recover_convergence(export) {
         Ok(conv) => conv,
         Err(err) => return quarantine(&err),
     };
     match accept_convergence(&conv, CONVERGENCE_NAME) {
-        Ok(vector) => persist_or_report(&vector, out_dir),
+        Ok(vector) => {
+            persist_or_report(&archetype_artifact(export, source_format, vector), out_dir)
+        }
         Err(err) => quarantine(&err),
     }
 }
@@ -139,40 +178,60 @@ fn quarantine(reason: &dyn std::fmt::Display) -> ExitCode {
     ExitCode::SUCCESS
 }
 
-/// Write the accepted vector to `out_dir`, or print it when no dir was given.
-fn persist_or_report(vector: &VectorFixture, out_dir: Option<&Path>) -> ExitCode {
+/// Write the accepted vector plus evidence artifact to `out_dir`, or describe
+/// its fidelity when no directory was given.
+fn persist_or_report(artifact: &IncidentScenarioArtifactV1, out_dir: Option<&Path>) -> ExitCode {
     match out_dir {
-        Some(dir) => match write_vector(vector, dir) {
-            Ok(path) => {
-                println!("accepted: wrote {}", path.display());
+        Some(dir) => match write_artifact(artifact, dir) {
+            Ok((vector_path, artifact_path)) => {
+                println!(
+                    "accepted ({:?}): wrote {} and {}",
+                    artifact.replay_fidelity,
+                    vector_path.display(),
+                    artifact_path.display()
+                );
                 ExitCode::SUCCESS
             }
             Err(err) => {
-                eprintln!("error: cannot write vector: {err}");
+                eprintln!("error: cannot write incident artifacts: {err}");
                 ExitCode::from(2)
             }
         },
         None => {
             println!(
-                "accepted: {} (pass an out-dir to persist)",
-                vector.scenario_name
+                "accepted ({:?}): {}; exact byte replay unavailable without sensitive local state; unavailable fields: {} (pass an out-dir to persist)",
+                artifact.replay_fidelity,
+                artifact.vector.scenario_name,
+                artifact
+                    .unavailable_fields
+                    .iter()
+                    .map(|field| field.field.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
             );
             ExitCode::SUCCESS
         }
     }
 }
 
-/// Write a vector as `<dir>/<name>.v1.json` (creating `dir`), returning the path.
-fn write_vector(vector: &VectorFixture, dir: &Path) -> std::io::Result<PathBuf> {
-    std::fs::create_dir_all(dir)?;
-    let stem = vector
-        .scenario_name
-        .rsplit_once('/')
-        .map_or(vector.scenario_name.as_str(), |(stem, _version)| stem);
-    let path = dir.join(format!("{stem}.v1.json"));
-    let json = serde_json::to_string_pretty(vector).expect("vector serializes");
-    std::fs::write(&path, format!("{json}\n"))?;
-    Ok(path)
+/// Write a shareable vector and its evidence envelope owner-only. No source
+/// export, transport bytes, or MLS checkpoint is copied into either file.
+fn write_artifact(
+    artifact: &IncidentScenarioArtifactV1,
+    dir: &Path,
+) -> std::io::Result<(PathBuf, PathBuf)> {
+    fs_private::create_dir_all_private(dir)?;
+    let stem = artifact.vector.scenario_name.rsplit_once('/').map_or(
+        artifact.vector.scenario_name.as_str(),
+        |(stem, _version)| stem,
+    );
+    let vector_path = dir.join(format!("{stem}.v1.json"));
+    let artifact_path = dir.join(format!("{stem}.incident.v1.json"));
+    let vector_json = serde_json::to_string_pretty(&artifact.vector).expect("vector serializes");
+    let artifact_json = serde_json::to_string_pretty(artifact).expect("artifact serializes");
+    fs_private::write_private(&vector_path, format!("{vector_json}\n").as_bytes())?;
+    fs_private::write_private(&artifact_path, format!("{artifact_json}\n").as_bytes())?;
+    Ok((vector_path, artifact_path))
 }
 
 #[cfg(test)]

--- a/crates/incident-replay/src/main.rs
+++ b/crates/incident-replay/src/main.rs
@@ -14,9 +14,10 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use incident_replay::{
-    AgentStateExport, ForkCommitKind, IncidentScenarioArtifactV1, IncidentSourceFormatV1,
-    QuarantineReason, Verdict, accept, accept_convergence, accept_exact_history,
-    archetype_artifact, classify, import_exact_history, is_stream, liveness_advisory, parse,
+    AgentStateExport, ForkCommitKind, IncidentReplayFidelityV1, IncidentReproductionStatusV1,
+    IncidentScenarioArtifactV1, IncidentSourceFormatV1, NormalizedHistoryImportError,
+    QuarantineReason, Verdict, accept, accept_attested_history, accept_convergence,
+    archetype_artifact, classify, import_attested_history, is_stream, liveness_advisory, parse,
     parse_stream, recover_convergence, recover_fork,
 };
 
@@ -118,15 +119,15 @@ fn run_fork_recovery(
     source_format: IncidentSourceFormatV1,
     out_dir: Option<&Path>,
 ) -> ExitCode {
-    match import_exact_history(export, source_format) {
+    match import_attested_history(export, source_format) {
         Ok(Some(artifact)) => {
-            return match accept_exact_history(artifact) {
+            return match accept_attested_history(artifact) {
                 Ok(artifact) => persist_or_report(&artifact, out_dir),
-                Err(error) => quarantine(&error),
+                Err(error) => normalized_history_failure(&error),
             };
         }
         Ok(None) => {}
-        Err(error) => return quarantine(&error),
+        Err(error) => return normalized_history_failure(&error),
     }
     let fork = match recover_fork(export) {
         Ok(fork) => fork,
@@ -150,15 +151,15 @@ fn run_convergence(
     source_format: IncidentSourceFormatV1,
     out_dir: Option<&Path>,
 ) -> ExitCode {
-    match import_exact_history(export, source_format) {
+    match import_attested_history(export, source_format) {
         Ok(Some(artifact)) => {
-            return match accept_exact_history(artifact) {
+            return match accept_attested_history(artifact) {
                 Ok(artifact) => persist_or_report(&artifact, out_dir),
-                Err(error) => quarantine(&error),
+                Err(error) => normalized_history_failure(&error),
             };
         }
         Ok(None) => {}
-        Err(error) => return quarantine(&error),
+        Err(error) => return normalized_history_failure(&error),
     }
     let conv = match recover_convergence(export) {
         Ok(conv) => conv,
@@ -180,15 +181,31 @@ fn quarantine(reason: &dyn std::fmt::Display) -> ExitCode {
     ExitCode::SUCCESS
 }
 
+fn normalized_history_failure(error: &NormalizedHistoryImportError) -> ExitCode {
+    if matches!(error, NormalizedHistoryImportError::Run(_)) {
+        eprintln!("error: normalized-history simulator infrastructure failed");
+        ExitCode::from(2)
+    } else {
+        quarantine(error)
+    }
+}
+
 /// Write the accepted vector plus evidence artifact to `out_dir`, or describe
 /// its fidelity when no directory was given.
 fn persist_or_report(artifact: &IncidentScenarioArtifactV1, out_dir: Option<&Path>) -> ExitCode {
+    if artifact.replay_fidelity == IncidentReplayFidelityV1::ProducerAttestedNormalizedHistory
+        && artifact.reproduction_status != IncidentReproductionStatusV1::Reproduced
+    {
+        eprintln!("error: refusing to persist an unreproduced normalized-history artifact");
+        return ExitCode::from(2);
+    }
     match out_dir {
         Some(dir) => match write_artifact(artifact, dir) {
             Ok((vector_path, artifact_path)) => {
                 println!(
-                    "accepted ({:?}): wrote {} and {}",
+                    "accepted ({:?}, {:?}): wrote {} and {}",
                     artifact.replay_fidelity,
+                    artifact.sensitivity,
                     vector_path.display(),
                     artifact_path.display()
                 );
@@ -201,9 +218,9 @@ fn persist_or_report(artifact: &IncidentScenarioArtifactV1, out_dir: Option<&Pat
         },
         None => {
             println!(
-                "accepted ({:?}): {}; exact byte replay unavailable without sensitive local state; unavailable fields: {} (pass an out-dir to persist)",
+                "accepted ({:?}, {:?}); byte replay unavailable without sensitive local state; unavailable fields: {} (pass an out-dir to persist)",
                 artifact.replay_fidelity,
-                artifact.vector.scenario_name,
+                artifact.sensitivity,
                 artifact
                     .unavailable_fields
                     .iter()
@@ -216,14 +233,20 @@ fn persist_or_report(artifact: &IncidentScenarioArtifactV1, out_dir: Option<&Pat
     }
 }
 
-/// Write a shareable vector and its evidence envelope owner-only. No source
-/// export, transport bytes, or MLS checkpoint is copied into either file.
+/// Write a vector and evidence envelope owner-only. Producer-attested Scenario
+/// IR may contain unredacted labels and payloads and remains confidential.
 fn write_artifact(
     artifact: &IncidentScenarioArtifactV1,
     dir: &Path,
 ) -> std::io::Result<(PathBuf, PathBuf)> {
     fs_private::create_dir_all_private(dir)?;
-    let stem = artifact_stem(&artifact.vector.scenario_name);
+    let stem = if artifact.sensitivity
+        == incident_replay::IncidentArtifactSensitivityV1::ConfidentialUnredactedScenario
+    {
+        "confidential-normalized-incident".to_owned()
+    } else {
+        artifact_stem(&artifact.vector.scenario_name)
+    };
     let vector_path = dir.join(format!("{stem}.v1.json"));
     let artifact_path = dir.join(format!("{stem}.incident.v1.json"));
     let vector_json = serde_json::to_string_pretty(&artifact.vector).expect("vector serializes");

--- a/crates/incident-replay/src/main.rs
+++ b/crates/incident-replay/src/main.rs
@@ -137,9 +137,10 @@ fn run_fork_recovery(
         ForkCommitKind::Membership => MEMBERSHIP_INCIDENT_NAME,
     };
     match accept(&fork, name) {
-        Ok(vector) => {
-            persist_or_report(&archetype_artifact(export, source_format, vector), out_dir)
-        }
+        Ok(vector) => match archetype_artifact(export, source_format, vector) {
+            Ok(artifact) => persist_or_report(&artifact, out_dir),
+            Err(error) => quarantine(&error),
+        },
         Err(err) => quarantine(&err),
     }
 }
@@ -164,9 +165,10 @@ fn run_convergence(
         Err(err) => return quarantine(&err),
     };
     match accept_convergence(&conv, CONVERGENCE_NAME) {
-        Ok(vector) => {
-            persist_or_report(&archetype_artifact(export, source_format, vector), out_dir)
-        }
+        Ok(vector) => match archetype_artifact(export, source_format, vector) {
+            Ok(artifact) => persist_or_report(&artifact, out_dir),
+            Err(error) => quarantine(&error),
+        },
         Err(err) => quarantine(&err),
     }
 }
@@ -221,10 +223,7 @@ fn write_artifact(
     dir: &Path,
 ) -> std::io::Result<(PathBuf, PathBuf)> {
     fs_private::create_dir_all_private(dir)?;
-    let stem = artifact.vector.scenario_name.rsplit_once('/').map_or(
-        artifact.vector.scenario_name.as_str(),
-        |(stem, _version)| stem,
-    );
+    let stem = artifact_stem(&artifact.vector.scenario_name);
     let vector_path = dir.join(format!("{stem}.v1.json"));
     let artifact_path = dir.join(format!("{stem}.incident.v1.json"));
     let vector_json = serde_json::to_string_pretty(&artifact.vector).expect("vector serializes");
@@ -232,6 +231,24 @@ fn write_artifact(
     fs_private::write_private(&vector_path, format!("{vector_json}\n").as_bytes())?;
     fs_private::write_private(&artifact_path, format!("{artifact_json}\n").as_bytes())?;
     Ok((vector_path, artifact_path))
+}
+
+fn artifact_stem(scenario_name: &str) -> String {
+    let raw_stem = scenario_name
+        .rsplit_once('/')
+        .map_or(scenario_name, |(stem, _version)| stem);
+    let mut stem = raw_stem
+        .chars()
+        .take(96)
+        .map(|character| match character {
+            'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' | '.' => character,
+            _ => '-',
+        })
+        .collect::<String>();
+    if stem.is_empty() || stem == "." || stem == ".." {
+        stem = "incident".into();
+    }
+    stem
 }
 
 #[cfg(test)]
@@ -251,5 +268,14 @@ mod tests {
             read_utf8_limited(io::Cursor::new("ciao".as_bytes()), 4).unwrap(),
             "ciao"
         );
+    }
+
+    #[test]
+    fn artifact_stem_is_one_safe_path_component() {
+        let stem = artifact_stem("../../outside/incident/v1");
+        assert!(!stem.contains('/'));
+        assert!(!stem.contains('\\'));
+        assert_ne!(stem, ".");
+        assert_ne!(stem, "..");
     }
 }

--- a/crates/incident-replay/src/main.rs
+++ b/crates/incident-replay/src/main.rs
@@ -182,7 +182,10 @@ fn quarantine(reason: &dyn std::fmt::Display) -> ExitCode {
 }
 
 fn normalized_history_failure(error: &NormalizedHistoryImportError) -> ExitCode {
-    if matches!(error, NormalizedHistoryImportError::Run(_)) {
+    if matches!(
+        error,
+        NormalizedHistoryImportError::Run(_) | NormalizedHistoryImportError::RunTimedOut
+    ) {
         eprintln!("error: normalized-history simulator infrastructure failed");
         ExitCode::from(2)
     } else {

--- a/crates/incident-replay/src/ndjson.rs
+++ b/crates/incident-replay/src/ndjson.rs
@@ -119,6 +119,7 @@ pub fn parse_stream(input: &str) -> Result<AgentStateExport, StreamParseError> {
     Ok(AgentStateExport {
         events,
         derived_projections: Default::default(),
+        normalized_scenario_history: None,
     })
 }
 

--- a/crates/incident-replay/tests/artifact.rs
+++ b/crates/incident-replay/tests/artifact.rs
@@ -151,6 +151,28 @@ fn attested_history_preconditions_have_typed_fail_closed_errors() {
 }
 
 #[test]
+fn missing_sensitive_state_attestation_fails_closed() {
+    let mut export = export_with_history();
+    let history = export
+        .normalized_scenario_history
+        .take()
+        .expect("history is present");
+    let mut encoded = serde_json::to_value(history).expect("history serializes");
+    encoded
+        .as_object_mut()
+        .expect("history is an object")
+        .remove("sensitive_state_included");
+    export.normalized_scenario_history = Some(
+        serde_json::from_value(encoded).expect("history without the attestation still parses"),
+    );
+
+    assert!(matches!(
+        import_attested_history(&export, IncidentSourceFormatV1::AgentStateDocument),
+        Err(NormalizedHistoryImportError::SensitiveStateIncluded)
+    ));
+}
+
+#[test]
 fn legacy_export_is_an_explicitly_inexact_archetype() {
     let mut export = export_with_history();
     export.normalized_scenario_history = None;

--- a/crates/incident-replay/tests/artifact.rs
+++ b/crates/incident-replay/tests/artifact.rs
@@ -1,0 +1,119 @@
+use incident_replay::{
+    EvidenceConfidenceV1, ExactHistoryImportError, ForkCommitKind, IncidentReplayFidelityV1,
+    IncidentSourceFormatV1, NormalizedActionEvidenceV1, NormalizedScenarioHistoryV1, RecoveredFork,
+    accept_exact_history, archetype_artifact, import_exact_history, parse, synthesize,
+};
+
+fn export_with_history() -> incident_replay::AgentStateExport {
+    let fork = RecoveredFork {
+        source_epoch: 30,
+        commit: ForkCommitKind::Membership,
+    };
+    let vector = synthesize(
+        &fork,
+        "exact-normalized-membership-incident/v1",
+        "alice",
+        "bob",
+    );
+    let action_count = vector.scenario.steps.len();
+    let mut events = vec![serde_json::json!({
+        "kind": {
+            "type": "fork_resolution",
+            "source_epoch": 30,
+            "winner": "candidate"
+        }
+    })];
+    events.extend(
+        (0..action_count)
+            .map(|_| serde_json::json!({ "kind": { "type": "normalized_source_action" } }))
+            .collect::<Vec<_>>(),
+    );
+    let mut export = parse(&serde_json::json!({ "events": events }).to_string()).expect("parses");
+    export.normalized_scenario_history = Some(NormalizedScenarioHistoryV1 {
+        schema_version: "1".into(),
+        complete: true,
+        scenario: vector.scenario,
+        expected_outcomes: vector.expected_outcomes,
+        action_evidence: (0..action_count)
+            .map(|step_index| NormalizedActionEvidenceV1 {
+                step_index,
+                source_event_indices: vec![step_index + 1],
+            })
+            .collect(),
+        incident_event_indices: vec![0],
+        unavailable_fields: Vec::new(),
+        sensitive_state_included: false,
+    });
+    export
+}
+
+#[test]
+fn exact_normalized_history_imports_and_reproduces() {
+    let export = export_with_history();
+    let artifact = import_exact_history(&export, IncidentSourceFormatV1::AgentStateDocument)
+        .expect("valid exact history imports")
+        .expect("history is present");
+
+    assert_eq!(
+        artifact.replay_fidelity,
+        IncidentReplayFidelityV1::ExactNormalizedHistory
+    );
+    assert_eq!(
+        artifact.evidence_confidence,
+        EvidenceConfidenceV1::ExactNormalizedAvailableEvidence
+    );
+    assert!(!artifact.byte_replay_available);
+    assert!(artifact.unavailable_fields.iter().any(|field| {
+        field.field == "mls_state_checkpoint" && field.reason.contains("sensitive")
+    }));
+    accept_exact_history(artifact).expect("normalized history reproduces recorded outcomes");
+}
+
+#[test]
+fn missing_action_mapping_fails_closed_instead_of_becoming_exact() {
+    let mut export = export_with_history();
+    export
+        .normalized_scenario_history
+        .as_mut()
+        .unwrap()
+        .action_evidence
+        .pop();
+    assert!(matches!(
+        import_exact_history(&export, IncidentSourceFormatV1::AgentStateDocument),
+        Err(ExactHistoryImportError::IncompleteActionEvidence)
+    ));
+}
+
+#[test]
+fn legacy_export_is_an_explicitly_inexact_archetype() {
+    let export = parse(r#"{ "events": [] }"#).expect("parses");
+    assert!(
+        import_exact_history(&export, IncidentSourceFormatV1::AgentStateDocument)
+            .expect("absence is not malformed")
+            .is_none()
+    );
+
+    let fork = RecoveredFork {
+        source_epoch: 30,
+        commit: ForkCommitKind::Membership,
+    };
+    let artifact = archetype_artifact(
+        &export,
+        IncidentSourceFormatV1::AgentStateDocument,
+        synthesize(&fork, "archetype/v1", "alice", "bob"),
+    );
+    assert_eq!(
+        artifact.replay_fidelity,
+        IncidentReplayFidelityV1::OutcomeEquivalentArchetype
+    );
+    assert_eq!(
+        artifact.evidence_confidence,
+        EvidenceConfidenceV1::DerivedOutcomeEquivalent
+    );
+    assert!(
+        artifact
+            .unavailable_fields
+            .iter()
+            .any(|field| { field.field == "exact_scenario_action_history" })
+    );
+}

--- a/crates/incident-replay/tests/artifact.rs
+++ b/crates/incident-replay/tests/artifact.rs
@@ -85,8 +85,60 @@ fn missing_action_mapping_fails_closed_instead_of_becoming_exact() {
 }
 
 #[test]
+fn exact_history_preconditions_have_typed_fail_closed_errors() {
+    let mut export = export_with_history();
+    export
+        .normalized_scenario_history
+        .as_mut()
+        .unwrap()
+        .sensitive_state_included = true;
+    assert!(matches!(
+        import_exact_history(&export, IncidentSourceFormatV1::AgentStateDocument),
+        Err(ExactHistoryImportError::SensitiveStateIncluded)
+    ));
+
+    let mut export = export_with_history();
+    export
+        .normalized_scenario_history
+        .as_mut()
+        .unwrap()
+        .expected_outcomes
+        .clear();
+    assert!(matches!(
+        import_exact_history(&export, IncidentSourceFormatV1::AgentStateDocument),
+        Err(ExactHistoryImportError::MissingExpectedOutcomes)
+    ));
+
+    let mut export = export_with_history();
+    export
+        .normalized_scenario_history
+        .as_mut()
+        .unwrap()
+        .incident_event_indices
+        .clear();
+    assert!(matches!(
+        import_exact_history(&export, IncidentSourceFormatV1::AgentStateDocument),
+        Err(ExactHistoryImportError::MissingIncidentEvidence)
+    ));
+
+    let mut export = export_with_history();
+    let event_count = export.events.len();
+    export
+        .normalized_scenario_history
+        .as_mut()
+        .unwrap()
+        .action_evidence[0]
+        .source_event_indices = vec![event_count];
+    assert!(matches!(
+        import_exact_history(&export, IncidentSourceFormatV1::AgentStateDocument),
+        Err(ExactHistoryImportError::SourceEventOutOfRange { .. })
+    ));
+}
+
+#[test]
 fn legacy_export_is_an_explicitly_inexact_archetype() {
-    let export = parse(r#"{ "events": [] }"#).expect("parses");
+    let mut export = export_with_history();
+    export.normalized_scenario_history = None;
     assert!(
         import_exact_history(&export, IncidentSourceFormatV1::AgentStateDocument)
             .expect("absence is not malformed")
@@ -101,7 +153,8 @@ fn legacy_export_is_an_explicitly_inexact_archetype() {
         &export,
         IncidentSourceFormatV1::AgentStateDocument,
         synthesize(&fork, "archetype/v1", "alice", "bob"),
-    );
+    )
+    .expect("incident evidence permits archetype synthesis");
     assert_eq!(
         artifact.replay_fidelity,
         IncidentReplayFidelityV1::OutcomeEquivalentArchetype
@@ -116,4 +169,21 @@ fn legacy_export_is_an_explicitly_inexact_archetype() {
             .iter()
             .any(|field| { field.field == "exact_scenario_action_history" })
     );
+}
+
+#[test]
+fn archetype_without_incident_evidence_fails_closed() {
+    let export = parse(r#"{ "events": [] }"#).expect("parses");
+    let fork = RecoveredFork {
+        source_epoch: 30,
+        commit: ForkCommitKind::Membership,
+    };
+    assert!(matches!(
+        archetype_artifact(
+            &export,
+            IncidentSourceFormatV1::AgentStateDocument,
+            synthesize(&fork, "archetype/v1", "alice", "bob"),
+        ),
+        Err(ExactHistoryImportError::MissingIncidentEvidence)
+    ));
 }

--- a/crates/incident-replay/tests/artifact.rs
+++ b/crates/incident-replay/tests/artifact.rs
@@ -1,8 +1,10 @@
 use incident_replay::{
-    EvidenceConfidenceV1, ExactHistoryImportError, ForkCommitKind, IncidentReplayFidelityV1,
-    IncidentSourceFormatV1, NormalizedActionEvidenceV1, NormalizedScenarioHistoryV1, RecoveredFork,
-    accept_exact_history, archetype_artifact, import_exact_history, parse, synthesize,
+    EvidenceConfidenceV1, ForkCommitKind, IncidentArtifactSensitivityV1, IncidentReplayFidelityV1,
+    IncidentReproductionStatusV1, IncidentSourceFormatV1, NormalizedActionEvidenceV1,
+    NormalizedHistoryImportError, NormalizedScenarioHistoryV1, RecoveredFork,
+    accept_attested_history, archetype_artifact, import_attested_history, parse, synthesize,
 };
+use std::collections::BTreeSet;
 
 fn export_with_history() -> incident_replay::AgentStateExport {
     let fork = RecoveredFork {
@@ -48,25 +50,38 @@ fn export_with_history() -> incident_replay::AgentStateExport {
 }
 
 #[test]
-fn exact_normalized_history_imports_and_reproduces() {
+fn producer_attested_history_imports_and_reproduces() {
     let export = export_with_history();
-    let artifact = import_exact_history(&export, IncidentSourceFormatV1::AgentStateDocument)
-        .expect("valid exact history imports")
+    let artifact = import_attested_history(&export, IncidentSourceFormatV1::AgentStateDocument)
+        .expect("valid normalized history imports")
         .expect("history is present");
 
     assert_eq!(
         artifact.replay_fidelity,
-        IncidentReplayFidelityV1::ExactNormalizedHistory
+        IncidentReplayFidelityV1::ProducerAttestedNormalizedHistory
     );
     assert_eq!(
         artifact.evidence_confidence,
-        EvidenceConfidenceV1::ExactNormalizedAvailableEvidence
+        EvidenceConfidenceV1::ProducerAttestedAvailableEvidence
+    );
+    assert_eq!(
+        artifact.sensitivity,
+        IncidentArtifactSensitivityV1::ConfidentialUnredactedScenario
+    );
+    assert_eq!(
+        artifact.reproduction_status,
+        IncidentReproductionStatusV1::Unverified
     );
     assert!(!artifact.byte_replay_available);
     assert!(artifact.unavailable_fields.iter().any(|field| {
         field.field == "mls_state_checkpoint" && field.reason.contains("sensitive")
     }));
-    accept_exact_history(artifact).expect("normalized history reproduces recorded outcomes");
+    let artifact =
+        accept_attested_history(artifact).expect("normalized history reproduces recorded outcomes");
+    assert_eq!(
+        artifact.reproduction_status,
+        IncidentReproductionStatusV1::Reproduced
+    );
 }
 
 #[test]
@@ -79,13 +94,13 @@ fn missing_action_mapping_fails_closed_instead_of_becoming_exact() {
         .action_evidence
         .pop();
     assert!(matches!(
-        import_exact_history(&export, IncidentSourceFormatV1::AgentStateDocument),
-        Err(ExactHistoryImportError::IncompleteActionEvidence)
+        import_attested_history(&export, IncidentSourceFormatV1::AgentStateDocument),
+        Err(NormalizedHistoryImportError::IncompleteActionEvidence)
     ));
 }
 
 #[test]
-fn exact_history_preconditions_have_typed_fail_closed_errors() {
+fn attested_history_preconditions_have_typed_fail_closed_errors() {
     let mut export = export_with_history();
     export
         .normalized_scenario_history
@@ -93,8 +108,8 @@ fn exact_history_preconditions_have_typed_fail_closed_errors() {
         .unwrap()
         .sensitive_state_included = true;
     assert!(matches!(
-        import_exact_history(&export, IncidentSourceFormatV1::AgentStateDocument),
-        Err(ExactHistoryImportError::SensitiveStateIncluded)
+        import_attested_history(&export, IncidentSourceFormatV1::AgentStateDocument),
+        Err(NormalizedHistoryImportError::SensitiveStateIncluded)
     ));
 
     let mut export = export_with_history();
@@ -105,8 +120,8 @@ fn exact_history_preconditions_have_typed_fail_closed_errors() {
         .expected_outcomes
         .clear();
     assert!(matches!(
-        import_exact_history(&export, IncidentSourceFormatV1::AgentStateDocument),
-        Err(ExactHistoryImportError::MissingExpectedOutcomes)
+        import_attested_history(&export, IncidentSourceFormatV1::AgentStateDocument),
+        Err(NormalizedHistoryImportError::MissingExpectedOutcomes)
     ));
 
     let mut export = export_with_history();
@@ -117,8 +132,8 @@ fn exact_history_preconditions_have_typed_fail_closed_errors() {
         .incident_event_indices
         .clear();
     assert!(matches!(
-        import_exact_history(&export, IncidentSourceFormatV1::AgentStateDocument),
-        Err(ExactHistoryImportError::MissingIncidentEvidence)
+        import_attested_history(&export, IncidentSourceFormatV1::AgentStateDocument),
+        Err(NormalizedHistoryImportError::MissingIncidentEvidence)
     ));
 
     let mut export = export_with_history();
@@ -130,8 +145,8 @@ fn exact_history_preconditions_have_typed_fail_closed_errors() {
         .action_evidence[0]
         .source_event_indices = vec![event_count];
     assert!(matches!(
-        import_exact_history(&export, IncidentSourceFormatV1::AgentStateDocument),
-        Err(ExactHistoryImportError::SourceEventOutOfRange { .. })
+        import_attested_history(&export, IncidentSourceFormatV1::AgentStateDocument),
+        Err(NormalizedHistoryImportError::SourceEventOutOfRange { .. })
     ));
 }
 
@@ -140,7 +155,7 @@ fn legacy_export_is_an_explicitly_inexact_archetype() {
     let mut export = export_with_history();
     export.normalized_scenario_history = None;
     assert!(
-        import_exact_history(&export, IncidentSourceFormatV1::AgentStateDocument)
+        import_attested_history(&export, IncidentSourceFormatV1::AgentStateDocument)
             .expect("absence is not malformed")
             .is_none()
     );
@@ -184,6 +199,82 @@ fn archetype_without_incident_evidence_fails_closed() {
             IncidentSourceFormatV1::AgentStateDocument,
             synthesize(&fork, "archetype/v1", "alice", "bob"),
         ),
-        Err(ExactHistoryImportError::MissingIncidentEvidence)
+        Err(NormalizedHistoryImportError::MissingIncidentEvidence)
     ));
+}
+
+#[test]
+fn committed_membership_fixture_drives_the_artifact_path() {
+    let export = parse(include_str!("fixtures/replayable-membership-fork.json"))
+        .expect("committed replay fixture parses");
+    let fork = RecoveredFork {
+        source_epoch: 30,
+        commit: ForkCommitKind::Membership,
+    };
+    let artifact = archetype_artifact(
+        &export,
+        IncidentSourceFormatV1::AgentStateDocument,
+        synthesize(&fork, "membership-fixture/v1", "alice", "bob"),
+    )
+    .expect("fixture carries contested incident evidence");
+    assert_eq!(
+        artifact.replay_fidelity,
+        IncidentReplayFidelityV1::OutcomeEquivalentArchetype
+    );
+}
+
+#[test]
+fn artifact_schema_tracks_the_serialized_top_level_contract() {
+    let export = export_with_history();
+    let artifact = import_attested_history(&export, IncidentSourceFormatV1::AgentStateDocument)
+        .expect("history imports")
+        .expect("history exists");
+    let artifact = accept_attested_history(artifact).expect("history reproduces");
+    let serialized = serde_json::to_value(&artifact).expect("artifact serializes");
+    let schema: serde_json::Value = serde_json::from_str(include_str!(
+        "../schemas/incident-scenario-artifact.v1.schema.json"
+    ))
+    .expect("schema parses");
+
+    let actual = serialized
+        .as_object()
+        .expect("artifact is an object")
+        .keys()
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let declared = schema["properties"]
+        .as_object()
+        .expect("schema properties")
+        .keys()
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let required = schema["required"]
+        .as_array()
+        .expect("schema required")
+        .iter()
+        .map(|value| value.as_str().expect("required name").to_owned())
+        .collect::<BTreeSet<_>>();
+
+    assert_eq!(
+        actual, declared,
+        "schema properties drifted from serde output"
+    );
+    assert_eq!(actual, required, "all v1 artifact fields must be required");
+    for field in [
+        "source_format",
+        "replay_fidelity",
+        "evidence_confidence",
+        "sensitivity",
+        "reproduction_status",
+    ] {
+        let value = serialized[field].as_str().expect("serialized enum");
+        assert!(
+            schema["properties"][field]["enum"]
+                .as_array()
+                .expect("schema enum")
+                .iter()
+                .any(|candidate| candidate.as_str() == Some(value)),
+            "schema enum for {field} does not contain {value}"
+        );
+    }
 }

--- a/crates/incident-replay/tests/fixtures/replayable-membership-fork.json
+++ b/crates/incident-replay/tests/fixtures/replayable-membership-fork.json
@@ -1,0 +1,37 @@
+{
+  "events": [
+    {
+      "kind": {
+        "type": "fork_resolution",
+        "source_epoch": 30,
+        "invalidated_msg_id": "synthetic-invalidated-commit",
+        "winner": "candidate"
+      }
+    },
+    {
+      "account_ref": "synthetic-alpha",
+      "kind": {
+        "type": "group_state_changed",
+        "epoch": 31,
+        "change_kind": "admin_added",
+        "actor_member_ref": "synthetic-alpha"
+      }
+    },
+    {
+      "account_ref": "synthetic-beta",
+      "kind": {
+        "type": "group_state_changed",
+        "epoch": 31,
+        "change_kind": "member_added",
+        "actor_member_ref": "synthetic-beta"
+      }
+    },
+    {
+      "account_ref": "synthetic-beta",
+      "kind": {
+        "type": "publish_outcome",
+        "msg_id": "synthetic-invalidated-commit"
+      }
+    }
+  ]
+}

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -653,14 +653,27 @@ explicit local rejoin/reset; v1 does not claim automatic repair for that strande
 
 ### 3.2 Resource and sensitivity measurements
 
-- [ ] Record convergence latency and blocked-send duration.
-- [ ] Record pass count, reorg count/depth/lateness, and unresolved outcomes.
-- [ ] Record commit/proposal/application dispositions and logical delivery/expiry/invalidation results.
-- [ ] Record CPU time, peak memory, database size/writes, queue depth, and replay probes.
-- [ ] Sweep constants around the pinned value in explicit test-policy builds.
-- [ ] For P4/P5, preserve one retained input set and fixed eligibility horizons while varying pass partitioning; keep
+- [x] Record convergence latency and blocked-send duration.
+- [x] Record pass count, reorg count/depth/lateness, and unresolved outcomes.
+- [x] Record commit/proposal/application dispositions and logical delivery/expiry/invalidation results.
+- [x] Record CPU time, peak memory, database size/writes, queue depth, and replay probes.
+- [x] Sweep constants around the pinned value in explicit test-policy builds.
+- [x] For P4/P5, preserve one retained input set and fixed eligibility horizons while varying pass partitioning; keep
   witness expiry, deferred commits, and anchor pruning as explicit boundary cases rather than accidental confounders.
-- [ ] Produce curves and boundary failures; never auto-tune production policy from simulator output.
+- [x] Produce curves and boundary failures; never auto-tune production policy from simulator output.
+
+`CampaignMeasurementsV1` is embedded in every scenario report. In-process reports record the conservative
+whole-scenario convergence-latency envelope, true queued-acceptance-to-publication/refusal wall time, decisions,
+restart-preserved reorg histograms, dispositions, logical outcomes, unresolved work, maximum sampled transport depth,
+exact completed OpenMLS replay probes, and file-backed SQLite/WAL/SHM size. The child-process campaign runner adds
+per-case CPU time, peak RSS, and OS-accounted write blocks and makes worker exit/signal failure explicit. OS write
+blocks may be zero under caching and are not presented as SQLite logical writes.
+
+The feature-gated policy sweep holds retained input, tip, anchor, time, eligibility horizons, and all other constants
+fixed, emits explicit rejected boundary points, and sets `production_auto_tuning_permitted` to false. P4/P5
+pass-partition invariance continues to use `fixed_point_is_invariant_to_same_horizon_batch_partitioning`; expiry,
+deferred-commit retirement, and retained-anchor pruning are covered by separately named boundary tests so a semantic
+eligibility change cannot masquerade as a scheduler result.
 
 ### 3.3 Incident replay
 
@@ -907,3 +920,5 @@ incorrect result.
 | 2026-08-02 | 2.2 initial independent reference adapter | Added a capability-limited symbolic-memory subject that executes the common group/publication/application lifecycle without production selector or canonicalizer calls; one compiled scenario now runs unchanged on reference and engine adapters with equal semantic observations, exact-only predicates add their true preflight capability, and assertion sampling no longer consumes later report evidence | `one_compiled_scenario_runs_unchanged_on_reference_and_engine_adapters`; `unsupported_exact_assertion_fails_before_reference_model_executes`; scenario IR suite |
 | 2026-08-02 | 2.3 retained multi-relay model and exit scenarios | Added real-engine delivery through durable per-relay histories with topology fanout/subscriptions, cursor/since/full/set queries, EOSE-versus-completeness observations, offline reconnect, visibility omission, duplicate/order policy, history equalization, and quiet-query diagnosis; the same compiled scenario runs on all three initial adapters, offline delivery comes from history, and unequal histories reach exact state equality only after reconciliation | `one_compiled_scenario_runs_unchanged_on_all_initial_adapters`; `offline_client_recovers_from_retained_history`; `unequal_relay_histories_converge_after_set_equalization`; `eose_does_not_heal_hidden_cursor_history_but_full_backfill_does`; `relay_reverse_order_and_duplicates_are_explicit_and_deduplicated` |
 | 2026-08-02 | Milestone 2 completion verification | Completed every 2.1-2.3 work item and exit scenario; the canonical IR no longer exposes mutable queue positions, all repository vectors compile, and retained-history behavior is distinct from healed packet loss | [MDK #1233](https://github.com/marmot-protocol/mdk/pull/1233); `cargo test -p cgka-conformance-simulator`; `cargo test -p incident-replay`; `just fast-ci` |
+| 2026-08-02 | 3.1 adversarial workload campaigns | Added the twelve-family workload catalog, small and sustained headline campaigns, real durable-phase process kills, resource-exhaustion/repair, multi-group and shared-account-device topologies, retained-relay disagreement, clock/cursor attacks, witness-enabled/disabled full-engine comparison, and mixed binary/policy preflight. Recorded the current losing-branch device repair limit and the future authenticated policy-capability boundary | `milestone3_campaigns`; `actual_process_kill_recovers_at_every_durable_phase`; explicit sustained campaign; proposal-expiry and multi-parent replay tests |
+| 2026-08-02 | 3.2 campaign measurements and policy sweeps | Embedded stable latency/blocking, pass/reorg, disposition/outcome, queue/replay/database measurements in scenario reports; added an isolated child-process runner for CPU/RSS/write accounting; and added fixed-input test-policy curves with named boundary failures and no production auto-tuning | `offline_retained_history_flood_runs_as_a_small_regression`; `policy_sweeps`; child-process smoke campaign; default and feature-enabled compile gates |

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -647,9 +647,10 @@ mixed convergence policies but permits mixed binary versions when their policy a
 future incompatible policy revision must introduce an authenticated required capability or GroupContext application
 component atomically with the new behavior; a diagnostic binary version is never protocol evidence.
 
-The losing-branch invite campaign records a current protocol limit: a device admitted only by the losing commit remains
-on a non-equivalent local state after the canonical group re-invites that account. The named outcome requires an
-explicit local rejoin/reset; v1 does not claim automatic repair for that stranded device.
+The losing-branch invite campaign records a current protocol limit: the devices admitted by competing commits remain
+non-equivalent after the canonical members settle. Reusing either already-consumed device signature key is not a valid
+repair (`DuplicateSignatureKey`), so the named outcome requires an explicit local reset/rejoin with fresh device
+state; v1 does not claim automatic repair for the stranded device.
 
 ### 3.2 Resource and sensitivity measurements
 
@@ -709,6 +710,13 @@ the separately tested resource-refused/redelivery repair contract. Report measur
 action and resource-category limiting cause. Incident tests cover both a reproducing exact normalized history and the
 ordinary legacy-export archetype whose evidence envelope explicitly names why exact action and byte replay are
 unavailable.
+
+Final integration verification also pins the topology compatibility boundary: resolving a legacy client-only
+scenario may add explicit deployment records to its report, but does not change its historical client-derived member
+identities. Explicitly authored account/device topology alone opts into account-derived credentials, including shared
+credentials for two modeled devices of one account. The complete 41-case canonical scenario suite passes with this
+boundary, including exact fixtures, bidirectional decryptability, generated chaos/delivery families, and strict
+pre-join resource retirement.
 
 ## Milestone 4: Independent Verification And Adequacy
 
@@ -945,3 +953,4 @@ incorrect result.
 | 2026-08-02 | 3.2 campaign measurements and policy sweeps | Embedded stable latency/blocking, pass/reorg, disposition/outcome, queue/replay/database measurements in scenario reports; added an isolated child-process runner for CPU/RSS/write accounting; and added fixed-input test-policy curves with named boundary failures and no production auto-tuning | `offline_retained_history_flood_runs_as_a_small_regression`; `policy_sweeps`; child-process smoke campaign; default and feature-enabled compile gates |
 | 2026-08-02 | 3.3 exact/derived incident replay evidence | Preserved accepted fork/convergence archetypes while labeling them outcome-equivalent and naming unavailable evidence; added fail-closed exact normalized Scenario IR import with per-step and contested-incident source mappings, semantic acceptance, explicit confidence, no embedded sensitive state, and owner-only vector/evidence output | Full `incident-replay` suite; `exact_normalized_history_imports_and_reproduces`; replayable synthetic membership-fork CLI smoke and `0600` mode check |
 | 2026-08-02 | Milestone 3 exit scenarios | Split the three headline workloads into small default regressions and explicit sustained campaigns; pinned replay-budget fail-closed repair, report first-failure/resource attribution, and exact-versus-unavailable incident outcomes | Three `small_regression` tests; explicit offline, mixed-traffic, and self-update sustained runs; `replay_budget_exhaustion_fails_closed_then_repairs_with_same_durable_inputs`; campaign metric and incident artifact tests |
+| 2026-08-02 | Milestone 3 integration verification | Preserved legacy client identities while limiting account-scoped credential sharing to explicitly authored topology; all canonical semantic oracles and active decryptability probes remain compatible with the new deployment model | `implicit_topology_preserves_legacy_client_identity_seeds`; `explicit_topology_shares_account_identity_across_devices`; `cargo test -p cgka-conformance-simulator --test canonical_scenarios` (41 passed) |

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -623,24 +623,33 @@ Status: `complete`
 
 ### 3.1 Required workload families
 
-- [ ] Offline retained-history flood with application traffic spanning many membership/state commits.
-- [ ] Sustained application traffic interspersed with proposals and commits.
-- [ ] Sequential self-update adversary racing privileged administrative changes.
-- [ ] Losing-branch joiner/invite/device-add, including an explicit successful repair, re-invite, or named unrecoverable
+- [x] Offline retained-history flood with application traffic spanning many membership/state commits.
+- [x] Sustained application traffic interspersed with proposals and commits.
+- [x] Sequential self-update adversary racing privileged administrative changes.
+- [x] Losing-branch joiner/invite/device-add, including an explicit successful repair, re-invite, or named unrecoverable
   user-visible outcome.
-- [ ] Unequal relay histories followed by reconciliation.
-- [ ] Crash/restart at every durable convergence transition.
-- [ ] Multi-group noisy-neighbor and per-group fairness.
-- [ ] Candidate graph/replay budget/resource exhaustion.
-- [ ] Multi-device account identity and witness deduplication.
-- [ ] App-message witness value: compare selection with/without witnesses, include proposal expiry and multi-parent
+- [x] Unequal relay histories followed by reconciliation.
+- [x] Crash/restart at every durable convergence transition.
+- [x] Multi-group noisy-neighbor and per-group fairness.
+- [x] Candidate graph/replay budget/resource exhaustion.
+- [x] Multi-device account identity and witness deduplication.
+- [x] App-message witness value: compare selection with/without witnesses, include proposal expiry and multi-parent
   commit cases, and decide whether the speculative mechanism earns its complexity.
-- [ ] Mixed binary and policy versions as controlled negative/compatibility tests. Do not require a production policy
+- [x] Mixed binary and policy versions as controlled negative/compatibility tests. Do not require a production policy
   stamp before Scenario IR v2 can carry explicit policy versions.
-- [ ] Clock movement, scheduler delay, and timestamp/cursor attacks.
+- [x] Clock movement, scheduler delay, and timestamp/cursor attacks.
 
 Each family varies schedule, storage mode, participant count, rates, restart placement, relay topology, and applicable
 test-only constants while preserving a stable semantic oracle.
+
+Policy compatibility decision: v1 does not add a policy-version wire field or app component. Scenario preflight rejects
+mixed convergence policies but permits mixed binary versions when their policy and capabilities are equivalent. A
+future incompatible policy revision must introduce an authenticated required capability or GroupContext application
+component atomically with the new behavior; a diagnostic binary version is never protocol evidence.
+
+The losing-branch invite campaign records a current protocol limit: a device admitted only by the losing commit remains
+on a non-equivalent local state after the canonical group re-invites that account. The named outcome requires an
+explicit local rejoin/reset; v1 does not claim automatic repair for that stranded device.
 
 ### 3.2 Resource and sensitivity measurements
 

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "Convergence Reliability And Simulation Plan"
 created: 2026-07-30
-updated: 2026-08-02
+updated: 2026-08-03
 tags: [marmot, cgka, convergence, simulation, verification, reliability]
 status: working-plan
 ---
@@ -663,12 +663,15 @@ state; v1 does not claim automatic repair for the stranded device.
   witness expiry, deferred commits, and anchor pruning as explicit boundary cases rather than accidental confounders.
 - [x] Produce curves and boundary failures; never auto-tune production policy from simulator output.
 
-`CampaignMeasurementsV1` is embedded in every scenario report. In-process reports record the conservative
-whole-scenario convergence-latency envelope, true queued-acceptance-to-publication/refusal wall time, decisions,
+`CampaignMeasurementsV1` is embedded in every scenario report. In-process reports record the wall time of the final
+successful fixed-point convergence attempt when a scenario requests one (and mark it unavailable otherwise), true
+queued-acceptance-to-publication/refusal wall time, decisions,
 restart-preserved reorg histograms, dispositions, logical outcomes, unresolved work, maximum sampled transport depth,
 exact completed OpenMLS replay probes, and file-backed SQLite/WAL/SHM size. The child-process campaign runner adds
-per-case CPU time, peak RSS, and OS-accounted write blocks and makes worker exit/signal failure explicit. OS write
-blocks may be zero under caching and are not presented as SQLite logical writes.
+per-case CPU time and peak RSS where the host exposes them, Linux OS-accounted write blocks, an explicit unavailable
+field list elsewhere, and worker exit/signal/timeout failure. OS write blocks may be zero under caching and are not
+presented as SQLite logical writes; every worker has a configurable hard deadline and is killed and reaped if it
+exceeds it.
 
 The feature-gated policy sweep holds retained input, tip, anchor, time, eligibility horizons, and all other constants
 fixed, emits explicit rejected boundary points, and sets `production_auto_tuning_permitted` to false. P4/P5
@@ -717,6 +720,11 @@ identities. Explicitly authored account/device topology alone opts into account-
 credentials for two modeled devices of one account. The complete 41-case canonical scenario suite passes with this
 boundary, including exact fixtures, bidirectional decryptability, generated chaos/delivery families, and strict
 pre-join resource retirement.
+
+The `just milestone3-ci` gate executes every catalog family (including the feature-gated witness and replay-budget
+campaigns), all three sustained headline workloads, policy sweeps, and a file-backed isolated worker with a hard
+timeout. GitHub's simulator job runs this gate in addition to the ordinary simulator and vector suites; the exit gate
+is not based on compile-only catalog coverage.
 
 ## Milestone 4: Independent Verification And Adequacy
 

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -682,20 +682,22 @@ eligibility change cannot masquerade as a scheduler result.
 ### 3.3 Incident replay
 
 - [x] Preserve normalized archetype synthesis for incomplete forensic evidence.
-- [x] Add exact-history IR import when evidence is sufficient.
+- [x] Add producer-attested normalized-history IR import when evidence is sufficient.
 - [x] Carry evidence confidence and unavailable fields into the scenario artifact.
 - [x] Keep sensitive exports and generated exact capsules out of version control.
 
-`IncidentScenarioArtifactV1` makes replay fidelity explicit. Existing Goggles audit exports continue through the proven
-fork/convergence archetype synthesizers and are labeled `outcome_equivalent_archetype` with derived confidence; the
-artifact names unavailable exact action history, participant delivery order, transport bytes, and MLS state. Exact
-normalized import is accepted only when a producer supplies complete Scenario IR, maps every step to source event
-indices, identifies the contested fork/convergence source rows, includes semantic expected outcomes, passes full IR
-validation, contains no sensitive state, and reproduces under the simulator. “Exact” means exact for that declared
-normalized evidence, not byte replay. Raw MLS bytes plus an engine checkpoint remain a separate opt-in sensitive local
-failure capsule.
+`IncidentScenarioArtifactV1` makes replay fidelity and trust boundaries explicit. Existing Goggles audit exports
+continue through the proven fork/convergence archetype synthesizers and are labeled
+`outcome_equivalent_archetype` with derived confidence; the artifact names unavailable action history, participant
+delivery order, transport bytes, and MLS state. Normalized import is `producer_attested_normalized_history`: it checks
+coverage and bounds of the producer's step-to-source mapping, validates the Scenario IR, and requires the declared
+outcomes to reproduce, but it does not independently prove semantic correspondence between arbitrary source events
+and declared actions. Imported free-form labels and application payloads remain
+`confidential_unredacted_scenario`, and the artifact records `unverified` until simulator reproduction changes it to
+`reproduced`. Raw MLS bytes plus an engine checkpoint remain a separate opt-in sensitive local failure capsule.
 
-The CLI writes the vector and evidence envelope owner-only and never copies the source export or checkpoint. Real
+The CLI writes the vector and evidence envelope owner-only and never copies the source export or checkpoint. These
+files are not shareable without separate redaction and review. Real
 exports belong under ignored `incident-exports/`; local generated output belongs under `target/` or ignored
 `incident-replay-output/`; sensitive replay-capsule filenames are ignored repository-wide.
 
@@ -710,9 +712,16 @@ Offline retained-history catch-up, mixed application/commit traffic, and the sel
 small default regression and a separately ignored sustained campaign. Replay-probe exhaustion fails closed while
 retaining the frozen durable inputs, then succeeds after the test-only ceiling is removed; opaque transport limits use
 the separately tested resource-refused/redelivery repair contract. Report measurement tests pin the first failing
-action and resource-category limiting cause. Incident tests cover both a reproducing exact normalized history and the
+action and resource-category limiting cause. Incident tests cover both a reproducing producer-attested history and the
 ordinary legacy-export archetype whose evidence envelope explicitly names why exact action and byte replay are
 unavailable.
+
+Milestone 3 also closes a production amplification loophole: application-bearing candidate re-materialization now
+draws from the same finite per-pass replay budget as the preceding candidate search instead of creating an unlimited
+fallback budget. The v1 numeric constants and branch-selection policy are unchanged, but the fail-closed boundary is
+observable: a near-ceiling pass can now return `ReplayBudgetExceeded` where the old path continued without a limit.
+The shared-budget regression retains the frozen inputs and proves the same durable work succeeds when capacity is
+restored.
 
 Final integration verification also pins the topology compatibility boundary: resolving a legacy client-only
 scenario may add explicit deployment records to its report, but does not change its historical client-derived member
@@ -957,8 +966,8 @@ incorrect result.
 | 2026-08-02 | 2.2 initial independent reference adapter | Added a capability-limited symbolic-memory subject that executes the common group/publication/application lifecycle without production selector or canonicalizer calls; one compiled scenario now runs unchanged on reference and engine adapters with equal semantic observations, exact-only predicates add their true preflight capability, and assertion sampling no longer consumes later report evidence | `one_compiled_scenario_runs_unchanged_on_reference_and_engine_adapters`; `unsupported_exact_assertion_fails_before_reference_model_executes`; scenario IR suite |
 | 2026-08-02 | 2.3 retained multi-relay model and exit scenarios | Added real-engine delivery through durable per-relay histories with topology fanout/subscriptions, cursor/since/full/set queries, EOSE-versus-completeness observations, offline reconnect, visibility omission, duplicate/order policy, history equalization, and quiet-query diagnosis; the same compiled scenario runs on all three initial adapters, offline delivery comes from history, and unequal histories reach exact state equality only after reconciliation | `one_compiled_scenario_runs_unchanged_on_all_initial_adapters`; `offline_client_recovers_from_retained_history`; `unequal_relay_histories_converge_after_set_equalization`; `eose_does_not_heal_hidden_cursor_history_but_full_backfill_does`; `relay_reverse_order_and_duplicates_are_explicit_and_deduplicated` |
 | 2026-08-02 | Milestone 2 completion verification | Completed every 2.1-2.3 work item and exit scenario; the canonical IR no longer exposes mutable queue positions, all repository vectors compile, and retained-history behavior is distinct from healed packet loss | [MDK #1233](https://github.com/marmot-protocol/mdk/pull/1233); `cargo test -p cgka-conformance-simulator`; `cargo test -p incident-replay`; `just fast-ci` |
-| 2026-08-02 | 3.1 adversarial workload campaigns | Added the twelve-family workload catalog, small and sustained headline campaigns, real durable-phase process kills, resource-exhaustion/repair, multi-group and shared-account-device topologies, retained-relay disagreement, clock/cursor attacks, witness-enabled/disabled full-engine comparison, and mixed binary/policy preflight. Recorded the current losing-branch device repair limit and the future authenticated policy-capability boundary | `milestone3_campaigns`; `actual_process_kill_recovers_at_every_durable_phase`; explicit sustained campaign; proposal-expiry and multi-parent replay tests |
+| 2026-08-02 | 3.1 adversarial workload campaigns | Added the twelve-family workload catalog, small and sustained headline campaigns, real durable-phase process kills, resource-exhaustion/repair, multi-group and shared-account-device topologies, retained-relay disagreement, clock/cursor attacks, witness-enabled/disabled full-engine comparison, and mixed binary/policy preflight. Recorded the current losing-branch device repair limit and the future authenticated policy-capability boundary | `milestone3_campaigns`; `kill_at_every_durable_convergence_phase_reopens_and_finishes`; explicit sustained campaign; proposal-expiry and multi-parent replay tests |
 | 2026-08-02 | 3.2 campaign measurements and policy sweeps | Embedded stable latency/blocking, pass/reorg, disposition/outcome, queue/replay/database measurements in scenario reports; added an isolated child-process runner for CPU/RSS/write accounting; and added fixed-input test-policy curves with named boundary failures and no production auto-tuning | `offline_retained_history_flood_runs_as_a_small_regression`; `policy_sweeps`; child-process smoke campaign; default and feature-enabled compile gates |
-| 2026-08-02 | 3.3 exact/derived incident replay evidence | Preserved accepted fork/convergence archetypes while labeling them outcome-equivalent and naming unavailable evidence; added fail-closed exact normalized Scenario IR import with per-step and contested-incident source mappings, semantic acceptance, explicit confidence, no embedded sensitive state, and owner-only vector/evidence output | Full `incident-replay` suite; `exact_normalized_history_imports_and_reproduces`; replayable synthetic membership-fork CLI smoke and `0600` mode check |
+| 2026-08-02 | 3.3 attested/derived incident replay evidence | Preserved accepted fork/convergence archetypes while labeling them outcome-equivalent and naming unavailable evidence; added fail-closed producer-attested normalized Scenario IR import with per-step and contested-incident source mappings, explicit trust/sensitivity status, semantic reproduction, and owner-only vector/evidence output | Full `incident-replay` suite; `producer_attested_history_imports_and_reproduces`; replayable synthetic membership-fork CLI smoke and `0600` mode check |
 | 2026-08-02 | Milestone 3 exit scenarios | Split the three headline workloads into small default regressions and explicit sustained campaigns; pinned replay-budget fail-closed repair, report first-failure/resource attribution, and exact-versus-unavailable incident outcomes | Three `small_regression` tests; explicit offline, mixed-traffic, and self-update sustained runs; `replay_budget_exhaustion_fails_closed_then_repairs_with_same_durable_inputs`; campaign metric and incident artifact tests |
 | 2026-08-02 | Milestone 3 integration verification | Preserved legacy client identities while limiting account-scoped credential sharing to explicitly authored topology; all canonical semantic oracles and active decryptability probes remain compatible with the new deployment model | `implicit_topology_preserves_legacy_client_identity_seeds`; `explicit_topology_shares_account_identity_across_devices`; `cargo test -p cgka-conformance-simulator --test canonical_scenarios` (41 passed) |

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -120,7 +120,7 @@ The baseline is useful scaffolding, but it is not yet the target reliability lab
 | 0. Assurance foundation | Guarantees, assumptions, constants, and formal gate are explicit | complete | Every constant is classified; formal warnings fail CI; protocol decisions are named |
 | 1. Trustworthy engine black box | Exact oracle, public subject boundary, full quiescence, replay capsules | complete | Known semantic mutations fail and captured failures replay |
 | 2. Scenario IR and retained relays | One adapter-neutral DSL/IR plus realistic offline/history sync | complete | One compiled case runs against reference, engine, and retained-relay adapters |
-| 3. Adversarial campaigns | Sustained real-world workloads, resource sweeps, incident import | not-started | Headline workload families produce bounded, diagnosable results |
+| 3. Adversarial campaigns | Sustained real-world workloads, resource sweeps, incident import | complete | Headline workload families produce bounded, diagnosable results |
 | 4. Independent verification | Reference model, liveness model, mutation adequacy, protocol decision gate | not-started | Model and tests detect seeded policy/lifecycle defects |
 | 5. App and process simulation | Real projections and lifecycle in one or many isolated runtimes | not-started | The same case agrees in-process and across N processes |
 | 6. Distributed campaigns | Container/VM/network/disk/version hardening and campaign operations | not-started | Repeatable soak and release campaigns retain actionable artifacts |
@@ -677,17 +677,38 @@ eligibility change cannot masquerade as a scheduler result.
 
 ### 3.3 Incident replay
 
-- [ ] Preserve normalized archetype synthesis for incomplete forensic evidence.
-- [ ] Add exact-history IR import when evidence is sufficient.
-- [ ] Carry evidence confidence and unavailable fields into the scenario artifact.
-- [ ] Keep sensitive exports and generated exact capsules out of version control.
+- [x] Preserve normalized archetype synthesis for incomplete forensic evidence.
+- [x] Add exact-history IR import when evidence is sufficient.
+- [x] Carry evidence confidence and unavailable fields into the scenario artifact.
+- [x] Keep sensitive exports and generated exact capsules out of version control.
+
+`IncidentScenarioArtifactV1` makes replay fidelity explicit. Existing Goggles audit exports continue through the proven
+fork/convergence archetype synthesizers and are labeled `outcome_equivalent_archetype` with derived confidence; the
+artifact names unavailable exact action history, participant delivery order, transport bytes, and MLS state. Exact
+normalized import is accepted only when a producer supplies complete Scenario IR, maps every step to source event
+indices, identifies the contested fork/convergence source rows, includes semantic expected outcomes, passes full IR
+validation, contains no sensitive state, and reproduces under the simulator. “Exact” means exact for that declared
+normalized evidence, not byte replay. Raw MLS bytes plus an engine checkpoint remain a separate opt-in sensitive local
+failure capsule.
+
+The CLI writes the vector and evidence envelope owner-only and never copies the source export or checkpoint. Real
+exports belong under ignored `incident-exports/`; local generated output belongs under `target/` or ignored
+`incident-replay-output/`; sensitive replay-capsule filenames are ignored repository-wide.
 
 ### Milestone 3 Exit Gate
 
-- [ ] The three headline workloads run both as small regressions and sustained campaigns.
-- [ ] Every resource exhaustion reaches a named fail-closed or retryable outcome with a tested repair path.
-- [ ] Campaign reports identify the first failing action and limiting resource.
-- [ ] Selected incident histories reproduce or clearly state why exact replay is impossible.
+- [x] The three headline workloads run both as small regressions and sustained campaigns.
+- [x] Every resource exhaustion reaches a named fail-closed or retryable outcome with a tested repair path.
+- [x] Campaign reports identify the first failing action and limiting resource.
+- [x] Selected incident histories reproduce or clearly state why exact replay is impossible.
+
+Offline retained-history catch-up, mixed application/commit traffic, and the self-update/admin adversary each have a
+small default regression and a separately ignored sustained campaign. Replay-probe exhaustion fails closed while
+retaining the frozen durable inputs, then succeeds after the test-only ceiling is removed; opaque transport limits use
+the separately tested resource-refused/redelivery repair contract. Report measurement tests pin the first failing
+action and resource-category limiting cause. Incident tests cover both a reproducing exact normalized history and the
+ordinary legacy-export archetype whose evidence envelope explicitly names why exact action and byte replay are
+unavailable.
 
 ## Milestone 4: Independent Verification And Adequacy
 
@@ -922,3 +943,5 @@ incorrect result.
 | 2026-08-02 | Milestone 2 completion verification | Completed every 2.1-2.3 work item and exit scenario; the canonical IR no longer exposes mutable queue positions, all repository vectors compile, and retained-history behavior is distinct from healed packet loss | [MDK #1233](https://github.com/marmot-protocol/mdk/pull/1233); `cargo test -p cgka-conformance-simulator`; `cargo test -p incident-replay`; `just fast-ci` |
 | 2026-08-02 | 3.1 adversarial workload campaigns | Added the twelve-family workload catalog, small and sustained headline campaigns, real durable-phase process kills, resource-exhaustion/repair, multi-group and shared-account-device topologies, retained-relay disagreement, clock/cursor attacks, witness-enabled/disabled full-engine comparison, and mixed binary/policy preflight. Recorded the current losing-branch device repair limit and the future authenticated policy-capability boundary | `milestone3_campaigns`; `actual_process_kill_recovers_at_every_durable_phase`; explicit sustained campaign; proposal-expiry and multi-parent replay tests |
 | 2026-08-02 | 3.2 campaign measurements and policy sweeps | Embedded stable latency/blocking, pass/reorg, disposition/outcome, queue/replay/database measurements in scenario reports; added an isolated child-process runner for CPU/RSS/write accounting; and added fixed-input test-policy curves with named boundary failures and no production auto-tuning | `offline_retained_history_flood_runs_as_a_small_regression`; `policy_sweeps`; child-process smoke campaign; default and feature-enabled compile gates |
+| 2026-08-02 | 3.3 exact/derived incident replay evidence | Preserved accepted fork/convergence archetypes while labeling them outcome-equivalent and naming unavailable evidence; added fail-closed exact normalized Scenario IR import with per-step and contested-incident source mappings, semantic acceptance, explicit confidence, no embedded sensitive state, and owner-only vector/evidence output | Full `incident-replay` suite; `exact_normalized_history_imports_and_reproduces`; replayable synthetic membership-fork CLI smoke and `0600` mode check |
+| 2026-08-02 | Milestone 3 exit scenarios | Split the three headline workloads into small default regressions and explicit sustained campaigns; pinned replay-budget fail-closed repair, report first-failure/resource attribution, and exact-versus-unavailable incident outcomes | Three `small_regression` tests; explicit offline, mixed-traffic, and self-update sustained runs; `replay_budget_exhaustion_fails_closed_then_repairs_with_same_durable_inputs`; campaign metric and incident artifact tests |


### PR DESCRIPTION
## Summary

Completes Milestone 3 of the convergence reliability plan.

- adds a deterministic twelve-family adversarial campaign catalog covering offline retained-history floods, sustained mixed traffic, self-update/admin races, losing-branch admissions, unequal relay histories, durable-phase crashes, multi-group fairness, resource pressure, multi-device accounts, witness A/B behavior, mixed-binary compatibility preflight, and clock/cursor attacks
- adds embedded campaign measurements plus an isolated child-process runner for CPU, RSS, page-cache-sensitive filesystem block-write lower bounds, database footprint, queue, replay, latency, pass, reorg, recovery, and disposition accounting
- adds feature-gated fixed-input policy sweeps without permitting production auto-tuning
- adds producer-attested normalized incident artifacts while retaining explicitly inexact outcome-equivalent archetypes when source evidence is incomplete
- updates the convergence reliability tracking plan and documents the v1 policy compatibility decision

## Behavior and protocol impact

This does not add a v1 wire policy field or Marmot app component. Mixed convergence policy versions fail scenario preflight; mixed binary versions remain valid when policy and capabilities are equivalent. A future incompatible policy must introduce an authenticated required capability or GroupContext application component with the behavior change.

Production convergence constants and the adopted branch-selection policy are not auto-tuned or numerically changed. There is one intentional production fail-closed behavior change: application-bearing candidate re-materialization now consumes the same finite per-pass replay budget as candidate search instead of using an unlimited fallback budget. A near-ceiling pass can therefore return `ReplayBudgetExceeded` where the old path continued without a limit. The regression proves frozen inputs remain durable and succeed when capacity is restored.

The remaining engine changes are observability and deterministic test seams. The collecting-phase crash hook now fires only after the retained input and pass transaction commits, so every named durable phase represents an actually durable boundary.

Legacy client-only scenarios retain their historical client-derived member identities on both engine and retained-relay subjects. Account-scoped credential sharing is enabled only by explicitly authored account/device topology.

The losing-branch admission campaign records the current fail-closed outcome: branch-only devices remain non-equivalent after canonical members settle, and reusing an already-consumed device signature key is rejected. Repair requires an explicit reset/rejoin with fresh device state.

## Incident evidence trust boundary

Normalized history is labeled `producer_attested_normalized_history`, not exact source-verified history. The importer validates IR, mapping coverage and bounds, and simulator reproduction, but cannot independently prove that an arbitrary source event semantically corresponds to the declared action. Imported free-form labels and application payloads are marked `confidential_unredacted_scenario`; artifacts remain `unverified` until reproduction succeeds and are not shareable without separate redaction and review. Infrastructure failures exit 2 rather than being reported as successful quarantine.

## Validation

- `just fast-ci`
- Scenario IR suite: 15 passed
- feature-gated Milestone 3 suite: 10 passed, 3 intentionally ignored sustained campaigns
- policy sweeps: 2 passed
- distributed convergence suite with test policy/crash features: 79 passed
- crash-recovery SQLite matrix: 3 passed, 1 child helper ignored
- full incident-replay suite
- real file-backed child-process campaign smoke with deadline/reap/resource report
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added process-isolated conformance campaigns with adversarial workloads, resource measurements, policy sweeps, and aggregate reports.
  * Added multi-group scenarios, grouped actions, detailed step timing, and expanded regression coverage.
  * Added versioned incident replay artifacts with exact-history validation, fidelity reporting, and sensitive-data safeguards.
* **Bug Fixes**
  * Improved resource-refusal recovery, convergence tracking, replay handling, and durable crash recovery.
* **Documentation**
  * Expanded simulator, scenario, incident replay, and reliability documentation with privacy guidance.
* **Chores**
  * Added automated Milestone 3 campaign checks to continuous integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->