### PR TITLE
Rebuild fork-resolution routing state on hydration

### DIFF
--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -727,19 +727,34 @@ impl<S: StorageProvider> Engine<S> {
         let ceiling = base_epoch
             .0
             .saturating_add(policy.convergence.max_rewind_commits);
-        for (message_id, source_epoch) in
-            retire_stale_convergence_deferred_commits(&self.storage, group_id, floor)?
-        {
+        for retired in retire_stale_convergence_deferred_commits(&self.storage, group_id, floor)? {
             self.audit_group(
                 group_id,
                 crate::audit_helpers::message_state_transition_event(
-                    hex::encode(message_id.as_slice()),
+                    hex::encode(retired.message_id.as_slice()),
                     Some(MessageState::ConvergenceDeferred),
                     MessageState::EpochInvalidated,
-                    Some(source_epoch),
+                    Some(retired.source_epoch),
                     "beyond_retained_anchor",
                 ),
             );
+            if retired.own_commit {
+                // A parked commit this device itself published aged out
+                // without ever being realized: the residual divergence the
+                // fail-closed anchor paths accept is now permanent for this
+                // branch, and on every other group surface the node looks
+                // healthy. Surface it beyond the audit row — this class of
+                // split was originally found only by diffing soak-fleet audit
+                // logs. Privacy-safe: aggregate reason only, no group or
+                // message identifiers.
+                tracing::warn!(
+                    target: "cgka_engine::distributed_convergence",
+                    method = "seed_convergence_pass_members",
+                    reason = "own_commit_retired_unrealized",
+                    "an own commit aged out of the retained candidate graph without being realized; this node may be permanently diverged from its fleet on this group"
+                );
+                self.engine_metrics.note_own_commit_retired_unrealized();
+            }
         }
         let projected = self
             .storage
@@ -1359,6 +1374,21 @@ impl<S: StorageProvider> Engine<S> {
                 self.storage
                     .put_convergence_pass(&pass)
                     .map_err(storage_projection_error)?;
+                // Operator-visible residual-divergence signal (beyond the
+                // audit row below): the fleet may have settled on a branch
+                // rooted at this node's own commit that this node can no
+                // longer realize. Left undetected, the node completes every
+                // pass on its own branch and looks healthy on every group
+                // surface while permanently split. Privacy-safe: aggregate
+                // reason only, no group or message identifiers.
+                tracing::warn!(
+                    target: "cgka_engine::distributed_convergence",
+                    method = "converge_stored_openmls_messages",
+                    reason = "anchor_lineage_mismatch",
+                    "selected own-commit branch is locally unrealizable; pass completed unapplied and this node may be diverged from its fleet"
+                );
+                self.engine_metrics
+                    .note_own_branch_unrealizable_blocked_pass();
                 self.audit_group_with_context(
                     group_id,
                     convergence_run_context(&run_id, ConvergencePhase::Blocked),

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -1328,7 +1328,7 @@ impl<S: StorageProvider> Engine<S> {
         let mut completed_pass = pass.clone();
         completed_pass.phase = ConvergencePassPhase::Completed;
         completed_pass.fairness_slot_available = true;
-        let observations = self.storage.with_transaction(|storage| {
+        let apply_outcome = self.storage.with_transaction(|storage| {
             let observations = apply_openmls_canonicalization_result_with_profile_policy(
                 storage,
                 group_id,
@@ -1338,7 +1338,56 @@ impl<S: StorageProvider> Engine<S> {
             )?;
             storage.put_convergence_pass(&completed_pass)?;
             Ok::<_, OpenMlsProjectionError>(observations)
-        })?;
+        });
+        let observations = match apply_outcome {
+            Ok(observations) => observations,
+            // The selected branch is locally unrealizable: its retained anchor
+            // no longer holds the parked own commit's post-merge state (the
+            // apply's `verify_rewound_anchor_lineage` backstop caught a
+            // clobber that happened after materialization proved this
+            // branch). Propagating the error would pin the group forever —
+            // the identical pass would be retried while the tip (and with it
+            // the parked row's retirement floor, `tip - max_rewind_commits`)
+            // never moves. Instead complete the pass unapplied: the next
+            // pass's materialization runs the same lineage proof against the
+            // clobbered anchor, prunes the branch, and settles on the
+            // next-best candidate, and later commits keep applying so the
+            // horizon genuinely retires the parked row.
+            Err(OpenMlsProjectionError::AnchorLineageMismatch) => {
+                pass.phase = ConvergencePassPhase::Completed;
+                pass.fairness_slot_available = false;
+                self.storage
+                    .put_convergence_pass(&pass)
+                    .map_err(storage_projection_error)?;
+                self.audit_group_with_context(
+                    group_id,
+                    convergence_run_context(&run_id, ConvergencePhase::Blocked),
+                    marmot_forensics::AuditEventKind::ConvergenceRunState {
+                        phase: ConvergencePhase::Blocked,
+                        current_tip_epoch: Some(previous_tip.0),
+                        retained_anchor_horizon: Some(retained_anchor_epoch),
+                        reason: Some("anchor_lineage_mismatch".to_string()),
+                        error_kind: Some("anchor_lineage_mismatch".to_string()),
+                    },
+                );
+                result.selected_tip = None;
+                result.selected_fork_epoch = None;
+                result.selected_branch_id = None;
+                result.convergence_status = ConvergenceStatus::Blocked;
+                // The apply transaction unwound, so none of this pass's
+                // dispositions were persisted; returning them would let
+                // `convergence_ingest_outcome` report terminal outcomes for
+                // rows the next pass may still accept.
+                result.accepted_commits.clear();
+                result.accepted_proposals.clear();
+                result.accepted_app_messages.clear();
+                result.dropped_messages.clear();
+                result.invalidated_app_messages.clear();
+                result.deferred_messages.clear();
+                return Ok(result);
+            }
+            Err(err) => return Err(err),
+        };
         crate::test_crash_hooks::pause_if_requested("convergence-pass-completed-durable");
         // Diagnostic only: settling-latency telemetry for the remediation
         // plan — pass open → apply, and the gap since the previous completed

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -1577,7 +1577,7 @@ impl<S: StorageProvider> Engine<S> {
             tracing::warn!(
                 target: "cgka_engine::hydrate",
                 method = "hydrate_one_stored_group",
-                %error,
+                transient = error.is_transient(),
                 "failed to rebuild fork-routing state; group stays on the convergence path"
             );
         }

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -1285,6 +1285,14 @@ impl<S: StorageProvider> Engine<S> {
         .map_err(|_| GroupHydrationQuarantineReason::GroupRecordLoadFailed)?;
         crate::openmls_projection::recover_interrupted_apply_snapshot(&self.storage, group_id)
             .map_err(|_| GroupHydrationQuarantineReason::GroupRecordLoadFailed)?;
+        // A fork-recovery ordering-metadata probe (pairwise fork resolution or
+        // the hydrate-time routing-state rebuild) snapshots the live group
+        // before rolling back to a retained fork snapshot. Process termination
+        // between the snapshot and the guard's `commit` strands the group at
+        // the rolled-back state; the surviving `fork-probe-` snapshot holds the
+        // live state that must win on reopen.
+        crate::openmls_projection::recover_interrupted_fork_probe(&self.storage, group_id)
+            .map_err(|_| GroupHydrationQuarantineReason::GroupRecordLoadFailed)?;
 
         let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
         let mut mls_group = {

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -100,6 +100,12 @@ fn hydration_quarantine_reason_tag(reason: GroupHydrationQuarantineReason) -> &'
             "pending_commit_recovery_failed"
         }
         GroupHydrationQuarantineReason::ForkProbeRecoveryFailed => "fork_probe_recovery_failed",
+        GroupHydrationQuarantineReason::RetainedAnchorProbeRecoveryFailed => {
+            "retained_anchor_probe_recovery_failed"
+        }
+        GroupHydrationQuarantineReason::ConvergenceApplyRecoveryFailed => {
+            "convergence_apply_recovery_failed"
+        }
     }
 }
 
@@ -1283,9 +1289,9 @@ impl<S: StorageProvider> Engine<S> {
             &self.storage,
             group_id,
         )
-        .map_err(|_| GroupHydrationQuarantineReason::GroupRecordLoadFailed)?;
+        .map_err(|_| GroupHydrationQuarantineReason::RetainedAnchorProbeRecoveryFailed)?;
         crate::openmls_projection::recover_interrupted_apply_snapshot(&self.storage, group_id)
-            .map_err(|_| GroupHydrationQuarantineReason::GroupRecordLoadFailed)?;
+            .map_err(|_| GroupHydrationQuarantineReason::ConvergenceApplyRecoveryFailed)?;
         // A fork-recovery ordering-metadata probe (pairwise fork resolution or
         // the hydrate-time routing-state rebuild) snapshots the live group
         // before rolling back to a retained fork snapshot. Process termination

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -1576,9 +1576,20 @@ impl<S: StorageProvider> Engine<S> {
         // the pending-publish restore above (a restored pending owns the
         // newest fork snapshot at its source epoch). Best-effort: a failed
         // rebuild only forfeits the pairwise fast path — distributed
-        // convergence still resolves the fork — so it must not quarantine a
-        // healthy group. Skipped while Unrecoverable: ingest is halted there
-        // and the rebuild's probe replay would touch frozen state.
+        // convergence still resolves the fork — so a rebuild error must not
+        // quarantine a healthy group. This is a different obligation from
+        // `recover_interrupted_fork_probe`, which ran earlier in this
+        // hydration and quarantines by design: a surviving `fork-probe-`
+        // snapshot means live state is stranded mid-rollback, and several of
+        // them means ambiguous state (the serialized-probe invariant is
+        // enforced at probe creation in
+        // `probe_commit_ordering_metadata_for_recovery`, so multiple probes
+        // is an invariant break, not a healthy group). A probe the rebuild
+        // itself starts is covered on THIS path by its `SnapshotRollbackGuard`
+        // — an in-process failure rolls back and releases here, never
+        // reaching the recovery arm. Skipped while Unrecoverable: ingest is
+        // halted there and the rebuild's probe replay would touch frozen
+        // state.
         if !group.unrecoverable
             && let Err(error) = self.rebuild_fork_routing_state_on_hydrate(group_id)
         {

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -1560,6 +1560,27 @@ impl<S: StorageProvider> Engine<S> {
             self.epoch_manager.set_stable(group_id.clone(), group.epoch);
             ("stable", "hydrate_stable_group")
         };
+        // Fork-routing state (`EpochManager::committed_from` + the
+        // fork-recovery incumbents) lives only in memory; rebuild both from
+        // durable evidence (retained `fork-` snapshots + stored commit rows)
+        // so a restarted member resolves a same-epoch rival on the same
+        // pairwise path it would have taken before the restart. Runs after
+        // the pending-publish restore above (a restored pending owns the
+        // newest fork snapshot at its source epoch). Best-effort: a failed
+        // rebuild only forfeits the pairwise fast path — distributed
+        // convergence still resolves the fork — so it must not quarantine a
+        // healthy group. Skipped while Unrecoverable: ingest is halted there
+        // and the rebuild's probe replay would touch frozen state.
+        if !group.unrecoverable
+            && let Err(error) = self.rebuild_fork_routing_state_on_hydrate(group_id)
+        {
+            tracing::warn!(
+                target: "cgka_engine::hydrate",
+                method = "hydrate_one_stored_group",
+                %error,
+                "failed to rebuild fork-routing state; group stays on the convergence path"
+            );
+        }
         if let Some(request) = leave_request {
             self.leave_requests.insert(group_id.clone(), request);
             self.leaving_groups.insert(group_id.clone());

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -99,6 +99,7 @@ fn hydration_quarantine_reason_tag(reason: GroupHydrationQuarantineReason) -> &'
         GroupHydrationQuarantineReason::PendingCommitRecoveryFailed => {
             "pending_commit_recovery_failed"
         }
+        GroupHydrationQuarantineReason::ForkProbeRecoveryFailed => "fork_probe_recovery_failed",
     }
 }
 
@@ -1292,7 +1293,7 @@ impl<S: StorageProvider> Engine<S> {
         // the rolled-back state; the surviving `fork-probe-` snapshot holds the
         // live state that must win on reopen.
         crate::openmls_projection::recover_interrupted_fork_probe(&self.storage, group_id)
-            .map_err(|_| GroupHydrationQuarantineReason::GroupRecordLoadFailed)?;
+            .map_err(|_| GroupHydrationQuarantineReason::ForkProbeRecoveryFailed)?;
 
         let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
         let mut mls_group = {

--- a/crates/cgka-engine/src/engine_metrics.rs
+++ b/crates/cgka-engine/src/engine_metrics.rs
@@ -178,7 +178,7 @@ struct LastAppliedBranch {
 /// Held by `Engine<S>` and incremented at the convergence apply site. Exposed
 /// to callers as an [`EngineMetricsSnapshot`] via `Engine::engine_metrics`.
 /// Diagnostic only; never an input to convergence or branch selection.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct EngineMetrics {
     /// Settle episodes: times a group reached `Settled` and applied a branch,
     /// summed across groups. Denominator of `observed_reorg_rate`.
@@ -215,6 +215,23 @@ pub struct EngineMetrics {
     admin_reservation_prepared: u64,
     /// One-attempt reservations consumed by a failed preparation.
     admin_reservation_failed: u64,
+    /// Convergence passes completed unapplied because the selected branch was
+    /// rooted at this device's own commit whose retained anchor no longer
+    /// holds that commit's post-merge state (apply-time
+    /// `AnchorLineageMismatch`). Residual-divergence signal: a non-zero value
+    /// means this node may sit on a branch the rest of the fleet abandoned —
+    /// see `own_commits_retired_unrealized` for when that split becomes
+    /// permanent.
+    own_branch_unrealizable_blocked_passes: u64,
+    /// Parked own commits terminalized at the retirement horizon without ever
+    /// being realized (their branch stayed unprovable until it aged out).
+    /// Each count is a permanently completed residual divergence on some
+    /// group: this node terminalized a commit of its own that the winning
+    /// branch never contained. On every other group surface such a node looks
+    /// healthy — this counter (with its paired warn-level trace and audit
+    /// rows) is the operator-visible trace. Atomic because the retirement
+    /// sweep runs on a `&self` seeding path.
+    own_commits_retired_unrealized: std::sync::atomic::AtomicU64,
     /// Per-group completion time of the last applied pass, in-memory only
     /// (never snapshotted); feeds `generation_gap_ms`.
     last_pass_completed_at_ms: HashMap<GroupId, u64>,
@@ -234,6 +251,8 @@ impl Default for EngineMetrics {
             admin_reservation_hold_observations: 0,
             admin_reservation_prepared: 0,
             admin_reservation_failed: 0,
+            own_branch_unrealizable_blocked_passes: 0,
+            own_commits_retired_unrealized: std::sync::atomic::AtomicU64::new(0),
             last_pass_completed_at_ms: HashMap::new(),
         }
     }
@@ -327,6 +346,21 @@ impl EngineMetrics {
         self.admin_reservation_hold_observations += 1;
     }
 
+    /// Record a convergence pass completed unapplied because the selected
+    /// branch — rooted at this device's own parked commit — failed the
+    /// apply-time anchor lineage proof (residual-divergence warning signal).
+    pub fn note_own_branch_unrealizable_blocked_pass(&mut self) {
+        self.own_branch_unrealizable_blocked_passes += 1;
+    }
+
+    /// Record a parked own commit terminalized at the retirement horizon
+    /// without ever being realized: a residual divergence became permanent.
+    /// `&self` because the retirement sweep runs while seeding a pass.
+    pub fn note_own_commit_retired_unrealized(&self) {
+        self.own_commits_retired_unrealized
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
     /// Record the outcome of the one-attempt admin reservation.
     pub fn note_admin_reservation_attempt(&mut self, prepared: bool) {
         if prepared {
@@ -358,6 +392,10 @@ impl EngineMetrics {
             admin_reservation_hold_observations: self.admin_reservation_hold_observations,
             admin_reservation_prepared: self.admin_reservation_prepared,
             admin_reservation_failed: self.admin_reservation_failed,
+            own_branch_unrealizable_blocked_passes: self.own_branch_unrealizable_blocked_passes,
+            own_commits_retired_unrealized: self
+                .own_commits_retired_unrealized
+                .load(std::sync::atomic::Ordering::Relaxed),
         }
     }
 }
@@ -390,6 +428,15 @@ pub struct EngineMetricsSnapshot {
     pub admin_reservation_prepared: u64,
     /// One-attempt admin reservations consumed by a failed preparation.
     pub admin_reservation_failed: u64,
+    /// Passes completed unapplied because an own-commit branch failed its
+    /// apply-time anchor lineage proof. Residual-divergence warning: this
+    /// node may hold a branch the fleet abandoned.
+    pub own_branch_unrealizable_blocked_passes: u64,
+    /// Parked own commits terminalized at the retirement horizon without
+    /// ever being realized. Each one is a residual divergence made permanent
+    /// — a node that looks healthy on every group surface but split from the
+    /// fleet's branch.
+    pub own_commits_retired_unrealized: u64,
 }
 
 impl EngineMetricsSnapshot {

--- a/crates/cgka-engine/src/epoch_manager.rs
+++ b/crates/cgka-engine/src/epoch_manager.rs
@@ -307,6 +307,18 @@ impl EpochManager {
         Ok((group_id, prior_epoch))
     }
 
+    /// Re-own a pre-commit epoch after a process restart. Hydration calls this
+    /// with epochs rebuilt from durable evidence of a confirmed own commit
+    /// (the stamped stored wire row), so the fork-detection router keeps
+    /// resolving same-epoch rivals pairwise instead of taking the
+    /// distributed-convergence detour a cold `committed_from` map would force.
+    pub(crate) fn restore_committed_from(&mut self, group_id: GroupId, epoch: EpochId) {
+        self.committed_from
+            .entry(group_id)
+            .or_default()
+            .insert(epoch);
+    }
+
     pub(crate) fn prune_committed_from_before(
         &mut self,
         group_id: &GroupId,

--- a/crates/cgka-engine/src/fork_recovery.rs
+++ b/crates/cgka-engine/src/fork_recovery.rs
@@ -112,13 +112,23 @@ impl ForkRecoveryManager {
     /// disk (a `create_group_snapshot` under an existing name would fail or
     /// clobber, depending on the backend).
     fn observe_snapshot_counter(&mut self, snapshot_name: &str) {
-        if let Some(counter) = snapshot_name
-            .strip_prefix("fork-")
-            .and_then(|suffix| suffix.split('-').nth(1))
-            .and_then(|counter| counter.parse::<u64>().ok())
-        {
-            self.observe_snapshot_counter_value(counter);
-        }
+        // Real fork snapshots are `fork-<epoch>-<counter>-<digest>`. Require
+        // the epoch field to parse as a number too: transient
+        // `fork-probe-<epoch>-<digest>` guard names share the `fork-` prefix,
+        // and taking `.nth(1)` alone would mis-read their EPOCH field as a
+        // counter (the same mis-parse the hydrate scan and the
+        // `fork_snapshot_counters` test helper already guard against).
+        let Some(suffix) = snapshot_name.strip_prefix("fork-") else {
+            return;
+        };
+        let mut parts = suffix.split('-');
+        let (Some(_source_epoch), Some(counter)) = (
+            parts.next().and_then(|part| part.parse::<u64>().ok()),
+            parts.next().and_then(|part| part.parse::<u64>().ok()),
+        ) else {
+            return;
+        };
+        self.observe_snapshot_counter_value(counter);
     }
 
     /// [`Self::observe_snapshot_counter`] for a counter that has already been
@@ -153,6 +163,10 @@ impl ForkRecoveryManager {
 
     fn peek_pending(&self, pending: PendingStateRef) -> Option<MessageId> {
         self.pending.get(&pending).map(|r| r.storage_id.clone())
+    }
+
+    fn peek_pending_snapshot(&self, pending: PendingStateRef) -> Option<String> {
+        self.pending.get(&pending).map(|r| r.snapshot_name.clone())
     }
 
     fn promote_pending(&mut self, pending: PendingStateRef) -> Option<MessageId> {
@@ -406,6 +420,19 @@ impl<S: StorageProvider> Engine<S> {
         self.fork_recovery.peek_pending(pending)
     }
 
+    /// Read the fork-recovery snapshot name a pending entry owns, without
+    /// consuming the record. `do_confirm_published` persists this name in the
+    /// [`cgka_traits::message::OwnCommitConvergenceStamp`] so the hydrate-time
+    /// routing rebuild can MATCH the (own commit → fork snapshot) pairing
+    /// against durable evidence instead of inferring it from snapshot-name
+    /// recency.
+    pub(crate) fn peek_pending_snapshot_name_for_recovery(
+        &self,
+        pending: PendingStateRef,
+    ) -> Option<String> {
+        self.fork_recovery.peek_pending_snapshot(pending)
+    }
+
     pub(crate) fn forget_pending_commit_for_recovery(
         &mut self,
         pending: PendingStateRef,
@@ -553,8 +580,12 @@ impl<S: StorageProvider> Engine<S> {
     ///   `Processed` commit row whose MLS wire bytes carry that epoch;
     /// - an own commit's ordering metadata comes from its confirm-time
     ///   [`cgka_traits::message::OwnCommitConvergenceStamp`] (MLS cannot
-    ///   replay a device's own commit), an inbound commit's from replaying it
-    ///   against the fork snapshot (the same probe the pairwise router uses);
+    ///   replay a device's own commit), and its snapshot pairing from the
+    ///   stamp's recorded `fork_snapshot_name` (matched against the on-disk
+    ///   names; a stamp predating the field falls back to newest-at-epoch
+    ///   inference). An inbound commit's metadata comes from replaying it
+    ///   against the fork snapshot (the same probe the pairwise router uses),
+    ///   which incidentally proves its pairing;
     /// - `committed_from` is re-owned only for epochs whose stored applied
     ///   evidence includes a stamped own-commit row, and only alongside a
     ///   rebuilt incumbent — so the pairwise router can never be steered into
@@ -575,8 +606,12 @@ impl<S: StorageProvider> Engine<S> {
         let pending_snapshots = self.fork_recovery.pending_snapshot_names(group_id);
         // Newest fork snapshot per source epoch (mirrors `newest_fork_snapshot`
         // in the pending-publish hydration path). Names that fail to parse —
-        // including transient `fork-probe-…` guards — are ignored.
+        // including transient `fork-probe-…` guards — are ignored. All parsed
+        // non-pending names are also kept per epoch so an own-commit stamp
+        // that RECORDS its snapshot name can be matched exactly, even when a
+        // newer snapshot exists at the same epoch.
         let mut newest_by_epoch: BTreeMap<u64, (u64, String)> = BTreeMap::new();
+        let mut scanned_names_by_epoch: BTreeMap<u64, BTreeSet<String>> = BTreeMap::new();
         for name in self.storage.list_group_snapshots(group_id)? {
             if pending_snapshots.contains(&name) {
                 continue;
@@ -599,6 +634,10 @@ impl<S: StorageProvider> Engine<S> {
             // allocator behind the highest counter on disk, and the next
             // `next_snapshot_name` after restart could mint a colliding name.
             self.fork_recovery.observe_snapshot_counter_value(counter);
+            scanned_names_by_epoch
+                .entry(source_epoch)
+                .or_default()
+                .insert(name.clone());
             let entry = newest_by_epoch
                 .entry(source_epoch)
                 .or_insert((counter, name.clone()));
@@ -715,8 +754,42 @@ impl<S: StorageProvider> Engine<S> {
                 // it; the horizon prune retires it once the group advances.
                 continue;
             };
+            let mut snapshot_name = snapshot_name;
             let (priority, committer) = match stamp {
-                Some(stamp) => (stamp.priority, stamp.committer),
+                Some(stamp) => {
+                    // An inbound commit proves its snapshot pairing by
+                    // replaying against it (the probe below). An own commit
+                    // cannot be replayed, so its pairing is proven by MATCH:
+                    // the confirm-time stamp records the snapshot name its
+                    // recovery record owned, and the rebuild adopts exactly
+                    // that snapshot — it is the snapshot, not the ordering
+                    // key, that a later `resolve()` rolls back to. A recorded
+                    // name that is no longer on disk (or is owned by a
+                    // restored pending publish) means the pairing cannot be
+                    // proven; leave the epoch on the convergence path rather
+                    // than pair the commit with a snapshot it never owned.
+                    // Stamps written before the field existed fall back to
+                    // the newest-snapshot inference below, which is safe
+                    // today only by exclusion (pending-owned snapshots are
+                    // skipped and a displaced incumbent is parked, not left
+                    // `Processed`) — the recorded name makes it exact.
+                    if let Some(recorded) = stamp.fork_snapshot_name {
+                        let retained = scanned_names_by_epoch
+                            .get(&source_epoch_raw)
+                            .is_some_and(|names| names.contains(&recorded));
+                        if !retained {
+                            tracing::warn!(
+                                target: "cgka_engine::fork_recovery",
+                                method = "rebuild_fork_routing_state_on_hydrate",
+                                source_epoch = source_epoch.0,
+                                "own-commit stamp names a fork snapshot that is no longer retained; not rebuilding this incumbent"
+                            );
+                            continue;
+                        }
+                        snapshot_name = recorded;
+                    }
+                    (stamp.priority, stamp.committer)
+                }
                 None => match self.probe_commit_ordering_metadata_for_recovery(
                     group_id,
                     source_epoch,
@@ -845,6 +918,32 @@ mod tests {
             self.release_attempts.lock().unwrap().push(name.to_string());
             Err(StorageError::Backend("release failed".into()))
         }
+    }
+
+    #[test]
+    fn observe_snapshot_counter_ignores_fork_probe_guard_names() {
+        let mut manager = ForkRecoveryManager::default();
+        let group_id = GroupId::new(b"group".to_vec());
+
+        // `fork-probe-<epoch>-<digest>` shares the `fork-` prefix; its epoch
+        // field (7) sits exactly where a real name's counter would be, and
+        // must not advance the allocator.
+        manager.observe_snapshot_counter("fork-probe-7-aabbccdd00112233");
+        // A name whose epoch field is not numeric must be ignored too.
+        manager.observe_snapshot_counter("fork-x-9-aabbccdd00112233");
+        let first = manager.next_snapshot_name(&group_id, EpochId(1));
+        assert!(
+            first.starts_with("fork-1-1-"),
+            "allocator advanced by a non-fork name: {first}"
+        );
+
+        // A real durable name does advance it past its counter.
+        manager.observe_snapshot_counter("fork-3-9-0011223344556677");
+        let next = manager.next_snapshot_name(&group_id, EpochId(3));
+        assert!(
+            next.starts_with("fork-3-10-"),
+            "allocator did not advance past a real durable counter: {next}"
+        );
     }
 
     #[test]

--- a/crates/cgka-engine/src/fork_recovery.rs
+++ b/crates/cgka-engine/src/fork_recovery.rs
@@ -611,8 +611,13 @@ impl<S: StorageProvider> Engine<S> {
         }
 
         let current_epoch = self.storage.get_group(group_id)?.epoch;
+        // Ungated: this rebuild also runs inside
+        // `retry_hydrate_quarantined_group`, where the group stays quarantined
+        // until hydration succeeds — the gated read maps quarantine to
+        // `MissingGroup` and would forfeit the pairwise fast-path rebuild on
+        // every quarantine-retry hydration.
         let policy = self
-            .convergence_policy_for_group(group_id)
+            .convergence_policy_for_group_ungated(group_id)
             .map_err(|e| EngineError::Backend(format!("load convergence policy: {e}")))?;
         let oldest_retained_epoch = EpochId(
             current_epoch

--- a/crates/cgka-engine/src/fork_recovery.rs
+++ b/crates/cgka-engine/src/fork_recovery.rs
@@ -18,15 +18,17 @@
 //! distributed-convergence pass, not terminal).
 
 use crate::engine::Engine;
+use crate::message_processor::ForkProbeError;
+use crate::openmls_projection::{OpenMlsContentKind, project_mls_message};
 use cgka_traits::engine::{CommitOrderingKey, CommitOrderingPriority};
 use cgka_traits::engine_state::PendingStateRef;
 use cgka_traits::error::EngineError;
-use cgka_traits::message::MessageState;
+use cgka_traits::message::{MessageState, StoredMessagePayload};
 use cgka_traits::storage::{MessageStorage, StorageError, StorageProvider};
 use cgka_traits::types::{EpochId, GroupId, MemberId, MessageId};
 use marmot_forensics::{AuditEventKind, ForkWinner};
 use sha2::{Digest, Sha256};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 #[derive(Clone, Debug)]
 struct CommitRecoveryRecord {
@@ -105,6 +107,20 @@ impl ForkRecoveryManager {
         Ok(name)
     }
 
+    /// Advance the snapshot-name allocator past a durable snapshot's counter,
+    /// so a name minted after restart can never collide with one already on
+    /// disk (a `create_group_snapshot` under an existing name would fail or
+    /// clobber, depending on the backend).
+    fn observe_snapshot_counter(&mut self, snapshot_name: &str) {
+        if let Some(counter) = snapshot_name
+            .strip_prefix("fork-")
+            .and_then(|suffix| suffix.split('-').nth(1))
+            .and_then(|counter| counter.parse::<u64>().ok())
+        {
+            self.snapshot_counter = self.snapshot_counter.max(counter);
+        }
+    }
+
     pub(crate) fn record_pending(
         &mut self,
         pending: PendingStateRef,
@@ -114,13 +130,7 @@ impl ForkRecoveryManager {
         ordering_key: CommitOrderingKey,
         snapshot_name: String,
     ) {
-        if let Some(counter) = snapshot_name
-            .strip_prefix("fork-")
-            .and_then(|suffix| suffix.split('-').nth(1))
-            .and_then(|counter| counter.parse::<u64>().ok())
-        {
-            self.snapshot_counter = self.snapshot_counter.max(counter);
-        }
+        self.observe_snapshot_counter(&snapshot_name);
         self.pending.insert(
             pending,
             CommitRecoveryRecord {
@@ -153,8 +163,27 @@ impl ForkRecoveryManager {
     }
 
     fn record_applied(&mut self, record: CommitRecoveryRecord) {
+        self.observe_snapshot_counter(&record.snapshot_name);
         self.incumbents
             .insert((record.group_id.clone(), record.source_epoch), record);
+    }
+
+    fn has_incumbent(&self, group_id: &GroupId, source_epoch: EpochId) -> bool {
+        self.incumbents
+            .contains_key(&(group_id.clone(), source_epoch))
+    }
+
+    /// Snapshot names currently owned by restored pending publishes for this
+    /// group. Hydration must not hand these to a rebuilt incumbent: after a
+    /// fork rewind, an unconfirmed re-commit from the same source epoch owns
+    /// the NEWEST `fork-<epoch>-…` snapshot while the previously applied
+    /// incumbent keeps an older one.
+    fn pending_snapshot_names(&self, group_id: &GroupId) -> BTreeSet<String> {
+        self.pending
+            .values()
+            .filter(|record| &record.group_id == group_id)
+            .map(|record| record.snapshot_name.clone())
+            .collect()
     }
 
     /// Decide the pairwise race and, when the candidate wins, displace the
@@ -499,6 +528,200 @@ impl<S: StorageProvider> Engine<S> {
             .prune_before(&self.storage, group_id, oldest_retained_epoch);
         self.epoch_manager
             .prune_committed_from_before(group_id, oldest_retained_epoch);
+        Ok(())
+    }
+
+    /// Rebuild the two fork-routing structures that live only in memory —
+    /// `EpochManager::committed_from` and the fork-recovery `incumbents` map —
+    /// from their durable evidence on session open. Without this, a restarted
+    /// member routes a same-epoch rival through distributed convergence while
+    /// the same member before the restart would have resolved it pairwise;
+    /// convergence eventually reaches the same branch, but the detour (and the
+    /// divergent intermediate states it produces) is avoidable.
+    ///
+    /// Durable evidence, per fork snapshot `fork-<source_epoch>-<counter>-…`
+    /// still on disk:
+    /// - the applied commit at that source epoch is the group's single
+    ///   `Processed` commit row whose MLS wire bytes carry that epoch;
+    /// - an own commit's ordering metadata comes from its confirm-time
+    ///   [`cgka_traits::message::OwnCommitConvergenceStamp`] (MLS cannot
+    ///   replay a device's own commit), an inbound commit's from replaying it
+    ///   against the fork snapshot (the same probe the pairwise router uses);
+    /// - `committed_from` is re-owned only for epochs whose stored applied
+    ///   evidence includes a stamped own-commit row, and only alongside a
+    ///   rebuilt incumbent — so the pairwise router can never be steered into
+    ///   the fail-closed `MissingSnapshot` arm by a half-rebuilt map.
+    ///
+    /// The rewind-horizon bound of [`Self::prune_fork_recovery_for_group`]
+    /// carries over: epochs below `current - max_rewind_commits` are not
+    /// rebuilt and their snapshots are released (best-effort), exactly as
+    /// `prune_before` would have done had the process kept running.
+    ///
+    /// Must run after any pending-publish restore for the group: an
+    /// unconfirmed re-commit staged from a rewound epoch owns the newest
+    /// `fork-` snapshot at that epoch, which this rebuild must skip.
+    pub(crate) fn rebuild_fork_routing_state_on_hydrate(
+        &mut self,
+        group_id: &GroupId,
+    ) -> Result<(), EngineError> {
+        let pending_snapshots = self.fork_recovery.pending_snapshot_names(group_id);
+        // Newest fork snapshot per source epoch (mirrors `newest_fork_snapshot`
+        // in the pending-publish hydration path). Names that fail to parse —
+        // including transient `fork-probe-…` guards — are ignored.
+        let mut newest_by_epoch: BTreeMap<u64, (u64, String)> = BTreeMap::new();
+        for name in self.storage.list_group_snapshots(group_id)? {
+            if pending_snapshots.contains(&name) {
+                continue;
+            }
+            let Some(suffix) = name.strip_prefix("fork-") else {
+                continue;
+            };
+            let mut parts = suffix.split('-');
+            let (Some(source_epoch), Some(counter)) = (
+                parts.next().and_then(|part| part.parse::<u64>().ok()),
+                parts.next().and_then(|part| part.parse::<u64>().ok()),
+            ) else {
+                continue;
+            };
+            let entry = newest_by_epoch
+                .entry(source_epoch)
+                .or_insert((counter, name.clone()));
+            if counter > entry.0 {
+                *entry = (counter, name);
+            }
+        }
+        if newest_by_epoch.is_empty() {
+            return Ok(());
+        }
+
+        let current_epoch = self.storage.get_group(group_id)?.epoch;
+        let policy = self
+            .convergence_policy_for_group(group_id)
+            .map_err(|e| EngineError::Backend(format!("load convergence policy: {e}")))?;
+        let oldest_retained_epoch = EpochId(
+            current_epoch
+                .0
+                .saturating_sub(policy.convergence.max_rewind_commits),
+        );
+
+        // One decode pass over the horizon's stored rows: the single
+        // `Processed` commit per source epoch (the applied incumbent), and the
+        // source epochs holding a stamped own-commit row (stamps are written
+        // only at confirm, so a stamped row proves "we ourselves committed
+        // from this epoch" regardless of the row's current state — a
+        // fork-invalidated own commit keeps its `committed_from` entry, same
+        // as the in-memory map).
+        type AppliedRow = (
+            MessageId,
+            Vec<u8>,
+            Option<cgka_traits::message::OwnCommitConvergenceStamp>,
+        );
+        let mut applied_by_epoch: BTreeMap<u64, AppliedRow> = BTreeMap::new();
+        let mut own_commit_epochs: BTreeSet<u64> = BTreeSet::new();
+        for record in self
+            .storage
+            .list_messages(group_id, oldest_retained_epoch)?
+        {
+            let Ok(payload) = StoredMessagePayload::decode(&record.payload) else {
+                continue;
+            };
+            let Some(message) = payload.as_openmls_wire() else {
+                continue;
+            };
+            let Ok(projection) = project_mls_message(&message.payload) else {
+                continue;
+            };
+            if projection.kind != OpenMlsContentKind::Commit {
+                continue;
+            }
+            let Some(source_epoch) = projection.source_epoch else {
+                continue;
+            };
+            let stamp = payload.own_commit_stamp().cloned();
+            if stamp.is_some() {
+                own_commit_epochs.insert(source_epoch);
+            }
+            if record.state != MessageState::Processed {
+                continue;
+            }
+            let row = (record.id.clone(), message.payload.clone(), stamp);
+            // Steady state holds one Processed commit per source epoch; if a
+            // crash left more, prefer the own-stamped row (its ordering
+            // metadata was authenticated at confirm time and needs no replay).
+            let entry = applied_by_epoch.entry(source_epoch).or_insert(row.clone());
+            if entry.2.is_none() && row.2.is_some() {
+                *entry = row;
+            }
+        }
+
+        for (source_epoch_raw, (_, snapshot_name)) in newest_by_epoch {
+            let source_epoch = EpochId(source_epoch_raw);
+            if source_epoch < oldest_retained_epoch {
+                // Outside the rewind horizon: had the process kept running,
+                // `prune_before` would have released this snapshot already.
+                match self
+                    .storage
+                    .release_group_snapshot(group_id, &snapshot_name)
+                {
+                    Ok(()) | Err(StorageError::SnapshotMissing(_)) => {}
+                    Err(_e) => tracing::warn!(
+                        target: "cgka_engine::fork_recovery",
+                        method = "rebuild_fork_routing_state_on_hydrate",
+                        source_epoch = source_epoch.0,
+                        "failed to release a fork snapshot outside the rewind horizon"
+                    ),
+                }
+                continue;
+            }
+            if self.fork_recovery.has_incumbent(group_id, source_epoch) {
+                continue;
+            }
+            let Some((storage_id, mls_bytes, stamp)) = applied_by_epoch.remove(&source_epoch_raw)
+            else {
+                // No applied commit row: the snapshot is an orphan of a crash
+                // between snapshot creation and the apply transaction. Leave
+                // it; the horizon prune retires it once the group advances.
+                continue;
+            };
+            let (priority, committer) = match stamp {
+                Some(stamp) => (stamp.priority, stamp.committer),
+                None => match self.probe_commit_ordering_metadata_for_recovery(
+                    group_id,
+                    source_epoch,
+                    &snapshot_name,
+                    &mls_bytes,
+                ) {
+                    Ok(metadata) => metadata,
+                    Err(ForkProbeError::InvalidCandidate) => {
+                        // The stored applied commit no longer replays against
+                        // its own pre-commit snapshot; without a trustworthy
+                        // ordering key, leave this epoch on the convergence
+                        // path (the pre-rebuild restart behavior).
+                        tracing::warn!(
+                            target: "cgka_engine::fork_recovery",
+                            method = "rebuild_fork_routing_state_on_hydrate",
+                            source_epoch = source_epoch.0,
+                            "stored applied commit failed its fork-snapshot replay; not rebuilding this incumbent"
+                        );
+                        continue;
+                    }
+                    Err(ForkProbeError::Engine(error)) => return Err(error),
+                },
+            };
+            let ordering_key =
+                CommitOrderingKey::from_commit_bytes(source_epoch, priority, committer, &mls_bytes);
+            self.fork_recovery.record_applied(CommitRecoveryRecord {
+                group_id: group_id.clone(),
+                source_epoch,
+                ordering_key,
+                storage_id,
+                snapshot_name,
+            });
+            if own_commit_epochs.contains(&source_epoch_raw) {
+                self.epoch_manager
+                    .restore_committed_from(group_id.clone(), source_epoch);
+            }
+        }
         Ok(())
     }
 }

--- a/crates/cgka-engine/src/fork_recovery.rs
+++ b/crates/cgka-engine/src/fork_recovery.rs
@@ -654,6 +654,8 @@ impl<S: StorageProvider> Engine<S> {
             }
         }
 
+        let mut rebuilt_source_epochs: Vec<u64> = Vec::new();
+        let mut restored_committed_from_epochs: Vec<u64> = Vec::new();
         for (source_epoch_raw, (_, snapshot_name)) in newest_by_epoch {
             let source_epoch = EpochId(source_epoch_raw);
             if source_epoch < oldest_retained_epoch {
@@ -717,10 +719,24 @@ impl<S: StorageProvider> Engine<S> {
                 storage_id,
                 snapshot_name,
             });
+            rebuilt_source_epochs.push(source_epoch.0);
             if own_commit_epochs.contains(&source_epoch_raw) {
                 self.epoch_manager
                     .restore_committed_from(group_id.clone(), source_epoch);
+                restored_committed_from_epochs.push(source_epoch.0);
             }
+        }
+        // Forensics: distinguish post-restart reconstruction from in-flight
+        // fork resolution — an incumbent whose epoch appears here was
+        // recovered from durable evidence, not freshly applied.
+        if !rebuilt_source_epochs.is_empty() {
+            self.audit_group(
+                group_id,
+                AuditEventKind::ForkRoutingRebuilt {
+                    rebuilt_source_epochs,
+                    restored_committed_from_epochs,
+                },
+            );
         }
         Ok(())
     }

--- a/crates/cgka-engine/src/fork_recovery.rs
+++ b/crates/cgka-engine/src/fork_recovery.rs
@@ -117,8 +117,16 @@ impl ForkRecoveryManager {
             .and_then(|suffix| suffix.split('-').nth(1))
             .and_then(|counter| counter.parse::<u64>().ok())
         {
-            self.snapshot_counter = self.snapshot_counter.max(counter);
+            self.observe_snapshot_counter_value(counter);
         }
+    }
+
+    /// [`Self::observe_snapshot_counter`] for a counter that has already been
+    /// parsed out of a durable snapshot name — used by the hydrate-time scan,
+    /// which must advance the allocator for EVERY snapshot it parses, not just
+    /// the ones it goes on to rebuild.
+    fn observe_snapshot_counter_value(&mut self, counter: u64) {
+        self.snapshot_counter = self.snapshot_counter.max(counter);
     }
 
     pub(crate) fn record_pending(
@@ -583,6 +591,14 @@ impl<S: StorageProvider> Engine<S> {
             ) else {
                 continue;
             };
+            // Advance the snapshot-name allocator for EVERY parsed durable
+            // name, before any filtering. Only rebuilt incumbents reach
+            // `record_applied` (which observes their counter); a snapshot
+            // skipped here as an orphan, dropped below the rewind horizon, or
+            // abandoned after a failed replay probe would otherwise leave the
+            // allocator behind the highest counter on disk, and the next
+            // `next_snapshot_name` after restart could mint a colliding name.
+            self.fork_recovery.observe_snapshot_counter_value(counter);
             let entry = newest_by_epoch
                 .entry(source_epoch)
                 .or_insert((counter, name.clone()));
@@ -648,9 +664,18 @@ impl<S: StorageProvider> Engine<S> {
             // Steady state holds one Processed commit per source epoch; if a
             // crash left more, prefer the own-stamped row (its ordering
             // metadata was authenticated at confirm time and needs no replay).
-            let entry = applied_by_epoch.entry(source_epoch).or_insert(row.clone());
-            if entry.2.is_none() && row.2.is_some() {
-                *entry = row;
+            // The vacant arm MOVES the row (the MLS payload is not cloned);
+            // the occupied arm only replaces when the newcomer is the
+            // own-stamped one.
+            match applied_by_epoch.entry(source_epoch) {
+                std::collections::btree_map::Entry::Vacant(slot) => {
+                    slot.insert(row);
+                }
+                std::collections::btree_map::Entry::Occupied(mut slot) => {
+                    if slot.get().2.is_none() && row.2.is_some() {
+                        slot.insert(row);
+                    }
+                }
             }
         }
 

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -2327,6 +2327,25 @@ impl<S: StorageProvider> Engine<S> {
             source_epoch.0,
             hex::encode(&digest[..8])
         );
+        // Enforce the "fork probes are serialized per group" invariant that
+        // `recover_interrupted_fork_probe` depends on: with at most one probe
+        // snapshot ever live, a surviving one after a crash unambiguously
+        // holds the newer live state. Refuse to open a second probe rather
+        // than create the multi-probe ambiguity that recovery can only fail
+        // closed on (quarantine). Probes run on the ingest and hydrate paths,
+        // both `&mut self`-serialized, so this should be unreachable — it
+        // turns a prose invariant into a checked one.
+        let existing_probe = self
+            .storage
+            .list_group_snapshots(group_id)
+            .map_err(|error| ForkProbeError::Engine(error.into()))?
+            .into_iter()
+            .any(|name| name.starts_with(crate::openmls_projection::FORK_PROBE_SNAPSHOT_PREFIX));
+        if existing_probe {
+            return Err(ForkProbeError::Engine(EngineError::Backend(
+                "fork-recovery ordering probe already in progress for this group".into(),
+            )));
+        }
         let guard = SnapshotRollbackGuard::create(&self.storage, group_id.clone(), probe_snapshot)
             .map_err(|error| ForkProbeError::Engine(error.into()))?;
         self.storage

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -2322,7 +2322,8 @@ impl<S: StorageProvider> Engine<S> {
         hasher.update(mls_bytes);
         let digest = hasher.finalize();
         let probe_snapshot = format!(
-            "fork-probe-{}-{}",
+            "{}{}-{}",
+            crate::openmls_projection::FORK_PROBE_SNAPSHOT_PREFIX,
             source_epoch.0,
             hex::encode(&digest[..8])
         );

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -71,7 +71,7 @@ enum ScheduledAutoCommitReplay {
     NotApplicable,
 }
 
-enum ForkProbeError {
+pub(crate) enum ForkProbeError {
     InvalidCandidate,
     Engine(EngineError),
 }
@@ -2308,7 +2308,7 @@ impl<S: StorageProvider> Engine<S> {
         }
     }
 
-    fn probe_commit_ordering_metadata_for_recovery(
+    pub(crate) fn probe_commit_ordering_metadata_for_recovery(
         &self,
         group_id: &GroupId,
         source_epoch: EpochId,

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -12,6 +12,7 @@ mod ingest;
 mod send;
 mod store;
 
+pub(crate) use ingest::ForkProbeError;
 pub(crate) use ingest::avatar_component_snapshot;
 pub(crate) use send::merge_capabilities;
 #[cfg(feature = "test-conformance-snapshot")]

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -478,6 +478,10 @@ pub(crate) fn own_commit_stamp(
         priority,
         consumed_proposal_refs,
         post_commit_tree_marker: None,
+        // Filled in by the caller from the pending fork-recovery record: the
+        // snapshot pairing is confirm-path bookkeeping, not derivable from the
+        // staged commit.
+        fork_snapshot_name: None,
     })
 }
 
@@ -658,11 +662,23 @@ pub fn project_mls_message(
 /// terminal disposition, leaving it `ConvergenceDeferred` forever. Malformed,
 /// non-OpenMLS, and non-commit rows remain untouched: this maintenance path
 /// must not turn old unrelated storage damage into a convergence failure.
+/// One commit retired below the retained-anchor horizon by
+/// [`retire_stale_convergence_deferred_commits`].
+pub(crate) struct RetiredDeferredCommit {
+    pub(crate) message_id: MessageId,
+    pub(crate) source_epoch: EpochId,
+    /// The retired row carried an own-commit convergence stamp: this device
+    /// published and confirmed it, and it aged out without ever being
+    /// realized. Retiring such a row completes a residual divergence — the
+    /// caller surfaces it as an operator-visible diagnostic.
+    pub(crate) own_commit: bool,
+}
+
 pub(crate) fn retire_stale_convergence_deferred_commits<S: StorageProvider>(
     storage: &S,
     group_id: &GroupId,
     retained_anchor_epoch: u64,
-) -> Result<Vec<(MessageId, EpochId)>, OpenMlsProjectionError> {
+) -> Result<Vec<RetiredDeferredCommit>, OpenMlsProjectionError> {
     storage.with_transaction(|storage| {
         let records = storage.list_messages(group_id, EpochId(0))?;
         let mut retired = Vec::new();
@@ -690,7 +706,11 @@ pub(crate) fn retire_stale_convergence_deferred_commits<S: StorageProvider>(
             }
 
             storage.update_message_state(&record.id, MessageState::EpochInvalidated)?;
-            retired.push((record.id, EpochId(source_epoch)));
+            retired.push(RetiredDeferredCommit {
+                own_commit: payload.own_commit_stamp().is_some(),
+                message_id: record.id,
+                source_epoch: EpochId(source_epoch),
+            });
         }
 
         Ok(retired)
@@ -2102,11 +2122,16 @@ pub(crate) fn recover_interrupted_apply_snapshot<S: StorageProvider>(
 /// cancellation, but it cannot run on process termination. A surviving
 /// `fork-probe-` snapshot therefore always contains the newer live state that
 /// must win on the next open; the on-disk OpenMLS state is stranded at the
-/// rolled-back fork snapshot. More than one probe snapshot is not expected:
-/// fork probes are serialized per group and hydrate runs before any new work
-/// (the same invariant [`recover_interrupted_retained_anchor_probe`] relies
-/// on). If storage contains several, fail closed instead of guessing which
-/// live state is newest.
+/// rolled-back fork snapshot. More than one probe snapshot cannot occur
+/// without an invariant break: fork probes are serialized per group —
+/// enforced at probe creation, which refuses to open a probe while another
+/// probe snapshot exists — and hydrate runs before any new work (the same
+/// invariant [`recover_interrupted_retained_anchor_probe`] relies on). If
+/// storage nevertheless contains several, fail closed (the caller
+/// quarantines) instead of guessing which live state is newest. This
+/// quarantine is deliberate and does not contradict the hydrate rebuild's
+/// "must not quarantine a healthy group" rule: a multi-probe group is not
+/// healthy, its live state is genuinely ambiguous.
 ///
 /// [`SnapshotRollbackGuard`]: crate::snapshot_guard::SnapshotRollbackGuard
 /// [`Engine::probe_commit_ordering_metadata_for_recovery`]: crate::message_processor::ingest::Engine::probe_commit_ordering_metadata_for_recovery
@@ -2754,6 +2779,17 @@ fn process_openmls_messages_inner<S: StorageProvider>(
             // of getting their own live branch pruned and terminalized.
             if !own_commits.is_canonical(&projection.message_digest) {
                 let Some(expected_marker) = stamp.post_commit_tree_marker.as_deref() else {
+                    // Operator-visible residual-divergence signal: pruning a
+                    // parked own commit's branch here means peers that
+                    // applied it may settle on a branch this node can never
+                    // realize, while every group surface on this node still
+                    // looks healthy. Privacy-safe: aggregate reason only.
+                    tracing::warn!(
+                        target: "cgka_engine::openmls_projection",
+                        method = "replay_openmls_messages_prevalidated",
+                        reason = "own_commit_stamp_without_marker",
+                        "pruning a parked own-commit branch: its pre-marker stamp cannot prove the retained anchor; this node may diverge from peers that applied the commit"
+                    );
                     return Err(OpenMlsProjectionError::Replay(format!(
                         "own commit at epoch {source_epoch} carries no post-merge marker; \
                          its anchor cannot be proven"
@@ -2762,6 +2798,15 @@ fn process_openmls_messages_inner<S: StorageProvider>(
                 let actual_marker = own_commit_post_merge_tree_marker(&mls_group)
                     .map_err(|e| OpenMlsProjectionError::Replay(format!("anchor marker: {e}")))?;
                 if actual_marker != expected_marker {
+                    // Same residual-divergence signal for a clobbered anchor
+                    // caught at materialization (a peer commit landing on the
+                    // same epoch replaced the anchor's contents).
+                    tracing::warn!(
+                        target: "cgka_engine::openmls_projection",
+                        method = "replay_openmls_messages_prevalidated",
+                        reason = "own_commit_anchor_clobbered",
+                        "pruning a parked own-commit branch: its retained anchor no longer holds the commit's post-merge state; this node may diverge from peers that applied the commit"
+                    );
                     return Err(OpenMlsProjectionError::Replay(format!(
                         "retained anchor at epoch {resulting_epoch} does not hold this own \
                          commit's post-merge state"
@@ -3433,6 +3478,7 @@ mod anchor_prefix_lineage_tests {
             priority: CommitOrderingPriority::Privileged,
             consumed_proposal_refs: Vec::new(),
             post_commit_tree_marker,
+            fork_snapshot_name: None,
         };
         MessageRecord {
             id: MessageId::new(id.to_vec()),

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -2058,6 +2058,47 @@ pub(crate) fn recover_interrupted_apply_snapshot<S: StorageProvider>(
     rollback_and_release_group_snapshot(storage, group_id, snapshot)
 }
 
+/// Recover the live state captured before a fork-recovery ordering-metadata
+/// probe that was interrupted by process termination.
+///
+/// [`Engine::probe_commit_ordering_metadata_for_recovery`] snapshots the live
+/// group, then rolls back to a retained fork snapshot to replay the probed
+/// commit against the correct pre-commit epoch. The [`SnapshotRollbackGuard`]
+/// restores the live state on the happy path and on in-process panics or async
+/// cancellation, but it cannot run on process termination. A surviving
+/// `fork-probe-` snapshot therefore always contains the newer live state that
+/// must win on the next open; the on-disk OpenMLS state is stranded at the
+/// rolled-back fork snapshot. More than one probe snapshot is not expected:
+/// fork probes are serialized per group and hydrate runs before any new work
+/// (the same invariant [`recover_interrupted_retained_anchor_probe`] relies
+/// on). If storage contains several, fail closed instead of guessing which
+/// live state is newest.
+///
+/// [`SnapshotRollbackGuard`]: crate::snapshot_guard::SnapshotRollbackGuard
+/// [`Engine::probe_commit_ordering_metadata_for_recovery`]: crate::message_processor::ingest::Engine::probe_commit_ordering_metadata_for_recovery
+pub(crate) fn recover_interrupted_fork_probe<S: StorageProvider>(
+    storage: &S,
+    group_id: &GroupId,
+) -> Result<(), OpenMlsProjectionError> {
+    let probes = storage
+        .list_group_snapshots(group_id)
+        .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?
+        .into_iter()
+        .filter(|name| name.starts_with(FORK_PROBE_SNAPSHOT_PREFIX))
+        .collect::<Vec<_>>();
+
+    let Some(snapshot) = probes.first() else {
+        return Ok(());
+    };
+    if probes.len() != 1 {
+        return Err(OpenMlsProjectionError::Snapshot(
+            "multiple interrupted fork-recovery probes".into(),
+        ));
+    }
+
+    rollback_and_release_group_snapshot(storage, group_id, snapshot)
+}
+
 fn restore_live_message_and_queue_records<S: StorageProvider>(
     storage: &S,
     messages: &[MessageRecord],
@@ -3132,6 +3173,14 @@ fn retained_anchor_probe_snapshot_name(group_id: &GroupId, epoch: u64) -> String
 }
 
 const RETAINED_ANCHOR_PROBE_SNAPSHOT_PREFIX: &str = "openmls-retained-probe-";
+
+/// Prefix for the transient snapshot created by
+/// [`crate::message_processor::ingest::Engine::probe_commit_ordering_metadata_for_recovery`]
+/// (the pairwise fork-resolution ordering-metadata probe). A surviving
+/// snapshot with this prefix identifies a probe interrupted by process
+/// termination; [`recover_interrupted_fork_probe`] restores the captured
+/// pre-probe live state before hydration loads MLS state.
+pub(crate) const FORK_PROBE_SNAPSHOT_PREFIX: &str = "fork-probe-";
 
 fn replay_snapshot_name(group_id: &GroupId, messages: &[TransportMessage]) -> String {
     let mut hasher = Sha256::new();

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -481,18 +481,49 @@ pub(crate) fn own_commit_stamp(
     })
 }
 
+/// Bumped whenever the marker derivation changes. Existing stamps then
+/// mismatch, so their anchors read as unprovable and the branch prunes —
+/// fail-closed, never fail-open.
+const OWN_COMMIT_POST_MERGE_MARKER_VERSION: u8 = 2;
+
 /// Fingerprint the state an own commit produced, for
 /// [`cgka_traits::message::OwnCommitConvergenceStamp::post_commit_tree_marker`].
 ///
 /// Call with the group AFTER `merge_pending_commit`. The ciphersuite is read
 /// from the group itself so the value recomputed at rewind time (which has no
 /// engine handle) is derived from exactly the same inputs.
+///
+/// The marker is `SHA-256(version || ciphersuite || len(GroupContext) ||
+/// TLS(GroupContext) || TLS(exported ratchet tree))`. This value does
+/// IDENTITY work — [`verify_rewound_anchor_lineage`] and the materialization
+/// rollforward accept a rewound anchor solely on its say-so — so unlike
+/// `compute_validated_tree_marker` (which certifies leaf-credential bytes for
+/// the open-time re-validation skip and deliberately hashes only the tree),
+/// it must bind the full GroupContext: epoch, tree hash, and confirmed
+/// transcript hash. A commit that leaves the ratchet tree unchanged (e.g. a
+/// group-data update) still advances the transcript, so two distinct
+/// lineages cannot share a marker the way they could share a tree.
 pub(crate) fn own_commit_post_merge_tree_marker(
     merged: &MlsGroup,
 ) -> Result<String, cgka_traits::error::EngineError> {
-    Ok(hex::encode(
-        crate::group_lifecycle::compute_validated_tree_marker(merged, merged.ciphersuite())?,
-    ))
+    let serialize_err =
+        |e: tls_codec::Error| cgka_traits::error::EngineError::Serialize(format!("{e}"));
+    let context_bytes = merged
+        .public_group()
+        .group_context()
+        .tls_serialize_detached()
+        .map_err(serialize_err)?;
+    let tree_bytes = merged
+        .export_ratchet_tree()
+        .tls_serialize_detached()
+        .map_err(serialize_err)?;
+    let mut hasher = Sha256::new();
+    hasher.update([OWN_COMMIT_POST_MERGE_MARKER_VERSION]);
+    hasher.update(u16::from(merged.ciphersuite()).to_be_bytes());
+    hasher.update((context_bytes.len() as u64).to_be_bytes());
+    hasher.update(&context_bytes);
+    hasher.update(&tree_bytes);
+    Ok(hex::encode(hasher.finalize()))
 }
 
 /// Give retained proposal rows the same terminal disposition when a local
@@ -1983,16 +2014,19 @@ fn anchor_realizable_own_commit_prefix<S: StorageProvider>(
 /// caller additionally rolls the group back to the pre-apply snapshot — so a
 /// failed proof leaves live state untouched.
 ///
-/// LIVENESS LIMITATION (deliberate, not papered over): when the anchor HAS
-/// been clobbered, the parked own commit can no longer be realized AT ALL. The
-/// anchor rewind is its only route — MLS `process_message` refuses this
-/// device's own commits, so normal replay cannot materialize it either. This
-/// node therefore fails closed and stays diverged from the branch the rest of
-/// the fleet selected until the rewind horizon retires the parked row
-/// (`BeyondRollbackHorizon` / `beyond_retained_anchor`), after which it
-/// reorgs onto whatever remains selectable. Correctness is preserved — no
-/// wrong lineage is ever installed — but liveness inside that window is not.
-/// Restoring it requires re-keying retained anchors by content rather than by
+/// LIVENESS: when the anchor HAS been clobbered, the parked own commit can no
+/// longer be realized AT ALL. The anchor rewind is its only route — MLS
+/// `process_message` refuses this device's own commits, so normal replay
+/// cannot materialize it either. Materialization runs this same proof
+/// per-branch and prunes an unprovable branch before selection, so a mismatch
+/// HERE means the anchor was clobbered between materialization and apply; the
+/// convergence driver then completes the pass unapplied instead of
+/// propagating the error (which would retry the identical selection forever
+/// and pin the tip — the wedge from the PR #1236 review), and the next pass
+/// prunes the branch at materialization and settles on what remains
+/// selectable. The node stays diverged from a fleet branch rooted at its own
+/// unrealizable commit until depth or a re-add reconverges them; removing
+/// that divergence needs retained anchors re-keyed by content rather than by
 /// epoch, which is shared with the convergence engine and out of scope here.
 fn verify_rewound_anchor_lineage<S: StorageProvider>(
     storage: &S,
@@ -2694,6 +2728,45 @@ fn process_openmls_messages_inner<S: StorageProvider>(
                 return Err(OpenMlsProjectionError::Replay(format!(
                     "own commit anchor epoch {anchor_epoch} does not match resulting epoch {resulting_epoch}"
                 )));
+            }
+            // Realizability is decided HERE, at materialization, with the same
+            // positive lineage proof the apply stage takes
+            // (`verify_rewound_anchor_lineage`): anchors are name-keyed by
+            // resulting epoch and replaced by every capture at that epoch, so
+            // the name and epoch checks above cannot see a clobber. A stamp
+            // with no marker (pre-marker row) or a marker the rewound state
+            // does not reproduce makes this branch unrealizable on this
+            // device; the Replay error prunes the branch
+            // (`probe_candidate_path` maps it to an unmaterialized candidate)
+            // so selection never nominates a branch the apply is guaranteed
+            // to refuse — that disagreement is what wedged the pass (PR #1236
+            // review).
+            //
+            // The proof is required only for NON-canonical rows — the parked
+            // displaced commits whose realization is the point of this arm.
+            // A `Processed` own commit is already applied on the live chain,
+            // the apply skips it via its already-applied prefix (never
+            // rewinding to its anchor), and its anchor here only provides
+            // replay context whose wrongness is self-limiting (subsequent
+            // commits fail to replay and the branch prunes) — so rows stamped
+            // before the marker existed (or under an older derivation) keep
+            // materializing their canonical prefix after an upgrade instead
+            // of getting their own live branch pruned and terminalized.
+            if !own_commits.is_canonical(&projection.message_digest) {
+                let Some(expected_marker) = stamp.post_commit_tree_marker.as_deref() else {
+                    return Err(OpenMlsProjectionError::Replay(format!(
+                        "own commit at epoch {source_epoch} carries no post-merge marker; \
+                         its anchor cannot be proven"
+                    )));
+                };
+                let actual_marker = own_commit_post_merge_tree_marker(&mls_group)
+                    .map_err(|e| OpenMlsProjectionError::Replay(format!("anchor marker: {e}")))?;
+                if actual_marker != expected_marker {
+                    return Err(OpenMlsProjectionError::Replay(format!(
+                        "retained anchor at epoch {resulting_epoch} does not hold this own \
+                         commit's post-merge state"
+                    )));
+                }
             }
             observations.push(OpenMlsReplayObservation::CommitStaged {
                 message_id,

--- a/crates/cgka-engine/src/publish.rs
+++ b/crates/cgka-engine/src/publish.rs
@@ -90,6 +90,7 @@ impl<S: StorageProvider> Engine<S> {
         // publish-confirm call), so re-attach it explicitly.
         let audit_context = self.epoch_manager.audit_context_for_pending(pending);
         let origin_commit_id = self.peek_pending_commit_for_recovery(pending);
+        let pending_fork_snapshot_name = self.peek_pending_snapshot_name_for_recovery(pending);
         let queued_intent = self.queued_intent_by_pending.get(&pending).cloned();
 
         let provider = EngineOpenMlsProvider::<S>::new(&self.crypto, self.storage.mls_storage());
@@ -136,10 +137,18 @@ impl<S: StorageProvider> Engine<S> {
                         // cannot re-derive priority or consumed proposal refs
                         // from the wire bytes later (MLS refuses to process
                         // own commits), so this is the only durable source.
-                        own_commit_stamp = Some(crate::openmls_projection::own_commit_stamp(
+                        let mut stamp = crate::openmls_projection::own_commit_stamp(
                             staged,
                             self.identity.self_id().clone(),
-                        )?);
+                        )?;
+                        // Bind the stamp to the exact fork snapshot this
+                        // commit's recovery record owns. The hydrate-time
+                        // routing rebuild uses this to prove the
+                        // (own commit → fork snapshot) pairing rather than
+                        // pairing the commit with whatever snapshot happens
+                        // to be newest at its source epoch.
+                        stamp.fork_snapshot_name = pending_fork_snapshot_name.clone();
+                        own_commit_stamp = Some(stamp);
                     }
                     let source_epoch = EpochId(mls_group.epoch().as_u64());
                     crate::openmls_projection::mark_consumed_proposal_records_processed(

--- a/crates/cgka-engine/tests/fork_detection.rs
+++ b/crates/cgka-engine/tests/fork_detection.rs
@@ -2487,3 +2487,67 @@ fn fork_snapshot_counters(storage: &SqliteAccountStorage, group_id: &GroupId) ->
         })
         .collect()
 }
+
+#[tokio::test]
+async fn hydrate_recovers_interrupted_fork_probe_snapshot() {
+    let local_id = b"fprobe-local".as_slice();
+    let (group_id, local_storage, _local_commit, _rival_root) =
+        forked_privileged_invites(local_id, b"fprobe-rival", b"fprobe-david", b"fprobe-eve").await;
+
+    // The live group record after the local's own commit applied (epoch 2).
+    let live_group = local_storage.get_group(&group_id).unwrap();
+    assert_eq!(live_group.epoch.0, 2);
+
+    // The retained fork snapshot for the local's own commit (source epoch 1).
+    let fork_snapshot = local_storage
+        .list_group_snapshots(&group_id)
+        .unwrap()
+        .into_iter()
+        .find(|name| name.strip_prefix("fork-").is_some() && !name.starts_with("fork-probe-"))
+        .expect("a retained fork-<epoch>-<counter> snapshot must exist after the local commit");
+
+    // Simulate the interrupted probe: capture the live state in a
+    // `fork-probe-` snapshot, then strand the on-disk group at the fork
+    // snapshot's pre-commit state (exactly what
+    // `probe_commit_ordering_metadata_for_recovery` does before the guard's
+    // `commit`).
+    local_storage
+        .create_group_snapshot(&group_id, "fork-probe-1-deadbeefcafebabe")
+        .unwrap();
+    local_storage
+        .rollback_group_to_snapshot(&group_id, &fork_snapshot)
+        .unwrap();
+
+    // Fixture invariant: the group is now stranded at the pre-commit state.
+    let stranded = local_storage.get_group(&group_id).unwrap();
+    assert_eq!(
+        stranded.epoch.0, 1,
+        "fixture must start in the crash-stranded pre-fork state"
+    );
+
+    // RESTART: hydration must detect the `fork-probe-` snapshot, restore the
+    // captured live state, and release the probe snapshot.
+    let mut local = reopen_legacy_client(local_id, local_storage.clone());
+    local
+        .hydrate_stable_groups_from_storage()
+        .expect("hydrate recovers the interrupted fork probe");
+
+    assert_eq!(
+        local_storage.get_group(&group_id).unwrap(),
+        live_group,
+        "hydrate must restore the pre-probe live state"
+    );
+    assert_eq!(
+        local.epoch(&group_id).unwrap().0,
+        2,
+        "the restored epoch must match the live state"
+    );
+    assert!(
+        !local_storage
+            .list_group_snapshots(&group_id)
+            .unwrap()
+            .iter()
+            .any(|name| name.starts_with("fork-probe-")),
+        "the recovered fork-probe snapshot must be released"
+    );
+}

--- a/crates/cgka-engine/tests/fork_detection.rs
+++ b/crates/cgka-engine/tests/fork_detection.rs
@@ -178,6 +178,25 @@ fn reopen_current_client(id: &[u8], storage: SqliteAccountStorage) -> Engine<Sql
     engine
 }
 
+/// Restart under the SAME legacy-compatibility profile `build_client` used.
+/// The restart-routing tests below must isolate the fork-routing rebuild:
+/// reopening under `ProtocolProfile::Current` would additionally arm the
+/// strict-cutover probe gate, which rejects the rival Add commit outright
+/// (see `strict_cutover_legacy_add_cannot_displace_valid_fork_incumbent`)
+/// instead of letting it race the incumbent.
+fn reopen_legacy_client(id: &[u8], storage: SqliteAccountStorage) -> Engine<SqliteAccountStorage> {
+    let mut engine = EngineBuilder::new(storage)
+        .legacy_compatibility_profile()
+        .identity(pad32(id))
+        .account_identity_proof_signer(proof_signer(id))
+        .feature_registry(selfremove_registry())
+        .peeler(Box::new(MockPeeler))
+        .build()
+        .unwrap();
+    engine.hydrate_stable_groups_from_storage().unwrap();
+    engine
+}
+
 fn raw_self_update_commit(
     storage: &SqliteAccountStorage,
     sender: &MemberId,
@@ -1594,6 +1613,304 @@ async fn pairwise_incumbent_defers_to_deeper_convergence_branch() {
         },
         "both nodes must end on the identical branch"
     );
+}
+
+/// Shared fixture for the restart-routing tests: `local` creates the group
+/// with `rival` as a second admin, then both invite someone from epoch 1
+/// without seeing each other's commit — a same-epoch privileged fork. Both
+/// confirm their own publish. Returns local's storage (for the restart), the
+/// two competing epoch-1 commits, and the group id.
+async fn forked_privileged_invites(
+    local_id: &[u8],
+    rival_id: &[u8],
+    local_invitee_id: &[u8],
+    rival_invitee_id: &[u8],
+) -> (
+    cgka_traits::types::GroupId,
+    SqliteAccountStorage,
+    TransportMessage,
+    TransportMessage,
+) {
+    let (mut local, local_storage) = build_client_with_storage(local_id);
+    let mut rival = build_client(rival_id);
+    let mut local_invitee = build_client(local_invitee_id);
+    let mut rival_invitee = build_client(rival_invitee_id);
+
+    let rival_kp = rival.fresh_key_package().await.unwrap();
+    let (group_id, create) = local
+        .create_group(CreateGroupRequest {
+            name: "restart-routing".into(),
+            description: String::new(),
+            members: vec![rival_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![rival.self_id()],
+        })
+        .await
+        .unwrap();
+    let welcome = match create {
+        SendResult::GroupCreated {
+            pending,
+            mut welcomes,
+        } => {
+            local.confirm_published(pending).await.unwrap();
+            welcomes.remove(0)
+        }
+        _ => unreachable!(),
+    };
+    rival.join_welcome(welcome).await.unwrap();
+    assert_eq!(local.epoch(&group_id).unwrap().0, 1);
+    assert_eq!(rival.epoch(&group_id).unwrap().0, 1);
+
+    let local_invitee_kp = local_invitee.fresh_key_package().await.unwrap();
+    let rival_invitee_kp = rival_invitee.fresh_key_package().await.unwrap();
+    let local_invite = local
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![local_invitee_kp],
+        })
+        .await
+        .unwrap();
+    let rival_invite = rival
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![rival_invitee_kp],
+        })
+        .await
+        .unwrap();
+    let (local_commit, rival_root) = match (local_invite, rival_invite) {
+        (
+            SendResult::GroupEvolution {
+                msg: l,
+                pending: lp,
+                ..
+            },
+            SendResult::GroupEvolution {
+                msg: r,
+                pending: rp,
+                ..
+            },
+        ) => {
+            local.confirm_published(lp).await.unwrap();
+            rival.confirm_published(rp).await.unwrap();
+            (l, r)
+        }
+        _ => unreachable!(),
+    };
+    assert_eq!(local.epoch(&group_id).unwrap().0, 2);
+    (group_id, local_storage, local_commit, rival_root)
+}
+
+#[tokio::test]
+async fn restarted_incumbent_keeper_still_resolves_pairwise_and_parks_loser_root() {
+    // The fork-routing state (`committed_from` + the fork-recovery incumbent)
+    // used to live only in memory: a RESTARTED member that had committed from
+    // epoch 1 no longer knew it, so the same-epoch rival detoured through
+    // distributed convergence instead of losing the pairwise race. After the
+    // hydrate-time rebuild, the restarted path must be byte-for-byte the
+    // no-restart path of `pairwise_incumbent_defers_to_deeper_convergence_branch`:
+    // Stale/AlreadyAtEpoch, no ForkRecovered, and the loser root parked
+    // `ConvergenceDeferred` at its source epoch.
+    use cgka_traits::ingest::{IngestOutcome, StaleReason};
+
+    // The local (restarted) member must WIN the pairwise race: privileged
+    // same-epoch commits order by committer identity, lower wins.
+    let first = b"restart-park-first".as_slice();
+    let second = b"restart-park-second".as_slice();
+    let (local_id, rival_id) = if pad32(first) < pad32(second) {
+        (first, second)
+    } else {
+        (second, first)
+    };
+    let (group_id, local_storage, local_commit, rival_root) = forked_privileged_invites(
+        local_id,
+        rival_id,
+        b"restart-park-david",
+        b"restart-park-eve",
+    )
+    .await;
+
+    let local_key = CommitOrderingKey::from_commit_bytes(
+        EpochId(1),
+        CommitOrderingPriority::Privileged,
+        MemberId::new(pad32(local_id)),
+        &local_commit.payload,
+    );
+    let rival_key = CommitOrderingKey::from_commit_bytes(
+        EpochId(1),
+        CommitOrderingPriority::Privileged,
+        MemberId::new(pad32(rival_id)),
+        &rival_root.payload,
+    );
+    assert!(
+        local_key < rival_key,
+        "identity choice must make the restarted incumbent win the pairwise race"
+    );
+
+    // RESTART: routing state must be rebuilt from durable evidence, not lost.
+    let mut local = reopen_legacy_client(local_id, local_storage.clone());
+    assert_eq!(local.epoch(&group_id).unwrap().0, 2);
+    let _ = local.drain_events();
+
+    let outcome = local
+        .ingest(TransportMessage {
+            envelope: TransportEnvelope::GroupMessage {
+                transport_group_id: group_id.as_slice().to_vec(),
+            },
+            ..rival_root.clone()
+        })
+        .await
+        .unwrap();
+    assert!(
+        matches!(
+            outcome,
+            IngestOutcome::Stale {
+                reason: StaleReason::AlreadyAtEpoch { .. }
+            }
+        ),
+        "restart must not reroute the pairwise loser into convergence, got {outcome:?}"
+    );
+    let events = local.drain_events();
+    assert!(
+        extract_fork_recovered(&events, &group_id).is_none(),
+        "incumbent-wins must not roll the restarted winner back"
+    );
+    assert_eq!(local.epoch(&group_id).unwrap().0, 2);
+
+    // Same parked disposition as the no-restart path: `ConvergenceDeferred`
+    // (reconsiderable by branch materialization), keyed by its SOURCE epoch.
+    let rival_root_content_id = {
+        use sha2::{Digest, Sha256};
+        MessageId::new(Sha256::digest(&rival_root.payload).to_vec())
+    };
+    let parked = local_storage.get_message(&rival_root_content_id).unwrap();
+    assert_eq!(
+        parked.state,
+        MessageState::ConvergenceDeferred,
+        "the pairwise loser-root must be parked reconsiderable after a restart too"
+    );
+    assert_eq!(
+        parked.epoch,
+        EpochId(1),
+        "the parked loser-root must be keyed by its source epoch"
+    );
+}
+
+#[tokio::test]
+async fn restarted_incumbent_rolls_back_to_winning_rival_via_rebuilt_snapshot() {
+    // Mirror image of the test above: the inbound rival WINS the pairwise
+    // race. The restarted member must roll back onto the rival commit through
+    // the durable fork snapshot referenced by the REBUILT incumbent record —
+    // emitting ForkRecovered exactly as the never-restarted path does.
+    let first = b"restart-roll-first".as_slice();
+    let second = b"restart-roll-second".as_slice();
+    // Local must LOSE: give it the higher (worse) committer identity.
+    let (local_id, rival_id) = if pad32(first) < pad32(second) {
+        (second, first)
+    } else {
+        (first, second)
+    };
+    let (group_id, local_storage, local_commit, rival_root) = forked_privileged_invites(
+        local_id,
+        rival_id,
+        b"restart-roll-david",
+        b"restart-roll-eve",
+    )
+    .await;
+
+    let local_key = CommitOrderingKey::from_commit_bytes(
+        EpochId(1),
+        CommitOrderingPriority::Privileged,
+        MemberId::new(pad32(local_id)),
+        &local_commit.payload,
+    );
+    let rival_key = CommitOrderingKey::from_commit_bytes(
+        EpochId(1),
+        CommitOrderingPriority::Privileged,
+        MemberId::new(pad32(rival_id)),
+        &rival_root.payload,
+    );
+    assert!(
+        rival_key < local_key,
+        "identity choice must make the inbound rival win the pairwise race"
+    );
+
+    // RESTART: both the incumbent's ordering key (from the stamped own-commit
+    // row) and its pre-commit snapshot binding must survive the reopen.
+    let mut local = reopen_legacy_client(local_id, local_storage.clone());
+    assert_eq!(local.epoch(&group_id).unwrap().0, 2);
+    let _ = local.drain_events();
+
+    local
+        .ingest(TransportMessage {
+            envelope: TransportEnvelope::GroupMessage {
+                transport_group_id: group_id.as_slice().to_vec(),
+            },
+            ..rival_root.clone()
+        })
+        .await
+        .unwrap();
+    let events = local.drain_events();
+    let (source_epoch, recovered_epoch, winner, invalidated) =
+        extract_fork_recovered(&events, &group_id)
+            .expect("restarted loser must emit ForkRecovered after rolling back to the rival");
+    assert_eq!(source_epoch.0, 1);
+    assert_eq!(recovered_epoch.0, 2);
+    assert_eq!(winner, &rival_key);
+    assert_eq!(invalidated, &local_key);
+    assert_eq!(local.epoch(&group_id).unwrap().0, 2);
+
+    // The group state now reflects the rival branch: its invitee joined, the
+    // abandoned local branch's invitee did not.
+    let members: Vec<_> = local
+        .members(&group_id)
+        .unwrap()
+        .iter()
+        .map(|m| m.id.clone())
+        .collect();
+    assert!(
+        members.contains(&MemberId::new(pad32(b"restart-roll-eve"))),
+        "rival branch's invitee must be present after the rebuilt rollback"
+    );
+    assert!(
+        !members.contains(&MemberId::new(pad32(b"restart-roll-david"))),
+        "the abandoned local branch's invitee must be gone"
+    );
+    // The invalidated own commit is retired on its durable row, exactly as in
+    // the never-restarted path. Resolve the row through the event: the
+    // rebuilt incumbent record carries the storage-layer identity. The
+    // displaced incumbent is parked `ConvergenceDeferred` at its source
+    // epoch, not retired terminally, so a peer that keeps extending its
+    // branch can still bring this node back onto it (see
+    // `pairwise_candidate_win_leaves_old_incumbent_reconsiderable`). A
+    // missing row is tolerated only for pre-parking recovery states.
+    let invalidated_commit_id = events
+        .iter()
+        .find_map(|event| match event {
+            GroupEvent::ForkRecovered {
+                group_id: event_group,
+                invalidated_commit_id,
+                ..
+            } if event_group == &group_id => Some(invalidated_commit_id.clone()),
+            _ => None,
+        })
+        .expect("ForkRecovered carries the invalidated commit's storage id");
+    match local_storage.get_message(&invalidated_commit_id) {
+        Ok(record) => {
+            assert_eq!(
+                record.state,
+                MessageState::ConvergenceDeferred,
+                "the displaced incumbent must stay reconsiderable after a restart-path rollback"
+            );
+            assert_eq!(
+                record.epoch,
+                EpochId(1),
+                "the parked incumbent must be keyed by its source epoch"
+            );
+        }
+        Err(cgka_traits::storage::StorageError::NotFound) => {}
+        Err(other) => panic!("unexpected storage error: {other:?}"),
+    }
 }
 
 #[tokio::test]

--- a/crates/cgka-engine/tests/fork_detection.rs
+++ b/crates/cgka-engine/tests/fork_detection.rs
@@ -2631,3 +2631,383 @@ async fn hydrate_recovers_interrupted_fork_probe_snapshot() {
         "the recovered fork-probe snapshot must be released"
     );
 }
+
+/// Observable form of the invariant the `is_canonical` carve-out in own-branch
+/// materialization rests on: a `Processed` commit row means "applied on this
+/// device's live canonical chain", so there is at most one `Processed` commit
+/// per source epoch, every `Processed` commit sits below the live tip — and in
+/// particular no own-stamped `Processed` row can survive off the chain.
+/// `PrevalidatedOwnCommits` builds its canonical set from exactly these rows
+/// and exempts them from the anchor lineage proof (the apply skips them via
+/// its already-applied prefix), so a displaced own commit left `Processed`
+/// would materialize a branch from an unproven anchor. Every displacement
+/// mechanism must therefore move the loser out of `Processed` in the same
+/// durable unit: the pairwise `resolve()` re-persists it
+/// `ConvergenceDeferred`, and a convergence reorg re-disposes the whole
+/// horizon from the captured live records.
+fn assert_processed_commit_rows_form_the_live_chain(
+    storage: &SqliteAccountStorage,
+    group_id: &GroupId,
+    tip: u64,
+    context: &str,
+) {
+    use cgka_engine::openmls_projection::{OpenMlsContentKind, project_mls_message};
+    use cgka_traits::message::StoredMessagePayload;
+    use std::collections::BTreeMap;
+
+    let mut processed_by_epoch: BTreeMap<u64, Vec<MessageId>> = BTreeMap::new();
+    for record in storage.list_messages(group_id, EpochId(0)).unwrap() {
+        if record.state != MessageState::Processed {
+            continue;
+        }
+        let Ok(payload) = StoredMessagePayload::decode(&record.payload) else {
+            continue;
+        };
+        let Some(message) = payload.as_openmls_wire() else {
+            continue;
+        };
+        let Ok(projection) = project_mls_message(&message.payload) else {
+            continue;
+        };
+        if projection.kind != OpenMlsContentKind::Commit {
+            continue;
+        }
+        let Some(source_epoch) = projection.source_epoch else {
+            continue;
+        };
+        assert!(
+            source_epoch < tip,
+            "{context}: a Processed commit at source epoch {source_epoch} sits at or above \
+             the live tip {tip} — it cannot be on the applied chain"
+        );
+        if payload.own_commit_stamp().is_some() {
+            assert!(
+                source_epoch < tip,
+                "{context}: an own-stamped Processed commit at source epoch {source_epoch} \
+                 is off the live chain (tip {tip})"
+            );
+        }
+        processed_by_epoch
+            .entry(source_epoch)
+            .or_default()
+            .push(record.id.clone());
+    }
+    for (source_epoch, ids) in &processed_by_epoch {
+        assert!(
+            ids.len() <= 1,
+            "{context}: {} Processed commit rows share source epoch {source_epoch} — a \
+             displaced commit was left Processed instead of being parked: {ids:?}",
+            ids.len()
+        );
+    }
+}
+
+#[tokio::test]
+async fn processed_own_commit_rows_never_survive_off_the_live_chain() {
+    // Pins the invariant `assert_processed_commit_rows_form_the_live_chain`
+    // documents, across BOTH mechanisms that move an own commit off the live
+    // chain:
+    //   (a) a pairwise CandidateWins displacement — `resolve()` must park the
+    //       own incumbent `ConvergenceDeferred`, never leave it `Processed`
+    //       on the abandoned branch;
+    //   (b) a convergence reorg back onto the own-commit branch — the
+    //       displaced rival-branch commits must leave `Processed` while the
+    //       own commit returns to it.
+    // If either mechanism ever leaks a `Processed` own-commit row off the
+    // chain, the `is_canonical` lineage-proof exemption in own-branch
+    // materialization becomes unsound (see the carve-out comment in
+    // `openmls_projection`), so this test failing means that exemption must
+    // be revisited, not the test weakened.
+    use cgka_traits::ingest::IngestOutcome;
+
+    // Privileged same-epoch commits order by committer identity: the rival's
+    // identity must sort BEFORE X's so the inbound candidate B wins.
+    let first = b"chain-first".as_slice();
+    let second = b"chain-second".as_slice();
+    let (rival_id, x_id) = if pad32(first) < pad32(second) {
+        (first, second)
+    } else {
+        (second, first)
+    };
+
+    let (mut x, x_storage) = build_client_with_storage(x_id);
+    let mut rival = build_client(rival_id);
+    let (mut y, _y_storage) = build_client_with_storage(b"chain-y");
+    let mut david = build_client(b"chain-david");
+    let mut eve = build_client(b"chain-eve");
+    let mut frank = build_client(b"chain-frank");
+
+    let rival_kp = rival.fresh_key_package().await.unwrap();
+    let y_kp = y.fresh_key_package().await.unwrap();
+    let (group_id, create) = x
+        .create_group(CreateGroupRequest {
+            name: "processed-own-chain".into(),
+            description: String::new(),
+            members: vec![rival_kp, y_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![rival.self_id(), y.self_id()],
+        })
+        .await
+        .unwrap();
+    let (rival_welcome, y_welcome) = match create {
+        SendResult::GroupCreated {
+            pending,
+            mut welcomes,
+        } => {
+            x.confirm_published(pending).await.unwrap();
+            let y_welcome = welcomes.remove(1);
+            (welcomes.remove(0), y_welcome)
+        }
+        _ => unreachable!(),
+    };
+    rival.join_welcome(rival_welcome).await.unwrap();
+    y.join_welcome(y_welcome).await.unwrap();
+
+    let route = |msg: TransportMessage| TransportMessage {
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+        ..msg
+    };
+
+    // X's own commit A (invite david) and the rival's competing B (invite
+    // eve), both from epoch 1.
+    let david_kp = david.fresh_key_package().await.unwrap();
+    let eve_kp = eve.fresh_key_package().await.unwrap();
+    let commit_a = match x
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![david_kp],
+        })
+        .await
+        .unwrap()
+    {
+        SendResult::GroupEvolution { msg, pending, .. } => {
+            x.confirm_published(pending).await.unwrap();
+            msg
+        }
+        _ => unreachable!(),
+    };
+    // Baseline: A is X's own confirmed commit ON the chain.
+    let a_row = x_storage.get_message(&commit_a.id).unwrap();
+    assert_eq!(a_row.state, MessageState::Processed);
+    assert_processed_commit_rows_form_the_live_chain(
+        &x_storage,
+        &group_id,
+        x.epoch(&group_id).unwrap().0,
+        "after own confirm",
+    );
+
+    let commit_b = match rival
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![eve_kp],
+        })
+        .await
+        .unwrap()
+    {
+        SendResult::GroupEvolution { msg, pending, .. } => {
+            rival.confirm_published(pending).await.unwrap();
+            msg
+        }
+        _ => unreachable!(),
+    };
+    let a_key = CommitOrderingKey::from_commit_bytes(
+        EpochId(1),
+        CommitOrderingPriority::Privileged,
+        MemberId::new(pad32(x_id)),
+        &commit_a.payload,
+    );
+    let b_key = CommitOrderingKey::from_commit_bytes(
+        EpochId(1),
+        CommitOrderingPriority::Privileged,
+        MemberId::new(pad32(rival_id)),
+        &commit_b.payload,
+    );
+    assert!(
+        b_key < a_key,
+        "identity choice must make the inbound candidate win the pairwise race"
+    );
+
+    // (a) B displaces A pairwise: the own commit must leave `Processed` in
+    // the same durable unit that rolls the chain onto B.
+    x.ingest(route(commit_b.clone())).await.unwrap();
+    x.drain_events();
+    assert_eq!(x.epoch(&group_id).unwrap().0, 2);
+    let displaced = x_storage.get_message(&commit_a.id).unwrap();
+    assert_eq!(
+        displaced.state,
+        MessageState::ConvergenceDeferred,
+        "the displaced own incumbent must be parked, never left Processed off-chain"
+    );
+    assert_processed_commit_rows_form_the_live_chain(
+        &x_storage,
+        &group_id,
+        x.epoch(&group_id).unwrap().0,
+        "after pairwise displacement",
+    );
+
+    // (b) Y grows the A-branch deeper; X reorgs back onto it through
+    // convergence. Now B is the commit leaving the chain.
+    y.ingest(route(commit_a.clone())).await.unwrap();
+    y.converge_stored_openmls_messages_at(&group_id, u64::MAX)
+        .expect("A settles on Y through convergence");
+    let frank_kp = frank.fresh_key_package().await.unwrap();
+    let follow_on = match y
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![frank_kp],
+        })
+        .await
+        .unwrap()
+    {
+        SendResult::GroupEvolution { msg, pending, .. } => {
+            y.confirm_published(pending).await.unwrap();
+            msg
+        }
+        _ => unreachable!(),
+    };
+    let outcome = x.ingest(route(follow_on)).await.unwrap();
+    assert!(
+        matches!(outcome, IngestOutcome::Buffered { .. }),
+        "the A-branch follow-on must enter the convergence pass, got {outcome:?}"
+    );
+    x.converge_stored_openmls_messages_at(&group_id, u64::MAX)
+        .expect("reorg back onto the deeper A-branch");
+    assert_eq!(x.epoch(&group_id).unwrap().0, 3);
+
+    // The own commit is back on the chain, uniquely `Processed` at epoch 1 —
+    // and the displaced rival commit did NOT stay `Processed` beside it.
+    let a_after = x_storage.get_message(&commit_a.id).unwrap();
+    assert_eq!(
+        a_after.state,
+        MessageState::Processed,
+        "the reorged-onto own commit must be Processed again"
+    );
+    // The rival commit's stored row may be re-keyed by content id on the
+    // convergence path, so find it by its wire payload rather than by the
+    // transport id.
+    let b_rows: Vec<_> = x_storage
+        .list_messages(&group_id, EpochId(0))
+        .unwrap()
+        .into_iter()
+        .filter(|record| {
+            cgka_traits::message::StoredMessagePayload::decode(&record.payload)
+                .ok()
+                .and_then(|payload| payload.as_openmls_wire().cloned())
+                .is_some_and(|message| message.payload == commit_b.payload)
+        })
+        .collect();
+    assert!(
+        !b_rows.is_empty(),
+        "the displaced rival commit's stored row must still exist"
+    );
+    for b_row in &b_rows {
+        assert_ne!(
+            b_row.state,
+            MessageState::Processed,
+            "the rival commit displaced by the reorg must not survive Processed off-chain"
+        );
+    }
+    assert_processed_commit_rows_form_the_live_chain(
+        &x_storage,
+        &group_id,
+        x.epoch(&group_id).unwrap().0,
+        "after convergence reorg onto the own-commit branch",
+    );
+}
+
+#[tokio::test]
+async fn restarted_incumbent_pairs_with_stamped_snapshot_not_newest_at_epoch() {
+    // The hydrate-time rebuild used to pair an own-commit incumbent with the
+    // NEWEST `fork-<epoch>-…` snapshot at its source epoch — an inference
+    // from name recency, where an inbound commit proves its pairing by
+    // replaying against the snapshot. The confirm-time stamp now records the
+    // snapshot name its recovery record owns, and the rebuild matches that
+    // name instead. This test plants a DECOY snapshot at the same source
+    // epoch with a higher counter, captured from the post-commit (epoch 2)
+    // state: recency-based pairing would adopt it, and the later pairwise
+    // rollback would land on the wrong epoch entirely. The recorded name must
+    // win — the restarted loser still rolls back onto the winning rival
+    // through the snapshot its own commit actually owns.
+    let first = b"stamp-pair-first".as_slice();
+    let second = b"stamp-pair-second".as_slice();
+    // Local must LOSE the pairwise race so the rollback actually runs.
+    let (local_id, rival_id) = if pad32(first) < pad32(second) {
+        (second, first)
+    } else {
+        (first, second)
+    };
+    let (group_id, local_storage, local_commit, rival_root) =
+        forked_privileged_invites(local_id, rival_id, b"stamp-pair-david", b"stamp-pair-eve").await;
+
+    let local_key = CommitOrderingKey::from_commit_bytes(
+        EpochId(1),
+        CommitOrderingPriority::Privileged,
+        MemberId::new(pad32(local_id)),
+        &local_commit.payload,
+    );
+    let rival_key = CommitOrderingKey::from_commit_bytes(
+        EpochId(1),
+        CommitOrderingPriority::Privileged,
+        MemberId::new(pad32(rival_id)),
+        &rival_root.payload,
+    );
+    assert!(
+        rival_key < local_key,
+        "identity choice must make the inbound rival win the pairwise race"
+    );
+
+    // The decoy: a snapshot named for source epoch 1 with a counter above any
+    // the engine has minted, but capturing the LIVE post-commit state
+    // (epoch 2). Under newest-at-epoch inference the rebuild would hand this
+    // to the own-commit incumbent, and `resolve()`'s rollback would "rewind"
+    // onto epoch-2 state where the rival's epoch-1 commit can never apply.
+    local_storage
+        .create_group_snapshot(&group_id, "fork-1-9000-00112233aabbccdd")
+        .unwrap();
+
+    // RESTART: the rebuild must pair the stamped own commit with the snapshot
+    // its stamp records, ignoring the newer decoy.
+    let mut local = reopen_legacy_client(local_id, local_storage.clone());
+    assert_eq!(local.epoch(&group_id).unwrap().0, 2);
+    let _ = local.drain_events();
+
+    local
+        .ingest(TransportMessage {
+            envelope: TransportEnvelope::GroupMessage {
+                transport_group_id: group_id.as_slice().to_vec(),
+            },
+            ..rival_root.clone()
+        })
+        .await
+        .unwrap();
+    let events = local.drain_events();
+    let (source_epoch, recovered_epoch, winner, invalidated) = extract_fork_recovered(
+        &events, &group_id,
+    )
+    .expect("the restarted loser must roll back through its own stamped snapshot, not the decoy");
+    assert_eq!(source_epoch.0, 1);
+    assert_eq!(recovered_epoch.0, 2);
+    assert_eq!(winner, &rival_key);
+    assert_eq!(invalidated, &local_key);
+    assert_eq!(local.epoch(&group_id).unwrap().0, 2);
+
+    // The rollback landed on the true pre-commit state: the rival branch
+    // applied, the abandoned local branch's invitee is gone.
+    let members: Vec<_> = local
+        .members(&group_id)
+        .unwrap()
+        .iter()
+        .map(|m| m.id.clone())
+        .collect();
+    assert!(
+        members.contains(&MemberId::new(pad32(b"stamp-pair-eve"))),
+        "rival branch's invitee must be present after the rollback"
+    );
+    assert!(
+        !members.contains(&MemberId::new(pad32(b"stamp-pair-david"))),
+        "the abandoned local branch's invitee must be gone"
+    );
+}

--- a/crates/cgka-engine/tests/fork_detection.rs
+++ b/crates/cgka-engine/tests/fork_detection.rs
@@ -2169,16 +2169,17 @@ async fn pairwise_candidate_win_with_rival_follow_on_fails_closed_not_wrong_line
     // adopting whatever the clobbered anchor happens to hold, i.e. installing a
     // lineage that never existed on any node.
     //
-    // NOTE — this is the clobbered-anchor LIVENESS limitation, not a
-    // silent-corruption path. Once the anchor is gone, the parked own commit
-    // cannot be realized at all: the anchor rewind is its only route, since MLS
+    // NOTE — once the anchor is gone, the parked own commit cannot be
+    // realized at all: the anchor rewind is its only route, since MLS
     // `process_message` refuses this device's own commits, so normal replay
-    // cannot materialize it either. X therefore fails closed and stays on its
-    // own branch, diverged from the fleet, until the rewind horizon retires the
-    // parked row and it reorgs onto whatever remains selectable. Correctness is
-    // preserved; liveness inside that window is not. Restoring it needs
-    // content-keyed retained anchors, which is shared with the convergence
-    // engine and out of scope for this fix.
+    // cannot materialize it either. Materialization runs the same lineage
+    // proof the apply does, so the pass PRUNES the unrealizable branch,
+    // terminalizes the parked row, and settles on the branch X already
+    // holds — leaving X live (later commits apply, own sends work) though
+    // diverged from the fleet's A-branch until depth or a re-add reconverges
+    // them. Correctness is preserved: no wrong lineage is ever installed.
+    // Content-keyed retained anchors would remove the divergence entirely and
+    // stay out of scope for this fix.
     use cgka_traits::ingest::IngestOutcome;
 
     let first = b"cwrf-first".as_slice();
@@ -2376,9 +2377,11 @@ async fn pairwise_candidate_win_with_rival_follow_on_fails_closed_not_wrong_line
         matches!(outcome_2, IngestOutcome::Buffered { .. }),
         "the second A-branch follow-on must enter the convergence pass, got {outcome_2:?}"
     );
-    let converge = x.converge_stored_openmls_messages_at(&group_id, u64::MAX);
+    let converge = x
+        .converge_stored_openmls_messages_at(&group_id, u64::MAX)
+        .expect("a pass over an unrealizable branch must complete, not error");
 
-    // Whatever convergence reports, the invariant is the same: X must NOT be
+    // The pass pruned the A-branch instead of selecting it: X must NOT be
     // holding a state assembled from the clobbered anchor.
     let x_members: Vec<_> = x
         .members(&group_id)
@@ -2401,14 +2404,74 @@ async fn pairwise_candidate_win_with_rival_follow_on_fails_closed_not_wrong_line
         3,
         "the refused rewind must leave X's live epoch untouched"
     );
-    // The parked own commit is still reconsiderable: nothing terminalized it,
-    // so once the horizon retires it (or a future engine key anchors by
-    // content) X is free to reorg.
-    let still_parked = x_storage.get_message(&commit_a.id).unwrap();
+    // The unrealizable parked own commit is terminalized by the settling
+    // pass: its anchor is provably gone (the rewind is its only route, and
+    // the lineage proof just refused that anchor), so leaving it
+    // reconsiderable would only make every future pass re-probe and re-prune
+    // its branch until the horizon retired it anyway.
+    let parked_after = x_storage.get_message(&commit_a.id).unwrap();
     assert_eq!(
-        still_parked.state,
-        MessageState::ConvergenceDeferred,
-        "failing closed must not terminalize the parked own commit"
+        parked_after.state,
+        MessageState::EpochInvalidated,
+        "the unrealizable own commit must be terminalized, not left to re-probe forever"
+    );
+
+    // LIVENESS REGRESSION (PR #1236 review): the pruned pass must leave the
+    // group fully usable — this is what the wedge broke. (a) Repeated passes
+    // keep completing without error and without moving the tip.
+    for _ in 0..2 {
+        x.converge_stored_openmls_messages_at(&group_id, u64::MAX)
+            .expect("later passes over the settled state must complete");
+    }
+    assert_eq!(x.epoch(&group_id).unwrap().0, 3);
+    // (b) A later inbound commit on X's current branch still applies and
+    // advances the tip.
+    let mut ivan = build_client(b"cwrf-ivan");
+    let ivan_kp = ivan.fresh_key_package().await.unwrap();
+    let rival_follow_on_2 = match rival
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![ivan_kp],
+        })
+        .await
+        .unwrap()
+    {
+        SendResult::GroupEvolution { msg, pending, .. } => {
+            rival.confirm_published(pending).await.unwrap();
+            msg
+        }
+        _ => unreachable!(),
+    };
+    x.ingest(route(rival_follow_on_2)).await.unwrap();
+    x.drain_events();
+    x.converge_stored_openmls_messages_at(&group_id, u64::MAX)
+        .expect("the rival's later commit must settle");
+    assert_eq!(
+        x.epoch(&group_id).unwrap().0,
+        4,
+        "X's tip must advance again after the unrealizable branch is pruned"
+    );
+    // (c) X's own sends work again — the wedge made these fail with a
+    // converge-inputs backend error.
+    let mut judy = build_client(b"cwrf-judy");
+    let judy_kp = judy.fresh_key_package().await.unwrap();
+    match x
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![judy_kp],
+        })
+        .await
+        .expect("X must be able to commit on its branch again")
+    {
+        SendResult::GroupEvolution { pending, .. } => {
+            x.confirm_published(pending).await.unwrap();
+        }
+        other => panic!("expected a group evolution, got {other:?}"),
+    }
+    assert_eq!(
+        x.epoch(&group_id).unwrap().0,
+        5,
+        "X's own commit must confirm and advance the tip"
     );
 }
 

--- a/crates/cgka-engine/tests/fork_detection.rs
+++ b/crates/cgka-engine/tests/fork_detection.rs
@@ -30,7 +30,7 @@ use cgka_traits::storage::{
 use cgka_traits::transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
 };
-use cgka_traits::types::{EpochId, MemberId, MessageId};
+use cgka_traits::types::{EpochId, GroupId, MemberId, MessageId};
 use openmls::group::MlsGroup;
 use openmls_basic_credential::SignatureKeyPair;
 use openmls_rust_crypto::RustCrypto;
@@ -2410,4 +2410,80 @@ async fn pairwise_candidate_win_with_rival_follow_on_fails_closed_not_wrong_line
         MessageState::ConvergenceDeferred,
         "failing closed must not terminalize the parked own commit"
     );
+}
+
+#[tokio::test]
+async fn hydrate_advances_snapshot_allocator_past_skipped_fork_snapshots() {
+    // The hydrate-time rebuild only advanced the snapshot-name allocator for
+    // snapshots it actually REBUILT (via `record_applied`). A snapshot the
+    // scan parsed and then skipped — an orphan of a crash between snapshot
+    // creation and the apply, a below-horizon leftover, or one whose replay
+    // probe failed — left the allocator behind the highest counter on disk,
+    // so the first post-restart `fork-<epoch>-<counter>-…` name could collide
+    // with (and clobber) a snapshot that is still there.
+    let local_id = b"alloc-local".as_slice();
+    let (group_id, local_storage, _local_commit, _rival_root) =
+        forked_privileged_invites(local_id, b"alloc-rival", b"alloc-david", b"alloc-eve").await;
+
+    // An orphan fork snapshot at the CURRENT epoch: nothing in storage is an
+    // applied commit row for source epoch 2, so the hydrate scan parses this
+    // name and then skips it. Its counter is far above every counter the
+    // engine has minted so far.
+    let orphan_counter = 9_000_u64;
+    let orphan = format!("fork-2-{orphan_counter}-0123456789abcdef");
+    local_storage
+        .create_group_snapshot(&group_id, &orphan)
+        .unwrap();
+
+    // RESTART: the scan must observe the orphan's counter even though it
+    // rebuilds nothing from it.
+    let mut local = reopen_legacy_client(local_id, local_storage.clone());
+    let before: Vec<u64> = fork_snapshot_counters(&local_storage, &group_id);
+    assert!(before.contains(&orphan_counter));
+
+    // Any new commit mints the next fork snapshot name from the allocator.
+    let mut frank = build_client(b"alloc-frank");
+    let frank_kp = frank.fresh_key_package().await.unwrap();
+    local
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![frank_kp],
+        })
+        .await
+        .unwrap();
+
+    let after = fork_snapshot_counters(&local_storage, &group_id);
+    let minted: Vec<u64> = after
+        .iter()
+        .copied()
+        .filter(|counter| !before.contains(counter))
+        .collect();
+    assert!(
+        !minted.is_empty(),
+        "the new commit must mint a fresh fork snapshot"
+    );
+    assert!(
+        minted.iter().all(|counter| *counter > orphan_counter),
+        "post-restart names must be allocated above every counter on disk, \
+         including skipped ones; minted {minted:?} vs orphan {orphan_counter}"
+    );
+    assert!(
+        after.contains(&orphan_counter),
+        "the skipped orphan snapshot must not have been clobbered"
+    );
+}
+
+fn fork_snapshot_counters(storage: &SqliteAccountStorage, group_id: &GroupId) -> Vec<u64> {
+    storage
+        .list_group_snapshots(group_id)
+        .unwrap()
+        .iter()
+        .filter_map(|name| {
+            name.strip_prefix("fork-")?
+                .split('-')
+                .nth(1)?
+                .parse::<u64>()
+                .ok()
+        })
+        .collect()
 }

--- a/crates/cgka-engine/tests/fork_detection.rs
+++ b/crates/cgka-engine/tests/fork_detection.rs
@@ -2632,6 +2632,39 @@ async fn hydrate_recovers_interrupted_fork_probe_snapshot() {
     );
 }
 
+#[tokio::test]
+async fn multiple_interrupted_fork_probes_quarantine_with_probe_reason() {
+    let local_id = b"fprobe2-local".as_slice();
+    let (group_id, local_storage, _local_commit, _rival_root) =
+        forked_privileged_invites(local_id, b"fprobe2-rival", b"fprobe2-david", b"fprobe2-eve")
+            .await;
+
+    // Two surviving `fork-probe-` snapshots break the probes-are-serialized
+    // invariant: recovery cannot tell which one holds the live state, so it
+    // must fail closed. The quarantine reason must name the probe-recovery
+    // failure, not masquerade as a group-record load failure.
+    local_storage
+        .create_group_snapshot(&group_id, "fork-probe-1-deadbeefcafebabe")
+        .unwrap();
+    local_storage
+        .create_group_snapshot(&group_id, "fork-probe-2-cafebabedeadbeef")
+        .unwrap();
+
+    let mut local = reopen_legacy_client_unhydrated(local_id, local_storage.clone());
+    local
+        .hydrate_stable_groups_from_storage()
+        .expect("one quarantined group must not abort account open");
+
+    assert_eq!(
+        local.quarantined_groups(),
+        vec![(
+            group_id.clone(),
+            cgka_traits::engine::GroupHydrationQuarantineReason::ForkProbeRecoveryFailed
+        )],
+        "ambiguous interrupted probes must quarantine with the probe-specific reason"
+    );
+}
+
 /// Observable form of the invariant the `is_canonical` carve-out in own-branch
 /// materialization rests on: a `Processed` commit row means "applied on this
 /// device's live canonical chain", so there is at most one `Processed` commit

--- a/crates/cgka-engine/tests/fork_detection.rs
+++ b/crates/cgka-engine/tests/fork_detection.rs
@@ -2665,6 +2665,63 @@ async fn multiple_interrupted_fork_probes_quarantine_with_probe_reason() {
     );
 }
 
+#[tokio::test]
+async fn multiple_interrupted_retained_anchor_probes_quarantine_with_probe_reason() {
+    let local_id = b"raprobe-local".as_slice();
+    let (group_id, local_storage, _local_commit, _rival_root) =
+        forked_privileged_invites(local_id, b"raprobe-rival", b"raprobe-david", b"raprobe-eve")
+            .await;
+
+    local_storage
+        .create_group_snapshot(&group_id, "openmls-retained-probe-deadbeefcafebabe")
+        .unwrap();
+    local_storage
+        .create_group_snapshot(&group_id, "openmls-retained-probe-cafebabedeadbeef")
+        .unwrap();
+
+    let mut local = reopen_legacy_client_unhydrated(local_id, local_storage.clone());
+    local
+        .hydrate_stable_groups_from_storage()
+        .expect("one quarantined group must not abort account open");
+
+    assert_eq!(
+        local.quarantined_groups(),
+        vec![(
+            group_id.clone(),
+            cgka_traits::engine::GroupHydrationQuarantineReason::RetainedAnchorProbeRecoveryFailed
+        )],
+        "ambiguous retained-anchor probes must quarantine with the probe-specific reason"
+    );
+}
+
+#[tokio::test]
+async fn multiple_interrupted_apply_snapshots_quarantine_with_apply_reason() {
+    let local_id = b"apsnap-local".as_slice();
+    let (group_id, local_storage, _local_commit, _rival_root) =
+        forked_privileged_invites(local_id, b"apsnap-rival", b"apsnap-david", b"apsnap-eve").await;
+
+    local_storage
+        .create_group_snapshot(&group_id, "openmls-apply-deadbeefcafebabe")
+        .unwrap();
+    local_storage
+        .create_group_snapshot(&group_id, "openmls-apply-cafebabedeadbeef")
+        .unwrap();
+
+    let mut local = reopen_legacy_client_unhydrated(local_id, local_storage.clone());
+    local
+        .hydrate_stable_groups_from_storage()
+        .expect("one quarantined group must not abort account open");
+
+    assert_eq!(
+        local.quarantined_groups(),
+        vec![(
+            group_id.clone(),
+            cgka_traits::engine::GroupHydrationQuarantineReason::ConvergenceApplyRecoveryFailed
+        )],
+        "ambiguous apply snapshots must quarantine with the apply-specific reason"
+    );
+}
+
 /// Observable form of the invariant the `is_canonical` carve-out in own-branch
 /// materialization rests on: a `Processed` commit row means "applied on this
 /// device's live canonical chain", so there is at most one `Processed` commit

--- a/crates/cgka-engine/tests/fork_detection.rs
+++ b/crates/cgka-engine/tests/fork_detection.rs
@@ -185,16 +185,27 @@ fn reopen_current_client(id: &[u8], storage: SqliteAccountStorage) -> Engine<Sql
 /// (see `strict_cutover_legacy_add_cannot_displace_valid_fork_incumbent`)
 /// instead of letting it race the incumbent.
 fn reopen_legacy_client(id: &[u8], storage: SqliteAccountStorage) -> Engine<SqliteAccountStorage> {
-    let mut engine = EngineBuilder::new(storage)
+    let mut engine = reopen_legacy_client_unhydrated(id, storage);
+    engine.hydrate_stable_groups_from_storage().unwrap();
+    engine
+}
+
+/// [`reopen_legacy_client`] without the hydration step, for tests whose
+/// subject IS the first `hydrate_stable_groups_from_storage` call after a
+/// simulated crash — hydrating during setup would perform the recovery before
+/// the assertion under test.
+fn reopen_legacy_client_unhydrated(
+    id: &[u8],
+    storage: SqliteAccountStorage,
+) -> Engine<SqliteAccountStorage> {
+    EngineBuilder::new(storage)
         .legacy_compatibility_profile()
         .identity(pad32(id))
         .account_identity_proof_signer(proof_signer(id))
         .feature_registry(selfremove_registry())
         .peeler(Box::new(MockPeeler))
         .build()
-        .unwrap();
-    engine.hydrate_stable_groups_from_storage().unwrap();
-    engine
+        .unwrap()
 }
 
 fn raw_self_update_commit(
@@ -1895,22 +1906,21 @@ async fn restarted_incumbent_rolls_back_to_winning_rival_via_rebuilt_snapshot() 
             _ => None,
         })
         .expect("ForkRecovered carries the invalidated commit's storage id");
-    match local_storage.get_message(&invalidated_commit_id) {
-        Ok(record) => {
-            assert_eq!(
-                record.state,
-                MessageState::ConvergenceDeferred,
-                "the displaced incumbent must stay reconsiderable after a restart-path rollback"
-            );
-            assert_eq!(
-                record.epoch,
-                EpochId(1),
-                "the parked incumbent must be keyed by its source epoch"
-            );
-        }
-        Err(cgka_traits::storage::StorageError::NotFound) => {}
-        Err(other) => panic!("unexpected storage error: {other:?}"),
-    }
+    // Displacement is atomic: the parked row is re-persisted in the same
+    // transaction as the rollback, so the id the event names must resolve.
+    let record = local_storage
+        .get_message(&invalidated_commit_id)
+        .expect("the displaced incumbent's parked row must exist");
+    assert_eq!(
+        record.state,
+        MessageState::ConvergenceDeferred,
+        "the displaced incumbent must stay reconsiderable after a restart-path rollback"
+    );
+    assert_eq!(
+        record.epoch,
+        EpochId(1),
+        "the parked incumbent must be keyed by its source epoch"
+    );
 }
 
 #[tokio::test]
@@ -2542,6 +2552,11 @@ fn fork_snapshot_counters(storage: &SqliteAccountStorage, group_id: &GroupId) ->
         .unwrap()
         .iter()
         .filter_map(|name| {
+            // `fork-probe-…` guards share the `fork-` prefix but carry no
+            // epoch/counter fields; parsing one would read "probe" garbage.
+            if name.starts_with("fork-probe-") {
+                return None;
+            }
             name.strip_prefix("fork-")?
                 .split('-')
                 .nth(1)?
@@ -2589,8 +2604,10 @@ async fn hydrate_recovers_interrupted_fork_probe_snapshot() {
     );
 
     // RESTART: hydration must detect the `fork-probe-` snapshot, restore the
-    // captured live state, and release the probe snapshot.
-    let mut local = reopen_legacy_client(local_id, local_storage.clone());
+    // captured live state, and release the probe snapshot. The reopen must
+    // NOT hydrate during setup — the explicit call below is the recovery
+    // under test.
+    let mut local = reopen_legacy_client_unhydrated(local_id, local_storage.clone());
     local
         .hydrate_stable_groups_from_storage()
         .expect("hydrate recovers the interrupted fork probe");

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -59,8 +59,10 @@ versioning through the workspace version in the root `Cargo.toml`.
   pairwise as it would have before the restart. The engine now rebuilds both
   maps during group hydration from evidence that is already durable: retained
   `fork-*` snapshots, stored commit rows, and their confirm-time convergence
-  stamps. No storage schema change; pruning bounds and the
-  `committed_from => incumbent` invariant carry over.
+  stamps, and records a `fork_routing_rebuilt` audit row so forensics can
+  tell post-restart reconstruction from in-flight fork resolution. No storage
+  schema change; pruning bounds and the `committed_from => incumbent`
+  invariant carry over.
   ([#1241](https://github.com/marmot-protocol/mdk/pull/1241))
 
 - Same-epoch commit races now converge every member onto the same branch. A

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -24,6 +24,17 @@ versioning through the workspace version in the root `Cargo.toml`.
   
 ### Fixed
 
+- A clobbered retained anchor no longer wedges a group permanently. Branch
+  materialization now runs the same positive lineage proof as the apply stage,
+  so convergence prunes a branch whose parked own commit can no longer be
+  proven (clobbered or pre-marker anchor) instead of selecting a branch the
+  apply is guaranteed to refuse; an apply-time mismatch completes the pass
+  unapplied rather than retrying the identical selection forever. The
+  own-commit stamp marker additionally binds the full MLS GroupContext
+  (epoch, tree hash, confirmed transcript hash), so two lineages that share a
+  ratchet tree — e.g. across group-data-only commits — can no longer satisfy
+  the anchor lineage check for each other.
+
 - Account projection storage types now redact encrypted group-image decryption
   and Blossom upload keys from `Debug` output, including nested group
   formatting. The TUI group diagnostics panel no longer retains or renders raw

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -24,12 +24,14 @@ versioning through the workspace version in the root `Cargo.toml`.
   
 ### Fixed
 
-- A group quarantined because interrupted fork-recovery probe snapshots could
-  not be restored on session open now reports the dedicated
-  `ForkProbeRecoveryFailed` hydration-quarantine reason (surfaced through the
-  app and FFI mirrors) instead of the generic `GroupRecordLoadFailed`, so
-  operators diagnosing a quarantine are pointed at the probe invariant rather
-  than a group-record load.
+- A group quarantined because an interrupted crash-recovery snapshot could not
+  be restored on session open now reports which recovery seam failed instead
+  of the generic `GroupRecordLoadFailed`: `ForkProbeRecoveryFailed` for
+  fork-recovery ordering probes, `RetainedAnchorProbeRecoveryFailed` for
+  retained-anchor convergence probes, and `ConvergenceApplyRecoveryFailed` for
+  convergence-apply snapshots (all surfaced through the app and FFI mirrors),
+  so operators diagnosing a quarantine are pointed at the failing recovery
+  rather than a group-record load that never happened.
   ([#1241](https://github.com/marmot-protocol/mdk/pull/1241))
 
 - A clobbered retained anchor no longer wedges a group permanently. Branch

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -36,6 +36,20 @@ versioning through the workspace version in the root `Cargo.toml`.
   the anchor lineage check for each other.
   ([#1236](https://github.com/marmot-protocol/mdk/pull/1236))
 
+- The residual divergence those fail-closed paths accept — a node
+  terminalizing its own unrealizable commit and staying on a branch the fleet
+  abandoned — is now operator-visible instead of audit-log-only: warn-level
+  structured tracing fires when an own-commit branch is pruned or blocked and
+  when a parked own commit ages out unrealized, and the engine metrics
+  snapshot gains `own_branch_unrealizable_blocked_passes` and
+  `own_commits_retired_unrealized` counters. The own-commit convergence stamp
+  additionally records the fork snapshot name its recovery record owns, so
+  the hydrate-time fork-routing rebuild proves the (own commit → snapshot)
+  pairing by exact match instead of inferring it from snapshot-name recency,
+  and refuses to open a second concurrent fork-recovery ordering probe —
+  turning the "fork probes are serialized per group" invariant that
+  interrupted-probe recovery relies on into a checked one.
+
 - Account projection storage types now redact encrypted group-image decryption
   and Blossom upload keys from `Debug` output, including nested group
   formatting. The TUI group diagnostics panel no longer retains or renders raw

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -24,6 +24,14 @@ versioning through the workspace version in the root `Cargo.toml`.
   
 ### Fixed
 
+- A group quarantined because interrupted fork-recovery probe snapshots could
+  not be restored on session open now reports the dedicated
+  `ForkProbeRecoveryFailed` hydration-quarantine reason (surfaced through the
+  app and FFI mirrors) instead of the generic `GroupRecordLoadFailed`, so
+  operators diagnosing a quarantine are pointed at the probe invariant rather
+  than a group-record load.
+  ([#1241](https://github.com/marmot-protocol/mdk/pull/1241))
+
 - A clobbered retained anchor no longer wedges a group permanently. Branch
   materialization now runs the same positive lineage proof as the apply stage,
   so convergence prunes a branch whose parked own commit can no longer be
@@ -34,7 +42,7 @@ versioning through the workspace version in the root `Cargo.toml`.
   (epoch, tree hash, confirmed transcript hash), so two lineages that share a
   ratchet tree — e.g. across group-data-only commits — can no longer satisfy
   the anchor lineage check for each other.
-  ([#1236](https://github.com/marmot-protocol/mdk/pull/1236))
+  ([#1241](https://github.com/marmot-protocol/mdk/pull/1241))
 
 - The residual divergence those fail-closed paths accept — a node
   terminalizing its own unrealizable commit and staying on a branch the fleet

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -52,6 +52,17 @@ versioning through the workspace version in the root `Cargo.toml`.
   avoiding false failures when unrelated startup work is delayed under loaded
   `nextest` shards.
 
+- Fork-resolution routing state now survives a process restart. Which
+  resolution path a member takes for a same-epoch commit race depended on two
+  in-memory maps (`committed_from` and the fork-recovery incumbents), so a
+  restarted member detoured through convergence instead of resolving the race
+  pairwise as it would have before the restart. The engine now rebuilds both
+  maps during group hydration from evidence that is already durable: retained
+  `fork-*` snapshots, stored commit rows, and their confirm-time convergence
+  stamps. No storage schema change; pruning bounds and the
+  `committed_from => incumbent` invariant carry over.
+  ([#1241](https://github.com/marmot-protocol/mdk/pull/1241))
+
 - Same-epoch commit races now converge every member onto the same branch. A
   member that had committed from the contested epoch resolved the race through
   pairwise fork recovery and invalidated the losing commit terminally, while

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -34,6 +34,7 @@ versioning through the workspace version in the root `Cargo.toml`.
   (epoch, tree hash, confirmed transcript hash), so two lineages that share a
   ratchet tree — e.g. across group-data-only commits — can no longer satisfy
   the anchor lineage check for each other.
+  ([#1236](https://github.com/marmot-protocol/mdk/pull/1236))
 
 - Account projection storage types now redact encrypted group-image decryption
   and Blossom upload keys from `Debug` output, including nested group

--- a/crates/marmot-app/src/groups.rs
+++ b/crates/marmot-app/src/groups.rs
@@ -333,6 +333,12 @@ pub enum AppGroupHydrationQuarantineReason {
     /// Hydrate found an interrupted fork-recovery probe, and restoring the
     /// surviving live-state snapshot failed.
     ForkProbeRecoveryFailed,
+    /// Hydrate found an interrupted retained-anchor convergence probe, and
+    /// restoring the surviving pre-probe live snapshot failed.
+    RetainedAnchorProbeRecoveryFailed,
+    /// Hydrate found an interrupted convergence-apply snapshot, and restoring
+    /// the surviving pre-apply live snapshot failed.
+    ConvergenceApplyRecoveryFailed,
 }
 
 impl From<GroupHydrationQuarantineReason> for AppGroupHydrationQuarantineReason {
@@ -347,6 +353,12 @@ impl From<GroupHydrationQuarantineReason> for AppGroupHydrationQuarantineReason 
             }
             GroupHydrationQuarantineReason::ForkProbeRecoveryFailed => {
                 Self::ForkProbeRecoveryFailed
+            }
+            GroupHydrationQuarantineReason::RetainedAnchorProbeRecoveryFailed => {
+                Self::RetainedAnchorProbeRecoveryFailed
+            }
+            GroupHydrationQuarantineReason::ConvergenceApplyRecoveryFailed => {
+                Self::ConvergenceApplyRecoveryFailed
             }
         }
     }

--- a/crates/marmot-app/src/groups.rs
+++ b/crates/marmot-app/src/groups.rs
@@ -330,6 +330,9 @@ pub enum AppGroupHydrationQuarantineReason {
     GroupRecordLoadFailed,
     /// Hydrate found a stranded pending commit, but recovery itself failed.
     PendingCommitRecoveryFailed,
+    /// Hydrate found an interrupted fork-recovery probe, and restoring the
+    /// surviving live-state snapshot failed.
+    ForkProbeRecoveryFailed,
 }
 
 impl From<GroupHydrationQuarantineReason> for AppGroupHydrationQuarantineReason {
@@ -341,6 +344,9 @@ impl From<GroupHydrationQuarantineReason> for AppGroupHydrationQuarantineReason 
             GroupHydrationQuarantineReason::GroupRecordLoadFailed => Self::GroupRecordLoadFailed,
             GroupHydrationQuarantineReason::PendingCommitRecoveryFailed => {
                 Self::PendingCommitRecoveryFailed
+            }
+            GroupHydrationQuarantineReason::ForkProbeRecoveryFailed => {
+                Self::ForkProbeRecoveryFailed
             }
         }
     }

--- a/crates/marmot-forensics/schema/audit-log-event.v2.schema.json
+++ b/crates/marmot-forensics/schema/audit-log-event.v2.schema.json
@@ -1433,6 +1433,28 @@
         {
           "type": "object",
           "additionalProperties": false,
+          "required": ["type"],
+          "properties": {
+            "type": {
+              "const": "fork_routing_rebuilt"
+            },
+            "rebuilt_source_epochs": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/u64"
+              }
+            },
+            "restored_committed_from_epochs": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/u64"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
           "required": ["type", "phase"],
           "properties": {
             "type": {

--- a/crates/marmot-forensics/src/audit.rs
+++ b/crates/marmot-forensics/src/audit.rs
@@ -864,6 +864,18 @@ pub enum AuditEventKind {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         invalidated_msg_id: Option<MessageRefHex>,
     },
+    /// Fork-resolution routing state (`committed_from` and the fork-recovery
+    /// incumbents) was rebuilt from durable evidence during group hydration.
+    /// Distinguishes post-restart reconstruction from an in-flight
+    /// `fork_resolution`: an incumbent whose epoch is listed here was
+    /// recovered from a retained snapshot and a stored commit row, not
+    /// freshly applied.
+    ForkRoutingRebuilt {
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        rebuilt_source_epochs: Vec<u64>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        restored_committed_from_epochs: Vec<u64>,
+    },
     /// A distributed-convergence run changed lifecycle phase. Correlated with
     /// its `convergence_decision` via the `convergence.run_id` context.
     ConvergenceRunState {
@@ -1105,6 +1117,7 @@ impl AuditEventKind {
             AuditEventKind::GroupHydrationRecovered { .. } => "group_hydration_recovered",
             AuditEventKind::SnapshotCreated { .. } => "snapshot_created",
             AuditEventKind::ForkResolution { .. } => "fork_resolution",
+            AuditEventKind::ForkRoutingRebuilt { .. } => "fork_routing_rebuilt",
             AuditEventKind::ConvergenceRunState { .. } => "convergence_run_state",
             AuditEventKind::ConvergenceDecision { .. } => "convergence_decision",
             AuditEventKind::PeelerOutcome { .. } => "peeler_outcome",

--- a/crates/marmot-forensics/src/audit/tests.rs
+++ b/crates/marmot-forensics/src/audit/tests.rs
@@ -752,6 +752,10 @@ fn sample_audit_event_kinds() -> Vec<AuditEventKind> {
             winner: ForkWinner::Candidate,
             invalidated_msg_id: Some("m".into()),
         },
+        AuditEventKind::ForkRoutingRebuilt {
+            rebuilt_source_epochs: vec![2, 5],
+            restored_committed_from_epochs: vec![2],
+        },
         AuditEventKind::ConvergenceRunState {
             phase: ConvergencePhase::Evaluating,
             current_tip_epoch: Some(3),

--- a/crates/marmot-uniffi/src/conversions/group.rs
+++ b/crates/marmot-uniffi/src/conversions/group.rs
@@ -591,6 +591,12 @@ pub enum AppGroupHydrationQuarantineReasonFfi {
     /// Hydrate found an interrupted fork-recovery probe, and restoring the
     /// surviving live-state snapshot failed.
     ForkProbeRecoveryFailed,
+    /// Hydrate found an interrupted retained-anchor convergence probe, and
+    /// restoring the surviving pre-probe live snapshot failed.
+    RetainedAnchorProbeRecoveryFailed,
+    /// Hydrate found an interrupted convergence-apply snapshot, and restoring
+    /// the surviving pre-apply live snapshot failed.
+    ConvergenceApplyRecoveryFailed,
 }
 
 impl From<AppGroupHydrationQuarantineReason> for AppGroupHydrationQuarantineReasonFfi {
@@ -607,6 +613,12 @@ impl From<AppGroupHydrationQuarantineReason> for AppGroupHydrationQuarantineReas
             }
             AppGroupHydrationQuarantineReason::ForkProbeRecoveryFailed => {
                 Self::ForkProbeRecoveryFailed
+            }
+            AppGroupHydrationQuarantineReason::RetainedAnchorProbeRecoveryFailed => {
+                Self::RetainedAnchorProbeRecoveryFailed
+            }
+            AppGroupHydrationQuarantineReason::ConvergenceApplyRecoveryFailed => {
+                Self::ConvergenceApplyRecoveryFailed
             }
         }
     }

--- a/crates/marmot-uniffi/src/conversions/group.rs
+++ b/crates/marmot-uniffi/src/conversions/group.rs
@@ -588,6 +588,9 @@ pub enum AppGroupHydrationQuarantineReasonFfi {
     GroupRecordLoadFailed,
     /// Hydrate found a stranded pending commit, but recovery itself failed.
     PendingCommitRecoveryFailed,
+    /// Hydrate found an interrupted fork-recovery probe, and restoring the
+    /// surviving live-state snapshot failed.
+    ForkProbeRecoveryFailed,
 }
 
 impl From<AppGroupHydrationQuarantineReason> for AppGroupHydrationQuarantineReasonFfi {
@@ -601,6 +604,9 @@ impl From<AppGroupHydrationQuarantineReason> for AppGroupHydrationQuarantineReas
             AppGroupHydrationQuarantineReason::GroupRecordLoadFailed => Self::GroupRecordLoadFailed,
             AppGroupHydrationQuarantineReason::PendingCommitRecoveryFailed => {
                 Self::PendingCommitRecoveryFailed
+            }
+            AppGroupHydrationQuarantineReason::ForkProbeRecoveryFailed => {
+                Self::ForkProbeRecoveryFailed
             }
         }
     }

--- a/crates/traits/src/engine.rs
+++ b/crates/traits/src/engine.rs
@@ -389,6 +389,10 @@ pub enum GroupHydrationQuarantineReason {
     GroupRecordLoadFailed,
     /// Hydrate found a stranded pending commit, but recovery itself failed.
     PendingCommitRecoveryFailed,
+    /// Hydrate found an interrupted fork-recovery probe (or more than one,
+    /// which breaks the probes-are-serialized-per-group invariant), and
+    /// restoring the surviving live-state snapshot failed.
+    ForkProbeRecoveryFailed,
 }
 
 /// Ordered, decrypted output the application should render / act on.

--- a/crates/traits/src/engine.rs
+++ b/crates/traits/src/engine.rs
@@ -393,6 +393,13 @@ pub enum GroupHydrationQuarantineReason {
     /// which breaks the probes-are-serialized-per-group invariant), and
     /// restoring the surviving live-state snapshot failed.
     ForkProbeRecoveryFailed,
+    /// Hydrate found an interrupted retained-anchor convergence probe (or
+    /// more than one), and restoring the surviving pre-probe live snapshot
+    /// failed.
+    RetainedAnchorProbeRecoveryFailed,
+    /// Hydrate found an interrupted convergence-apply snapshot (or more than
+    /// one), and restoring the surviving pre-apply live snapshot failed.
+    ConvergenceApplyRecoveryFailed,
 }
 
 /// Ordered, decrypted output the application should render / act on.

--- a/crates/traits/src/message.rs
+++ b/crates/traits/src/message.rs
@@ -45,6 +45,22 @@ pub struct OwnCommitConvergenceStamp {
     /// field. Absent means "cannot be proven", and the fast path is refused.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub post_commit_tree_marker: Option<String>,
+    /// Name of the pre-commit fork-recovery snapshot (`fork-<epoch>-<counter>-…`)
+    /// this commit's pairwise-recovery record owned when it was published,
+    /// captured at confirm time from the same record `resolve()` would roll
+    /// back to. The hydrate-time fork-routing rebuild pairs an own-commit
+    /// incumbent with a fork snapshot by MATCHING this name against the
+    /// snapshots still on disk, instead of inferring the pairing from
+    /// "newest snapshot at the source epoch" — a name-based inference that is
+    /// exactly the kind of unproven identity claim the post-merge marker
+    /// exists to eliminate. It is the snapshot, not the ordering key, that a
+    /// later `resolve()` rewinds to, so the pairing must be exact.
+    ///
+    /// `Option` because rows stamped by older engine versions predate the
+    /// field. Absent means the rebuild falls back to the newest-snapshot
+    /// inference for this row.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fork_snapshot_name: Option<String>,
 }
 
 /// Typed envelope for the opaque bytes stored in [`MessageRecord::payload`].

--- a/crates/traits/tests/snapshots.rs
+++ b/crates/traits/tests/snapshots.rs
@@ -309,9 +309,11 @@ fn stored_message_payload_own_commit_wire_round_trips_with_stamp() {
         priority: CommitOrderingPriority::Privileged,
         consumed_proposal_refs: vec!["0a0b".into()],
         // `None` on purpose: this is the shape of every row written before
-        // `post_commit_tree_marker` existed, and `skip_serializing_if` must
-        // keep the stored bytes byte-identical for them.
+        // `post_commit_tree_marker` / `fork_snapshot_name` existed, and
+        // `skip_serializing_if` must keep the stored bytes byte-identical for
+        // them.
         post_commit_tree_marker: None,
+        fork_snapshot_name: None,
     };
     let payload = StoredMessagePayload::own_commit_wire(message.clone(), stamp.clone());
 
@@ -330,6 +332,7 @@ fn stored_message_payload_own_commit_wire_round_trips_with_stamp() {
     // retained-anchor fast path).
     let marked = OwnCommitConvergenceStamp {
         post_commit_tree_marker: Some("ab".repeat(32)),
+        fork_snapshot_name: Some("fork-3-7-0011223344556677".into()),
         ..stamp.clone()
     };
     let marked_payload = StoredMessagePayload::own_commit_wire(message, marked.clone());


### PR DESCRIPTION
Stacked on #1236, which unified the outcome of same-epoch fork resolution across the pairwise and convergence paths. This PR removes the restart detour that #1236 documented as a follow-up.

## What breaks

Which resolution path a member takes for a same-epoch commit race is decided by two maps that lived only in memory: `EpochManager::committed_from` (the epochs we ourselves committed from, read by the ingest router) and `ForkRecoveryManager::incumbents` (the applied commit, its ordering key, and its pre-commit snapshot per contested epoch). A daemon restart wiped both, so a member that would have resolved a race pairwise instead detoured through a full convergence pass. The outcome converges either way since #1236, but resolution behavior should not depend on process uptime.

## The fix

Hydration rebuilds both maps from evidence the existing durable transactions already produce, so there is no storage schema change and no new write path to tear:

- Retained `fork-<epoch>-<counter>-<hash8>` snapshots are durable and listable; the source epoch is in the name.
- The incumbent commit for each such epoch is the stored `Processed` commit row whose MLS wire bytes carry that source epoch. Own commits recover their ordering key from the confirm-time `OwnCommitConvergenceStamp` (the stamp exists for exactly this reason: MLS cannot replay a device's own commit). Inbound commits recover priority and committer through the existing `probe_commit_ordering_metadata_for_recovery` replay against the fork snapshot.
- `committed_from` entries are restored only alongside a successfully rebuilt incumbent, preserving the invariant that the pairwise router never runs without its snapshot. Half-rebuilt state could otherwise steer ingest into the fail-closed `MissingSnapshot` arm, which would be worse than the convergence detour it replaces.
- Epochs below the rewind horizon are skipped and their snapshots released, matching `prune_fork_recovery_for_group`. Rebuilt snapshot names advance the name allocator so a post-restart snapshot cannot collide with a pre-restart one.
- Rebuild failures are best-effort: the group stays on the convergence path (the behavior every restart had before this PR) and is never quarantined.

## Crash consistency

There is no separate routing-state write. The rebuild derives from artifacts written inside the existing apply/confirm transactions, so a crash between a commit's transaction and the old in-memory map mutation now reconstructs the post-transaction truth on reopen. An orphan snapshot with no `Processed` row (crash between snapshot creation and apply) is skipped and eventually retired by the horizon prune; the rebuild probe itself runs under the existing `SnapshotRollbackGuard` and boot-time interrupted-probe recovery.

## Tests

Two restart tests in `fork_detection.rs`, one per pairwise verdict: a reopened incumbent-keeper still resolves a losing rival pairwise and parks its root `ConvergenceDeferred` at the source epoch, and a winning rival still triggers `ForkRecovered` rollback through the rebuilt snapshot. Full `cgka-engine` suite is green under `--features test-policy-overrides` (the feature CI enables; the pinned-policy check rejects test-only policies without it); clippy and fmt are clean.

## Known limits

- A convergence reorg marks the selected commit `Processed` without registering an incumbent, so a rebuilt incumbent at that epoch pairs the pre-fork snapshot with the reorg winner's row. The in-memory map has the same staleness class; this PR does not widen it.
- Duplicate crash-leftover snapshots at one epoch (non-newest) are skipped, not released; they were equally orphaned before this change.

One more detour closed: the marmot wakes up from hibernation and still remembers which branch of the burrow it dug.


## Divergence from the live map, on purpose

The rebuild re-arms `committed_from` for a fork-invalidated own commit only when that epoch's incumbent also rebuilds (the winner's `Processed` row and snapshot are present). The live map keeps the entry unconditionally. The stricter rule is deliberate: re-arming without an incumbent would steer the pairwise router into the fail-closed `MissingSnapshot` arm, and an orphaned entry buys nothing once the snapshot is gone. In the common post-loss shape (winner applied, snapshot retained) the two agree.

The rebuild also emits a `fork_routing_rebuilt` audit row per group (rebuilt incumbent epochs plus the `committed_from` epochs restored with them), so forensics can tell post-restart reconstruction from in-flight fork resolution.

## Follow-up candidate, not in this PR

Mirroring the stricter rule in the live path would mean clearing `committed_from` when our own commit loses a pairwise race. One wrinkle to weigh first: after a loss the incumbent slot holds the winner, and `we_committed_from` is what routes a third same-epoch rival to the cheap pairwise check against it. Clearing the entry live would push that rival through a full convergence pass instead, and a restart would re-arm the entry anyway (stamped own row plus rebuilt incumbent). Worth deciding with the routing predicate itself: routing on `has_incumbent` instead of `we_committed_from` may be the cleaner unification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fork-resolution state now survives process restarts, improving recovery and convergence after interruptions.
  * Unverifiable retained branches and anchors are safely pruned instead of causing repeated failures.
  * Anchor mismatches are handled as recoverable blocked operations, allowing messages to be reconsidered later.
  * Interrupted fork-recovery probes are detected and restored safely.

* **Audit**
  * Added audit records for reconstructed fork-routing state, including recovered source and committed epochs.

* **Tests**
  * Expanded restart, rollback, convergence, and fork-recovery coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
