### PR TITLE
Fix/incident replay halt evidence followups

### DIFF
--- a/crates/incident-replay/AGENTS.md
+++ b/crates/incident-replay/AGENTS.md
@@ -169,14 +169,22 @@ Precedence, highest first:
    stable` alone is the engine's ordinary healthy state (see the rejected designs
    below). Clearing is decided per **`(engine_id, group_ref)`** — `Unrecoverable`
    is per-group state, so a repair in one group must not clear another group's
-   halt — by **newest halt vs. newest repair**, with surviving halts folded back
+   halt — by **repair strictly after the newest halt**, with surviving halts
+   folded back
    per engine so an engine halted in two groups is still one halted engine with
    the union of its reasons. Newest-wins needs no global event ordering because a
    live halt is continuously re-asserted (every session open re-emits
    `hydrate_unrecoverable_group`; every convergence attempt emits
    `already_unrecoverable`), so a halt that outlived its repair leaves rows after
    it. Both rows come from one engine — one clock, one recorder file — so rule 6's
-   cross-device grace does not apply here. It therefore outranks rule 6, which it usually
+   cross-device grace does not apply here. Two boundaries of that comparison are
+   contract, not incident: a repair sharing the halt's millisecond does **not**
+   clear it (a tie orders nothing, and the two orders mean opposite things), and
+   **one untimed halt row makes the whole halt side unorderable** — not just that
+   row. The untimed row may be the newest halt evidence there is, so the newest
+   *timed* halt is only a lower bound on the halt's position and a repair after
+   that bound proves nothing; taking it as the halt's position is the fail-open
+   direction, clearing a live halt on partially instrumented input. It therefore outranks rule 6, which it usually
    explains: on the real 26a9f546 export the halted engine is exactly the one
    rule 6 labelled `went dark`, and reporting the inference over the diagnosis
    would send the operator to re-pull for a confirmation they already have.

--- a/crates/incident-replay/AGENTS.md
+++ b/crates/incident-replay/AGENTS.md
@@ -108,8 +108,16 @@ incident becomes a vector only if the simulator reproduces the recorded outcome
     only *after* a failure — and one rule keeps it honest: a lower route may
     override a higher route's quarantine only by producing an accepted vector. A
     second quarantine never displaces the higher-precedence one; it becomes an
-    `advisory (fallback route):` instead. Vector names live here too: they are
-    pipeline facts, not CLI ones.
+    `advisory (fallback route):` instead. When the fall-through *does* produce an
+    accepted vector, the superseded finding is also written into that artifact's
+    `unavailable_fields` as `contested_convergence_replay`, with the same sentence
+    the advisory carries: the advisory is stdout, the artifact is what gets
+    persisted and read later as evidence, and an envelope showing a clean accepted
+    archetype with no trace of the higher-precedence incident that shared the
+    export fails the standard `archetype` already enforces on itself. The
+    `fallback route` finding has no such home by construction — both routes failed
+    closed, so there is no accepted artifact — and the advisory line is its only
+    surface. Vector names live here too: they are pipeline facts, not CLI ones.
 - **Module:** `src/main.rs`
   - **Role:** CLI — read one export file, detect its format, print the `Routing`.
     Reading and formatting only; route policy is `src/route.rs`. Exits 0 for any

--- a/crates/incident-replay/AGENTS.md
+++ b/crates/incident-replay/AGENTS.md
@@ -151,7 +151,19 @@ Precedence, highest first:
 5. **Quarantine `unrecoverable_halt`** — an engine recorded halting
    unrecoverably, so its group stays blocked until a verified repair clears the
    marker. Two audit surfaces arm it, and the reason string from whichever fired
-   is reported per engine: `convergence_run_state` with `phase: unrecoverable`
+   is reported per engine — **causes first-class, re-assertions only when there is
+   no cause**. `already_unrecoverable` (emitted on every convergence attempt
+   against an already-halted group) and `hydrate_unrecoverable_group` (every
+   session open over one) *arm* the gate like any other reason, because a window
+   of nothing but re-assertions is still a live halt, but they never say why the
+   engine stopped: beside a real cause they are noise in the line an operator
+   reads first, and `BTreeSet` order puts `already_unrecoverable` ahead of the
+   diagnosis. Once the cause is known they add nothing — that a halt is durable
+   and still being retried is what rule 5 *means*. When re-assertions are all the
+   export has (the real 26a9f546 shape: the halt predates the window) they are
+   reported, because the engine still has to be named and "the halt stands, cause
+   not in this window" is the honest reading. The two surfaces are
+   `convergence_run_state` with `phase: unrecoverable`
    (mdk#1110 — reason `frozen_pass_integrity_failure` from `error_kind:
    frozen_member_integrity`, and the reason-less `error_kind:
    missing_retained_anchor`, which is why the gate falls back to `error_kind`.

--- a/crates/incident-replay/src/artifact.rs
+++ b/crates/incident-replay/src/artifact.rs
@@ -349,7 +349,7 @@ fn with_byte_replay_unavailable(
     unavailable_fields
 }
 
-fn unavailable(field: &str, reason: &str) -> UnavailableEvidenceV1 {
+pub(crate) fn unavailable(field: &str, reason: &str) -> UnavailableEvidenceV1 {
     UnavailableEvidenceV1 {
         field: field.into(),
         reason: reason.into(),

--- a/crates/incident-replay/src/classify.rs
+++ b/crates/incident-replay/src/classify.rs
@@ -146,7 +146,8 @@ impl fmt::Display for QuarantineReason {
 pub struct HaltedEngine {
     /// The engine that halted.
     pub engine_id: String,
-    /// Every distinct halt reason it recorded, deduplicated and in sort order.
+    /// Why it halted, deduplicated and in sort order: the causes it recorded, or
+    /// its re-assertions when it recorded no cause. See [`reported_halt_reasons`].
     pub reasons: Vec<String>,
 }
 
@@ -410,10 +411,33 @@ fn unrecoverable_halt(export: &AgentStateExport) -> Option<QuarantineReason> {
         .into_iter()
         .map(|(engine_id, reasons)| HaltedEngine {
             engine_id: engine_id.to_owned(),
-            reasons: reasons.into_iter().map(str::to_owned).collect(),
+            reasons: reported_halt_reasons(&reasons),
         })
         .collect();
     (!engines.is_empty()).then_some(QuarantineReason::UnrecoverableHalt { engines })
+}
+
+/// One engine's halt reasons as the operator should read them: its causes, or its
+/// re-assertions when it recorded no cause.
+///
+/// A re-assertion never names why the engine stopped (see
+/// [`export::is_halt_re_assertion`]), so beside a real cause it is noise in the
+/// line an operator reads first. It is not dropped unconditionally, because a
+/// halt that predates the export window leaves nothing *but* re-assertions and
+/// that engine still has to be named — which is also the honest report for it:
+/// this export shows the halt standing, not what caused it.
+///
+/// [`export::is_halt_re_assertion`]: crate::export::is_halt_re_assertion
+fn reported_halt_reasons(reasons: &BTreeSet<&str>) -> Vec<String> {
+    let causes: Vec<String> = reasons
+        .iter()
+        .filter(|reason| !crate::export::is_halt_re_assertion(reason))
+        .map(|reason| (*reason).to_owned())
+        .collect();
+    if causes.is_empty() {
+        return reasons.iter().map(|reason| (*reason).to_owned()).collect();
+    }
+    causes
 }
 
 /// Per-engine activity, folded from the event log.

--- a/crates/incident-replay/src/classify.rs
+++ b/crates/incident-replay/src/classify.rs
@@ -301,8 +301,11 @@ pub fn halt_advisory(export: &AgentStateExport) -> Option<QuarantineReason> {
 struct HaltLifecycle<'a> {
     /// Every distinct reason the engine gave for halting this group.
     reasons: BTreeSet<&'a str>,
-    /// The newest halt row's timestamp, when the halt rows carry one.
+    /// The newest *timed* halt row's timestamp. Only the halt's position when
+    /// every halt row carried a clock — see [`HaltLifecycle::halt_position_ms`].
     last_halt_ms: Option<u64>,
+    /// Whether any halt row carried no clock at all.
+    untimed_halt: bool,
     /// The newest verified-repair row's timestamp, when it carries one.
     last_repair_ms: Option<u64>,
 }
@@ -334,10 +337,26 @@ impl HaltLifecycle<'_> {
         if self.reasons.is_empty() {
             return false;
         }
-        match (self.last_halt_ms, self.last_repair_ms) {
+        match (self.halt_position_ms(), self.last_repair_ms) {
             (Some(halt), Some(repair)) => repair <= halt,
             _ => true,
         }
+    }
+
+    /// Where the halt sits on the engine's clock, or `None` when its evidence
+    /// cannot be placed there at all.
+    ///
+    /// One untimed halt row makes the *whole* halt side unorderable, not just
+    /// that row: the untimed row may be the newest evidence of the halt, so the
+    /// newest timed row is a lower bound on the halt's position rather than the
+    /// position itself, and a repair after that bound proves nothing. Reading the
+    /// newest timed row as the answer is the one direction [`Self::still_halted`]
+    /// must not take — it clears a halt whose position is unknown.
+    fn halt_position_ms(&self) -> Option<u64> {
+        if self.untimed_halt {
+            return None;
+        }
+        self.last_halt_ms
     }
 }
 
@@ -364,7 +383,10 @@ fn unrecoverable_halt(export: &AgentStateExport) -> Option<QuarantineReason> {
         if let Some(reason) = event.kind.unrecoverable_halt_reason() {
             let lifecycle = lifecycles.entry(group_scope).or_default();
             lifecycle.reasons.insert(reason);
-            lifecycle.last_halt_ms = lifecycle.last_halt_ms.max(event.wall_time_ms);
+            match event.wall_time_ms {
+                Some(ms) => lifecycle.last_halt_ms = lifecycle.last_halt_ms.max(Some(ms)),
+                None => lifecycle.untimed_halt = true,
+            }
         } else if event.kind.is_verified_repair() {
             // Recorded even when no halt has been seen yet: the fold is over
             // timestamps, not file order, so a repair may legitimately arrive

--- a/crates/incident-replay/src/export.rs
+++ b/crates/incident-replay/src/export.rs
@@ -44,6 +44,29 @@ const VERIFIED_REPAIR_REASON: &str = "join_welcome_repair";
 /// on the floor should one ever not.
 const UNSPECIFIED_HALT_REASON: &str = "unspecified";
 
+/// Halt reasons that re-assert an existing halt instead of naming its cause.
+///
+/// `already_unrecoverable` is emitted on every convergence attempt against an
+/// already-halted group (`cgka-engine/src/distributed_convergence.rs`) and
+/// `hydrate_unrecoverable_group` on every session open over one
+/// (`cgka-engine/src/engine.rs`). Both are the halt restating itself — the
+/// property rule 5's newest-wins clearing relies on — so they arm the gate like
+/// any other halt reason. Neither says why the engine stopped. See
+/// [`is_halt_re_assertion`] for what that means for reporting.
+const HALT_RE_ASSERTION_REASONS: [&str; 2] =
+    ["already_unrecoverable", "hydrate_unrecoverable_group"];
+
+/// Whether `reason` only re-asserts a halt rather than naming its cause.
+///
+/// Purely a reporting distinction: rule 5 arms on any halt reason, and a window
+/// carrying nothing but re-assertions is still a live halt. It exists because
+/// `reasons` is the first thing an operator reads, and once a cause is known a
+/// re-assertion adds nothing — that the halt is durable and still being retried
+/// is what rule 5 *means*, not a separate finding.
+pub(crate) fn is_halt_re_assertion(reason: &str) -> bool {
+    HALT_RE_ASSERTION_REASONS.contains(&reason)
+}
+
 /// A parsed export, reduced to the classifier's inputs.
 #[derive(Debug, Clone, Deserialize)]
 pub struct AgentStateExport {

--- a/crates/incident-replay/src/route.rs
+++ b/crates/incident-replay/src/route.rs
@@ -38,7 +38,7 @@ use cgka_conformance_simulator::VectorFixture;
 
 use crate::artifact::{
     IncidentScenarioArtifactV1, IncidentSourceFormatV1, NormalizedHistoryImportError,
-    accept_attested_history, archetype_artifact, import_attested_history,
+    accept_attested_history, archetype_artifact, import_attested_history, unavailable,
 };
 use crate::classify::{QuarantineReason, Verdict, classify, halt_advisory, liveness_advisory};
 use crate::export::AgentStateExport;
@@ -56,6 +56,11 @@ pub const CONVERGENCE_NAME: &str = "convergence-incident/v1";
 /// A higher-precedence route quarantined, but a lower one reproduced an incident
 /// from the same export.
 const SUPERSEDED_ROUTE: &str = "superseded route";
+/// The [`IncidentScenarioArtifactV1::unavailable_fields`] entry for the same
+/// finding: the accepted archetype stands for the lower-precedence incident, and
+/// the contested convergence the export also carried is evidence it does not
+/// cover.
+const CONTESTED_CONVERGENCE_REPLAY: &str = "contested_convergence_replay";
 /// A higher-precedence route quarantined and the fall-through could not rescue
 /// it either.
 const FALLBACK_ROUTE: &str = "fallback route";
@@ -265,13 +270,26 @@ fn fall_through_to_fork(
         return Outcome::Quarantine { reason: superseded };
     }
     match fork_route(export, source_format) {
-        Ok(artifact) => {
+        Ok(mut artifact) => {
+            // Said once, then reported twice: as the stdout advisory and as the
+            // accepted artifact's own statement of what it does not cover. The
+            // artifact is what gets written to disk and read later as evidence, so
+            // a finding that lives only in `advisories` dies with the terminal —
+            // and the envelope would show a clean accepted archetype with no trace
+            // of the higher-precedence incident that shared the export.
+            let detail = format!("contested convergence could not be replayed: {superseded}");
+            artifact
+                .unavailable_fields
+                .push(unavailable(CONTESTED_CONVERGENCE_REPLAY, &detail));
             advisories.push(Advisory {
                 label: SUPERSEDED_ROUTE,
-                detail: format!("contested convergence could not be replayed: {superseded}"),
+                detail,
             });
             Outcome::Accepted(artifact)
         }
+        // No artifact exists on this path — both routes failed closed, so there is
+        // no accepted envelope for the finding to enter and the advisory is its
+        // only surface. Construction, not omission (AGENTS.md, `src/route.rs`).
         Err(fallback) => {
             advisories.push(Advisory {
                 label: FALLBACK_ROUTE,

--- a/crates/incident-replay/tests/classify.rs
+++ b/crates/incident-replay/tests/classify.rs
@@ -302,10 +302,13 @@ fn a_group_hydrated_into_the_unrecoverable_state_quarantines() {
 }
 
 #[test]
-fn both_halt_surfaces_on_one_engine_report_one_entry_per_reason() {
+fn both_halt_surfaces_on_one_engine_fold_into_one_report() {
     // An engine that halts mid-pass and then hydrates back into the halt records
-    // both surfaces, repeatedly. The report is per engine, with each distinct
-    // reason once: a halt is a state, not a count, so repetition is not severity.
+    // both surfaces, repeatedly. It is still one halted engine: a halt is a state,
+    // not a count, so repetition is neither severity nor a second entry. What
+    // remains is the cause — the two hydrate rows only re-assert the halt the
+    // frozen-pass failure already explained (see
+    // `a_halt_cause_is_reported_without_its_re_assertions`).
     let export = load("quarantine-repeated-halt.json");
     assert_eq!(
         classify(&export),
@@ -313,8 +316,55 @@ fn both_halt_surfaces_on_one_engine_report_one_entry_per_reason() {
             reason: QuarantineReason::UnrecoverableHalt {
                 engines: vec![HaltedEngine {
                     engine_id: "engine-a".into(),
+                    reasons: vec!["frozen_pass_integrity_failure".into()],
+                }],
+            }
+        }
+    );
+}
+
+#[test]
+fn a_halt_cause_is_reported_without_its_re_assertions() {
+    // `reasons` is the first thing an operator reads, and two of the strings that
+    // reach it never name a cause: `already_unrecoverable` is emitted on *every*
+    // convergence attempt against an already-halted group, and
+    // `hydrate_unrecoverable_group` on every session open over one. They are the
+    // halt re-asserting itself — which is why newest-wins clearing works at all —
+    // but next to a real cause they are noise, and `BTreeSet` order puts
+    // `already_unrecoverable` first, ahead of the diagnosis. Neither adds anything
+    // once the cause is known: every halt stands until a verified repair, so
+    // "durable" and "still being retried" are rule 5, not findings.
+    assert_eq!(
+        classify(&load("quarantine-halt-cause-among-re-assertions.json")),
+        Verdict::Quarantine {
+            reason: QuarantineReason::UnrecoverableHalt {
+                engines: vec![HaltedEngine {
+                    engine_id: "engine-a".into(),
+                    reasons: vec!["frozen_pass_integrity_failure".into()],
+                }],
+            }
+        }
+    );
+}
+
+#[test]
+fn a_halt_that_predates_the_export_reports_its_re_assertions() {
+    // The real 26a9f546 shape: the halt happened before the export window, so
+    // every row in it is a re-assertion and there is no cause to promote. The
+    // demotion must not silence the engine — an export of nothing but
+    // re-assertions is still a live halt, and rule 5 has to name the device.
+    // Reporting them is also the honest answer: this export shows the halt
+    // standing, not what caused it, and the operator's next move is to widen the
+    // window rather than to treat a re-assertion as the diagnosis. Each distinct
+    // reason appears once however many rows carried it.
+    assert_eq!(
+        classify(&load("quarantine-halt-re-asserted-only.json")),
+        Verdict::Quarantine {
+            reason: QuarantineReason::UnrecoverableHalt {
+                engines: vec![HaltedEngine {
+                    engine_id: "engine-a".into(),
                     reasons: vec![
-                        "frozen_pass_integrity_failure".into(),
+                        "already_unrecoverable".into(),
                         "hydrate_unrecoverable_group".into(),
                     ],
                 }],

--- a/crates/incident-replay/tests/classify.rs
+++ b/crates/incident-replay/tests/classify.rs
@@ -406,6 +406,49 @@ fn an_untimed_repair_does_not_clear_a_halt() {
 }
 
 #[test]
+fn one_untimed_halt_row_among_timed_ones_still_blocks_a_later_repair() {
+    // Mixed instrumentation: the same engine and group recorded an untimed halt, a
+    // timed halt, and then a repair newer than the *timed* halt. The untimed row
+    // may be the newest evidence of all — nothing in the export says otherwise —
+    // so the halt is unorderable and stands, exactly as when no halt row carries a
+    // clock at all. Reading the newest timed halt as *the* halt position is the
+    // fail-open direction: it lets a repair clear a halt whose real position is
+    // unknown, turning a live halt into a healthy verdict on partially
+    // instrumented input.
+    assert_eq!(
+        classify(&load("quarantine-partially-timed-halt-with-repair.json")),
+        Verdict::Quarantine {
+            reason: QuarantineReason::UnrecoverableHalt {
+                engines: vec![HaltedEngine {
+                    engine_id: "engine-a".into(),
+                    reasons: vec!["hydrate_unrecoverable_group".into()],
+                }],
+            }
+        }
+    );
+}
+
+#[test]
+fn a_repair_sharing_the_halt_millisecond_does_not_clear_it() {
+    // The other boundary of the same comparison: both rows carry a clock, and it
+    // is the same one. A millisecond is coarser than the two transitions, so a
+    // tie says only that they landed in the same tick — not which came first —
+    // and the two orders have opposite meanings. Strictly-after is therefore the
+    // rule, and a tie fails closed like any other unorderable pair.
+    assert_eq!(
+        classify(&load("quarantine-halt-and-repair-at-one-instant.json")),
+        Verdict::Quarantine {
+            reason: QuarantineReason::UnrecoverableHalt {
+                engines: vec![HaltedEngine {
+                    engine_id: "engine-a".into(),
+                    reasons: vec!["hydrate_unrecoverable_group".into()],
+                }],
+            }
+        }
+    );
+}
+
+#[test]
 fn a_convergence_run_at_the_tip_proves_the_engine_is_not_behind() {
     // engine-b's group-state evidence stops at epoch 4, but it went on to run a
     // convergence pass whose canonical tip was 6 — an epoch it can only have

--- a/crates/incident-replay/tests/fixtures/quarantine-halt-and-repair-at-one-instant.json
+++ b/crates/incident-replay/tests/fixtures/quarantine-halt-and-repair-at-one-instant.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "marmot-agent-state/v1",
+  "events": [
+    {
+      "engine_id": "engine-a",
+      "group_ref": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "wall_time_ms": 1000000000000,
+      "kind": { "type": "epoch_state_changed", "epoch": 7, "new_state": "unrecoverable", "reason": "hydrate_unrecoverable_group" }
+    },
+    {
+      "engine_id": "engine-a",
+      "group_ref": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "wall_time_ms": 1000000000000,
+      "kind": { "type": "epoch_state_changed", "epoch": 8, "new_state": "stable", "reason": "join_welcome_repair" }
+    }
+  ],
+  "derived_projections": { "pagination": {} }
+}

--- a/crates/incident-replay/tests/fixtures/quarantine-halt-cause-among-re-assertions.json
+++ b/crates/incident-replay/tests/fixtures/quarantine-halt-cause-among-re-assertions.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": "marmot-agent-state/v1",
+  "events": [
+    {
+      "engine_id": "engine-a",
+      "group_ref": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "wall_time_ms": 1000000000000,
+      "kind": {
+        "type": "convergence_run_state",
+        "phase": "unrecoverable",
+        "current_tip_epoch": 7,
+        "reason": "frozen_pass_integrity_failure",
+        "error_kind": "frozen_member_integrity"
+      }
+    },
+    {
+      "engine_id": "engine-a",
+      "group_ref": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "wall_time_ms": 1000000060000,
+      "kind": { "type": "epoch_state_changed", "epoch": 7, "new_state": "unrecoverable", "reason": "hydrate_unrecoverable_group" }
+    },
+    {
+      "engine_id": "engine-a",
+      "group_ref": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "wall_time_ms": 1000000120000,
+      "kind": {
+        "type": "convergence_run_state",
+        "phase": "unrecoverable",
+        "current_tip_epoch": 7,
+        "reason": "already_unrecoverable"
+      }
+    }
+  ],
+  "derived_projections": { "pagination": {} }
+}

--- a/crates/incident-replay/tests/fixtures/quarantine-halt-re-asserted-only.json
+++ b/crates/incident-replay/tests/fixtures/quarantine-halt-re-asserted-only.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": "marmot-agent-state/v1",
+  "events": [
+    {
+      "engine_id": "engine-a",
+      "group_ref": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "wall_time_ms": 1000000000000,
+      "kind": { "type": "epoch_state_changed", "epoch": 7, "new_state": "unrecoverable", "reason": "hydrate_unrecoverable_group" }
+    },
+    {
+      "engine_id": "engine-a",
+      "group_ref": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "wall_time_ms": 1000000060000,
+      "kind": {
+        "type": "convergence_run_state",
+        "phase": "unrecoverable",
+        "current_tip_epoch": 7,
+        "reason": "already_unrecoverable"
+      }
+    },
+    {
+      "engine_id": "engine-a",
+      "group_ref": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "wall_time_ms": 1000000120000,
+      "kind": {
+        "type": "convergence_run_state",
+        "phase": "unrecoverable",
+        "current_tip_epoch": 7,
+        "reason": "already_unrecoverable"
+      }
+    }
+  ],
+  "derived_projections": { "pagination": {} }
+}

--- a/crates/incident-replay/tests/fixtures/quarantine-partially-timed-halt-with-repair.json
+++ b/crates/incident-replay/tests/fixtures/quarantine-partially-timed-halt-with-repair.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "marmot-agent-state/v1",
+  "events": [
+    {
+      "engine_id": "engine-a",
+      "group_ref": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "kind": { "type": "epoch_state_changed", "epoch": 7, "new_state": "unrecoverable", "reason": "hydrate_unrecoverable_group" }
+    },
+    {
+      "engine_id": "engine-a",
+      "group_ref": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "wall_time_ms": 1000000000000,
+      "kind": { "type": "epoch_state_changed", "epoch": 7, "new_state": "unrecoverable", "reason": "hydrate_unrecoverable_group" }
+    },
+    {
+      "engine_id": "engine-a",
+      "group_ref": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "wall_time_ms": 1000000060000,
+      "kind": { "type": "epoch_state_changed", "epoch": 8, "new_state": "stable", "reason": "join_welcome_repair" }
+    }
+  ],
+  "derived_projections": { "pagination": {} }
+}

--- a/crates/incident-replay/tests/route.rs
+++ b/crates/incident-replay/tests/route.rs
@@ -50,6 +50,71 @@ fn a_fail_closed_convergence_falls_through_to_a_clean_fork() {
 }
 
 #[test]
+fn a_superseded_route_is_recorded_in_the_accepted_artifact() {
+    // The advisory line is stdout; the artifact is what gets written to disk and
+    // passed around as evidence. Without this, someone opening the persisted
+    // envelope sees a clean accepted fork archetype with no trace that the same
+    // export carried a higher-precedence contested convergence at the same epoch
+    // that could not be replayed — which is exactly the standard `archetype`
+    // enforces on itself ("an artifact that cannot point at its own source rows is
+    // not publishable evidence"). `unavailable_fields` is where the artifact
+    // already states what it could not cover, so the finding belongs there.
+    let routing = routed("convergence-failclosed-with-clean-fork.json");
+
+    let Outcome::Accepted(artifact) = &routing.outcome else {
+        panic!("expected the fork fallback to be accepted, got {routing:?}");
+    };
+    let superseded = artifact
+        .unavailable_fields
+        .iter()
+        .find(|evidence| evidence.field == "contested_convergence_replay")
+        .unwrap_or_else(|| {
+            panic!(
+                "artifact should record the superseded route, got {:?}",
+                artifact.unavailable_fields
+            )
+        });
+    assert!(
+        superseded
+            .reason
+            .contains("quorum boost is not provably decisive"),
+        "the recorded reason should be why the convergence failed closed, got {:?}",
+        superseded.reason
+    );
+    // Text and artifact must say the same thing, or the operator reading one and
+    // the auditor reading the other disagree about the same export.
+    assert_eq!(
+        routing
+            .advisories
+            .iter()
+            .find(|advisory| advisory.label == "superseded route")
+            .map(|advisory| advisory.detail.as_str()),
+        Some(superseded.reason.as_str()),
+    );
+}
+
+#[test]
+fn a_clean_route_records_no_superseded_evidence() {
+    // The counterpart: an export whose highest-precedence route reproduced has
+    // nothing superseded, so the field must be absent rather than present-and-
+    // empty. Otherwise every artifact would carry the entry and it would stop
+    // meaning anything.
+    let routing = routed("replayable-membership-fork.json");
+
+    let Outcome::Accepted(artifact) = &routing.outcome else {
+        panic!("expected the fork route to be accepted, got {routing:?}");
+    };
+    assert!(
+        !artifact
+            .unavailable_fields
+            .iter()
+            .any(|evidence| evidence.field == "contested_convergence_replay"),
+        "an unsuperseded artifact should not claim a superseded route, got {:?}",
+        artifact.unavailable_fields
+    );
+}
+
+#[test]
 fn a_fallback_that_also_fails_leaves_the_higher_quarantine_primary() {
     // Fall-through may only upgrade the outcome. When the fork route fails too,
     // the convergence quarantine stays primary — it is the higher-precedence


### PR DESCRIPTION
**What this fixes**

1. **Fail-closed halt ordering** (`29fe191b` → now `7d2ff4cf`): an untimed halt row alongside a timed one let a newer `join_welcome_repair` clear a halt that must stand — the RED test classified a live halt as `Healthy`. The comparison now fails closed: a halt whose timing cannot be established is never cleared by a later repair, and a repair at the same timestamp cannot clear it either. Both directions are mutation-checked (reverting to the `Option::max` reading fails the mixed-timing fixture; relaxing `repair <= halt` to `<` fails the tie fixture).
2. **Superseded routes become artifact evidence** (`8271d8ff`): the accepted path now records the superseded convergence route in `IncidentScenarioArtifactV1` instead of leaving it as log-only advisory.
3. **Causes ahead of re-assertions** (`9b0daf7f`): `HaltedEngine.reasons` now reports causes; re-assertions appear only when there is no cause.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved incident replay halt handling by prioritizing substantive causes over duplicate re-assertions.
  * Untimed or partially timed halt evidence remains blocking, and repairs at the same timestamp as a halt cannot clear it.
  * Accepted fallback routes now preserve details about superseded convergence attempts and their failure reasons.
  * Improved artifact availability reporting when replay evidence cannot be retained.

* **Documentation**
  * Clarified fallback advisories, artifact persistence, halt prioritization, and halt-clearing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->