### PR TITLE
Fix simulator production output audit

### DIFF
--- a/crates/cgka-conformance-simulator/tests/tracing_audit.rs
+++ b/crates/cgka-conformance-simulator/tests/tracing_audit.rs
@@ -161,7 +161,7 @@ fn production_library_sources_do_not_write_direct_output() {
 
     for root in production_source_roots(&repo) {
         for file in rust_source_files(&root) {
-            if is_cli_binary(&file) {
+            if is_cli_binary(&file) || is_feature_gated_test_support(&file) {
                 continue;
             }
 
@@ -188,6 +188,10 @@ fn production_library_sources_do_not_write_direct_output() {
         "direct output audit failed:\n{}",
         failures.join("\n")
     );
+}
+
+fn is_feature_gated_test_support(path: &Path) -> bool {
+    path.file_name().and_then(|name| name.to_str()) == Some("test_support.rs")
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
## What changed

- exclude feature-gated `test_support.rs` modules from the production direct-output audit
- retain the audit for production library sources and CLI exclusions

## Root cause

The Pi terminal-harness work introduced a feature-gated test-support module that intentionally prints child-process logs when an end-to-end test panics. The simulator audit scanned that test-only module as production code, so the `Simulator and vectors` CI job failed on its `eprintln!` diagnostic.

## Impact

The production-output policy remains enforced for production library code, while shared end-to-end test diagnostics no longer cause a false positive.

## Validation

- `cargo test -p cgka-conformance-simulator --test tracing_audit`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved conformance auditing to correctly exclude command-line tools and feature-gated test-support files from production-library checks.
  * Reduced false positives when validating direct output and public API conformance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->