### PR TITLE
Move full simulator campaigns to nightly CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,6 +321,11 @@ jobs:
       - name: Install cargo-nextest
         uses: taiki-e/install-action@b18fb392e1a1b90971f7c7572c92790fa54f23d5 # nextest
 
+      - name: Install just
+        uses: taiki-e/install-action@b18fb392e1a1b90971f7c7572c92790fa54f23d5 # just
+        with:
+          tool: just
+
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
@@ -328,17 +333,10 @@ jobs:
         # Multi-minute generated reliability batches and the adversarial
         # campaign run in the scheduled Simulator Nightly workflow. Independent
         # convergence checks run in their dedicated fast gate below.
-        run: |
-          cargo nextest run -p cgka-conformance-simulator --locked --profile ci \
-            -E 'not binary(adversarial_reliability_campaigns) and not binary(policy_sweeps) and not binary(independent_reference_model) and not binary(lifecycle_model) and not binary(mutation_adequacy) and not binary(protocol_decision_gate) and not (binary(canonical_scenarios) & (test(=convergence_chaos_family_generates_specs_with_semantic_expectations) | test(=convergence_chaos_family_seed_changes_scenarios) | test(=convergence_e2e_delivery_family_runs_generated_variants)))'
+        run: just simulator-smoke
 
       - name: Run simulator doctests
         run: cargo test -p cgka-conformance-simulator --doc --locked
-
-      - name: Install just
-        uses: taiki-e/install-action@b18fb392e1a1b90971f7c7572c92790fa54f23d5 # just
-        with:
-          tool: just
 
       - name: Verify convergence with independent models
         run: just convergence-verification-ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,8 +324,13 @@ jobs:
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
-      - name: Run simulator tests
-        run: cargo nextest run -p cgka-conformance-simulator --locked --profile ci
+      - name: Run simulator smoke tests
+        # Multi-minute generated reliability batches and the Milestone 3
+        # campaign run in the scheduled Simulator Nightly workflow. Milestone
+        # 4 binaries run in their dedicated fast gate below.
+        run: |
+          cargo nextest run -p cgka-conformance-simulator --locked --profile ci \
+            -E 'not binary(milestone3_campaigns) and not binary(policy_sweeps) and not binary(independent_reference_model) and not binary(lifecycle_model) and not binary(mutation_adequacy) and not binary(protocol_decision_gate) and not (binary(canonical_scenarios) & (test(=convergence_chaos_family_generates_specs_with_semantic_expectations) | test(=convergence_chaos_family_seed_changes_scenarios) | test(=convergence_e2e_delivery_family_runs_generated_variants)))'
 
       - name: Run simulator doctests
         run: cargo test -p cgka-conformance-simulator --doc --locked
@@ -334,9 +339,6 @@ jobs:
         uses: taiki-e/install-action@b18fb392e1a1b90971f7c7572c92790fa54f23d5 # just
         with:
           tool: just
-
-      - name: Run Milestone 3 adversarial campaign gate
-        run: just milestone3-ci
 
       - name: Run Milestone 4 independent verification gate
         run: just milestone4-ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,12 +325,12 @@ jobs:
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Run simulator smoke tests
-        # Multi-minute generated reliability batches and the Milestone 3
-        # campaign run in the scheduled Simulator Nightly workflow. Milestone
-        # 4 binaries run in their dedicated fast gate below.
+        # Multi-minute generated reliability batches and the adversarial
+        # campaign run in the scheduled Simulator Nightly workflow. Independent
+        # convergence checks run in their dedicated fast gate below.
         run: |
           cargo nextest run -p cgka-conformance-simulator --locked --profile ci \
-            -E 'not binary(milestone3_campaigns) and not binary(policy_sweeps) and not binary(independent_reference_model) and not binary(lifecycle_model) and not binary(mutation_adequacy) and not binary(protocol_decision_gate) and not (binary(canonical_scenarios) & (test(=convergence_chaos_family_generates_specs_with_semantic_expectations) | test(=convergence_chaos_family_seed_changes_scenarios) | test(=convergence_e2e_delivery_family_runs_generated_variants)))'
+            -E 'not binary(adversarial_reliability_campaigns) and not binary(policy_sweeps) and not binary(independent_reference_model) and not binary(lifecycle_model) and not binary(mutation_adequacy) and not binary(protocol_decision_gate) and not (binary(canonical_scenarios) & (test(=convergence_chaos_family_generates_specs_with_semantic_expectations) | test(=convergence_chaos_family_seed_changes_scenarios) | test(=convergence_e2e_delivery_family_runs_generated_variants)))'
 
       - name: Run simulator doctests
         run: cargo test -p cgka-conformance-simulator --doc --locked
@@ -340,8 +340,8 @@ jobs:
         with:
           tool: just
 
-      - name: Run Milestone 4 independent verification gate
-        run: just milestone4-ci
+      - name: Verify convergence with independent models
+        run: just convergence-verification-ci
 
       - name: Run encrypted file-backed vector report
         run: |

--- a/.github/workflows/simulator-nightly.yml
+++ b/.github/workflows/simulator-nightly.yml
@@ -50,20 +50,20 @@ jobs:
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Run complete simulator suite
-        # Milestone 3 and 4 binaries run below with their required feature sets
-        # and model checks; exclude only those duplicate invocations here.
+        # Adversarial campaigns and independent convergence checks run below
+        # with their required feature sets; exclude only those duplicates here.
         run: |
           cargo nextest run -p cgka-conformance-simulator --features conformance-slow --locked --profile ci \
-            -E 'not binary(milestone3_campaigns) and not binary(policy_sweeps) and not binary(independent_reference_model) and not binary(lifecycle_model) and not binary(mutation_adequacy) and not binary(protocol_decision_gate)'
+            -E 'not binary(adversarial_reliability_campaigns) and not binary(policy_sweeps) and not binary(independent_reference_model) and not binary(lifecycle_model) and not binary(mutation_adequacy) and not binary(protocol_decision_gate)'
 
       - name: Run simulator doctests
         run: cargo test -p cgka-conformance-simulator --doc --locked
 
-      - name: Run Milestone 3 adversarial campaign gate
-        run: just milestone3-ci
+      - name: Run adversarial reliability campaigns
+        run: just adversarial-reliability-ci
 
-      - name: Run Milestone 4 independent verification gate
-        run: just milestone4-ci
+      - name: Verify convergence with independent models
+        run: just convergence-verification-ci
 
       - name: Run encrypted file-backed vector report
         run: |

--- a/.github/workflows/simulator-nightly.yml
+++ b/.github/workflows/simulator-nightly.yml
@@ -1,0 +1,84 @@
+name: Simulator Nightly
+
+on:
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: simulator-nightly
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  CARGO_PROFILE_TEST_DEBUG: "0"
+
+jobs:
+  simulator-nightly:
+    name: Full simulator, campaigns, and vectors
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        run: |
+          set -euo pipefail
+          toolchain="$(sed -n 's/^channel = "\(.*\)"/\1/p' rust-toolchain.toml)"
+          rustup toolchain install "$toolchain" --profile minimal
+          rustup default "$toolchain"
+          rustc --version
+          cargo --version
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@b18fb392e1a1b90971f7c7572c92790fa54f23d5
+
+      - name: Install just
+        uses: taiki-e/install-action@b18fb392e1a1b90971f7c7572c92790fa54f23d5
+        with:
+          tool: just
+
+      - name: Cache Cargo artifacts
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Run complete simulator suite
+        # Milestone 3 and 4 binaries run below with their required feature sets
+        # and model checks; exclude only those duplicate invocations here.
+        run: |
+          cargo nextest run -p cgka-conformance-simulator --features conformance-slow --locked --profile ci \
+            -E 'not binary(milestone3_campaigns) and not binary(policy_sweeps) and not binary(independent_reference_model) and not binary(lifecycle_model) and not binary(mutation_adequacy) and not binary(protocol_decision_gate)'
+
+      - name: Run simulator doctests
+        run: cargo test -p cgka-conformance-simulator --doc --locked
+
+      - name: Run Milestone 3 adversarial campaign gate
+        run: just milestone3-ci
+
+      - name: Run Milestone 4 independent verification gate
+        run: just milestone4-ci
+
+      - name: Run encrypted file-backed vector report
+        run: |
+          cargo run -p cgka-conformance-simulator --bin cgka-conformance-simulator-report --locked -- \
+            --vectors crates/cgka-conformance-simulator/vectors \
+            --out target/cgka-conformance-simulator-nightly-reports \
+            --storage file \
+            --strict-oracle
+          jq -s -e 'all(.[]; .metadata.storage_backend == "encrypted-file-sqlite")' \
+            target/cgka-conformance-simulator-nightly-reports/*-report.json >/dev/null
+
+      - name: Upload nightly vector report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: cgka-conformance-simulator-nightly-reports
+          path: target/cgka-conformance-simulator-nightly-reports
+          if-no-files-found: warn

--- a/.github/workflows/simulator-nightly.yml
+++ b/.github/workflows/simulator-nightly.yml
@@ -7,10 +7,11 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 concurrency:
-  group: simulator-nightly
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: false
 
 env:
   CARGO_TERM_COLOR: always
@@ -52,9 +53,7 @@ jobs:
       - name: Run complete simulator suite
         # Adversarial campaigns and independent convergence checks run below
         # with their required feature sets; exclude only those duplicates here.
-        run: |
-          cargo nextest run -p cgka-conformance-simulator --features conformance-slow --locked --profile ci \
-            -E 'not binary(adversarial_reliability_campaigns) and not binary(policy_sweeps) and not binary(independent_reference_model) and not binary(lifecycle_model) and not binary(mutation_adequacy) and not binary(protocol_decision_gate)'
+        run: just simulator-full
 
       - name: Run simulator doctests
         run: cargo test -p cgka-conformance-simulator --doc --locked
@@ -82,3 +81,15 @@ jobs:
           name: cgka-conformance-simulator-nightly-reports
           path: target/cgka-conformance-simulator-nightly-reports
           if-no-files-found: warn
+
+      - name: Report nightly failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          run_date="$(date -u +%F)"
+          gh issue create \
+            --repo "${{ github.repository }}" \
+            --title "Simulator nightly failed (${run_date})" \
+            --body "The simulator nightly failed. Run: ${RUN_URL}"

--- a/Justfile
+++ b/Justfile
@@ -256,17 +256,17 @@ conformance:
 conformance-slow:
     cargo nextest run -p cgka-conformance-simulator --features conformance-slow
 
-# Full Milestone 3 campaign gate: all catalog families, test-policy A/B and
+# Full adversarial reliability gate: all catalog families, test-policy A/B,
 # resource sweeps, sustained headline workloads, and the isolated process runner.
-milestone3-ci:
-    cargo nextest run -p cgka-conformance-simulator --features test-policy-overrides --test milestone3_campaigns --locked
-    cargo test -p cgka-conformance-simulator --features test-policy-overrides --test milestone3_campaigns --locked -- --ignored
+adversarial-reliability-ci:
+    cargo nextest run -p cgka-conformance-simulator --features test-policy-overrides --test adversarial_reliability_campaigns --locked
+    cargo test -p cgka-conformance-simulator --features test-policy-overrides --test adversarial_reliability_campaigns --locked -- --ignored
     cargo nextest run -p cgka-conformance-simulator --features test-policy-overrides --test policy_sweeps --locked
-    cargo run -p cgka-conformance-simulator --features test-policy-overrides --bin cgka-conformance-campaign --locked -- --cases 1 --case-timeout-secs 300 --out target/cgka-milestone3-ci --storage file
+    cargo run -p cgka-conformance-simulator --features test-policy-overrides --bin cgka-conformance-campaign --locked -- --cases 1 --case-timeout-secs 300 --out target/cgka-adversarial-reliability-ci --storage file
 
-# Independent model, lifecycle/fairness, mutation adequacy, and protocol
-# decision gates.
-milestone4-ci:
+# Independent convergence model, lifecycle/fairness, mutation adequacy, and
+# protocol decision gates.
+convergence-verification-ci:
     cargo nextest run -p cgka-conformance-simulator --test independent_reference_model --locked
     cargo nextest run -p cgka-conformance-simulator --test lifecycle_model --locked
     cargo nextest run -p cgka-conformance-simulator --test mutation_adequacy --locked

--- a/Justfile
+++ b/Justfile
@@ -353,7 +353,7 @@ tla-liveness-counterexample: _tla-tools
         exit 1
     fi
     cat "$output"
-    rg -q 'Temporal properties were violated' "$output"
+    grep -q 'Temporal properties were violated' "$output"
 
 policy-casegen:
     @cargo run -p cgka-conformance-simulator --bin cgka-policy-casegen -- --format tamarin formal/tamarin/policy_cases.json

--- a/Justfile
+++ b/Justfile
@@ -2,6 +2,8 @@ set shell := ["bash", "-cu"]
 
 otlp-features := "marmot-app/otlp-export,marmot-uniffi/otlp-export,wn-cli/otlp-export"
 test-features := "wn-cli/test-policy-overrides,cgka-engine/test-crash-hooks"
+simulator-dedicated-filter := "not binary(adversarial_reliability_campaigns) and not binary(policy_sweeps) and not binary(independent_reference_model) and not binary(lifecycle_model) and not binary(mutation_adequacy) and not binary(protocol_decision_gate)"
+simulator-smoke-filter := simulator-dedicated-filter + " and not (binary(canonical_scenarios) & (test(=convergence_chaos_family_generates_specs_with_semantic_expectations) | test(=convergence_chaos_family_seed_changes_scenarios) | test(=convergence_e2e_delivery_family_runs_generated_variants)))"
 
 default:
     @just --list
@@ -255,6 +257,38 @@ conformance:
 
 conformance-slow:
     cargo nextest run -p cgka-conformance-simulator --features conformance-slow
+
+# Fast PR feedback: ordinary simulator coverage without dedicated verification
+# binaries or the generated multi-minute reliability batches.
+simulator-smoke:
+    cargo nextest run -p cgka-conformance-simulator --locked --profile ci -E '{{simulator-smoke-filter}}'
+
+# Complete generic simulator coverage for the nightly lane. Dedicated
+# adversarial and independent-verification binaries run in later recipes.
+simulator-full: simulator-filter-contract
+    cargo nextest run -p cgka-conformance-simulator --features conformance-slow --locked --profile ci -E '{{simulator-dedicated-filter}}'
+
+# Prove that the generic nightly lane restores exactly the generated batches
+# intentionally removed from the PR smoke lane.
+simulator-filter-contract:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    work_dir="$(mktemp -d)"
+    trap 'rm -rf "$work_dir"' EXIT
+    list_tests() {
+        jq -r '."rust-suites" | to_entries[] | .key as $suite | .value.testcases | to_entries[] | select(.value["filter-match"].status == "matches") | "\($suite)::\(.key)"' | sort
+    }
+    cargo nextest list -p cgka-conformance-simulator --features conformance-slow --locked --profile ci \
+        -E '{{simulator-dedicated-filter}}' --message-format json | list_tests >"$work_dir/full"
+    cargo nextest list -p cgka-conformance-simulator --locked --profile ci \
+        -E '{{simulator-smoke-filter}}' --message-format json | list_tests >"$work_dir/smoke"
+    comm -23 "$work_dir/full" "$work_dir/smoke" >"$work_dir/actual"
+    printf '%s\n' \
+        'cgka-conformance-simulator::canonical_scenarios::convergence_chaos_family_generates_specs_with_semantic_expectations' \
+        'cgka-conformance-simulator::canonical_scenarios::convergence_chaos_family_seed_changes_scenarios' \
+        'cgka-conformance-simulator::canonical_scenarios::convergence_e2e_delivery_family_runs_generated_variants' \
+        >"$work_dir/expected"
+    diff -u "$work_dir/expected" "$work_dir/actual"
 
 # Full adversarial reliability gate: all catalog families, test-policy A/B,
 # resource sweeps, sustained headline workloads, and the isolated process runner.

--- a/crates/cgka-conformance-simulator/MUTATION_MATRIX.md
+++ b/crates/cgka-conformance-simulator/MUTATION_MATRIX.md
@@ -8,7 +8,7 @@ observation and keeps this table exactly aligned with the executable catalog.
 | --- | --- | --- | --- |
 | `selector_comparison_order` | Raw depth precedes effective depth | Independent reference differential | Tamarin policy corpus and `generated_policy_cases_match_selector` |
 | `witness_sender_epoch_deduplication` | Repeated messages count as distinct senders | Independent reference differential | Witness scoring properties and same-sender duplicate campaigns |
-| `app_witness_admission_removal` | Valid app witnesses are ignored | Witness enabled/disabled A/B | Milestone 3 witness-policy campaign and `witness_mode_is_a_first_class_input_not_a_policy_rewrite` |
+| `app_witness_admission_removal` | Valid app witnesses are ignored | Witness enabled/disabled A/B | Adversarial reliability witness-policy campaign and `witness_mode_is_a_first_class_input_not_a_policy_rewrite` |
 | `cutoff_boundary_admission` | Exact rewind boundary is excluded | Reference/canonicalizer boundary | Retained-anchor and rollback-horizon canonicalization tests |
 | `frozen_member_persistence` | Crash discards the durable frozen revision together with volatile staged state | Executable Rust lifecycle mutation transition | TLC/Stateright durable/volatile recovery checks and durable convergence-phase kill matrix |
 | `scheduler_deadline_rearm` | New input after settlement does not re-arm | Executable Rust lifecycle mutation transition | Virtual-time re-arm and deferred-input scheduler regressions |

--- a/crates/cgka-conformance-simulator/README.md
+++ b/crates/cgka-conformance-simulator/README.md
@@ -131,29 +131,29 @@ cargo test -p cgka-conformance-simulator
 # Slower validation: raises property-test case counts according to test cost.
 cargo test -p cgka-conformance-simulator --features conformance-slow
 
-# Milestone 3 catalog and small headline regressions.
-cargo test -p cgka-conformance-simulator --test milestone3_campaigns
+# Adversarial reliability catalog and small headline regressions.
+cargo test -p cgka-conformance-simulator --test adversarial_reliability_campaigns
 
 # Deliberately slow offline, mixed-traffic, and self-update campaigns.
-cargo test -p cgka-conformance-simulator --test milestone3_campaigns \
+cargo test -p cgka-conformance-simulator --test adversarial_reliability_campaigns \
   -- --ignored --nocapture
 
 # Full generated adversarial catalog with durable report artifacts.
 cargo run -p cgka-conformance-simulator --bin cgka-conformance-simulator-report -- \
-  --family milestone3-adversarial/v1 --seed 7 --cases 12 \
-  --out target/cgka-milestone3-reports --storage file --strict-oracle
+  --family adversarial-reliability/v1 --seed 7 --cases 12 \
+  --out target/cgka-adversarial-reliability-reports --storage file --strict-oracle
 
 # Run each adversarial case in its own process and add OS resource measurements.
 cargo run -p cgka-conformance-simulator --bin cgka-conformance-campaign -- \
   --seed 7 --cases 12 --case-timeout-secs 300 \
-  --out target/cgka-milestone3-process-campaign --storage file
+  --out target/cgka-adversarial-reliability-process-campaign --storage file
 
 # Test-only one-variable policy curves around fixed retained inputs/horizons.
 cargo test -p cgka-conformance-simulator --features test-policy-overrides \
   --test policy_sweeps
 
-# Milestone 4 independent model, liveness, mutation, and protocol-decision gate.
-just milestone4-ci
+# Independent convergence model, liveness, mutation, and protocol-decision gate.
+just convergence-verification-ci
 ```
 
 Every `ScenarioReport` embeds `campaign_measurements` v1. Its convergence latency is the measured wall time of the

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -441,9 +441,9 @@ regression, covers a new semantic edge, or is the smallest readable example of a
 
 ## Tooling And Report Checks
 
-### Milestone 3 Adversarial Catalog
+### Adversarial Reliability Catalog
 
-`milestone3-adversarial/v1` rotates through twelve deterministic workload shapes: retained-history offline floods;
+`adversarial-reliability/v1` rotates through twelve deterministic workload shapes: retained-history offline floods;
 sustained app/proposal/commit traffic; self-update versus admin progress; a named unrecoverable losing-branch invite;
 unequal relay reconciliation; restart boundaries plus the engine's real SIGKILL durable-phase matrix; multi-group noisy
 neighbors; replay-budget exhaustion; shared-account multi-device witnesses; full-engine app-witness A/B selection;

--- a/crates/cgka-conformance-simulator/src/bin/cgka-conformance-campaign.rs
+++ b/crates/cgka-conformance-simulator/src/bin/cgka-conformance-campaign.rs
@@ -1,5 +1,5 @@
 use cgka_conformance_simulator::{
-    HarnessStorageMode, ScenarioReport, generate_milestone3_adversarial_case,
+    HarnessStorageMode, ScenarioReport, generate_adversarial_reliability_case,
     run_generated_case_report_with_storage_mode,
 };
 use serde::{Deserialize, Serialize};
@@ -117,7 +117,7 @@ async fn run() -> Result<ExitCode, Box<dyn Error>> {
 
 async fn run_worker(args: &Args) -> Result<ExitCode, Box<dyn Error>> {
     let case_index = args.case_index.ok_or("worker requires --case-index")?;
-    let case = generate_milestone3_adversarial_case(args.seed, case_index as u64);
+    let case = generate_adversarial_reliability_case(args.seed, case_index as u64);
     let report = run_generated_case_report_with_storage_mode(&case, None, args.storage).await?;
     if let Some(parent) = args.out.parent() {
         fs_private::create_dir_all_private(parent)?;
@@ -143,7 +143,7 @@ fn parse_args(args: impl Iterator<Item = String>) -> Result<Args, Box<dyn Error>
     let mut seed = 7;
     let mut cases = 12;
     let mut case_index = None;
-    let mut out = PathBuf::from("target/cgka-milestone3-process-campaign");
+    let mut out = PathBuf::from("target/cgka-adversarial-reliability-process-campaign");
     let mut storage = HarnessStorageMode::TempFileBackedSqlite;
     let mut case_timeout = Duration::from_secs(300);
     let mut worker = false;

--- a/crates/cgka-conformance-simulator/src/family.rs
+++ b/crates/cgka-conformance-simulator/src/family.rs
@@ -195,6 +195,8 @@ pub fn generate_adversarial_reliability_self_update_regression(seed: u64) -> Gen
     })
 }
 
+/// Build a reduced catalog case while preserving its deterministic identity
+/// and strict reliability oracle.
 fn adversarial_reliability_regression_case(
     seed: u64,
     case_index: u64,
@@ -1141,6 +1143,7 @@ fn convergence_chaos_restart_delivery_faults(
     (scenario, expected)
 }
 
+/// Select one of the twelve adversarial workload shapes by stable case index.
 fn adversarial_reliability_case(
     rng: &mut StdRng,
     case_index: u64,
@@ -1176,6 +1179,7 @@ fn adversarial_reliability_case(
     }
 }
 
+/// Build the full retained-history flood, scaling its rounds by catalog cycle.
 fn adversarial_reliability_offline_retained_flood(
     case_index: u64,
 ) -> (
@@ -1188,6 +1192,7 @@ fn adversarial_reliability_offline_retained_flood(
     adversarial_reliability_offline_retained_flood_with_rounds(case_index, rounds)
 }
 
+/// Build a retained-relay catch-up workload with an explicit flood duration.
 fn adversarial_reliability_offline_retained_flood_with_rounds(
     case_index: u64,
     rounds: usize,
@@ -1277,6 +1282,7 @@ fn adversarial_reliability_offline_retained_flood_with_rounds(
     )
 }
 
+/// Build sustained mixed application, proposal, and commit traffic.
 fn adversarial_reliability_sustained_mixed_traffic(
     rng: &mut StdRng,
     case_index: u64,
@@ -1290,6 +1296,7 @@ fn adversarial_reliability_sustained_mixed_traffic(
     adversarial_reliability_sustained_mixed_traffic_with_rounds(rng, case_index, rounds)
 }
 
+/// Build mixed traffic with an explicit number of deterministic rounds.
 fn adversarial_reliability_sustained_mixed_traffic_with_rounds(
     rng: &mut StdRng,
     case_index: u64,
@@ -1355,6 +1362,7 @@ fn adversarial_reliability_sustained_mixed_traffic_with_rounds(
     )
 }
 
+/// Build the full self-update stream followed by an administrative race.
 fn adversarial_reliability_self_update_adversary(
     case_index: u64,
 ) -> (
@@ -1366,6 +1374,7 @@ fn adversarial_reliability_self_update_adversary(
     adversarial_reliability_self_update_adversary_with_rounds(case_index, 12)
 }
 
+/// Build a self-update/admin race with an explicit update count.
 fn adversarial_reliability_self_update_adversary_with_rounds(
     case_index: u64,
     rounds: usize,
@@ -1421,6 +1430,7 @@ fn adversarial_reliability_self_update_adversary_with_rounds(
     )
 }
 
+/// Build an invite from a losing branch and require its named terminal outcome.
 fn adversarial_reliability_losing_invite_outcome(
     case_index: u64,
 ) -> (
@@ -1497,6 +1507,7 @@ fn adversarial_reliability_losing_invite_outcome(
     )
 }
 
+/// Build split relay histories that must reconcile after set equalization.
 fn adversarial_reliability_unequal_relay_reconciliation(
     case_index: u64,
 ) -> (
@@ -1564,6 +1575,7 @@ fn adversarial_reliability_unequal_relay_reconciliation(
     )
 }
 
+/// Build restart transitions around durable convergence-phase boundaries.
 fn adversarial_reliability_restart_boundaries(
     case_index: u64,
 ) -> (
@@ -1615,6 +1627,7 @@ fn adversarial_reliability_restart_boundaries(
     )
 }
 
+/// Build concurrent groups to verify noisy-neighbor workload isolation.
 fn adversarial_reliability_multi_group_noisy_neighbor(
     case_index: u64,
 ) -> (
@@ -1700,6 +1713,7 @@ fn adversarial_reliability_multi_group_noisy_neighbor(
     )
 }
 
+/// Build a shared-account, multi-device witness topology and workload.
 fn adversarial_reliability_multi_device_account(
     case_index: u64,
 ) -> (
@@ -1753,6 +1767,7 @@ fn adversarial_reliability_multi_device_account(
     )
 }
 
+/// Build competing branches whose selection depends on application witnesses.
 fn adversarial_reliability_app_witness_value(
     case_index: u64,
 ) -> (
@@ -1827,6 +1842,7 @@ fn adversarial_reliability_app_witness_value(
     )
 }
 
+/// Build a mixed-binary compatibility case with policy preflight constraints.
 fn adversarial_reliability_mixed_binary_compatibility(
     case_index: u64,
 ) -> (
@@ -1866,6 +1882,7 @@ fn adversarial_reliability_mixed_binary_compatibility(
     )
 }
 
+/// Build clock, scheduler, timestamp, and relay-cursor adversarial inputs.
 fn adversarial_reliability_clock_cursor_attack(
     case_index: u64,
 ) -> (
@@ -1930,6 +1947,7 @@ fn adversarial_reliability_clock_cursor_attack(
     )
 }
 
+/// Construct account, device, process, and client mappings for a workload.
 fn adversarial_reliability_account_topology(
     clients: &[(&str, &str, &str)],
 ) -> crate::ScenarioTopologyV2 {
@@ -1971,6 +1989,7 @@ fn adversarial_reliability_account_topology(
     }
 }
 
+/// Construct a topology in which every client reads from one retained relay.
 fn adversarial_reliability_single_relay_topology(clients: &[String]) -> crate::ScenarioTopologyV2 {
     let mut topology = adversarial_reliability_account_topology(
         &clients
@@ -1989,6 +2008,7 @@ fn adversarial_reliability_single_relay_topology(clients: &[String]) -> crate::S
     topology
 }
 
+/// Construct unequal relay subscriptions for later history reconciliation.
 fn adversarial_reliability_split_relay_topology(clients: &[String]) -> crate::ScenarioTopologyV2 {
     let mut topology = adversarial_reliability_single_relay_topology(clients);
     topology.relays = vec![

--- a/crates/cgka-conformance-simulator/src/family.rs
+++ b/crates/cgka-conformance-simulator/src/family.rs
@@ -150,7 +150,7 @@ pub fn generate_adversarial_reliability_case(seed: u64, case_index: u64) -> Gene
     add_strict_reliability_oracle(&mut scenario, &mut expected_outcomes);
     GeneratedScenarioCase {
         family_name,
-        generator_version: "1".into(),
+        generator_version: "2".into(),
         seed,
         case_index,
         subject,
@@ -170,7 +170,7 @@ pub fn generate_adversarial_reliability_sustained_regression(seed: u64) -> Gener
     add_strict_reliability_oracle(&mut scenario, &mut expected_outcomes);
     GeneratedScenarioCase {
         family_name,
-        generator_version: "1-regression".into(),
+        generator_version: "2-regression".into(),
         seed,
         case_index,
         subject,
@@ -214,7 +214,7 @@ fn adversarial_reliability_regression_case(
     add_strict_reliability_oracle(&mut scenario, &mut expected_outcomes);
     GeneratedScenarioCase {
         family_name,
-        generator_version: "1-regression".into(),
+        generator_version: "2-regression".into(),
         seed,
         case_index,
         subject,

--- a/crates/cgka-conformance-simulator/src/family.rs
+++ b/crates/cgka-conformance-simulator/src/family.rs
@@ -129,24 +129,24 @@ pub fn generate_convergence_chaos_family(seed: u64, cases: usize) -> Vec<Generat
     out
 }
 
-/// Generate the Milestone 3 adversarial catalog. Case indices rotate through
+/// Generate the adversarial reliability catalog. Case indices rotate through
 /// every required workload family; requesting more than twelve cases repeats
 /// the catalog with a new deterministic case id and schedule seed.
-pub fn generate_milestone3_adversarial_family(
+pub fn generate_adversarial_reliability_family(
     seed: u64,
     cases: usize,
 ) -> Vec<GeneratedScenarioCase> {
     (0..cases)
-        .map(|case_index| generate_milestone3_adversarial_case(seed, case_index as u64))
+        .map(|case_index| generate_adversarial_reliability_case(seed, case_index as u64))
         .collect()
 }
 
 /// Generate one catalog case without regenerating and discarding every prior
 /// index. This is the process-runner entry point for deterministic isolation.
-pub fn generate_milestone3_adversarial_case(seed: u64, case_index: u64) -> GeneratedScenarioCase {
+pub fn generate_adversarial_reliability_case(seed: u64, case_index: u64) -> GeneratedScenarioCase {
     let mut rng = StdRng::seed_from_u64(seed ^ 0x4d33_4144_5645_5253 ^ case_index.rotate_left(17));
     let (family_name, subject, mut scenario, mut expected_outcomes) =
-        milestone3_case(&mut rng, case_index);
+        adversarial_reliability_case(&mut rng, case_index);
     add_strict_reliability_oracle(&mut scenario, &mut expected_outcomes);
     GeneratedScenarioCase {
         family_name,
@@ -161,12 +161,12 @@ pub fn generate_milestone3_adversarial_case(seed: u64, case_index: u64) -> Gener
 
 /// One-round form of the sustained mixed-traffic workload for normal
 /// regression suites. The adversarial family retains the multi-round campaign.
-pub fn generate_milestone3_sustained_regression(seed: u64) -> GeneratedScenarioCase {
+pub fn generate_adversarial_reliability_sustained_regression(seed: u64) -> GeneratedScenarioCase {
     let case_index = 1_u64;
     let mut rng = StdRng::seed_from_u64(seed ^ 0x4d33_4144_5645_5253 ^ case_index.rotate_left(17));
     let (family_name, subject, mut scenario, mut expected_outcomes) =
-        milestone3_sustained_mixed_traffic_with_rounds(&mut rng, case_index, 1);
-    scenario.name = "milestone3/sustained-mixed-traffic/regression".into();
+        adversarial_reliability_sustained_mixed_traffic_with_rounds(&mut rng, case_index, 1);
+    scenario.name = "adversarial-reliability/sustained-mixed-traffic/regression".into();
     add_strict_reliability_oracle(&mut scenario, &mut expected_outcomes);
     GeneratedScenarioCase {
         family_name,
@@ -181,21 +181,21 @@ pub fn generate_milestone3_sustained_regression(seed: u64) -> GeneratedScenarioC
 
 /// One-round offline catch-up form for normal regression suites. The catalog
 /// case retains the multi-round retained-history flood.
-pub fn generate_milestone3_offline_regression(seed: u64) -> GeneratedScenarioCase {
-    milestone3_regression_case(seed, 0, |_, case_index| {
-        milestone3_offline_retained_flood_with_rounds(case_index, 1)
+pub fn generate_adversarial_reliability_offline_regression(seed: u64) -> GeneratedScenarioCase {
+    adversarial_reliability_regression_case(seed, 0, |_, case_index| {
+        adversarial_reliability_offline_retained_flood_with_rounds(case_index, 1)
     })
 }
 
 /// Two-update adversary for normal regression suites. The catalog case retains
 /// the sustained self-update stream before the privileged removal race.
-pub fn generate_milestone3_self_update_regression(seed: u64) -> GeneratedScenarioCase {
-    milestone3_regression_case(seed, 2, |_, case_index| {
-        milestone3_self_update_adversary_with_rounds(case_index, 2)
+pub fn generate_adversarial_reliability_self_update_regression(seed: u64) -> GeneratedScenarioCase {
+    adversarial_reliability_regression_case(seed, 2, |_, case_index| {
+        adversarial_reliability_self_update_adversary_with_rounds(case_index, 2)
     })
 }
 
-fn milestone3_regression_case(
+fn adversarial_reliability_regression_case(
     seed: u64,
     case_index: u64,
     build: impl FnOnce(
@@ -1141,7 +1141,7 @@ fn convergence_chaos_restart_delivery_faults(
     (scenario, expected)
 }
 
-fn milestone3_case(
+fn adversarial_reliability_case(
     rng: &mut StdRng,
     case_index: u64,
 ) -> (
@@ -1151,31 +1151,32 @@ fn milestone3_case(
     Vec<TraceExpectation>,
 ) {
     match case_index % 12 {
-        0 => milestone3_offline_retained_flood(case_index),
-        1 => milestone3_sustained_mixed_traffic(rng, case_index),
-        2 => milestone3_self_update_adversary(case_index),
-        3 => milestone3_losing_invite_outcome(case_index),
-        4 => milestone3_unequal_relay_reconciliation(case_index),
-        5 => milestone3_restart_boundaries(case_index),
-        6 => milestone3_multi_group_noisy_neighbor(case_index),
+        0 => adversarial_reliability_offline_retained_flood(case_index),
+        1 => adversarial_reliability_sustained_mixed_traffic(rng, case_index),
+        2 => adversarial_reliability_self_update_adversary(case_index),
+        3 => adversarial_reliability_losing_invite_outcome(case_index),
+        4 => adversarial_reliability_unequal_relay_reconciliation(case_index),
+        5 => adversarial_reliability_restart_boundaries(case_index),
+        6 => adversarial_reliability_multi_group_noisy_neighbor(case_index),
         7 => {
             let (mut scenario, expected) = convergence_chaos_large_commit_storm(rng, case_index);
-            scenario.name = format!("milestone3/candidate-replay-pressure/case-{case_index}");
+            scenario.name =
+                format!("adversarial-reliability/candidate-replay-pressure/case-{case_index}");
             (
-                "milestone3/candidate-replay-pressure/v1".into(),
+                "adversarial-reliability/candidate-replay-pressure/v1".into(),
                 GeneratedSubjectKind::Engine,
                 scenario,
                 expected,
             )
         }
-        8 => milestone3_multi_device_account(case_index),
-        9 => milestone3_app_witness_value(case_index),
-        10 => milestone3_mixed_binary_compatibility(case_index),
-        _ => milestone3_clock_cursor_attack(case_index),
+        8 => adversarial_reliability_multi_device_account(case_index),
+        9 => adversarial_reliability_app_witness_value(case_index),
+        10 => adversarial_reliability_mixed_binary_compatibility(case_index),
+        _ => adversarial_reliability_clock_cursor_attack(case_index),
     }
 }
 
-fn milestone3_offline_retained_flood(
+fn adversarial_reliability_offline_retained_flood(
     case_index: u64,
 ) -> (
     String,
@@ -1184,10 +1185,10 @@ fn milestone3_offline_retained_flood(
     Vec<TraceExpectation>,
 ) {
     let rounds = 3 + usize::try_from((case_index / 12) % 3).unwrap_or(0);
-    milestone3_offline_retained_flood_with_rounds(case_index, rounds)
+    adversarial_reliability_offline_retained_flood_with_rounds(case_index, rounds)
 }
 
-fn milestone3_offline_retained_flood_with_rounds(
+fn adversarial_reliability_offline_retained_flood_with_rounds(
     case_index: u64,
     rounds: usize,
 ) -> (
@@ -1259,20 +1260,24 @@ fn milestone3_offline_retained_flood_with_rounds(
     ]);
     let expected = vec![clients_converged(["alice", "bob", "carol"], None, Some(3))];
     (
-        "milestone3/offline-retained-history-flood/v1".into(),
+        "adversarial-reliability/offline-retained-history-flood/v1".into(),
         GeneratedSubjectKind::RetainedRelay,
         ScenarioSpec {
-            name: format!("milestone3/offline-retained-history-flood/case-{case_index}"),
+            name: format!(
+                "adversarial-reliability/offline-retained-history-flood/case-{case_index}"
+            ),
             spec_version: "2".into(),
             clients,
-            topology: milestone3_single_relay_topology(&labels(["alice", "bob", "carol", "david"])),
+            topology: adversarial_reliability_single_relay_topology(&labels([
+                "alice", "bob", "carol", "david",
+            ])),
             steps,
         },
         expected,
     )
 }
 
-fn milestone3_sustained_mixed_traffic(
+fn adversarial_reliability_sustained_mixed_traffic(
     rng: &mut StdRng,
     case_index: u64,
 ) -> (
@@ -1282,10 +1287,10 @@ fn milestone3_sustained_mixed_traffic(
     Vec<TraceExpectation>,
 ) {
     let rounds = 4 + usize::try_from((case_index / 12) % 4).unwrap_or(0);
-    milestone3_sustained_mixed_traffic_with_rounds(rng, case_index, rounds)
+    adversarial_reliability_sustained_mixed_traffic_with_rounds(rng, case_index, rounds)
 }
 
-fn milestone3_sustained_mixed_traffic_with_rounds(
+fn adversarial_reliability_sustained_mixed_traffic_with_rounds(
     rng: &mut StdRng,
     case_index: u64,
     rounds: usize,
@@ -1337,10 +1342,10 @@ fn milestone3_sustained_mixed_traffic_with_rounds(
         tick(["bob", "carol", "david"]),
     ]);
     (
-        "milestone3/sustained-mixed-traffic/v1".into(),
+        "adversarial-reliability/sustained-mixed-traffic/v1".into(),
         GeneratedSubjectKind::Engine,
         ScenarioSpec {
-            name: format!("milestone3/sustained-mixed-traffic/case-{case_index}"),
+            name: format!("adversarial-reliability/sustained-mixed-traffic/case-{case_index}"),
             spec_version: "2".into(),
             clients,
             topology: Default::default(),
@@ -1350,7 +1355,7 @@ fn milestone3_sustained_mixed_traffic_with_rounds(
     )
 }
 
-fn milestone3_self_update_adversary(
+fn adversarial_reliability_self_update_adversary(
     case_index: u64,
 ) -> (
     String,
@@ -1358,10 +1363,10 @@ fn milestone3_self_update_adversary(
     ScenarioSpec,
     Vec<TraceExpectation>,
 ) {
-    milestone3_self_update_adversary_with_rounds(case_index, 12)
+    adversarial_reliability_self_update_adversary_with_rounds(case_index, 12)
 }
 
-fn milestone3_self_update_adversary_with_rounds(
+fn adversarial_reliability_self_update_adversary_with_rounds(
     case_index: u64,
     rounds: usize,
 ) -> (
@@ -1403,10 +1408,10 @@ fn milestone3_self_update_adversary_with_rounds(
         tick(["alice", "bob", "carol"]),
     ]);
     (
-        "milestone3/self-update-admin-race/v1".into(),
+        "adversarial-reliability/self-update-admin-race/v1".into(),
         GeneratedSubjectKind::Engine,
         ScenarioSpec {
-            name: format!("milestone3/self-update-admin-race/case-{case_index}"),
+            name: format!("adversarial-reliability/self-update-admin-race/case-{case_index}"),
             spec_version: "2".into(),
             clients,
             topology: Default::default(),
@@ -1416,7 +1421,7 @@ fn milestone3_self_update_adversary_with_rounds(
     )
 }
 
-fn milestone3_losing_invite_outcome(
+fn adversarial_reliability_losing_invite_outcome(
     case_index: u64,
 ) -> (
     String,
@@ -1473,10 +1478,10 @@ fn milestone3_losing_invite_outcome(
         },
     ];
     (
-        "milestone3/losing-invite-unrecoverable/v1".into(),
+        "adversarial-reliability/losing-invite-unrecoverable/v1".into(),
         GeneratedSubjectKind::Engine,
         ScenarioSpec {
-            name: format!("milestone3/losing-invite-unrecoverable/case-{case_index}"),
+            name: format!("adversarial-reliability/losing-invite-unrecoverable/case-{case_index}"),
             spec_version: "2".into(),
             clients: clients.clone(),
             topology: Default::default(),
@@ -1492,7 +1497,7 @@ fn milestone3_losing_invite_outcome(
     )
 }
 
-fn milestone3_unequal_relay_reconciliation(
+fn adversarial_reliability_unequal_relay_reconciliation(
     case_index: u64,
 ) -> (
     String,
@@ -1546,20 +1551,20 @@ fn milestone3_unequal_relay_reconciliation(
         tick(["bob"]),
     ];
     (
-        "milestone3/unequal-relay-reconciliation/v1".into(),
+        "adversarial-reliability/unequal-relay-reconciliation/v1".into(),
         GeneratedSubjectKind::RetainedRelay,
         ScenarioSpec {
-            name: format!("milestone3/unequal-relay-reconciliation/case-{case_index}"),
+            name: format!("adversarial-reliability/unequal-relay-reconciliation/case-{case_index}"),
             spec_version: "2".into(),
             clients: clients.clone(),
-            topology: milestone3_split_relay_topology(&clients),
+            topology: adversarial_reliability_split_relay_topology(&clients),
             steps,
         },
         vec![clients_converged(["alice", "bob"], None, Some(2))],
     )
 }
 
-fn milestone3_restart_boundaries(
+fn adversarial_reliability_restart_boundaries(
     case_index: u64,
 ) -> (
     String,
@@ -1597,10 +1602,10 @@ fn milestone3_restart_boundaries(
         },
     ];
     (
-        "milestone3/restart-boundaries/v1".into(),
+        "adversarial-reliability/restart-boundaries/v1".into(),
         GeneratedSubjectKind::Engine,
         ScenarioSpec {
-            name: format!("milestone3/restart-boundaries/case-{case_index}"),
+            name: format!("adversarial-reliability/restart-boundaries/case-{case_index}"),
             spec_version: "2".into(),
             clients,
             topology: Default::default(),
@@ -1610,7 +1615,7 @@ fn milestone3_restart_boundaries(
     )
 }
 
-fn milestone3_multi_group_noisy_neighbor(
+fn adversarial_reliability_multi_group_noisy_neighbor(
     case_index: u64,
 ) -> (
     String,
@@ -1682,10 +1687,10 @@ fn milestone3_multi_group_noisy_neighbor(
         ),
     ]);
     (
-        "milestone3/multi-group-noisy-neighbor/v1".into(),
+        "adversarial-reliability/multi-group-noisy-neighbor/v1".into(),
         GeneratedSubjectKind::Engine,
         ScenarioSpec {
-            name: format!("milestone3/multi-group-noisy-neighbor/case-{case_index}"),
+            name: format!("adversarial-reliability/multi-group-noisy-neighbor/case-{case_index}"),
             spec_version: "2".into(),
             clients,
             topology: Default::default(),
@@ -1695,7 +1700,7 @@ fn milestone3_multi_group_noisy_neighbor(
     )
 }
 
-fn milestone3_multi_device_account(
+fn adversarial_reliability_multi_device_account(
     case_index: u64,
 ) -> (
     String,
@@ -1704,7 +1709,7 @@ fn milestone3_multi_device_account(
     Vec<TraceExpectation>,
 ) {
     let clients = labels(["alice-phone", "alice-laptop", "bob"]);
-    let topology = milestone3_account_topology(&[
+    let topology = adversarial_reliability_account_topology(&[
         ("alice-phone", "account:alice", "build-a"),
         ("alice-laptop", "account:alice", "build-a"),
         ("bob", "account:bob", "build-a"),
@@ -1735,10 +1740,10 @@ fn milestone3_multi_device_account(
         tick(["alice-phone", "alice-laptop", "bob"]),
     ];
     (
-        "milestone3/multi-device-account/v1".into(),
+        "adversarial-reliability/multi-device-account/v1".into(),
         GeneratedSubjectKind::Engine,
         ScenarioSpec {
-            name: format!("milestone3/multi-device-account/case-{case_index}"),
+            name: format!("adversarial-reliability/multi-device-account/case-{case_index}"),
             spec_version: "2".into(),
             clients: clients.clone(),
             topology,
@@ -1748,7 +1753,7 @@ fn milestone3_multi_device_account(
     )
 }
 
-fn milestone3_app_witness_value(
+fn adversarial_reliability_app_witness_value(
     case_index: u64,
 ) -> (
     String,
@@ -1757,7 +1762,7 @@ fn milestone3_app_witness_value(
     Vec<TraceExpectation>,
 ) {
     let scenario = ScenarioSpec {
-        name: format!("milestone3/app-witness-value/case-{case_index}"),
+        name: format!("adversarial-reliability/app-witness-value/case-{case_index}"),
         spec_version: "2".into(),
         topology: Default::default(),
         clients: labels(["alice", "bob", "carol", "david", "eve", "frank"]),
@@ -1815,14 +1820,14 @@ fn milestone3_app_witness_value(
         ],
     };
     (
-        "milestone3/app-witness-value/v1".into(),
+        "adversarial-reliability/app-witness-value/v1".into(),
         GeneratedSubjectKind::Engine,
         scenario,
         vec![clients_converged(["alice", "bob", "carol"], None, None)],
     )
 }
 
-fn milestone3_mixed_binary_compatibility(
+fn adversarial_reliability_mixed_binary_compatibility(
     case_index: u64,
 ) -> (
     String,
@@ -1831,15 +1836,17 @@ fn milestone3_mixed_binary_compatibility(
     Vec<TraceExpectation>,
 ) {
     let clients = labels(["alice", "bob"]);
-    let topology = milestone3_account_topology(&[
+    let topology = adversarial_reliability_account_topology(&[
         ("alice", "account:alice", "mdk-previous"),
         ("bob", "account:bob", "mdk-current"),
     ]);
     (
-        "milestone3/mixed-binary-compatibility-preflight/v1".into(),
+        "adversarial-reliability/mixed-binary-compatibility-preflight/v1".into(),
         GeneratedSubjectKind::Engine,
         ScenarioSpec {
-            name: format!("milestone3/mixed-binary-compatibility-preflight/case-{case_index}"),
+            name: format!(
+                "adversarial-reliability/mixed-binary-compatibility-preflight/case-{case_index}"
+            ),
             spec_version: "2".into(),
             clients,
             topology,
@@ -1859,7 +1866,7 @@ fn milestone3_mixed_binary_compatibility(
     )
 }
 
-fn milestone3_clock_cursor_attack(
+fn adversarial_reliability_clock_cursor_attack(
     case_index: u64,
 ) -> (
     String,
@@ -1910,20 +1917,22 @@ fn milestone3_clock_cursor_attack(
         tick(["bob"]),
     ];
     (
-        "milestone3/clock-scheduler-cursor/v1".into(),
+        "adversarial-reliability/clock-scheduler-cursor/v1".into(),
         GeneratedSubjectKind::RetainedRelay,
         ScenarioSpec {
-            name: format!("milestone3/clock-scheduler-cursor/case-{case_index}"),
+            name: format!("adversarial-reliability/clock-scheduler-cursor/case-{case_index}"),
             spec_version: "2".into(),
             clients: clients.clone(),
-            topology: milestone3_single_relay_topology(&clients),
+            topology: adversarial_reliability_single_relay_topology(&clients),
             steps,
         },
         vec![clients_converged(["alice", "bob"], Some(1), Some(2))],
     )
 }
 
-fn milestone3_account_topology(clients: &[(&str, &str, &str)]) -> crate::ScenarioTopologyV2 {
+fn adversarial_reliability_account_topology(
+    clients: &[(&str, &str, &str)],
+) -> crate::ScenarioTopologyV2 {
     let mut accounts = BTreeSet::new();
     crate::ScenarioTopologyV2 {
         accounts: clients
@@ -1962,8 +1971,8 @@ fn milestone3_account_topology(clients: &[(&str, &str, &str)]) -> crate::Scenari
     }
 }
 
-fn milestone3_single_relay_topology(clients: &[String]) -> crate::ScenarioTopologyV2 {
-    let mut topology = milestone3_account_topology(
+fn adversarial_reliability_single_relay_topology(clients: &[String]) -> crate::ScenarioTopologyV2 {
+    let mut topology = adversarial_reliability_account_topology(
         &clients
             .iter()
             .map(|client| (client.as_str(), client.as_str(), "mdk-current"))
@@ -1980,8 +1989,8 @@ fn milestone3_single_relay_topology(clients: &[String]) -> crate::ScenarioTopolo
     topology
 }
 
-fn milestone3_split_relay_topology(clients: &[String]) -> crate::ScenarioTopologyV2 {
-    let mut topology = milestone3_single_relay_topology(clients);
+fn adversarial_reliability_split_relay_topology(clients: &[String]) -> crate::ScenarioTopologyV2 {
+    let mut topology = adversarial_reliability_single_relay_topology(clients);
     topology.relays = vec![
         crate::ScenarioRelayV2 {
             id: "relay:a".into(),

--- a/crates/cgka-conformance-simulator/src/lib.rs
+++ b/crates/cgka-conformance-simulator/src/lib.rs
@@ -80,11 +80,12 @@ pub use failure_capsule::{
     write_failure_capsule,
 };
 pub use family::{
-    GeneratedScenarioCase, GeneratedSubjectKind, generate_convergence_chaos_family,
-    generate_convergence_e2e_delivery_family, generate_milestone3_adversarial_case,
-    generate_milestone3_adversarial_family, generate_milestone3_offline_regression,
-    generate_milestone3_self_update_regression, generate_milestone3_sustained_regression,
-    generate_send_leave_family, run_generated_case_report, run_generated_case_report_with_capture,
+    GeneratedScenarioCase, GeneratedSubjectKind, generate_adversarial_reliability_case,
+    generate_adversarial_reliability_family, generate_adversarial_reliability_offline_regression,
+    generate_adversarial_reliability_self_update_regression,
+    generate_adversarial_reliability_sustained_regression, generate_convergence_chaos_family,
+    generate_convergence_e2e_delivery_family, generate_send_leave_family,
+    run_generated_case_report, run_generated_case_report_with_capture,
     run_generated_case_report_with_storage_mode,
 };
 pub use oracle::{

--- a/crates/cgka-conformance-simulator/src/policy_contract.rs
+++ b/crates/cgka-conformance-simulator/src/policy_contract.rs
@@ -1,4 +1,4 @@
-//! Machine-readable Milestone 4 convergence-policy classification.
+//! Machine-readable convergence-policy classification.
 //!
 //! This is conformance metadata, not a wire format. Marmot convergence v1 is
 //! the implicit mandatory baseline. A future behavior-changing policy requires

--- a/crates/cgka-conformance-simulator/src/report.rs
+++ b/crates/cgka-conformance-simulator/src/report.rs
@@ -4,8 +4,8 @@ use std::path::{Path, PathBuf};
 use crate::{
     CoverageMatrixEntry, FailureCapsuleSensitivity, FailureCapsuleV1, GeneratedScenarioCase,
     HarnessStorageMode, ScenarioReport, VectorFixture, coverage_matrix_entry,
-    generate_convergence_chaos_family, generate_convergence_e2e_delivery_family,
-    generate_milestone3_adversarial_family, generate_send_leave_family,
+    generate_adversarial_reliability_family, generate_convergence_chaos_family,
+    generate_convergence_e2e_delivery_family, generate_send_leave_family,
     run_generated_case_report_with_capture, run_vector_fixture_report_with_capture,
     write_failure_capsule,
 };
@@ -238,7 +238,7 @@ async fn run_generated_family_reports(
         "send-leave/v1" => generate_send_leave_family(seed, cases),
         "convergence-e2e-delivery/v1" => generate_convergence_e2e_delivery_family(seed, cases),
         "convergence-chaos/v1" => generate_convergence_chaos_family(seed, cases),
-        "milestone3-adversarial/v1" => generate_milestone3_adversarial_family(seed, cases),
+        "adversarial-reliability/v1" => generate_adversarial_reliability_family(seed, cases),
         other => return Err(format!("unsupported family {other}").into()),
     };
 
@@ -590,7 +590,7 @@ fn next_value(
 }
 
 pub fn report_usage() -> &'static str {
-    "Usage: cgka-conformance-simulator-report [--replay-capsule FILE | --vectors FILE_OR_DIR ... | --family send-leave/v1|convergence-e2e-delivery/v1|convergence-chaos/v1|milestone3-adversarial/v1 --seed N --cases N] [--out DIR] [--storage memory|file] [--strict-oracle|--allow-weak-oracle] [--capture-sensitive-replay]"
+    "Usage: cgka-conformance-simulator-report [--replay-capsule FILE | --vectors FILE_OR_DIR ... | --family send-leave/v1|convergence-e2e-delivery/v1|convergence-chaos/v1|adversarial-reliability/v1 --seed N --cases N] [--out DIR] [--storage memory|file] [--strict-oracle|--allow-weak-oracle] [--capture-sensitive-replay]"
 }
 
 #[cfg(test)]

--- a/crates/cgka-conformance-simulator/tests/adversarial_reliability_campaigns.rs
+++ b/crates/cgka-conformance-simulator/tests/adversarial_reliability_campaigns.rs
@@ -27,6 +27,22 @@ fn adversarial_reliability_catalog_covers_every_required_workload_shape() {
     }
 }
 
+#[test]
+fn generator_versions_track_the_renamed_output_contract() {
+    assert!(
+        generate_adversarial_reliability_family(7, 12)
+            .iter()
+            .all(|case| case.generator_version == "2")
+    );
+    for case in [
+        generate_adversarial_reliability_offline_regression(7),
+        generate_adversarial_reliability_sustained_regression(7),
+        generate_adversarial_reliability_self_update_regression(7),
+    ] {
+        assert_eq!(case.generator_version, "2-regression");
+    }
+}
+
 async fn assert_generated_case(case_index: usize) -> cgka_conformance_simulator::ScenarioReport {
     assert_case(&generate_adversarial_reliability_case(7, case_index as u64)).await
 }

--- a/crates/cgka-conformance-simulator/tests/adversarial_reliability_campaigns.rs
+++ b/crates/cgka-conformance-simulator/tests/adversarial_reliability_campaigns.rs
@@ -4,17 +4,18 @@ use cgka_conformance_simulator::{
     engine_harness_feature_registry, run_scenario_report_with_subject,
 };
 use cgka_conformance_simulator::{
-    SubjectFailureCategory, compile_scenario, generate_milestone3_adversarial_case,
-    generate_milestone3_adversarial_family, generate_milestone3_offline_regression,
-    generate_milestone3_self_update_regression, generate_milestone3_sustained_regression,
-    run_generated_case_report, run_generated_case_report_with_capture,
+    SubjectFailureCategory, compile_scenario, generate_adversarial_reliability_case,
+    generate_adversarial_reliability_family, generate_adversarial_reliability_offline_regression,
+    generate_adversarial_reliability_self_update_regression,
+    generate_adversarial_reliability_sustained_regression, run_generated_case_report,
+    run_generated_case_report_with_capture,
 };
 #[cfg(feature = "test-policy-overrides")]
 use cgka_traits::group::ProtocolProfile;
 
 #[test]
-fn milestone3_catalog_covers_every_required_workload_shape() {
-    let cases = generate_milestone3_adversarial_family(7, 12);
+fn adversarial_reliability_catalog_covers_every_required_workload_shape() {
+    let cases = generate_adversarial_reliability_family(7, 12);
     let names = cases
         .iter()
         .map(|case| case.family_name.as_str())
@@ -27,7 +28,7 @@ fn milestone3_catalog_covers_every_required_workload_shape() {
 }
 
 async fn assert_generated_case(case_index: usize) -> cgka_conformance_simulator::ScenarioReport {
-    assert_case(&generate_milestone3_adversarial_case(7, case_index as u64)).await
+    assert_case(&generate_adversarial_reliability_case(7, case_index as u64)).await
 }
 
 async fn assert_case(
@@ -61,7 +62,7 @@ async fn assert_case(
 
 #[tokio::test]
 async fn offline_retained_history_flood_runs_as_a_small_regression() {
-    let report = assert_case(&generate_milestone3_offline_regression(7)).await;
+    let report = assert_case(&generate_adversarial_reliability_offline_regression(7)).await;
     let measurements = &report.campaign_measurements;
     assert_eq!(measurements.schema_version, "1");
     assert!(measurements.total_wall_us > 0);
@@ -86,7 +87,7 @@ async fn offline_retained_history_flood_runs_as_a_small_regression() {
 
 #[tokio::test]
 async fn retained_relay_rejects_unavailable_sensitive_checkpoint_capture() {
-    let case = generate_milestone3_offline_regression(7);
+    let case = generate_adversarial_reliability_offline_regression(7);
     let error = run_generated_case_report_with_capture(
         &case,
         None,
@@ -106,7 +107,7 @@ async fn offline_retained_history_flood_campaign() {
 
 #[tokio::test]
 async fn sustained_mixed_traffic_runs_as_a_small_regression() {
-    let case = generate_milestone3_sustained_regression(7);
+    let case = generate_adversarial_reliability_sustained_regression(7);
     let report = run_generated_case_report(&case, None)
         .await
         .expect("sustained regression runs");
@@ -130,7 +131,7 @@ async fn sustained_mixed_traffic_campaign() {
 
 #[tokio::test]
 async fn self_update_admin_race_runs_as_a_small_regression() {
-    let _ = assert_case(&generate_milestone3_self_update_regression(7)).await;
+    let _ = assert_case(&generate_adversarial_reliability_self_update_regression(7)).await;
 }
 
 #[ignore = "sustained self-update adversary; run explicitly"]
@@ -153,7 +154,7 @@ async fn remaining_catalog_workloads_execute_under_the_strict_oracle() {
 
 #[tokio::test]
 async fn mixed_binary_versions_run_but_mixed_policies_are_rejected() {
-    let case = generate_milestone3_adversarial_case(7, 10);
+    let case = generate_adversarial_reliability_case(7, 10);
     let _ = assert_case(&case).await;
 
     let mut incompatible = case.scenario.clone();
@@ -166,7 +167,7 @@ async fn mixed_binary_versions_run_but_mixed_policies_are_rejected() {
 #[cfg(feature = "test-policy-overrides")]
 #[tokio::test]
 async fn full_engine_witness_ab_pair_can_select_different_canonical_branches() {
-    let cases = generate_milestone3_adversarial_family(7, 10);
+    let cases = generate_adversarial_reliability_family(7, 10);
     let case = &cases[9];
     let mut standard = EngineHarnessSubject::new_with_topology(
         &case.scenario.clients,


### PR DESCRIPTION
## What changed

- keep the required `Simulator and vectors` PR check, but make its simulator pass a focused smoke lane
- move the generated multi-minute batches, adversarial reliability campaigns, policy sweeps, ignored sustained campaigns, and process-isolated campaign runner to one scheduled nightly job
- retain simulator doctests, independent convergence verification, and the encrypted 19-vector report on every PR
- centralize the smoke and full nextest filters in reproducible `just` recipes, with a contract check for their intended coverage delta
- make nightly failures open a GitHub issue containing the failed run URL
- prevent scheduled and manually dispatched nightly runs from cancelling one another
- replace historical milestone labels across the simulator with descriptive campaign, scenario, recipe, and CI names
- version the renamed generator output contract as `2` / `2-regression`
- use portable `grep` in the liveness counterexample check because the Ubuntu runner does not install ripgrep

## Coverage tradeoff

Per-PR coverage intentionally decreases to restore useful feedback time. The PR lane no longer runs:

- the `adversarial_reliability_campaigns` binary, including its ignored multi-round campaigns
- the `policy_sweeps` binary
- the process-isolated adversarial campaign runner
- these three generated multi-minute batches from `canonical_scenarios`:
  - `convergence_chaos_family_generates_specs_with_semantic_expectations`
  - `convergence_chaos_family_seed_changes_scenarios`
  - `convergence_e2e_delivery_family_runs_generated_variants`

Those checks now run after merge in `Simulator Nightly`, together with the broader `conformance-slow` configuration. A regression confined to that coverage can therefore land before nightly catches it. To make that deferred signal visible, a failed nightly opens a GitHub issue linked to the run.

The PR lane continues to run the other 267 simulator tests, doctests, independent convergence/model checks, and the encrypted vector report. The nightly runs the full generic suite plus every dedicated campaign and verification recipe.

## Why

The simulator check had become dominated by generated reliability campaigns rather than PR feedback. A prior green run spent 18m40s in the initial simulator suite; after the newer coverage landed, one run spent 31m05s there and the complete job took 47m23s. Serializing the heavy tests made this worse because the two chaos batches alone took 10m58s and 13m49s.

The simulator surfaces now describe their purpose directly: `adversarial-reliability/v1`, `adversarial_reliability_campaigns`, `adversarial-reliability-ci`, and `convergence-verification-ci`.

The original master failure after the simulator work was a separate portability issue: the liveness counterexample check invoked `rg` on a runner where ripgrep was unavailable, producing exit code 127. That check now uses `grep`, which is present on the Ubuntu image.

## Validation

- live post-review `Simulator and vectors` job passed in 5m48s; its smoke step passed in 4m04s
- `just simulator-filter-contract`
- adversarial generator-version contract test passes
- all simulator targets compile with `test-policy-overrides`
- renamed campaign target and catalog test pass
- full `just convergence-verification-ci` passes, including the expected TLA counterexample check
- `actionlint .github/workflows/ci.yml .github/workflows/simulator-nightly.yml`
- both workflow files parse with Ruby's YAML parser
- `RUSTDOCFLAGS='-D warnings' cargo doc -p cgka-conformance-simulator --no-deps --features test-policy-overrides`
- `cargo fmt --all -- --check`
- `git diff --check`