### PR TITLE
test(marmot-app): stabilize runtime start ordering check

### DIFF
--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -47,6 +47,11 @@ versioning through the workspace version in the root `Cargo.toml`.
   `NSEC…` argv identities are rejected at the same early gate as lowercase
   `nsec…`.
 
+- The runtime-start local-readiness regression test now asserts startup-before-
+  subscription ordering directly while retaining a bounded hang deadline,
+  avoiding false failures when unrelated startup work is delayed under loaded
+  `nextest` shards.
+
 - `MarmotApp` now permits only one live in-memory engine session per account
   across direct clients and managed workers. Concurrent opens return the typed
   `AccountSessionBusy` error, and worker reconnect drops the failed session

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -1030,10 +1030,22 @@ async fn runtime_local_ready_before_directory_subscribe_body() {
         .with_test_relay_client(relay.clone());
     let runtime = MarmotAppRuntime::new(app);
 
-    tokio::time::timeout(std::time::Duration::from_secs(5), runtime.start())
-        .await
-        .expect("runtime start must not wait for network subscription registration")
-        .unwrap();
+    // Poll startup first so a correct implementation returns before the spawned
+    // registration task can run. If startup ever awaits registration instead,
+    // the blocked-subscribe signal wins immediately; the timeout only bounds a
+    // genuine local-startup hang.
+    let start_result = tokio::time::timeout(std::time::Duration::from_secs(30), async {
+        tokio::select! {
+            biased;
+            result = runtime.start() => result,
+            () = relay.wait_for_blocked_subscribe() => {
+                panic!("runtime start waited for network subscription registration");
+            }
+        }
+    })
+    .await
+    .expect("runtime local startup must complete within the outer deadline");
+    start_result.unwrap();
     assert!(runtime.shared_services().lifecycle().is_running());
 
     tokio::time::timeout(

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -1049,7 +1049,7 @@ async fn runtime_local_ready_before_directory_subscribe_body() {
     assert!(runtime.shared_services().lifecycle().is_running());
 
     tokio::time::timeout(
-        std::time::Duration::from_secs(5),
+        std::time::Duration::from_secs(30),
         relay.wait_for_blocked_subscribe(),
     )
     .await


### PR DESCRIPTION
## Summary

- assert runtime startup completes before the blocked directory-subscription registration using deterministic `tokio::select!` ordering
- retain a 30-second outer deadline for genuine local-startup hangs without treating normal shard load as a regression
- document the test-harness stabilization in the MDK compatibility-cohort changelog

## Verification

- mutation check: test fails immediately when `MarmotAppRuntime::start()` is temporarily changed to await the blocked initial subscription
- `cargo fmt --all -- --check`
- focused test: 10/10 passes
- `cargo test -p marmot-app --lib --locked` (536 passed)
- CI-equivalent `nextest` partition `count:4/4` with workflow features/profile (749 passed)
- focused `nextest` run with CI profile/features (1 passed)
- `cargo clippy -p marmot-app --all-targets --locked -- -D warnings`

Fixes #1254


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened runtime startup regression coverage to verify startup completes before relay subscription begins.
  * Improved failure detection when startup unexpectedly waits on network registration.
  * Increased test time limits to reduce flaky failures.

* **Documentation**
  * Added an unreleased changelog entry describing the readiness test update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->