### PR TITLE
fix(openclaw): bound timeline context size

### DIFF
--- a/integrations/openclaw/marmot/src/dispatch.ts
+++ b/integrations/openclaw/marmot/src/dispatch.ts
@@ -235,6 +235,96 @@ function replyFallbackBody(availability: string): string {
 }
 
 /**
+ * Aggregate bound for the rendered conversation-history supplemental entry,
+ * mirroring the Hermes adapter-local bound (#1223): retain at most the newest
+ * eight records and keep the complete serialized entry — envelope, records,
+ * and aggregate truncation metadata — within 16 KiB of UTF-8.
+ */
+export const TIMELINE_CONTEXT_MESSAGE_LIMIT = 8;
+export const TIMELINE_CONTEXT_BYTE_LIMIT = 16 * 1024;
+
+interface TimelineContextPayload {
+  order: "chronological";
+  relation: "before_current_message";
+  messages: AgentControlTimelineMessage[];
+  messages_truncated?: boolean;
+  omitted_message_count?: number;
+  oversized_message_count?: number;
+}
+
+function timelineContextEntry(payload: TimelineContextPayload) {
+  return {
+    label: "Marmot conversation history",
+    source: "marmot",
+    type: "chat_window",
+    payload,
+  };
+}
+
+/** UTF-8 size of the complete serialized supplemental entry. */
+function timelineContextEntryBytes(payload: TimelineContextPayload): number {
+  return Buffer.byteLength(JSON.stringify(timelineContextEntry(payload)), "utf8");
+}
+
+/**
+ * Whether one record alone already exceeds the budget, judged against an entry
+ * carrying the truncation metadata that would accompany its omission.
+ */
+function timelineMessageExceedsByteLimit(message: AgentControlTimelineMessage): boolean {
+  return (
+    timelineContextEntryBytes({
+      order: "chronological",
+      relation: "before_current_message",
+      messages: [message],
+      messages_truncated: true,
+      omitted_message_count: 1,
+    }) > TIMELINE_CONTEXT_BYTE_LIMIT
+  );
+}
+
+/**
+ * Build the bounded conversation-history entry: drop oldest records first,
+ * keep retained records in chronological order, and omit an oversized
+ * remaining record rather than exceed the byte budget. Reports only aggregate
+ * omitted/oversized counts (privacy-safe).
+ */
+function boundTimelineContextEntry(history: AgentControlTimelineMessage[]) {
+  const bounded = history.slice(-TIMELINE_CONTEXT_MESSAGE_LIMIT);
+  let omittedMessageCount = history.length - bounded.length;
+  let oversizedMessageCount = 0;
+  for (const message of history.slice(0, omittedMessageCount)) {
+    if (timelineMessageExceedsByteLimit(message)) {
+      oversizedMessageCount += 1;
+    }
+  }
+
+  for (;;) {
+    const payload: TimelineContextPayload = {
+      order: "chronological",
+      relation: "before_current_message",
+      messages: bounded,
+      ...(omittedMessageCount > 0
+        ? { messages_truncated: true, omitted_message_count: omittedMessageCount }
+        : {}),
+      ...(oversizedMessageCount > 0 ? { oversized_message_count: oversizedMessageCount } : {}),
+    };
+    if (timelineContextEntryBytes(payload) <= TIMELINE_CONTEXT_BYTE_LIMIT) {
+      return timelineContextEntry(payload);
+    }
+    const dropped = bounded.shift();
+    if (dropped === undefined) {
+      // The metadata-only envelope is intentionally tiny, so this is a
+      // defensive fallback rather than an expected path.
+      return timelineContextEntry(payload);
+    }
+    if (timelineMessageExceedsByteLimit(dropped)) {
+      oversizedMessageCount += 1;
+    }
+    omittedMessageCount += 1;
+  }
+}
+
+/**
  * Convert Marmot reply hydration and buffered ambient facts into OpenClaw's
  * native, explicitly-untrusted supplemental context. None of this data enters a
  * system prompt, and ambient events never invoke this dispatcher themselves.
@@ -268,16 +358,7 @@ function inboundSupplemental(
     });
   }
   if (history.length > 0) {
-    untrustedContext.push({
-      label: "Marmot conversation history",
-      source: "marmot",
-      type: "chat_window",
-      payload: {
-        order: "chronological",
-        relation: "before_current_message",
-        messages: history,
-      },
-    });
+    untrustedContext.push(boundTimelineContextEntry(history));
   }
   for (const ambient of message.ambientContext ?? []) {
     untrustedContext.push({

--- a/integrations/openclaw/marmot/src/dispatch.ts
+++ b/integrations/openclaw/marmot/src/dispatch.ts
@@ -286,7 +286,10 @@ function timelineMessageExceedsByteLimit(message: AgentControlTimelineMessage): 
  * Build the bounded conversation-history entry: drop oldest records first,
  * keep retained records in chronological order, and omit an oversized
  * remaining record rather than exceed the byte budget. Reports only aggregate
- * omitted/oversized counts (privacy-safe).
+ * omitted/oversized counts (privacy-safe). `oversized_message_count` counts
+ * every omitted record that is individually unrenderable — including records
+ * dropped by the count window, where size never drove the decision — matching
+ * the Hermes adapter's shared contract.
  */
 function boundTimelineContextEntry(history: AgentControlTimelineMessage[]) {
   const bounded = history.slice(-TIMELINE_CONTEXT_MESSAGE_LIMIT);
@@ -311,12 +314,9 @@ function boundTimelineContextEntry(history: AgentControlTimelineMessage[]) {
     if (timelineContextEntryBytes(payload) <= TIMELINE_CONTEXT_BYTE_LIMIT) {
       return timelineContextEntry(payload);
     }
-    const dropped = bounded.shift();
-    if (dropped === undefined) {
-      // The metadata-only envelope is intentionally tiny, so this is a
-      // defensive fallback rather than an expected path.
-      return timelineContextEntry(payload);
-    }
+    // Always defined: an empty `bounded` renders a metadata-only payload that
+    // fits the budget, so the check above returns before `shift` can drain it.
+    const dropped = bounded.shift() as AgentControlTimelineMessage;
     if (timelineMessageExceedsByteLimit(dropped)) {
       oversizedMessageCount += 1;
     }
@@ -493,6 +493,8 @@ export function createMarmotInboundDispatcher(
             recorded_at: message.recordedAt ?? 0,
             message_id_hex: message.messageIdHex,
           },
+          // Deliberately over-fetch beyond TIMELINE_CONTEXT_MESSAGE_LIMIT so
+          // the bounded entry can report an exact omitted_message_count.
           limit: 20,
         },
       );

--- a/integrations/openclaw/marmot/test/dispatch.test.ts
+++ b/integrations/openclaw/marmot/test/dispatch.test.ts
@@ -5,6 +5,8 @@ import type { MarmotInboundMessage } from "../src/inbound.js";
 import {
   buildMarmotTurnConfig,
   createMarmotInboundDispatcher,
+  TIMELINE_CONTEXT_BYTE_LIMIT,
+  TIMELINE_CONTEXT_MESSAGE_LIMIT,
   type MarmotDispatchClient,
   type OpenClawChannelRuntime,
 } from "../src/dispatch.js";
@@ -828,5 +830,171 @@ describe("createMarmotInboundDispatcher inbound media", () => {
     expect(downloads).toHaveLength(0);
     const ctxArg = buildCtxMock.mock.calls[0]?.[0] as Record<string, unknown>;
     expect("media" in ctxArg).toBe(false);
+  });
+});
+
+describe("timeline context budget", () => {
+  interface ChatWindowEntry {
+    label: string;
+    source: string;
+    type: string;
+    payload: {
+      order: string;
+      relation: string;
+      messages: Array<Record<string, unknown>>;
+      messages_truncated?: boolean;
+      omitted_message_count?: number;
+      oversized_message_count?: number;
+    };
+  }
+
+  const utf8Bytes = (value: unknown): number =>
+    Buffer.byteLength(JSON.stringify(value), "utf8");
+
+  async function renderTimelineEntry(history: unknown[]): Promise<ChatWindowEntry | undefined> {
+    buildCtxMock.mockClear();
+    const runtimeChannel: OpenClawChannelRuntime = {
+      routing: {
+        resolveAgentRoute: () => ({
+          agentId: "agent",
+          accountId: "default",
+          sessionKey: "agent:marmot",
+        }),
+      },
+      session: {
+        resolveStorePath: () => "/tmp/openclaw-marmot-history-budget",
+        recordInboundSession: vi.fn(),
+      },
+      reply: {
+        dispatchReplyWithBufferedBlockDispatcher: vi.fn(async () => undefined),
+      },
+    };
+    const dispatch = createMarmotInboundDispatcher({
+      cfg: {},
+      runtimeChannel,
+      client: stubClient(emptyCalls(), { history }) as unknown as MarmotDispatchClient,
+      channelAccountId: "default",
+      groupActivation: "always",
+      mentionPatterns: [],
+    });
+
+    await dispatch({
+      accountIdHex: HEX32("aa"),
+      groupIdHex: HEX32("cc"),
+      messageIdHex: HEX32("dd"),
+      senderAccountIdHex: HEX32("bb"),
+      text: "ping",
+      recordedAt: 1_721_000_000,
+    });
+
+    const context = buildCtxMock.mock.calls.at(-1)?.[0] as unknown as {
+      supplemental?: { untrustedContext?: ChatWindowEntry[] };
+    };
+    return context.supplemental?.untrustedContext?.find((entry) => entry.type === "chat_window");
+  }
+
+  it("passes a small page through without truncation metadata", async () => {
+    const messages = [0, 1, 2].map((index) => ({
+      message_id_hex: `${index}`,
+      text: `message-${index}`,
+    }));
+
+    const entry = await renderTimelineEntry(messages);
+
+    expect(entry?.payload.messages).toEqual(messages);
+    expect(entry?.payload).not.toHaveProperty("messages_truncated");
+    expect(utf8Bytes(entry)).toBeLessThanOrEqual(TIMELINE_CONTEXT_BYTE_LIMIT);
+  });
+
+  it("omits one oversized record rather than exceeding the budget", async () => {
+    const entry = await renderTimelineEntry([
+      { message_id_hex: "newest", text: "🙂".repeat(10_000) },
+    ]);
+
+    expect(entry?.payload.messages).toEqual([]);
+    expect(entry?.payload.omitted_message_count).toBe(1);
+    expect(entry?.payload.oversized_message_count).toBe(1);
+    expect(utf8Bytes(entry)).toBeLessThanOrEqual(TIMELINE_CONTEXT_BYTE_LIMIT);
+  });
+
+  it("counts multiple oversized records dropped oldest-first", async () => {
+    const entry = await renderTimelineEntry([
+      { message_id_hex: "old-1", text: "🙂".repeat(10_000) },
+      { message_id_hex: "old-2", text: "🙂".repeat(10_000) },
+      { message_id_hex: "newest", text: "kept" },
+    ]);
+
+    expect(entry?.payload.messages.map((message) => message.message_id_hex)).toEqual(["newest"]);
+    expect(entry?.payload.omitted_message_count).toBe(2);
+    expect(entry?.payload.oversized_message_count).toBe(2);
+    expect(JSON.stringify(entry)).not.toContain("old-1");
+    expect(JSON.stringify(entry)).not.toContain("old-2");
+  });
+
+  it("counts oversized records outside the count window", async () => {
+    const entry = await renderTimelineEntry(
+      Array.from({ length: TIMELINE_CONTEXT_MESSAGE_LIMIT + 1 }, (_, index) => ({
+        message_id_hex: `${index}`,
+        text: "🙂".repeat(10_000),
+      })),
+    );
+
+    expect(entry?.payload.messages).toEqual([]);
+    expect(entry?.payload.omitted_message_count).toBe(TIMELINE_CONTEXT_MESSAGE_LIMIT + 1);
+    expect(entry?.payload.oversized_message_count).toBe(TIMELINE_CONTEXT_MESSAGE_LIMIT + 1);
+  });
+
+  it("does not misclassify a record displaced by aggregate metadata", async () => {
+    const finalMessage: { message_id_hex: string; text: string } = {
+      message_id_hex: "final",
+      text: "",
+    };
+    const referenceEntry = {
+      label: "Marmot conversation history",
+      source: "marmot",
+      type: "chat_window",
+      payload: {
+        order: "chronological",
+        relation: "before_current_message",
+        messages: [finalMessage],
+        messages_truncated: true,
+        omitted_message_count: 1,
+      },
+    };
+    finalMessage.text = "x".repeat(TIMELINE_CONTEXT_BYTE_LIMIT - utf8Bytes(referenceEntry));
+    // Sanity: as the sole retained record (with omission metadata) it exactly fits.
+    expect(utf8Bytes(referenceEntry)).toBeLessThanOrEqual(TIMELINE_CONTEXT_BYTE_LIMIT);
+
+    const entry = await renderTimelineEntry([
+      { message_id_hex: "oversized", text: "🙂".repeat(10_000) },
+      ...Array.from({ length: TIMELINE_CONTEXT_MESSAGE_LIMIT - 1 }, (_, index) => ({
+        message_id_hex: `small-${index}`,
+        text: "",
+      })),
+      finalMessage,
+    ]);
+
+    expect(entry?.payload.messages).toEqual([]);
+    expect(entry?.payload.omitted_message_count).toBe(TIMELINE_CONTEXT_MESSAGE_LIMIT + 1);
+    expect(entry?.payload.oversized_message_count).toBe(1);
+  });
+
+  it("retains only the newest records from a twenty-record page", async () => {
+    const messageId = (index: number) => index.toString(16).padStart(64, "0");
+    const messages = Array.from({ length: 20 }, (_, index) => ({
+      message_id_hex: messageId(index),
+      text: "x".repeat(1_500),
+    }));
+
+    const entry = await renderTimelineEntry(messages);
+
+    expect(entry?.payload.messages.map((message) => message.message_id_hex)).toEqual(
+      Array.from({ length: TIMELINE_CONTEXT_MESSAGE_LIMIT }, (_, index) =>
+        messageId(20 - TIMELINE_CONTEXT_MESSAGE_LIMIT + index),
+      ),
+    );
+    expect(entry?.payload.omitted_message_count).toBe(20 - TIMELINE_CONTEXT_MESSAGE_LIMIT);
+    expect(entry?.payload).not.toHaveProperty("oversized_message_count");
+    expect(utf8Bytes(entry)).toBeLessThanOrEqual(TIMELINE_CONTEXT_BYTE_LIMIT);
   });
 });


### PR DESCRIPTION
## Summary

- retain at most the newest eight timeline records in the OpenClaw inbound `chat_window` supplemental entry
- enforce a 16 KiB UTF-8 budget over the complete serialized entry, including the envelope, records, and aggregate truncation metadata
- drop oldest records first, preserve retained chronological order, and omit an oversized remaining record rather than exceeding the budget
- report only aggregate omitted/oversized counts; referenced-message and ambient context behavior unchanged
- cover small, oversized, count-window, chronological, aggregate-metadata, and twenty-record cases through the inbound dispatch path

## Scope

OpenClaw parity with the Hermes adapter-local bound from #1234, addressing the OpenClaw portion of #1223. It deliberately does not implement the broader host-session watermark/delta design from that issue.

The control protocol's per-record and frame limits remain unchanged; this adds the missing OpenClaw-local rendered-context bound. The byte budget is measured over `JSON.stringify` of the full `{label, source, type, payload}` entry, the OpenClaw host's rendered form (the Hermes bound measures its prefixed string line).

## Validation

- `pnpm typecheck` — clean
- `pnpm test` — 205 passed, 1 skipped (22 files), including six new `timeline context budget` cases in `test/dispatch.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Conversation history shared with integrations is now limited to the eight most recent messages and 16 KiB.
  * Oversized or older messages are automatically omitted, with truncation details provided when applicable.
  * Newer conversation records are prioritized when the history exceeds the available limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->