### PR TITLE
Fix physical iOS Marmot root lease startup

### DIFF
--- a/crates/fs-private/src/lib.rs
+++ b/crates/fs-private/src/lib.rs
@@ -63,7 +63,10 @@ fn finish_private_exclusive_file_lease(
 ) -> io::Result<PrivateExclusiveFileLease> {
     use std::os::fd::AsRawFd;
 
-    if !file.metadata()?.file_type().is_file() {
+    let metadata = file
+        .metadata()
+        .map_err(|error| io_context("read private lease file metadata", path, error))?;
+    if !metadata.file_type().is_file() {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             format!(
@@ -139,11 +142,12 @@ impl PreparedDirectory {
         use std::os::fd::{AsRawFd, FromRawFd};
         use std::os::unix::ffi::OsStrExt;
 
-        if !matches!(
-            Path::new(name).components().next(),
-            Some(std::path::Component::Normal(_))
-        ) || Path::new(name).components().count() != 1
-        {
+        let mut name_components = Path::new(name).components();
+        let single_normal = matches!(
+            (name_components.next(), name_components.next()),
+            (Some(std::path::Component::Normal(_)), None)
+        );
+        if !single_normal {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "private lease name must be one non-empty path component",
@@ -227,11 +231,17 @@ pub fn prepare_directory_path(
     let normalized_path = resolve_root_owned_alias(path)?;
     let path = normalized_path.as_deref().unwrap_or(path);
 
+    #[cfg(not(target_vendor = "apple"))]
     let mut components = Vec::<OsString>::new();
+    let mut has_normal_component = false;
     for component in path.components() {
         match component {
             Component::RootDir | Component::CurDir => {}
-            Component::Normal(component) => components.push(component.to_owned()),
+            Component::Normal(_component) => {
+                has_normal_component = true;
+                #[cfg(not(target_vendor = "apple"))]
+                components.push(_component.to_owned());
+            }
             Component::ParentDir => {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
@@ -246,7 +256,7 @@ pub fn prepare_directory_path(
             }
         }
     }
-    if components.is_empty() && policy == ExistingDirectoryMode::Enforce {
+    if !has_normal_component && policy == ExistingDirectoryMode::Enforce {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             "refusing to change the current or root directory mode",
@@ -1022,11 +1032,14 @@ mod unix_tests {
         )
         .expect("prepare root");
 
-        for name in ["", ".", "..", "child/lock"] {
-            assert!(
-                prepared
-                    .try_acquire_private_exclusive_file_lease(std::ffi::OsStr::new(name))
-                    .is_err()
+        for name in ["", ".", "..", "child/lock", "/etc/passwd", "../escape"] {
+            let error = prepared
+                .try_acquire_private_exclusive_file_lease(std::ffi::OsStr::new(name))
+                .expect_err("invalid lease name must be rejected");
+            assert_eq!(
+                error.kind(),
+                io::ErrorKind::InvalidInput,
+                "name {name:?} must be rejected by name validation"
             );
         }
 

--- a/crates/fs-private/src/lib.rs
+++ b/crates/fs-private/src/lib.rs
@@ -11,7 +11,7 @@
 
 use std::fs::OpenOptions;
 use std::io;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Owner-only mode for files holding private data.
 pub const PRIVATE_FILE_MODE: u32 = 0o600;
@@ -47,19 +47,33 @@ pub struct PrivateExclusiveFileLease {
 pub fn try_acquire_private_exclusive_file_lease(
     path: &Path,
 ) -> io::Result<PrivateExclusiveFileLease> {
-    use std::os::fd::AsRawFd;
-
     let mut options = OpenOptions::new();
     options.read(true).write(true).create(true);
     set_private_file_mode(&mut options);
-    let file = options.open(path)?;
+    let file = options
+        .open(path)
+        .map_err(|error| io_context("open private lease file", path, error))?;
+    finish_private_exclusive_file_lease(file, path)
+}
+
+#[cfg(unix)]
+fn finish_private_exclusive_file_lease(
+    file: std::fs::File,
+    path: &Path,
+) -> io::Result<PrivateExclusiveFileLease> {
+    use std::os::fd::AsRawFd;
+
     if !file.metadata()?.file_type().is_file() {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
-            "private lease target must be a regular file",
+            format!(
+                "validate private lease file at {}: target must be a regular file",
+                path.display()
+            ),
         ));
     }
-    set_handle_private(&file)?;
+    set_handle_private(&file)
+        .map_err(|error| io_context("set private lease file mode", path, error))?;
 
     loop {
         let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
@@ -70,7 +84,7 @@ pub fn try_acquire_private_exclusive_file_lease(
         if error.kind() == io::ErrorKind::Interrupted {
             continue;
         }
-        return Err(error);
+        return Err(io_context("acquire nonblocking private lease", path, error));
     }
 }
 
@@ -91,7 +105,8 @@ pub enum ExistingDirectoryMode {
 #[cfg(unix)]
 #[derive(Debug)]
 pub struct PreparedDirectory {
-    _directory: std::fs::File,
+    directory: std::fs::File,
+    path: PathBuf,
     mode: u32,
     uid: libc::uid_t,
     created: bool,
@@ -113,16 +128,66 @@ impl PreparedDirectory {
     pub fn was_created(&self) -> bool {
         self.created
     }
+
+    /// Try to acquire a private lease file directly beneath this verified
+    /// directory without resolving the directory pathname again.
+    pub fn try_acquire_private_exclusive_file_lease(
+        &self,
+        name: &std::ffi::OsStr,
+    ) -> io::Result<PrivateExclusiveFileLease> {
+        use std::ffi::CString;
+        use std::os::fd::{AsRawFd, FromRawFd};
+        use std::os::unix::ffi::OsStrExt;
+
+        if !matches!(
+            Path::new(name).components().next(),
+            Some(std::path::Component::Normal(_))
+        ) || Path::new(name).components().count() != 1
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "private lease name must be one non-empty path component",
+            ));
+        }
+        let name_c = CString::new(name.as_bytes()).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "private lease name contains a NUL byte",
+            )
+        })?;
+        let path = self.path.join(name);
+        let descriptor = unsafe {
+            libc::openat(
+                self.directory.as_raw_fd(),
+                name_c.as_ptr(),
+                libc::O_RDWR | libc::O_CREAT | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+                libc::c_uint::try_from(PRIVATE_FILE_MODE).expect("0600 fits c_uint"),
+            )
+        };
+        if descriptor < 0 {
+            return Err(io_context(
+                "open private lease file relative to prepared directory",
+                &path,
+                io::Error::last_os_error(),
+            ));
+        }
+        let file = unsafe { std::fs::File::from_raw_fd(descriptor) };
+        finish_private_exclusive_file_lease(file, &path)
+    }
 }
 
-/// Open or create every component of `path` relative to directory
-/// descriptors, refusing symlinks at every step.
+/// Open or create `path` while refusing symlinks.
 ///
 /// Missing components are created at `mode` (subject only to a temporarily
 /// more-restrictive umask) and immediately brought to the requested mode via
 /// `fchmod`. Existing ancestors are never chmodded. The leaf follows `policy`,
 /// allowing owned directories to be enforced while externally managed socket
-/// parents are preserved and validated by the caller.
+/// parents are preserved and validated by the caller. Apple platforms open the
+/// complete authorized path (or deepest complete existing ancestor) with
+/// `O_NOFOLLOW_ANY`, then operate descriptor-relative below that anchor. This
+/// avoids independently opening sandbox-managed ancestors such as `/private`
+/// and `/private/var` on physical iOS. Other Unix platforms retain the
+/// component-by-component descriptor walk from `/` or `.`.
 #[cfg(unix)]
 pub fn prepare_directory_path(
     path: &Path,
@@ -153,6 +218,12 @@ pub fn prepare_directory_path(
     // every caller-controlled component below it is still opened with
     // `O_NOFOLLOW`. Without this narrow normalization, ordinary temp-backed
     // homes could never use the descriptor walk.
+    // iOS App Group APIs return the canonical `/private/...` spelling. Avoid
+    // even probing its first sandbox-managed ancestor independently; the
+    // complete-path open below is the authorization boundary.
+    #[cfg(target_os = "ios")]
+    let normalized_path: Option<PathBuf> = None;
+    #[cfg(not(target_os = "ios"))]
     let normalized_path = resolve_root_owned_alias(path)?;
     let path = normalized_path.as_deref().unwrap_or(path);
 
@@ -182,20 +253,30 @@ pub fn prepare_directory_path(
         ));
     }
 
-    let start = if path.is_absolute() {
-        Path::new("/")
-    } else {
-        Path::new(".")
+    #[cfg(target_vendor = "apple")]
+    let (mut current, components, mut current_path) = open_apple_authorized_ancestor(path)?;
+    #[cfg(not(target_vendor = "apple"))]
+    let (mut current, mut current_path): (OwnedFd, PathBuf) = {
+        let start = if path.is_absolute() {
+            Path::new("/")
+        } else {
+            Path::new(".")
+        };
+        let mut options = OpenOptions::new();
+        use std::os::unix::fs::OpenOptionsExt;
+        options
+            .read(true)
+            .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC);
+        let directory = options
+            .open(start)
+            .map(Into::into)
+            .map_err(|error| io_context("open directory-walk anchor", start, error))?;
+        (directory, start.to_owned())
     };
-    let mut options = OpenOptions::new();
-    use std::os::unix::fs::OpenOptionsExt;
-    options
-        .read(true)
-        .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC);
-    let mut current: OwnedFd = options.open(start)?.into();
     let mut leaf_created = false;
 
     for (index, component) in components.iter().enumerate() {
+        let component_path = current_path.join(component);
         let component = CString::new(component.as_bytes()).map_err(|_| {
             io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -214,34 +295,106 @@ pub fn prepare_directory_path(
                 } else {
                     let mkdir_error = io::Error::last_os_error();
                     if mkdir_error.kind() != io::ErrorKind::AlreadyExists {
-                        return Err(mkdir_error);
+                        return Err(io_context(
+                            "create directory component",
+                            &component_path,
+                            mkdir_error,
+                        ));
                     }
                 }
-                open_directory_at(current.as_raw_fd(), &component)?
+                open_directory_at(current.as_raw_fd(), &component).map_err(|error| {
+                    io_context(
+                        "open newly created directory component",
+                        &component_path,
+                        error,
+                    )
+                })?
             }
-            Err(error) => return Err(error),
+            Err(error) => {
+                return Err(io_context(
+                    "open directory component",
+                    &component_path,
+                    error,
+                ));
+            }
         };
         if created {
-            fchmod_directory(next.as_raw_fd(), platform_mode)?;
+            fchmod_directory(next.as_raw_fd(), platform_mode).map_err(|error| {
+                io_context("set created directory mode", &component_path, error)
+            })?;
         }
         if index + 1 == components.len() {
             leaf_created = created;
         }
         current = next;
+        current_path = component_path;
     }
 
     if policy == ExistingDirectoryMode::Enforce && !leaf_created {
-        fchmod_directory(current.as_raw_fd(), platform_mode)?;
+        fchmod_directory(current.as_raw_fd(), platform_mode)
+            .map_err(|error| io_context("set existing directory mode", path, error))?;
     }
 
     let directory = std::fs::File::from(current);
-    let metadata = directory.metadata()?;
+    let metadata = directory
+        .metadata()
+        .map_err(|error| io_context("read prepared directory metadata", path, error))?;
     let prepared = PreparedDirectory {
         mode: metadata.mode() & MAX_MODE,
         uid: metadata.uid(),
         created: leaf_created,
-        _directory: directory,
+        directory,
+        path: path.to_owned(),
     };
+
+    #[cfg(target_vendor = "apple")]
+    fn open_apple_authorized_ancestor(
+        path: &Path,
+    ) -> io::Result<(OwnedFd, Vec<OsString>, PathBuf)> {
+        use std::os::unix::fs::OpenOptionsExt;
+
+        let mut candidate = path.to_owned();
+        let mut missing = Vec::new();
+        loop {
+            let mut options = OpenOptions::new();
+            options
+                .read(true)
+                .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW_ANY | libc::O_CLOEXEC);
+            match options.open(&candidate) {
+                Ok(directory) => {
+                    missing.reverse();
+                    return Ok((directory.into(), missing, candidate));
+                }
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                    let Some(name) = candidate.file_name() else {
+                        return Err(io_context(
+                            "open authorized directory anchor",
+                            &candidate,
+                            error,
+                        ));
+                    };
+                    missing.push(name.to_owned());
+                    if !candidate.pop() {
+                        return Err(io_context(
+                            "locate authorized directory anchor",
+                            path,
+                            error,
+                        ));
+                    }
+                    if candidate.as_os_str().is_empty() {
+                        candidate.push(".");
+                    }
+                }
+                Err(error) => {
+                    return Err(io_context(
+                        "open complete authorized directory path",
+                        &candidate,
+                        error,
+                    ));
+                }
+            }
+        }
+    }
 
     fn open_directory_at(parent: libc::c_int, component: &CString) -> io::Result<OwnedFd> {
         let descriptor = unsafe {
@@ -265,6 +418,7 @@ pub fn prepare_directory_path(
         }
     }
 
+    #[cfg(not(target_os = "ios"))]
     fn resolve_root_owned_alias(path: &Path) -> io::Result<Option<std::path::PathBuf>> {
         use std::os::unix::fs::MetadataExt;
         use std::path::Component;
@@ -300,6 +454,13 @@ pub fn prepare_directory_path(
     }
 
     Ok(prepared)
+}
+
+fn io_context(operation: &str, path: &Path, error: io::Error) -> io::Error {
+    io::Error::new(
+        error.kind(),
+        format!("{operation} at {}: {error}", path.display()),
+    )
 }
 
 /// Configure `options` to create files owner-only (0600). No-op off Unix.
@@ -820,6 +981,68 @@ mod unix_tests {
         assert_eq!(mode_of(&target), 0o755);
         assert!(prepare_directory_path(&link, 0o700, ExistingDirectoryMode::Enforce).is_err());
         assert_eq!(mode_of(&target), 0o755);
+    }
+
+    #[test]
+    fn prepared_directory_lease_is_private_nonblocking_and_descriptor_relative() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("marmot");
+        let prepared = prepare_directory_path(&root, 0o700, ExistingDirectoryMode::Enforce)
+            .expect("prepare fresh root");
+        let name = std::ffi::OsStr::new(".runtime.lock");
+
+        let first = prepared
+            .try_acquire_private_exclusive_file_lease(name)
+            .expect("acquire initial lease");
+        assert_eq!(mode_of(&root), 0o700);
+        assert_eq!(mode_of(&root.join(name)), 0o600);
+
+        let blocked = prepared
+            .try_acquire_private_exclusive_file_lease(name)
+            .expect_err("second owner must not block");
+        assert_eq!(blocked.kind(), io::ErrorKind::WouldBlock);
+
+        drop(first);
+        drop(
+            prepared
+                .try_acquire_private_exclusive_file_lease(name)
+                .expect("released lease can be reacquired"),
+        );
+    }
+
+    #[test]
+    fn prepared_directory_lease_rejects_invalid_names_and_symlink_targets() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let prepared = prepare_directory_path(
+            dir.path(),
+            PRIVATE_DIR_MODE,
+            ExistingDirectoryMode::Preserve,
+        )
+        .expect("prepare root");
+
+        for name in ["", ".", "..", "child/lock"] {
+            assert!(
+                prepared
+                    .try_acquire_private_exclusive_file_lease(std::ffi::OsStr::new(name))
+                    .is_err()
+            );
+        }
+
+        let target = dir.path().join("target");
+        let link = dir.path().join("lease-link");
+        std::fs::write(&target, b"unchanged").unwrap();
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o644)).unwrap();
+        symlink(&target, &link).unwrap();
+
+        assert!(
+            prepared
+                .try_acquire_private_exclusive_file_lease(std::ffi::OsStr::new("lease-link"))
+                .is_err()
+        );
+        assert_eq!(std::fs::read(&target).unwrap(), b"unchanged");
+        assert_eq!(mode_of(&target), 0o644);
     }
 
     #[test]

--- a/crates/marmot-app/src/root_runtime_lease.rs
+++ b/crates/marmot-app/src/root_runtime_lease.rs
@@ -40,7 +40,7 @@ impl MarmotRootRuntimeLease {
     pub fn try_acquire(root: impl AsRef<Path>) -> Result<Self, AppError> {
         let root = root.as_ref();
         #[cfg(unix)]
-        fs_private::prepare_directory_path(
+        let prepared_root = fs_private::prepare_directory_path(
             root,
             fs_private::PRIVATE_DIR_MODE,
             fs_private::ExistingDirectoryMode::Preserve,
@@ -51,12 +51,20 @@ impl MarmotRootRuntimeLease {
         #[cfg(unix)]
         {
             let path = root.join(MARMOT_ROOT_RUNTIME_LOCK_FILE);
-            match fs_private::try_acquire_private_exclusive_file_lease(&path) {
+            match prepared_root.try_acquire_private_exclusive_file_lease(std::ffi::OsStr::new(
+                MARMOT_ROOT_RUNTIME_LOCK_FILE,
+            )) {
                 Ok(lease) => Ok(Self { _lease: lease }),
                 Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
                     Err(AppError::RuntimeBusy)
                 }
-                Err(error) => Err(AppError::Io(error)),
+                Err(error) => Err(AppError::Io(io::Error::new(
+                    error.kind(),
+                    format!(
+                        "acquire Marmot root runtime lease at {}: {error}",
+                        path.display()
+                    ),
+                ))),
             }
         }
 
@@ -76,6 +84,28 @@ mod tests {
     use crate::{MarmotApp, MarmotAppConfig};
     use marmot_account::AccountHome;
     use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn root_lease_creates_a_private_root_and_lock_file() {
+        let parent = tempfile::tempdir().unwrap();
+        let root = parent.path().join("Marmot");
+
+        let lease = MarmotRootRuntimeLease::try_acquire(&root).unwrap();
+
+        assert_eq!(
+            std::fs::metadata(&root).unwrap().permissions().mode() & 0o7777,
+            fs_private::PRIVATE_DIR_MODE
+        );
+        assert_eq!(
+            std::fs::metadata(root.join(MARMOT_ROOT_RUNTIME_LOCK_FILE))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o7777,
+            fs_private::PRIVATE_FILE_MODE
+        );
+        drop(lease);
+    }
 
     #[test]
     fn second_root_lease_is_busy_until_every_owner_drops() {
@@ -113,6 +143,33 @@ mod tests {
             & 0o7777;
         assert_eq!(lock_mode, fs_private::PRIVATE_FILE_MODE);
         drop(lease);
+    }
+
+    #[test]
+    fn root_lease_rejects_symlink_root_and_lock_file() {
+        use std::os::unix::fs::symlink;
+
+        let parent = tempfile::tempdir().unwrap();
+        let target_root = parent.path().join("target-root");
+        let linked_root = parent.path().join("linked-root");
+        std::fs::create_dir(&target_root).unwrap();
+        symlink(&target_root, &linked_root).unwrap();
+        assert!(matches!(
+            MarmotRootRuntimeLease::try_acquire(&linked_root),
+            Err(AppError::Io(_))
+        ));
+        assert!(!target_root.join(MARMOT_ROOT_RUNTIME_LOCK_FILE).exists());
+
+        let root = parent.path().join("real-root");
+        std::fs::create_dir(&root).unwrap();
+        let target_file = parent.path().join("target-file");
+        std::fs::write(&target_file, b"unchanged").unwrap();
+        symlink(&target_file, root.join(MARMOT_ROOT_RUNTIME_LOCK_FILE)).unwrap();
+        assert!(matches!(
+            MarmotRootRuntimeLease::try_acquire(&root),
+            Err(AppError::Io(_))
+        ));
+        assert_eq!(std::fs::read(target_file).unwrap(), b"unchanged");
     }
 
     #[test]

--- a/crates/marmot-app/src/root_runtime_lease.rs
+++ b/crates/marmot-app/src/root_runtime_lease.rs
@@ -50,7 +50,6 @@ impl MarmotRootRuntimeLease {
 
         #[cfg(unix)]
         {
-            let path = root.join(MARMOT_ROOT_RUNTIME_LOCK_FILE);
             match prepared_root.try_acquire_private_exclusive_file_lease(std::ffi::OsStr::new(
                 MARMOT_ROOT_RUNTIME_LOCK_FILE,
             )) {
@@ -60,10 +59,7 @@ impl MarmotRootRuntimeLease {
                 }
                 Err(error) => Err(AppError::Io(io::Error::new(
                     error.kind(),
-                    format!(
-                        "acquire Marmot root runtime lease at {}: {error}",
-                        path.display()
-                    ),
+                    format!("acquire Marmot root runtime lease: {error}"),
                 ))),
             }
         }
@@ -164,12 +160,22 @@ mod tests {
         std::fs::create_dir(&root).unwrap();
         let target_file = parent.path().join("target-file");
         std::fs::write(&target_file, b"unchanged").unwrap();
+        std::fs::set_permissions(&target_file, std::fs::Permissions::from_mode(0o644)).unwrap();
         symlink(&target_file, root.join(MARMOT_ROOT_RUNTIME_LOCK_FILE)).unwrap();
         assert!(matches!(
             MarmotRootRuntimeLease::try_acquire(&root),
             Err(AppError::Io(_))
         ));
-        assert_eq!(std::fs::read(target_file).unwrap(), b"unchanged");
+        assert_eq!(std::fs::read(&target_file).unwrap(), b"unchanged");
+        assert_eq!(
+            std::fs::metadata(&target_file)
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o7777,
+            0o644,
+            "symlink target mode must not be tightened"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- make Marmot root preparation compatible with physical iOS App Group sandboxes
- retain symlink rejection by opening complete Apple paths with `O_NOFOLLOW_ANY`
- create missing descendants and the runtime lock relative to verified directory descriptors
- preserve the exclusive nonblocking `flock` lease and typed `RuntimeBusy` result
- add operation and path context to filesystem errors surfaced through UniFFI

## Root cause

Commit `82f3e2f3` changed root preparation to walk absolute paths one directory descriptor at a time from `/`. A physical iOS sandbox authorizes the complete App Group container path but does not allow independently opening every sandbox-managed ancestor, so startup failed at `openat("var")` with `EPERM` before the lock file or `flock` was reached.

On Apple platforms, root preparation now opens the complete authorized path—or the deepest complete existing ancestor—with `O_NOFOLLOW_ANY`, then uses descriptor-relative operations for application-owned descendants. Non-Apple Unix keeps the existing component walk.

## Security posture

The Apple path delegates sandbox-ancestor traversal to the kernel's whole-path resolver instead of opening each ancestor separately. `O_NOFOLLOW_ANY` continues to reject symlinks anywhere in the resolved path. Missing descendants use `mkdirat`/`openat`, and the lease file is opened relative to the verified root descriptor with `O_NOFOLLOW`. Existing root modes remain preserved while newly created roots and lock files remain 0700/0600.

## Validation

- `cargo test -p fs-private -- --test-threads=1` — 24 passed
- `cargo test -p marmot-app root_runtime_lease` — 5 passed
- `cargo test -p marmot-app` — 561 unit tests passed; 5 unrelated `relay_runtime` scenarios currently fail
- `cargo test -p marmot-uniffi` — 95 unit, 2 fixture, and 27 smoke tests passed
- `cargo clippy -p fs-private -p marmot-app -p marmot-uniffi --all-targets -- -D warnings`
- `cargo check -p fs-private --target aarch64-apple-ios`
- `cargo check -p fs-private --target aarch64-linux-android`
- `cargo fmt --all -- --check`
- `git diff --check`

The five current relay-runtime failures are:

- `encrypted_media_endpoint_updates_are_full_replacement_and_admin_only`
- `encrypted_media_upload_sends_ciphertext_and_download_decrypts_plaintext`
- `relay_app_runtime_synthesizes_system_row_for_retention_change`
- `retained_media_rehydrates_a_retired_current_epoch_before_the_group_advances`
- `self_removal_suppresses_account_unread_while_peer_removal_preserves_it`

White Noise iOS bindings were not regenerated; they can be refreshed separately from this MDK commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security & Reliability**
  - Improved private lease acquisition with safer directory-relative handling.
  - Rejects invalid names and symlink-based paths.
  - Preserves required private permissions for root and lock files.

- **Error Handling**
  - Added clearer operation and path context to lease and directory errors.

- **Platform Support**
  - Improved path handling for Apple and iOS sandbox environments.

- **Validation**
  - Added coverage for nonblocking acquisition, permissions, invalid names, and unsafe symlink scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->