### PR TITLE
Anchor the private directory walk below the ancestors Android refuses to open

### DIFF
--- a/crates/fs-private/src/lib.rs
+++ b/crates/fs-private/src/lib.rs
@@ -190,7 +190,8 @@ impl PreparedDirectory {
 /// complete authorized path (or deepest complete existing ancestor) with
 /// `O_NOFOLLOW_ANY`, then operate descriptor-relative below that anchor. This
 /// avoids independently opening sandbox-managed ancestors such as `/private`
-/// and `/private/var` on physical iOS. Other Unix platforms retain the
+/// and `/private/var` on physical iOS. Android anchors below the ancestors its
+/// app sandbox refuses to open, including `/`. Other Unix platforms retain the
 /// component-by-component descriptor walk from `/` or `.`.
 #[cfg(unix)]
 pub fn prepare_directory_path(
@@ -265,7 +266,34 @@ pub fn prepare_directory_path(
 
     #[cfg(target_vendor = "apple")]
     let (mut current, components, mut current_path) = open_apple_authorized_ancestor(path)?;
-    #[cfg(not(target_vendor = "apple"))]
+    // An Android app domain is denied opening `/` and the private root's
+    // system-owned parents, so the walk has to anchor deeper.
+    #[cfg(target_os = "android")]
+    let (mut current, mut current_path): (OwnedFd, PathBuf) = {
+        let start = if path.is_absolute() {
+            Path::new("/")
+        } else {
+            Path::new(".")
+        };
+        let mut options = OpenOptions::new();
+        use std::os::unix::fs::OpenOptionsExt;
+        options
+            .read(true)
+            .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC);
+        let (depth, directory, anchor) =
+            open_walk_anchor(start, &components, |prefix| options.open(prefix)).ok_or_else(
+                || {
+                    io_context(
+                        "locate openable directory-walk anchor",
+                        path,
+                        io::Error::from(io::ErrorKind::PermissionDenied),
+                    )
+                },
+            )?;
+        components.drain(..depth);
+        (directory.into(), anchor)
+    };
+    #[cfg(not(any(target_vendor = "apple", target_os = "android")))]
     let (mut current, mut current_path): (OwnedFd, PathBuf) = {
         let start = if path.is_absolute() {
             Path::new("/")
@@ -464,6 +492,33 @@ pub fn prepare_directory_path(
     }
 
     Ok(prepared)
+}
+
+/// Pick the descriptor-walk anchor among the prefixes of `root` joined with
+/// `components`: the shallowest prefix `open` accepts below the deepest one it
+/// rejects, as its component depth, opened value, and path.
+///
+/// Probing continues past rejected prefixes and stops at the first missing one.
+#[cfg(all(unix, any(target_os = "android", test)))]
+fn open_walk_anchor<T>(
+    root: &Path,
+    components: &[std::ffi::OsString],
+    mut open: impl FnMut(&Path) -> io::Result<T>,
+) -> Option<(usize, T, PathBuf)> {
+    let mut prefix = root.to_owned();
+    let mut anchor = open(root).ok().map(|opened| (0, opened, prefix.clone()));
+    for (index, component) in components.iter().enumerate() {
+        prefix.push(component);
+        match open(&prefix) {
+            Ok(opened) if anchor.is_none() => {
+                anchor = Some((index + 1, opened, prefix.clone()));
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == io::ErrorKind::NotFound => break,
+            Err(_) => anchor = None,
+        }
+    }
+    anchor
 }
 
 fn io_context(operation: &str, path: &Path, error: io::Error) -> io::Error {
@@ -991,6 +1046,87 @@ mod unix_tests {
         assert_eq!(mode_of(&target), 0o755);
         assert!(prepare_directory_path(&link, 0o700, ExistingDirectoryMode::Enforce).is_err());
         assert_eq!(mode_of(&target), 0o755);
+    }
+
+    fn walk_anchor(root: &Path, components: &[&str]) -> Option<(usize, PathBuf)> {
+        use std::os::unix::fs::OpenOptionsExt;
+
+        let owned: Vec<std::ffi::OsString> =
+            components.iter().map(std::ffi::OsString::from).collect();
+        let mut options = OpenOptions::new();
+        options
+            .read(true)
+            .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC);
+        open_walk_anchor(root, &owned, |prefix| options.open(prefix))
+            .map(|(depth, _directory, path)| (depth, path))
+    }
+
+    fn effectively_root() -> bool {
+        (unsafe { libc::geteuid() }) == 0
+    }
+
+    #[test]
+    fn open_walk_anchor_descends_past_a_traverse_only_ancestor() {
+        if effectively_root() {
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let blocked = dir.path().join("blocked");
+        let inner = blocked.join("inner");
+        std::fs::create_dir_all(inner.join("leaf")).unwrap();
+        // Traversal without read, as Android grants on `/data`.
+        std::fs::set_permissions(&blocked, std::fs::Permissions::from_mode(0o111)).unwrap();
+
+        let anchor = walk_anchor(dir.path(), &["blocked", "inner", "leaf"]);
+
+        std::fs::set_permissions(&blocked, std::fs::Permissions::from_mode(0o700)).unwrap();
+        assert_eq!(anchor, Some((2, inner)));
+    }
+
+    #[test]
+    fn open_walk_anchor_discards_candidates_above_a_blocked_ancestor() {
+        if effectively_root() {
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let blocked = dir.path().join("readable").join("blocked");
+        let inner = blocked.join("inner");
+        std::fs::create_dir_all(&inner).unwrap();
+        std::fs::set_permissions(&blocked, std::fs::Permissions::from_mode(0o111)).unwrap();
+
+        let anchor = walk_anchor(dir.path(), &["readable", "blocked", "inner"]);
+
+        std::fs::set_permissions(&blocked, std::fs::Permissions::from_mode(0o700)).unwrap();
+        assert_eq!(anchor, Some((3, inner)));
+    }
+
+    #[test]
+    fn open_walk_anchor_keeps_the_root_when_no_ancestor_is_blocked() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("first").join("second")).unwrap();
+        assert_eq!(
+            walk_anchor(dir.path(), &["first", "second"]),
+            Some((0, dir.path().to_owned()))
+        );
+    }
+
+    #[test]
+    fn open_walk_anchor_stops_at_the_first_missing_component() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(
+            walk_anchor(dir.path(), &["missing", "deeper"]),
+            Some((0, dir.path().to_owned()))
+        );
+    }
+
+    #[test]
+    fn open_walk_anchor_reports_no_anchor_when_nothing_opens() {
+        let components: Vec<std::ffi::OsString> =
+            ["a", "b"].iter().map(std::ffi::OsString::from).collect();
+        let anchor = open_walk_anchor(Path::new("/"), &components, |_| {
+            Err::<(), _>(io::Error::from(io::ErrorKind::PermissionDenied))
+        });
+        assert!(anchor.is_none());
     }
 
     #[test]

--- a/crates/fs-private/src/lib.rs
+++ b/crates/fs-private/src/lib.rs
@@ -281,14 +281,8 @@ pub fn prepare_directory_path(
             .read(true)
             .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC);
         let (depth, directory, anchor) =
-            open_walk_anchor(start, &components, |prefix| options.open(prefix)).ok_or_else(
-                || {
-                    io_context(
-                        "locate openable directory-walk anchor",
-                        path,
-                        io::Error::from(io::ErrorKind::PermissionDenied),
-                    )
-                },
+            open_walk_anchor(start, &components, |prefix| options.open(prefix)).map_err(
+                |error| io_context("locate openable directory-walk anchor", path, error),
             )?;
         components.drain(..depth);
         (directory.into(), anchor)
@@ -496,29 +490,51 @@ pub fn prepare_directory_path(
 
 /// Pick the descriptor-walk anchor among the prefixes of `root` joined with
 /// `components`: the shallowest prefix `open` accepts below the deepest one it
-/// rejects, as its component depth, opened value, and path.
+/// denies, as its component depth, opened value, and path.
 ///
-/// Probing continues past rejected prefixes and stops at the first missing one.
+/// Probing continues past denied prefixes and stops at the first missing one.
+/// Every other rejection fails the lookup instead of descending: `O_NOFOLLOW`
+/// only guards a path's final component, so skipping a symlinked prefix would
+/// let the next, deeper probe resolve through that symlink and anchor outside
+/// the intended tree.
 #[cfg(all(unix, any(target_os = "android", test)))]
 fn open_walk_anchor<T>(
     root: &Path,
     components: &[std::ffi::OsString],
     mut open: impl FnMut(&Path) -> io::Result<T>,
-) -> Option<(usize, T, PathBuf)> {
+) -> io::Result<(usize, T, PathBuf)> {
     let mut prefix = root.to_owned();
-    let mut anchor = open(root).ok().map(|opened| (0, opened, prefix.clone()));
-    for (index, component) in components.iter().enumerate() {
-        prefix.push(component);
+    let mut anchor: Option<(usize, T, PathBuf)> = None;
+    for depth in 0..=components.len() {
+        if depth > 0 {
+            prefix.push(&components[depth - 1]);
+        }
         match open(&prefix) {
             Ok(opened) if anchor.is_none() => {
-                anchor = Some((index + 1, opened, prefix.clone()));
+                anchor = Some((depth, opened, prefix.clone()));
             }
             Ok(_) => {}
+            // A denied ancestor is the only obstacle this anchor exists for,
+            // so keep descending but drop the candidates above it.
+            Err(error) if error.kind() == io::ErrorKind::PermissionDenied => anchor = None,
             Err(error) if error.kind() == io::ErrorKind::NotFound => break,
-            Err(_) => anchor = None,
+            // A symlinked prefix reports ELOOP or ENOTDIR depending on the
+            // platform, and a non-directory prefix is unusable either way.
+            Err(error) => {
+                return Err(io_context(
+                    "open directory-walk anchor candidate",
+                    &prefix,
+                    error,
+                ));
+            }
         }
     }
-    anchor
+    anchor.ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "every candidate prefix was denied",
+        )
+    })
 }
 
 fn io_context(operation: &str, path: &Path, error: io::Error) -> io::Error {
@@ -1048,7 +1064,15 @@ mod unix_tests {
         assert_eq!(mode_of(&target), 0o755);
     }
 
-    fn walk_anchor(root: &Path, components: &[&str]) -> Option<(usize, PathBuf)> {
+    fn walk_anchor(root: &Path, components: &[&str]) -> io::Result<(usize, PathBuf)> {
+        walk_anchor_probing(root, components).0
+    }
+
+    /// The anchor lookup plus every prefix it probed, in order.
+    fn walk_anchor_probing(
+        root: &Path,
+        components: &[&str],
+    ) -> (io::Result<(usize, PathBuf)>, Vec<PathBuf>) {
         use std::os::unix::fs::OpenOptionsExt;
 
         let owned: Vec<std::ffi::OsString> =
@@ -1057,8 +1081,13 @@ mod unix_tests {
         options
             .read(true)
             .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC);
-        open_walk_anchor(root, &owned, |prefix| options.open(prefix))
-            .map(|(depth, _directory, path)| (depth, path))
+        let mut probed = Vec::new();
+        let anchor = open_walk_anchor(root, &owned, |prefix| {
+            probed.push(prefix.to_owned());
+            options.open(prefix)
+        })
+        .map(|(depth, _directory, path)| (depth, path));
+        (anchor, probed)
     }
 
     fn effectively_root() -> bool {
@@ -1080,7 +1109,10 @@ mod unix_tests {
         let anchor = walk_anchor(dir.path(), &["blocked", "inner", "leaf"]);
 
         std::fs::set_permissions(&blocked, std::fs::Permissions::from_mode(0o700)).unwrap();
-        assert_eq!(anchor, Some((2, inner)));
+        assert_eq!(
+            anchor.expect("anchor below the traverse-only ancestor"),
+            (2, inner)
+        );
     }
 
     #[test]
@@ -1097,7 +1129,10 @@ mod unix_tests {
         let anchor = walk_anchor(dir.path(), &["readable", "blocked", "inner"]);
 
         std::fs::set_permissions(&blocked, std::fs::Permissions::from_mode(0o700)).unwrap();
-        assert_eq!(anchor, Some((3, inner)));
+        assert_eq!(
+            anchor.expect("anchor below the blocked ancestor"),
+            (3, inner)
+        );
     }
 
     #[test]
@@ -1105,8 +1140,8 @@ mod unix_tests {
         let dir = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(dir.path().join("first").join("second")).unwrap();
         assert_eq!(
-            walk_anchor(dir.path(), &["first", "second"]),
-            Some((0, dir.path().to_owned()))
+            walk_anchor(dir.path(), &["first", "second"]).expect("anchor at the root"),
+            (0, dir.path().to_owned())
         );
     }
 
@@ -1114,8 +1149,8 @@ mod unix_tests {
     fn open_walk_anchor_stops_at_the_first_missing_component() {
         let dir = tempfile::tempdir().unwrap();
         assert_eq!(
-            walk_anchor(dir.path(), &["missing", "deeper"]),
-            Some((0, dir.path().to_owned()))
+            walk_anchor(dir.path(), &["missing", "deeper"]).expect("anchor at the root"),
+            (0, dir.path().to_owned())
         );
     }
 
@@ -1123,10 +1158,66 @@ mod unix_tests {
     fn open_walk_anchor_reports_no_anchor_when_nothing_opens() {
         let components: Vec<std::ffi::OsString> =
             ["a", "b"].iter().map(std::ffi::OsString::from).collect();
-        let anchor = open_walk_anchor(Path::new("/"), &components, |_| {
+        let error = open_walk_anchor(Path::new("/"), &components, |_| {
             Err::<(), _>(io::Error::from(io::ErrorKind::PermissionDenied))
-        });
-        assert!(anchor.is_none());
+        })
+        .map(|(depth, _directory, path)| (depth, path))
+        .expect_err("no openable prefix");
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+    }
+
+    #[test]
+    fn open_walk_anchor_rejects_a_symlinked_prefix_component() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let outside = dir.path().join("outside");
+        std::fs::create_dir_all(outside.join("leaf")).unwrap();
+        let inside = dir.path().join("inside");
+        std::fs::create_dir(&inside).unwrap();
+        symlink(&outside, inside.join("link")).unwrap();
+
+        let (anchor, probed) = walk_anchor_probing(dir.path(), &["inside", "link", "leaf"]);
+
+        let error = anchor.expect_err("symlinked prefix component");
+        assert_ne!(error.kind(), io::ErrorKind::PermissionDenied);
+        assert_ne!(error.kind(), io::ErrorKind::NotFound);
+        // Probing must stop at the symlink: the next prefix would have resolved
+        // through it and anchored under `outside`.
+        assert_eq!(
+            probed,
+            vec![dir.path().to_owned(), inside.clone(), inside.join("link")]
+        );
+        assert_eq!(std::fs::read_dir(&outside).unwrap().count(), 1);
+    }
+
+    #[test]
+    fn open_walk_anchor_rejects_a_symlink_below_a_denied_ancestor() {
+        use std::os::unix::fs::symlink;
+
+        if effectively_root() {
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let outside = dir.path().join("outside");
+        std::fs::create_dir_all(outside.join("leaf")).unwrap();
+        let blocked = dir.path().join("blocked");
+        std::fs::create_dir(&blocked).unwrap();
+        symlink(&outside, blocked.join("link")).unwrap();
+        // Traversal without read, as Android grants on `/data`.
+        std::fs::set_permissions(&blocked, std::fs::Permissions::from_mode(0o111)).unwrap();
+
+        let (anchor, probed) = walk_anchor_probing(dir.path(), &["blocked", "link", "leaf"]);
+
+        std::fs::set_permissions(&blocked, std::fs::Permissions::from_mode(0o700)).unwrap();
+        let error = anchor.expect_err("symlink below a denied ancestor");
+        // The denial is forgiven, the symlink below it is not.
+        assert_ne!(error.kind(), io::ErrorKind::PermissionDenied);
+        assert_eq!(
+            probed,
+            vec![dir.path().to_owned(), blocked.clone(), blocked.join("link")]
+        );
+        assert_eq!(std::fs::read_dir(&outside).unwrap().count(), 1);
     }
 
     #[test]


### PR DESCRIPTION
Closes #1237

`prepare_directory_path` anchors its descriptor walk at `/` on every non-Apple platform. Android app domains are denied opening `/`, so preparing an absolute private path fails with `Permission denied (os error 13)` before the walk begins, and the exclusive root lease can never be acquired — the client cannot bootstrap at all.

This adds an Android anchor as a sibling of the Apple one introduced in #1266, following the same shape: anchor at a directory the sandbox actually authorizes, then work descriptor-relative below it.

## Why the root open fails

Probed from inside a real app domain (uid 10491) on a Pixel 9 Pro XL, opening each prefix with `O_DIRECTORY|O_RDONLY`:

```
DENIED     /
DENIED     /data
DENIED     /data/user
DENIED     /data/user/0
OPENABLE   /data/user/0/<package>
OPENABLE   /data/user/0/<package>/files
```

`/` is `drwxr-xr-x root:root` — world-readable — so its denial is SELinux policy rather than permission bits. `/data` is `0771` and `/data/user` is `0511`: they grant traversal but not read, which is why a directory *open* fails there while path resolution through them succeeds. `/data/user/0` is a `0771` bind mount of `/data/data` (same inode, its own `/proc/mounts` entry), not a symlink.

Four consecutive denials precede the first openable directory, so stopping the probe at the first failure finds nothing.

## Approach

A new `#[cfg(target_os = "android")]` arm anchors at the **shallowest openable prefix below the deepest denied ancestor**, drains the components it consumed, and hands the rest to the existing loop. The per-component `openat` walk with `O_DIRECTORY|O_NOFOLLOW|O_CLOEXEC`, the mode enforcement, and the creation policy are untouched.

Anchoring at the *deepest* openable prefix was implemented first and rejected: once the full path exists — every launch after the first — the deepest openable prefix is the leaf itself, the walk loop runs zero times, and no app-controlled component is ever checked with `O_NOFOLLOW`. The shallowest-below-the-last-denial rule skips only the system-owned prefix. Candidates above a denial must also be discarded, otherwise a hypothetical openable `/` with a denied `/data` would anchor at `/` and then fail on the first `openat`.

## Security trade

The skipped prefix (`/`, `/data`, `/data/user`, `/data/user/0`) is entirely system-owned and unwritable by any app. Every component of the app's own subtree below the anchor retains its `O_NOFOLLOW` check.

The one property given up: `O_NOFOLLOW` guards only the final component of an `open`, so intermediate components of the anchor path are resolved with symlinks followed. Substituting one would require write access to a root/system-owned directory. Linux has no `O_NOFOLLOW_ANY` equivalent for the whole-path open that the Apple arm uses; `openat2` with `RESOLVE_NO_SYMLINKS` is the closest, and it cannot be used here because the bind-mounted `/data/user/0` is part of the canonical path Android hands the client.

A stronger alternative, if you would prefer it: have the caller pass a base directory descriptor — Android already holds one for its files directory — and walk relative to that. It preserves the full `O_NOFOLLOW` chain with no trusted prefix at all, at the cost of an API change across consumers. Happy to rework it that way.

## Platform isolation

The commit deletes exactly two lines: one doc-comment sentence, and the third arm's `cfg` predicate, widened from `not(target_vendor = "apple")` to `not(any(target_vendor = "apple", target_os = "android"))`. Its body is byte-for-byte unchanged, and no Apple code appears in the diff. The arms are mutually exclusive at compile time, and the probe helper is gated `all(unix, any(target_os = "android", test))`, so a release build for any other platform never compiles it.

## Tests

Five new tests, host-runnable: the prefix probe is factored to take an opener closure, so the anchor-selection rule is exercised on macOS and Linux rather than needing a device. Fixtures use mode `0111` — execute without read, mirroring `/data`; `0000` would remove traversal and make everything below unreachable. Tests skip under euid 0, since root bypasses these bits.

The suite was mutation-checked rather than assumed: against the rejected deepest-openable rule 2 of 5 fail, and against stopping at the first denial 3 of 5 fail.

## Verification

| Command | Result |
|---|---|
| `cargo fmt --all -- --check` | pass |
| `cargo clippy -p fs-private --all-targets -- -D warnings` | pass |
| `cargo test -p fs-private` | 29 passed, 0 failed |
| `cargo check -p marmot-app` | pass |
| `cargo check -p fs-private --target aarch64-linux-android` | pass |
| `cargo clippy -p fs-private --target aarch64-linux-android -- -D warnings` | pass |

The cross-compile gate was confirmed non-vacuous by planting a deliberate type error inside the Android block: the host check still passed while the Android check failed with E0308.

On a Pixel 9 Pro XL, with bindings built from this commit: bootstrap succeeds, the resolved root is byte-identical to the path used before the failure was introduced, the existing store (accounts, key packages, SQLite database) is read in place, and the chat list populates. Zero `Permission denied` and zero exceptions during startup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory path handling on Android when sandbox permissions restrict access to root or parent directories.
  * Added more reliable path traversal when intermediate directories are inaccessible or missing.

* **Documentation**
  * Clarified Android-specific directory anchoring behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->