### PR TITLE
Fix Hermes installer guided setup

### DIFF
--- a/integrations/hermes/marmot/README.md
+++ b/integrations/hermes/marmot/README.md
@@ -47,16 +47,20 @@ One-line install:
 curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-hermes-marmot.sh" | bash
 ```
 
+In guided setup, the allowed-message-sender prompt accepts one or more `npub` or
+raw hex public keys separated by commas. Leaving that prompt blank explicitly
+opens Marmot messaging to every sender by writing
+`MARMOT_ALLOW_ALL_USERS=true`.
+
 For repeatable noninteractive setup, pass the allowed inviter/welcomer and allowed
 message sender as either an `npub` or raw hex public key. `--allow-user` may be
-repeated to authorize multiple senders:
+repeated or given a comma-separated list to authorize multiple senders:
 
 ```sh
 curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-hermes-marmot.sh" | \
   bash -s -- --yes \
     --allow-welcomer npub1... \
-    --allow-user npub1... \
-    --allow-user 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+    --allow-user npub1...,0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 ```
 
 Generated-identity onboarding is the default (and can be selected explicitly

--- a/integrations/hermes/marmot/tests/test_installer_env.sh
+++ b/integrations/hermes/marmot/tests/test_installer_env.sh
@@ -95,6 +95,11 @@ cat >"$mock_bin/hermes" <<'EOF'
 if [ "${1:-}" = "--version" ]; then
     printf '%s\n' "Hermes 0.19.0"
 fi
+if [ "${1:-}" = "plugins" ] && [ "${2:-}" = "enable" ] && [ "${3:-}" = "marmot" ]; then
+    # Reproduce an interactive child that drains a curl-piped installer's stdin.
+    # The installer must isolate this command from its own source stream.
+    cat >/dev/null
+fi
 exit 0
 EOF
 
@@ -215,6 +220,13 @@ env_file="$case_root/hermes-home/.env"
 assert_env_contains "$env_file" "MARMOT_ALLOWED_USERS=$user_a"
 assert_env_contains "$env_file" "MARMOT_ALLOW_ALL_USERS=false"
 
+case_root="$fixture_root/comma-separated-users"
+run_installer "$case_root" --allow-user "$user_a,$user_b"
+env_file="$case_root/hermes-home/.env"
+[ -f "$env_file" ]
+assert_env_contains "$env_file" "MARMOT_ALLOWED_USERS=$user_a,$user_b"
+assert_env_contains "$env_file" "MARMOT_ALLOW_ALL_USERS=false"
+
 case_root="$fixture_root/reinstall-union"
 run_installer "$case_root" --allow-user "$user_a"
 env_file="$case_root/hermes-home/.env"
@@ -302,7 +314,7 @@ if command -v script >/dev/null 2>&1 \
     && command -v timeout >/dev/null 2>&1 \
     && script --version 2>&1 | grep -qi 'util-linux'; then
     guided_status=0
-    printf '\n\n\n\nn\nn\n%s\n\n' "$user_a" | timeout 10s script -qefc \
+    printf '\n\n\n\n' | timeout 10s script -qefc \
         "env -i HOME='$case_root/home' HERMES_HOME='$case_root/hermes-home' PATH=/usr/bin:/bin WN_AGENT_SHA=9.9.9 MARMOT_RELEASE_TAG=wn-agent-v9.9.9-test bash '$installer' --dry-run --hermes-home '$case_root/hermes-home' --allow-welcomer '$user_a'" \
         /dev/null >"$guided_log" 2>&1 || guided_status=$?
     if [ "$guided_status" -ne 0 ]; then
@@ -310,8 +322,13 @@ if command -v script >/dev/null 2>&1 \
         cat "$guided_log" >&2
         exit 1
     fi
-    if ! grep -Fq "Allow Marmot messages from any sender?" "$guided_log"; then
+    if ! grep -Fq "Allowed Marmot message senders, comma-separated npub or hex (blank allows all senders)" "$guided_log"; then
         echo "guided prompt output missing; captured log:" >&2
+        cat "$guided_log" >&2
+        exit 1
+    fi
+    if ! grep -Fq "would set MARMOT_ALLOW_ALL_USERS=true" "$guided_log"; then
+        echo "guided blank sender entry did not enable all senders; captured log:" >&2
         cat "$guided_log" >&2
         exit 1
     fi

--- a/scripts/install-hermes-marmot.sh
+++ b/scripts/install-hermes-marmot.sh
@@ -80,7 +80,8 @@ Options:
                            or 64-character hex public key; this must be a public
                            key, never an nsec or raw secret key
   --generate-identity      Explicitly use generated-identity onboarding (default)
-  --allow-user VALUE       Allow Marmot messages from this npub or hex account id; may repeat
+  --allow-user VALUE       Allow Marmot messages from npub/hex account ids;
+                           may repeat or contain comma-separated values
   --allow-all-users        Allow Marmot messages from any sender (explicit opt-in)
   --relay URL              Relay URL for wn-agent/bootstrap; may repeat
   --enable-streaming       Configure Marmot live preview streaming
@@ -815,7 +816,10 @@ enable_hermes_plugin() {
         log "would run: hermes plugins enable marmot"
         return 0
     fi
-    if run hermes plugins enable marmot; then
+    # Hermes may ask whether the plugin can override built-in tools. The
+    # installer does not grant that privileged capability, and the command
+    # must not consume a curl-piped installer's remaining source from stdin.
+    if run hermes plugins enable marmot </dev/null; then
         log "enabled Hermes plugin: marmot"
     else
         warn "could not auto-enable; run 'hermes plugins enable marmot'"
@@ -1424,44 +1428,15 @@ if [ "$INTERACTIVE" -eq 1 ]; then
             fi
         fi
         if [ "$prompt_sender_auth" -eq 1 ]; then
-            while true; do
-                if ! user_reply="$(prompt_value "Allowed Marmot message sender npub or hex (blank to finish)" "")"; then
-                    sender_auth_not_configured_message
-                    exit 1
-                fi
-                if [ -n "$user_reply" ]; then
-                    ALLOW_USERS+=("$user_reply")
-                    continue
-                fi
-                if [ "${#ALLOW_USERS[@]}" -gt 0 ]; then
-                    break
-                fi
-                if [ "${#ALLOW_WELCOMERS[@]}" -gt 0 ]; then
-                    if prompt_yes_no "Also allow configured welcomer identity/identities to message Hermes?" "no"; then
-                        ALLOW_USERS+=("${ALLOW_WELCOMERS[@]}")
-                    else
-                        welcomer_prompt_status=$?
-                        if [ "$welcomer_prompt_status" -eq 2 ]; then
-                            sender_auth_not_configured_message
-                            exit 1
-                        fi
-                    fi
-                fi
-                if [ "${#ALLOW_USERS[@]}" -gt 0 ]; then
-                    break
-                fi
-                if prompt_yes_no "Allow Marmot messages from any sender? This sets MARMOT_ALLOW_ALL_USERS=true." "no"; then
-                    EXPLICIT_ALLOW_ALL=1
-                    break
-                else
-                    allow_all_prompt_status=$?
-                    if [ "$allow_all_prompt_status" -eq 2 ]; then
-                        sender_auth_not_configured_message
-                        exit 1
-                    fi
-                fi
-                printf 'Add at least one allowed sender or opt into allow-all before continuing.\n' >"$(prompt_tty_path)"
-            done
+            if ! user_reply="$(prompt_value "Allowed Marmot message senders, comma-separated npub or hex (blank allows all senders)" "")"; then
+                sender_auth_not_configured_message
+                exit 1
+            fi
+            if [ -n "$user_reply" ]; then
+                ALLOW_USERS+=("$user_reply")
+            else
+                EXPLICIT_ALLOW_ALL=1
+            fi
         fi
     fi
 fi


### PR DESCRIPTION
## Summary

- replace the repeated Hermes sender prompt with one comma-separated allowlist entry
- make a blank guided sender entry explicitly persist `MARMOT_ALLOW_ALL_USERS=true`
- prevent `hermes plugins enable marmot` from consuming the remaining source of a `curl | bash` installation
- document and test the guided and noninteractive behaviors

## Root cause

Hermes can prompt while enabling the Marmot plugin. When the installer itself is supplied on stdin, that child command inherited the same stream and could consume the remaining installer source. The install then stopped after plugin enablement, before bootstrap, service setup, and Hermes authorization/configuration completed.

The guided sender flow also prompted once per sender even though the underlying parser already accepted comma-separated values, making a repeated entry look necessary.

## User impact

The documented one-line installer can complete reliably when streamed through Bash. Guided installs now accept all sender identities in one visible step; leaving the step blank clearly opts into accepting every sender. Noninteractive installs remain fail-closed unless `--allow-user` or `--allow-all-users` is supplied.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s integrations/hermes/marmot/tests` (168 tests)
- `just hermes-dev-script-test`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streamlined guided setup for sender authorization with a single comma-separated input.
  * Leaving the sender prompt blank now explicitly allows messages from all senders.
  * Noninteractive installation supports comma-separated values for `--allow-user`.

* **Documentation**
  * Updated installation guidance to explain sender authorization options and blank-input behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->