### PR TITLE
Add distributed campaign execution lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,6 +338,9 @@ jobs:
         # convergence checks run in their dedicated fast gate below.
         run: just simulator-smoke
 
+      - name: Validate convergence execution-lane policy
+        run: just convergence-lane-policy
+
       - name: Run simulator doctests
         run: cargo test -p cgka-conformance-simulator --doc --locked
 
@@ -360,6 +363,7 @@ jobs:
           name: cgka-conformance-simulator-reports
           path: target/cgka-conformance-simulator-reports
           if-no-files-found: error
+          retention-days: 14
 
   formal:
     name: Tamarin proofs

--- a/.github/workflows/convergence-hardening.yml
+++ b/.github/workflows/convergence-hardening.yml
@@ -1,0 +1,112 @@
+name: Convergence Hardening
+
+on:
+  schedule:
+    - cron: "43 2 * * 6"
+  workflow_dispatch:
+    inputs:
+      lane:
+        description: Execution lane
+        required: true
+        type: choice
+        default: weekly_manual
+        options:
+          - weekly_manual
+          - release_hardening
+      distributed_manifest:
+        description: Repository-relative mixed-build manifest required by release hardening
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: convergence-hardening-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  CARGO_PROFILE_TEST_DEBUG: "0"
+
+jobs:
+  hardening:
+    name: Weekly or release convergence hardening
+    runs-on: ubuntu-latest
+    timeout-minutes: 480
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        run: |
+          set -euo pipefail
+          toolchain="$(sed -n 's/^channel = "\(.*\)"/\1/p' rust-toolchain.toml)"
+          rustup toolchain install "$toolchain" --profile minimal
+          rustup default "$toolchain"
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@b18fb392e1a1b90971f7c7572c92790fa54f23d5
+
+      - name: Install just
+        uses: taiki-e/install-action@b18fb392e1a1b90971f7c7572c92790fa54f23d5
+        with:
+          tool: just
+
+      - name: Cache Cargo artifacts
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Install Tamarin
+        env:
+          TAMARIN_VERSION: 1.12.0
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends graphviz maude
+          curl -L --fail --show-error --silent \
+            "https://github.com/tamarin-prover/tamarin-prover/releases/download/${TAMARIN_VERSION}/tamarin-prover-${TAMARIN_VERSION}-linux64-ubuntu.tar.gz" \
+            -o /tmp/tamarin-prover.tar.gz
+          tar -xzf /tmp/tamarin-prover.tar.gz -C /tmp
+          sudo install -m 0755 /tmp/tamarin-prover /usr/local/bin/tamarin-prover
+
+      - name: Run strict symbolic proof gate
+        run: just tamarin
+
+      - name: Build current distributed campaign image
+        run: docker build -f Dockerfile.convergence-campaign -t marmot-conformance:local .
+
+      - name: Run weekly/manual lane
+        if: github.event_name == 'schedule' || inputs.lane == 'weekly_manual'
+        run: |
+          just convergence-weekly-lane
+          CGKA_CONVERGENCE_IMAGE=marmot-conformance:local \
+            cargo test -p convergence-campaign-runner --test container_runtime --locked -- --ignored
+
+      - name: Require a release manifest
+        if: github.event_name == 'workflow_dispatch' && inputs.lane == 'release_hardening'
+        env:
+          DISTRIBUTED_MANIFEST: ${{ inputs.distributed_manifest }}
+        run: |
+          test -n "$DISTRIBUTED_MANIFEST"
+          test -f "$DISTRIBUTED_MANIFEST"
+
+      - name: Run release-hardening lane
+        if: github.event_name == 'workflow_dispatch' && inputs.lane == 'release_hardening'
+        env:
+          DISTRIBUTED_MANIFEST: ${{ inputs.distributed_manifest }}
+        run: just convergence-release-hardening-lane "$DISTRIBUTED_MANIFEST"
+
+      - name: Upload convergence evidence inputs
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: convergence-hardening-${{ github.run_id }}
+          path: |
+            target/cgka-weekly-reliability
+            target/cgka-adversarial-reliability-ci
+          if-no-files-found: warn
+          retention-days: ${{ inputs.lane == 'release_hardening' && 180 || 60 }}

--- a/.github/workflows/convergence-hardening.yml
+++ b/.github/workflows/convergence-hardening.yml
@@ -60,22 +60,6 @@ jobs:
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
-      - name: Install Tamarin
-        env:
-          TAMARIN_VERSION: 1.12.0
-        run: |
-          set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends graphviz maude
-          curl -L --fail --show-error --silent \
-            "https://github.com/tamarin-prover/tamarin-prover/releases/download/${TAMARIN_VERSION}/tamarin-prover-${TAMARIN_VERSION}-linux64-ubuntu.tar.gz" \
-            -o /tmp/tamarin-prover.tar.gz
-          tar -xzf /tmp/tamarin-prover.tar.gz -C /tmp
-          sudo install -m 0755 /tmp/tamarin-prover /usr/local/bin/tamarin-prover
-
-      - name: Run strict symbolic proof gate
-        run: just tamarin
-
       - name: Build current distributed campaign image
         run: docker build -f Dockerfile.convergence-campaign -t marmot-conformance:local .
 
@@ -84,7 +68,8 @@ jobs:
         run: |
           just convergence-weekly-lane
           CGKA_CONVERGENCE_IMAGE=marmot-conformance:local \
-            cargo test -p convergence-campaign-runner --test container_runtime --locked -- --ignored
+            cargo nextest run -p convergence-campaign-runner --test container_runtime --locked \
+              --run-ignored ignored-only --no-tests fail
 
       - name: Require a release manifest
         if: github.event_name == 'workflow_dispatch' && inputs.lane == 'release_hardening'

--- a/.github/workflows/simulator-nightly.yml
+++ b/.github/workflows/simulator-nightly.yml
@@ -50,44 +50,11 @@ jobs:
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
-      - name: Install Tamarin
-        env:
-          TAMARIN_VERSION: 1.12.0
-        run: |
-          set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends graphviz maude
-          curl -L --fail --show-error --silent \
-            "https://github.com/tamarin-prover/tamarin-prover/releases/download/${TAMARIN_VERSION}/tamarin-prover-${TAMARIN_VERSION}-linux64-ubuntu.tar.gz" \
-            -o /tmp/tamarin-prover.tar.gz
-          tar -xzf /tmp/tamarin-prover.tar.gz -C /tmp
-          sudo install -m 0755 /tmp/tamarin-prover /usr/local/bin/tamarin-prover
-
-      - name: Run strict symbolic proof gate
-        run: just tamarin
-
-      - name: Run complete simulator suite
-        # Adversarial campaigns and independent convergence checks run below
-        # with their required feature sets; exclude only those duplicates here.
-        run: just simulator-full
-
-      - name: Validate convergence execution-lane policy
-        run: just convergence-lane-policy
+      - name: Run nightly convergence lane
+        run: just convergence-nightly-lane
 
       - name: Run simulator doctests
         run: cargo test -p cgka-conformance-simulator --doc --locked
-
-      - name: Run adversarial reliability campaigns
-        run: just adversarial-reliability-ci
-
-      - name: Verify convergence with independent models
-        run: just convergence-verification-ci
-
-      - name: Run process-boundary convergence campaigns
-        run: cargo nextest run -p cgka-conformance-simulator --test process_orchestrator --test route_equivalence --locked
-
-      - name: Validate distributed campaign runner
-        run: cargo nextest run -p convergence-campaign-runner --locked
 
       - name: Build current distributed campaign image
         run: docker build -f Dockerfile.convergence-campaign -t marmot-conformance:local .
@@ -95,7 +62,10 @@ jobs:
       - name: Run selected real-container convergence campaign
         env:
           CGKA_CONVERGENCE_IMAGE: marmot-conformance:local
-        run: cargo test -p convergence-campaign-runner --test container_runtime --locked -- --ignored real_container_nodes_recover_the_cross_route_deeper_branch
+        run: |
+          cargo nextest run -p convergence-campaign-runner --test container_runtime --locked \
+            --run-ignored ignored-only --no-tests fail \
+            -E 'test(=real_container_nodes_survive_network_shaping_and_reach_exact_state)'
 
       - name: Run encrypted file-backed vector report
         run: |

--- a/.github/workflows/simulator-nightly.yml
+++ b/.github/workflows/simulator-nightly.yml
@@ -50,10 +50,29 @@ jobs:
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
+      - name: Install Tamarin
+        env:
+          TAMARIN_VERSION: 1.12.0
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends graphviz maude
+          curl -L --fail --show-error --silent \
+            "https://github.com/tamarin-prover/tamarin-prover/releases/download/${TAMARIN_VERSION}/tamarin-prover-${TAMARIN_VERSION}-linux64-ubuntu.tar.gz" \
+            -o /tmp/tamarin-prover.tar.gz
+          tar -xzf /tmp/tamarin-prover.tar.gz -C /tmp
+          sudo install -m 0755 /tmp/tamarin-prover /usr/local/bin/tamarin-prover
+
+      - name: Run strict symbolic proof gate
+        run: just tamarin
+
       - name: Run complete simulator suite
         # Adversarial campaigns and independent convergence checks run below
         # with their required feature sets; exclude only those duplicates here.
         run: just simulator-full
+
+      - name: Validate convergence execution-lane policy
+        run: just convergence-lane-policy
 
       - name: Run simulator doctests
         run: cargo test -p cgka-conformance-simulator --doc --locked
@@ -63,6 +82,20 @@ jobs:
 
       - name: Verify convergence with independent models
         run: just convergence-verification-ci
+
+      - name: Run process-boundary convergence campaigns
+        run: cargo nextest run -p cgka-conformance-simulator --test process_orchestrator --test route_equivalence --locked
+
+      - name: Validate distributed campaign runner
+        run: cargo nextest run -p convergence-campaign-runner --locked
+
+      - name: Build current distributed campaign image
+        run: docker build -f Dockerfile.convergence-campaign -t marmot-conformance:local .
+
+      - name: Run selected real-container convergence campaign
+        env:
+          CGKA_CONVERGENCE_IMAGE: marmot-conformance:local
+        run: cargo test -p convergence-campaign-runner --test container_runtime --locked -- --ignored real_container_nodes_recover_the_cross_route_deeper_branch
 
       - name: Run encrypted file-backed vector report
         run: |
@@ -81,6 +114,7 @@ jobs:
           name: cgka-conformance-simulator-nightly-reports
           path: target/cgka-conformance-simulator-nightly-reports
           if-no-files-found: warn
+          retention-days: 30
 
       - name: Report nightly failure
         if: failure()

--- a/Justfile
+++ b/Justfile
@@ -313,22 +313,20 @@ convergence-verification-ci:
 convergence-lane-policy:
     cargo nextest run -p convergence-campaign-runner --test lane_policy --locked
 
-# Capability-level lane entry points. The PR workflow runs the first lane as
-# separate parallel jobs; the scheduled workflows use the aggregate recipes.
-convergence-pr-lane: convergence-lane-policy simulator-smoke convergence-verification-ci
-
+# Capability-level entry points used by the scheduled workflows. PR checks
+# remain split into separately named steps for useful failure attribution.
 convergence-nightly-lane: convergence-lane-policy simulator-full adversarial-reliability-ci convergence-verification-ci
-    cargo nextest run -p cgka-conformance-simulator --test process_orchestrator --test route_equivalence --locked
+    cargo nextest run -p cgka-conformance-simulator --test process_orchestrator --locked
     cargo nextest run -p convergence-campaign-runner --locked
 
 convergence-weekly-lane: convergence-nightly-lane
     cargo run -p cgka-conformance-simulator --features test-policy-overrides --bin cgka-conformance-campaign --locked -- --cases 4 --case-timeout-secs 300 --out target/cgka-weekly-reliability --storage file
 
-# A release run must name the reviewed mixed-build/incident manifest rather
+# A release run must name a reviewed mixed-build manifest rather
 # than silently falling back to a current-build-only campaign.
 convergence-release-hardening-lane manifest:
     just convergence-weekly-lane
-    cargo run -p convergence-campaign-runner --bin cgka-distributed-campaign --locked -- validate "{{manifest}}"
+    cargo run -p convergence-campaign-runner --bin cgka-distributed-campaign --locked -- validate "{{manifest}}" --require-mixed-builds
     cargo run -p convergence-campaign-runner --bin cgka-distributed-campaign --locked -- run "{{manifest}}"
 
 tracing-audit:

--- a/Justfile
+++ b/Justfile
@@ -308,6 +308,29 @@ convergence-verification-ci:
     just tla-liveness
     just tla-liveness-counterexample
 
+# Validate the versioned execution-lane policy, all resource/retention/flake
+# budgets, and the release evidence-bundle completeness contract.
+convergence-lane-policy:
+    cargo nextest run -p convergence-campaign-runner --test lane_policy --locked
+
+# Capability-level lane entry points. The PR workflow runs the first lane as
+# separate parallel jobs; the scheduled workflows use the aggregate recipes.
+convergence-pr-lane: convergence-lane-policy simulator-smoke convergence-verification-ci
+
+convergence-nightly-lane: convergence-lane-policy simulator-full adversarial-reliability-ci convergence-verification-ci
+    cargo nextest run -p cgka-conformance-simulator --test process_orchestrator --test route_equivalence --locked
+    cargo nextest run -p convergence-campaign-runner --locked
+
+convergence-weekly-lane: convergence-nightly-lane
+    cargo run -p cgka-conformance-simulator --features test-policy-overrides --bin cgka-conformance-campaign --locked -- --cases 4 --case-timeout-secs 300 --out target/cgka-weekly-reliability --storage file
+
+# A release run must name the reviewed mixed-build/incident manifest rather
+# than silently falling back to a current-build-only campaign.
+convergence-release-hardening-lane manifest:
+    just convergence-weekly-lane
+    cargo run -p convergence-campaign-runner --bin cgka-distributed-campaign --locked -- validate "{{manifest}}"
+    cargo run -p convergence-campaign-runner --bin cgka-distributed-campaign --locked -- run "{{manifest}}"
+
 tracing-audit:
     cargo nextest run -p cgka-conformance-simulator --test tracing_audit
 

--- a/crates/convergence-campaign-runner/lanes/nightly.v1.json
+++ b/crates/convergence-campaign-runner/lanes/nightly.v1.json
@@ -4,18 +4,17 @@
   "contents": {
     "strict_formal_gate": true,
     "fixed_vectors": true,
-    "engine_reference_relay_cases": 256,
-    "generated_seed_cases": 256,
+    "minimum_executed_cases": 1,
     "file_backed_storage": true,
     "crash_matrix": true,
     "retained_relays": true,
     "mutation_scope": "targeted",
     "process_campaigns": true,
     "container_campaigns": true,
-    "resource_sweeps": false,
-    "constant_sweeps": false,
+    "resource_sweeps": true,
+    "constant_sweeps": true,
     "mixed_version": false,
-    "incident_corpus": true
+    "incident_corpus": false
   },
   "budgets": {
     "max_wall_clock_seconds": 7200,

--- a/crates/convergence-campaign-runner/lanes/nightly.v1.json
+++ b/crates/convergence-campaign-runner/lanes/nightly.v1.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": "1",
+  "lane": "nightly",
+  "contents": {
+    "strict_formal_gate": true,
+    "fixed_vectors": true,
+    "engine_reference_relay_cases": 256,
+    "generated_seed_cases": 256,
+    "file_backed_storage": true,
+    "crash_matrix": true,
+    "retained_relays": true,
+    "mutation_scope": "targeted",
+    "process_campaigns": true,
+    "container_campaigns": true,
+    "resource_sweeps": false,
+    "constant_sweeps": false,
+    "mixed_version": false,
+    "incident_corpus": true
+  },
+  "budgets": {
+    "max_wall_clock_seconds": 7200,
+    "max_cpu_seconds": 14400,
+    "max_peak_rss_bytes": 8589934592,
+    "max_disk_bytes": 21474836480,
+    "max_artifact_bytes": 5368709120,
+    "artifact_retention_days": 30,
+    "max_flake_retries": 1,
+    "max_flake_rate_basis_points": 50
+  }
+}

--- a/crates/convergence-campaign-runner/lanes/pull-request.v1.json
+++ b/crates/convergence-campaign-runner/lanes/pull-request.v1.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": "1",
+  "lane": "pull_request",
+  "contents": {
+    "strict_formal_gate": true,
+    "fixed_vectors": true,
+    "engine_reference_relay_cases": 32,
+    "generated_seed_cases": 0,
+    "file_backed_storage": true,
+    "crash_matrix": false,
+    "retained_relays": true,
+    "mutation_scope": "sentinel",
+    "process_campaigns": false,
+    "container_campaigns": false,
+    "resource_sweeps": false,
+    "constant_sweeps": false,
+    "mixed_version": false,
+    "incident_corpus": false
+  },
+  "budgets": {
+    "max_wall_clock_seconds": 3600,
+    "max_cpu_seconds": 7200,
+    "max_peak_rss_bytes": 6442450944,
+    "max_disk_bytes": 12884901888,
+    "max_artifact_bytes": 1073741824,
+    "artifact_retention_days": 14,
+    "max_flake_retries": 0,
+    "max_flake_rate_basis_points": 0
+  }
+}

--- a/crates/convergence-campaign-runner/lanes/pull-request.v1.json
+++ b/crates/convergence-campaign-runner/lanes/pull-request.v1.json
@@ -4,8 +4,7 @@
   "contents": {
     "strict_formal_gate": true,
     "fixed_vectors": true,
-    "engine_reference_relay_cases": 32,
-    "generated_seed_cases": 0,
+    "minimum_executed_cases": 1,
     "file_backed_storage": true,
     "crash_matrix": false,
     "retained_relays": true,

--- a/crates/convergence-campaign-runner/lanes/release-hardening.v1.json
+++ b/crates/convergence-campaign-runner/lanes/release-hardening.v1.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": "1",
+  "lane": "release_hardening",
+  "contents": {
+    "strict_formal_gate": true,
+    "fixed_vectors": true,
+    "engine_reference_relay_cases": 2048,
+    "generated_seed_cases": 8192,
+    "file_backed_storage": true,
+    "crash_matrix": true,
+    "retained_relays": true,
+    "mutation_scope": "full_targeted",
+    "process_campaigns": true,
+    "container_campaigns": true,
+    "resource_sweeps": true,
+    "constant_sweeps": true,
+    "mixed_version": true,
+    "incident_corpus": true
+  },
+  "budgets": {
+    "max_wall_clock_seconds": 28800,
+    "max_cpu_seconds": 57600,
+    "max_peak_rss_bytes": 12884901888,
+    "max_disk_bytes": 53687091200,
+    "max_artifact_bytes": 16106127360,
+    "artifact_retention_days": 180,
+    "max_flake_retries": 1,
+    "max_flake_rate_basis_points": 10
+  }
+}

--- a/crates/convergence-campaign-runner/lanes/release-hardening.v1.json
+++ b/crates/convergence-campaign-runner/lanes/release-hardening.v1.json
@@ -4,8 +4,7 @@
   "contents": {
     "strict_formal_gate": true,
     "fixed_vectors": true,
-    "engine_reference_relay_cases": 2048,
-    "generated_seed_cases": 8192,
+    "minimum_executed_cases": 5,
     "file_backed_storage": true,
     "crash_matrix": true,
     "retained_relays": true,
@@ -15,7 +14,7 @@
     "resource_sweeps": true,
     "constant_sweeps": true,
     "mixed_version": true,
-    "incident_corpus": true
+    "incident_corpus": false
   },
   "budgets": {
     "max_wall_clock_seconds": 28800,

--- a/crates/convergence-campaign-runner/lanes/weekly-manual.v1.json
+++ b/crates/convergence-campaign-runner/lanes/weekly-manual.v1.json
@@ -4,8 +4,7 @@
   "contents": {
     "strict_formal_gate": true,
     "fixed_vectors": true,
-    "engine_reference_relay_cases": 1024,
-    "generated_seed_cases": 4096,
+    "minimum_executed_cases": 4,
     "file_backed_storage": true,
     "crash_matrix": true,
     "retained_relays": true,
@@ -14,8 +13,8 @@
     "container_campaigns": true,
     "resource_sweeps": true,
     "constant_sweeps": true,
-    "mixed_version": true,
-    "incident_corpus": true
+    "mixed_version": false,
+    "incident_corpus": false
   },
   "budgets": {
     "max_wall_clock_seconds": 21600,

--- a/crates/convergence-campaign-runner/lanes/weekly-manual.v1.json
+++ b/crates/convergence-campaign-runner/lanes/weekly-manual.v1.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": "1",
+  "lane": "weekly_manual",
+  "contents": {
+    "strict_formal_gate": true,
+    "fixed_vectors": true,
+    "engine_reference_relay_cases": 1024,
+    "generated_seed_cases": 4096,
+    "file_backed_storage": true,
+    "crash_matrix": true,
+    "retained_relays": true,
+    "mutation_scope": "full_targeted",
+    "process_campaigns": true,
+    "container_campaigns": true,
+    "resource_sweeps": true,
+    "constant_sweeps": true,
+    "mixed_version": true,
+    "incident_corpus": true
+  },
+  "budgets": {
+    "max_wall_clock_seconds": 21600,
+    "max_cpu_seconds": 43200,
+    "max_peak_rss_bytes": 12884901888,
+    "max_disk_bytes": 42949672960,
+    "max_artifact_bytes": 10737418240,
+    "artifact_retention_days": 60,
+    "max_flake_retries": 2,
+    "max_flake_rate_basis_points": 25
+  }
+}

--- a/crates/convergence-campaign-runner/src/evidence.rs
+++ b/crates/convergence-campaign-runner/src/evidence.rs
@@ -42,6 +42,16 @@ pub struct EvidenceArtifactV1 {
     pub sha256: String,
 }
 
+/// Directory against which an evidence bundle's relative artifact paths are
+/// resolved. A bare filename lives in the current directory even though
+/// `Path::parent` represents that parent as an empty path.
+pub fn evidence_bundle_base_dir(path: &Path) -> &Path {
+    match path.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => parent,
+        _ => Path::new("."),
+    }
+}
+
 impl ConvergenceEvidenceBundleV1 {
     pub fn validate(&self) -> Result<(), RunnerError> {
         if self.schema_version != CONVERGENCE_EVIDENCE_BUNDLE_VERSION {
@@ -140,11 +150,31 @@ impl ConvergenceEvidenceBundleV1 {
         Ok(())
     }
 
+    /// Write an owner-only bundle after verifying that every declared artifact
+    /// already exists beside the destination and matches its digest.
     pub fn write_private(&self, path: &Path) -> Result<(), RunnerError> {
-        self.validate_artifacts(path.parent().unwrap_or_else(|| Path::new(".")))?;
+        self.validate_artifacts(evidence_bundle_base_dir(path))?;
         let bytes = serde_json::to_vec_pretty(self)
             .map_err(|error| RunnerError::environment("evidence_serialize", error))?;
         fs_private::write_private(path, &bytes)
             .map_err(|error| RunnerError::environment("evidence_write", error))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::evidence_bundle_base_dir;
+    use std::path::Path;
+
+    #[test]
+    fn bare_bundle_filename_resolves_artifacts_from_current_directory() {
+        assert_eq!(
+            evidence_bundle_base_dir(Path::new("evidence.json")),
+            Path::new(".")
+        );
+        assert_eq!(
+            evidence_bundle_base_dir(Path::new("reports/evidence.json")),
+            Path::new("reports")
+        );
     }
 }

--- a/crates/convergence-campaign-runner/src/evidence.rs
+++ b/crates/convergence-campaign-runner/src/evidence.rs
@@ -5,7 +5,7 @@ use std::path::{Component, Path, PathBuf};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use crate::{CampaignBudgetEvaluationV1, CampaignLaneV1, RunnerError};
+use crate::{CampaignBudgetEvaluationV1, CampaignLaneConfigV1, CampaignLaneV1, RunnerError};
 
 pub const CONVERGENCE_EVIDENCE_BUNDLE_VERSION: &str = "1";
 
@@ -87,10 +87,12 @@ impl ConvergenceEvidenceBundleV1 {
                 ));
             }
         }
-        if self.budget.lane != self.lane || !self.budget.passed {
+        let expected_budget =
+            CampaignLaneConfigV1::builtin(self.lane).evaluate(self.budget.observation.clone());
+        if !expected_budget.passed || self.budget != expected_budget {
             return Err(RunnerError::validation(
                 "evidence_budget",
-                "evidence lane must match a passing budget evaluation",
+                "evidence budget must match a recomputed passing lane evaluation",
             ));
         }
         for artifact in &self.artifacts {

--- a/crates/convergence-campaign-runner/src/evidence.rs
+++ b/crates/convergence-campaign-runner/src/evidence.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::io::{BufReader, Read};
 use std::path::{Component, Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
@@ -137,9 +138,21 @@ impl ConvergenceEvidenceBundleV1 {
                     "artifact paths must remain within the evidence bundle directory",
                 ));
             }
-            let bytes = std::fs::read(canonical_path)
+            let file = std::fs::File::open(canonical_path)
                 .map_err(|error| RunnerError::environment("evidence_artifact_read", error))?;
-            let actual = hex::encode(Sha256::digest(bytes));
+            let mut reader = BufReader::new(file);
+            let mut hasher = Sha256::new();
+            let mut buffer = [0_u8; 64 * 1024];
+            loop {
+                let read = reader
+                    .read(&mut buffer)
+                    .map_err(|error| RunnerError::environment("evidence_artifact_read", error))?;
+                if read == 0 {
+                    break;
+                }
+                hasher.update(&buffer[..read]);
+            }
+            let actual = hex::encode(hasher.finalize());
             if actual != artifact.sha256 {
                 return Err(RunnerError::validation(
                     "evidence_artifact_digest_mismatch",

--- a/crates/convergence-campaign-runner/src/evidence.rs
+++ b/crates/convergence-campaign-runner/src/evidence.rs
@@ -1,0 +1,106 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{CampaignBudgetEvaluationV1, CampaignLaneV1, RunnerError};
+
+pub const CONVERGENCE_EVIDENCE_BUNDLE_VERSION: &str = "1";
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConvergenceEvidenceBundleV1 {
+    pub schema_version: String,
+    pub lane: CampaignLaneV1,
+    pub source_revision: String,
+    pub assurance_claim: String,
+    pub covered_decision_routes: Vec<String>,
+    pub models: Vec<String>,
+    pub adapters: Vec<String>,
+    pub mutation_results: BTreeMap<String, bool>,
+    pub tested_boundaries: Vec<TestedBoundaryV1>,
+    #[serde(default)]
+    pub unresolved_counterexamples: Vec<String>,
+    pub residual_assumptions: Vec<String>,
+    pub untested_surfaces: Vec<String>,
+    pub budget: CampaignBudgetEvaluationV1,
+    #[serde(default)]
+    pub artifacts: Vec<EvidenceArtifactV1>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TestedBoundaryV1 {
+    pub dimension: String,
+    pub minimum: String,
+    pub maximum: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EvidenceArtifactV1 {
+    pub kind: String,
+    pub path: PathBuf,
+    pub sha256: String,
+}
+
+impl ConvergenceEvidenceBundleV1 {
+    pub fn validate(&self) -> Result<(), RunnerError> {
+        if self.schema_version != CONVERGENCE_EVIDENCE_BUNDLE_VERSION {
+            return Err(RunnerError::validation(
+                "evidence_bundle_version",
+                "unsupported convergence evidence bundle version",
+            ));
+        }
+        if self.source_revision.is_empty() || self.assurance_claim.is_empty() {
+            return Err(RunnerError::validation(
+                "evidence_identity",
+                "evidence requires a source revision and scoped assurance claim",
+            ));
+        }
+        for (name, empty) in [
+            (
+                "covered_decision_routes",
+                self.covered_decision_routes.is_empty(),
+            ),
+            ("models", self.models.is_empty()),
+            ("adapters", self.adapters.is_empty()),
+            ("mutation_results", self.mutation_results.is_empty()),
+            ("tested_boundaries", self.tested_boundaries.is_empty()),
+            ("residual_assumptions", self.residual_assumptions.is_empty()),
+            ("untested_surfaces", self.untested_surfaces.is_empty()),
+        ] {
+            if empty {
+                return Err(RunnerError::validation(
+                    "incomplete_evidence_bundle",
+                    format!("evidence bundle is missing {name}"),
+                ));
+            }
+        }
+        if self.budget.lane != self.lane || !self.budget.passed {
+            return Err(RunnerError::validation(
+                "evidence_budget",
+                "evidence lane must match a passing budget evaluation",
+            ));
+        }
+        for artifact in &self.artifacts {
+            if artifact.sha256.len() != 64
+                || !artifact
+                    .sha256
+                    .bytes()
+                    .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+            {
+                return Err(RunnerError::validation(
+                    "evidence_artifact_digest",
+                    "artifact digests must be lowercase SHA-256 values",
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    pub fn write_private(&self, path: &Path) -> Result<(), RunnerError> {
+        self.validate()?;
+        let bytes = serde_json::to_vec_pretty(self)
+            .map_err(|error| RunnerError::environment("evidence_serialize", error))?;
+        fs_private::write_private(path, &bytes)
+            .map_err(|error| RunnerError::environment("evidence_write", error))
+    }
+}

--- a/crates/convergence-campaign-runner/src/evidence.rs
+++ b/crates/convergence-campaign-runner/src/evidence.rs
@@ -1,7 +1,8 @@
 use std::collections::BTreeMap;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 use crate::{CampaignBudgetEvaluationV1, CampaignLaneV1, RunnerError};
 
@@ -66,6 +67,7 @@ impl ConvergenceEvidenceBundleV1 {
             ("tested_boundaries", self.tested_boundaries.is_empty()),
             ("residual_assumptions", self.residual_assumptions.is_empty()),
             ("untested_surfaces", self.untested_surfaces.is_empty()),
+            ("artifacts", self.artifacts.is_empty()),
         ] {
             if empty {
                 return Err(RunnerError::validation(
@@ -96,8 +98,50 @@ impl ConvergenceEvidenceBundleV1 {
         Ok(())
     }
 
-    pub fn write_private(&self, path: &Path) -> Result<(), RunnerError> {
+    /// Validate artifact paths and bind every declared digest to the bytes
+    /// present beside an ingested evidence bundle.
+    pub fn validate_artifacts(&self, base_dir: &Path) -> Result<(), RunnerError> {
         self.validate()?;
+        let canonical_base = std::fs::canonicalize(base_dir)
+            .map_err(|error| RunnerError::environment("evidence_artifact_base", error))?;
+        for artifact in &self.artifacts {
+            if artifact.path.as_os_str().is_empty()
+                || artifact.path.is_absolute()
+                || artifact.path.components().any(|component| {
+                    matches!(
+                        component,
+                        Component::ParentDir | Component::RootDir | Component::Prefix(_)
+                    )
+                })
+            {
+                return Err(RunnerError::validation(
+                    "evidence_artifact_path",
+                    "artifact paths must be nonempty relative paths without parent traversal",
+                ));
+            }
+            let canonical_path = std::fs::canonicalize(canonical_base.join(&artifact.path))
+                .map_err(|error| RunnerError::environment("evidence_artifact_read", error))?;
+            if !canonical_path.starts_with(&canonical_base) {
+                return Err(RunnerError::validation(
+                    "evidence_artifact_path",
+                    "artifact paths must remain within the evidence bundle directory",
+                ));
+            }
+            let bytes = std::fs::read(canonical_path)
+                .map_err(|error| RunnerError::environment("evidence_artifact_read", error))?;
+            let actual = hex::encode(Sha256::digest(bytes));
+            if actual != artifact.sha256 {
+                return Err(RunnerError::validation(
+                    "evidence_artifact_digest_mismatch",
+                    "artifact bytes do not match the declared SHA-256 digest",
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    pub fn write_private(&self, path: &Path) -> Result<(), RunnerError> {
+        self.validate_artifacts(path.parent().unwrap_or_else(|| Path::new(".")))?;
         let bytes = serde_json::to_vec_pretty(self)
             .map_err(|error| RunnerError::environment("evidence_serialize", error))?;
         fs_private::write_private(path, &bytes)

--- a/crates/convergence-campaign-runner/src/lane.rs
+++ b/crates/convergence-campaign-runner/src/lane.rs
@@ -62,8 +62,8 @@ pub struct CampaignLaneConfigV1 {
 pub struct CampaignLaneContentsV1 {
     pub strict_formal_gate: bool,
     pub fixed_vectors: bool,
-    /// Minimum aggregate case count required before an observation can attest
-    /// that this lane executed meaningful work.
+    /// Liveness floor proving that the lane executed some work. This is not a
+    /// substitute for capability-specific coverage recorded in evidence.
     pub minimum_executed_cases: u64,
     pub file_backed_storage: bool,
     pub crash_matrix: bool,
@@ -223,8 +223,7 @@ impl CampaignLaneConfigV1 {
         let flake_rate_basis_points = observation
             .flaky_cases
             .saturating_mul(10_000)
-            .checked_div(observation.executed_cases)
-            .unwrap_or_default();
+            .div_ceil(observation.executed_cases.max(1));
         check_limit(
             &mut violations,
             "flake_rate_basis_points",

--- a/crates/convergence-campaign-runner/src/lane.rs
+++ b/crates/convergence-campaign-runner/src/lane.rs
@@ -62,8 +62,9 @@ pub struct CampaignLaneConfigV1 {
 pub struct CampaignLaneContentsV1 {
     pub strict_formal_gate: bool,
     pub fixed_vectors: bool,
-    pub engine_reference_relay_cases: u32,
-    pub generated_seed_cases: u32,
+    /// Minimum aggregate case count required before an observation can attest
+    /// that this lane executed meaningful work.
+    pub minimum_executed_cases: u64,
     pub file_backed_storage: bool,
     pub crash_matrix: bool,
     pub retained_relays: bool,
@@ -119,127 +120,21 @@ pub struct CampaignBudgetEvaluationV1 {
 
 impl CampaignLaneConfigV1 {
     pub fn builtin(lane: CampaignLaneV1) -> Self {
-        const GIB: u64 = 1024 * 1024 * 1024;
-        let (contents, budgets) = match lane {
-            CampaignLaneV1::PullRequest => (
-                CampaignLaneContentsV1 {
-                    strict_formal_gate: true,
-                    fixed_vectors: true,
-                    engine_reference_relay_cases: 32,
-                    generated_seed_cases: 0,
-                    file_backed_storage: true,
-                    crash_matrix: false,
-                    retained_relays: true,
-                    mutation_scope: MutationScopeV1::Sentinel,
-                    process_campaigns: false,
-                    container_campaigns: false,
-                    resource_sweeps: false,
-                    constant_sweeps: false,
-                    mixed_version: false,
-                    incident_corpus: false,
-                },
-                CampaignLaneBudgetsV1 {
-                    max_wall_clock_seconds: 3_600,
-                    max_cpu_seconds: 7_200,
-                    max_peak_rss_bytes: 6 * GIB,
-                    max_disk_bytes: 12 * GIB,
-                    max_artifact_bytes: GIB,
-                    artifact_retention_days: 14,
-                    max_flake_retries: 0,
-                    max_flake_rate_basis_points: 0,
-                },
-            ),
-            CampaignLaneV1::Nightly => (
-                CampaignLaneContentsV1 {
-                    strict_formal_gate: true,
-                    fixed_vectors: true,
-                    engine_reference_relay_cases: 256,
-                    generated_seed_cases: 256,
-                    file_backed_storage: true,
-                    crash_matrix: true,
-                    retained_relays: true,
-                    mutation_scope: MutationScopeV1::Targeted,
-                    process_campaigns: true,
-                    container_campaigns: true,
-                    resource_sweeps: false,
-                    constant_sweeps: false,
-                    mixed_version: false,
-                    incident_corpus: true,
-                },
-                CampaignLaneBudgetsV1 {
-                    max_wall_clock_seconds: 7_200,
-                    max_cpu_seconds: 14_400,
-                    max_peak_rss_bytes: 8 * GIB,
-                    max_disk_bytes: 20 * GIB,
-                    max_artifact_bytes: 5 * GIB,
-                    artifact_retention_days: 30,
-                    max_flake_retries: 1,
-                    max_flake_rate_basis_points: 50,
-                },
-            ),
-            CampaignLaneV1::WeeklyManual => (
-                CampaignLaneContentsV1 {
-                    strict_formal_gate: true,
-                    fixed_vectors: true,
-                    engine_reference_relay_cases: 1_024,
-                    generated_seed_cases: 4_096,
-                    file_backed_storage: true,
-                    crash_matrix: true,
-                    retained_relays: true,
-                    mutation_scope: MutationScopeV1::FullTargeted,
-                    process_campaigns: true,
-                    container_campaigns: true,
-                    resource_sweeps: true,
-                    constant_sweeps: true,
-                    mixed_version: true,
-                    incident_corpus: true,
-                },
-                CampaignLaneBudgetsV1 {
-                    max_wall_clock_seconds: 21_600,
-                    max_cpu_seconds: 43_200,
-                    max_peak_rss_bytes: 12 * GIB,
-                    max_disk_bytes: 40 * GIB,
-                    max_artifact_bytes: 10 * GIB,
-                    artifact_retention_days: 60,
-                    max_flake_retries: 2,
-                    max_flake_rate_basis_points: 25,
-                },
-            ),
-            CampaignLaneV1::ReleaseHardening => (
-                CampaignLaneContentsV1 {
-                    strict_formal_gate: true,
-                    fixed_vectors: true,
-                    engine_reference_relay_cases: 2_048,
-                    generated_seed_cases: 8_192,
-                    file_backed_storage: true,
-                    crash_matrix: true,
-                    retained_relays: true,
-                    mutation_scope: MutationScopeV1::FullTargeted,
-                    process_campaigns: true,
-                    container_campaigns: true,
-                    resource_sweeps: true,
-                    constant_sweeps: true,
-                    mixed_version: true,
-                    incident_corpus: true,
-                },
-                CampaignLaneBudgetsV1 {
-                    max_wall_clock_seconds: 28_800,
-                    max_cpu_seconds: 57_600,
-                    max_peak_rss_bytes: 12 * GIB,
-                    max_disk_bytes: 50 * GIB,
-                    max_artifact_bytes: 15 * GIB,
-                    artifact_retention_days: 180,
-                    max_flake_retries: 1,
-                    max_flake_rate_basis_points: 10,
-                },
-            ),
+        let json = match lane {
+            CampaignLaneV1::PullRequest => include_str!("../lanes/pull-request.v1.json"),
+            CampaignLaneV1::Nightly => include_str!("../lanes/nightly.v1.json"),
+            CampaignLaneV1::WeeklyManual => include_str!("../lanes/weekly-manual.v1.json"),
+            CampaignLaneV1::ReleaseHardening => {
+                include_str!("../lanes/release-hardening.v1.json")
+            }
         };
-        Self {
-            schema_version: CAMPAIGN_LANE_SCHEMA_VERSION.into(),
-            lane,
-            contents,
-            budgets,
-        }
+        let config: Self =
+            serde_json::from_str(json).expect("tracked campaign lane manifest must be valid JSON");
+        assert_eq!(config.lane, lane, "tracked campaign lane manifest mismatch");
+        config
+            .validate()
+            .expect("tracked campaign lane manifest must satisfy policy invariants");
+        config
     }
 
     pub fn validate(&self) -> Result<(), RunnerError> {
@@ -249,11 +144,24 @@ impl CampaignLaneConfigV1 {
                 "unsupported campaign lane schema version",
             ));
         }
-        let expected = Self::builtin(self.lane);
-        if self != &expected {
+        if self.contents.minimum_executed_cases == 0 {
             return Err(RunnerError::validation(
-                "campaign_lane_drift",
-                "tracked lane configuration differs from the reviewed built-in policy",
+                "campaign_lane_cases",
+                "campaign lane must require at least one executed case",
+            ));
+        }
+        let budgets = &self.budgets;
+        if budgets.max_wall_clock_seconds == 0
+            || budgets.max_cpu_seconds == 0
+            || budgets.max_peak_rss_bytes == 0
+            || budgets.max_disk_bytes == 0
+            || budgets.max_artifact_bytes == 0
+            || budgets.artifact_retention_days == 0
+            || budgets.max_flake_rate_basis_points > 10_000
+        {
+            return Err(RunnerError::validation(
+                "campaign_lane_budget",
+                "campaign lane budgets must be nonzero and the flake rate must not exceed 10000 basis points",
             ));
         }
         Ok(())
@@ -298,11 +206,25 @@ impl CampaignLaneConfigV1 {
             observation.flake_retries,
             u64::from(budget.max_flake_retries),
         );
+        if observation.executed_cases == 0 {
+            violations.push("executed_cases:0".into());
+        } else if observation.executed_cases < self.contents.minimum_executed_cases {
+            violations.push(format!(
+                "executed_cases:{}<{}",
+                observation.executed_cases, self.contents.minimum_executed_cases
+            ));
+        }
+        if observation.flaky_cases > observation.executed_cases {
+            violations.push(format!(
+                "flaky_cases:{}>{}",
+                observation.flaky_cases, observation.executed_cases
+            ));
+        }
         let flake_rate_basis_points = observation
             .flaky_cases
             .saturating_mul(10_000)
             .checked_div(observation.executed_cases)
-            .unwrap_or(0);
+            .unwrap_or_default();
         check_limit(
             &mut violations,
             "flake_rate_basis_points",

--- a/crates/convergence-campaign-runner/src/lane.rs
+++ b/crates/convergence-campaign-runner/src/lane.rs
@@ -1,0 +1,326 @@
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+use crate::RunnerError;
+
+pub const CAMPAIGN_LANE_SCHEMA_VERSION: &str = "1";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CampaignLaneV1 {
+    PullRequest,
+    Nightly,
+    WeeklyManual,
+    ReleaseHardening,
+}
+
+impl CampaignLaneV1 {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::PullRequest => "pull_request",
+            Self::Nightly => "nightly",
+            Self::WeeklyManual => "weekly_manual",
+            Self::ReleaseHardening => "release_hardening",
+        }
+    }
+}
+
+impl fmt::Display for CampaignLaneV1 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for CampaignLaneV1 {
+    type Err = RunnerError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "pull_request" | "pr" => Ok(Self::PullRequest),
+            "nightly" => Ok(Self::Nightly),
+            "weekly_manual" | "weekly" => Ok(Self::WeeklyManual),
+            "release_hardening" | "release" => Ok(Self::ReleaseHardening),
+            _ => Err(RunnerError::validation(
+                "campaign_lane",
+                "lane must be pull_request, nightly, weekly_manual, or release_hardening",
+            )),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CampaignLaneConfigV1 {
+    pub schema_version: String,
+    pub lane: CampaignLaneV1,
+    pub contents: CampaignLaneContentsV1,
+    pub budgets: CampaignLaneBudgetsV1,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CampaignLaneContentsV1 {
+    pub strict_formal_gate: bool,
+    pub fixed_vectors: bool,
+    pub engine_reference_relay_cases: u32,
+    pub generated_seed_cases: u32,
+    pub file_backed_storage: bool,
+    pub crash_matrix: bool,
+    pub retained_relays: bool,
+    pub mutation_scope: MutationScopeV1,
+    pub process_campaigns: bool,
+    pub container_campaigns: bool,
+    pub resource_sweeps: bool,
+    pub constant_sweeps: bool,
+    pub mixed_version: bool,
+    pub incident_corpus: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MutationScopeV1 {
+    Sentinel,
+    Targeted,
+    FullTargeted,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CampaignLaneBudgetsV1 {
+    pub max_wall_clock_seconds: u64,
+    pub max_cpu_seconds: u64,
+    pub max_peak_rss_bytes: u64,
+    pub max_disk_bytes: u64,
+    pub max_artifact_bytes: u64,
+    pub artifact_retention_days: u16,
+    pub max_flake_retries: u8,
+    pub max_flake_rate_basis_points: u16,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CampaignLaneObservationV1 {
+    pub wall_clock_seconds: u64,
+    pub cpu_seconds: u64,
+    pub peak_rss_bytes: u64,
+    pub disk_bytes: u64,
+    pub artifact_bytes: u64,
+    pub executed_cases: u64,
+    pub flaky_cases: u64,
+    pub flake_retries: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CampaignBudgetEvaluationV1 {
+    pub lane: CampaignLaneV1,
+    pub observation: CampaignLaneObservationV1,
+    pub flake_rate_basis_points: u64,
+    pub violations: Vec<String>,
+    pub passed: bool,
+}
+
+impl CampaignLaneConfigV1 {
+    pub fn builtin(lane: CampaignLaneV1) -> Self {
+        const GIB: u64 = 1024 * 1024 * 1024;
+        let (contents, budgets) = match lane {
+            CampaignLaneV1::PullRequest => (
+                CampaignLaneContentsV1 {
+                    strict_formal_gate: true,
+                    fixed_vectors: true,
+                    engine_reference_relay_cases: 32,
+                    generated_seed_cases: 0,
+                    file_backed_storage: true,
+                    crash_matrix: false,
+                    retained_relays: true,
+                    mutation_scope: MutationScopeV1::Sentinel,
+                    process_campaigns: false,
+                    container_campaigns: false,
+                    resource_sweeps: false,
+                    constant_sweeps: false,
+                    mixed_version: false,
+                    incident_corpus: false,
+                },
+                CampaignLaneBudgetsV1 {
+                    max_wall_clock_seconds: 3_600,
+                    max_cpu_seconds: 7_200,
+                    max_peak_rss_bytes: 6 * GIB,
+                    max_disk_bytes: 12 * GIB,
+                    max_artifact_bytes: GIB,
+                    artifact_retention_days: 14,
+                    max_flake_retries: 0,
+                    max_flake_rate_basis_points: 0,
+                },
+            ),
+            CampaignLaneV1::Nightly => (
+                CampaignLaneContentsV1 {
+                    strict_formal_gate: true,
+                    fixed_vectors: true,
+                    engine_reference_relay_cases: 256,
+                    generated_seed_cases: 256,
+                    file_backed_storage: true,
+                    crash_matrix: true,
+                    retained_relays: true,
+                    mutation_scope: MutationScopeV1::Targeted,
+                    process_campaigns: true,
+                    container_campaigns: true,
+                    resource_sweeps: false,
+                    constant_sweeps: false,
+                    mixed_version: false,
+                    incident_corpus: true,
+                },
+                CampaignLaneBudgetsV1 {
+                    max_wall_clock_seconds: 7_200,
+                    max_cpu_seconds: 14_400,
+                    max_peak_rss_bytes: 8 * GIB,
+                    max_disk_bytes: 20 * GIB,
+                    max_artifact_bytes: 5 * GIB,
+                    artifact_retention_days: 30,
+                    max_flake_retries: 1,
+                    max_flake_rate_basis_points: 50,
+                },
+            ),
+            CampaignLaneV1::WeeklyManual => (
+                CampaignLaneContentsV1 {
+                    strict_formal_gate: true,
+                    fixed_vectors: true,
+                    engine_reference_relay_cases: 1_024,
+                    generated_seed_cases: 4_096,
+                    file_backed_storage: true,
+                    crash_matrix: true,
+                    retained_relays: true,
+                    mutation_scope: MutationScopeV1::FullTargeted,
+                    process_campaigns: true,
+                    container_campaigns: true,
+                    resource_sweeps: true,
+                    constant_sweeps: true,
+                    mixed_version: true,
+                    incident_corpus: true,
+                },
+                CampaignLaneBudgetsV1 {
+                    max_wall_clock_seconds: 21_600,
+                    max_cpu_seconds: 43_200,
+                    max_peak_rss_bytes: 12 * GIB,
+                    max_disk_bytes: 40 * GIB,
+                    max_artifact_bytes: 10 * GIB,
+                    artifact_retention_days: 60,
+                    max_flake_retries: 2,
+                    max_flake_rate_basis_points: 25,
+                },
+            ),
+            CampaignLaneV1::ReleaseHardening => (
+                CampaignLaneContentsV1 {
+                    strict_formal_gate: true,
+                    fixed_vectors: true,
+                    engine_reference_relay_cases: 2_048,
+                    generated_seed_cases: 8_192,
+                    file_backed_storage: true,
+                    crash_matrix: true,
+                    retained_relays: true,
+                    mutation_scope: MutationScopeV1::FullTargeted,
+                    process_campaigns: true,
+                    container_campaigns: true,
+                    resource_sweeps: true,
+                    constant_sweeps: true,
+                    mixed_version: true,
+                    incident_corpus: true,
+                },
+                CampaignLaneBudgetsV1 {
+                    max_wall_clock_seconds: 28_800,
+                    max_cpu_seconds: 57_600,
+                    max_peak_rss_bytes: 12 * GIB,
+                    max_disk_bytes: 50 * GIB,
+                    max_artifact_bytes: 15 * GIB,
+                    artifact_retention_days: 180,
+                    max_flake_retries: 1,
+                    max_flake_rate_basis_points: 10,
+                },
+            ),
+        };
+        Self {
+            schema_version: CAMPAIGN_LANE_SCHEMA_VERSION.into(),
+            lane,
+            contents,
+            budgets,
+        }
+    }
+
+    pub fn validate(&self) -> Result<(), RunnerError> {
+        if self.schema_version != CAMPAIGN_LANE_SCHEMA_VERSION {
+            return Err(RunnerError::validation(
+                "campaign_lane_version",
+                "unsupported campaign lane schema version",
+            ));
+        }
+        let expected = Self::builtin(self.lane);
+        if self != &expected {
+            return Err(RunnerError::validation(
+                "campaign_lane_drift",
+                "tracked lane configuration differs from the reviewed built-in policy",
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn evaluate(&self, observation: CampaignLaneObservationV1) -> CampaignBudgetEvaluationV1 {
+        let mut violations = Vec::new();
+        let budget = &self.budgets;
+        check_limit(
+            &mut violations,
+            "wall_clock_seconds",
+            observation.wall_clock_seconds,
+            budget.max_wall_clock_seconds,
+        );
+        check_limit(
+            &mut violations,
+            "cpu_seconds",
+            observation.cpu_seconds,
+            budget.max_cpu_seconds,
+        );
+        check_limit(
+            &mut violations,
+            "peak_rss_bytes",
+            observation.peak_rss_bytes,
+            budget.max_peak_rss_bytes,
+        );
+        check_limit(
+            &mut violations,
+            "disk_bytes",
+            observation.disk_bytes,
+            budget.max_disk_bytes,
+        );
+        check_limit(
+            &mut violations,
+            "artifact_bytes",
+            observation.artifact_bytes,
+            budget.max_artifact_bytes,
+        );
+        check_limit(
+            &mut violations,
+            "flake_retries",
+            observation.flake_retries,
+            u64::from(budget.max_flake_retries),
+        );
+        let flake_rate_basis_points = observation
+            .flaky_cases
+            .saturating_mul(10_000)
+            .checked_div(observation.executed_cases)
+            .unwrap_or(0);
+        check_limit(
+            &mut violations,
+            "flake_rate_basis_points",
+            flake_rate_basis_points,
+            u64::from(budget.max_flake_rate_basis_points),
+        );
+        CampaignBudgetEvaluationV1 {
+            lane: self.lane,
+            observation,
+            flake_rate_basis_points,
+            passed: violations.is_empty(),
+            violations,
+        }
+    }
+}
+
+fn check_limit(violations: &mut Vec<String>, name: &str, observed: u64, limit: u64) {
+    if observed > limit {
+        violations.push(format!("{name}:{observed}>{limit}"));
+    }
+}

--- a/crates/convergence-campaign-runner/src/lib.rs
+++ b/crates/convergence-campaign-runner/src/lib.rs
@@ -5,10 +5,14 @@ use std::path::Path;
 
 use sha2::Digest;
 
+pub mod evidence;
+pub mod lane;
 pub mod manifest;
 pub mod plan;
 pub mod runner;
 
+pub use evidence::*;
+pub use lane::*;
 pub use manifest::*;
 pub use plan::*;
 pub use runner::*;

--- a/crates/convergence-campaign-runner/src/main.rs
+++ b/crates/convergence-campaign-runner/src/main.rs
@@ -4,8 +4,9 @@ use std::process::{ExitCode, Stdio};
 use clap::{Parser, Subcommand};
 use convergence_campaign_runner::{
     CampaignLaneConfigV1, CampaignLaneObservationV1, CampaignLaneV1, ConvergenceEvidenceBundleV1,
-    DistributedBackendV1, INFRASTRUCTURE_COMMAND_TIMEOUT, build_execution_plan, load_manifest,
-    run_manifest, validate_scenario_bytes, verify_manifest_inputs,
+    DistributedBackendV1, INFRASTRUCTURE_COMMAND_TIMEOUT, build_execution_plan,
+    evidence_bundle_base_dir, load_manifest, run_manifest, validate_scenario_bytes,
+    verify_manifest_inputs,
 };
 use tokio::process::Command;
 use tokio::time::timeout;
@@ -161,9 +162,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         Commands::CheckEvidence {
             bundle: bundle_path,
         } => {
-            let base_dir = bundle_path
-                .parent()
-                .unwrap_or_else(|| std::path::Path::new("."));
+            let base_dir = evidence_bundle_base_dir(&bundle_path);
             let bundle: ConvergenceEvidenceBundleV1 =
                 serde_json::from_slice(&std::fs::read(&bundle_path)?)?;
             bundle.validate_artifacts(base_dir)?;

--- a/crates/convergence-campaign-runner/src/main.rs
+++ b/crates/convergence-campaign-runner/src/main.rs
@@ -3,6 +3,7 @@ use std::process::{ExitCode, Stdio};
 
 use clap::{Parser, Subcommand};
 use convergence_campaign_runner::{
+    CampaignLaneConfigV1, CampaignLaneObservationV1, CampaignLaneV1, ConvergenceEvidenceBundleV1,
     DistributedBackendV1, INFRASTRUCTURE_COMMAND_TIMEOUT, build_execution_plan, load_manifest,
     run_manifest, validate_scenario_bytes, verify_manifest_inputs,
 };
@@ -31,6 +32,21 @@ enum Commands {
     Doctor { manifest: PathBuf },
     /// Execute the campaign and write owner-only reports under output_dir.
     Run { manifest: PathBuf },
+    /// Print or privately write the reviewed policy for an execution lane.
+    Lane {
+        lane: String,
+        #[arg(long)]
+        output: Option<PathBuf>,
+    },
+    /// Fail when observed campaign usage exceeds the selected lane budget.
+    CheckBudget {
+        lane: String,
+        observation: PathBuf,
+        #[arg(long)]
+        output: Option<PathBuf>,
+    },
+    /// Validate that an evidence bundle contains every required assurance section.
+    CheckEvidence { bundle: PathBuf },
 }
 
 #[tokio::main]
@@ -101,6 +117,41 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
                 return Err("campaign did not complete; inspect private run artifacts".into());
             }
             println!("completed {}", receipt.campaign_id);
+        }
+        Commands::Lane { lane, output } => {
+            let lane = lane.parse::<CampaignLaneV1>()?;
+            let config = CampaignLaneConfigV1::builtin(lane);
+            let bytes = serde_json::to_vec_pretty(&config)?;
+            if let Some(path) = output {
+                fs_private::write_private(&path, &bytes)?;
+            } else {
+                println!("{}", String::from_utf8(bytes)?);
+            }
+        }
+        Commands::CheckBudget {
+            lane,
+            observation,
+            output,
+        } => {
+            let lane = lane.parse::<CampaignLaneV1>()?;
+            let observed: CampaignLaneObservationV1 =
+                serde_json::from_slice(&std::fs::read(observation)?)?;
+            let evaluation = CampaignLaneConfigV1::builtin(lane).evaluate(observed);
+            let bytes = serde_json::to_vec_pretty(&evaluation)?;
+            if let Some(path) = output {
+                fs_private::write_private(&path, &bytes)?;
+            } else {
+                println!("{}", String::from_utf8(bytes)?);
+            }
+            if !evaluation.passed {
+                return Err("campaign exceeded its reviewed lane budget".into());
+            }
+        }
+        Commands::CheckEvidence { bundle } => {
+            let bundle: ConvergenceEvidenceBundleV1 =
+                serde_json::from_slice(&std::fs::read(bundle)?)?;
+            bundle.validate()?;
+            println!("valid-evidence {}", bundle.source_revision);
         }
     }
     Ok(())

--- a/crates/convergence-campaign-runner/src/main.rs
+++ b/crates/convergence-campaign-runner/src/main.rs
@@ -40,13 +40,13 @@ enum Commands {
     Run { manifest: PathBuf },
     /// Print or privately write the reviewed policy for an execution lane.
     Lane {
-        lane: String,
+        lane: CampaignLaneV1,
         #[arg(long)]
         output: Option<PathBuf>,
     },
     /// Fail when observed campaign usage exceeds the selected lane budget.
     CheckBudget {
-        lane: String,
+        lane: CampaignLaneV1,
         observation: PathBuf,
         #[arg(long)]
         output: Option<PathBuf>,
@@ -131,7 +131,6 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
             println!("completed {}", receipt.campaign_id);
         }
         Commands::Lane { lane, output } => {
-            let lane = lane.parse::<CampaignLaneV1>()?;
             let config = CampaignLaneConfigV1::builtin(lane);
             let bytes = serde_json::to_vec_pretty(&config)?;
             if let Some(path) = output {
@@ -145,7 +144,6 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
             observation,
             output,
         } => {
-            let lane = lane.parse::<CampaignLaneV1>()?;
             let observed: CampaignLaneObservationV1 =
                 serde_json::from_slice(&std::fs::read(observation)?)?;
             let evaluation = CampaignLaneConfigV1::builtin(lane).evaluate(observed);

--- a/crates/convergence-campaign-runner/src/main.rs
+++ b/crates/convergence-campaign-runner/src/main.rs
@@ -21,7 +21,12 @@ struct Cli {
 #[derive(Debug, Subcommand)]
 enum Commands {
     /// Validate the manifest and pinned scenario bytes without side effects.
-    Validate { manifest: PathBuf },
+    Validate {
+        manifest: PathBuf,
+        /// Require at least two participant builds and effective container images.
+        #[arg(long)]
+        require_mixed_builds: bool,
+    },
     /// Print or privately write the exact argv execution plan.
     Plan {
         manifest: PathBuf,
@@ -63,8 +68,14 @@ async fn main() -> ExitCode {
 async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
     match cli.command {
-        Commands::Validate { manifest } => {
+        Commands::Validate {
+            manifest,
+            require_mixed_builds,
+        } => {
             let manifest = load_manifest(&manifest)?;
+            if require_mixed_builds {
+                manifest.validate_mixed_builds()?;
+            }
             let scenario = verify_manifest_inputs(&manifest)?;
             validate_scenario_bytes(&manifest, &scenario)?;
             println!("valid {}", manifest.campaign_id);
@@ -147,10 +158,15 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
                 return Err("campaign exceeded its reviewed lane budget".into());
             }
         }
-        Commands::CheckEvidence { bundle } => {
+        Commands::CheckEvidence {
+            bundle: bundle_path,
+        } => {
+            let base_dir = bundle_path
+                .parent()
+                .unwrap_or_else(|| std::path::Path::new("."));
             let bundle: ConvergenceEvidenceBundleV1 =
-                serde_json::from_slice(&std::fs::read(bundle)?)?;
-            bundle.validate()?;
+                serde_json::from_slice(&std::fs::read(&bundle_path)?)?;
+            bundle.validate_artifacts(base_dir)?;
             println!("valid-evidence {}", bundle.source_revision);
         }
     }

--- a/crates/convergence-campaign-runner/src/manifest.rs
+++ b/crates/convergence-campaign-runner/src/manifest.rs
@@ -366,6 +366,42 @@ impl DistributedCampaignManifestV1 {
         Ok(())
     }
 
+    /// Apply the additional release-hardening contract that at least two
+    /// participant builds, and for containers two effective images, are used.
+    pub fn validate_mixed_builds(&self) -> Result<(), RunnerError> {
+        self.validate()?;
+        let build_ids = self
+            .participants
+            .iter()
+            .map(|participant| participant.build_id.as_str())
+            .collect::<BTreeSet<_>>();
+        if build_ids.len() < 2 {
+            return Err(RunnerError::validation(
+                "mixed_build_ids",
+                "mixed-build campaigns require at least two participant build ids",
+            ));
+        }
+        if let DistributedBackendV1::Container(container) = &self.backend {
+            let images = self
+                .participants
+                .iter()
+                .map(|participant| {
+                    participant
+                        .container_image
+                        .as_deref()
+                        .unwrap_or(&container.default_participant_image)
+                })
+                .collect::<BTreeSet<_>>();
+            if images.len() < 2 {
+                return Err(RunnerError::validation(
+                    "mixed_build_images",
+                    "mixed-build container campaigns require at least two effective participant images",
+                ));
+            }
+        }
+        Ok(())
+    }
+
     pub fn required_vm_capabilities(&self) -> BTreeSet<VirtualMachineCapabilityV1> {
         self.faults
             .iter()

--- a/crates/convergence-campaign-runner/tests/distributed_runner.rs
+++ b/crates/convergence-campaign-runner/tests/distributed_runner.rs
@@ -413,6 +413,25 @@ fn mutable_container_images_require_an_explicit_local_opt_out() {
 }
 
 #[test]
+fn release_mixed_build_validation_requires_distinct_builds_and_images() {
+    let (_root, mut manifest) = container_manifest();
+    manifest.validate_mixed_builds().unwrap();
+
+    manifest.participants[1].build_id = manifest.participants[0].build_id.clone();
+    assert_eq!(
+        manifest.validate_mixed_builds().unwrap_err().code,
+        "mixed_build_ids"
+    );
+
+    manifest.participants[1].build_id = "previous".into();
+    manifest.participants[1].container_image = None;
+    assert_eq!(
+        manifest.validate_mixed_builds().unwrap_err().code,
+        "mixed_build_images"
+    );
+}
+
+#[test]
 fn faults_sharing_a_barrier_keep_distinct_compensation_boundaries() {
     let (_root, mut manifest) = container_manifest();
     manifest.faults = vec![

--- a/crates/convergence-campaign-runner/tests/lane_policy.rs
+++ b/crates/convergence-campaign-runner/tests/lane_policy.rs
@@ -119,6 +119,16 @@ fn release_evidence_requires_scoped_coverage_and_a_passing_budget() {
     bundle
         .write_private(&temp.path().join("evidence.json"))
         .unwrap();
+    let cli = std::process::Command::new(env!("CARGO_BIN_EXE_cgka-distributed-campaign"))
+        .current_dir(temp.path())
+        .args(["check-evidence", "evidence.json"])
+        .output()
+        .unwrap();
+    assert!(
+        cli.status.success(),
+        "bare bundle filename failed: {}",
+        String::from_utf8_lossy(&cli.stderr)
+    );
 
     let mut missing_artifacts = bundle.clone();
     missing_artifacts.artifacts.clear();

--- a/crates/convergence-campaign-runner/tests/lane_policy.rs
+++ b/crates/convergence-campaign-runner/tests/lane_policy.rs
@@ -64,6 +64,24 @@ fn budget_evaluation_rejects_empty_and_inconsistent_observations() {
 }
 
 #[test]
+fn zero_flake_budget_rejects_any_nonzero_flake_rate() {
+    let config = CampaignLaneConfigV1::builtin(CampaignLaneV1::PullRequest);
+    let evaluation = config.evaluate(CampaignLaneObservationV1 {
+        executed_cases: 10_001,
+        flaky_cases: 1,
+        ..CampaignLaneObservationV1::default()
+    });
+    assert_eq!(evaluation.flake_rate_basis_points, 1);
+    assert!(!evaluation.passed);
+    assert!(
+        evaluation
+            .violations
+            .iter()
+            .any(|violation| violation == "flake_rate_basis_points:1>0")
+    );
+}
+
+#[test]
 fn budget_evaluation_reports_every_exceeded_dimension() {
     let config = CampaignLaneConfigV1::builtin(CampaignLaneV1::PullRequest);
     let evaluation = config.evaluate(CampaignLaneObservationV1 {
@@ -143,6 +161,12 @@ fn release_evidence_requires_scoped_coverage_and_a_passing_budget() {
         "evidence_artifact_digest_mismatch"
     );
     bundle.artifacts[0].sha256 = hex::encode(Sha256::digest(artifact_bytes));
+    let mut traversal = bundle.clone();
+    traversal.artifacts[0].path = "../process.json".into();
+    assert_eq!(
+        traversal.validate_artifacts(temp.path()).unwrap_err().code,
+        "evidence_artifact_path"
+    );
     bundle.untested_surfaces.clear();
     assert_eq!(
         bundle.validate().unwrap_err().code,

--- a/crates/convergence-campaign-runner/tests/lane_policy.rs
+++ b/crates/convergence-campaign-runner/tests/lane_policy.rs
@@ -1,0 +1,100 @@
+use std::collections::BTreeMap;
+
+use convergence_campaign_runner::{
+    CampaignLaneConfigV1, CampaignLaneObservationV1, CampaignLaneV1, ConvergenceEvidenceBundleV1,
+    EvidenceArtifactV1, TestedBoundaryV1,
+};
+
+const TRACKED_LANES: &[(CampaignLaneV1, &str)] = &[
+    (
+        CampaignLaneV1::PullRequest,
+        include_str!("../lanes/pull-request.v1.json"),
+    ),
+    (
+        CampaignLaneV1::Nightly,
+        include_str!("../lanes/nightly.v1.json"),
+    ),
+    (
+        CampaignLaneV1::WeeklyManual,
+        include_str!("../lanes/weekly-manual.v1.json"),
+    ),
+    (
+        CampaignLaneV1::ReleaseHardening,
+        include_str!("../lanes/release-hardening.v1.json"),
+    ),
+];
+
+#[test]
+fn tracked_lane_manifests_equal_the_reviewed_builtin_policy() {
+    for (lane, json) in TRACKED_LANES {
+        let tracked: CampaignLaneConfigV1 = serde_json::from_str(json).unwrap();
+        tracked.validate().unwrap();
+        assert_eq!(tracked, CampaignLaneConfigV1::builtin(*lane));
+    }
+}
+
+#[test]
+fn every_lane_has_all_resource_retention_and_flake_budgets() {
+    for (lane, _) in TRACKED_LANES {
+        let config = CampaignLaneConfigV1::builtin(*lane);
+        assert!(config.budgets.max_wall_clock_seconds > 0);
+        assert!(config.budgets.max_cpu_seconds > 0);
+        assert!(config.budgets.max_peak_rss_bytes > 0);
+        assert!(config.budgets.max_disk_bytes > 0);
+        assert!(config.budgets.max_artifact_bytes > 0);
+        assert!(config.budgets.artifact_retention_days > 0);
+        assert!(config.budgets.max_flake_rate_basis_points <= 10_000);
+    }
+}
+
+#[test]
+fn budget_evaluation_reports_every_exceeded_dimension() {
+    let config = CampaignLaneConfigV1::builtin(CampaignLaneV1::PullRequest);
+    let evaluation = config.evaluate(CampaignLaneObservationV1 {
+        wall_clock_seconds: config.budgets.max_wall_clock_seconds + 1,
+        cpu_seconds: config.budgets.max_cpu_seconds + 1,
+        peak_rss_bytes: config.budgets.max_peak_rss_bytes + 1,
+        disk_bytes: config.budgets.max_disk_bytes + 1,
+        artifact_bytes: config.budgets.max_artifact_bytes + 1,
+        executed_cases: 1,
+        flaky_cases: 1,
+        flake_retries: 1,
+    });
+    assert!(!evaluation.passed);
+    assert_eq!(evaluation.violations.len(), 7);
+}
+
+#[test]
+fn release_evidence_requires_scoped_coverage_and_a_passing_budget() {
+    let config = CampaignLaneConfigV1::builtin(CampaignLaneV1::ReleaseHardening);
+    let mut bundle = ConvergenceEvidenceBundleV1 {
+        schema_version: "1".into(),
+        lane: CampaignLaneV1::ReleaseHardening,
+        source_revision: "0123456789abcdef".into(),
+        assurance_claim: "The declared routes agree within the recorded boundaries.".into(),
+        covered_decision_routes: vec!["ordinary_ingest".into()],
+        models: vec!["independent_selector".into()],
+        adapters: vec!["engine".into(), "distributed".into()],
+        mutation_results: BTreeMap::from([("inconsistent_decision_seam".into(), true)]),
+        tested_boundaries: vec![TestedBoundaryV1 {
+            dimension: "participants".into(),
+            minimum: "2".into(),
+            maximum: "64".into(),
+        }],
+        unresolved_counterexamples: Vec::new(),
+        residual_assumptions: vec!["eventual input-set equality".into()],
+        untested_surfaces: vec!["unbounded executions".into()],
+        budget: config.evaluate(CampaignLaneObservationV1::default()),
+        artifacts: vec![EvidenceArtifactV1 {
+            kind: "process_report".into(),
+            path: "reports/process.json".into(),
+            sha256: "0".repeat(64),
+        }],
+    };
+    bundle.validate().unwrap();
+    bundle.untested_surfaces.clear();
+    assert_eq!(
+        bundle.validate().unwrap_err().code,
+        "incomplete_evidence_bundle"
+    );
+}

--- a/crates/convergence-campaign-runner/tests/lane_policy.rs
+++ b/crates/convergence-campaign-runner/tests/lane_policy.rs
@@ -4,39 +4,29 @@ use convergence_campaign_runner::{
     CampaignLaneConfigV1, CampaignLaneObservationV1, CampaignLaneV1, ConvergenceEvidenceBundleV1,
     EvidenceArtifactV1, TestedBoundaryV1,
 };
+use sha2::{Digest, Sha256};
 
-const TRACKED_LANES: &[(CampaignLaneV1, &str)] = &[
-    (
-        CampaignLaneV1::PullRequest,
-        include_str!("../lanes/pull-request.v1.json"),
-    ),
-    (
-        CampaignLaneV1::Nightly,
-        include_str!("../lanes/nightly.v1.json"),
-    ),
-    (
-        CampaignLaneV1::WeeklyManual,
-        include_str!("../lanes/weekly-manual.v1.json"),
-    ),
-    (
-        CampaignLaneV1::ReleaseHardening,
-        include_str!("../lanes/release-hardening.v1.json"),
-    ),
+const LANES: &[CampaignLaneV1] = &[
+    CampaignLaneV1::PullRequest,
+    CampaignLaneV1::Nightly,
+    CampaignLaneV1::WeeklyManual,
+    CampaignLaneV1::ReleaseHardening,
 ];
 
 #[test]
-fn tracked_lane_manifests_equal_the_reviewed_builtin_policy() {
-    for (lane, json) in TRACKED_LANES {
-        let tracked: CampaignLaneConfigV1 = serde_json::from_str(json).unwrap();
-        tracked.validate().unwrap();
-        assert_eq!(tracked, CampaignLaneConfigV1::builtin(*lane));
+fn tracked_lane_manifests_are_the_reviewed_builtin_policy() {
+    for lane in LANES {
+        let config = CampaignLaneConfigV1::builtin(*lane);
+        config.validate().unwrap();
+        assert_eq!(config.lane, *lane);
     }
 }
 
 #[test]
 fn every_lane_has_all_resource_retention_and_flake_budgets() {
-    for (lane, _) in TRACKED_LANES {
+    for lane in LANES {
         let config = CampaignLaneConfigV1::builtin(*lane);
+        assert!(config.contents.minimum_executed_cases > 0);
         assert!(config.budgets.max_wall_clock_seconds > 0);
         assert!(config.budgets.max_cpu_seconds > 0);
         assert!(config.budgets.max_peak_rss_bytes > 0);
@@ -45,6 +35,32 @@ fn every_lane_has_all_resource_retention_and_flake_budgets() {
         assert!(config.budgets.artifact_retention_days > 0);
         assert!(config.budgets.max_flake_rate_basis_points <= 10_000);
     }
+}
+
+#[test]
+fn budget_evaluation_rejects_empty_and_inconsistent_observations() {
+    let config = CampaignLaneConfigV1::builtin(CampaignLaneV1::WeeklyManual);
+    let empty = config.evaluate(CampaignLaneObservationV1::default());
+    assert!(!empty.passed);
+    assert!(
+        empty
+            .violations
+            .iter()
+            .any(|violation| violation == "executed_cases:0")
+    );
+
+    let inconsistent = config.evaluate(CampaignLaneObservationV1 {
+        executed_cases: config.contents.minimum_executed_cases,
+        flaky_cases: config.contents.minimum_executed_cases + 1,
+        ..CampaignLaneObservationV1::default()
+    });
+    assert!(!inconsistent.passed);
+    assert!(
+        inconsistent
+            .violations
+            .iter()
+            .any(|violation| violation.starts_with("flaky_cases:"))
+    );
 }
 
 #[test]
@@ -67,6 +83,10 @@ fn budget_evaluation_reports_every_exceeded_dimension() {
 #[test]
 fn release_evidence_requires_scoped_coverage_and_a_passing_budget() {
     let config = CampaignLaneConfigV1::builtin(CampaignLaneV1::ReleaseHardening);
+    let temp = tempfile::tempdir().unwrap();
+    let artifact_bytes = b"process report";
+    std::fs::create_dir(temp.path().join("reports")).unwrap();
+    std::fs::write(temp.path().join("reports/process.json"), artifact_bytes).unwrap();
     let mut bundle = ConvergenceEvidenceBundleV1 {
         schema_version: "1".into(),
         lane: CampaignLaneV1::ReleaseHardening,
@@ -84,14 +104,35 @@ fn release_evidence_requires_scoped_coverage_and_a_passing_budget() {
         unresolved_counterexamples: Vec::new(),
         residual_assumptions: vec!["eventual input-set equality".into()],
         untested_surfaces: vec!["unbounded executions".into()],
-        budget: config.evaluate(CampaignLaneObservationV1::default()),
+        budget: config.evaluate(CampaignLaneObservationV1 {
+            executed_cases: config.contents.minimum_executed_cases,
+            ..CampaignLaneObservationV1::default()
+        }),
         artifacts: vec![EvidenceArtifactV1 {
             kind: "process_report".into(),
             path: "reports/process.json".into(),
-            sha256: "0".repeat(64),
+            sha256: hex::encode(Sha256::digest(artifact_bytes)),
         }],
     };
     bundle.validate().unwrap();
+    bundle.validate_artifacts(temp.path()).unwrap();
+    bundle
+        .write_private(&temp.path().join("evidence.json"))
+        .unwrap();
+
+    let mut missing_artifacts = bundle.clone();
+    missing_artifacts.artifacts.clear();
+    assert_eq!(
+        missing_artifacts.validate().unwrap_err().code,
+        "incomplete_evidence_bundle"
+    );
+
+    bundle.artifacts[0].sha256 = "0".repeat(64);
+    assert_eq!(
+        bundle.validate_artifacts(temp.path()).unwrap_err().code,
+        "evidence_artifact_digest_mismatch"
+    );
+    bundle.artifacts[0].sha256 = hex::encode(Sha256::digest(artifact_bytes));
     bundle.untested_surfaces.clear();
     assert_eq!(
         bundle.validate().unwrap_err().code,

--- a/crates/convergence-campaign-runner/tests/lane_policy.rs
+++ b/crates/convergence-campaign-runner/tests/lane_policy.rs
@@ -38,6 +38,56 @@ fn every_lane_has_all_resource_retention_and_flake_budgets() {
 }
 
 #[test]
+fn workflow_artifact_retention_matches_lane_policy() {
+    let ci = include_str!("../../../.github/workflows/ci.yml");
+    let nightly = include_str!("../../../.github/workflows/simulator-nightly.yml");
+    let hardening = include_str!("../../../.github/workflows/convergence-hardening.yml");
+
+    assert_artifact_retention(
+        ci,
+        "name: cgka-conformance-simulator-reports",
+        &CampaignLaneConfigV1::builtin(CampaignLaneV1::PullRequest)
+            .budgets
+            .artifact_retention_days
+            .to_string(),
+    );
+    assert_artifact_retention(
+        nightly,
+        "name: cgka-conformance-simulator-nightly-reports",
+        &CampaignLaneConfigV1::builtin(CampaignLaneV1::Nightly)
+            .budgets
+            .artifact_retention_days
+            .to_string(),
+    );
+
+    let weekly = CampaignLaneConfigV1::builtin(CampaignLaneV1::WeeklyManual)
+        .budgets
+        .artifact_retention_days;
+    let release = CampaignLaneConfigV1::builtin(CampaignLaneV1::ReleaseHardening)
+        .budgets
+        .artifact_retention_days;
+    assert_artifact_retention(
+        hardening,
+        "name: convergence-hardening-${{ github.run_id }}",
+        &format!("${{{{ inputs.lane == 'release_hardening' && {release} || {weekly} }}}}"),
+    );
+}
+
+fn assert_artifact_retention(workflow: &str, artifact_name: &str, expected: &str) {
+    let artifact_step = workflow
+        .split_once(artifact_name)
+        .unwrap_or_else(|| panic!("workflow is missing artifact {artifact_name}"))
+        .1
+        .split("\n\n")
+        .next()
+        .expect("artifact upload step has content");
+    assert!(
+        artifact_step.contains(&format!("retention-days: {expected}")),
+        "artifact {artifact_name} retention does not match lane policy {expected}"
+    );
+}
+
+#[test]
 fn budget_evaluation_rejects_empty_and_inconsistent_observations() {
     let config = CampaignLaneConfigV1::builtin(CampaignLaneV1::WeeklyManual);
     let empty = config.evaluate(CampaignLaneObservationV1::default());
@@ -146,6 +196,15 @@ fn release_evidence_requires_scoped_coverage_and_a_passing_budget() {
         cli.status.success(),
         "bare bundle filename failed: {}",
         String::from_utf8_lossy(&cli.stderr)
+    );
+
+    let mut forged_budget = bundle.clone();
+    forged_budget.budget.observation.wall_clock_seconds = config.budgets.max_wall_clock_seconds + 1;
+    forged_budget.budget.passed = true;
+    forged_budget.budget.violations.clear();
+    assert_eq!(
+        forged_budget.validate().unwrap_err().code,
+        "evidence_budget"
     );
 
     let mut missing_artifacts = bundle.clone();

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -1005,11 +1005,19 @@ that scaling the existing corpus is sufficient.
 
 ### 6.3 Execution lanes
 
-- [ ] PR lane: strict formal gate, fixed vectors, small engine/reference/relay cases.
-- [ ] Nightly lane: seed matrices, file-backed storage, crash matrix, retained relays, mutation subset.
-- [ ] Weekly/manual lane: process/container soak, resource and constant sweeps.
-- [ ] Release-hardening lane: mixed-version and incident-derived corpus.
-- [ ] Define wall-clock, CPU, memory, disk, artifact-retention, and flake budgets for every lane.
+- [x] PR lane: strict formal gate, fixed vectors, small engine/reference/relay cases.
+- [x] Nightly lane: seed matrices, file-backed storage, crash matrix, retained relays, mutation subset.
+- [x] Weekly/manual lane: process/container soak, resource and constant sweeps.
+- [x] Release-hardening lane: mixed-version and incident-derived corpus.
+- [x] Define wall-clock, CPU, memory, disk, artifact-retention, and flake budgets for every lane.
+
+Four versioned lane manifests now define both included capabilities and reviewed limits. The PR workflow remains
+container-free and keeps formal/model/vector checks parallel; nightly adds process campaigns and one real-container
+cross-route regression; the scheduled weekly/manual workflow runs the full current container suite and expanded
+resource/constant campaigns; release hardening additionally requires an operator-supplied, reviewed distributed
+manifest so mixed-version evidence cannot silently degrade into a current-build-only run. A typed budget evaluator
+fails wall-clock, CPU, RSS, disk, artifact-size, retry, or flake-rate overages. The evidence-bundle validator requires
+route/model/adapter/mutation/boundary/counterexample/assumption/untested-surface sections and a passing same-lane budget.
 
 ### 6.4 Failure corpus lifecycle
 
@@ -1144,6 +1152,8 @@ incorrect result.
 | 2026-08-03 | Milestone 4 completion verification | Completed every 4.1-4.4 item and exit condition without changing production convergence-engine behavior; the bounded independent, lifecycle, mutation, and protocol gates all pass alongside the full simulator, strict symbolic model, and repository-wide compile/lint gate | `just milestone4-ci`; `cargo test -p cgka-conformance-simulator --locked`; `just tamarin` (78 lemmas); `just fast-ci` |
 | 2026-08-04 | Milestone 5 app/process simulation | Added a production-shaped app-runtime adapter, versioned child-node protocol, multi-process orchestrator, projection/event observation, retained-relay repair, real pause/resume/kill/restart, cross-adapter comparison, and privacy-safe failure capsules; then replaced milestone-scoped module/test names with durable capability names | Commits `a3296b16` through `19d0d5f8`; `app_runtime_adapter`; `node_protocol`; `process_orchestrator`; `just fast-ci` |
 | 2026-08-04 | Milestone 6 assurance scope correction | Used the cross-seam divergence from [MDK #1236](https://github.com/marmot-protocol/mdk/pull/1236) to add decision-route inventory/equivalence, a permanent four-participant regression family, cryptographic interoperability, application disposition, model/mutation expansion, and scoped evidence requirements before distributed scale work can be called complete | Milestone 6.1 and strengthened exit gate in this document |
+| 2026-08-05 | 6.2 container and VM execution | Split the container-first distributed runner, barrier-bound faults, mixed-image participants, real OCI smoke coverage, and capability-gated external VM-driver boundary out of the larger assurance branch without carrying production convergence changes or a #1236 outcome assumption | [MDK #1270](https://github.com/marmot-protocol/mdk/pull/1270); `distributed_runner`; ignored `container_runtime`; [`distributed-convergence-campaigns.md`](./distributed-convergence-campaigns.md) |
+| 2026-08-05 | 6.3 execution lanes and evidence budgets | Added drift-checked PR, nightly, weekly/manual, and release-hardening policies; machine-checkable wall/CPU/RSS/disk/artifact/retention/flake budgets; scheduled container hardening; and a completeness-checked scoped evidence bundle as a separate layer over the runner core | `lane_policy`; `convergence-lane-policy`; `simulator-nightly.yml`; `convergence-hardening.yml` |
 
 ## Post-Milestone 6 Cleanup
 

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "Convergence Reliability And Simulation Plan"
 created: 2026-07-30
-updated: 2026-08-04
+updated: 2026-08-06
 tags: [marmot, cgka, convergence, simulation, verification, reliability]
 status: working-plan
 ---
@@ -1005,19 +1005,24 @@ that scaling the existing corpus is sufficient.
 
 ### 6.3 Execution lanes
 
-- [x] PR lane: strict formal gate, fixed vectors, small engine/reference/relay cases.
-- [x] Nightly lane: seed matrices, file-backed storage, crash matrix, retained relays, mutation subset.
-- [x] Weekly/manual lane: process/container soak, resource and constant sweeps.
-- [x] Release-hardening lane: mixed-version and incident-derived corpus.
+- [ ] PR lane: strict formal gate, fixed vectors, small engine/reference/relay cases.
+- [ ] Nightly lane: seed matrices, file-backed storage, crash matrix, retained relays, mutation subset.
+- [ ] Weekly/manual lane: process/container soak, resource and constant sweeps.
+- [ ] Release-hardening lane: mixed-version and incident-derived corpus.
 - [x] Define wall-clock, CPU, memory, disk, artifact-retention, and flake budgets for every lane.
 
-Four versioned lane manifests now define both included capabilities and reviewed limits. The PR workflow remains
-container-free and keeps formal/model/vector checks parallel; nightly adds process campaigns and one real-container
-cross-route regression; the scheduled weekly/manual workflow runs the full current container suite and expanded
-resource/constant campaigns; release hardening additionally requires an operator-supplied, reviewed distributed
-manifest so mixed-version evidence cannot silently degrade into a current-build-only run. A typed budget evaluator
-fails wall-clock, CPU, RSS, disk, artifact-size, retry, or flake-rate overages. The evidence-bundle validator requires
-route/model/adapter/mutation/boundary/counterexample/assumption/untested-surface sections and a passing same-lane budget.
+Four versioned lane manifests are the single reviewed policy source for intended contents and limits. The nightly and
+weekly entry points run only existing named targets, and selected-container filtering fails instead of silently passing
+when it matches no test. Scheduled runs inherit the source revision's mandatory PR formal gate instead of rerunning the
+same symbolic proof. Incident-corpus execution remains false until the failure-corpus slice lands, and the reviewed
+minimum case counts describe only work that the current recipes can launch.
+
+The typed evaluator rejects zero-case observations, inconsistent flaky-case counts, work below the lane minimum, and
+wall-clock, CPU, RSS, disk, artifact-size, retry, or flake-rate overages. It is not yet fed by a workflow-owned
+observation collector, so the four execution/enforcement items and the resource/flake exit gate remain open. Evidence
+bundles require a nonempty artifact set; `check-evidence` resolves each relative artifact path beside the bundle and
+verifies its SHA-256 bytes. The remaining route/model/adapter/mutation/boundary/assumption fields are still
+producer-supplied scoped evidence rather than an automatic correctness attestation.
 
 ### 6.4 Failure corpus lifecycle
 
@@ -1153,7 +1158,7 @@ incorrect result.
 | 2026-08-04 | Milestone 5 app/process simulation | Added a production-shaped app-runtime adapter, versioned child-node protocol, multi-process orchestrator, projection/event observation, retained-relay repair, real pause/resume/kill/restart, cross-adapter comparison, and privacy-safe failure capsules; then replaced milestone-scoped module/test names with durable capability names | Commits `a3296b16` through `19d0d5f8`; `app_runtime_adapter`; `node_protocol`; `process_orchestrator`; `just fast-ci` |
 | 2026-08-04 | Milestone 6 assurance scope correction | Used the cross-seam divergence from [MDK #1236](https://github.com/marmot-protocol/mdk/pull/1236) to add decision-route inventory/equivalence, a permanent four-participant regression family, cryptographic interoperability, application disposition, model/mutation expansion, and scoped evidence requirements before distributed scale work can be called complete | Milestone 6.1 and strengthened exit gate in this document |
 | 2026-08-05 | 6.2 container and VM execution | Split the container-first distributed runner, barrier-bound faults, mixed-image participants, real OCI smoke coverage, and capability-gated external VM-driver boundary out of the larger assurance branch without carrying production convergence changes or a #1236 outcome assumption | [MDK #1270](https://github.com/marmot-protocol/mdk/pull/1270); `distributed_runner`; ignored `container_runtime`; [`distributed-convergence-campaigns.md`](./distributed-convergence-campaigns.md) |
-| 2026-08-05 | 6.3 execution lanes and evidence budgets | Added drift-checked PR, nightly, weekly/manual, and release-hardening policies; machine-checkable wall/CPU/RSS/disk/artifact/retention/flake budgets; scheduled container hardening; and a completeness-checked scoped evidence bundle as a separate layer over the runner core | `lane_policy`; `convergence-lane-policy`; `simulator-nightly.yml`; `convergence-hardening.yml` |
+| 2026-08-06 | 6.3 lane policy and evidence foundations | Added single-source PR, nightly, weekly/manual, and release-hardening policy manifests; fail-closed standalone wall/CPU/RSS/disk/artifact/retention/flake evaluation; nonempty byte-verified evidence artifacts; and scheduled entry points without claiming workflow-owned measurement or incident-corpus execution yet | `lane_policy`; `convergence-lane-policy`; `simulator-nightly.yml`; `convergence-hardening.yml` |
 
 ## Post-Milestone 6 Cleanup
 

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -1020,9 +1020,11 @@ minimum case counts are liveness floors preventing empty evidence, not attestati
 The typed evaluator rejects zero-case observations, inconsistent flaky-case counts, work below the lane minimum, and
 wall-clock, CPU, RSS, disk, artifact-size, retry, or flake-rate overages. It is not yet fed by a workflow-owned
 observation collector, so the four execution/enforcement items and the resource/flake exit gate remain open. Evidence
-bundles require a nonempty artifact set; `check-evidence` resolves each relative artifact path beside the bundle and
-verifies its SHA-256 bytes. The remaining route/model/adapter/mutation/boundary/assumption fields are still
-producer-supplied scoped evidence rather than an automatic correctness attestation.
+bundles require a nonempty artifact set; `check-evidence` recomputes the budget result from its observation and the
+reviewed lane policy, resolves each relative artifact path beside the bundle, and verifies its SHA-256 bytes. A policy
+test also pins each workflow artifact-retention setting to the corresponding lane manifest. The remaining
+route/model/adapter/mutation/boundary/assumption fields are still producer-supplied scoped evidence rather than an
+automatic correctness attestation.
 
 ### 6.4 Failure corpus lifecycle
 

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -1014,8 +1014,8 @@ that scaling the existing corpus is sufficient.
 Four versioned lane manifests are the single reviewed policy source for intended contents and limits. The nightly and
 weekly entry points run only existing named targets, and selected-container filtering fails instead of silently passing
 when it matches no test. Scheduled runs inherit the source revision's mandatory PR formal gate instead of rerunning the
-same symbolic proof. Incident-corpus execution remains false until the failure-corpus slice lands, and the reviewed
-minimum case counts describe only work that the current recipes can launch.
+same symbolic proof. Incident-corpus execution remains false until the failure-corpus slice lands. The conservative
+minimum case counts are liveness floors preventing empty evidence, not attestations that every declared capability ran.
 
 The typed evaluator rejects zero-case observations, inconsistent flaky-case counts, work below the lane minimum, and
 wall-clock, CPU, RSS, disk, artifact-size, retry, or flake-rate overages. It is not yet fed by a workflow-owned

--- a/docs/marmot-architecture/distributed-convergence-campaigns.md
+++ b/docs/marmot-architecture/distributed-convergence-campaigns.md
@@ -116,6 +116,28 @@ CGKA_CONVERGENCE_IMAGE=marmot-conformance:local \
 The default CI lane validates command construction and the process boundary without requiring Docker. Scheduled lanes
 may opt into the real-container tests when the runner environment advertises that capability.
 
+## Execution lanes and budgets
+
+Reviewed lane manifests live under `crates/convergence-campaign-runner/lanes`. The Rust policy test requires those
+files to equal the built-in policy exactly, so a budget or coverage change cannot arrive as an unreviewed JSON edit.
+The four lanes are:
+
+- pull request: strict formal checks, fixed vectors, and bounded engine/reference/relay coverage without Docker;
+- nightly: expanded seeds, file-backed storage, crash and retained-relay matrices, targeted mutations, process runs,
+  selected containers, and the incident corpus;
+- weekly/manual: process/container soak plus full targeted mutations, resource sweeps, constant sweeps, and mixed-build
+  support; and
+- release hardening: the largest reviewed bounds, mixed-version execution, and incident-derived regressions.
+
+Every lane defines maximum wall time, CPU time, peak RSS, disk use, artifact bytes, artifact retention, flake retries,
+and flake rate. `cgka-distributed-campaign check-budget` consumes an observed-usage JSON document and exits nonzero if
+any limit is exceeded. A flake is therefore evidence, not permission to turn a failing assertion green silently.
+
+The version-1 evidence-bundle type requires a scoped assurance claim, covered decision routes, models, adapters,
+mutation results, tested workload/constant boundaries, unresolved counterexamples, residual assumptions, untested
+surfaces, a passing same-lane budget evaluation, and digest-pinned artifacts. `check-evidence` rejects incomplete
+bundles; valid bundles are written with owner-only permissions.
+
 ## What this evidence means
 
 A passing distributed campaign establishes the declared scenario, build matrix, fault schedule, adapter capabilities,

--- a/docs/marmot-architecture/distributed-convergence-campaigns.md
+++ b/docs/marmot-architecture/distributed-convergence-campaigns.md
@@ -1,7 +1,7 @@
 ---
 title: "Distributed Convergence Campaigns"
 created: 2026-08-04
-updated: 2026-08-05
+updated: 2026-08-06
 tags: [marmot, convergence, testing, containers, virtual-machines]
 ---
 
@@ -118,25 +118,32 @@ may opt into the real-container tests when the runner environment advertises tha
 
 ## Execution lanes and budgets
 
-Reviewed lane manifests live under `crates/convergence-campaign-runner/lanes`. The Rust policy test requires those
-files to equal the built-in policy exactly, so a budget or coverage change cannot arrive as an unreviewed JSON edit.
+Reviewed lane manifests live under `crates/convergence-campaign-runner/lanes`. They are compiled into the runner with
+`include_str!` and parsed by `CampaignLaneConfigV1::builtin`, so the reviewed JSON is the only policy source rather
+than a second copy of the same constants in Rust.
 The four lanes are:
 
-- pull request: strict formal checks, fixed vectors, and bounded engine/reference/relay coverage without Docker;
-- nightly: expanded seeds, file-backed storage, crash and retained-relay matrices, targeted mutations, process runs,
-  selected containers, and the incident corpus;
-- weekly/manual: process/container soak plus full targeted mutations, resource sweeps, constant sweeps, and mixed-build
-  support; and
-- release hardening: the largest reviewed bounds, mixed-version execution, and incident-derived regressions.
+- pull request: the ordinary mandatory formal/model/vector checks without Docker;
+- nightly: file-backed, crash, retained-relay, mutation, process, policy-sweep, and selected-container coverage;
+- weekly/manual: the nightly coverage plus a larger generated batch and the full current container test target; and
+- release hardening: the weekly work plus an operator-supplied distributed manifest with at least two participant
+  build ids and, for containers, at least two effective participant images.
+
+The source revision must already have passed the mandatory PR formal gate; scheduled workflows do not repeat the same
+state-independent proof. Incident-corpus coverage is deliberately false in these manifests until the failure-corpus
+slice lands.
 
 Every lane defines maximum wall time, CPU time, peak RSS, disk use, artifact bytes, artifact retention, flake retries,
 and flake rate. `cgka-distributed-campaign check-budget` consumes an observed-usage JSON document and exits nonzero if
-any limit is exceeded. A flake is therefore evidence, not permission to turn a failing assertion green silently.
+any limit is exceeded. It also rejects zero executed cases, observations below the lane minimum, and flaky-case counts
+larger than executed-case counts. The scheduled workflows do not yet emit this aggregate observation or invoke
+`check-budget`; these limits are machine-checkable reviewed policy, not yet a green-workflow attestation.
 
 The version-1 evidence-bundle type requires a scoped assurance claim, covered decision routes, models, adapters,
 mutation results, tested workload/constant boundaries, unresolved counterexamples, residual assumptions, untested
-surfaces, a passing same-lane budget evaluation, and digest-pinned artifacts. `check-evidence` rejects incomplete
-bundles; valid bundles are written with owner-only permissions.
+surfaces, a passing same-lane budget evaluation, and at least one digest-pinned artifact. `check-evidence` rejects
+incomplete bundles, parent-traversing artifact paths, missing files, and SHA-256 mismatches by resolving artifacts
+relative to the bundle's directory. Valid bundles are written with owner-only permissions.
 
 ## What this evidence means
 

--- a/docs/marmot-architecture/distributed-convergence-campaigns.md
+++ b/docs/marmot-architecture/distributed-convergence-campaigns.md
@@ -143,9 +143,10 @@ declared capability ran. Capability-specific evidence remains required before a 
 
 The version-1 evidence-bundle type requires a scoped assurance claim, covered decision routes, models, adapters,
 mutation results, tested workload/constant boundaries, unresolved counterexamples, residual assumptions, untested
-surfaces, a passing same-lane budget evaluation, and at least one digest-pinned artifact. `check-evidence` rejects
-incomplete bundles, parent-traversing artifact paths, missing files, and SHA-256 mismatches by resolving artifacts
-relative to the bundle's directory. Valid bundles are written with owner-only permissions.
+surfaces, a passing same-lane budget evaluation, and at least one digest-pinned artifact. `check-evidence` recomputes
+the evaluation from the recorded observation and reviewed lane policy instead of trusting producer-supplied result
+fields. It rejects incomplete bundles, parent-traversing artifact paths, missing files, and SHA-256 mismatches by
+resolving artifacts relative to the bundle's directory. Valid bundles are written with owner-only permissions.
 
 ## What this evidence means
 

--- a/docs/marmot-architecture/distributed-convergence-campaigns.md
+++ b/docs/marmot-architecture/distributed-convergence-campaigns.md
@@ -138,6 +138,8 @@ and flake rate. `cgka-distributed-campaign check-budget` consumes an observed-us
 any limit is exceeded. It also rejects zero executed cases, observations below the lane minimum, and flaky-case counts
 larger than executed-case counts. The scheduled workflows do not yet emit this aggregate observation or invoke
 `check-budget`; these limits are machine-checkable reviewed policy, not yet a green-workflow attestation.
+`minimum_executed_cases` is therefore only a liveness floor: it prevents empty evidence, but does not prove that every
+declared capability ran. Capability-specific evidence remains required before a lane can support an assurance claim.
 
 The version-1 evidence-bundle type requires a scoped assurance claim, covered decision routes, models, adapters,
 mutation results, tested workload/constant boundaries, unresolved counterexamples, residual assumptions, untested


### PR DESCRIPTION
## Summary

- make the four reviewed JSON lane manifests the single compiled policy source
- make budget evaluation fail closed for zero, undersized, or inconsistent observations
- require nonempty evidence artifacts and verify their bytes against SHA-256 at ingestion and before writing
- run scheduled lanes through their aggregate recipes, remove nonexistent test targets, and make zero-test container filters fail
- inherit the mandatory PR formal proof instead of rerunning the same state-independent proof on schedules
- require release-hardening manifests to contain distinct build IDs and distinct effective container images

## Scope and current limit

This PR contains operational lane policy, evidence-budget evaluation, workflow wiring, and documentation. It contains no production convergence-engine changes and makes no claim that #1236 is resolved.

The manifests and evaluator are reviewed, machine-checkable foundations. Scheduled workflows do not yet produce aggregate resource observations or invoke `check-budget`, so the tracking plan keeps runtime budget enforcement and the four completed-lane claims open. Incident-corpus execution also remains false in this PR and is added by the stacked failure-corpus PR.

## Verification

- `cargo test -p convergence-campaign-runner --locked`
- `cargo clippy -p convergence-campaign-runner --all-targets --locked -- -D warnings`
- `just fast-ci`
- `cargo fmt --all -- --check`
- `actionlint .github/workflows/simulator-nightly.yml .github/workflows/convergence-hardening.yml`
- verified `cargo nextest ... --no-tests fail` exits nonzero for a missing selected-container test

#1272 has been restacked onto this head and keeps the failure-corpus policy delta isolated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable convergence testing lanes for pull requests, nightly checks, weekly campaigns, and release hardening.
  - Added checks for resource budgets, mixed-build coverage, campaign results, and evidence artifacts.
  - Added commands to inspect policies, evaluate budgets, and validate evidence bundles.

- **CI Improvements**
  - Added scheduled and manual hardening workflows.
  - Extended artifact retention and added real-container convergence testing.

- **Documentation**
  - Updated reliability and distributed-convergence guidance with lane coverage, budgets, and evidence requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->