### PR TITLE
Enforce convergence capability naming

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -445,10 +445,24 @@ naming-gate:
     #!/usr/bin/env bash
     set -euo pipefail
     ./scripts/check_legacy_naming.sh
-    tracked_milestone_names="$(git ls-files | awk -F/ 'tolower($NF) ~ /milestone/ { print }')"
-    if [[ -n "$tracked_milestone_names" ]]; then
-        echo "tracked filenames must use capability names, not milestone names:" >&2
-        echo "$tracked_milestone_names" >&2
+    is_milestone_path() {
+        local lowercase
+        lowercase="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+        [[ "$lowercase" == *milestone* ]]
+    }
+    is_milestone_path "docs/milestone-5/design.md"
+    is_milestone_path "docs/design-milestone.md"
+    is_milestone_path "docs/MileStone-6/design.md"
+    ! is_milestone_path "docs/capability/design.md"
+    tracked_milestone_paths=()
+    while IFS= read -r -d '' path; do
+        if is_milestone_path "$path"; then
+            tracked_milestone_paths+=("$path")
+        fi
+    done < <(git ls-files -z)
+    if (( ${#tracked_milestone_paths[@]} > 0 )); then
+        echo "tracked paths must use capability names, not milestone names:" >&2
+        printf '%s\n' "${tracked_milestone_paths[@]}" >&2
         exit 1
     fi
 

--- a/Justfile
+++ b/Justfile
@@ -442,10 +442,18 @@ dead-code-audit:
 
 # Guard against retired legacy naming reappearing (see PR #725).
 naming-gate:
+    #!/usr/bin/env bash
+    set -euo pipefail
     ./scripts/check_legacy_naming.sh
+    tracked_milestone_names="$(git ls-files | awk -F/ 'tolower($NF) ~ /milestone/ { print }')"
+    if [[ -n "$tracked_milestone_names" ]]; then
+        echo "tracked filenames must use capability names, not milestone names:" >&2
+        echo "$tracked_milestone_names" >&2
+        exit 1
+    fi
 
 # Keep convergence policy, resource, scheduler, and history-recovery constants
-# attached to reviewed Milestone 0 ledger entries.
+# attached to reviewed convergence-constant ledger entries.
 convergence-ledger-gate:
     ./scripts/check_convergence_constant_ledger.sh
 

--- a/crates/cgka-conformance-simulator/AGENTS.md
+++ b/crates/cgka-conformance-simulator/AGENTS.md
@@ -167,7 +167,7 @@ the property-test registry. This file is the agent-facing model.
 - **Module:** `src/bin/cgka-conformance-campaign.rs`
   - **Role:** Parent/worker campaign runner. Executes each generated case in an isolated child process and combines the
     durable scenario report with `wait4` wall/CPU/peak-RSS/write measurements. This is the engine campaign boundary for
-    real process isolation; it is not yet the app/CLI multi-process adapter planned for Milestone 5.
+    real process isolation; the app-runtime and child-process adapters are separate production-shaped boundaries.
 
 - **Module:** `src/bin/cgka-policy-casegen.rs`
   - **Role:** Policy-case generator CLI; reads `formal/tamarin/policy_cases.json` and parses/reasons over the bounded

--- a/crates/cgka-conformance-simulator/src/process_orchestrator.rs
+++ b/crates/cgka-conformance-simulator/src/process_orchestrator.rs
@@ -275,7 +275,7 @@ impl ProcessOrchestrator {
         if processes.values().collect::<BTreeSet<_>>().len() != processes.len() {
             return Err(ProcessOrchestratorError::new(
                 "shared_process_unsupported",
-                "Milestone 5 nodes require one account-device participant per process",
+                "process-adapter nodes require one account-device participant per process",
             ));
         }
         let process_relays = compiled


### PR DESCRIPTION
## Summary

- reject tracked filenames containing `milestone` so long-lived artifacts use capability-oriented names
- replace two remaining milestone-scoped descriptions in the simulator with enduring process-adapter terminology
- rename the convergence ledger comment around the capability it guards

## Scope

This is the naming-only slice extracted from #1250. It is based directly on `master`, has no dependency on the distributed runner stack, and changes no convergence behavior.

## Verification

- `just naming-gate`
- `cargo fmt --all -- --check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved process-adapter configuration validation by clearly reporting when multiple account-device participants are assigned to one process.
  - Added strict checks that reject tracked filenames containing “milestone” and display the offending paths.

- **Documentation**
  - Clarified campaign process isolation and distinguished it from application-runtime and child-process adapters.
  - Updated related validation terminology to reference reviewed convergence-constant ledger entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->