### PR TITLE
Ignore retired relays in discovered account routes

### DIFF
--- a/crates/marmot-app/src/client/push.rs
+++ b/crates/marmot-app/src/client/push.rs
@@ -513,6 +513,7 @@ impl AppClient {
             .into_iter()
             .map(TransportEndpoint)
             .collect(),
+            "notification trigger relay discovery",
         ))
     }
 

--- a/crates/marmot-app/src/client/push.rs
+++ b/crates/marmot-app/src/client/push.rs
@@ -505,13 +505,15 @@ impl AppClient {
         } else {
             Vec::new()
         };
-        Ok(notifications::select_notification_trigger_relays(
-            &record_relay_hints,
-            &server_inbox_relays,
-        )
-        .into_iter()
-        .map(TransportEndpoint)
-        .collect())
+        Ok(self.app.retain_safe_discovered_endpoints(
+            notifications::select_notification_trigger_relays(
+                &record_relay_hints,
+                &server_inbox_relays,
+            )
+            .into_iter()
+            .map(TransportEndpoint)
+            .collect(),
+        ))
     }
 
     fn local_member_leaf(&self, group_id: &GroupId) -> Result<(String, u32), AppError> {

--- a/crates/marmot-app/src/directory/methods.rs
+++ b/crates/marmot-app/src/directory/methods.rs
@@ -262,19 +262,20 @@ impl MarmotApp {
             }
         }
         self.remember_directory_relay_lists(account_id_hex, &relay_lists)?;
-        if relay_lists.nip65.relays.is_empty() {
+        let source_relays = self.retain_safe_discovered_endpoints(
+            relay_lists
+                .nip65
+                .relays
+                .iter()
+                .cloned()
+                .map(TransportEndpoint)
+                .collect(),
+        );
+        if source_relays.is_empty() {
             return Err(AppError::MissingRelayLists(vec![
                 MissingRelayListKind::Nip65,
             ]));
         }
-
-        let source_relays = relay_lists
-            .nip65
-            .relays
-            .iter()
-            .cloned()
-            .map(TransportEndpoint)
-            .collect::<Vec<_>>();
         let records = self
             .fetch_key_package_events_for_account_id(account_id_hex, &source_relays)
             .await?;
@@ -630,7 +631,7 @@ impl MarmotApp {
         endpoints: Vec<TransportEndpoint>,
     ) -> Vec<TransportEndpoint> {
         self.relay_plane
-            .retain_safe_discovered_endpoints(endpoints, "directory write-relay discovery")
+            .retain_safe_discovered_endpoints(endpoints, "published relay-list route")
     }
 
     pub(crate) fn directory_source_relays(

--- a/crates/marmot-app/src/directory/methods.rs
+++ b/crates/marmot-app/src/directory/methods.rs
@@ -262,7 +262,7 @@ impl MarmotApp {
             }
         }
         self.remember_directory_relay_lists(account_id_hex, &relay_lists)?;
-        let source_relays = self.retain_safe_discovered_endpoints(
+        let mut source_relays = self.retain_safe_discovered_endpoints(
             relay_lists
                 .nip65
                 .relays
@@ -270,7 +270,11 @@ impl MarmotApp {
                 .cloned()
                 .map(TransportEndpoint)
                 .collect(),
+            "key package directory fetch",
         );
+        if source_relays.is_empty() {
+            source_relays = self.directory_source_relays(&[]);
+        }
         if source_relays.is_empty() {
             return Err(AppError::MissingRelayLists(vec![
                 MissingRelayListKind::Nip65,
@@ -620,8 +624,10 @@ impl MarmotApp {
         &self.config.directory_search_fallback_seeds
     }
 
-    /// Narrow relay endpoints discovered from another account's published
-    /// relay list to the ones this device is willing to dial.
+    /// Narrow network-sourced relay-list endpoints to the ones this device is
+    /// willing to dial, whether the list belongs to this device's local account
+    /// or to another account. Published data remains untrusted in both cases;
+    /// filtering affects only the operation's route and never rewrites the list.
     ///
     /// Routes to the same host-safety rule configured endpoints face; see
     /// [`RelaySafetyPolicy::retain_safe_endpoints`] for why a published list
@@ -629,9 +635,10 @@ impl MarmotApp {
     pub(crate) fn retain_safe_discovered_endpoints(
         &self,
         endpoints: Vec<TransportEndpoint>,
+        context: &str,
     ) -> Vec<TransportEndpoint> {
         self.relay_plane
-            .retain_safe_discovered_endpoints(endpoints, "published relay-list route")
+            .retain_safe_discovered_endpoints(endpoints, context)
     }
 
     pub(crate) fn directory_source_relays(

--- a/crates/marmot-app/src/directory/search.rs
+++ b/crates/marmot-app/src/directory/search.rs
@@ -663,6 +663,7 @@ fn write_relays_from_record(
             .into_iter()
             .map(TransportEndpoint)
             .collect(),
+        "directory search write-relay discovery",
     );
     (!safe.is_empty()).then(|| {
         (

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -1665,6 +1665,32 @@ impl MarmotApp {
         if bootstrap.default_relays.is_empty() && !has_directional_nip65_relays {
             return Err(AppError::MissingDefaultRelays);
         }
+        self.relay_plane
+            .sanitize_relay_endpoints(
+                bootstrap.default_relays.clone(),
+                "account relay-list declaration",
+            )
+            .map_err(AppError::RelayDirectory)?;
+        self.relay_plane
+            .sanitize_relay_endpoints(
+                bootstrap.bootstrap_relays.clone(),
+                "account relay-list publication",
+            )
+            .map_err(AppError::RelayDirectory)?;
+        if let Some(relays) = nip65_relay_set {
+            self.relay_plane
+                .sanitize_relay_endpoints(
+                    relays.read_relays.clone(),
+                    "account NIP-65 read-relay declaration",
+                )
+                .map_err(AppError::RelayDirectory)?;
+            self.relay_plane
+                .sanitize_relay_endpoints(
+                    relays.write_relays.clone(),
+                    "account NIP-65 write-relay declaration",
+                )
+                .map_err(AppError::RelayDirectory)?;
+        }
         let account = self.account_home().account(label)?;
         let signer = self.account_signer_for_summary(&account)?;
         let account_id = MemberId::new(hex::decode(&account.account_id_hex)?);
@@ -1715,11 +1741,13 @@ impl MarmotApp {
             .await
     }
 
-    /// Outbox routing for account-scoped events. Prefers the account's own
-    /// declared NIP-65 write relays (read from the local relay-list cache, no
-    /// network), so e.g. republishing your relay lists / profile goes to *your*
-    /// relays rather than whatever defaults the caller passed. Falls back to
-    /// `fallback` only when the account has no NIP-65 list yet (cold start).
+    /// Outbox routing for account-scoped events. Prefers the safe subset of the
+    /// account's declared NIP-65 write relays (read from the local relay-list
+    /// cache, no network), so e.g. republishing your relay lists / profile goes
+    /// to *your* relays rather than whatever defaults the caller passed. Falls
+    /// back to `fallback` when the account has no usable NIP-65 relay. Filtering
+    /// here affects only the operation's route; it does not rewrite the cached
+    /// or published relay list.
     fn outbox_endpoints(
         &self,
         account_id_hex: &str,
@@ -1729,11 +1757,9 @@ impl MarmotApp {
             .account_relay_list_status_for_account_id(account_id_hex)
             .map(|status| status.nip65.relays)
             .unwrap_or_default();
-        if nip65.is_empty() {
-            fallback
-        } else {
-            nip65.into_iter().map(TransportEndpoint).collect()
-        }
+        let safe = self
+            .retain_safe_discovered_endpoints(nip65.into_iter().map(TransportEndpoint).collect());
+        if safe.is_empty() { fallback } else { safe }
     }
 
     pub fn messages(&self, label: &str) -> Result<Vec<AppMessageRecord>, AppError> {
@@ -2771,17 +2797,20 @@ impl MarmotApp {
             if entry.relay_lists.inbox.relays.is_empty() {
                 continue;
             }
-            inbox_routes
-                .entry(MemberId::new(hex::decode(entry.account_id_hex)?))
-                .or_insert_with(|| {
-                    entry
-                        .relay_lists
-                        .inbox
-                        .relays
-                        .into_iter()
-                        .map(TransportEndpoint)
-                        .collect()
-                });
+            let endpoints = self.retain_safe_discovered_endpoints(
+                entry
+                    .relay_lists
+                    .inbox
+                    .relays
+                    .into_iter()
+                    .map(TransportEndpoint)
+                    .collect(),
+            );
+            if !endpoints.is_empty() {
+                inbox_routes
+                    .entry(MemberId::new(hex::decode(entry.account_id_hex)?))
+                    .or_insert(endpoints);
+            }
         }
 
         let account = self.account_home().account(&state.label)?;
@@ -3244,37 +3273,37 @@ impl MarmotApp {
                     .await?;
             }
         }
-        if relay_lists.nip65.relays.is_empty() {
+        let source_relays = self.retain_safe_discovered_endpoints(
+            relay_lists
+                .nip65
+                .relays
+                .iter()
+                .cloned()
+                .map(TransportEndpoint)
+                .collect(),
+        );
+        if source_relays.is_empty() {
             return Err(AppError::MissingRelayLists(vec![
                 MissingRelayListKind::Nip65,
             ]));
         }
-        let source_relays = relay_lists
-            .nip65
-            .relays
-            .iter()
-            .cloned()
-            .map(TransportEndpoint)
-            .collect::<Vec<_>>();
 
-        if !source_relays.is_empty() {
-            let mut relay_records = self
-                .fetch_key_package_events_for_account_id(&account_id_hex, &source_relays)
-                .await?;
-            sort_directory_records(&mut relay_records);
-            for record in relay_records {
-                match key_package_from_record(record) {
-                    Ok(fetched) => {
-                        packages.push(account_key_package_record_from_fetched(fetched));
-                    }
-                    Err(err) => {
-                        tracing::warn!(
-                            target: "marmot_app::key_packages",
-                            method = "account_key_package_records",
-                            error_kind = err.privacy_safe_kind(),
-                            "skipping invalid key package event while listing account packages"
-                        );
-                    }
+        let mut relay_records = self
+            .fetch_key_package_events_for_account_id(&account_id_hex, &source_relays)
+            .await?;
+        sort_directory_records(&mut relay_records);
+        for record in relay_records {
+            match key_package_from_record(record) {
+                Ok(fetched) => {
+                    packages.push(account_key_package_record_from_fetched(fetched));
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        target: "marmot_app::key_packages",
+                        method = "account_key_package_records",
+                        error_kind = err.privacy_safe_kind(),
+                        "skipping invalid key package event while listing account packages"
+                    );
                 }
             }
         }
@@ -3559,29 +3588,33 @@ impl MarmotApp {
                 return validated_cached_key_package(&account_id, &key_package);
             }
             if !entry.relay_lists.nip65.relays.is_empty() {
-                let source_relays = entry
-                    .relay_lists
-                    .nip65
-                    .relays
-                    .iter()
-                    .cloned()
-                    .map(TransportEndpoint)
-                    .collect::<Vec<_>>();
-                let records = self
-                    .fetch_key_package_events_for_account_id(&account_id, &source_relays)
-                    .await?;
-                let mut fetched = fresh_or_cached_key_package(
-                    &account_id,
-                    latest_fresh_key_package_from_records(
+                let source_relays = self.retain_safe_discovered_endpoints(
+                    entry
+                        .relay_lists
+                        .nip65
+                        .relays
+                        .iter()
+                        .cloned()
+                        .map(TransportEndpoint)
+                        .collect(),
+                );
+                if !source_relays.is_empty() {
+                    let records = self
+                        .fetch_key_package_events_for_account_id(&account_id, &source_relays)
+                        .await?;
+                    let mut fetched = fresh_or_cached_key_package(
                         &account_id,
-                        records,
-                        self.directory_freshness(),
-                    )?,
-                    Some(entry.clone()),
-                )?;
-                fetched.relay_lists = entry.relay_lists;
-                self.remember_directory_key_package(&fetched)?;
-                return Ok(fetched.key_package);
+                        latest_fresh_key_package_from_records(
+                            &account_id,
+                            records,
+                            self.directory_freshness(),
+                        )?,
+                        Some(entry.clone()),
+                    )?;
+                    fetched.relay_lists = entry.relay_lists;
+                    self.remember_directory_key_package(&fetched)?;
+                    return Ok(fetched.key_package);
+                }
             }
         }
 
@@ -3910,13 +3943,18 @@ impl MarmotApp {
         relay_lists: &AccountRelayListStatus,
     ) -> Vec<TransportEndpoint> {
         if !relay_lists.inbox.relays.is_empty() {
-            return relay_lists
-                .inbox
-                .relays
-                .iter()
-                .cloned()
-                .map(TransportEndpoint)
-                .collect();
+            let safe = self.retain_safe_discovered_endpoints(
+                relay_lists
+                    .inbox
+                    .relays
+                    .iter()
+                    .cloned()
+                    .map(TransportEndpoint)
+                    .collect(),
+            );
+            if !safe.is_empty() {
+                return safe;
+            }
         }
         let _ = label;
         self.relay_endpoints()
@@ -3929,15 +3967,21 @@ impl MarmotApp {
         // KeyPackages publish to (and are fetched from) the account's NIP-65
         // (kind 10002) outbox relays; there is no dedicated KeyPackage relay
         // list. Fall back to the configured default relays when the account has
-        // no NIP-65 list yet.
+        // no usable NIP-65 relay. This runtime fallback is not published as a
+        // replacement for the account's relay list.
         if !relay_lists.nip65.relays.is_empty() {
-            return relay_lists
-                .nip65
-                .relays
-                .iter()
-                .cloned()
-                .map(TransportEndpoint)
-                .collect();
+            let safe = self.retain_safe_discovered_endpoints(
+                relay_lists
+                    .nip65
+                    .relays
+                    .iter()
+                    .cloned()
+                    .map(TransportEndpoint)
+                    .collect(),
+            );
+            if !safe.is_empty() {
+                return safe;
+            }
         }
         self.relay_endpoints()
     }

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -1550,7 +1550,10 @@ impl MarmotApp {
     ///
     /// Routing code must use `AccountRelayListStatus::nip65.relays`, which is
     /// the write-capable subset. Returning the union here keeps the established
-    /// getter -> edit -> setter flow from deleting read-only entries.
+    /// getter -> edit -> setter flow from deleting read-only entries. Because
+    /// this faithfully returns published data, it can include retired or unsafe
+    /// endpoints; clients must classify the result and remove every non-allowed
+    /// entry before passing an edited list to a setter.
     pub fn account_nip65_relays(&self, label: &str) -> Result<Vec<String>, AppError> {
         let state = self.account_relay_list_status(label)?.nip65;
         let relay_set = nip65_relay_set_from_state(&state);
@@ -1569,6 +1572,10 @@ impl MarmotApp {
         Ok(relays)
     }
 
+    /// Return the published inbox list without hiding retired entries.
+    ///
+    /// Clients must classify the result and remove every non-allowed entry
+    /// before passing an edited list to [`Self::set_account_inbox_relays`].
     pub fn account_inbox_relays(&self, label: &str) -> Result<Vec<String>, AppError> {
         Ok(self.account_relay_list_status(label)?.inbox.relays)
     }
@@ -1665,32 +1672,7 @@ impl MarmotApp {
         if bootstrap.default_relays.is_empty() && !has_directional_nip65_relays {
             return Err(AppError::MissingDefaultRelays);
         }
-        self.relay_plane
-            .sanitize_relay_endpoints(
-                bootstrap.default_relays.clone(),
-                "account relay-list declaration",
-            )
-            .map_err(AppError::RelayDirectory)?;
-        self.relay_plane
-            .sanitize_relay_endpoints(
-                bootstrap.bootstrap_relays.clone(),
-                "account relay-list publication",
-            )
-            .map_err(AppError::RelayDirectory)?;
-        if let Some(relays) = nip65_relay_set {
-            self.relay_plane
-                .sanitize_relay_endpoints(
-                    relays.read_relays.clone(),
-                    "account NIP-65 read-relay declaration",
-                )
-                .map_err(AppError::RelayDirectory)?;
-            self.relay_plane
-                .sanitize_relay_endpoints(
-                    relays.write_relays.clone(),
-                    "account NIP-65 write-relay declaration",
-                )
-                .map_err(AppError::RelayDirectory)?;
-        }
+        self.validate_account_relay_list_declarations(&bootstrap, nip65_relay_set)?;
         let account = self.account_home().account(label)?;
         let signer = self.account_signer_for_summary(&account)?;
         let account_id = MemberId::new(hex::decode(&account.account_id_hex)?);
@@ -1741,6 +1723,48 @@ impl MarmotApp {
             .await
     }
 
+    /// Validate caller-owned relay-list declarations without applying the dial
+    /// route's aggregate endpoint cap to the published list itself. Validating
+    /// one entry at a time retains the exact retired/invalid/unsafe policy while
+    /// the separately constructed publication route remains capped normally.
+    fn validate_account_relay_list_declarations(
+        &self,
+        bootstrap: &AccountRelayListBootstrap,
+        nip65_relay_set: Option<&NostrNip65RelaySet>,
+    ) -> Result<(), AppError> {
+        let mut declarations: Vec<(&[TransportEndpoint], &str)> = Vec::new();
+        if let Some(relays) = nip65_relay_set {
+            declarations.extend([
+                (
+                    relays.read_relays.as_slice(),
+                    "account NIP-65 read-relay declaration",
+                ),
+                (
+                    relays.write_relays.as_slice(),
+                    "account NIP-65 write-relay declaration",
+                ),
+            ]);
+        }
+        declarations.extend([
+            (
+                bootstrap.default_relays.as_slice(),
+                "account relay-list declaration",
+            ),
+            (
+                bootstrap.bootstrap_relays.as_slice(),
+                "account relay-list publication",
+            ),
+        ]);
+        for (endpoints, context) in declarations {
+            for endpoint in endpoints {
+                self.relay_plane
+                    .sanitize_relay_endpoints(vec![endpoint.clone()], context)
+                    .map_err(AppError::RelayDirectory)?;
+            }
+        }
+        Ok(())
+    }
+
     /// Outbox routing for account-scoped events. Prefers the safe subset of the
     /// account's declared NIP-65 write relays (read from the local relay-list
     /// cache, no network), so e.g. republishing your relay lists / profile goes
@@ -1757,8 +1781,10 @@ impl MarmotApp {
             .account_relay_list_status_for_account_id(account_id_hex)
             .map(|status| status.nip65.relays)
             .unwrap_or_default();
-        let safe = self
-            .retain_safe_discovered_endpoints(nip65.into_iter().map(TransportEndpoint).collect());
+        let safe = self.retain_safe_discovered_endpoints(
+            nip65.into_iter().map(TransportEndpoint).collect(),
+            "local account outbox routing",
+        );
         if safe.is_empty() { fallback } else { safe }
     }
 
@@ -2794,9 +2820,6 @@ impl MarmotApp {
             );
         }
         for entry in self.directory_entries()? {
-            if entry.relay_lists.inbox.relays.is_empty() {
-                continue;
-            }
             let endpoints = self.retain_safe_discovered_endpoints(
                 entry
                     .relay_lists
@@ -2805,6 +2828,7 @@ impl MarmotApp {
                     .into_iter()
                     .map(TransportEndpoint)
                     .collect(),
+                "directory inbox routing",
             );
             if !endpoints.is_empty() {
                 inbox_routes
@@ -3259,9 +3283,10 @@ impl MarmotApp {
         };
         // Discover the account's NIP-65 list via default relays when it is not
         // cached yet, mirroring fetch_latest_key_package_for_account_id. We never
-        // pull KeyPackage events from arbitrary default relays: the source set is
-        // always the account's own NIP-65 relays, and we fail closed when that
-        // list is missing.
+        // normally pull KeyPackage events from the account's own NIP-65 relays.
+        // When that published route exists but every endpoint is unusable, use
+        // the configured directory relays as the same operational fallback used
+        // when local accounts publish a KeyPackage without rewriting NIP-65.
         if !has_explicit_bootstrap_relays && relay_lists.nip65.relays.is_empty() {
             let discovery_relays = self.directory_source_relays(&[]);
             if !discovery_relays.is_empty() {
@@ -3273,7 +3298,7 @@ impl MarmotApp {
                     .await?;
             }
         }
-        let source_relays = self.retain_safe_discovered_endpoints(
+        let mut source_relays = self.retain_safe_discovered_endpoints(
             relay_lists
                 .nip65
                 .relays
@@ -3281,7 +3306,11 @@ impl MarmotApp {
                 .cloned()
                 .map(TransportEndpoint)
                 .collect(),
+            "account key package listing",
         );
+        if source_relays.is_empty() {
+            source_relays = self.directory_source_relays(&[]);
+        }
         if source_relays.is_empty() {
             return Err(AppError::MissingRelayLists(vec![
                 MissingRelayListKind::Nip65,
@@ -3587,34 +3616,33 @@ impl MarmotApp {
             if let Some(key_package) = entry.key_package {
                 return validated_cached_key_package(&account_id, &key_package);
             }
-            if !entry.relay_lists.nip65.relays.is_empty() {
-                let source_relays = self.retain_safe_discovered_endpoints(
-                    entry
-                        .relay_lists
-                        .nip65
-                        .relays
-                        .iter()
-                        .cloned()
-                        .map(TransportEndpoint)
-                        .collect(),
-                );
-                if !source_relays.is_empty() {
-                    let records = self
-                        .fetch_key_package_events_for_account_id(&account_id, &source_relays)
-                        .await?;
-                    let mut fetched = fresh_or_cached_key_package(
+            let source_relays = self.retain_safe_discovered_endpoints(
+                entry
+                    .relay_lists
+                    .nip65
+                    .relays
+                    .iter()
+                    .cloned()
+                    .map(TransportEndpoint)
+                    .collect(),
+                "member key package fetch",
+            );
+            if !source_relays.is_empty() {
+                let records = self
+                    .fetch_key_package_events_for_account_id(&account_id, &source_relays)
+                    .await?;
+                let mut fetched = fresh_or_cached_key_package(
+                    &account_id,
+                    latest_fresh_key_package_from_records(
                         &account_id,
-                        latest_fresh_key_package_from_records(
-                            &account_id,
-                            records,
-                            self.directory_freshness(),
-                        )?,
-                        Some(entry.clone()),
-                    )?;
-                    fetched.relay_lists = entry.relay_lists;
-                    self.remember_directory_key_package(&fetched)?;
-                    return Ok(fetched.key_package);
-                }
+                        records,
+                        self.directory_freshness(),
+                    )?,
+                    Some(entry.clone()),
+                )?;
+                fetched.relay_lists = entry.relay_lists;
+                self.remember_directory_key_package(&fetched)?;
+                return Ok(fetched.key_package);
             }
         }
 
@@ -3939,25 +3967,34 @@ impl MarmotApp {
 
     fn account_inbox_endpoints(
         &self,
-        label: &str,
+        _label: &str,
         relay_lists: &AccountRelayListStatus,
     ) -> Vec<TransportEndpoint> {
-        if !relay_lists.inbox.relays.is_empty() {
-            let safe = self.retain_safe_discovered_endpoints(
-                relay_lists
-                    .inbox
-                    .relays
-                    .iter()
-                    .cloned()
-                    .map(TransportEndpoint)
-                    .collect(),
-            );
-            if !safe.is_empty() {
-                return safe;
-            }
+        let offered = relay_lists.inbox.relays.len();
+        let safe = self.retain_safe_discovered_endpoints(
+            relay_lists
+                .inbox
+                .relays
+                .iter()
+                .cloned()
+                .map(TransportEndpoint)
+                .collect(),
+            "local account inbox activation",
+        );
+        if !safe.is_empty() {
+            return safe;
         }
-        let _ = label;
-        self.relay_endpoints()
+        let fallback = self.relay_endpoints();
+        if offered > 0 {
+            tracing::warn!(
+                target: "marmot_app::relay_plane",
+                method = "account_inbox_endpoints",
+                offered = offered,
+                fallback = fallback.len(),
+                "published account inbox has no usable endpoints; using configured defaults"
+            );
+        }
+        fallback
     }
 
     fn key_package_endpoints(
@@ -3969,21 +4006,31 @@ impl MarmotApp {
         // list. Fall back to the configured default relays when the account has
         // no usable NIP-65 relay. This runtime fallback is not published as a
         // replacement for the account's relay list.
-        if !relay_lists.nip65.relays.is_empty() {
-            let safe = self.retain_safe_discovered_endpoints(
-                relay_lists
-                    .nip65
-                    .relays
-                    .iter()
-                    .cloned()
-                    .map(TransportEndpoint)
-                    .collect(),
-            );
-            if !safe.is_empty() {
-                return safe;
-            }
+        let offered = relay_lists.nip65.relays.len();
+        let safe = self.retain_safe_discovered_endpoints(
+            relay_lists
+                .nip65
+                .relays
+                .iter()
+                .cloned()
+                .map(TransportEndpoint)
+                .collect(),
+            "local account key package routing",
+        );
+        if !safe.is_empty() {
+            return safe;
         }
-        self.relay_endpoints()
+        let fallback = self.relay_endpoints();
+        if offered > 0 {
+            tracing::warn!(
+                target: "marmot_app::relay_plane",
+                method = "key_package_endpoints",
+                offered = offered,
+                fallback = fallback.len(),
+                "published account outbox has no usable endpoints; using configured defaults"
+            );
+        }
+        fallback
     }
 
     fn transport_label(&self) -> &'static str {

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -2046,6 +2046,21 @@ fn nip65_relay_list_targets_only_include_write_capable_entries() {
 }
 
 #[test]
+fn relay_list_declaration_validation_does_not_apply_the_dial_route_cap() {
+    let dir = tempfile::tempdir().unwrap();
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+    let declared = (0..17)
+        .map(|index| TransportEndpoint(format!("wss://relay-{index}.example")))
+        .collect::<Vec<_>>();
+
+    app.validate_account_relay_list_declarations(
+        &AccountRelayListBootstrap::new(declared, Vec::new()),
+        None,
+    )
+    .expect("published list size must not inherit the dial route's endpoint cap");
+}
+
+#[test]
 fn newer_all_read_nip65_list_clears_stale_write_targets() {
     let account_id = "11".repeat(32);
     let mut older = NostrTransportEvent::new_unsigned(

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -408,6 +408,8 @@ fn endpoint(url: &str) -> TransportEndpoint {
 }
 
 #[derive(Clone, Debug)]
+// Mirrors `src/tests.rs::TestExternalAccountSigner`; keep both shims aligned
+// when the `NostrSigner` or account-identity-proof signer traits change.
 struct TestExternalAccountSigner {
     keys: nostr::Keys,
 }
@@ -5917,6 +5919,9 @@ async fn import_ignores_retired_published_routes_without_rewriting_relay_lists()
 }
 
 #[tokio::test]
+// External signers were a distinct reported failure mode: this intentionally
+// pins `login_external_signer`, not only the shared routing helpers exercised
+// by the nsec-import regression above.
 async fn external_signer_login_ignores_retired_routes_without_rewriting_relay_lists() {
     let publisher_dir = tempfile::tempdir().unwrap();
     let publisher_home = AccountHome::open(publisher_dir.path());
@@ -5981,22 +5986,108 @@ async fn external_signer_login_ignores_retired_routes_without_rewriting_relay_li
 }
 
 #[tokio::test]
-async fn relay_list_edits_reject_retired_endpoints() {
+async fn remote_key_package_fetch_falls_back_when_published_outbox_is_retired() {
+    let publisher_dir = tempfile::tempdir().unwrap();
+    let publisher_home = AccountHome::open(publisher_dir.path());
+    let (_relay, publisher_app, relay_url) = mock_app(&publisher_dir).await;
+    let publisher_runtime = MarmotAppRuntime::new(publisher_app.clone());
+    let created = publisher_runtime
+        .create_identity(AccountSetupRequest {
+            default_relays: vec![endpoint(&relay_url)],
+            bootstrap_relays: vec![endpoint(&relay_url)],
+            publish_initial_key_package: true,
+            ..AccountSetupRequest::default()
+        })
+        .await
+        .unwrap();
+    publish_account_relay_lists_at(
+        &publisher_home,
+        &created.account.label,
+        &relay_url,
+        "wss://relay.damus.io",
+        test_unix_now_seconds() + 1,
+    )
+    .await;
+
+    let consumer_dir = tempfile::tempdir().unwrap();
+    let consumer = MarmotApp::with_relay_and_config(
+        consumer_dir.path(),
+        relay_url.clone(),
+        MarmotAppConfig::default().with_allow_loopback_relay_endpoints(true),
+    );
+    let fetched = consumer
+        .fetch_latest_key_package_for_account_id(
+            &created.account.account_id_hex,
+            vec![endpoint(&relay_url)],
+        )
+        .await
+        .expect("configured directory relays should recover a remote KeyPackage");
+
+    assert_eq!(
+        fetched.relay_lists.nip65.relays,
+        vec!["wss://relay.damus.io"]
+    );
+    assert_eq!(
+        fetched.key_package.bytes().len(),
+        created.key_package_bytes.unwrap()
+    );
+
+    publisher_runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn relay_list_edits_reject_retired_endpoints_in_every_input_role() {
     let dir = tempfile::tempdir().unwrap();
     let home = AccountHome::open(dir.path());
     home.create_account("alice").unwrap();
     let (_seed, app, seed_url) = mock_app(&dir).await;
 
-    let result = app
+    let inbox = app
         .set_account_inbox_relays(
             "alice",
             vec![endpoint(&seed_url), endpoint("wss://relay.nostr.band")],
             vec![endpoint(&seed_url)],
         )
         .await;
-
     assert!(
-        matches!(result, Err(AppError::RelayDirectory(message)) if message.contains("retired"))
+        matches!(inbox, Err(AppError::RelayDirectory(message)) if message.contains("account relay-list declaration") && message.contains("retired"))
+    );
+
+    let bootstrap = app
+        .publish_account_relay_lists(
+            "alice",
+            AccountRelayListBootstrap::new(
+                vec![endpoint(&seed_url)],
+                vec![endpoint("wss://relay.damus.io")],
+            ),
+        )
+        .await;
+    assert!(
+        matches!(bootstrap, Err(AppError::RelayDirectory(message)) if message.contains("account relay-list publication") && message.contains("retired"))
+    );
+
+    let nip65_read = app
+        .publish_account_nip65_relay_set(
+            "alice",
+            vec![endpoint("wss://relay.nostr.band")],
+            vec![endpoint(&seed_url)],
+            vec![endpoint(&seed_url)],
+        )
+        .await;
+    assert!(
+        matches!(nip65_read, Err(AppError::RelayDirectory(message)) if message.contains("account NIP-65 read-relay declaration") && message.contains("retired"))
+    );
+
+    let nip65_write = app
+        .publish_account_nip65_relay_set(
+            "alice",
+            vec![endpoint(&seed_url)],
+            vec![endpoint("wss://relay.damus.io")],
+            vec![endpoint(&seed_url)],
+        )
+        .await;
+    assert!(
+        matches!(nip65_write, Err(AppError::RelayDirectory(message)) if message.contains("account NIP-65 write-relay declaration") && message.contains("retired"))
     );
 }
 

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -407,6 +407,79 @@ fn endpoint(url: &str) -> TransportEndpoint {
     TransportEndpoint(url.to_owned())
 }
 
+#[derive(Clone, Debug)]
+struct TestExternalAccountSigner {
+    keys: nostr::Keys,
+}
+
+impl nostr::NostrSigner for TestExternalAccountSigner {
+    fn backend(&self) -> nostr::signer::SignerBackend<'_> {
+        self.keys.backend()
+    }
+
+    fn get_public_key(
+        &self,
+    ) -> nostr::util::BoxedFuture<'_, Result<nostr::PublicKey, nostr::SignerError>> {
+        self.keys.get_public_key()
+    }
+
+    fn sign_event(
+        &self,
+        unsigned: nostr::UnsignedEvent,
+    ) -> nostr::util::BoxedFuture<'_, Result<nostr::Event, nostr::SignerError>> {
+        self.keys.sign_event(unsigned)
+    }
+
+    fn nip04_encrypt<'a>(
+        &'a self,
+        public_key: &'a nostr::PublicKey,
+        content: &'a str,
+    ) -> nostr::util::BoxedFuture<'a, Result<String, nostr::SignerError>> {
+        self.keys.nip04_encrypt(public_key, content)
+    }
+
+    fn nip04_decrypt<'a>(
+        &'a self,
+        public_key: &'a nostr::PublicKey,
+        encrypted_content: &'a str,
+    ) -> nostr::util::BoxedFuture<'a, Result<String, nostr::SignerError>> {
+        self.keys.nip04_decrypt(public_key, encrypted_content)
+    }
+
+    fn nip44_encrypt<'a>(
+        &'a self,
+        public_key: &'a nostr::PublicKey,
+        content: &'a str,
+    ) -> nostr::util::BoxedFuture<'a, Result<String, nostr::SignerError>> {
+        self.keys.nip44_encrypt(public_key, content)
+    }
+
+    fn nip44_decrypt<'a>(
+        &'a self,
+        public_key: &'a nostr::PublicKey,
+        payload: &'a str,
+    ) -> nostr::util::BoxedFuture<'a, Result<String, nostr::SignerError>> {
+        self.keys.nip44_decrypt(public_key, payload)
+    }
+}
+
+impl cgka_engine::account_identity_proof::AccountIdentityProofSigner for TestExternalAccountSigner {
+    fn sign_account_identity_proof(
+        &self,
+        request: &cgka_engine::account_identity_proof::AccountIdentityProofRequest,
+    ) -> Result<[u8; 64], String> {
+        if self.keys.public_key().to_bytes().as_slice() != request.account_identity.as_slice() {
+            return Err("request account identity does not match test signer".into());
+        }
+        let event = request.proof_event().and_then(|event| {
+            event
+                .sign_with_keys(&self.keys)
+                .map_err(|err| err.to_string())
+        })?;
+        request.signature_from_signed_event(event)
+    }
+}
+
 async fn publish_nostr_event_at(
     home: &AccountHome,
     label: &str,
@@ -5778,6 +5851,153 @@ async fn relay_list_empty_fetch_keeps_cached_lists() {
         .unwrap()
         .expect("cached directory entry");
     assert_eq!(directory_entry.relay_lists, cached);
+}
+
+#[tokio::test]
+async fn import_ignores_retired_published_routes_without_rewriting_relay_lists() {
+    use nostr::prelude::ToBech32;
+
+    let publisher_dir = tempfile::tempdir().unwrap();
+    let publisher_home = AccountHome::open(publisher_dir.path());
+    let keys = Keys::generate();
+    let secret_hex = keys.secret_key().to_secret_hex();
+    let secret_nsec = keys.secret_key().to_bech32().unwrap();
+    publisher_home
+        .import_account("publisher", &secret_hex)
+        .unwrap();
+
+    let (_relay, relay_url) = mock_relay().await;
+    publish_account_relay_lists_at(
+        &publisher_home,
+        "publisher",
+        &relay_url,
+        "wss://relay.damus.io",
+        test_unix_now_seconds(),
+    )
+    .await;
+
+    let app_dir = tempfile::tempdir().unwrap();
+    let app = MarmotApp::with_relay_and_config(
+        app_dir.path(),
+        relay_url.clone(),
+        MarmotAppConfig::default().with_allow_loopback_relay_endpoints(true),
+    );
+    let runtime = MarmotAppRuntime::new(app.clone());
+    let imported = runtime
+        .create_or_import_account(AccountSetupRequest {
+            import_nsec: Some(zeroize::Zeroizing::new(secret_nsec)),
+            default_relays: vec![endpoint(&relay_url)],
+            bootstrap_relays: vec![endpoint(&relay_url)],
+            discovery_relays: vec![endpoint(&relay_url)],
+            publish_missing_relay_lists: true,
+            publish_initial_key_package: true,
+            ..AccountSetupRequest::default()
+        })
+        .await
+        .expect("a retired published relay must not block account import");
+
+    assert!(imported.relay_lists.complete);
+    assert_eq!(
+        imported.relay_lists.nip65.relays,
+        vec!["wss://relay.damus.io"]
+    );
+    assert_eq!(
+        imported.relay_lists.inbox.relays,
+        vec!["wss://relay.damus.io"]
+    );
+    assert!(imported.key_package_bytes.is_some());
+    assert_eq!(
+        app.account_relay_list_status(&imported.account.label)
+            .unwrap(),
+        imported.relay_lists,
+        "runtime filtering must not rewrite or hide the published relay lists"
+    );
+
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn external_signer_login_ignores_retired_routes_without_rewriting_relay_lists() {
+    let publisher_dir = tempfile::tempdir().unwrap();
+    let publisher_home = AccountHome::open(publisher_dir.path());
+    let keys = Keys::generate();
+    publisher_home
+        .import_account("publisher", &keys.secret_key().to_secret_hex())
+        .unwrap();
+
+    let (_relay, relay_url) = mock_relay().await;
+    publish_account_relay_lists_at(
+        &publisher_home,
+        "publisher",
+        &relay_url,
+        "wss://relay.nostr.band",
+        test_unix_now_seconds(),
+    )
+    .await;
+
+    let app_dir = tempfile::tempdir().unwrap();
+    let app = MarmotApp::with_relay_and_config(
+        app_dir.path(),
+        relay_url.clone(),
+        MarmotAppConfig::default().with_allow_loopback_relay_endpoints(true),
+    );
+    let runtime = MarmotAppRuntime::new(app.clone());
+    let logged_in = runtime
+        .login_external_signer(
+            keys.public_key().to_hex(),
+            TestExternalAccountSigner { keys },
+            AccountSetupRequest {
+                default_relays: vec![endpoint(&relay_url)],
+                bootstrap_relays: vec![endpoint(&relay_url)],
+                discovery_relays: vec![endpoint(&relay_url)],
+                publish_missing_relay_lists: true,
+                publish_initial_key_package: true,
+                ..AccountSetupRequest::default()
+            },
+        )
+        .await
+        .expect("a retired published relay must not block external-signer login");
+
+    assert!(logged_in.account.external_signing);
+    assert!(!logged_in.account.local_signing);
+    assert!(logged_in.relay_lists.complete);
+    assert_eq!(
+        logged_in.relay_lists.nip65.relays,
+        vec!["wss://relay.nostr.band"]
+    );
+    assert_eq!(
+        logged_in.relay_lists.inbox.relays,
+        vec!["wss://relay.nostr.band"]
+    );
+    assert!(logged_in.key_package_bytes.is_some());
+    assert_eq!(
+        app.account_relay_list_status(&logged_in.account.label)
+            .unwrap(),
+        logged_in.relay_lists,
+        "runtime filtering must not rewrite or hide external accounts' published relay lists"
+    );
+
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn relay_list_edits_reject_retired_endpoints() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(dir.path());
+    home.create_account("alice").unwrap();
+    let (_seed, app, seed_url) = mock_app(&dir).await;
+
+    let result = app
+        .set_account_inbox_relays(
+            "alice",
+            vec![endpoint(&seed_url), endpoint("wss://relay.nostr.band")],
+            vec![endpoint(&seed_url)],
+        )
+        .await;
+
+    assert!(
+        matches!(result, Err(AppError::RelayDirectory(message)) if message.contains("retired"))
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- preserve published NIP-65 and Marmot inbox relay lists exactly as discovered so clients can display and classify retired entries
- drop retired or otherwise unsafe discovered endpoints only when constructing runtime inbox, outbox, KeyPackage, directory, and push routes
- fall back to configured White Noise directory relays when a discovered local or remote KeyPackage route has no usable endpoints, without publishing a replacement relay list
- reject retired endpoints in every relay-list edit role (default, inbox, bootstrap, NIP-65 read, and NIP-65 write)
- keep relay-list declaration validation independent from the runtime dial-route endpoint-count limit

## Root cause

Account setup cached a discovered relay list containing a retired relay and later passed that list unchanged into the fail-closed relay-plane activation boundary. A published `relay.damus.io` or `relay.nostr.band` inbox route therefore aborted activation for both imported nsec identities and external signers.

The denylist remains enforced. This change distinguishes untrusted discovered routing data, which is filtered per endpoint at use time, from caller-configured relay-list edits, which remain fail-closed. If a published list becomes empty after filtering, runtime routing uses configured fallback relays; the published list itself is neither rewritten nor replaced.

This addresses the retired-relay login/signup failure tracked in #842. Signed group routes remain fail-closed and are intentionally unchanged by this account-route fix.

## User impact

Existing identities can sign in even when their published relay lists contain retired relays. Remote KeyPackage lookup also continues through configured directory relays when a contact's published NIP-65 list contains only retired entries. The original lists remain visible through the bindings, and `classify_relay_endpoints` continues to label those entries as `retired` for relay settings UI.

## Validation

- `just fast-ci`
- `cargo test -p marmot-app --test relay_runtime import_ignores_retired_published_routes_without_rewriting_relay_lists -- --exact`
- `cargo test -p marmot-app --test relay_runtime external_signer_login_ignores_retired_routes_without_rewriting_relay_lists -- --exact`
- `cargo test -p marmot-app --test relay_runtime remote_key_package_fetch_falls_back_when_published_outbox_is_retired -- --exact`
- `cargo test -p marmot-app --test relay_runtime relay_list_edits_reject_retired_endpoints_in_every_input_role -- --exact`
- `cargo test -p marmot-app tests::relay_list_declaration_validation_does_not_apply_the_dial_route_cap -- --exact`
- existing relay-safety unit regression for both retired hosts

A broader `cargo test -p marmot-app` run passed all 561 unit tests and 79 relay-runtime tests before five unrelated media/retention/removal integration cases failed; two of those failures also reproduce when run individually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relay safety checks across notifications, inbox and outbox routing, key-package discovery, and account relay-list operations.
  * Added fallback routing when configured relay endpoints are no longer safe or available.
  * Prevented retired relay endpoints from being added through relay-list edits.
  * Preserved existing published relay lists during imports and external-signer logins, even when routes are retired.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->