### PR TITLE
Make account import setup resumable

### DIFF
--- a/crates/cgka-conformance-simulator/src/app_runtime.rs
+++ b/crates/cgka-conformance-simulator/src/app_runtime.rs
@@ -1078,6 +1078,7 @@ fn app_error(error: AppError) -> SubjectError {
         | AppError::ExternalSignerRejected
         | AppError::MissingDirectoryEntry(_)
         | AppError::NotificationsDisabled
+        | AppError::AccountSetupRecoveryRequired
         | AppError::ReactionNotFound => SubjectFailureCategory::ExpectedRefusal,
         AppError::Account(_)
         | AppError::AccountHome(_)

--- a/crates/cgka-conformance-simulator/src/app_runtime.rs
+++ b/crates/cgka-conformance-simulator/src/app_runtime.rs
@@ -1079,6 +1079,9 @@ fn app_error(error: AppError) -> SubjectError {
         | AppError::MissingDirectoryEntry(_)
         | AppError::NotificationsDisabled
         | AppError::AccountSetupRecoveryRequired
+        | AppError::AccountSetupRetryRequired
+        | AppError::AccountSetupResetNotApplicable
+        | AppError::AccountSetupKeyPackageRecoveryAvailable
         | AppError::ReactionNotFound => SubjectFailureCategory::ExpectedRefusal,
         AppError::Account(_)
         | AppError::AccountHome(_)

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -24,6 +24,9 @@ versioning through the workspace version in the root `Cargo.toml`.
   
 ### Fixed
 
+- Account setup interruptions now have stable JSON recovery codes and repair
+  hints instead of falling through to the generic `command_failed` bucket.
+
 - Account projection storage types now redact encrypted group-image decryption
   and Blossom upload keys from `Debug` output, including nested group
   formatting. The TUI group diagnostics panel no longer retains or renders raw

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -604,6 +604,27 @@ fn app_error_json(err: &AppError) -> Value {
             "code": "account_catch_up",
             "message": err.to_string(),
         }),
+        AppError::AccountSetupRecoveryRequired => json!({
+            "code": "account_setup_recovery_required",
+            "message": err.to_string(),
+            "repair": {
+                "action": "confirm possible orphaned KeyPackage exposure, then retry with the host recovery API",
+            },
+        }),
+        AppError::AccountSetupRetryRequired => json!({
+            "code": "account_setup_retry_required",
+            "message": err.to_string(),
+            "repair": { "action": "retry the original account setup operation" },
+        }),
+        AppError::AccountSetupResetNotApplicable => json!({
+            "code": "account_setup_reset_not_applicable",
+            "message": err.to_string(),
+        }),
+        AppError::AccountSetupKeyPackageRecoveryAvailable => json!({
+            "code": "account_setup_key_package_recovery_available",
+            "message": err.to_string(),
+            "repair": { "action": "retry the original account setup operation" },
+        }),
         other => json!({
             "code": "command_failed",
             "message": other.to_string(),
@@ -689,6 +710,31 @@ mod tests {
             assert!(!message.contains(nsec), "{message}");
             let json = wn_error_json(&err).to_string();
             assert!(!json.contains(nsec), "{json}");
+        }
+    }
+
+    #[test]
+    fn account_setup_recovery_errors_have_stable_json_codes() {
+        let cases = [
+            (
+                AppError::AccountSetupRecoveryRequired,
+                "account_setup_recovery_required",
+            ),
+            (
+                AppError::AccountSetupRetryRequired,
+                "account_setup_retry_required",
+            ),
+            (
+                AppError::AccountSetupResetNotApplicable,
+                "account_setup_reset_not_applicable",
+            ),
+            (
+                AppError::AccountSetupKeyPackageRecoveryAvailable,
+                "account_setup_key_package_recovery_available",
+            ),
+        ];
+        for (error, code) in cases {
+            assert_eq!(wn_error_json(&WnError::App(error))["code"], code);
         }
     }
 }

--- a/crates/marmot-account/src/error.rs
+++ b/crates/marmot-account/src/error.rs
@@ -33,6 +33,8 @@ pub enum AccountHomeError {
     InvalidAccountLabel(String),
     #[error("stored account id does not match stored secret key")]
     AccountIdMismatch,
+    #[error("durable account setup state is missing")]
+    AccountSetupStateMissing,
     #[error("unsupported account secret storage backend: {0}")]
     UnsupportedSecretBackend(String),
     #[error("account secret store is not initialized: {0}")]

--- a/crates/marmot-account/src/home.rs
+++ b/crates/marmot-account/src/home.rs
@@ -9,13 +9,14 @@ use std::fs;
 use zeroize::Zeroizing;
 
 use crate::error::{AccountHomeError, AccountHomeResult};
-use crate::io::{read_json, validate_account_label, write_json};
+use crate::io::{read_json, validate_account_label, write_json, write_secret_json};
 use crate::secret_store::{
     AccountSecretStore, KeychainSecretStore, LocalFileSecretStore,
     scrub_and_remove_local_secret_file,
 };
 
 const ACCOUNT_RECORD_FILE: &str = "account.json";
+const ACCOUNT_SETUP_STATE_FILE: &str = ".account-setup.json";
 /// Per-account NIP-49 KEY_SECURITY_BYTE status record. Records only a status
 /// byte, never key material, so it is written with public file permissions.
 const ACCOUNT_KEY_SECURITY_FILE: &str = "key-security.json";
@@ -93,6 +94,31 @@ pub struct AccountSummary {
 pub struct NostrAccountImport {
     account: AccountSummary,
     reused_account_id_credential: bool,
+}
+
+/// Durable provenance and progress for an account setup that has not committed.
+///
+/// This file is created with the account record and removed only after the app
+/// runtime has completed setup. It makes task cancellation and process death
+/// recoverable without treating the mere existence of `session.sqlite` as evidence
+/// that a KeyPackage was previously published.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AccountSetupState {
+    pub account_id_hex: String,
+    pub reused_account_id_credential: bool,
+    pub phase: AccountSetupPhase,
+}
+
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AccountSetupPhase {
+    #[default]
+    LocalStateCreated,
+    /// Set before entering KeyPackage preparation/publication. If the task is
+    /// cancelled after this point, the SQLCipher lifecycle is authoritative:
+    /// exact signed bytes are persisted there before the first network send.
+    KeyPackagePublicationStarted,
+    KeyPackagePublicationConfirmed,
 }
 
 impl NostrAccountImport {
@@ -274,9 +300,24 @@ impl AccountHome {
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         validate_account_label(&account_id_hex)?;
 
-        if self.account_record_path(&account_id_hex).exists()
-            || self.secret_store.has_secret_for_label(&account_id_hex)?
-        {
+        if self.account_record_path(&account_id_hex).exists() {
+            let account = self.account(&account_id_hex)?;
+            let Some(setup) = self.account_setup_state(&account_id_hex)? else {
+                return Err(AccountHomeError::AccountExists(account_id_hex));
+            };
+            if !account.local_signing || setup.account_id_hex != account.account_id_hex {
+                return Err(AccountHomeError::AccountExists(account_id_hex));
+            }
+            let stored_keys = self.secret_store.load_secret(&account)?;
+            if stored_keys.public_key() != keys.public_key() {
+                return Err(AccountHomeError::AccountIdMismatch);
+            }
+            return Ok(NostrAccountImport {
+                account,
+                reused_account_id_credential: setup.reused_account_id_credential,
+            });
+        }
+        if self.secret_store.has_secret_for_label(&account_id_hex)? {
             return Err(AccountHomeError::AccountExists(account_id_hex));
         }
         if self
@@ -304,13 +345,93 @@ impl AccountHome {
             }
             self.write_account_record(&account)?;
         } else {
-            self.write_new_signing_account(&account, &keys)?;
+            self.write_account_record(&account)?;
+            if let Err(err) = self.secret_store.write_secret(&account, &keys) {
+                let _ = fs::remove_file(self.account_record_path(&account.label));
+                let _ = fs::remove_dir(self.account_dir(&account.label));
+                return Err(err);
+            }
+        }
+        if let Err(err) = self.begin_account_setup(&account, reused_account_id_credential) {
+            if !reused_account_id_credential {
+                let _ = self.secret_store.remove_secret(&account);
+            }
+            let _ = fs::remove_file(self.account_record_path(&account.label));
+            let _ = fs::remove_dir_all(self.account_dir(&account.label));
+            return Err(err);
         }
 
         Ok(NostrAccountImport {
             account,
             reused_account_id_credential,
         })
+    }
+
+    /// Create the durable setup journal for a newly-created account.
+    pub fn begin_account_setup(
+        &self,
+        account: &AccountSummary,
+        reused_account_id_credential: bool,
+    ) -> AccountHomeResult<AccountSetupState> {
+        let state = AccountSetupState {
+            account_id_hex: account.account_id_hex.clone(),
+            reused_account_id_credential,
+            phase: AccountSetupPhase::LocalStateCreated,
+        };
+        write_secret_json(self.account_setup_state_path(&account.label), &state)?;
+        Ok(state)
+    }
+
+    pub fn account_setup_state(
+        &self,
+        account_ref: &str,
+    ) -> AccountHomeResult<Option<AccountSetupState>> {
+        let account = self.account(account_ref)?;
+        match read_json(self.account_setup_state_path(&account.label)) {
+            Ok(state) => Ok(Some(state)),
+            Err(AccountHomeError::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => {
+                Ok(None)
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    pub fn set_account_setup_phase(
+        &self,
+        account_ref: &str,
+        phase: AccountSetupPhase,
+    ) -> AccountHomeResult<()> {
+        let account = self.account(account_ref)?;
+        let Some(mut state) = self.account_setup_state(&account.label)? else {
+            return Ok(());
+        };
+        if state.account_id_hex != account.account_id_hex {
+            return Err(AccountHomeError::AccountIdMismatch);
+        }
+        state.phase = phase;
+        write_secret_json(self.account_setup_state_path(&account.label), &state)
+    }
+
+    pub fn complete_account_setup(&self, account_ref: &str) -> AccountHomeResult<()> {
+        let account = self.account(account_ref)?;
+        match fs::remove_file(self.account_setup_state_path(&account.label)) {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    /// Remove an explicitly-authorized legacy incomplete setup while retaining
+    /// the matching account-id-keyed credential for the immediate retry.
+    pub fn reset_incomplete_setup_preserving_credential(
+        &self,
+        account_ref: &str,
+    ) -> AccountHomeResult<()> {
+        let account = self.account(account_ref)?;
+        let preserve = self
+            .secret_store
+            .has_secret_for_account_id(&account.account_id_hex)?;
+        self.remove_account_inner(account_ref, Some(&account), preserve)
     }
 
     pub fn add_public_account(&self, public_key: &str) -> AccountHomeResult<AccountSummary> {
@@ -831,5 +952,9 @@ impl AccountHome {
 
     fn account_record_path(&self, label: &str) -> PathBuf {
         self.account_dir(label).join(ACCOUNT_RECORD_FILE)
+    }
+
+    fn account_setup_state_path(&self, label: &str) -> PathBuf {
+        self.account_dir(label).join(ACCOUNT_SETUP_STATE_FILE)
     }
 }

--- a/crates/marmot-account/src/home.rs
+++ b/crates/marmot-account/src/home.rs
@@ -106,7 +106,19 @@ pub struct NostrAccountImport {
 pub struct AccountSetupState {
     pub account_id_hex: String,
     pub reused_account_id_credential: bool,
+    #[serde(default)]
+    pub kind: AccountSetupKind,
     pub phase: AccountSetupPhase,
+}
+
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AccountSetupKind {
+    #[default]
+    ImportedIdentity,
+    GeneratedIdentity,
+    PublicIdentity,
+    ExternalSigner,
 }
 
 #[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -200,6 +212,97 @@ impl AccountHome {
         self.write_signing_account(&keys)
     }
 
+    /// Create a generated identity with its setup journal durable before the
+    /// account becomes visible. A restart can therefore resume the same
+    /// identity instead of minting another one.
+    pub fn create_nostr_account_for_setup(&self) -> AccountHomeResult<AccountSummary> {
+        let keys = nostr::Keys::generate();
+        let account = AccountSummary {
+            label: keys.public_key().to_hex(),
+            account_id_hex: keys.public_key().to_hex(),
+            local_signing: true,
+            external_signing: false,
+            signed_out: false,
+        };
+        let _guard = self
+            .mutation_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        validate_account_label(&account.label)?;
+        if self.account_record_path(&account.label).exists() {
+            return Err(AccountHomeError::AccountExists(account.label));
+        }
+        self.begin_account_setup_with(
+            &account,
+            false,
+            AccountSetupKind::GeneratedIdentity,
+            AccountSetupPhase::LocalStateCreated,
+        )?;
+        if let Err(err) = self.secret_store.write_secret(&account, &keys) {
+            let _ = self.secret_store.remove_secret(&account);
+            let _ = fs::remove_dir_all(self.account_dir(&account.label));
+            return Err(err);
+        }
+        if let Err(err) = self.write_account_record(&account) {
+            let _ = self.secret_store.remove_secret(&account);
+            let _ = fs::remove_dir_all(self.account_dir(&account.label));
+            return Err(err);
+        }
+        Ok(account)
+    }
+
+    /// Recover the one generated setup that did not yet remove its journal.
+    pub fn resumable_generated_account_setup(&self) -> AccountHomeResult<Option<AccountSummary>> {
+        let _guard = self
+            .mutation_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let dir = self.accounts_dir();
+        if !dir.exists() {
+            return Ok(None);
+        }
+        let mut entries = fs::read_dir(&dir)?.collect::<Result<Vec<_>, _>>()?;
+        entries.sort_by_key(|entry| entry.file_name());
+        for entry in entries {
+            let Some(label) = entry.file_name().to_str().map(str::to_owned) else {
+                continue;
+            };
+            let Some(state) = self.raw_account_setup_state(&label)? else {
+                continue;
+            };
+            if state.kind != AccountSetupKind::GeneratedIdentity {
+                continue;
+            }
+            let account = AccountSummary {
+                label: label.clone(),
+                account_id_hex: state.account_id_hex,
+                local_signing: true,
+                external_signing: false,
+                signed_out: false,
+            };
+            if account.label != account.account_id_hex {
+                return Err(AccountHomeError::AccountIdMismatch);
+            }
+            if !self.account_record_path(&label).exists() {
+                let has_secret = self.secret_store.has_secret_for_label(&label)?
+                    || self
+                        .secret_store
+                        .has_secret_for_account_id(&account.account_id_hex)?;
+                if !has_secret {
+                    fs::remove_dir_all(self.account_dir(&label))?;
+                    continue;
+                }
+                self.write_account_record(&account)?;
+            }
+            let keys = self.secret_store.load_secret(&account)?;
+            if keys.public_key().to_hex() != account.account_id_hex {
+                return Err(AccountHomeError::AccountIdMismatch);
+            }
+            return Ok(Some(account));
+        }
+        Ok(None)
+    }
+
     pub fn import_account(
         &self,
         label: &str,
@@ -280,11 +383,11 @@ impl AccountHome {
         self.write_signing_account(&keys)
     }
 
-    /// Import a Nostr private key for runtime account setup, recovering only an
-    /// exact orphaned account-id-keyed credential.
+    /// Import a Nostr private key for runtime account setup, resuming only an
+    /// exact journaled setup or orphaned account-id-keyed credential.
     ///
-    /// Existing account records remain duplicates and are rejected. This is
-    /// narrower than [`Self::import_account_idempotent`]: it exists for
+    /// Committed account records remain duplicates and are rejected. This is
+    /// narrower than [`Self::import_account_idempotent`]: it also exists for
     /// uninstall/reinstall recovery where an app's filesystem home was removed
     /// while its Keychain entry survived.
     pub fn import_nostr_account_idempotent(
@@ -303,7 +406,7 @@ impl AccountHome {
         if self.account_record_path(&account_id_hex).exists() {
             let account = self.account(&account_id_hex)?;
             let Some(setup) = self.account_setup_state(&account_id_hex)? else {
-                return Err(AccountHomeError::AccountExists(account_id_hex));
+                return Err(AccountHomeError::AccountExists(account.label));
             };
             if !account.local_signing || setup.account_id_hex != account.account_id_hex {
                 return Err(AccountHomeError::AccountExists(account_id_hex));
@@ -317,17 +420,6 @@ impl AccountHome {
                 reused_account_id_credential: setup.reused_account_id_credential,
             });
         }
-        if self.secret_store.has_secret_for_label(&account_id_hex)? {
-            return Err(AccountHomeError::AccountExists(account_id_hex));
-        }
-        if self
-            .accounts()?
-            .iter()
-            .any(|account| account.local_signing && account.account_id_hex == account_id_hex)
-        {
-            return Err(AccountHomeError::AccountIdInUse(account_id_hex));
-        }
-
         let account = AccountSummary {
             label: account_id_hex.clone(),
             account_id_hex,
@@ -335,28 +427,62 @@ impl AccountHome {
             external_signing: false,
             signed_out: false,
         };
+        if let Some(setup) = self.raw_account_setup_state(&account.label)? {
+            if setup.account_id_hex != account.account_id_hex
+                || setup.kind != AccountSetupKind::ImportedIdentity
+            {
+                return Err(AccountHomeError::AccountExists(account.label));
+            }
+            match self.secret_store.load_secret(&account) {
+                Ok(stored_keys) if stored_keys.public_key() == keys.public_key() => {}
+                Ok(_) => return Err(AccountHomeError::AccountIdMismatch),
+                Err(AccountHomeError::SecretNotFound(_)) => {
+                    self.secret_store.write_secret(&account, &keys)?;
+                }
+                Err(AccountHomeError::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => {
+                    self.secret_store.write_secret(&account, &keys)?;
+                }
+                Err(err) => return Err(err),
+            }
+            self.write_account_record(&account)?;
+            return Ok(NostrAccountImport {
+                account,
+                reused_account_id_credential: setup.reused_account_id_credential,
+            });
+        }
+        if self.secret_store.has_secret_for_label(&account.label)? {
+            return Err(AccountHomeError::AccountExists(account.label));
+        }
+        if self.accounts()?.iter().any(|existing| {
+            existing.local_signing && existing.account_id_hex == account.account_id_hex
+        }) {
+            return Err(AccountHomeError::AccountIdInUse(account.account_id_hex));
+        }
         let reused_account_id_credential = self
             .secret_store
             .has_secret_for_account_id(&account.account_id_hex)?;
+        let setup = AccountSetupState {
+            account_id_hex: account.account_id_hex.clone(),
+            reused_account_id_credential,
+            kind: AccountSetupKind::ImportedIdentity,
+            phase: AccountSetupPhase::LocalStateCreated,
+        };
+        self.write_account_setup_state(&account.label, &setup)?;
         if reused_account_id_credential {
             let stored_keys = self.secret_store.load_secret(&account)?;
             if stored_keys.public_key() != keys.public_key() {
                 return Err(AccountHomeError::AccountIdMismatch);
             }
-            self.write_account_record(&account)?;
         } else {
-            self.write_account_record(&account)?;
             if let Err(err) = self.secret_store.write_secret(&account, &keys) {
-                let _ = fs::remove_file(self.account_record_path(&account.label));
-                let _ = fs::remove_dir(self.account_dir(&account.label));
+                let _ = fs::remove_dir_all(self.account_dir(&account.label));
                 return Err(err);
             }
         }
-        if let Err(err) = self.begin_account_setup(&account, reused_account_id_credential) {
+        if let Err(err) = self.write_account_record(&account) {
             if !reused_account_id_credential {
                 let _ = self.secret_store.remove_secret(&account);
             }
-            let _ = fs::remove_file(self.account_record_path(&account.label));
             let _ = fs::remove_dir_all(self.account_dir(&account.label));
             return Err(err);
         }
@@ -373,12 +499,28 @@ impl AccountHome {
         account: &AccountSummary,
         reused_account_id_credential: bool,
     ) -> AccountHomeResult<AccountSetupState> {
+        self.begin_account_setup_with(
+            account,
+            reused_account_id_credential,
+            AccountSetupKind::ImportedIdentity,
+            AccountSetupPhase::LocalStateCreated,
+        )
+    }
+
+    pub fn begin_account_setup_with(
+        &self,
+        account: &AccountSummary,
+        reused_account_id_credential: bool,
+        kind: AccountSetupKind,
+        phase: AccountSetupPhase,
+    ) -> AccountHomeResult<AccountSetupState> {
         let state = AccountSetupState {
             account_id_hex: account.account_id_hex.clone(),
             reused_account_id_credential,
-            phase: AccountSetupPhase::LocalStateCreated,
+            kind,
+            phase,
         };
-        write_secret_json(self.account_setup_state_path(&account.label), &state)?;
+        self.write_account_setup_state(&account.label, &state)?;
         Ok(state)
     }
 
@@ -387,7 +529,11 @@ impl AccountHome {
         account_ref: &str,
     ) -> AccountHomeResult<Option<AccountSetupState>> {
         let account = self.account(account_ref)?;
-        match read_json(self.account_setup_state_path(&account.label)) {
+        self.raw_account_setup_state(&account.label)
+    }
+
+    fn raw_account_setup_state(&self, label: &str) -> AccountHomeResult<Option<AccountSetupState>> {
+        match read_json(self.account_setup_state_path(label)) {
             Ok(state) => Ok(Some(state)),
             Err(AccountHomeError::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => {
                 Ok(None)
@@ -403,13 +549,22 @@ impl AccountHome {
     ) -> AccountHomeResult<()> {
         let account = self.account(account_ref)?;
         let Some(mut state) = self.account_setup_state(&account.label)? else {
-            return Ok(());
+            return Err(AccountHomeError::AccountSetupStateMissing);
         };
         if state.account_id_hex != account.account_id_hex {
             return Err(AccountHomeError::AccountIdMismatch);
         }
         state.phase = phase;
         write_secret_json(self.account_setup_state_path(&account.label), &state)
+    }
+
+    fn write_account_setup_state(
+        &self,
+        label: &str,
+        state: &AccountSetupState,
+    ) -> AccountHomeResult<()> {
+        validate_account_label(label)?;
+        write_secret_json(self.account_setup_state_path(label), state)
     }
 
     pub fn complete_account_setup(&self, account_ref: &str) -> AccountHomeResult<()> {

--- a/crates/marmot-account/src/lib.rs
+++ b/crates/marmot-account/src/lib.rs
@@ -17,8 +17,8 @@ mod time;
 
 pub use error::{AccountError, AccountHomeError, AccountHomeResult, AccountResult};
 pub use home::{
-    AccountHome, AccountSummary, DEFAULT_KEYCHAIN_SERVICE_NAME, EXTERNAL_SQLCIPHER_SECRET_FILE,
-    NostrAccountImport,
+    AccountHome, AccountSetupPhase, AccountSetupState, AccountSummary,
+    DEFAULT_KEYCHAIN_SERVICE_NAME, EXTERNAL_SQLCIPHER_SECRET_FILE, NostrAccountImport,
 };
 pub use key_package::{
     KeyPackagePublication, KeyPackagePublishError, KeyPackagePublishReceipt, KeyPackagePublisher,

--- a/crates/marmot-account/src/lib.rs
+++ b/crates/marmot-account/src/lib.rs
@@ -17,7 +17,7 @@ mod time;
 
 pub use error::{AccountError, AccountHomeError, AccountHomeResult, AccountResult};
 pub use home::{
-    AccountHome, AccountSetupPhase, AccountSetupState, AccountSummary,
+    AccountHome, AccountSetupKind, AccountSetupPhase, AccountSetupState, AccountSummary,
     DEFAULT_KEYCHAIN_SERVICE_NAME, EXTERNAL_SQLCIPHER_SECRET_FILE, NostrAccountImport,
 };
 pub use key_package::{

--- a/crates/marmot-account/tests/home.rs
+++ b/crates/marmot-account/tests/home.rs
@@ -477,6 +477,30 @@ fn account_home_runtime_import_does_not_capture_mismatched_keychain_credential()
 }
 
 #[test]
+fn runtime_import_resumes_only_while_durable_setup_is_incomplete() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(dir.path());
+    let keys = nostr::Keys::generate();
+    let secret = keys.secret_key().to_secret_hex();
+
+    let first = home.import_nostr_account_idempotent(&secret).unwrap();
+    let resumed = home.import_nostr_account_idempotent(&secret).unwrap();
+    assert_eq!(resumed.account(), first.account());
+    assert!(
+        home.account_setup_state(&first.account().label)
+            .unwrap()
+            .is_some()
+    );
+
+    home.complete_account_setup(&first.account().label).unwrap();
+    assert!(matches!(
+        home.import_nostr_account_idempotent(&secret),
+        Err(AccountHomeError::AccountExists(account))
+            if account == first.account().account_id_hex
+    ));
+}
+
+#[test]
 fn account_home_keychain_keeps_signing_secret_when_public_twin_record_is_removed() {
     install_mock_keyring();
     let dir = tempfile::tempdir().unwrap();

--- a/crates/marmot-account/tests/home.rs
+++ b/crates/marmot-account/tests/home.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex, Once};
 
 use marmot_account::{
-    AccountHome, AccountHomeError, AccountHomeResult, AccountSecretStore, AccountSummary,
-    KeychainSecretStore,
+    AccountHome, AccountHomeError, AccountHomeResult, AccountSecretStore, AccountSetupKind,
+    AccountSetupPhase, AccountSetupState, AccountSummary, KeychainSecretStore,
 };
 use nostr::nips::nip19::FromBech32;
 use nostr::nips::nip49::{EncryptedSecretKey, KeySecurity};
@@ -106,6 +106,83 @@ fn account_home_import_accepts_nsec_and_reopens_the_same_identity() {
             .to_hex(),
         imported.account_id_hex
     );
+}
+
+#[test]
+fn runtime_import_recovers_journal_before_secret_or_account_record() {
+    let dir = tempfile::tempdir().unwrap();
+    let keys = nostr::Keys::generate();
+    let account_id = keys.public_key().to_hex();
+    let account_dir = dir.path().join("accounts").join(&account_id);
+    std::fs::create_dir_all(&account_dir).unwrap();
+    std::fs::write(
+        account_dir.join(".account-setup.json"),
+        serde_json::to_vec(&AccountSetupState {
+            account_id_hex: account_id.clone(),
+            reused_account_id_credential: false,
+            kind: AccountSetupKind::ImportedIdentity,
+            phase: AccountSetupPhase::LocalStateCreated,
+        })
+        .unwrap(),
+    )
+    .unwrap();
+
+    let home = AccountHome::open(dir.path());
+    let imported = home
+        .import_nostr_account_idempotent(&keys.secret_key().to_secret_hex())
+        .unwrap();
+
+    assert_eq!(imported.account().account_id_hex, account_id);
+    assert_eq!(home.accounts().unwrap().len(), 1);
+    assert_eq!(
+        home.load_signing_keys(&account_id).unwrap().public_key(),
+        keys.public_key()
+    );
+}
+
+#[test]
+fn runtime_import_recovers_journal_and_secret_before_account_record() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(dir.path());
+    let keys = nostr::Keys::generate();
+    let account_id = keys.public_key().to_hex();
+    let account = home
+        .import_nostr_account(&keys.secret_key().to_secret_hex())
+        .unwrap();
+    std::fs::remove_file(home.account_dir(&account.label).join("account.json")).unwrap();
+    std::fs::write(
+        home.account_dir(&account.label).join(".account-setup.json"),
+        serde_json::to_vec(&AccountSetupState {
+            account_id_hex: account_id.clone(),
+            reused_account_id_credential: false,
+            kind: AccountSetupKind::ImportedIdentity,
+            phase: AccountSetupPhase::LocalStateCreated,
+        })
+        .unwrap(),
+    )
+    .unwrap();
+
+    let imported = home
+        .import_nostr_account_idempotent(&keys.secret_key().to_secret_hex())
+        .unwrap();
+
+    assert_eq!(imported.account().account_id_hex, account_id);
+    assert_eq!(home.accounts().unwrap().len(), 1);
+}
+
+#[test]
+fn setup_phase_update_fails_when_journal_is_missing() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(dir.path());
+    let account = home.create_nostr_account().unwrap();
+
+    assert!(matches!(
+        home.set_account_setup_phase(
+            &account.label,
+            AccountSetupPhase::KeyPackagePublicationStarted
+        ),
+        Err(AccountHomeError::AccountSetupStateMissing)
+    ));
 }
 
 #[test]

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -260,15 +260,15 @@ impl AppClient {
             .await?;
         self.refresh_routing()?;
         self.runtime.activate_transport(None).await?;
-        if self
-            .runtime
-            .key_package_maintenance_status()?
-            .is_some_and(|lifecycle| lifecycle.pending_replacement.is_some())
-        {
+        let lifecycle = self.runtime.key_package_maintenance_status()?;
+        if lifecycle.as_ref().is_some_and(|lifecycle| {
+            lifecycle.pending_replacement.is_some() || lifecycle.current_key_package.is_none()
+        }) {
             // A prior ambiguous or rejected setup attempt already owns exact
-            // signed bytes and private material. Resume that replacement;
-            // republish_key_package deliberately rejects pending rotations and
-            // would otherwise make account setup non-idempotent.
+            // signed bytes and private material, or a journaled setup owns a
+            // stable slot that has not promoted a current package yet. Resume
+            // or prepare that replacement; republish_key_package deliberately
+            // rejects pending rotations and requires a current package.
             Ok(self.runtime.publish_fresh_key_package().await?)
         } else {
             Ok(self.runtime.republish_key_package().await?)

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -260,7 +260,19 @@ impl AppClient {
             .await?;
         self.refresh_routing()?;
         self.runtime.activate_transport(None).await?;
-        Ok(self.runtime.republish_key_package().await?)
+        if self
+            .runtime
+            .key_package_maintenance_status()?
+            .is_some_and(|lifecycle| lifecycle.pending_replacement.is_some())
+        {
+            // A prior ambiguous or rejected setup attempt already owns exact
+            // signed bytes and private material. Resume that replacement;
+            // republish_key_package deliberately rejects pending rotations and
+            // would otherwise make account setup non-idempotent.
+            Ok(self.runtime.publish_fresh_key_package().await?)
+        } else {
+            Ok(self.runtime.republish_key_package().await?)
+        }
     }
 
     pub fn maintenance_status(

--- a/crates/marmot-app/src/client/projection.rs
+++ b/crates/marmot-app/src/client/projection.rs
@@ -596,6 +596,13 @@ fn read_marker_error_code(error: &AppError) -> &'static str {
         AppError::AccountSetupRecoveryRequired => {
             "read_marker_failed:account_setup_recovery_required"
         }
+        AppError::AccountSetupRetryRequired => "read_marker_failed:account_setup_retry_required",
+        AppError::AccountSetupResetNotApplicable => {
+            "read_marker_failed:account_setup_reset_not_applicable"
+        }
+        AppError::AccountSetupKeyPackageRecoveryAvailable => {
+            "read_marker_failed:account_setup_key_package_recovery_available"
+        }
         AppError::RuntimeStopping => "read_marker_failed:runtime_stopping",
         AppError::ReactionNotFound => "read_marker_failed:reaction_not_found",
         AppError::TransportClosed => "read_marker_failed:transport_closed",

--- a/crates/marmot-app/src/client/projection.rs
+++ b/crates/marmot-app/src/client/projection.rs
@@ -593,6 +593,9 @@ fn read_marker_error_code(error: &AppError) -> &'static str {
         AppError::BlockingTask(_) => "read_marker_failed:blocking_task",
         AppError::RuntimeBusy => "read_marker_failed:runtime_busy",
         AppError::AccountSessionBusy => "read_marker_failed:account_session_busy",
+        AppError::AccountSetupRecoveryRequired => {
+            "read_marker_failed:account_setup_recovery_required"
+        }
         AppError::RuntimeStopping => "read_marker_failed:runtime_stopping",
         AppError::ReactionNotFound => "read_marker_failed:reaction_not_found",
         AppError::TransportClosed => "read_marker_failed:transport_closed",

--- a/crates/marmot-app/src/error.rs
+++ b/crates/marmot-app/src/error.rs
@@ -131,6 +131,12 @@ pub enum AppError {
         "incomplete account setup requires explicit recovery because prior KeyPackage exposure cannot be ruled out"
     )]
     AccountSetupRecoveryRequired,
+    #[error("durable account setup can be resumed by retrying the original operation")]
+    AccountSetupRetryRequired,
+    #[error("account is not in the legacy incomplete-setup reset state")]
+    AccountSetupResetNotApplicable,
+    #[error("recoverable KeyPackage setup state exists; retry instead of resetting")]
+    AccountSetupKeyPackageRecoveryAvailable,
     #[error("marmot runtime is shutting down")]
     RuntimeStopping,
     #[error("no matching reaction by this account to retract")]
@@ -215,6 +221,11 @@ impl AppError {
             Self::RuntimeBusy => "runtime_busy",
             Self::AccountSessionBusy => "account_session_busy",
             Self::AccountSetupRecoveryRequired => "account_setup_recovery_required",
+            Self::AccountSetupRetryRequired => "account_setup_retry_required",
+            Self::AccountSetupResetNotApplicable => "account_setup_reset_not_applicable",
+            Self::AccountSetupKeyPackageRecoveryAvailable => {
+                "account_setup_key_package_recovery_available"
+            }
             Self::RuntimeStopping => "runtime_stopping",
             Self::ReactionNotFound => "reaction_not_found",
             Self::TransportClosed => "transport_closed",
@@ -259,6 +270,7 @@ fn account_home_error_kind(error: &AccountHomeError) -> &'static str {
         AccountHomeError::InvalidPublicKey => "account_home_invalid_public_key",
         AccountHomeError::InvalidAccountLabel(_) => "account_home_invalid_account_label",
         AccountHomeError::AccountIdMismatch => "account_home_account_id_mismatch",
+        AccountHomeError::AccountSetupStateMissing => "account_home_setup_state_missing",
         AccountHomeError::UnsupportedSecretBackend(_) => "account_home_unsupported_secret_backend",
         AccountHomeError::SecretStoreNotInitialized(_) => {
             "account_home_secret_store_not_initialized"

--- a/crates/marmot-app/src/error.rs
+++ b/crates/marmot-app/src/error.rs
@@ -123,6 +123,14 @@ pub enum AppError {
     /// owns the account's in-memory engine session.
     #[error("marmot account session is already in use")]
     AccountSessionBusy,
+    /// An account database predates the durable setup journal and has no
+    /// recoverable stable KeyPackage slot. Local evidence cannot prove that a
+    /// previously signed package was never exposed, so automatic rotation is
+    /// forbidden. The host may offer the explicit incomplete-setup reset API.
+    #[error(
+        "incomplete account setup requires explicit recovery because prior KeyPackage exposure cannot be ruled out"
+    )]
+    AccountSetupRecoveryRequired,
     #[error("marmot runtime is shutting down")]
     RuntimeStopping,
     #[error("no matching reaction by this account to retract")]
@@ -206,6 +214,7 @@ impl AppError {
             Self::BlockingTask(_) => "blocking_task",
             Self::RuntimeBusy => "runtime_busy",
             Self::AccountSessionBusy => "account_session_busy",
+            Self::AccountSetupRecoveryRequired => "account_setup_recovery_required",
             Self::RuntimeStopping => "runtime_stopping",
             Self::ReactionNotFound => "reaction_not_found",
             Self::TransportClosed => "transport_closed",

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -3150,6 +3150,23 @@ impl MarmotApp {
         }
     }
 
+    /// Remove compatibility artifacts that live outside the account directory.
+    /// Account-home deletion cannot otherwise make setup rollback complete.
+    fn remove_account_key_package_artifacts(&self, label: &str) -> Result<(), AppError> {
+        for path in [
+            self.key_package_record_path(label),
+            self.key_package_cutover_replacement_pending_path(label),
+            self.key_package_cutover_scan_complete_path(label),
+        ] {
+            match fs::remove_file(path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error.into()),
+            }
+        }
+        Ok(())
+    }
+
     fn key_package_cutover_scan_complete(&self, label: &str) -> bool {
         self.key_package_cutover_scan_complete_path(label).exists()
     }
@@ -3537,6 +3554,7 @@ impl MarmotApp {
         label: &str,
     ) -> Result<(), AppError> {
         let account_storage_preexisted = self.account_storage_path(label).exists();
+        let setup_in_progress = self.account_home().account_setup_state(label)?.is_some();
         let storage = self.account_storage(label)?;
         let existing_lifecycle = storage.key_package_lifecycle()?;
         if existing_lifecycle
@@ -3561,18 +3579,27 @@ impl MarmotApp {
                 }
             }
             Ok(None)
-                if !account_storage_preexisted
+                if (!account_storage_preexisted || setup_in_progress)
                     && storage.stored_key_package_bundles()?.is_empty() =>
             {
-                // Only a newly-created account database can mint the first
-                // slot without migration evidence. An existing database with
-                // missing cache authority fails closed even when no private
-                // bundles remain: it may previously have published under a
-                // now-unrecoverable `d` slot.
+                // Only a newly-created or durably journaled account setup can
+                // mint the first slot without migration evidence. Other
+                // existing databases fail closed even when no private bundles
+                // remain: they may have published under an unrecoverable `d`.
                 let mut slot = [0u8; 32];
                 OsRng.fill_bytes(&mut slot);
                 storage
                     .put_key_package_lifecycle(&empty_key_package_lifecycle(hex::encode(slot)))?;
+                if self.mark_key_package_cutover_replacement_pending(label) {
+                    return Ok(());
+                }
+            }
+            Ok(None) | Err(_) if account_storage_preexisted && !setup_in_progress => {
+                // A database created before the durable setup journal is
+                // ambiguous: it may be an interrupted fresh setup, or an
+                // upgraded device whose published stable slot was lost. Do not
+                // mint a second slot. Keep normal account reads available; the
+                // setup publication boundary surfaces the typed recovery state.
                 if self.mark_key_package_cutover_replacement_pending(label) {
                     return Ok(());
                 }
@@ -3592,6 +3619,18 @@ impl MarmotApp {
         Err(AppError::Io(std::io::Error::other(
             "could not persist strict cutover replacement intent before session open",
         )))
+    }
+
+    fn legacy_incomplete_setup_requires_recovery(&self, label: &str) -> Result<bool, AppError> {
+        if !self.account_storage_path(label).exists()
+            || self.account_home().account_setup_state(label)?.is_some()
+            || self.key_package_record_path(label).exists()
+        {
+            return Ok(false);
+        }
+        let storage = self.account_storage(label)?;
+        Ok(storage.key_package_lifecycle()?.is_none()
+            && storage.stored_key_package_bundles()?.is_empty())
     }
 
     async fn member_key_package(&self, member_ref: &str) -> Result<KeyPackage, AppError> {

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -13,7 +13,8 @@ use cgka_traits::engine::GroupEvent;
 use cgka_traits::storage::{KeyPackageBundleStorage, MaintenanceStorage};
 use cgka_traits::{GroupId, SecretBytes, TransportEndpoint};
 use marmot_account::{
-    AccountHome, AccountHomeError, AccountSetupPhase, AccountSummary, NostrAccountImport,
+    AccountHome, AccountHomeError, AccountSetupKind, AccountSetupPhase, AccountSummary,
+    NostrAccountImport,
 };
 use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, Notify, broadcast, mpsc, oneshot, watch};
@@ -3420,26 +3421,20 @@ impl AccountManager {
             .account_setup_state(&account.label)?
             .is_some()
         {
-            return Err(AppError::RelayDirectory(
-                "durable account setup state is recoverable by retry; reset is not allowed".into(),
-            ));
+            return Err(AppError::AccountSetupRetryRequired);
         }
         if !self
             .app
             .key_package_cutover_replacement_pending(&account.label)
         {
-            return Err(AppError::RelayDirectory(
-                "account is not in the legacy incomplete-setup recovery state".into(),
-            ));
+            return Err(AppError::AccountSetupResetNotApplicable);
         }
         let storage = self.app.account_storage(&account.label)?;
         if storage.key_package_lifecycle()?.is_some()
             || !storage.stored_key_package_bundles()?.is_empty()
             || self.app.key_package_record_path(&account.label).exists()
         {
-            return Err(AppError::RelayDirectory(
-                "account has recoverable KeyPackage state; reset is not allowed".into(),
-            ));
+            return Err(AppError::AccountSetupKeyPackageRecoveryAvailable);
         }
 
         self.set_account_tearing_down(&account.account_id_hex, true);
@@ -4004,8 +3999,14 @@ impl AccountManager {
                 .account_home()
                 .account_setup_state(&account.label)?
                 .map(|state| state.phase);
-            if setup_phase == Some(AccountSetupPhase::KeyPackagePublicationConfirmed) {
-                Some(self.confirmed_setup_key_package_bytes(&account.label)?)
+            let confirmed_bytes =
+                if setup_phase == Some(AccountSetupPhase::KeyPackagePublicationConfirmed) {
+                    self.confirmed_setup_key_package_bytes(&account.label)?
+                } else {
+                    None
+                };
+            if let Some(bytes) = confirmed_bytes {
+                Some(bytes)
             } else {
                 self.shared.lifecycle().ensure_running()?;
                 if setup_phase.is_some()
@@ -4137,6 +4138,24 @@ impl AccountManager {
                 err,
             );
         }
+        if self
+            .app
+            .account_home()
+            .account_setup_state(&account.label)?
+            .is_none()
+        {
+            self.app.account_home().begin_account_setup_with(
+                &account,
+                false,
+                AccountSetupKind::ExternalSigner,
+                AccountSetupPhase::LocalStateCreated,
+            )?;
+        }
+        let setup_already_reached_publication = self
+            .app
+            .account_home()
+            .account_setup_state(&account.label)?
+            .is_some_and(|state| state.phase != AccountSetupPhase::LocalStateCreated);
 
         let directory_bootstrap_relays = directory_bootstrap_relays_for_setup(&request);
         // An external-signer account is pre-existing by definition, so resolve
@@ -4162,6 +4181,9 @@ impl AccountManager {
         {
             Ok(relay_lists) => relay_lists,
             Err(err) => {
+                if setup_already_reached_publication {
+                    return Err(err);
+                }
                 return self.rollback_external_signer_setup(
                     &account.label,
                     created_account,
@@ -4172,8 +4194,18 @@ impl AccountManager {
         };
 
         let key_package_bytes = if request.publish_initial_key_package {
+            self.app.account_home().set_account_setup_phase(
+                &account.label,
+                AccountSetupPhase::KeyPackagePublicationStarted,
+            )?;
             match self.publish_initial_key_package_for_account(&account).await {
-                Ok(bytes) => Some(bytes),
+                Ok(bytes) => {
+                    self.app.account_home().set_account_setup_phase(
+                        &account.label,
+                        AccountSetupPhase::KeyPackagePublicationConfirmed,
+                    )?;
+                    Some(bytes)
+                }
                 // Session lifecycle state owns exact signed bytes and private
                 // material before network exposure. Once KeyPackage setup has
                 // started, deleting a freshly-added external account could
@@ -4203,6 +4235,9 @@ impl AccountManager {
                 .set_account_signed_out(&account.label, false)?;
         }
         self.reconcile().await?;
+        self.app
+            .account_home()
+            .complete_account_setup(&account.label)?;
 
         Ok(AccountSetupResult {
             account,
@@ -4406,13 +4441,13 @@ impl AccountManager {
         Ok(key_package.bytes().len())
     }
 
-    fn confirmed_setup_key_package_bytes(&self, label: &str) -> Result<usize, AppError> {
-        self.app
+    fn confirmed_setup_key_package_bytes(&self, label: &str) -> Result<Option<usize>, AppError> {
+        Ok(self
+            .app
             .account_storage(label)?
             .key_package_lifecycle()?
             .and_then(|lifecycle| lifecycle.current_key_package)
-            .map(|key_package| key_package.bytes().len())
-            .ok_or(AppError::AccountSetupRecoveryRequired)
+            .map(|key_package| key_package.bytes().len()))
     }
 
     fn signed_out_account_for_identity(
@@ -4465,11 +4500,10 @@ impl AccountManager {
             {
                 return Err(AppError::IdentityKeyMismatch);
             }
-            self.app
-                .account_home()
-                .begin_account_setup(&account, false)?;
-            self.app.account_home().set_account_setup_phase(
-                &account.label,
+            self.app.account_home().begin_account_setup_with(
+                &account,
+                false,
+                AccountSetupKind::ImportedIdentity,
                 AccountSetupPhase::KeyPackagePublicationStarted,
             )?;
             return Ok(false);
@@ -4498,18 +4532,22 @@ impl AccountManager {
         match request.identity.as_deref() {
             Some(value) => {
                 let account = account_home.add_public_account(value)?;
-                if let Err(error) = account_home.begin_account_setup(&account, false) {
+                if let Err(error) = account_home.begin_account_setup_with(
+                    &account,
+                    false,
+                    AccountSetupKind::PublicIdentity,
+                    AccountSetupPhase::LocalStateCreated,
+                ) {
                     let _ = account_home.remove_account(&account.label);
                     return Err(error.into());
                 }
                 Ok((account, None))
             }
             None => {
-                let account = account_home.create_nostr_account()?;
-                if let Err(error) = account_home.begin_account_setup(&account, false) {
-                    let _ = account_home.remove_account(&account.label);
-                    return Err(error.into());
-                }
+                let account = match account_home.resumable_generated_account_setup()? {
+                    Some(account) => account,
+                    None => account_home.create_nostr_account_for_setup()?,
+                };
                 Ok((account, None))
             }
         }
@@ -4531,6 +4569,7 @@ impl AccountManager {
             return self.rollback_account_after_setup_failure(label, err);
         }
         if upgraded_public_account {
+            let _ = self.app.account_home().complete_account_setup(label);
             let _ = self
                 .app
                 .account_home()

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -10,8 +10,11 @@ use std::time::{Duration, Instant};
 use cgka_traits::agent_text_stream::AGENT_TEXT_STREAM_EXPORTER_CACHE_KEY;
 use cgka_traits::app_event::MarmotAppEvent as MarmotInnerEvent;
 use cgka_traits::engine::GroupEvent;
+use cgka_traits::storage::{KeyPackageBundleStorage, MaintenanceStorage};
 use cgka_traits::{GroupId, SecretBytes, TransportEndpoint};
-use marmot_account::{AccountHome, AccountHomeError, AccountSummary, NostrAccountImport};
+use marmot_account::{
+    AccountHome, AccountHomeError, AccountSetupPhase, AccountSummary, NostrAccountImport,
+};
 use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, Notify, broadcast, mpsc, oneshot, watch};
 use tokio::task::{JoinHandle, JoinSet};
@@ -3232,6 +3235,34 @@ impl MarmotAppRuntime {
         self.accounts.create_or_import_account(request).await
     }
 
+    pub async fn reset_incomplete_account_setup(
+        &self,
+        nsec: &str,
+        acknowledge_possible_key_package_orphan: bool,
+    ) -> Result<(), AppError> {
+        self.accounts
+            .reset_incomplete_account_setup(nsec, acknowledge_possible_key_package_orphan)
+            .await
+    }
+
+    /// Consent-gated compatibility recovery followed by an immediate retry of
+    /// the same setup request. Keeping both operations inside the runtime
+    /// prevents a host crash from turning reset into a separate manual step.
+    pub async fn recover_incomplete_account_setup(
+        &self,
+        request: AccountSetupRequest,
+        acknowledge_possible_key_package_orphan: bool,
+    ) -> Result<AccountSetupResult, AppError> {
+        let nsec = request
+            .import_nsec
+            .as_deref()
+            .ok_or(AppError::UnexpectedPrivateKey)?;
+        self.accounts
+            .reset_incomplete_account_setup(nsec, acknowledge_possible_key_package_orphan)
+            .await?;
+        self.accounts.create_or_import_account(request).await
+    }
+
     pub async fn shutdown(&self) {
         let started_at = Instant::now();
         self.shared.lifecycle().begin_shutdown();
@@ -3343,7 +3374,85 @@ impl AccountManager {
             // unlinked inode and a later re-import silently splits writes
             // across a stale handle.
             self.app.drop_account_caches(&account.label);
+            self.app
+                .remove_account_key_package_artifacts(&account.label)?;
             self.app.account_home().remove_account(&account.label)?;
+            Ok(())
+        }
+        .await;
+        self.set_account_tearing_down(&account.account_id_hex, false);
+        result
+    }
+
+    /// Explicit recovery for an account created before durable setup journals.
+    ///
+    /// This is intentionally not automatic: without a lifecycle/legacy slot,
+    /// local files cannot prove that an old KeyPackage was never exposed. The
+    /// caller must present the matching nsec and explicitly acknowledge that
+    /// resetting can orphan such an unknown publication. The credential is
+    /// retained so the next `create_or_import_account` reuses it rather than
+    /// creating a duplicate keychain entry.
+    pub async fn reset_incomplete_account_setup(
+        &self,
+        nsec: &str,
+        acknowledge_possible_key_package_orphan: bool,
+    ) -> Result<(), AppError> {
+        self.shared.lifecycle().ensure_running()?;
+        if !acknowledge_possible_key_package_orphan {
+            return Err(AppError::AccountSetupRecoveryRequired);
+        }
+        let account_id = AccountHome::account_id_for_secret(nsec)?;
+        let account = self.app.account_home().account(&account_id)?;
+        if !account.local_signing
+            || self
+                .app
+                .account_home()
+                .load_signing_keys(&account.label)?
+                .public_key()
+                .to_hex()
+                != account_id
+        {
+            return Err(AppError::IdentityKeyMismatch);
+        }
+        if self
+            .app
+            .account_home()
+            .account_setup_state(&account.label)?
+            .is_some()
+        {
+            return Err(AppError::RelayDirectory(
+                "durable account setup state is recoverable by retry; reset is not allowed".into(),
+            ));
+        }
+        if !self
+            .app
+            .key_package_cutover_replacement_pending(&account.label)
+        {
+            return Err(AppError::RelayDirectory(
+                "account is not in the legacy incomplete-setup recovery state".into(),
+            ));
+        }
+        let storage = self.app.account_storage(&account.label)?;
+        if storage.key_package_lifecycle()?.is_some()
+            || !storage.stored_key_package_bundles()?.is_empty()
+            || self.app.key_package_record_path(&account.label).exists()
+        {
+            return Err(AppError::RelayDirectory(
+                "account has recoverable KeyPackage state; reset is not allowed".into(),
+            ));
+        }
+
+        self.set_account_tearing_down(&account.account_id_hex, true);
+        let result = async {
+            if let Some(worker) = self.workers.lock().await.remove(&account.account_id_hex) {
+                worker.shutdown().await;
+            }
+            self.app.drop_account_caches(&account.label);
+            self.app
+                .remove_account_key_package_artifacts(&account.label)?;
+            self.app
+                .account_home()
+                .reset_incomplete_setup_preserving_credential(&account.label)?;
             Ok(())
         }
         .await;
@@ -3774,6 +3883,11 @@ impl AccountManager {
         let imports_private_key = request.import_nsec.is_some();
         let creates_new_private_key = request.identity.is_none() && request.import_nsec.is_none();
         let directory_bootstrap_relays = directory_bootstrap_relays_for_setup(&request);
+        if let Some(nsec) = request.import_nsec.as_deref()
+            && self.legacy_incomplete_account_for_import(nsec)?
+        {
+            return Err(AppError::AccountSetupRecoveryRequired);
+        }
         let identity_key: Option<&str> = request
             .import_nsec
             .as_ref()
@@ -3788,7 +3902,13 @@ impl AccountManager {
             self.create_nostr_account_from_setup(&request)?
         };
         let reactivating_existing = account.signed_out;
-        let rollback_on_setup_failure = !reactivating_existing;
+        let setup_already_reached_publication = self
+            .app
+            .account_home()
+            .account_setup_state(&account.label)?
+            .is_some_and(|state| state.phase != AccountSetupPhase::LocalStateCreated);
+        let rollback_on_setup_failure =
+            !reactivating_existing && !setup_already_reached_publication;
 
         if imports_private_key || reactivating_existing || !account.local_signing {
             // Resolve a pre-existing identity's profile from public indexers, not
@@ -3879,18 +3999,45 @@ impl AccountManager {
         };
 
         let key_package_bytes = if request.publish_initial_key_package && account.local_signing {
-            self.shared.lifecycle().ensure_running()?;
-            match self.publish_initial_key_package_for_account(&account).await {
-                Ok(bytes) => Some(bytes),
-                Err(err) => {
+            let setup_phase = self
+                .app
+                .account_home()
+                .account_setup_state(&account.label)?
+                .map(|state| state.phase);
+            if setup_phase == Some(AccountSetupPhase::KeyPackagePublicationConfirmed) {
+                Some(self.confirmed_setup_key_package_bytes(&account.label)?)
+            } else {
+                self.shared.lifecycle().ensure_running()?;
+                if setup_phase.is_some()
+                    && let Err(err) = self.app.account_home().set_account_setup_phase(
+                        &account.label,
+                        AccountSetupPhase::KeyPackagePublicationStarted,
+                    )
+                {
                     if rollback_on_setup_failure {
                         return self.rollback_import_after_setup_failure(
                             &account,
                             private_key_import.as_ref(),
-                            err,
+                            err.into(),
                         );
                     }
-                    return Err(err);
+                    return Err(err.into());
+                }
+                match self.publish_initial_key_package_for_account(&account).await {
+                    Ok(bytes) => {
+                        self.app.account_home().set_account_setup_phase(
+                            &account.label,
+                            AccountSetupPhase::KeyPackagePublicationConfirmed,
+                        )?;
+                        Some(bytes)
+                    }
+                    Err(err) => {
+                        // Publication-started state plus the SQLCipher lifecycle
+                        // is sufficient to retry safely after any ordinary error
+                        // or task cancellation. Never delete possibly exposed
+                        // exact bytes/private material here.
+                        return Err(err);
+                    }
                 }
             }
         } else {
@@ -3917,6 +4064,9 @@ impl AccountManager {
                 .set_account_signed_out(&account.label, false)?;
         }
         self.reconcile().await?;
+        self.app
+            .account_home()
+            .complete_account_setup(&account.label)?;
 
         Ok(AccountSetupResult {
             account,
@@ -4024,14 +4174,12 @@ impl AccountManager {
         let key_package_bytes = if request.publish_initial_key_package {
             match self.publish_initial_key_package_for_account(&account).await {
                 Ok(bytes) => Some(bytes),
-                Err(err) => {
-                    return self.rollback_external_signer_setup(
-                        &account.label,
-                        created_account,
-                        upgraded_public_account,
-                        err,
-                    );
-                }
+                // Session lifecycle state owns exact signed bytes and private
+                // material before network exposure. Once KeyPackage setup has
+                // started, deleting a freshly-added external account could
+                // orphan an ambiguously accepted publication; keep it for an
+                // exact-byte retry instead.
+                Err(err) => return Err(err),
             }
         } else {
             None
@@ -4243,10 +4391,28 @@ impl AccountManager {
         &self,
         account: &AccountSummary,
     ) -> Result<usize, AppError> {
+        if self
+            .app
+            .legacy_incomplete_setup_requires_recovery(&account.label)?
+        {
+            let _ = self
+                .app
+                .mark_key_package_cutover_replacement_pending(&account.label);
+            return Err(AppError::AccountSetupRecoveryRequired);
+        }
         self.app.status(&account.label)?;
         let mut client = self.app.client(&account.label).await?;
         let key_package = client.publish_key_package().await?;
         Ok(key_package.bytes().len())
+    }
+
+    fn confirmed_setup_key_package_bytes(&self, label: &str) -> Result<usize, AppError> {
+        self.app
+            .account_storage(label)?
+            .key_package_lifecycle()?
+            .and_then(|lifecycle| lifecycle.current_key_package)
+            .map(|key_package| key_package.bytes().len())
+            .ok_or(AppError::AccountSetupRecoveryRequired)
     }
 
     fn signed_out_account_for_identity(
@@ -4266,6 +4432,60 @@ impl AccountManager {
         }
     }
 
+    fn legacy_incomplete_account_for_import(&self, nsec: &str) -> Result<bool, AppError> {
+        let account_id = AccountHome::account_id_for_secret(nsec)?;
+        let account = match self.app.account_home().account(&account_id) {
+            Ok(account) if account.local_signing && !account.signed_out => account,
+            Ok(_) | Err(AccountHomeError::UnknownAccount(_)) => return Ok(false),
+            Err(err) => return Err(err.into()),
+        };
+        if self
+            .app
+            .account_home()
+            .account_setup_state(&account.label)?
+            .is_none()
+            && self.app.account_storage_path(&account.label).exists()
+            && self
+                .app
+                .account_storage(&account.label)?
+                .key_package_lifecycle()?
+                .is_some_and(|lifecycle| lifecycle.pending_replacement.is_some())
+        {
+            // Pre-journal MDK could strand an account after persisting the exact
+            // replacement but before returning from setup. Adopt that durable
+            // attempt into the journal so same-nsec login resumes its bytes.
+            // Validate the credential before changing any provenance state.
+            if self
+                .app
+                .account_home()
+                .load_signing_keys(&account.label)?
+                .public_key()
+                .to_hex()
+                != account_id
+            {
+                return Err(AppError::IdentityKeyMismatch);
+            }
+            self.app
+                .account_home()
+                .begin_account_setup(&account, false)?;
+            self.app.account_home().set_account_setup_phase(
+                &account.label,
+                AccountSetupPhase::KeyPackagePublicationStarted,
+            )?;
+            return Ok(false);
+        }
+        if !self
+            .app
+            .legacy_incomplete_setup_requires_recovery(&account.label)?
+        {
+            return Ok(false);
+        }
+        let _ = self
+            .app
+            .mark_key_package_cutover_replacement_pending(&account.label);
+        Ok(true)
+    }
+
     fn create_nostr_account_from_setup(
         &self,
         request: &AccountSetupRequest,
@@ -4276,8 +4496,22 @@ impl AccountManager {
             return Ok((imported.account().clone(), Some(imported)));
         }
         match request.identity.as_deref() {
-            Some(value) => Ok((account_home.add_public_account(value)?, None)),
-            None => Ok((account_home.create_nostr_account()?, None)),
+            Some(value) => {
+                let account = account_home.add_public_account(value)?;
+                if let Err(error) = account_home.begin_account_setup(&account, false) {
+                    let _ = account_home.remove_account(&account.label);
+                    return Err(error.into());
+                }
+                Ok((account, None))
+            }
+            None => {
+                let account = account_home.create_nostr_account()?;
+                if let Err(error) = account_home.begin_account_setup(&account, false) {
+                    let _ = account_home.remove_account(&account.label);
+                    return Err(error.into());
+                }
+                Ok((account, None))
+            }
         }
     }
 
@@ -4315,6 +4549,11 @@ impl AccountManager {
         // so a later re-import does not reuse a handle bound to the now-unlinked
         // inode. See `drop_account_caches` and mdk#220.
         self.app.drop_account_caches(account);
+        if let Err(rollback) = self.app.remove_account_key_package_artifacts(account) {
+            return Err(AppError::RelayDirectory(format!(
+                "failed to roll back account after setup failure: {source}; rollback error: {rollback}"
+            )));
+        }
         match self.app.account_home().remove_account(account) {
             Ok(()) => Err(source),
             Err(rollback) => Err(AppError::RelayDirectory(format!(
@@ -4334,6 +4573,14 @@ impl AccountManager {
         };
 
         self.app.drop_account_caches(&account.label);
+        if let Err(rollback) = self
+            .app
+            .remove_account_key_package_artifacts(&account.label)
+        {
+            return Err(AppError::RelayDirectory(format!(
+                "failed to roll back account after setup failure: {source}; rollback error: {rollback}"
+            )));
+        }
         match self
             .app
             .account_home()

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -1823,6 +1823,10 @@ fn existing_account_database_without_slot_evidence_fails_closed() {
 
     app.ensure_strict_cutover_replacement_intent_before_session_open(&account.label)
         .unwrap();
+    assert!(
+        app.legacy_incomplete_setup_requires_recovery(&account.label)
+            .unwrap()
+    );
 
     assert!(
         app.account_storage(&account.label)
@@ -1833,6 +1837,78 @@ fn existing_account_database_without_slot_evidence_fails_closed() {
         "an existing database must not mint a second stable slot without migration evidence"
     );
     assert!(app.key_package_cutover_replacement_pending(&account.label));
+}
+
+#[test]
+fn durable_incomplete_setup_can_provision_slot_after_database_creation() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(directory.path());
+    let account = home.create_account("journaled-fresh-setup").unwrap();
+    home.begin_account_setup(&account, false).unwrap();
+    let app = MarmotApp::with_relay(directory.path(), "wss://relay.example");
+
+    // Reproduce the critical ordering: an advisory/local operation creates the
+    // encrypted DB before strict KeyPackage initialization runs.
+    app.account_storage(&account.label).unwrap();
+    app.ensure_strict_cutover_replacement_intent_before_session_open(&account.label)
+        .unwrap();
+
+    let lifecycle = app
+        .account_storage(&account.label)
+        .unwrap()
+        .key_package_lifecycle()
+        .unwrap()
+        .unwrap();
+    assert_eq!(lifecycle.stable_slot_id.len(), 64);
+}
+
+#[tokio::test]
+async fn legacy_ambiguous_setup_requires_consent_before_reset() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(directory.path());
+    let keys = nostr::Keys::generate();
+    let secret = keys.secret_key().to_secret_hex();
+    let account = home.import_nostr_account(&secret).unwrap();
+    let app = MarmotApp::with_relay(directory.path(), "wss://relay.example");
+
+    app.account_storage(&account.label).unwrap();
+    app.ensure_strict_cutover_replacement_intent_before_session_open(&account.label)
+        .unwrap();
+    assert!(
+        app.legacy_incomplete_setup_requires_recovery(&account.label)
+            .unwrap()
+    );
+    assert!(app.key_package_cutover_replacement_pending(&account.label));
+
+    let runtime = MarmotAppRuntime::new(app.clone());
+    let retry_error = runtime
+        .create_or_import_account(AccountSetupRequest {
+            import_nsec: Some(zeroize::Zeroizing::new(secret.clone())),
+            ..AccountSetupRequest::default()
+        })
+        .await
+        .expect_err("ordinary same-nsec retry must identify the legacy recovery state");
+    assert!(matches!(
+        retry_error,
+        AppError::AccountSetupRecoveryRequired
+    ));
+    assert!(matches!(
+        runtime.reset_incomplete_account_setup(&secret, false).await,
+        Err(AppError::AccountSetupRecoveryRequired)
+    ));
+    runtime
+        .reset_incomplete_account_setup(&secret, true)
+        .await
+        .unwrap();
+    assert!(matches!(
+        home.account(&account.label),
+        Err(AccountHomeError::UnknownAccount(_))
+    ));
+    assert!(!app.key_package_cutover_replacement_pending(&account.label));
+
+    let retried = home.import_nostr_account_idempotent(&secret).unwrap();
+    assert_eq!(retried.account().account_id_hex, account.account_id_hex);
+    runtime.shutdown().await;
 }
 
 #[tokio::test]

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -830,7 +830,6 @@ async fn app_runtime_private_key_import_recovers_orphaned_keychain_credential() 
 
 #[tokio::test]
 async fn failed_key_package_setup_retries_same_nsec_after_restart() {
-    use marmot_account::AccountSetupPhase;
     use nostr::prelude::ToBech32;
 
     let dir = tempfile::tempdir().unwrap();
@@ -871,7 +870,7 @@ async fn failed_key_package_setup_retries_same_nsec_after_restart() {
             .unwrap()
             .unwrap()
             .phase,
-        AccountSetupPhase::KeyPackagePublicationStarted
+        marmot_account::AccountSetupPhase::KeyPackagePublicationStarted
     );
     assert!(
         first_home
@@ -921,6 +920,116 @@ async fn failed_key_package_setup_retries_same_nsec_after_restart() {
 }
 
 #[tokio::test]
+async fn failed_generated_identity_setup_resumes_same_identity_after_restart() {
+    let dir = tempfile::tempdir().unwrap();
+    let rejecting = Arc::new(AtomicBool::new(true));
+    let relay = LocalRelay::new(
+        RelayBuilder::default().write_policy(RejectKeyPackagesWhileArmed(rejecting.clone())),
+    );
+    relay.run().await.unwrap();
+    let url = relay.url().await.to_string();
+    let config = MarmotAppConfig::default().with_allow_loopback_relay_endpoints(true);
+    let setup = || AccountSetupRequest {
+        default_relays: vec![endpoint(&url)],
+        bootstrap_relays: vec![endpoint(&url)],
+        publish_missing_relay_lists: true,
+        publish_initial_key_package: true,
+        ..AccountSetupRequest::default()
+    };
+
+    let first_app = MarmotApp::with_relay_and_config(dir.path(), url.clone(), config.clone());
+    let first_runtime = MarmotAppRuntime::new(first_app);
+    first_runtime
+        .create_identity(setup())
+        .await
+        .expect_err("the first generated identity KeyPackage publish must fail");
+    let first_home = AccountHome::open(dir.path());
+    let first_account = first_home.accounts().unwrap().into_iter().next().unwrap();
+    assert_eq!(
+        first_home
+            .account_setup_state(&first_account.label)
+            .unwrap()
+            .unwrap()
+            .kind,
+        marmot_account::AccountSetupKind::GeneratedIdentity
+    );
+    first_runtime.shutdown().await;
+
+    rejecting.store(false, Ordering::Relaxed);
+    let second_app = MarmotApp::with_relay_and_config(dir.path(), url.clone(), config);
+    let second_runtime = MarmotAppRuntime::new(second_app);
+    let retried = second_runtime
+        .create_identity(setup())
+        .await
+        .expect("create-identity retry must resume the generated identity");
+    assert_eq!(retried.account.account_id_hex, first_account.account_id_hex);
+    assert_eq!(AccountHome::open(dir.path()).accounts().unwrap().len(), 1);
+    second_runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn failed_external_signer_setup_resumes_after_restart() {
+    let dir = tempfile::tempdir().unwrap();
+    let rejecting = Arc::new(AtomicBool::new(true));
+    let relay = LocalRelay::new(
+        RelayBuilder::default().write_policy(RejectKeyPackagesWhileArmed(rejecting.clone())),
+    );
+    relay.run().await.unwrap();
+    let url = relay.url().await.to_string();
+    let config = MarmotAppConfig::default().with_allow_loopback_relay_endpoints(true);
+    let keys = Keys::generate();
+    let public_key = keys.public_key().to_hex();
+    let setup = || AccountSetupRequest {
+        default_relays: vec![endpoint(&url)],
+        bootstrap_relays: vec![endpoint(&url)],
+        publish_missing_relay_lists: true,
+        publish_initial_key_package: true,
+        ..AccountSetupRequest::default()
+    };
+
+    let first_app = MarmotApp::with_relay_and_config(dir.path(), url.clone(), config.clone());
+    let first_runtime = MarmotAppRuntime::new(first_app);
+    first_runtime
+        .login_external_signer(
+            public_key.clone(),
+            TestExternalAccountSigner { keys: keys.clone() },
+            setup(),
+        )
+        .await
+        .expect_err("the first external-signer KeyPackage publish must fail");
+    let first_home = AccountHome::open(dir.path());
+    assert_eq!(
+        first_home
+            .account_setup_state(&public_key)
+            .unwrap()
+            .unwrap()
+            .phase,
+        marmot_account::AccountSetupPhase::KeyPackagePublicationStarted
+    );
+    first_runtime.shutdown().await;
+
+    rejecting.store(false, Ordering::Relaxed);
+    let second_app = MarmotApp::with_relay_and_config(dir.path(), url.clone(), config);
+    let second_runtime = MarmotAppRuntime::new(second_app);
+    let retried = second_runtime
+        .login_external_signer(
+            public_key.clone(),
+            TestExternalAccountSigner { keys },
+            setup(),
+        )
+        .await
+        .expect("external-signer retry must resume its pending publication");
+    assert_eq!(retried.account.account_id_hex, public_key);
+    assert!(
+        AccountHome::open(dir.path())
+            .account_setup_state(&retried.account.label)
+            .unwrap()
+            .is_none()
+    );
+    second_runtime.shutdown().await;
+}
+
+#[tokio::test]
 async fn cancelled_key_package_setup_resumes_exact_pending_attempt_after_restart() {
     use marmot_account::AccountSetupPhase;
     use nostr::prelude::ToBech32;
@@ -964,9 +1073,10 @@ async fn cancelled_key_package_setup_resumes_exact_pending_attempt_after_restart
     assert!(attempt.await.unwrap_err().is_cancelled());
 
     let first_home = AccountHome::open(dir.path());
+    let account = first_home.account(&account_id).unwrap();
     assert_eq!(
         first_home
-            .account_setup_state(&account_id)
+            .account_setup_state(&account.label)
             .unwrap()
             .unwrap()
             .phase,
@@ -974,13 +1084,13 @@ async fn cancelled_key_package_setup_resumes_exact_pending_attempt_after_restart
     );
     assert!(
         first_home
-            .account_dir(&account_id)
+            .account_dir(&account.label)
             .join("session.sqlite")
             .exists()
     );
 
     armed.store(false, Ordering::Relaxed);
-    release.notify_waiters();
+    release.notify_one();
     first_runtime.shutdown().await;
     drop(first_runtime);
     drop(first_app);

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::path::Path;
-#[cfg(feature = "test-policy-overrides")]
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Once};
 
@@ -34,7 +33,7 @@ use nostr_sdk::prelude::{
 use sha2::{Digest, Sha256};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::{Mutex, mpsc, oneshot};
+use tokio::sync::{Mutex, Notify, mpsc, oneshot};
 use tokio::time::{Duration, Instant, sleep, timeout};
 use transport_nostr_adapter::{
     KIND_MARMOT_KEY_PACKAGE, KIND_NIP65_RELAY_LIST, NostrRelayClient, NostrSdkRelayClient,
@@ -113,6 +112,52 @@ impl WritePolicy for RejectDeletionEvents {
             } else {
                 PolicyResult::Accept
             }
+        })
+    }
+}
+
+#[derive(Debug)]
+struct RejectKeyPackagesWhileArmed(Arc<AtomicBool>);
+
+impl WritePolicy for RejectKeyPackagesWhileArmed {
+    fn admit_event<'a>(
+        &'a self,
+        event: &'a nostr::Event,
+        _addr: &'a SocketAddr,
+    ) -> BoxedFuture<'a, PolicyResult> {
+        Box::pin(async move {
+            if self.0.load(Ordering::Relaxed)
+                && event.kind == Kind::Custom(KIND_MARMOT_KEY_PACKAGE as u16)
+            {
+                PolicyResult::Reject("injected key package rejection".into())
+            } else {
+                PolicyResult::Accept
+            }
+        })
+    }
+}
+
+#[derive(Debug)]
+struct BlockKeyPackagesWhileArmed {
+    armed: Arc<AtomicBool>,
+    entered: Arc<Notify>,
+    release: Arc<Notify>,
+}
+
+impl WritePolicy for BlockKeyPackagesWhileArmed {
+    fn admit_event<'a>(
+        &'a self,
+        event: &'a nostr::Event,
+        _addr: &'a SocketAddr,
+    ) -> BoxedFuture<'a, PolicyResult> {
+        Box::pin(async move {
+            if self.armed.load(Ordering::Relaxed)
+                && event.kind == Kind::Custom(KIND_MARMOT_KEY_PACKAGE as u16)
+            {
+                self.entered.notify_one();
+                self.release.notified().await;
+            }
+            PolicyResult::Accept
         })
     }
 }
@@ -781,6 +826,180 @@ async fn app_runtime_private_key_import_recovers_orphaned_keychain_credential() 
     );
 
     recovered_runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn failed_key_package_setup_retries_same_nsec_after_restart() {
+    use marmot_account::AccountSetupPhase;
+    use nostr::prelude::ToBech32;
+
+    let dir = tempfile::tempdir().unwrap();
+    let rejecting = Arc::new(AtomicBool::new(true));
+    let relay = LocalRelay::new(
+        RelayBuilder::default().write_policy(RejectKeyPackagesWhileArmed(rejecting.clone())),
+    );
+    relay.run().await.unwrap();
+    let url = relay.url().await.to_string();
+    let config = MarmotAppConfig::default().with_allow_loopback_relay_endpoints(true);
+    let secret = Keys::generate().secret_key().to_bech32().unwrap();
+    let account_id = AccountHome::account_id_for_secret(&secret).unwrap();
+    let setup = |secret: &str| AccountSetupRequest {
+        identity: None,
+        import_nsec: Some(zeroize::Zeroizing::new(secret.to_owned())),
+        default_relays: vec![endpoint(&url)],
+        bootstrap_relays: vec![endpoint(&url)],
+        publish_missing_relay_lists: true,
+        publish_initial_key_package: true,
+        ..AccountSetupRequest::default()
+    };
+
+    let first_app = MarmotApp::with_relay_and_config(dir.path(), url.clone(), config.clone());
+    let first_runtime = MarmotAppRuntime::new(first_app.clone());
+    let error = first_runtime
+        .create_or_import_account(setup(&secret))
+        .await
+        .expect_err("the first KeyPackage publish must be rejected");
+    assert!(
+        error.to_string().contains("key package publication failed"),
+        "unexpected setup boundary: {error}"
+    );
+    let first_home = AccountHome::open(dir.path());
+    let account = first_home.account(&account_id).unwrap();
+    assert_eq!(
+        first_home
+            .account_setup_state(&account.label)
+            .unwrap()
+            .unwrap()
+            .phase,
+        AccountSetupPhase::KeyPackagePublicationStarted
+    );
+    assert!(
+        first_home
+            .account_dir(&account.label)
+            .join("session.sqlite")
+            .exists()
+    );
+    // Simulate the exact shape left by an older app build: the encrypted
+    // lifecycle owns an exact pending publication, but setup predates the
+    // durable journal introduced by this fix.
+    std::fs::remove_file(
+        first_home
+            .account_dir(&account.label)
+            .join(".account-setup.json"),
+    )
+    .unwrap();
+    first_runtime.shutdown().await;
+    drop(first_runtime);
+    drop(first_app);
+
+    rejecting.store(false, Ordering::Relaxed);
+    let second_app = MarmotApp::with_relay_and_config(dir.path(), url.clone(), config);
+    let second_runtime = MarmotAppRuntime::new(second_app.clone());
+    let retried = second_runtime
+        .create_or_import_account(setup(&secret))
+        .await
+        .expect("the same nsec must resume after restart");
+    assert_eq!(retried.account.account_id_hex, account_id);
+    let second_home = AccountHome::open(dir.path());
+    assert_eq!(second_home.accounts().unwrap().len(), 1);
+    assert!(
+        second_home
+            .account_setup_state(&retried.account.label)
+            .unwrap()
+            .is_none(),
+        "the setup journal is removed only after commit"
+    );
+    let lifecycle = second_runtime
+        .key_package_maintenance_status(&account_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(lifecycle.current_key_package.is_some());
+    assert!(lifecycle.pending_replacement.is_none());
+    assert_eq!(lifecycle.stable_slot_id.len(), 64);
+    second_runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn cancelled_key_package_setup_resumes_exact_pending_attempt_after_restart() {
+    use marmot_account::AccountSetupPhase;
+    use nostr::prelude::ToBech32;
+
+    let dir = tempfile::tempdir().unwrap();
+    let armed = Arc::new(AtomicBool::new(true));
+    let entered = Arc::new(Notify::new());
+    let release = Arc::new(Notify::new());
+    let relay = LocalRelay::new(
+        RelayBuilder::default().write_policy(BlockKeyPackagesWhileArmed {
+            armed: armed.clone(),
+            entered: entered.clone(),
+            release: release.clone(),
+        }),
+    );
+    relay.run().await.unwrap();
+    let url = relay.url().await.to_string();
+    let config = MarmotAppConfig::default().with_allow_loopback_relay_endpoints(true);
+    let secret = Keys::generate().secret_key().to_bech32().unwrap();
+    let account_id = AccountHome::account_id_for_secret(&secret).unwrap();
+    let setup = |secret: &str| AccountSetupRequest {
+        identity: None,
+        import_nsec: Some(zeroize::Zeroizing::new(secret.to_owned())),
+        default_relays: vec![endpoint(&url)],
+        bootstrap_relays: vec![endpoint(&url)],
+        publish_missing_relay_lists: true,
+        publish_initial_key_package: true,
+        ..AccountSetupRequest::default()
+    };
+
+    let first_app = MarmotApp::with_relay_and_config(dir.path(), url.clone(), config.clone());
+    let first_runtime = MarmotAppRuntime::new(first_app.clone());
+    let attempt_runtime = first_runtime.clone();
+    let first_setup = setup(&secret);
+    let attempt =
+        tokio::spawn(async move { attempt_runtime.create_or_import_account(first_setup).await });
+    timeout(Duration::from_secs(10), entered.notified())
+        .await
+        .expect("KeyPackage publication must reach the blocking relay");
+    attempt.abort();
+    assert!(attempt.await.unwrap_err().is_cancelled());
+
+    let first_home = AccountHome::open(dir.path());
+    assert_eq!(
+        first_home
+            .account_setup_state(&account_id)
+            .unwrap()
+            .unwrap()
+            .phase,
+        AccountSetupPhase::KeyPackagePublicationStarted
+    );
+    assert!(
+        first_home
+            .account_dir(&account_id)
+            .join("session.sqlite")
+            .exists()
+    );
+
+    armed.store(false, Ordering::Relaxed);
+    release.notify_waiters();
+    first_runtime.shutdown().await;
+    drop(first_runtime);
+    drop(first_app);
+
+    let second_app = MarmotApp::with_relay_and_config(dir.path(), url.clone(), config);
+    let second_runtime = MarmotAppRuntime::new(second_app);
+    let retried = second_runtime
+        .create_or_import_account(setup(&secret))
+        .await
+        .expect("cancelled setup must resume without deleting local data");
+    assert_eq!(retried.account.account_id_hex, account_id);
+    let lifecycle = second_runtime
+        .key_package_maintenance_status(&account_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(lifecycle.current_key_package.is_some());
+    assert!(lifecycle.pending_replacement.is_none());
+    second_runtime.shutdown().await;
 }
 
 #[tokio::test]

--- a/crates/marmot-uniffi/src/commands/account.rs
+++ b/crates/marmot-uniffi/src/commands/account.rs
@@ -160,6 +160,61 @@ impl Marmot {
         })
     }
 
+    /// Remove only the legacy ambiguous partial-account shape so a subsequent
+    /// `login` with the same nsec can recreate it. The acknowledgement is
+    /// required because old local state cannot prove that no KeyPackage was
+    /// exposed before its stable slot was lost.
+    pub async fn reset_incomplete_account_setup(
+        &self,
+        nsec: String,
+        acknowledge_possible_key_package_orphan: bool,
+    ) -> Result<(), MarmotKitError> {
+        let nsec = Zeroizing::new(nsec);
+        self.runtime
+            .reset_incomplete_account_setup(nsec.as_str(), acknowledge_possible_key_package_orphan)
+            .await?;
+        Ok(())
+    }
+
+    /// Consent-gated one-call recovery for installations stranded before MDK
+    /// had durable account-setup journals. This validates the same nsec,
+    /// removes only the recognized ambiguous partial shape, preserves an
+    /// existing account-id Keychain credential, and immediately retries login.
+    pub async fn login_recovering_incomplete_setup(
+        &self,
+        nsec: String,
+        default_relays: Vec<String>,
+        bootstrap_relays: Vec<String>,
+        acknowledge_possible_key_package_orphan: bool,
+    ) -> Result<AccountSummaryFfi, MarmotKitError> {
+        if !marmot_app::is_nostr_secret(&nsec) {
+            return Err(MarmotKitError::InvalidIdentity {
+                details: "incomplete setup recovery requires an nsec".into(),
+            });
+        }
+        let request = AccountSetupRequest {
+            identity: None,
+            import_nsec: Some(Zeroizing::new(nsec)),
+            default_relays: endpoints(&default_relays),
+            bootstrap_relays: endpoints(&bootstrap_relays),
+            discovery_relays: ffi_discovery_relays(&bootstrap_relays),
+            publish_missing_relay_lists: true,
+            publish_initial_key_package: true,
+        };
+        let result = self
+            .runtime
+            .recover_incomplete_account_setup(request, acknowledge_possible_key_package_orphan)
+            .await?;
+        Ok(AccountSummaryFfi {
+            label: result.account.label,
+            account_id_hex: result.account.account_id_hex,
+            local_signing: result.account.local_signing,
+            external_signing: result.account.external_signing,
+            signed_out: result.account.signed_out,
+            running: true,
+        })
+    }
+
     /// Log in with an external account signer such as Amber/NIP-55.
     ///
     /// MDK stores only the account public key and device-local database

--- a/crates/marmot-uniffi/src/errors.rs
+++ b/crates/marmot-uniffi/src/errors.rs
@@ -48,6 +48,11 @@ pub enum MarmotKitError {
     /// account's in-memory engine session. Retry only after that owner closes.
     #[error("marmot account session is already in use")]
     AccountSessionBusy,
+    /// A pre-journal account has an encrypted database but no recoverable
+    /// stable KeyPackage slot. Automatic retry cannot prove non-exposure; the
+    /// host may offer `reset_incomplete_account_setup` with explicit consent.
+    #[error("incomplete account setup requires explicit recovery")]
+    AccountSetupRecoveryRequired,
     #[error("marmot runtime is shutting down")]
     RuntimeStopping,
     /// An account worker's transport catch-up failed (sync error or timeout).
@@ -220,6 +225,7 @@ impl From<AppError> for MarmotKitError {
             AppError::TransportClosed => Self::TransportClosed,
             AppError::RuntimeBusy => Self::RuntimeBusy,
             AppError::AccountSessionBusy => Self::AccountSessionBusy,
+            AppError::AccountSetupRecoveryRequired => Self::AccountSetupRecoveryRequired,
             AppError::RuntimeStopping => Self::RuntimeStopping,
             AppError::AccountCatchUp(details) => Self::AccountCatchUp { details },
             // #484: a transient storage busy error can also surface directly at
@@ -540,6 +546,12 @@ mod tests {
             ),
             "invalid KeyPackage events must not be flattened into InvalidIdentity, got {ffi:?}"
         );
+    }
+
+    #[test]
+    fn incomplete_account_setup_crosses_ffi_as_typed_recovery() {
+        let ffi: MarmotKitError = AppError::AccountSetupRecoveryRequired.into();
+        assert!(matches!(ffi, MarmotKitError::AccountSetupRecoveryRequired));
     }
 
     #[test]

--- a/crates/marmot-uniffi/src/errors.rs
+++ b/crates/marmot-uniffi/src/errors.rs
@@ -53,6 +53,12 @@ pub enum MarmotKitError {
     /// host may offer `reset_incomplete_account_setup` with explicit consent.
     #[error("incomplete account setup requires explicit recovery")]
     AccountSetupRecoveryRequired,
+    #[error("durable account setup can be resumed by retrying")]
+    AccountSetupRetryRequired,
+    #[error("account is not eligible for incomplete-setup reset")]
+    AccountSetupResetNotApplicable,
+    #[error("recoverable KeyPackage setup state exists; retry instead of resetting")]
+    AccountSetupKeyPackageRecoveryAvailable,
     #[error("marmot runtime is shutting down")]
     RuntimeStopping,
     /// An account worker's transport catch-up failed (sync error or timeout).
@@ -226,6 +232,11 @@ impl From<AppError> for MarmotKitError {
             AppError::RuntimeBusy => Self::RuntimeBusy,
             AppError::AccountSessionBusy => Self::AccountSessionBusy,
             AppError::AccountSetupRecoveryRequired => Self::AccountSetupRecoveryRequired,
+            AppError::AccountSetupRetryRequired => Self::AccountSetupRetryRequired,
+            AppError::AccountSetupResetNotApplicable => Self::AccountSetupResetNotApplicable,
+            AppError::AccountSetupKeyPackageRecoveryAvailable => {
+                Self::AccountSetupKeyPackageRecoveryAvailable
+            }
             AppError::RuntimeStopping => Self::RuntimeStopping,
             AppError::AccountCatchUp(details) => Self::AccountCatchUp { details },
             // #484: a transient storage busy error can also surface directly at
@@ -552,6 +563,22 @@ mod tests {
     fn incomplete_account_setup_crosses_ffi_as_typed_recovery() {
         let ffi: MarmotKitError = AppError::AccountSetupRecoveryRequired.into();
         assert!(matches!(ffi, MarmotKitError::AccountSetupRecoveryRequired));
+    }
+
+    #[test]
+    fn account_setup_reset_refusals_cross_ffi_as_typed_variants() {
+        assert!(matches!(
+            MarmotKitError::from(AppError::AccountSetupRetryRequired),
+            MarmotKitError::AccountSetupRetryRequired
+        ));
+        assert!(matches!(
+            MarmotKitError::from(AppError::AccountSetupResetNotApplicable),
+            MarmotKitError::AccountSetupResetNotApplicable
+        ));
+        assert!(matches!(
+            MarmotKitError::from(AppError::AccountSetupKeyPackageRecoveryAvailable),
+            MarmotKitError::AccountSetupKeyPackageRecoveryAvailable
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add a durable account-setup journal that distinguishes local creation, KeyPackage publication start, and confirmed publication
- resume the exact persisted KeyPackage/private material after relay failure, cancellation, or restart instead of minting a new stable slot
- clean root-level KeyPackage compatibility artifacts and cached account handles during safe rollback
- add typed, consent-gated recovery APIs for pre-journal installations whose prior KeyPackage exposure cannot be proven
- expose the recovery state and one-call same-`nsec` retry through UniFFI

## Root cause

Account setup could create the encrypted account database and strict-cutover replacement marker before setup committed. The marker lives outside the account directory, so ordinary rollback did not remove it, while cancellation and shutdown could bypass Result-based rollback entirely.

A later import of the same `nsec` therefore saw an existing database without recoverable stable-slot evidence and classified the partial setup as a legacy device whose kind-30443 `d` slot had been lost. Attempts to republish also rejected a durable pending replacement instead of resuming it.

## Compatibility and safety

New failures retain an explicit setup phase plus the stable device-local slot, private bundle, fanout state, and exact signed publication bytes. Retries resume those bytes.

Pre-journal accounts with a durable pending replacement are adopted into the journal and resume automatically. The older ambiguous shape with no lifecycle, legacy record, or private bundle returns `AccountSetupRecoveryRequired`; hosts can obtain explicit consent and call `login_recovering_incomplete_setup`.

The recovery path does not blindly mint a replacement slot, delete another device's KeyPackage, or discard ambiguously exposed private material.

## Validation

- `cargo test -p marmot-account`
- `cargo test -p marmot-app --lib -- --test-threads=1` (564 passed)
- relay rejection, legacy pre-journal restart, and same-`nsec` recovery regression
- cancellation during publication followed by exact pending-attempt resume
- `cargo test -p marmot-uniffi`
- `just fast-ci`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable account-setup progress tracking and restart-safe setup recovery.
  * Added consent-gated options to reset or resume incomplete account setup.
  * Improved key-package publication retries after interruptions or failures.
  * Added clear recovery-required errors and diagnostics across supported interfaces.

* **Bug Fixes**
  * Prevented account and credential cleanup from leaving inconsistent partial state.
  * Improved handling of legacy incomplete account imports and retries.
  * Preserved pending setup work across restarts and cancellations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->