### PR TITLE
fix: fail when the control socket link disappears

### DIFF
--- a/crates/agent-connector/src/lib.rs
+++ b/crates/agent-connector/src/lib.rs
@@ -333,14 +333,16 @@ pub async fn serve_socket(config: AgentConnectorConfig) -> Result<(), ConnectorE
     let socket_path = config.socket.clone();
     let max_connections = config.max_connections;
     let connector = AgentConnector::open(config)?;
+    let link_loss = wait_control_socket_link_loss(&socket_path, link_identity);
+    tokio::pin!(link_loss);
     tokio::select! {
         res = connector.start() => res?,
-        res = wait_control_socket_link_loss(&socket_path, link_identity) => res?,
+        res = &mut link_loss => res?,
     }
     let connection_limiter = Arc::new(Semaphore::new(max_connections));
     loop {
         let accepted = tokio::select! {
-            res = wait_control_socket_link_loss(&socket_path, link_identity) => {
+            res = &mut link_loss => {
                 return res;
             }
             accepted = listener.accept() => accepted,

--- a/crates/agent-connector/src/lib.rs
+++ b/crates/agent-connector/src/lib.rs
@@ -335,15 +335,20 @@ pub async fn serve_socket(config: AgentConnectorConfig) -> Result<(), ConnectorE
     let connector = AgentConnector::open(config)?;
     let link_loss = wait_control_socket_link_loss(&socket_path, link_identity);
     tokio::pin!(link_loss);
+    // Losing the published path makes this process unreachable, so cancellation
+    // of startup is intentional: it has the same failure semantics as the
+    // supervisor terminating an orphaned process. Completed startup writes are
+    // retained and the next start rechecks them before applying missing state.
+    // Revisit this contract before adding a non-restart-safe mutation to start().
     tokio::select! {
         res = connector.start() => res?,
-        res = &mut link_loss => res?,
+        err = &mut link_loss => return Err(err),
     }
     let connection_limiter = Arc::new(Semaphore::new(max_connections));
     loop {
         let accepted = tokio::select! {
-            res = &mut link_loss => {
-                return res;
+            err = &mut link_loss => {
+                return Err(err);
             }
             accepted = listener.accept() => accepted,
         };
@@ -415,9 +420,9 @@ pub async fn serve_socket(config: AgentConnectorConfig) -> Result<(), ConnectorE
 async fn wait_control_socket_link_loss(
     socket_path: &Path,
     link_identity: fs_private::UnixSocketInode,
-) -> Result<(), ConnectorError> {
+) -> ConnectorError {
     let mut ticker = tokio::time::interval(CONTROL_SOCKET_LINK_POLL_INTERVAL);
-    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     loop {
         ticker.tick().await;
         if let Err(err) = verify_control_socket_link(socket_path, link_identity) {
@@ -427,7 +432,7 @@ async fn wait_control_socket_link_loss(
                 error_code = "control_socket_link_lost",
                 "control socket path no longer names the bound listener"
             );
-            return Err(err);
+            return err;
         }
     }
 }

--- a/crates/agent-connector/src/lib.rs
+++ b/crates/agent-connector/src/lib.rs
@@ -37,7 +37,7 @@ pub use identity::{
 pub use socket::{bind_connector_socket, bind_connector_socket_with_mode, default_socket_path};
 
 use std::future::Future;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Duration;
@@ -55,7 +55,7 @@ pub(crate) use marmot_app::AppMessageQuery;
 
 use crate::allowlist::AllowlistStore;
 use crate::event_projection::InboundCatchUpDriver;
-use crate::socket::bind_connector_socket_with_owned_home;
+use crate::socket::{bind_connector_socket_with_owned_home, verify_control_socket_link};
 use crate::stream_session::{DebugFinalSendStore, SendIdempotencyStore, StreamSessionStore};
 use crate::validation::{endpoint, validate_control_plane_config};
 
@@ -106,6 +106,9 @@ pub const MAX_CONTROL_CONNECTIONS: usize = 64;
 /// Long-lived inbound subscriptions are capped separately so one-shot sends,
 /// stream finalization, and policy operations retain connection capacity.
 pub(crate) const MAX_CONTROL_SUBSCRIPTIONS: usize = 16;
+/// Poll interval while `AgentConnector::start` runs so a removed or replaced
+/// control-socket path is detected before the accept loop begins.
+pub(crate) const CONTROL_SOCKET_LINK_POLL_INTERVAL: Duration = Duration::from_millis(250);
 
 pub(crate) async fn with_control_operation_timeout<T, F>(
     operation: &'static str,
@@ -321,18 +324,28 @@ pub async fn serve_socket(config: AgentConnectorConfig) -> Result<(), ConnectorE
             "DANGER: dev allow-any invite policy is enabled; authenticated welcomers bypass the allowlist"
         );
     }
-    let listener = bind_connector_socket_with_owned_home(
+    let (listener, link_identity) = bind_connector_socket_with_owned_home(
         &config.socket,
         config.socket_dir_mode,
         config.socket_mode,
         Some(&config.home),
     )?;
+    let socket_path = config.socket.clone();
     let max_connections = config.max_connections;
     let connector = AgentConnector::open(config)?;
-    connector.start().await?;
+    tokio::select! {
+        res = connector.start() => res?,
+        res = wait_control_socket_link_loss(&socket_path, link_identity) => res?,
+    }
     let connection_limiter = Arc::new(Semaphore::new(max_connections));
     loop {
-        let (mut stream, _peer_addr) = match listener.accept().await {
+        let accepted = tokio::select! {
+            res = wait_control_socket_link_loss(&socket_path, link_identity) => {
+                return res;
+            }
+            accepted = listener.accept() => accepted,
+        };
+        let (mut stream, _peer_addr) = match accepted {
             Ok(accepted) => accepted,
             Err(err) => {
                 let connection_error =
@@ -394,5 +407,25 @@ pub async fn serve_socket(config: AgentConnectorConfig) -> Result<(), ConnectorE
                 );
             }
         });
+    }
+}
+
+async fn wait_control_socket_link_loss(
+    socket_path: &Path,
+    link_identity: fs_private::UnixSocketInode,
+) -> Result<(), ConnectorError> {
+    let mut ticker = tokio::time::interval(CONTROL_SOCKET_LINK_POLL_INTERVAL);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    loop {
+        ticker.tick().await;
+        if let Err(err) = verify_control_socket_link(socket_path, link_identity) {
+            tracing::error!(
+                target: "agent_connector",
+                method = "serve_socket",
+                error_code = "control_socket_link_lost",
+                "control socket path no longer names the bound listener"
+            );
+            return Err(err);
+        }
     }
 }

--- a/crates/agent-connector/src/socket.rs
+++ b/crates/agent-connector/src/socket.rs
@@ -24,6 +24,7 @@ pub fn bind_connector_socket_with_mode(
     socket_mode: u32,
 ) -> Result<UnixListener, ConnectorError> {
     bind_connector_socket_with_owned_home(socket, socket_dir_mode, socket_mode, None)
+        .map(|(listener, _link_identity)| listener)
 }
 
 pub(crate) fn bind_connector_socket_with_owned_home(
@@ -31,28 +32,40 @@ pub(crate) fn bind_connector_socket_with_owned_home(
     socket_dir_mode: u32,
     socket_mode: u32,
     owned_home: Option<&Path>,
-) -> Result<UnixListener, ConnectorError> {
+) -> Result<(UnixListener, fs_private::UnixSocketInode), ConnectorError> {
     let _parent_guard = socket
         .parent()
         .map(|parent| prepare_socket_dir(parent, socket_dir_mode, owned_home))
         .transpose()?;
-    let listener = match bind_private(socket, socket_mode) {
-        Ok(listener) => listener,
+    let (listener, link_identity) = match bind_private(socket, socket_mode) {
+        Ok(bound) => bound,
         Err(error) if error.kind() == ErrorKind::AddrInUse => {
             remove_stale_socket(socket, &error)?;
             bind_private(socket, socket_mode)?
         }
         Err(error) => return Err(error.into()),
     };
-    Ok(listener)
+    Ok((listener, link_identity))
 }
 
 /// Bind through a 0700 staging dir so the socket never exists at
 /// umask-default permissions, even when `socket_dir_mode` is group-accessible.
-fn bind_private(socket: &Path, socket_mode: u32) -> std::io::Result<UnixListener> {
-    let listener = fs_private::bind_unix_listener_private(socket, socket_mode)?;
+fn bind_private(
+    socket: &Path,
+    socket_mode: u32,
+) -> std::io::Result<(UnixListener, fs_private::UnixSocketInode)> {
+    let bound = fs_private::bind_unix_listener_private_tracked(socket, socket_mode)?;
+    let link_identity = bound.link_identity();
+    let listener = bound.into_listener();
     listener.set_nonblocking(true)?;
-    UnixListener::from_std(listener)
+    Ok((UnixListener::from_std(listener)?, link_identity))
+}
+
+pub(crate) fn verify_control_socket_link(
+    socket: &Path,
+    link_identity: fs_private::UnixSocketInode,
+) -> Result<(), ConnectorError> {
+    fs_private::verify_unix_socket_inode(socket, link_identity).map_err(ConnectorError::from)
 }
 
 fn remove_stale_socket(socket: &Path, bind_error: &std::io::Error) -> std::io::Result<()> {

--- a/crates/agent-connector/src/tests.rs
+++ b/crates/agent-connector/src/tests.rs
@@ -679,20 +679,59 @@ async fn connector_serve_fails_fast_when_control_socket_link_removed() {
     let socket = dir.path().join("dev").join("wn-agent.sock");
     let config = test_config(dir.path(), socket.clone(), Vec::new(), false, false);
     let server = tokio::spawn(serve_socket(config));
-    tokio::time::timeout(Duration::from_secs(5), async {
-        while !socket.exists() {
-            sleep(Duration::from_millis(25)).await;
-        }
-    })
-    .await
-    .expect("control socket should appear at the final path");
+    let response = send_control_request(
+        &socket,
+        "steady-state-before-unlink",
+        AgentControlRequest::AccountList,
+    )
+    .await;
+    assert!(matches!(
+        response.payload,
+        AgentControlResponse::AccountList { .. }
+    ));
     std::fs::remove_file(&socket).expect("unlink final control socket path");
     let err = tokio::time::timeout(Duration::from_secs(2), server)
         .await
         .expect("serve must fail fast after the control socket link is removed")
         .expect("serve task must not panic")
         .expect_err("serve must exit with an error");
-    assert_eq!(err.code(), "io_error");
+    let crate::ConnectorError::Io(err) = err else {
+        panic!("expected control-socket I/O error");
+    };
+    assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+}
+
+#[tokio::test]
+async fn connector_serve_fails_fast_when_control_socket_link_replaced() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("dev").join("wn-agent.sock");
+    let replacement_path = dir.path().join("dev").join("replacement.sock");
+    let config = test_config(dir.path(), socket.clone(), Vec::new(), false, false);
+    let server = tokio::spawn(serve_socket(config));
+    let response = send_control_request(
+        &socket,
+        "steady-state-before-replacement",
+        AgentControlRequest::AccountList,
+    )
+    .await;
+    assert!(matches!(
+        response.payload,
+        AgentControlResponse::AccountList { .. }
+    ));
+
+    let _replacement = std::os::unix::net::UnixListener::bind(&replacement_path)
+        .expect("bind replacement control socket");
+    std::fs::rename(&replacement_path, &socket)
+        .expect("atomically replace final control socket path");
+    let err = tokio::time::timeout(Duration::from_secs(2), server)
+        .await
+        .expect("serve must fail fast after the control socket link is replaced")
+        .expect("serve task must not panic")
+        .expect_err("serve must exit with an error");
+    let crate::ConnectorError::Io(err) = err else {
+        panic!("expected control-socket I/O error");
+    };
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
 }
 
 #[tokio::test]

--- a/crates/agent-connector/src/tests.rs
+++ b/crates/agent-connector/src/tests.rs
@@ -674,6 +674,28 @@ async fn connector_socket_bind_rejects_unconfigured_group_writable_parent() {
 }
 
 #[tokio::test]
+async fn connector_serve_fails_fast_when_control_socket_link_removed() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("dev").join("wn-agent.sock");
+    let config = test_config(dir.path(), socket.clone(), Vec::new(), false, false);
+    let server = tokio::spawn(serve_socket(config));
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while !socket.exists() {
+            sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .expect("control socket should appear at the final path");
+    std::fs::remove_file(&socket).expect("unlink final control socket path");
+    let err = tokio::time::timeout(Duration::from_secs(2), server)
+        .await
+        .expect("serve must fail fast after the control socket link is removed")
+        .expect("serve task must not panic")
+        .expect_err("serve must exit with an error");
+    assert_eq!(err.code(), "io_error");
+}
+
+#[tokio::test]
 async fn connector_control_plane_requires_token_for_group_shared_modes() {
     let dir = tempfile::tempdir().unwrap();
     let socket = dir.path().join("dev").join("wn-agent.sock");

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -60,6 +60,10 @@ versioning through the workspace version in the root `Cargo.toml`.
   `NSEC…` argv identities are rejected at the same early gate as lowercase
   `nsec…`.
 
+- `wn-agent serve` now exits when its control-socket path is removed or
+  replaced while the listener is still bound, instead of staying alive with an
+  unreachable Unix listener after the final hard link disappears.
+
 - The runtime-start local-readiness regression test now asserts startup-before-
   subscription ordering directly while retaining a bounded hang deadline,
   avoiding false failures when unrelated startup work is delayed under loaded

--- a/crates/fs-private/src/lib.rs
+++ b/crates/fs-private/src/lib.rs
@@ -1022,11 +1022,15 @@ pub fn bind_unix_listener_private_tracked(
     builder.create(&staging_dir)?;
 
     let staged_socket = staging_dir.join(name);
-    let outcome = (|| {
+    let outcome: io::Result<_> = (|| {
         let listener = std::os::unix::net::UnixListener::bind(&staged_socket)?;
         std::fs::set_permissions(&staged_socket, std::fs::Permissions::from_mode(mode))?;
+        let link_identity = unix_socket_inode(&staged_socket)?;
         // link(2) fails if the target exists, unlike rename: preserves bind's
-        // AddrInUse contract instead of silently replacing a live socket.
+        // AddrInUse contract instead of silently replacing a live socket. Keep
+        // every fallible validation before this atomic publication: POSIX has
+        // no atomic compare-and-unlink operation that could safely compensate
+        // a later error without risking removal of a concurrent replacement.
         std::fs::hard_link(&staged_socket, final_path).map_err(|err| {
             if err.kind() == io::ErrorKind::AlreadyExists {
                 io::Error::new(
@@ -1037,18 +1041,11 @@ pub fn bind_unix_listener_private_tracked(
                 err
             }
         })?;
-        let link_identity = unix_socket_inode(final_path)?;
-        if unix_socket_inode(&staged_socket)? != link_identity {
-            return Err(io::Error::other(
-                "staged socket hard link identity mismatch",
-            ));
-        }
         Ok((listener, link_identity))
     })();
     let _ = std::fs::remove_file(&staged_socket);
     let _ = std::fs::remove_dir(&staging_dir);
     let (listener, link_identity) = outcome?;
-    verify_unix_socket_inode(final_path, link_identity)?;
     Ok(BoundUnixListener {
         listener,
         link_identity,

--- a/crates/fs-private/src/lib.rs
+++ b/crates/fs-private/src/lib.rs
@@ -897,6 +897,72 @@ pub fn parse_octal_mode(value: &str) -> Result<u32, String> {
     Ok(mode)
 }
 
+/// Device/inode identity of a bound Unix socket path entry.
+#[cfg(unix)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct UnixSocketInode {
+    dev: u64,
+    ino: u64,
+}
+
+/// Read the device/inode identity of an existing Unix socket path.
+#[cfg(unix)]
+fn unix_socket_inode(path: &Path) -> io::Result<UnixSocketInode> {
+    use std::os::unix::fs::{FileTypeExt, MetadataExt};
+
+    let metadata = std::fs::symlink_metadata(path)?;
+    if !metadata.file_type().is_socket() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "path is not a Unix socket",
+        ));
+    }
+    Ok(UnixSocketInode {
+        dev: metadata.dev(),
+        ino: metadata.ino(),
+    })
+}
+
+/// Fail when `path` is missing, is not a Unix socket, or no longer names
+/// `expected` (for example after an external unlink or replacement).
+#[cfg(unix)]
+pub fn verify_unix_socket_inode(path: &Path, expected: UnixSocketInode) -> io::Result<()> {
+    const LINK_LOST: &str = "unix socket path no longer names the bound listener";
+
+    let actual = match unix_socket_inode(path) {
+        Ok(identity) => identity,
+        Err(err) if err.kind() == io::ErrorKind::InvalidInput => {
+            return Err(io::Error::new(io::ErrorKind::InvalidInput, LINK_LOST));
+        }
+        Err(err) => return Err(err),
+    };
+    if actual != expected {
+        return Err(io::Error::new(io::ErrorKind::InvalidInput, LINK_LOST));
+    }
+    Ok(())
+}
+
+/// Unix listener bound through [`bind_unix_listener_private_tracked`],
+/// retaining the final-path link identity callers must keep stable while
+/// serving.
+#[cfg(unix)]
+#[derive(Debug)]
+pub struct BoundUnixListener {
+    listener: std::os::unix::net::UnixListener,
+    link_identity: UnixSocketInode,
+}
+
+#[cfg(unix)]
+impl BoundUnixListener {
+    pub fn link_identity(&self) -> UnixSocketInode {
+        self.link_identity
+    }
+
+    pub fn into_listener(self) -> std::os::unix::net::UnixListener {
+        self.listener
+    }
+}
+
 /// The staging directory `bind_unix_listener_private` binds through for
 /// `final_path`. Exposed so callers and tests can assert staging cleanup
 /// without re-deriving the (otherwise private) naming scheme.
@@ -929,6 +995,16 @@ pub fn bind_unix_listener_private(
     final_path: &Path,
     mode: u32,
 ) -> io::Result<std::os::unix::net::UnixListener> {
+    bind_unix_listener_private_tracked(final_path, mode).map(BoundUnixListener::into_listener)
+}
+
+/// Bind as [`bind_unix_listener_private`] does, retaining the final-path link
+/// identity so long-lived services can detect an unlink or replacement.
+#[cfg(unix)]
+pub fn bind_unix_listener_private_tracked(
+    final_path: &Path,
+    mode: u32,
+) -> io::Result<BoundUnixListener> {
     use std::os::unix::fs::DirBuilderExt;
     use std::os::unix::fs::PermissionsExt;
 
@@ -961,11 +1037,22 @@ pub fn bind_unix_listener_private(
                 err
             }
         })?;
-        Ok(listener)
+        let link_identity = unix_socket_inode(final_path)?;
+        if unix_socket_inode(&staged_socket)? != link_identity {
+            return Err(io::Error::other(
+                "staged socket hard link identity mismatch",
+            ));
+        }
+        Ok((listener, link_identity))
     })();
     let _ = std::fs::remove_file(&staged_socket);
     let _ = std::fs::remove_dir(&staging_dir);
-    outcome
+    let (listener, link_identity) = outcome?;
+    verify_unix_socket_inode(final_path, link_identity)?;
+    Ok(BoundUnixListener {
+        listener,
+        link_identity,
+    })
 }
 
 #[cfg(test)]
@@ -1685,6 +1772,31 @@ mod unix_tests {
         );
         assert_eq!(std::fs::read(&target).unwrap(), b"unchanged");
         assert_eq!(mode_of(&target), 0o644);
+    }
+
+    #[test]
+    fn verify_unix_socket_inode_fails_when_final_path_unlinked() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("test.sock");
+        let bound = bind_unix_listener_private_tracked(&socket, 0o600).unwrap();
+        let identity = bound.link_identity();
+        std::fs::remove_file(&socket).unwrap();
+        let err = verify_unix_socket_inode(&socket, identity).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn verify_unix_socket_inode_fails_when_path_names_a_different_socket() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = dir.path().join("first.sock");
+        let second = dir.path().join("second.sock");
+        let first_bound = bind_unix_listener_private_tracked(&first, 0o600).unwrap();
+        let first_identity = first_bound.link_identity();
+        drop(first_bound);
+        drop(bind_unix_listener_private(&second, 0o600).unwrap());
+        std::fs::rename(&second, &first).unwrap();
+        let err = verify_unix_socket_inode(&first, first_identity).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
     }
 
     #[test]

--- a/crates/fs-private/src/lib.rs
+++ b/crates/fs-private/src/lib.rs
@@ -929,13 +929,7 @@ fn unix_socket_inode(path: &Path) -> io::Result<UnixSocketInode> {
 pub fn verify_unix_socket_inode(path: &Path, expected: UnixSocketInode) -> io::Result<()> {
     const LINK_LOST: &str = "unix socket path no longer names the bound listener";
 
-    let actual = match unix_socket_inode(path) {
-        Ok(identity) => identity,
-        Err(err) if err.kind() == io::ErrorKind::InvalidInput => {
-            return Err(io::Error::new(io::ErrorKind::InvalidInput, LINK_LOST));
-        }
-        Err(err) => return Err(err),
-    };
+    let actual = unix_socket_inode(path)?;
     if actual != expected {
         return Err(io::Error::new(io::ErrorKind::InvalidInput, LINK_LOST));
     }


### PR DESCRIPTION
Fixes #1279

## Summary
- preserve the published Unix socket device/inode identity during private staged binding without changing the existing public bind API
- verify that `wn-agent serve` control-socket path still names the bound listener during startup and while accepting connections
- exit with a structured error if the final socket path is removed or replaced, instead of retaining an unreachable orphan listener
- add unlink/replacement regression coverage and an `Unreleased` changelog entry

## Verification
- `cargo fmt --all --check`
- `cargo test -p fs-private --locked` (45 passed)
- `cargo test -p agent-connector --locked connector_serve_fails_fast_when_control_socket_link_removed` (passed)
- `cargo test -p agent-connector --locked` (133 unit tests + 1 integration test passed)
- `just fast-ci`
- independent Composer review: passed; no security concerns or blocking logic errors

## Sensitive paths
- `crates/agent-connector/src/lib.rs`
- `crates/agent-connector/src/socket.rs`
- `crates/agent-connector/src/tests.rs`
- `crates/fs-private/src/lib.rs`

Sensitive socket/service lifecycle code changed. Explicit human approval is required at the merge gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - `wn-agent serve` now detects when its control-socket path is removed or replaced and exits promptly with an error.
  - Improved socket validation helps prevent communication through an unexpected socket.

- **Documentation**
  - Added changelog information describing the updated control-socket behavior.

- **Tests**
  - Added coverage for control-socket paths that are removed or replaced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Scope

This PR hardens the supervised, long-lived `wn-agent` control socket. The standalone `wnd`/CLI daemon also uses `bind_unix_listener_private`, but its lifecycle and shutdown path are independent and are intentionally left out of this change rather than broadening a security-sensitive patch. It should receive the same link-loss supervision in a focused follow-up.
