### PR TITLE
feat(pairing): add rotating single-use session lifecycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -914,6 +914,8 @@ dependencies = [
  "tls_codec",
  "tokio",
  "tracing",
+ "x25519-dalek 2.0.1",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ chacha20poly1305 = "0.10"
 scrypt = "0.11"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "stream"] }
 zeroize = "1"
+x25519-dalek = { version = "2", features = ["reusable_secrets", "zeroize"] }
 keyring-core = "1"
 quinn = { version = "0.11", default-features = false, features = ["log", "platform-verifier", "runtime-tokio", "rustls-ring"] }
 rcgen = "0.14"

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -9,8 +9,8 @@ what trouble it introduces, and what result the engine is supposed to produce.
 
 Portable vectors live in `vectors/*.json`. They are the cross-implementation cases.
 
-Rust-only harness scenarios live in `tests/canonical_scenarios.rs`. They cover engine behavior that still needs direct
-harness access.
+Rust-only harness scenarios live in `tests/canonical_scenarios.rs` and focused sibling test files. They cover engine
+behavior that still needs direct harness access.
 
 Generated families live in `src/family.rs`. They produce seeded adversarial `ScenarioSpec` cases. Promote one into
 `vectors/` only when it should become a stable named contract.
@@ -190,6 +190,14 @@ the top-level portable-vector test (Phase 5 wires the directory into CI).
 ## Rust-Only Harness Scenarios
 
 These are real simulator scenarios that are still tied to Rust harness details.
+
+### `stale_qr_race_rejects_first_scan_and_accepts_newest`
+
+- Setup: one account renders a pairing QR, then rotates it before either QR is scanned.
+- Pressure: a device scans the stale QR before another device scans the newest QR.
+- Expected: the stale scan receives typed `Superseded`; the newest scan succeeds and becomes the only `Scanned`
+  session.
+- File: `tests/pairing_session.rs`.
 
 ### `three_client_happy_path_via_harness`
 

--- a/crates/cgka-conformance-simulator/src/client.rs
+++ b/crates/cgka-conformance-simulator/src/client.rs
@@ -33,7 +33,10 @@ use cgka_traits::peeler::TransportPeeler;
 use cgka_traits::storage::{ConvergencePassStorage, MessageStorage, StorageProvider};
 use cgka_traits::transport::{TransportEnvelope, TransportMessage};
 use cgka_traits::types::{EpochId, GroupId, MemberId, MessageId};
-use cgka_traits::{ConvergenceCutoffCause, ConvergencePassPhase, DurableConvergencePass};
+use cgka_traits::{
+    ConvergenceCutoffCause, ConvergencePassPhase, DurableConvergencePass, PairingSessionDescriptor,
+    PairingSessionError, PairingSessionId, PairingSessionState,
+};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -562,6 +565,26 @@ impl HarnessClient {
 
     pub fn engine_mut(&mut self) -> &mut Engine<SqliteAccountStorage> {
         self.engine.as_mut().expect("harness engine is available")
+    }
+
+    pub fn start_pairing_session(
+        &mut self,
+    ) -> Result<PairingSessionDescriptor, PairingSessionError> {
+        self.engine_mut().start_pairing_session()
+    }
+
+    pub fn scan_pairing_session(
+        &mut self,
+        session_id: &PairingSessionId,
+    ) -> Result<(), PairingSessionError> {
+        self.engine_mut().scan_pairing_session(session_id)
+    }
+
+    pub fn pairing_session_state(
+        &mut self,
+        session_id: &PairingSessionId,
+    ) -> Result<PairingSessionState, PairingSessionError> {
+        self.engine_mut().pairing_session_state(session_id)
     }
 
     pub fn storage(&self) -> &SqliteAccountStorage {

--- a/crates/cgka-conformance-simulator/tests/AGENTS.md
+++ b/crates/cgka-conformance-simulator/tests/AGENTS.md
@@ -40,6 +40,9 @@ Map for simulator tests.
 - **File:** `openmls_replay_probe.rs`
   - **Owns:** OpenMLS replay and candidate materialization probes.
 
+- **File:** `pairing_session.rs`
+  - **Owns:** Engine-owned pairing-session rotation and stale-QR winner semantics through `HarnessClient`.
+
 - **File:** `proptest_invariants.rs`
   - **Owns:** Property tests for selector order, canonicalization, capability matrices, lifecycle/restart behavior,
     generated send/leave histories, and delivery-profile convergence.

--- a/crates/cgka-conformance-simulator/tests/pairing_session.rs
+++ b/crates/cgka-conformance-simulator/tests/pairing_session.rs
@@ -1,0 +1,41 @@
+//! Canonical pairing-session races through the public conformance harness.
+
+use cgka_conformance_simulator::{ClientBuilder, TransportBus};
+use cgka_traits::{CgkaEngine, PairingSessionError, PairingSessionState};
+
+fn pad32(name: &[u8]) -> Vec<u8> {
+    let mut out = vec![0u8; 32];
+    let len = name.len().min(out.len());
+    out[..len].copy_from_slice(&name[..len]);
+    out
+}
+
+#[test]
+fn stale_qr_race_rejects_first_scan_and_accepts_newest() {
+    let bus = TransportBus::ordered();
+    let mut account = ClientBuilder::new(pad32(b"alice")).attach(&bus);
+
+    let stale = account
+        .engine_mut()
+        .start_pairing_session()
+        .expect("start first pairing QR");
+    let current = account
+        .engine_mut()
+        .start_pairing_session()
+        .expect("rotate pairing QR");
+
+    assert_eq!(
+        account.engine_mut().scan_pairing_session(&stale.session_id),
+        Err(PairingSessionError::Superseded)
+    );
+    account
+        .engine_mut()
+        .scan_pairing_session(&current.session_id)
+        .expect("newest QR wins");
+    assert_eq!(
+        account
+            .engine_mut()
+            .pairing_session_state(&current.session_id),
+        Ok(PairingSessionState::Scanned)
+    );
+}

--- a/crates/cgka-conformance-simulator/tests/pairing_session.rs
+++ b/crates/cgka-conformance-simulator/tests/pairing_session.rs
@@ -1,7 +1,7 @@
 //! Canonical pairing-session races through the public conformance harness.
 
 use cgka_conformance_simulator::{ClientBuilder, TransportBus};
-use cgka_traits::{CgkaEngine, PairingSessionError, PairingSessionState};
+use cgka_traits::{PairingSessionError, PairingSessionState};
 
 fn pad32(name: &[u8]) -> Vec<u8> {
     let mut out = vec![0u8; 32];
@@ -16,26 +16,19 @@ fn stale_qr_race_rejects_first_scan_and_accepts_newest() {
     let mut account = ClientBuilder::new(pad32(b"alice")).attach(&bus);
 
     let stale = account
-        .engine_mut()
         .start_pairing_session()
         .expect("start first pairing QR");
-    let current = account
-        .engine_mut()
-        .start_pairing_session()
-        .expect("rotate pairing QR");
+    let current = account.start_pairing_session().expect("rotate pairing QR");
 
     assert_eq!(
-        account.engine_mut().scan_pairing_session(&stale.session_id),
+        account.scan_pairing_session(&stale.session_id),
         Err(PairingSessionError::Superseded)
     );
     account
-        .engine_mut()
         .scan_pairing_session(&current.session_id)
         .expect("newest QR wins");
     assert_eq!(
-        account
-            .engine_mut()
-            .pairing_session_state(&current.session_id),
+        account.pairing_session_state(&current.session_id),
         Ok(PairingSessionState::Scanned)
     );
 }

--- a/crates/cgka-engine/Cargo.toml
+++ b/crates/cgka-engine/Cargo.toml
@@ -37,6 +37,8 @@ marmot-forensics.workspace = true
 nostr.workspace = true
 rand.workspace = true
 sha2.workspace = true
+zeroize.workspace = true
+x25519-dalek.workspace = true
 # Pure-Rust secp256k1 used only to validate that a Marmot credential identity
 # is a well-formed BIP-340 x-only public key (foundation/identity.md). Already
 # resolved transitively via openmls_rust_crypto -> hpke-rs-rust-crypto -> k256;

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -26,7 +26,7 @@ use cgka_traits::error::EngineError;
 use cgka_traits::group::{Group, Member, ProtocolProfile};
 use cgka_traits::group_context::GroupContext;
 use cgka_traits::ingest::IngestOutcome;
-use cgka_traits::maintenance::{MaintenanceRandom, WallClock};
+use cgka_traits::maintenance::{MaintenanceRandom, MonotonicClock, WallClock};
 use cgka_traits::message::{MessageState, StoredMessagePayload};
 use cgka_traits::peeler::TransportPeeler;
 use cgka_traits::storage::{LeaveRequest, StorageError, StorageProvider};
@@ -50,7 +50,7 @@ use rand::RngCore;
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tls_codec::{Deserialize as _, Serialize as _};
 
 /// Default ciphersuite. MLS-1.0 mandatory-to-implement; TLS-ish naming.
@@ -83,6 +83,25 @@ impl WallClock for SystemWallClock {
             .as_millis()
             .try_into()
             .unwrap_or(u64::MAX)
+    }
+}
+
+#[derive(Debug)]
+struct SystemMonotonicClock {
+    origin: Instant,
+}
+
+impl Default for SystemMonotonicClock {
+    fn default() -> Self {
+        Self {
+            origin: Instant::now(),
+        }
+    }
+}
+
+impl MonotonicClock for SystemMonotonicClock {
+    fn elapsed(&self) -> Duration {
+        self.origin.elapsed()
     }
 }
 
@@ -171,6 +190,7 @@ pub struct Engine<S: StorageProvider> {
     pub(crate) max_past_epochs: usize,
     pub(crate) wall_clock: Arc<dyn WallClock>,
     pub(crate) maintenance_random: Arc<dyn MaintenanceRandom>,
+    pub(crate) pairing_monotonic_clock: Arc<dyn MonotonicClock>,
     pub(crate) pairing_sessions: PairingSessionManager,
 
     /// Per-group state-machine owner. Every transition, pending-ref
@@ -353,6 +373,7 @@ pub struct EngineBuilder<S: StorageProvider> {
     max_past_epochs: usize,
     wall_clock: Arc<dyn WallClock>,
     maintenance_random: Arc<dyn MaintenanceRandom>,
+    pairing_monotonic_clock: Arc<dyn MonotonicClock>,
     convergence_clock: Arc<dyn ConvergenceClock>,
     #[cfg(feature = "test-policy-overrides")]
     admit_app_witnesses: bool,
@@ -376,6 +397,7 @@ impl<S: StorageProvider> EngineBuilder<S> {
             max_past_epochs: crate::wire_format::DEFAULT_MAX_PAST_EPOCHS,
             wall_clock: Arc::new(SystemWallClock),
             maintenance_random: Arc::new(OsMaintenanceRandom),
+            pairing_monotonic_clock: Arc::new(SystemMonotonicClock::default()),
             convergence_clock: Arc::new(SystemConvergenceClock::default()),
             #[cfg(feature = "test-policy-overrides")]
             admit_app_witnesses: true,
@@ -452,6 +474,12 @@ impl<S: StorageProvider> EngineBuilder<S> {
     ) -> Self {
         self.wall_clock = wall_clock;
         self.maintenance_random = maintenance_random;
+        self
+    }
+
+    /// Install the process-local clock that bounds pairing bearer-token TTLs.
+    pub fn pairing_monotonic_clock(mut self, clock: Arc<dyn MonotonicClock>) -> Self {
+        self.pairing_monotonic_clock = clock;
         self
     }
 
@@ -548,6 +576,7 @@ impl<S: StorageProvider> EngineBuilder<S> {
             max_past_epochs: self.max_past_epochs,
             wall_clock: self.wall_clock,
             maintenance_random: self.maintenance_random,
+            pairing_monotonic_clock: self.pairing_monotonic_clock,
             pairing_sessions: PairingSessionManager::default(),
             epoch_manager: crate::epoch_manager::EpochManager::new(),
             fork_recovery: crate::fork_recovery::ForkRecoveryManager::default(),
@@ -2592,8 +2621,11 @@ impl<S: StorageProvider> Engine<S> {
 #[async_trait]
 impl<S: StorageProvider + 'static> CgkaEngine for Engine<S> {
     fn start_pairing_session(&mut self) -> Result<PairingSessionDescriptor, PairingSessionError> {
-        let now_ms = self.wall_clock.now_ms();
-        let expires_at_ms = now_ms.saturating_add(DEFAULT_PAIRING_SESSION_TTL_MS);
+        let wall_now_ms = self.wall_clock.now_ms();
+        let expires_at_ms = wall_now_ms.saturating_add(DEFAULT_PAIRING_SESSION_TTL_MS);
+        let monotonic_now = self.pairing_monotonic_clock.elapsed();
+        let expires_at_monotonic =
+            monotonic_now.saturating_add(Duration::from_millis(DEFAULT_PAIRING_SESSION_TTL_MS));
         let session_id = loop {
             let mut session_id_bytes = [0u8; 32];
             rand::rngs::OsRng.fill_bytes(&mut session_id_bytes);
@@ -2609,7 +2641,12 @@ impl<S: StorageProvider + 'static> CgkaEngine for Engine<S> {
             ephemeral_public_key,
             expires_at_ms,
         };
-        let operation = self.pairing_sessions.start(descriptor, private_key, now_ms);
+        let operation = self.pairing_sessions.start(
+            descriptor,
+            private_key,
+            monotonic_now,
+            expires_at_monotonic,
+        );
         self.record_pairing_transitions(operation.transitions);
         Ok(operation.result)
     }
@@ -2620,7 +2657,7 @@ impl<S: StorageProvider + 'static> CgkaEngine for Engine<S> {
     ) -> Result<PairingSessionState, PairingSessionError> {
         let operation = self
             .pairing_sessions
-            .state(session_id, self.wall_clock.now_ms());
+            .state(session_id, self.pairing_monotonic_clock.elapsed());
         self.record_pairing_transitions(operation.transitions);
         operation.result
     }
@@ -2631,7 +2668,7 @@ impl<S: StorageProvider + 'static> CgkaEngine for Engine<S> {
     ) -> Result<(), PairingSessionError> {
         let operation = self
             .pairing_sessions
-            .scan(session_id, self.wall_clock.now_ms());
+            .scan(session_id, self.pairing_monotonic_clock.elapsed());
         self.record_pairing_transitions(operation.transitions);
         operation.result
     }
@@ -2642,7 +2679,7 @@ impl<S: StorageProvider + 'static> CgkaEngine for Engine<S> {
     ) -> Result<(), PairingSessionError> {
         let operation = self
             .pairing_sessions
-            .approve(session_id, self.wall_clock.now_ms());
+            .approve(session_id, self.pairing_monotonic_clock.elapsed());
         self.record_pairing_transitions(operation.transitions);
         operation.result
     }
@@ -2653,7 +2690,7 @@ impl<S: StorageProvider + 'static> CgkaEngine for Engine<S> {
     ) -> Result<(), PairingSessionError> {
         let operation = self
             .pairing_sessions
-            .reject(session_id, self.wall_clock.now_ms());
+            .reject(session_id, self.pairing_monotonic_clock.elapsed());
         self.record_pairing_transitions(operation.transitions);
         operation.result
     }

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -12,6 +12,7 @@ use crate::bounded_id_set::{BoundedIdSet, DEDUP_CACHE_CAPACITY};
 use crate::convergence_clock::{ConvergenceClock, ConvergenceTime, SystemConvergenceClock};
 use crate::feature_registry::FeatureRegistry;
 use crate::identity::Identity;
+use crate::pairing_session::{PairingSessionManager, PairingSessionTransition};
 use async_trait::async_trait;
 use cgka_traits::OutboundFanout;
 use cgka_traits::app_components::{AppComponentId, AppComponentSet, default_group_components};
@@ -32,6 +33,10 @@ use cgka_traits::storage::{LeaveRequest, StorageError, StorageProvider};
 use cgka_traits::transport::{TransportEnvelope, TransportMessage};
 use cgka_traits::types::MessageId;
 use cgka_traits::types::{EpochId, GroupId, MemberId};
+use cgka_traits::{
+    DEFAULT_PAIRING_SESSION_TTL_MS, PairingSessionDescriptor, PairingSessionError,
+    PairingSessionId, PairingSessionState,
+};
 use marmot_forensics::{
     AuditEngineContext, AuditEventContext, AuditEventKind, AuditGroupContext, AuditRecord,
     ForensicRecorder, NoopRecorder,
@@ -166,6 +171,7 @@ pub struct Engine<S: StorageProvider> {
     pub(crate) max_past_epochs: usize,
     pub(crate) wall_clock: Arc<dyn WallClock>,
     pub(crate) maintenance_random: Arc<dyn MaintenanceRandom>,
+    pub(crate) pairing_sessions: PairingSessionManager,
 
     /// Per-group state-machine owner. Every transition, pending-ref
     /// allocation, and fork-detection marker flows through this struct.
@@ -542,6 +548,7 @@ impl<S: StorageProvider> EngineBuilder<S> {
             max_past_epochs: self.max_past_epochs,
             wall_clock: self.wall_clock,
             maintenance_random: self.maintenance_random,
+            pairing_sessions: PairingSessionManager::default(),
             epoch_manager: crate::epoch_manager::EpochManager::new(),
             fork_recovery: crate::fork_recovery::ForkRecoveryManager::default(),
             events_buf: VecDeque::new(),
@@ -588,6 +595,25 @@ impl<S: StorageProvider> EngineBuilder<S> {
 }
 
 impl<S: StorageProvider> Engine<S> {
+    fn record_pairing_transitions(
+        &self,
+        transitions: impl IntoIterator<Item = PairingSessionTransition>,
+    ) {
+        for transition in transitions {
+            self.recorder.record(AuditRecord::new(
+                None,
+                AuditEventKind::PairingSession {
+                    previous_state: transition
+                        .previous_state
+                        .map(|state| state.as_str().to_string()),
+                    new_state: transition.new_state.as_str().to_string(),
+                    reason: transition.reason.to_string(),
+                    expires_at_ms: transition.expires_at_ms,
+                },
+            ));
+        }
+    }
+
     /// Change the explicit replay-probe ceiling for a running exhaustion
     /// campaign. Production builds do not expose this method.
     #[cfg(feature = "test-policy-overrides")]
@@ -2565,6 +2591,73 @@ impl<S: StorageProvider> Engine<S> {
 
 #[async_trait]
 impl<S: StorageProvider + 'static> CgkaEngine for Engine<S> {
+    fn start_pairing_session(&mut self) -> Result<PairingSessionDescriptor, PairingSessionError> {
+        let now_ms = self.wall_clock.now_ms();
+        let expires_at_ms = now_ms.saturating_add(DEFAULT_PAIRING_SESSION_TTL_MS);
+        let session_id = loop {
+            let mut session_id_bytes = [0u8; 32];
+            rand::rngs::OsRng.fill_bytes(&mut session_id_bytes);
+            let session_id = PairingSessionId::new(session_id_bytes);
+            if !self.pairing_sessions.contains(&session_id) {
+                break session_id;
+            }
+        };
+        let private_key = x25519_dalek::ReusableSecret::random_from_rng(rand::rngs::OsRng);
+        let ephemeral_public_key = *x25519_dalek::PublicKey::from(&private_key).as_bytes();
+        let descriptor = PairingSessionDescriptor {
+            session_id,
+            ephemeral_public_key,
+            expires_at_ms,
+        };
+        let operation = self.pairing_sessions.start(descriptor, private_key, now_ms);
+        self.record_pairing_transitions(operation.transitions);
+        Ok(operation.result)
+    }
+
+    fn pairing_session_state(
+        &mut self,
+        session_id: &PairingSessionId,
+    ) -> Result<PairingSessionState, PairingSessionError> {
+        let operation = self
+            .pairing_sessions
+            .state(session_id, self.wall_clock.now_ms());
+        self.record_pairing_transitions(operation.transitions);
+        operation.result
+    }
+
+    fn scan_pairing_session(
+        &mut self,
+        session_id: &PairingSessionId,
+    ) -> Result<(), PairingSessionError> {
+        let operation = self
+            .pairing_sessions
+            .scan(session_id, self.wall_clock.now_ms());
+        self.record_pairing_transitions(operation.transitions);
+        operation.result
+    }
+
+    fn approve_pairing_session(
+        &mut self,
+        session_id: &PairingSessionId,
+    ) -> Result<(), PairingSessionError> {
+        let operation = self
+            .pairing_sessions
+            .approve(session_id, self.wall_clock.now_ms());
+        self.record_pairing_transitions(operation.transitions);
+        operation.result
+    }
+
+    fn reject_pairing_session(
+        &mut self,
+        session_id: &PairingSessionId,
+    ) -> Result<(), PairingSessionError> {
+        let operation = self
+            .pairing_sessions
+            .reject(session_id, self.wall_clock.now_ms());
+        self.record_pairing_transitions(operation.transitions);
+        operation.result
+    }
+
     async fn ingest(&mut self, msg: TransportMessage) -> Result<IngestOutcome, EngineError> {
         self.ingest_with_audit_context(msg, None).await
     }

--- a/crates/cgka-engine/src/lib.rs
+++ b/crates/cgka-engine/src/lib.rs
@@ -63,6 +63,7 @@ pub mod maintenance;
 pub(crate) mod message_disposition;
 pub mod message_processor;
 pub mod openmls_projection;
+pub(crate) mod pairing_session;
 pub mod pending_commit_guard;
 pub mod provider;
 pub mod publish;

--- a/crates/cgka-engine/src/pairing_session.rs
+++ b/crates/cgka-engine/src/pairing_session.rs
@@ -1,0 +1,303 @@
+use cgka_traits::{
+    PairingSessionDescriptor, PairingSessionError, PairingSessionId, PairingSessionState,
+};
+use std::collections::HashMap;
+use x25519_dalek::ReusableSecret;
+use zeroize::Zeroize;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct PairingSessionTransition {
+    pub previous_state: Option<PairingSessionState>,
+    pub new_state: PairingSessionState,
+    pub reason: &'static str,
+    pub expires_at_ms: u64,
+}
+
+pub(crate) struct PairingOperation<T> {
+    pub result: T,
+    pub transitions: Vec<PairingSessionTransition>,
+}
+
+struct ActivePairingSession {
+    descriptor: PairingSessionDescriptor,
+    private_key: ReusableSecret,
+    state: PairingSessionState,
+}
+
+impl ActivePairingSession {
+    fn wipe_private_key(&mut self) {
+        self.private_key.zeroize();
+    }
+}
+
+impl Drop for ActivePairingSession {
+    fn drop(&mut self) {
+        self.wipe_private_key();
+    }
+}
+
+impl zeroize::ZeroizeOnDrop for ActivePairingSession {}
+
+#[derive(Clone, Copy)]
+struct TerminalPairingSession {
+    state: PairingSessionState,
+    expires_at_ms: u64,
+}
+
+#[derive(Default)]
+pub(crate) struct PairingSessionManager {
+    active: Option<ActivePairingSession>,
+    terminal: HashMap<PairingSessionId, TerminalPairingSession>,
+}
+
+impl PairingSessionManager {
+    pub fn contains(&self, session_id: &PairingSessionId) -> bool {
+        self.active
+            .as_ref()
+            .is_some_and(|session| session.descriptor.session_id == *session_id)
+            || self.terminal.contains_key(session_id)
+    }
+
+    pub fn start(
+        &mut self,
+        descriptor: PairingSessionDescriptor,
+        private_key: ReusableSecret,
+        now_ms: u64,
+    ) -> PairingOperation<PairingSessionDescriptor> {
+        self.prune_terminal(now_ms);
+        let mut transitions = self.expire_active_if_due(now_ms);
+        if self.active.is_some() {
+            transitions.push(
+                self.terminalize_active(PairingSessionState::Superseded, "new_session_started"),
+            );
+        }
+
+        let returned_descriptor = descriptor.clone();
+        transitions.push(PairingSessionTransition {
+            previous_state: None,
+            new_state: PairingSessionState::Active,
+            reason: "started",
+            expires_at_ms: descriptor.expires_at_ms,
+        });
+        self.active = Some(ActivePairingSession {
+            descriptor,
+            private_key,
+            state: PairingSessionState::Active,
+        });
+        PairingOperation {
+            result: returned_descriptor,
+            transitions,
+        }
+    }
+
+    pub fn state(
+        &mut self,
+        session_id: &PairingSessionId,
+        now_ms: u64,
+    ) -> PairingOperation<Result<PairingSessionState, PairingSessionError>> {
+        let transitions = self.expire_active_if_due(now_ms);
+        self.prune_terminal(now_ms);
+        let result = if let Some(active) = self
+            .active
+            .as_ref()
+            .filter(|session| session.descriptor.session_id == *session_id)
+        {
+            Ok(active.state)
+        } else if let Some(terminal) = self.terminal.get(session_id) {
+            Ok(terminal.state)
+        } else {
+            // Sessions are intentionally process-local. After restart there is
+            // nothing to rehydrate, so any missing bearer capability fails
+            // closed as expired rather than entering an ambiguous state.
+            Err(PairingSessionError::Expired)
+        };
+        PairingOperation {
+            result,
+            transitions,
+        }
+    }
+
+    pub fn scan(
+        &mut self,
+        session_id: &PairingSessionId,
+        now_ms: u64,
+    ) -> PairingOperation<Result<(), PairingSessionError>> {
+        let mut transitions = self.expire_active_if_due(now_ms);
+        self.prune_terminal(now_ms);
+        let result = if let Some(active) = self
+            .active
+            .as_mut()
+            .filter(|session| session.descriptor.session_id == *session_id)
+        {
+            match active.state {
+                PairingSessionState::Active => {
+                    active.state = PairingSessionState::Scanned;
+                    transitions.push(PairingSessionTransition {
+                        previous_state: Some(PairingSessionState::Active),
+                        new_state: PairingSessionState::Scanned,
+                        reason: "qr_scanned",
+                        expires_at_ms: active.descriptor.expires_at_ms,
+                    });
+                    Ok(())
+                }
+                PairingSessionState::Scanned => Err(PairingSessionError::AlreadyScanned),
+                _ => unreachable!("active slot contains only non-terminal states"),
+            }
+        } else if let Some(terminal) = self.terminal.get(session_id) {
+            Err(error_for_terminal_state(terminal.state))
+        } else {
+            Err(PairingSessionError::Expired)
+        };
+        PairingOperation {
+            result,
+            transitions,
+        }
+    }
+
+    pub fn approve(
+        &mut self,
+        session_id: &PairingSessionId,
+        now_ms: u64,
+    ) -> PairingOperation<Result<(), PairingSessionError>> {
+        self.finish_scanned(
+            session_id,
+            now_ms,
+            PairingSessionState::Approved,
+            "local_user_approved",
+        )
+    }
+
+    pub fn reject(
+        &mut self,
+        session_id: &PairingSessionId,
+        now_ms: u64,
+    ) -> PairingOperation<Result<(), PairingSessionError>> {
+        self.finish_scanned(
+            session_id,
+            now_ms,
+            PairingSessionState::Rejected,
+            "local_user_rejected",
+        )
+    }
+
+    fn finish_scanned(
+        &mut self,
+        session_id: &PairingSessionId,
+        now_ms: u64,
+        terminal_state: PairingSessionState,
+        reason: &'static str,
+    ) -> PairingOperation<Result<(), PairingSessionError>> {
+        let mut transitions = self.expire_active_if_due(now_ms);
+        self.prune_terminal(now_ms);
+        let active_state = self
+            .active
+            .as_ref()
+            .filter(|session| session.descriptor.session_id == *session_id)
+            .map(|session| session.state);
+        let result = match active_state {
+            Some(PairingSessionState::Scanned) => {
+                transitions.push(self.terminalize_active(terminal_state, reason));
+                Ok(())
+            }
+            Some(PairingSessionState::Active) => Err(PairingSessionError::NotScanned),
+            Some(_) => unreachable!("active slot contains only non-terminal states"),
+            None => self
+                .terminal
+                .get(session_id)
+                .map(|terminal| Err(error_for_terminal_state(terminal.state)))
+                .unwrap_or(Err(PairingSessionError::Expired)),
+        };
+        PairingOperation {
+            result,
+            transitions,
+        }
+    }
+
+    fn expire_active_if_due(&mut self, now_ms: u64) -> Vec<PairingSessionTransition> {
+        if self
+            .active
+            .as_ref()
+            .is_some_and(|session| now_ms >= session.descriptor.expires_at_ms)
+        {
+            vec![self.terminalize_active(PairingSessionState::Expired, "ttl_elapsed")]
+        } else {
+            Vec::new()
+        }
+    }
+
+    fn terminalize_active(
+        &mut self,
+        state: PairingSessionState,
+        reason: &'static str,
+    ) -> PairingSessionTransition {
+        debug_assert!(state.is_terminal());
+        let active = self.active.as_mut().expect("active pairing session");
+        let previous_state = active.state;
+        let session_id = active.descriptor.session_id.clone();
+        let expires_at_ms = active.descriptor.expires_at_ms;
+        // Wipe the original in-place before moving/dropping the session. This
+        // avoids leaving key bytes in the vacated `Option` payload.
+        active.wipe_private_key();
+        let retired = self.active.take().expect("active pairing session");
+        drop(retired);
+        self.terminal.insert(
+            session_id,
+            TerminalPairingSession {
+                state,
+                expires_at_ms,
+            },
+        );
+        PairingSessionTransition {
+            previous_state: Some(previous_state),
+            new_state: state,
+            reason,
+            expires_at_ms,
+        }
+    }
+
+    fn prune_terminal(&mut self, now_ms: u64) {
+        self.terminal
+            .retain(|_, session| now_ms < session.expires_at_ms);
+    }
+}
+
+fn error_for_terminal_state(state: PairingSessionState) -> PairingSessionError {
+    match state {
+        PairingSessionState::Approved => PairingSessionError::AlreadyAccepted,
+        PairingSessionState::Expired => PairingSessionError::Expired,
+        PairingSessionState::Superseded => PairingSessionError::Superseded,
+        PairingSessionState::Rejected => PairingSessionError::Rejected,
+        PairingSessionState::Active | PairingSessionState::Scanned => {
+            unreachable!("terminal map contains only terminal states")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn terminal_key_wipe_overwrites_private_material_in_place() {
+        fn assert_zeroize_on_drop<T: zeroize::ZeroizeOnDrop>() {}
+        assert_zeroize_on_drop::<ActivePairingSession>();
+
+        let mut session = ActivePairingSession {
+            descriptor: PairingSessionDescriptor {
+                session_id: PairingSessionId::new([1; 32]),
+                ephemeral_public_key: [2; 32],
+                expires_at_ms: 30_000,
+            },
+            private_key: ReusableSecret::random_from_rng(rand::rngs::OsRng),
+            state: PairingSessionState::Scanned,
+        };
+
+        session.wipe_private_key();
+
+        let public_after_wipe = x25519_dalek::PublicKey::from(&session.private_key);
+        assert_eq!(
+            public_after_wipe.as_bytes(),
+            &x25519_dalek::x25519([0; 32], x25519_dalek::X25519_BASEPOINT_BYTES)
+        );
+    }
+}

--- a/crates/cgka-engine/src/pairing_session.rs
+++ b/crates/cgka-engine/src/pairing_session.rs
@@ -2,6 +2,7 @@ use cgka_traits::{
     PairingSessionDescriptor, PairingSessionError, PairingSessionId, PairingSessionState,
 };
 use std::collections::HashMap;
+use std::time::Duration;
 use x25519_dalek::ReusableSecret;
 use zeroize::Zeroize;
 
@@ -20,6 +21,7 @@ pub(crate) struct PairingOperation<T> {
 
 struct ActivePairingSession {
     descriptor: PairingSessionDescriptor,
+    expires_at_monotonic: Duration,
     private_key: ReusableSecret,
     state: PairingSessionState,
 }
@@ -41,7 +43,7 @@ impl zeroize::ZeroizeOnDrop for ActivePairingSession {}
 #[derive(Clone, Copy)]
 struct TerminalPairingSession {
     state: PairingSessionState,
-    expires_at_ms: u64,
+    expires_at_monotonic: Duration,
 }
 
 #[derive(Default)]
@@ -62,10 +64,11 @@ impl PairingSessionManager {
         &mut self,
         descriptor: PairingSessionDescriptor,
         private_key: ReusableSecret,
-        now_ms: u64,
+        now_monotonic: Duration,
+        expires_at_monotonic: Duration,
     ) -> PairingOperation<PairingSessionDescriptor> {
-        self.prune_terminal(now_ms);
-        let mut transitions = self.expire_active_if_due(now_ms);
+        self.prune_terminal(now_monotonic);
+        let mut transitions = self.expire_active_if_due(now_monotonic);
         if self.active.is_some() {
             transitions.push(
                 self.terminalize_active(PairingSessionState::Superseded, "new_session_started"),
@@ -81,6 +84,7 @@ impl PairingSessionManager {
         });
         self.active = Some(ActivePairingSession {
             descriptor,
+            expires_at_monotonic,
             private_key,
             state: PairingSessionState::Active,
         });
@@ -93,10 +97,10 @@ impl PairingSessionManager {
     pub fn state(
         &mut self,
         session_id: &PairingSessionId,
-        now_ms: u64,
+        now_monotonic: Duration,
     ) -> PairingOperation<Result<PairingSessionState, PairingSessionError>> {
-        let transitions = self.expire_active_if_due(now_ms);
-        self.prune_terminal(now_ms);
+        let transitions = self.expire_active_if_due(now_monotonic);
+        self.prune_terminal(now_monotonic);
         let result = if let Some(active) = self
             .active
             .as_ref()
@@ -120,10 +124,10 @@ impl PairingSessionManager {
     pub fn scan(
         &mut self,
         session_id: &PairingSessionId,
-        now_ms: u64,
+        now_monotonic: Duration,
     ) -> PairingOperation<Result<(), PairingSessionError>> {
-        let mut transitions = self.expire_active_if_due(now_ms);
-        self.prune_terminal(now_ms);
+        let mut transitions = self.expire_active_if_due(now_monotonic);
+        self.prune_terminal(now_monotonic);
         let result = if let Some(active) = self
             .active
             .as_mut()
@@ -157,11 +161,11 @@ impl PairingSessionManager {
     pub fn approve(
         &mut self,
         session_id: &PairingSessionId,
-        now_ms: u64,
+        now_monotonic: Duration,
     ) -> PairingOperation<Result<(), PairingSessionError>> {
         self.finish_scanned(
             session_id,
-            now_ms,
+            now_monotonic,
             PairingSessionState::Approved,
             "local_user_approved",
         )
@@ -170,11 +174,11 @@ impl PairingSessionManager {
     pub fn reject(
         &mut self,
         session_id: &PairingSessionId,
-        now_ms: u64,
+        now_monotonic: Duration,
     ) -> PairingOperation<Result<(), PairingSessionError>> {
         self.finish_scanned(
             session_id,
-            now_ms,
+            now_monotonic,
             PairingSessionState::Rejected,
             "local_user_rejected",
         )
@@ -183,12 +187,12 @@ impl PairingSessionManager {
     fn finish_scanned(
         &mut self,
         session_id: &PairingSessionId,
-        now_ms: u64,
+        now_monotonic: Duration,
         terminal_state: PairingSessionState,
         reason: &'static str,
     ) -> PairingOperation<Result<(), PairingSessionError>> {
-        let mut transitions = self.expire_active_if_due(now_ms);
-        self.prune_terminal(now_ms);
+        let mut transitions = self.expire_active_if_due(now_monotonic);
+        self.prune_terminal(now_monotonic);
         let active_state = self
             .active
             .as_ref()
@@ -213,11 +217,11 @@ impl PairingSessionManager {
         }
     }
 
-    fn expire_active_if_due(&mut self, now_ms: u64) -> Vec<PairingSessionTransition> {
+    fn expire_active_if_due(&mut self, now_monotonic: Duration) -> Vec<PairingSessionTransition> {
         if self
             .active
             .as_ref()
-            .is_some_and(|session| now_ms >= session.descriptor.expires_at_ms)
+            .is_some_and(|session| now_monotonic >= session.expires_at_monotonic)
         {
             vec![self.terminalize_active(PairingSessionState::Expired, "ttl_elapsed")]
         } else {
@@ -235,6 +239,7 @@ impl PairingSessionManager {
         let previous_state = active.state;
         let session_id = active.descriptor.session_id.clone();
         let expires_at_ms = active.descriptor.expires_at_ms;
+        let expires_at_monotonic = active.expires_at_monotonic;
         // Wipe the original in-place before moving/dropping the session. This
         // avoids leaving key bytes in the vacated `Option` payload.
         active.wipe_private_key();
@@ -244,7 +249,7 @@ impl PairingSessionManager {
             session_id,
             TerminalPairingSession {
                 state,
-                expires_at_ms,
+                expires_at_monotonic,
             },
         );
         PairingSessionTransition {
@@ -255,9 +260,9 @@ impl PairingSessionManager {
         }
     }
 
-    fn prune_terminal(&mut self, now_ms: u64) {
+    fn prune_terminal(&mut self, now_monotonic: Duration) {
         self.terminal
-            .retain(|_, session| now_ms < session.expires_at_ms);
+            .retain(|_, session| now_monotonic < session.expires_at_monotonic);
     }
 }
 
@@ -288,6 +293,7 @@ mod tests {
                 ephemeral_public_key: [2; 32],
                 expires_at_ms: 30_000,
             },
+            expires_at_monotonic: Duration::from_millis(30_000),
             private_key: ReusableSecret::random_from_rng(rand::rngs::OsRng),
             state: PairingSessionState::Scanned,
         };

--- a/crates/cgka-engine/tests/pairing_session.rs
+++ b/crates/cgka-engine/tests/pairing_session.rs
@@ -5,38 +5,60 @@ use cgka_engine::EngineBuilder;
 use cgka_traits::error::PeelerError;
 use cgka_traits::group_context::GroupContextSnapshot;
 use cgka_traits::ingest::PeeledMessage;
-use cgka_traits::maintenance::{MaintenanceRandom, WallClock};
+use cgka_traits::maintenance::{MaintenanceRandom, MonotonicClock, WallClock};
 use cgka_traits::peeler::TransportPeeler;
 use cgka_traits::transport::{EncryptedPayload, Timestamp, TransportMessage};
 use cgka_traits::{CgkaEngine, DEFAULT_PAIRING_SESSION_TTL_MS, MemberId, PairingSessionState};
 use marmot_forensics::{AuditEventKind, AuditRecord, ForensicRecorder};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 use storage_sqlite::SqliteAccountStorage;
 
 mod support;
 use support::proof_signer;
 
 #[derive(Default)]
-struct ManualWallClock(AtomicU64);
+struct ManualClock {
+    wall_ms: AtomicU64,
+    monotonic_ms: AtomicU64,
+}
 
-impl ManualWallClock {
+impl ManualClock {
     fn new(now_ms: u64) -> Self {
-        Self(AtomicU64::new(now_ms))
+        Self {
+            wall_ms: AtomicU64::new(now_ms),
+            monotonic_ms: AtomicU64::new(0),
+        }
     }
 
     fn advance(&self, delta_ms: u64) {
-        self.0.fetch_add(delta_ms, Ordering::SeqCst);
+        self.wall_ms.fetch_add(delta_ms, Ordering::SeqCst);
+        self.monotonic_ms.fetch_add(delta_ms, Ordering::SeqCst);
+    }
+
+    fn set_wall_ms(&self, now_ms: u64) {
+        self.wall_ms.store(now_ms, Ordering::SeqCst);
+    }
+
+    fn advance_monotonic(&self, delta_ms: u64) {
+        self.monotonic_ms.fetch_add(delta_ms, Ordering::SeqCst);
     }
 }
 
-impl WallClock for ManualWallClock {
+impl WallClock for ManualClock {
     fn now(&self) -> Timestamp {
         Timestamp(self.now_ms() / 1_000)
     }
 
     fn now_ms(&self) -> u64 {
-        self.0.load(Ordering::SeqCst)
+        self.wall_ms.load(Ordering::SeqCst)
+    }
+}
+
+impl MonotonicClock for ManualClock {
+    fn elapsed(&self) -> Duration {
+        Duration::from_millis(self.monotonic_ms.load(Ordering::SeqCst))
     }
 }
 
@@ -101,12 +123,12 @@ fn valid_identity(seed: &[u8]) -> Vec<u8> {
     }
 }
 
-fn build_engine(clock: Arc<ManualWallClock>) -> cgka_engine::Engine<SqliteAccountStorage> {
+fn build_engine(clock: Arc<ManualClock>) -> cgka_engine::Engine<SqliteAccountStorage> {
     build_engine_with_recorder(clock, None)
 }
 
 fn build_engine_with_recorder(
-    clock: Arc<ManualWallClock>,
+    clock: Arc<ManualClock>,
     recorder: Option<Box<dyn ForensicRecorder>>,
 ) -> cgka_engine::Engine<SqliteAccountStorage> {
     let mut builder = EngineBuilder::new(SqliteAccountStorage::in_memory().unwrap())
@@ -114,7 +136,8 @@ fn build_engine_with_recorder(
         .identity(valid_identity(b"pairing-session"))
         .account_identity_proof_signer(proof_signer(b"pairing-session"))
         .peeler(Box::new(StubPeeler))
-        .maintenance_sources(clock, Arc::new(FixedMaintenanceRandom));
+        .maintenance_sources(clock.clone(), Arc::new(FixedMaintenanceRandom))
+        .pairing_monotonic_clock(clock);
     if let Some(recorder) = recorder {
         builder = builder.recorder(recorder);
     }
@@ -138,7 +161,7 @@ impl CapturingRecorder {
 
 #[test]
 fn rotation_expires_old_qr_and_returns_fresh_material() {
-    let clock = Arc::new(ManualWallClock::new(1_000));
+    let clock = Arc::new(ManualClock::new(1_000));
     let mut engine = build_engine(clock.clone());
 
     let first = engine.start_pairing_session().expect("start first session");
@@ -167,7 +190,7 @@ fn rotation_expires_old_qr_and_returns_fresh_material() {
 
 #[test]
 fn expired_session_is_rejected_before_scan() {
-    let clock = Arc::new(ManualWallClock::new(1_000));
+    let clock = Arc::new(ManualClock::new(1_000));
     let mut engine = build_engine(clock.clone());
     let session = engine.start_pairing_session().expect("start session");
 
@@ -180,8 +203,23 @@ fn expired_session_is_rejected_before_scan() {
 }
 
 #[test]
+fn wall_clock_rollback_does_not_extend_session_ttl() {
+    let clock = Arc::new(ManualClock::new(100_000));
+    let mut engine = build_engine(clock.clone());
+    let session = engine.start_pairing_session().expect("start session");
+
+    clock.set_wall_ms(1_000);
+    clock.advance_monotonic(DEFAULT_PAIRING_SESSION_TTL_MS);
+
+    assert_eq!(
+        engine.scan_pairing_session(&session.session_id),
+        Err(cgka_traits::PairingSessionError::Expired)
+    );
+}
+
+#[test]
 fn stale_qr_loses_to_newest_session() {
-    let clock = Arc::new(ManualWallClock::new(1_000));
+    let clock = Arc::new(ManualClock::new(1_000));
     let mut engine = build_engine(clock);
 
     let stale = engine.start_pairing_session().expect("start stale session");
@@ -202,7 +240,7 @@ fn stale_qr_loses_to_newest_session() {
 
 #[test]
 fn approved_session_is_single_use_and_requires_a_scan() {
-    let clock = Arc::new(ManualWallClock::new(1_000));
+    let clock = Arc::new(ManualClock::new(1_000));
     let mut engine = build_engine(clock);
     let session = engine.start_pairing_session().expect("start session");
 
@@ -233,7 +271,7 @@ fn approved_session_is_single_use_and_requires_a_scan() {
 
 #[test]
 fn rejected_session_remains_terminal_until_its_ttl() {
-    let clock = Arc::new(ManualWallClock::new(1_000));
+    let clock = Arc::new(ManualClock::new(1_000));
     let mut engine = build_engine(clock.clone());
     let session = engine.start_pairing_session().expect("start session");
     engine
@@ -261,7 +299,7 @@ fn rejected_session_remains_terminal_until_its_ttl() {
 
 #[test]
 fn restart_fails_closed_for_in_flight_session() {
-    let clock = Arc::new(ManualWallClock::new(1_000));
+    let clock = Arc::new(ManualClock::new(1_000));
     let session = {
         let mut engine = build_engine(clock.clone());
         engine.start_pairing_session().expect("start session")
@@ -280,7 +318,7 @@ fn restart_fails_closed_for_in_flight_session() {
 
 #[test]
 fn every_pairing_transition_emits_a_privacy_safe_audit_row() {
-    let clock = Arc::new(ManualWallClock::new(1_000));
+    let clock = Arc::new(ManualClock::new(1_000));
     let capture = CapturingRecorder::default();
     let mut engine = build_engine_with_recorder(clock.clone(), Some(Box::new(capture.clone())));
 

--- a/crates/cgka-engine/tests/pairing_session.rs
+++ b/crates/cgka-engine/tests/pairing_session.rs
@@ -1,0 +1,341 @@
+//! Engine-owned pairing-session lifecycle tests.
+
+use async_trait::async_trait;
+use cgka_engine::EngineBuilder;
+use cgka_traits::error::PeelerError;
+use cgka_traits::group_context::GroupContextSnapshot;
+use cgka_traits::ingest::PeeledMessage;
+use cgka_traits::maintenance::{MaintenanceRandom, WallClock};
+use cgka_traits::peeler::TransportPeeler;
+use cgka_traits::transport::{EncryptedPayload, Timestamp, TransportMessage};
+use cgka_traits::{CgkaEngine, DEFAULT_PAIRING_SESSION_TTL_MS, MemberId, PairingSessionState};
+use marmot_forensics::{AuditEventKind, AuditRecord, ForensicRecorder};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use storage_sqlite::SqliteAccountStorage;
+
+mod support;
+use support::proof_signer;
+
+#[derive(Default)]
+struct ManualWallClock(AtomicU64);
+
+impl ManualWallClock {
+    fn new(now_ms: u64) -> Self {
+        Self(AtomicU64::new(now_ms))
+    }
+
+    fn advance(&self, delta_ms: u64) {
+        self.0.fetch_add(delta_ms, Ordering::SeqCst);
+    }
+}
+
+impl WallClock for ManualWallClock {
+    fn now(&self) -> Timestamp {
+        Timestamp(self.now_ms() / 1_000)
+    }
+
+    fn now_ms(&self) -> u64 {
+        self.0.load(Ordering::SeqCst)
+    }
+}
+
+#[derive(Default)]
+struct FixedMaintenanceRandom;
+
+impl MaintenanceRandom for FixedMaintenanceRandom {
+    fn next_u64(&self) -> u64 {
+        0
+    }
+}
+
+struct StubPeeler;
+
+#[async_trait]
+impl TransportPeeler for StubPeeler {
+    async fn peel_group_message(
+        &self,
+        _msg: &TransportMessage,
+        _ctx: &GroupContextSnapshot,
+    ) -> Result<PeeledMessage, PeelerError> {
+        Err(PeelerError::Backend("test peeler".into()))
+    }
+
+    async fn peel_welcome(&self, _msg: &TransportMessage) -> Result<PeeledMessage, PeelerError> {
+        Err(PeelerError::Backend("test peeler".into()))
+    }
+
+    async fn wrap_group_message(
+        &self,
+        _payload: &EncryptedPayload,
+        _ctx: &GroupContextSnapshot,
+    ) -> Result<TransportMessage, PeelerError> {
+        Err(PeelerError::Backend("test peeler".into()))
+    }
+
+    async fn wrap_welcome(
+        &self,
+        _payload: &EncryptedPayload,
+        _recipient: &MemberId,
+    ) -> Result<TransportMessage, PeelerError> {
+        Err(PeelerError::Backend("test peeler".into()))
+    }
+}
+
+fn valid_identity(seed: &[u8]) -> Vec<u8> {
+    use k256::schnorr::SigningKey;
+    use sha2::{Digest, Sha256};
+
+    let mut counter = 0u64;
+    loop {
+        let material: [u8; 32] = Sha256::new()
+            .chain_update(b"cgka-engine-test-identity-v1")
+            .chain_update(seed)
+            .chain_update(counter.to_be_bytes())
+            .finalize()
+            .into();
+        if let Ok(key) = SigningKey::from_bytes(&material) {
+            return key.verifying_key().to_bytes().to_vec();
+        }
+        counter += 1;
+    }
+}
+
+fn build_engine(clock: Arc<ManualWallClock>) -> cgka_engine::Engine<SqliteAccountStorage> {
+    build_engine_with_recorder(clock, None)
+}
+
+fn build_engine_with_recorder(
+    clock: Arc<ManualWallClock>,
+    recorder: Option<Box<dyn ForensicRecorder>>,
+) -> cgka_engine::Engine<SqliteAccountStorage> {
+    let mut builder = EngineBuilder::new(SqliteAccountStorage::in_memory().unwrap())
+        .legacy_compatibility_profile()
+        .identity(valid_identity(b"pairing-session"))
+        .account_identity_proof_signer(proof_signer(b"pairing-session"))
+        .peeler(Box::new(StubPeeler))
+        .maintenance_sources(clock, Arc::new(FixedMaintenanceRandom));
+    if let Some(recorder) = recorder {
+        builder = builder.recorder(recorder);
+    }
+    builder.build().expect("build engine")
+}
+
+#[derive(Clone, Default)]
+struct CapturingRecorder(Arc<Mutex<Vec<AuditEventKind>>>);
+
+impl ForensicRecorder for CapturingRecorder {
+    fn record(&self, record: AuditRecord) {
+        self.0.lock().unwrap().push(record.kind);
+    }
+}
+
+impl CapturingRecorder {
+    fn kinds(&self) -> Vec<AuditEventKind> {
+        self.0.lock().unwrap().clone()
+    }
+}
+
+#[test]
+fn rotation_expires_old_qr_and_returns_fresh_material() {
+    let clock = Arc::new(ManualWallClock::new(1_000));
+    let mut engine = build_engine(clock.clone());
+
+    let first = engine.start_pairing_session().expect("start first session");
+    assert_eq!(
+        engine.pairing_session_state(&first.session_id),
+        Ok(PairingSessionState::Active)
+    );
+    assert_eq!(first.expires_at_ms, 1_000 + DEFAULT_PAIRING_SESSION_TTL_MS);
+
+    clock.advance(DEFAULT_PAIRING_SESSION_TTL_MS);
+    let second = engine
+        .start_pairing_session()
+        .expect("rotate expired session");
+
+    assert_ne!(second.session_id, first.session_id);
+    assert_ne!(second.ephemeral_public_key, first.ephemeral_public_key);
+    assert_eq!(
+        engine.pairing_session_state(&first.session_id),
+        Err(cgka_traits::PairingSessionError::Expired)
+    );
+    assert_eq!(
+        engine.pairing_session_state(&second.session_id),
+        Ok(PairingSessionState::Active)
+    );
+}
+
+#[test]
+fn expired_session_is_rejected_before_scan() {
+    let clock = Arc::new(ManualWallClock::new(1_000));
+    let mut engine = build_engine(clock.clone());
+    let session = engine.start_pairing_session().expect("start session");
+
+    clock.advance(DEFAULT_PAIRING_SESSION_TTL_MS);
+
+    assert_eq!(
+        engine.scan_pairing_session(&session.session_id),
+        Err(cgka_traits::PairingSessionError::Expired)
+    );
+}
+
+#[test]
+fn stale_qr_loses_to_newest_session() {
+    let clock = Arc::new(ManualWallClock::new(1_000));
+    let mut engine = build_engine(clock);
+
+    let stale = engine.start_pairing_session().expect("start stale session");
+    let current = engine
+        .start_pairing_session()
+        .expect("start winner session");
+
+    assert_eq!(
+        engine.scan_pairing_session(&stale.session_id),
+        Err(cgka_traits::PairingSessionError::Superseded)
+    );
+    assert_eq!(engine.scan_pairing_session(&current.session_id), Ok(()));
+    assert_eq!(
+        engine.pairing_session_state(&current.session_id),
+        Ok(PairingSessionState::Scanned)
+    );
+}
+
+#[test]
+fn approved_session_is_single_use_and_requires_a_scan() {
+    let clock = Arc::new(ManualWallClock::new(1_000));
+    let mut engine = build_engine(clock);
+    let session = engine.start_pairing_session().expect("start session");
+
+    assert_eq!(
+        engine.approve_pairing_session(&session.session_id),
+        Err(cgka_traits::PairingSessionError::NotScanned)
+    );
+    engine
+        .scan_pairing_session(&session.session_id)
+        .expect("scan session");
+    engine
+        .approve_pairing_session(&session.session_id)
+        .expect("approve session");
+
+    assert_eq!(
+        engine.pairing_session_state(&session.session_id),
+        Ok(PairingSessionState::Approved)
+    );
+    assert_eq!(
+        engine.approve_pairing_session(&session.session_id),
+        Err(cgka_traits::PairingSessionError::AlreadyAccepted)
+    );
+    assert_eq!(
+        engine.scan_pairing_session(&session.session_id),
+        Err(cgka_traits::PairingSessionError::AlreadyAccepted)
+    );
+}
+
+#[test]
+fn rejected_session_remains_terminal_until_its_ttl() {
+    let clock = Arc::new(ManualWallClock::new(1_000));
+    let mut engine = build_engine(clock.clone());
+    let session = engine.start_pairing_session().expect("start session");
+    engine
+        .scan_pairing_session(&session.session_id)
+        .expect("scan session");
+    engine
+        .reject_pairing_session(&session.session_id)
+        .expect("reject session");
+
+    assert_eq!(
+        engine.pairing_session_state(&session.session_id),
+        Ok(PairingSessionState::Rejected)
+    );
+    assert_eq!(
+        engine.approve_pairing_session(&session.session_id),
+        Err(cgka_traits::PairingSessionError::Rejected)
+    );
+
+    clock.advance(DEFAULT_PAIRING_SESSION_TTL_MS);
+    assert_eq!(
+        engine.pairing_session_state(&session.session_id),
+        Err(cgka_traits::PairingSessionError::Expired)
+    );
+}
+
+#[test]
+fn restart_fails_closed_for_in_flight_session() {
+    let clock = Arc::new(ManualWallClock::new(1_000));
+    let session = {
+        let mut engine = build_engine(clock.clone());
+        engine.start_pairing_session().expect("start session")
+    };
+
+    let mut restarted = build_engine(clock);
+    assert_eq!(
+        restarted.pairing_session_state(&session.session_id),
+        Err(cgka_traits::PairingSessionError::Expired)
+    );
+    assert_eq!(
+        restarted.scan_pairing_session(&session.session_id),
+        Err(cgka_traits::PairingSessionError::Expired)
+    );
+}
+
+#[test]
+fn every_pairing_transition_emits_a_privacy_safe_audit_row() {
+    let clock = Arc::new(ManualWallClock::new(1_000));
+    let capture = CapturingRecorder::default();
+    let mut engine = build_engine_with_recorder(clock.clone(), Some(Box::new(capture.clone())));
+
+    let stale = engine.start_pairing_session().unwrap();
+    let rejected = engine.start_pairing_session().unwrap();
+    assert_eq!(
+        engine.pairing_session_state(&stale.session_id),
+        Ok(PairingSessionState::Superseded)
+    );
+    engine.scan_pairing_session(&rejected.session_id).unwrap();
+    engine.reject_pairing_session(&rejected.session_id).unwrap();
+
+    let expired = engine.start_pairing_session().unwrap();
+    clock.advance(DEFAULT_PAIRING_SESSION_TTL_MS);
+    assert_eq!(
+        engine.pairing_session_state(&expired.session_id),
+        Err(cgka_traits::PairingSessionError::Expired)
+    );
+
+    let approved = engine.start_pairing_session().unwrap();
+    engine.scan_pairing_session(&approved.session_id).unwrap();
+    engine
+        .approve_pairing_session(&approved.session_id)
+        .unwrap();
+
+    let kinds = capture.kinds();
+    let transitions: Vec<(Option<&str>, &str, &str)> = kinds
+        .iter()
+        .filter_map(|kind| match kind {
+            AuditEventKind::PairingSession {
+                previous_state,
+                new_state,
+                reason,
+                ..
+            } => Some((
+                previous_state.as_deref(),
+                new_state.as_str(),
+                reason.as_str(),
+            )),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        transitions,
+        vec![
+            (None, "active", "started"),
+            (Some("active"), "superseded", "new_session_started"),
+            (None, "active", "started"),
+            (Some("active"), "scanned", "qr_scanned"),
+            (Some("scanned"), "rejected", "local_user_rejected"),
+            (None, "active", "started"),
+            (Some("active"), "expired", "ttl_elapsed"),
+            (None, "active", "started"),
+            (Some("active"), "scanned", "qr_scanned"),
+            (Some("scanned"), "approved", "local_user_approved"),
+        ]
+    );
+}

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -11,6 +11,12 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ### Added
 
+- `cgka-engine` now owns one short-lived device-pairing session per account,
+  rotating a fresh random session id and ephemeral X25519 key every 30 seconds.
+  Stale, expired, rejected, and replayed QR scans fail with typed errors;
+  terminal transitions wipe private key material and emit privacy-safe forensic
+  audit rows without bearer tokens or keys.
+
 - `marmot-markdown` now recognizes bare `www.example.com/path` text as web
   autolinks. The AST preserves the displayed `www.` source while exposing an
   explicit `Www` autolink kind so renderers can synthesize `https://`

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -11,9 +11,11 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ### Added
 
-- `cgka-engine` now owns one short-lived device-pairing session per account,
-  rotating a fresh random session id and ephemeral X25519 key every 30 seconds.
-  Stale, expired, rejected, and replayed QR scans fail with typed errors;
+- `cgka-engine` now owns one short-lived device-pairing session per account and
+  issues a fresh random session id and ephemeral X25519 key at the client's
+  explicit QR-rotation call. Each bearer capability expires after at most 30
+  seconds of process-local monotonic time. Stale, expired, rejected, and
+  replayed QR scans fail with typed errors;
   terminal transitions wipe private key material and emit privacy-safe forensic
   audit rows without bearer tokens or keys.
 

--- a/crates/marmot-forensics/schema/audit-log-event.v2.schema.json
+++ b/crates/marmot-forensics/schema/audit-log-event.v2.schema.json
@@ -1686,6 +1686,28 @@
         {
           "type": "object",
           "additionalProperties": false,
+          "required": ["type", "new_state", "reason", "expires_at_ms"],
+          "properties": {
+            "type": {
+              "const": "pairing_session"
+            },
+            "previous_state": {
+              "type": "string"
+            },
+            "new_state": {
+              "type": "string"
+            },
+            "reason": {
+              "type": "string"
+            },
+            "expires_at_ms": {
+              "$ref": "#/$defs/u64"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
           "required": [
             "type",
             "stale_base_epoch",

--- a/crates/marmot-forensics/src/audit.rs
+++ b/crates/marmot-forensics/src/audit.rs
@@ -1045,6 +1045,19 @@ pub enum AuditEventKind {
         arms: u64,
         arm_threshold: u64,
     },
+    /// One engine-owned device-pairing lifecycle transition.
+    ///
+    /// Deliberately excludes the bearer session id, X25519 public key, and
+    /// private key. The state, reason, and deadline are sufficient to diagnose
+    /// stale-QR races without turning the forensic stream into a capability
+    /// disclosure channel.
+    PairingSession {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        previous_state: Option<String>,
+        new_state: String,
+        reason: String,
+        expires_at_ms: u64,
+    },
     /// A durable convergence pass whose base epoch disagreed with the device's
     /// current tip was discarded, freeing convergence to reopen at the tip.
     /// Non-terminal by construction: it records a repair, not a fault. The
@@ -1115,6 +1128,7 @@ impl AuditEventKind {
             AuditEventKind::SyncDrain { .. } => "sync_drain",
             AuditEventKind::EpochStallBackfillArmed { .. } => "epoch_stall_backfill_armed",
             AuditEventKind::EpochStallBackfillEscalated { .. } => "epoch_stall_backfill_escalated",
+            AuditEventKind::PairingSession { .. } => "pairing_session",
             AuditEventKind::ConvergencePassDiscarded { .. } => "convergence_pass_discarded",
         }
     }

--- a/crates/marmot-forensics/src/audit/tests.rs
+++ b/crates/marmot-forensics/src/audit/tests.rs
@@ -869,6 +869,12 @@ fn sample_audit_event_kinds() -> Vec<AuditEventKind> {
             arms: 3,
             arm_threshold: 3,
         },
+        AuditEventKind::PairingSession {
+            previous_state: Some("scanned".into()),
+            new_state: "approved".into(),
+            reason: "local_user_approved".into(),
+            expires_at_ms: 1_700_000_030_000,
+        },
         AuditEventKind::ConvergencePassDiscarded {
             stale_base_epoch: 7,
             current_tip_epoch: 13,

--- a/crates/traits/src/engine.rs
+++ b/crates/traits/src/engine.rs
@@ -606,13 +606,18 @@ pub trait CgkaEngine: Send + Sync {
     ///
     /// Starting a session deterministically supersedes any unexpired active
     /// session. The returned bearer token and X25519 public key must be passed
-    /// only through the rendered QR; neither is logged by the engine.
+    /// only through the rendered QR; neither is logged by the engine. This
+    /// synchronous call is also the explicit rotation seam: clients schedule
+    /// the next call from the returned display deadline, while the engine owns
+    /// fresh material, supersession, and authoritative expiry.
     fn start_pairing_session(&mut self) -> Result<PairingSessionDescriptor, PairingSessionError>;
 
     /// Observe one session's current lifecycle state.
     ///
-    /// Deadline checks are lazy and use the engine's injected wall clock.
-    /// A session missing after process restart fails closed as expired.
+    /// Deadline checks are lazy and use the engine's process-local monotonic
+    /// clock. The descriptor's Unix deadline is only for client scheduling,
+    /// display, and audit. A session missing after process restart fails closed
+    /// as expired.
     fn pairing_session_state(
         &mut self,
         session_id: &PairingSessionId,

--- a/crates/traits/src/engine.rs
+++ b/crates/traits/src/engine.rs
@@ -25,6 +25,9 @@ use crate::error::EngineError;
 use crate::group::{Member, ProtocolProfile};
 use crate::group_context::{GroupContext, SecretBytes};
 use crate::ingest::IngestOutcome;
+use crate::pairing::{
+    PairingSessionDescriptor, PairingSessionError, PairingSessionId, PairingSessionState,
+};
 use crate::transport::TransportMessage;
 use crate::transport_adapter::TransportEndpoint;
 use crate::types::{EpochId, GroupId, MemberId, MessageId};
@@ -597,6 +600,42 @@ pub struct CreateGroupRequest {
 /// Method docs describe legal state transitions and error classes.
 #[async_trait]
 pub trait CgkaEngine: Send + Sync {
+    // ── Account pairing ─────────────────────────────────────────────────────
+
+    /// Start a fresh short-lived pairing session.
+    ///
+    /// Starting a session deterministically supersedes any unexpired active
+    /// session. The returned bearer token and X25519 public key must be passed
+    /// only through the rendered QR; neither is logged by the engine.
+    fn start_pairing_session(&mut self) -> Result<PairingSessionDescriptor, PairingSessionError>;
+
+    /// Observe one session's current lifecycle state.
+    ///
+    /// Deadline checks are lazy and use the engine's injected wall clock.
+    /// A session missing after process restart fails closed as expired.
+    fn pairing_session_state(
+        &mut self,
+        session_id: &PairingSessionId,
+    ) -> Result<PairingSessionState, PairingSessionError>;
+
+    /// Mark the current QR as scanned exactly once.
+    fn scan_pairing_session(
+        &mut self,
+        session_id: &PairingSessionId,
+    ) -> Result<(), PairingSessionError>;
+
+    /// Consume a scanned session after local-user approval.
+    fn approve_pairing_session(
+        &mut self,
+        session_id: &PairingSessionId,
+    ) -> Result<(), PairingSessionError>;
+
+    /// Terminally reject a scanned session.
+    fn reject_pairing_session(
+        &mut self,
+        session_id: &PairingSessionId,
+    ) -> Result<(), PairingSessionError>;
+
     // ── Inbound ─────────────────────────────────────────────────────────────
 
     /// Ingest a raw transport message.

--- a/crates/traits/src/lib.rs
+++ b/crates/traits/src/lib.rs
@@ -18,6 +18,7 @@ pub mod group_context;
 pub mod ingest;
 pub mod maintenance;
 pub mod message;
+pub mod pairing;
 pub mod peeler;
 pub mod storage;
 pub mod transport;
@@ -95,6 +96,7 @@ pub use maintenance::{
     TransportFanoutTarget, WallClock,
 };
 pub use message::{MessageRecord, MessageState, OwnCommitConvergenceStamp, StoredMessagePayload};
+pub use pairing::*;
 pub use peeler::{GroupMessageMetadata, TransportPeeler};
 pub use storage::{
     CapabilityStorage, ConvergencePassStorage, DisbandCandidate, DisbandCandidateStorage,

--- a/crates/traits/src/pairing.rs
+++ b/crates/traits/src/pairing.rs
@@ -1,0 +1,103 @@
+//! Pairing-session identifiers, descriptors, state, and typed errors.
+//!
+//! The QR token is a short-lived bearer capability. Its `Debug` output is
+//! deliberately redacted even though callers can access the raw bytes for QR
+//! encoding.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Fixed engine-owned lifetime for one rendered pairing QR.
+pub const DEFAULT_PAIRING_SESSION_TTL_MS: u64 = 30_000;
+
+/// Random 256-bit identifier carried by a pairing QR.
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct PairingSessionId([u8; 32]);
+
+impl PairingSessionId {
+    pub fn new(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+
+    pub fn into_bytes(self) -> [u8; 32] {
+        self.0
+    }
+}
+
+impl fmt::Debug for PairingSessionId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("PairingSessionId(<redacted>)")
+    }
+}
+
+/// Public QR material for one short-lived pairing session.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PairingSessionDescriptor {
+    pub session_id: PairingSessionId,
+    pub ephemeral_public_key: [u8; 32],
+    pub expires_at_ms: u64,
+}
+
+impl fmt::Debug for PairingSessionDescriptor {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PairingSessionDescriptor")
+            .field("session_id", &"<redacted>")
+            .field("ephemeral_public_key", &"<redacted>")
+            .field("expires_at_ms", &self.expires_at_ms)
+            .finish()
+    }
+}
+
+/// Pairing-session lifecycle state.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PairingSessionState {
+    Active,
+    Scanned,
+    Approved,
+    Expired,
+    Superseded,
+    Rejected,
+}
+
+impl PairingSessionState {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Scanned => "scanned",
+            Self::Approved => "approved",
+            Self::Expired => "expired",
+            Self::Superseded => "superseded",
+            Self::Rejected => "rejected",
+        }
+    }
+
+    pub const fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            Self::Approved | Self::Expired | Self::Superseded | Self::Rejected
+        )
+    }
+}
+
+/// Typed pairing-session rejection. No variant displays the bearer token.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum PairingSessionError {
+    #[error("pairing session expired")]
+    Expired,
+    #[error("pairing session was superseded")]
+    Superseded,
+    #[error("pairing session was already accepted")]
+    AlreadyAccepted,
+    #[error("pairing session was already scanned")]
+    AlreadyScanned,
+    #[error("pairing session was rejected")]
+    Rejected,
+    #[error("pairing session has not been scanned")]
+    NotScanned,
+}


### PR DESCRIPTION
## Summary
- add engine-owned pairing sessions with one active token per account, 30-second TTLs, rotation supersession, and single-use terminal states
- generate ephemeral X25519 key material and cryptographically random session IDs in memory, wiping private material on every terminal transition
- add typed public APIs/errors, privacy-safe audit records, regression coverage, and the stale-QR conformance scenario

## Test plan
- just fast-ci
- cargo test -p cgka-engine --features test-policy-overrides
- cargo test -p cgka-engine --test pairing_session
- cargo test -p cgka-traits
- cargo test -p marmot-forensics
- cargo test -p cgka-conformance-simulator --test pairing_session
- isolated unrelated app-runtime test: cargo test -p cgka-conformance-simulator --test app_runtime_adapter --features test-policy-overrides cold_reopen_recovers_quiet_offline_history_without_a_live_trigger -- --exact --nocapture

Full workspace just test reached 464 passing tests before an unrelated, load-sensitive app-runtime settlement test timed out; that test passes alone. The remaining tests were canceled by fail-fast. GitHub CI will run the clean full matrix.

## Security-sensitive paths
- crates/cgka-engine/src/pairing_session.rs
- crates/cgka-engine/src/engine.rs
- crates/traits/src/pairing.rs

Fixes #1276

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added device-pairing sessions with fresh QR credentials and a 30-second expiration.
  - Added session lifecycle actions for scanning, approval, rejection, and status checks.
  - Added clear errors for expired, superseded, reused, or invalid pairing attempts.

- **Security**
  - Sensitive pairing keys are securely wiped when sessions end.
  - Debug output and audit records exclude private session material.

- **Audit & Documentation**
  - Added privacy-safe audit events for pairing state transitions.
  - Updated changelog and conformance scenario documentation.

- **Tests**
  - Added coverage for expiration, session rotation, stale QR rejection, restart behavior, and approval rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->