### PR TITLE
Add commit-addressed checkpoints for own-commit fork recovery

### DIFF
--- a/crates/cgka-engine/src/canonicalization.rs
+++ b/crates/cgka-engine/src/canonicalization.rs
@@ -316,6 +316,7 @@ pub enum DeferredMessageReason {
 pub enum CanonicalizationError {
     UnsupportedPolicy,
     MissingRetainedAnchor,
+    MissingOwnCommitCheckpoint,
     CandidateStateUnavailable,
     MlsValidationFailed,
     OutboundIntentStale,
@@ -1112,10 +1113,13 @@ fn convergence_status_for_result(
 }
 
 fn has_blocking_convergence_error(result: &CanonicalizationResult) -> bool {
-    result
-        .errors
-        .iter()
-        .any(|error| matches!(error, CanonicalizationError::MissingRetainedAnchor))
+    result.errors.iter().any(|error| {
+        matches!(
+            error,
+            CanonicalizationError::MissingRetainedAnchor
+                | CanonicalizationError::MissingOwnCommitCheckpoint
+        )
+    })
 }
 
 fn app_message_expired(

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -1252,16 +1252,19 @@ impl<S: StorageProvider> Engine<S> {
             );
         }
 
-        // retained-history.md:30-31 — a required retained state missing inside
-        // the rollback horizon MUST report `MissingRetainedAnchor`, leave
-        // canonical group state unchanged, and move the group to
-        // `Unrecoverable`. Halt before applying anything. Persist the marker
-        // on the group record so process restart cannot silently clear it
-        // (mdk#971).
-        if result
-            .errors
-            .contains(&CanonicalizationError::MissingRetainedAnchor)
-        {
+        // Missing branch state inside the rollback horizon must leave
+        // canonical state unchanged and move the group to `Unrecoverable`.
+        // This includes an epoch anchor and the exact checkpoint required to
+        // realize a locally authored pre-upgrade commit.
+        let missing_retained_state = result.errors.iter().copied().find(|error| {
+            matches!(
+                error,
+                CanonicalizationError::MissingRetainedAnchor
+                    | CanonicalizationError::MissingOwnCommitCheckpoint
+            )
+        });
+        if let Some(missing_retained_state) = missing_retained_state {
+            let error_kind = canonicalization_error_tag(missing_retained_state);
             let mut group = self
                 .storage
                 .get_group(group_id)
@@ -1284,7 +1287,7 @@ impl<S: StorageProvider> Engine<S> {
                     previous_state,
                     new_state: "unrecoverable".to_string(),
                     epoch: epoch.0,
-                    reason: "missing_retained_anchor".to_string(),
+                    reason: error_kind.to_string(),
                     pending_ref: None,
                     pending_kind: None,
                 },
@@ -1300,7 +1303,7 @@ impl<S: StorageProvider> Engine<S> {
                     current_tip_epoch: Some(previous_tip.0),
                     retained_anchor_horizon: Some(retained_anchor_epoch),
                     reason: None,
-                    error_kind: Some("missing_retained_anchor".to_string()),
+                    error_kind: Some(error_kind.to_string()),
                 },
             );
             return Ok(result);
@@ -2120,6 +2123,7 @@ fn canonicalization_error_tag(error: CanonicalizationError) -> &'static str {
     match error {
         CanonicalizationError::UnsupportedPolicy => "unsupported_policy",
         CanonicalizationError::MissingRetainedAnchor => "missing_retained_anchor",
+        CanonicalizationError::MissingOwnCommitCheckpoint => "missing_own_commit_checkpoint",
         CanonicalizationError::CandidateStateUnavailable => "candidate_state_unavailable",
         CanonicalizationError::MlsValidationFailed => "mls_validation_failed",
         CanonicalizationError::OutboundIntentStale => "outbound_intent_stale",

--- a/crates/cgka-engine/src/fork_recovery.rs
+++ b/crates/cgka-engine/src/fork_recovery.rs
@@ -14,7 +14,8 @@
 //! commit is the transport-layer `MessageId`. The two are kept separate inside
 //! `CommitRecoveryRecord` so the ordering key remains transport-independent
 //! while the engine can still reach back to the storage record that needs
-//! `MessageState::EpochInvalidated`.
+//! parking as `MessageState::ConvergenceDeferred` (reconsiderable by a later
+//! distributed-convergence pass, not terminal).
 
 use crate::engine::Engine;
 use cgka_traits::engine::{CommitOrderingKey, CommitOrderingPriority};
@@ -32,8 +33,9 @@ struct CommitRecoveryRecord {
     group_id: GroupId,
     source_epoch: EpochId,
     ordering_key: CommitOrderingKey,
-    /// Storage-layer identity of the commit. Used to update
-    /// `MessageState::EpochInvalidated` when this commit loses a fork.
+    /// Storage-layer identity of the commit. Used to park the row
+    /// `MessageState::ConvergenceDeferred` when this commit loses a fork
+    /// (its branch stays reconsiderable for distributed convergence).
     storage_id: MessageId,
     snapshot_name: String,
 }
@@ -43,8 +45,8 @@ pub(crate) enum ForkResolution {
     CandidateWins {
         winner: CommitOrderingKey,
         invalidated: CommitOrderingKey,
-        /// `MessageId` of the now-invalidated incumbent, for the storage
-        /// `update_message_state` call site.
+        /// `MessageId` of the now-displaced incumbent, for the storage
+        /// write that parks its row `ConvergenceDeferred`.
         invalidated_storage_id: MessageId,
     },
     IncumbentWins {
@@ -176,12 +178,45 @@ impl ForkRecoveryManager {
             });
         }
 
+        // Capture the incumbent's stored row BEFORE the rollback: the
+        // pre-commit snapshot predates the incumbent's own persist, so the
+        // rollback below sweeps its row away entirely. Re-persisting it
+        // afterwards (parked, see below) is what keeps the displaced branch
+        // reconsiderable.
+        let displaced_incumbent_row = match storage.get_message(&incumbent.storage_id) {
+            Ok(record) => Some(record),
+            Err(StorageError::NotFound) => None,
+            Err(e) => return Err(EngineError::Storage(e)),
+        };
         storage.rollback_group_to_snapshot(group_id, &incumbent.snapshot_name)?;
         match storage.release_group_snapshot(group_id, &incumbent.snapshot_name) {
             Ok(()) | Err(StorageError::SnapshotMissing(_)) => {}
             Err(e) => return Err(EngineError::Storage(e)),
         }
         self.incumbents.remove(&key);
+
+        // Park the pairwise-losing incumbent `ConvergenceDeferred`, not
+        // terminally `EpochInvalidated` — the mirror of the incumbent-wins
+        // seam in `ingest_group_message`. The losing branch may still gain
+        // follow-on commits from peers that applied it and never saw the
+        // candidate; distributed convergence then selects the DEEPER branch,
+        // and every convergence-only node reorgs onto it. A terminal (or
+        // missing) row is excluded from convergence input, so this node could
+        // never materialize that branch's root and would diverge from the
+        // fleet forever. If the incumbent's branch also loses in convergence,
+        // it is re-classified terminal there (`LosingBranch`).
+        //
+        // The row is re-keyed at the commit's SOURCE epoch (convergence
+        // derives its rewind target from `record.epoch`) and its payload is
+        // preserved verbatim — for an own commit it carries the convergence
+        // ordering stamp (`stamp_processed_own_commit_record`) that replay
+        // needs to rebuild the ordering key (MLS refuses to process own
+        // commits).
+        if let Some(mut record) = displaced_incumbent_row {
+            record.epoch = incumbent.source_epoch;
+            record.state = MessageState::ConvergenceDeferred;
+            storage.put_message(&record)?;
+        }
 
         Ok(ForkResolution::CandidateWins {
             winner: candidate_key,
@@ -370,18 +405,14 @@ impl<S: StorageProvider> Engine<S> {
         {
             self.epoch_manager
                 .set_stable(group_id.clone(), source_epoch);
-            match self
-                .storage
-                .update_message_state(invalidated_storage_id, MessageState::EpochInvalidated)
-            {
-                Ok(()) | Err(StorageError::NotFound) => {}
-                Err(e) => return Err(EngineError::Storage(e)),
-            }
+            // `ForkRecoveryManager::resolve` parked the displaced incumbent's
+            // row `ConvergenceDeferred` at its source epoch (captured before
+            // the rollback swept it); record the transition for forensics.
             self.audit_group(
                 group_id,
                 crate::audit_helpers::message_state_changed_event(
                     hex::encode(invalidated_storage_id.as_slice()),
-                    MessageState::EpochInvalidated,
+                    MessageState::ConvergenceDeferred,
                     "fork_loser",
                 ),
             );

--- a/crates/cgka-engine/src/fork_recovery.rs
+++ b/crates/cgka-engine/src/fork_recovery.rs
@@ -576,6 +576,37 @@ mod tests {
             self.release_attempts.lock().unwrap().push(name.to_string());
             Err(StorageError::Backend("release failed".into()))
         }
+
+        fn create_group_state_checkpoint(
+            &self,
+            _group_id: &GroupId,
+            _checkpoint: &cgka_traits::storage::GroupStateCheckpointRef,
+        ) -> StorageResult<()> {
+            unused()
+        }
+
+        fn restore_group_state_checkpoint(
+            &self,
+            _group_id: &GroupId,
+            _checkpoint_id: &str,
+        ) -> StorageResult<()> {
+            unused()
+        }
+
+        fn list_group_state_checkpoints(
+            &self,
+            _group_id: &GroupId,
+        ) -> StorageResult<Vec<cgka_traits::storage::GroupStateCheckpointRef>> {
+            unused()
+        }
+
+        fn release_group_state_checkpoint(
+            &self,
+            _group_id: &GroupId,
+            _checkpoint_id: &str,
+        ) -> StorageResult<()> {
+            unused()
+        }
     }
 
     #[test]

--- a/crates/cgka-engine/src/fork_recovery.rs
+++ b/crates/cgka-engine/src/fork_recovery.rs
@@ -160,10 +160,8 @@ impl ForkRecoveryManager {
     /// Decide the pairwise race and, when the candidate wins, displace the
     /// incumbent atomically.
     ///
-    /// Bounded by `StorageProvider` rather than `MessageStorage` specifically
-    /// so the displacement can run inside `with_transaction`: capture,
-    /// rollback, re-persist and release are one durable unit. Nothing weaker
-    /// works — see the ordering comment below.
+    /// Bounded by `StorageProvider` so capture, rollback, re-persist and
+    /// release can join one transaction.
     fn resolve<S: StorageProvider>(
         &mut self,
         storage: &S,
@@ -190,60 +188,13 @@ impl ForkRecoveryManager {
             });
         }
 
-        // Atomicity rationale (durability of the displaced branch). Capture,
-        // rollback, re-persist and release are ONE durable unit.
-        //
-        // They have to be. The rollback sweeps the incumbent's stored row away
-        // (the pre-commit snapshot predates that row's own persist), so if the
-        // re-persist failed on its own the displaced branch would be gone with
-        // no way back: a later `resolve` cannot repair it, because (1) the
-        // rollback already removed the row so the capture would read
-        // `NotFound` and silently park nothing, and (2) there typically IS no
-        // later resolve — storage now sits at the pre-incumbent epoch, so a
-        // redelivery of the same candidate applies cleanly with no WrongEpoch
-        // and no fork resolution at all. The branch would vanish silently.
-        //
-        // SQLite snapshot ops JOIN an outer transaction rather than driving
-        // their own (`storage_sqlite::storage::snapshots::
-        // snapshot_rollback_joins_outer_transaction` /
-        // `snapshot_create_joins_outer_transaction`), which is what makes this
-        // grouping possible; `apply_openmls_canonicalization_result` relies on
-        // the same property. A failure anywhere inside therefore unwinds the
-        // rollback too, leaving the incumbent applied, its row intact and its
-        // snapshot retained — genuinely retryable.
-        //
-        // The in-memory `incumbents.remove` stays OUTSIDE, after the commit:
-        // it is the point of no return and must not be reached for a
-        // transaction that rolled back.
-        //
-        // Park the pairwise-losing incumbent `ConvergenceDeferred`, not
-        // terminally `EpochInvalidated` — the mirror of the incumbent-wins
-        // seam in `ingest_group_message`. The losing branch may still gain
-        // follow-on commits from peers that applied it and never saw the
-        // candidate; distributed convergence then selects the DEEPER branch,
-        // and every convergence-only node reorgs onto it. A terminal (or
-        // missing) row is excluded from convergence input, so this node could
-        // never materialize that branch's root and would diverge from the
-        // fleet forever.
-        //
-        // If the incumbent's branch loses in convergence too, its commits are
-        // NOT terminalized there: an eligible-but-unselected branch's commits
-        // are re-deferred `ConvergenceDeferred`
-        // (`NonSelectedEligibleBranch` in
-        // `classify_losing_materialized_candidate_commits`), so they stay
-        // reconsiderable pass after pass. (`LosingBranch` is an APP-message
-        // invalidation reason, not a commit disposition.) Terminalization
-        // happens only at the rewind horizon —
-        // `BeyondRollbackHorizon`/`BeyondAnchor`, or the
-        // `beyond_retained_anchor` retirement in
-        // `seed_convergence_pass_members`.
-        //
-        // The row is re-keyed at the commit's SOURCE epoch (convergence
-        // derives its rewind target from `record.epoch`) and its payload is
-        // preserved verbatim — for an own commit it carries the convergence
-        // ordering stamp (`stamp_processed_own_commit_record`) that replay
-        // needs to rebuild the ordering key (MLS refuses to process own
-        // commits).
+        // Rollback removes the incumbent row because its snapshot predates the
+        // commit. Capture and re-persist it atomically so the displaced branch
+        // remains reconsiderable. A nested call joins its caller's transaction;
+        // either way, an error aborts the boundary that contains this rollback.
+        // Re-key the row to its source epoch because convergence derives the
+        // rewind target from `record.epoch`. Remove the in-memory incumbent only
+        // after that transaction commits.
         let snapshot_name = incumbent.snapshot_name.clone();
         let incumbent_storage_id = incumbent.storage_id.clone();
         let incumbent_source_epoch = incumbent.source_epoch;

--- a/crates/cgka-engine/src/fork_recovery.rs
+++ b/crates/cgka-engine/src/fork_recovery.rs
@@ -48,6 +48,11 @@ pub(crate) enum ForkResolution {
         /// `MessageId` of the now-displaced incumbent, for the storage
         /// write that parks its row `ConvergenceDeferred`.
         invalidated_storage_id: MessageId,
+        /// The row `resolve` actually re-persisted `ConvergenceDeferred`, if
+        /// any. `None` when the incumbent had no stored row to capture before
+        /// the rollback (`get_message` → `NotFound`), in which case nothing was
+        /// parked and no `message_state_changed` audit row may claim otherwise.
+        parked: Option<MessageId>,
     },
     IncumbentWins {
         /// Ordering key of the commit this node kept. Carried so the
@@ -152,7 +157,14 @@ impl ForkRecoveryManager {
             .insert((record.group_id.clone(), record.source_epoch), record);
     }
 
-    fn resolve<S: MessageStorage>(
+    /// Decide the pairwise race and, when the candidate wins, displace the
+    /// incumbent atomically.
+    ///
+    /// Bounded by `StorageProvider` rather than `MessageStorage` specifically
+    /// so the displacement can run inside `with_transaction`: capture,
+    /// rollback, re-persist and release are one durable unit. Nothing weaker
+    /// works — see the ordering comment below.
+    fn resolve<S: StorageProvider>(
         &mut self,
         storage: &S,
         group_id: &GroupId,
@@ -178,38 +190,31 @@ impl ForkRecoveryManager {
             });
         }
 
-        // Capture the incumbent's stored row BEFORE the rollback: the
-        // pre-commit snapshot predates the incumbent's own persist, so the
-        // rollback below sweeps its row away entirely. Re-persisting it
-        // afterwards (parked, see below) is what keeps the displaced branch
-        // reconsiderable.
-        let displaced_incumbent_row = match storage.get_message(&incumbent.storage_id) {
-            Ok(record) => Some(record),
-            Err(StorageError::NotFound) => None,
-            Err(e) => return Err(EngineError::Storage(e)),
-        };
-        storage.rollback_group_to_snapshot(group_id, &incumbent.snapshot_name)?;
-
-        // Ordering rationale (recoverability). The displaced row is
-        // re-persisted BEFORE the recovery snapshot is released and before
-        // the in-memory incumbent is dropped. The rollback sweeps the
-        // incumbent's row away, so a failure between rollback and re-persist
-        // must stay retryable: with this order it returns `Err` while the
-        // snapshot is still retained and `self.incumbents` still holds the
-        // record that names it, so the caller fails closed and a later
-        // resolve can redo the rollback + re-persist. Releasing or forgetting
-        // first would lose the displaced branch permanently (row swept,
-        // snapshot gone, record gone). The in-memory removal is therefore the
-        // last step — the point of no return.
+        // Atomicity rationale (durability of the displaced branch). Capture,
+        // rollback, re-persist and release are ONE durable unit.
         //
-        // The snapshot operations necessarily sit OUTSIDE any storage
-        // transaction: create/rollback/release drive their own SQLite
-        // transactions (see the boundary comment in
-        // `openmls_projection::apply_openmls_canonicalization_result_inner`).
-        // The re-persist is a single-row write and is already atomic on its
-        // own, so there is no multi-write group here worth wrapping in
-        // `with_transaction` — and this manager is generic over
-        // `MessageStorage`, which does not expose one.
+        // They have to be. The rollback sweeps the incumbent's stored row away
+        // (the pre-commit snapshot predates that row's own persist), so if the
+        // re-persist failed on its own the displaced branch would be gone with
+        // no way back: a later `resolve` cannot repair it, because (1) the
+        // rollback already removed the row so the capture would read
+        // `NotFound` and silently park nothing, and (2) there typically IS no
+        // later resolve — storage now sits at the pre-incumbent epoch, so a
+        // redelivery of the same candidate applies cleanly with no WrongEpoch
+        // and no fork resolution at all. The branch would vanish silently.
+        //
+        // SQLite snapshot ops JOIN an outer transaction rather than driving
+        // their own (`storage_sqlite::storage::snapshots::
+        // snapshot_rollback_joins_outer_transaction` /
+        // `snapshot_create_joins_outer_transaction`), which is what makes this
+        // grouping possible; `apply_openmls_canonicalization_result` relies on
+        // the same property. A failure anywhere inside therefore unwinds the
+        // rollback too, leaving the incumbent applied, its row intact and its
+        // snapshot retained — genuinely retryable.
+        //
+        // The in-memory `incumbents.remove` stays OUTSIDE, after the commit:
+        // it is the point of no return and must not be reached for a
+        // transaction that rolled back.
         //
         // Park the pairwise-losing incumbent `ConvergenceDeferred`, not
         // terminally `EpochInvalidated` — the mirror of the incumbent-wins
@@ -219,8 +224,19 @@ impl ForkRecoveryManager {
         // and every convergence-only node reorgs onto it. A terminal (or
         // missing) row is excluded from convergence input, so this node could
         // never materialize that branch's root and would diverge from the
-        // fleet forever. If the incumbent's branch also loses in convergence,
-        // it is re-classified terminal there (`LosingBranch`).
+        // fleet forever.
+        //
+        // If the incumbent's branch loses in convergence too, its commits are
+        // NOT terminalized there: an eligible-but-unselected branch's commits
+        // are re-deferred `ConvergenceDeferred`
+        // (`NonSelectedEligibleBranch` in
+        // `classify_losing_materialized_candidate_commits`), so they stay
+        // reconsiderable pass after pass. (`LosingBranch` is an APP-message
+        // invalidation reason, not a commit disposition.) Terminalization
+        // happens only at the rewind horizon —
+        // `BeyondRollbackHorizon`/`BeyondAnchor`, or the
+        // `beyond_retained_anchor` retirement in
+        // `seed_convergence_pass_members`.
         //
         // The row is re-keyed at the commit's SOURCE epoch (convergence
         // derives its rewind target from `record.epoch`) and its payload is
@@ -228,22 +244,41 @@ impl ForkRecoveryManager {
         // ordering stamp (`stamp_processed_own_commit_record`) that replay
         // needs to rebuild the ordering key (MLS refuses to process own
         // commits).
-        if let Some(mut record) = displaced_incumbent_row {
-            record.epoch = incumbent.source_epoch;
-            record.state = MessageState::ConvergenceDeferred;
-            storage.put_message(&record)?;
-        }
+        let snapshot_name = incumbent.snapshot_name.clone();
+        let incumbent_storage_id = incumbent.storage_id.clone();
+        let incumbent_source_epoch = incumbent.source_epoch;
+        let parked =
+            storage.with_transaction(|storage| -> Result<Option<MessageId>, EngineError> {
+                let displaced_incumbent_row = match storage.get_message(&incumbent_storage_id) {
+                    Ok(record) => Some(record),
+                    Err(StorageError::NotFound) => None,
+                    Err(e) => return Err(EngineError::Storage(e)),
+                };
+                storage.rollback_group_to_snapshot(group_id, &snapshot_name)?;
 
-        match storage.release_group_snapshot(group_id, &incumbent.snapshot_name) {
-            Ok(()) | Err(StorageError::SnapshotMissing(_)) => {}
-            Err(e) => return Err(EngineError::Storage(e)),
-        }
+                let parked = match displaced_incumbent_row {
+                    Some(mut record) => {
+                        record.epoch = incumbent_source_epoch;
+                        record.state = MessageState::ConvergenceDeferred;
+                        storage.put_message(&record)?;
+                        Some(record.id)
+                    }
+                    None => None,
+                };
+
+                match storage.release_group_snapshot(group_id, &snapshot_name) {
+                    Ok(()) | Err(StorageError::SnapshotMissing(_)) => {}
+                    Err(e) => return Err(EngineError::Storage(e)),
+                }
+                Ok(parked)
+            })?;
         self.incumbents.remove(&key);
 
         Ok(ForkResolution::CandidateWins {
             winner: candidate_key,
             invalidated: incumbent.ordering_key,
             invalidated_storage_id: incumbent.storage_id,
+            parked,
         })
     }
 
@@ -420,24 +455,25 @@ impl<S: StorageProvider> Engine<S> {
                 invalidated_msg_id,
             },
         );
-        if let ForkResolution::CandidateWins {
-            invalidated_storage_id,
-            ..
-        } = &resolution
-        {
+        if let ForkResolution::CandidateWins { parked, .. } = &resolution {
             self.epoch_manager
                 .set_stable(group_id.clone(), source_epoch);
-            // `ForkRecoveryManager::resolve` parked the displaced incumbent's
-            // row `ConvergenceDeferred` at its source epoch (captured before
-            // the rollback swept it); record the transition for forensics.
-            self.audit_group(
-                group_id,
-                crate::audit_helpers::message_state_changed_event(
-                    hex::encode(invalidated_storage_id.as_slice()),
-                    MessageState::ConvergenceDeferred,
-                    "fork_loser",
-                ),
-            );
+            // Record the transition for forensics — but ONLY for a row that
+            // was really re-persisted. `resolve` parks nothing when the
+            // incumbent had no stored row to capture before the rollback, and
+            // a `message_state_changed` row naming a msg_id that has no
+            // storage row would make the audit log describe a transition that
+            // never happened.
+            if let Some(parked) = parked {
+                self.audit_group(
+                    group_id,
+                    crate::audit_helpers::message_state_changed_event(
+                        hex::encode(parked.as_slice()),
+                        MessageState::ConvergenceDeferred,
+                        "fork_loser",
+                    ),
+                );
+            }
         }
         Ok(resolution)
     }

--- a/crates/cgka-engine/src/fork_recovery.rs
+++ b/crates/cgka-engine/src/fork_recovery.rs
@@ -189,12 +189,28 @@ impl ForkRecoveryManager {
             Err(e) => return Err(EngineError::Storage(e)),
         };
         storage.rollback_group_to_snapshot(group_id, &incumbent.snapshot_name)?;
-        match storage.release_group_snapshot(group_id, &incumbent.snapshot_name) {
-            Ok(()) | Err(StorageError::SnapshotMissing(_)) => {}
-            Err(e) => return Err(EngineError::Storage(e)),
-        }
-        self.incumbents.remove(&key);
 
+        // Ordering rationale (recoverability). The displaced row is
+        // re-persisted BEFORE the recovery snapshot is released and before
+        // the in-memory incumbent is dropped. The rollback sweeps the
+        // incumbent's row away, so a failure between rollback and re-persist
+        // must stay retryable: with this order it returns `Err` while the
+        // snapshot is still retained and `self.incumbents` still holds the
+        // record that names it, so the caller fails closed and a later
+        // resolve can redo the rollback + re-persist. Releasing or forgetting
+        // first would lose the displaced branch permanently (row swept,
+        // snapshot gone, record gone). The in-memory removal is therefore the
+        // last step — the point of no return.
+        //
+        // The snapshot operations necessarily sit OUTSIDE any storage
+        // transaction: create/rollback/release drive their own SQLite
+        // transactions (see the boundary comment in
+        // `openmls_projection::apply_openmls_canonicalization_result_inner`).
+        // The re-persist is a single-row write and is already atomic on its
+        // own, so there is no multi-write group here worth wrapping in
+        // `with_transaction` — and this manager is generic over
+        // `MessageStorage`, which does not expose one.
+        //
         // Park the pairwise-losing incumbent `ConvergenceDeferred`, not
         // terminally `EpochInvalidated` — the mirror of the incumbent-wins
         // seam in `ingest_group_message`. The losing branch may still gain
@@ -217,6 +233,12 @@ impl ForkRecoveryManager {
             record.state = MessageState::ConvergenceDeferred;
             storage.put_message(&record)?;
         }
+
+        match storage.release_group_snapshot(group_id, &incumbent.snapshot_name) {
+            Ok(()) | Err(StorageError::SnapshotMissing(_)) => {}
+            Err(e) => return Err(EngineError::Storage(e)),
+        }
+        self.incumbents.remove(&key);
 
         Ok(ForkResolution::CandidateWins {
             winner: candidate_key,

--- a/crates/cgka-engine/src/fork_recovery.rs
+++ b/crates/cgka-engine/src/fork_recovery.rs
@@ -47,7 +47,14 @@ pub(crate) enum ForkResolution {
         /// `update_message_state` call site.
         invalidated_storage_id: MessageId,
     },
-    IncumbentWins,
+    IncumbentWins {
+        /// Ordering key of the commit this node kept. Carried so the
+        /// `fork_resolution` audit row can record WHICH branch survived —
+        /// without it, incumbent-wins rows are unverifiable against other
+        /// nodes' logs (cross-node convergence cannot be proven from
+        /// forensics alone).
+        kept: CommitOrderingKey,
+    },
     MissingSnapshot,
 }
 
@@ -164,7 +171,9 @@ impl ForkRecoveryManager {
             candidate_mls_bytes,
         );
         if candidate_key >= incumbent.ordering_key {
-            return Ok(ForkResolution::IncumbentWins);
+            return Ok(ForkResolution::IncumbentWins {
+                kept: incumbent.ordering_key,
+            });
         }
 
         storage.rollback_group_to_snapshot(group_id, &incumbent.snapshot_name)?;
@@ -337,7 +346,11 @@ impl<S: StorageProvider> Engine<S> {
                 Some(hex::encode(invalidated.commit_digest)),
                 Some(hex::encode(invalidated_storage_id.as_slice())),
             ),
-            ForkResolution::IncumbentWins => (ForkWinner::Incumbent, None, None),
+            ForkResolution::IncumbentWins { kept } => (
+                ForkWinner::Incumbent,
+                Some(hex::encode(kept.commit_digest)),
+                None,
+            ),
             ForkResolution::MissingSnapshot => (ForkWinner::MissingSnapshot, None, None),
         };
         self.audit_group(

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -883,7 +883,7 @@ impl<S: StorageProvider> Engine<S> {
                                         &group_id, &msg.id, msg_epoch, current,
                                     ));
                                 }
-                                ForkResolution::IncumbentWins
+                                ForkResolution::IncumbentWins { .. }
                                 | ForkResolution::CandidateWins { .. } => {
                                     // recovery_snapshot_name_for_fork and
                                     // resolve_fork_candidate read the same
@@ -945,10 +945,43 @@ impl<S: StorageProvider> Engine<S> {
                                     Some((msg_epoch, winner, invalidated, invalidated_storage_id));
                                 continue;
                             }
-                            ForkResolution::IncumbentWins => {
-                                self.update_stored_message_state(
-                                    &msg.id,
-                                    MessageState::EpochInvalidated,
+                            ForkResolution::IncumbentWins { .. } => {
+                                // The candidate lost this node's PAIRWISE race
+                                // — but nodes that did not commit from this
+                                // epoch resolve the same conflict through
+                                // distributed convergence, where a deeper
+                                // candidate branch outranks the ordering key.
+                                // Terminal `EpochInvalidated` froze this node
+                                // on its own lineage forever (convergence
+                                // never re-admits it — see
+                                // `convergence_input::can_start_pass`), so two
+                                // honest nodes could keep different branches
+                                // permanently. Park the loser
+                                // `ConvergenceDeferred` instead: that state
+                                // re-enters branch materialization (see
+                                // `unresolved_commit_state`) so a later pass
+                                // can still select its branch once follow-on
+                                // commits arrive — while staying out of the
+                                // linear pending replay, which would choke on
+                                // a cross-branch commit. If its branch loses
+                                // in convergence too, it is re-classified
+                                // terminal (`LosingBranch`) there.
+                                //
+                                // Re-persist the full row (not just the state):
+                                // the row was stored above under this node's
+                                // CURRENT epoch, but convergence-input rows are
+                                // keyed by the commit's SOURCE epoch (see
+                                // `buffer_openmls_convergence_message_with_time`)
+                                // — the apply stage reads `record.epoch` to
+                                // pick the retained-anchor rewind target, so a
+                                // current-epoch row would make the reorg replay
+                                // this epoch-N commit against the live tip
+                                // state (WrongEpoch).
+                                self.persist_openmls_wire_message(
+                                    &openmls_msg,
+                                    &group_id,
+                                    msg_epoch,
+                                    MessageState::ConvergenceDeferred,
                                 )?;
                                 return Ok(IngestOutcome::Stale {
                                     reason: StaleReason::AlreadyAtEpoch { current, msg_epoch },

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -977,12 +977,35 @@ impl<S: StorageProvider> Engine<S> {
                                 // current-epoch row would make the reorg replay
                                 // this epoch-N commit against the live tip
                                 // state (WrongEpoch).
+                                //
+                                // Load-bearing invariant: this arm is reachable
+                                // only while NO convergence pass is active —
+                                // `commit_should_enter_convergence` routes any
+                                // stale commit into convergence whenever a pass
+                                // is live (its `active_pass` term), so a commit
+                                // that reaches this pairwise seam never belongs
+                                // to an open pass. The parked row is therefore
+                                // always picked up by the NEXT pass:
+                                // `seed_convergence_pass_members` seeds pass
+                                // membership from a storage scan that includes
+                                // `ConvergenceDeferred` rows. If that routing
+                                // guard is ever relaxed, a row parked here
+                                // while a pass is open would belong to no pass
+                                // and become an orphan.
                                 self.persist_openmls_wire_message(
                                     &openmls_msg,
                                     &group_id,
                                     msg_epoch,
                                     MessageState::ConvergenceDeferred,
                                 )?;
+                                self.audit_group(
+                                    &group_id,
+                                    crate::audit_helpers::message_state_changed_event(
+                                        hex::encode(msg.id.as_slice()),
+                                        MessageState::ConvergenceDeferred,
+                                        "pairwise_fork_loser",
+                                    ),
+                                );
                                 return Ok(IngestOutcome::Stale {
                                     reason: StaleReason::AlreadyAtEpoch { current, msg_epoch },
                                 });

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -940,6 +940,7 @@ impl<S: StorageProvider> Engine<S> {
                                 winner,
                                 invalidated,
                                 invalidated_storage_id,
+                                ..
                             } => {
                                 pending_recovery =
                                     Some((msg_epoch, winner, invalidated, invalidated_storage_id));
@@ -963,9 +964,22 @@ impl<S: StorageProvider> Engine<S> {
                                 // can still select its branch once follow-on
                                 // commits arrive — while staying out of the
                                 // linear pending replay, which would choke on
-                                // a cross-branch commit. If its branch loses
-                                // in convergence too, it is re-classified
-                                // terminal (`LosingBranch`) there.
+                                // a cross-branch commit.
+                                //
+                                // If its branch loses in convergence too, the
+                                // commit is NOT terminalized there: an
+                                // eligible-but-unselected branch's commits are
+                                // re-deferred `ConvergenceDeferred`
+                                // (`NonSelectedEligibleBranch` in
+                                // `classify_losing_materialized_candidate_commits`)
+                                // and stay reconsiderable in later passes.
+                                // (`LosingBranch` is an APP-message
+                                // invalidation reason, not a commit
+                                // disposition.) Commits go terminal only at
+                                // the rewind horizon —
+                                // `BeyondRollbackHorizon`/`BeyondAnchor`, or
+                                // the `beyond_retained_anchor` retirement in
+                                // `seed_convergence_pass_members`.
                                 //
                                 // Re-persist the full row (not just the state):
                                 // the row was stored above under this node's

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -947,65 +947,11 @@ impl<S: StorageProvider> Engine<S> {
                                 continue;
                             }
                             ForkResolution::IncumbentWins { .. } => {
-                                // The candidate lost this node's PAIRWISE race
-                                // — but nodes that did not commit from this
-                                // epoch resolve the same conflict through
-                                // distributed convergence, where a deeper
-                                // candidate branch outranks the ordering key.
-                                // Terminal `EpochInvalidated` froze this node
-                                // on its own lineage forever (convergence
-                                // never re-admits it — see
-                                // `convergence_input::can_start_pass`), so two
-                                // honest nodes could keep different branches
-                                // permanently. Park the loser
-                                // `ConvergenceDeferred` instead: that state
-                                // re-enters branch materialization (see
-                                // `unresolved_commit_state`) so a later pass
-                                // can still select its branch once follow-on
-                                // commits arrive — while staying out of the
-                                // linear pending replay, which would choke on
-                                // a cross-branch commit.
-                                //
-                                // If its branch loses in convergence too, the
-                                // commit is NOT terminalized there: an
-                                // eligible-but-unselected branch's commits are
-                                // re-deferred `ConvergenceDeferred`
-                                // (`NonSelectedEligibleBranch` in
-                                // `classify_losing_materialized_candidate_commits`)
-                                // and stay reconsiderable in later passes.
-                                // (`LosingBranch` is an APP-message
-                                // invalidation reason, not a commit
-                                // disposition.) Commits go terminal only at
-                                // the rewind horizon —
-                                // `BeyondRollbackHorizon`/`BeyondAnchor`, or
-                                // the `beyond_retained_anchor` retirement in
-                                // `seed_convergence_pass_members`.
-                                //
-                                // Re-persist the full row (not just the state):
-                                // the row was stored above under this node's
-                                // CURRENT epoch, but convergence-input rows are
-                                // keyed by the commit's SOURCE epoch (see
-                                // `buffer_openmls_convergence_message_with_time`)
-                                // — the apply stage reads `record.epoch` to
-                                // pick the retained-anchor rewind target, so a
-                                // current-epoch row would make the reorg replay
-                                // this epoch-N commit against the live tip
-                                // state (WrongEpoch).
-                                //
-                                // Load-bearing invariant: this arm is reachable
-                                // only while NO convergence pass is active —
-                                // `commit_should_enter_convergence` routes any
-                                // stale commit into convergence whenever a pass
-                                // is live (its `active_pass` term), so a commit
-                                // that reaches this pairwise seam never belongs
-                                // to an open pass. The parked row is therefore
-                                // always picked up by the NEXT pass:
-                                // `seed_convergence_pass_members` seeds pass
-                                // membership from a storage scan that includes
-                                // `ConvergenceDeferred` rows. If that routing
-                                // guard is ever relaxed, a row parked here
-                                // while a pass is open would belong to no pass
-                                // and become an orphan.
+                                // Keep the pairwise loser eligible for a later
+                                // distributed pass, and key it by the commit's
+                                // source epoch as required by replay. This seam
+                                // is reachable only with no active pass; the
+                                // next pass seeds this deferred row from storage.
                                 self.persist_openmls_wire_message(
                                     &openmls_msg,
                                     &group_id,

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -338,6 +338,10 @@ pub enum OpenMlsProjectionError {
     Storage(String),
     InvalidPolicy(String),
     ReplayBudgetExceeded,
+    /// A locally authored commit predates commit-addressed checkpoints. Its
+    /// branch cannot be reconstructed safely from the network wire or an
+    /// epoch-keyed anchor.
+    MissingOwnCommitCheckpoint,
     /// A branch-addressed own-commit checkpoint restored state that does not
     /// match the resulting epoch and epoch authenticator stamped at confirm
     /// time. The apply is aborted and rolled back rather than installing an
@@ -386,6 +390,9 @@ impl std::fmt::Display for OpenMlsProjectionError {
             }
             OpenMlsProjectionError::ReplayBudgetExceeded => {
                 write!(f, "convergence replay budget exceeded")
+            }
+            OpenMlsProjectionError::MissingOwnCommitCheckpoint => {
+                write!(f, "own commit has no branch-addressed checkpoint")
             }
             OpenMlsProjectionError::CheckpointStateMismatch => {
                 write!(
@@ -1014,15 +1021,14 @@ pub(crate) fn canonicalize_stored_openmls_messages_with_profile_policy<S: Storag
                 if record.state == MessageState::Processed {
                     own_commits.insert_canonical(projection.message_digest);
                 }
-                // The stamp is written only at confirm time, so its presence
-                // alone proves this is an own commit MLS cannot re-process.
-                // Register it independently of `Processed`: a pairwise
-                // CandidateWins resolution parks the displaced own incumbent
-                // `ConvergenceDeferred` (see `fork_recovery`), and replaying
-                // its branch still needs the stamp — the prefix-canonical
-                // guard at the stamp's use site keeps a diverging prefix from
-                // mis-realizing it.
-                if let Some(stamp) = own_commit_stamp {
+                // Confirmed own commits remain prevalidated while canonical or
+                // parked for convergence. Terminal states must not regain
+                // checkpoint-based eligibility.
+                if matches!(
+                    record.state,
+                    MessageState::Processed | MessageState::ConvergenceDeferred
+                ) && let Some(stamp) = own_commit_stamp
+                {
                     own_commits.insert_stamped(projection.message_digest, stamp);
                 }
                 commit_messages.push(StoredCommitMessage {
@@ -1272,7 +1278,7 @@ fn canonicalize_stored_openmls_messages_from_current<S: StorageProvider>(
         },
         ReplayBudget::new,
     );
-    let path_result = build_stored_openmls_candidate_paths(
+    let path_result = match build_stored_openmls_candidate_paths(
         storage,
         group_id,
         work.commit_messages,
@@ -1281,7 +1287,23 @@ fn canonicalize_stored_openmls_messages_from_current<S: StorageProvider>(
         &work.own_commits,
         work.profile_policy,
         &mut replay_budget,
-    )?;
+    ) {
+        Ok(result) => result,
+        Err(OpenMlsProjectionError::MissingOwnCommitCheckpoint) => {
+            // Older stamps have no exact post-merge checkpoint. Treat that as
+            // missing required retained state so the convergence coordinator
+            // durably halts the group instead of repeatedly selecting a branch
+            // this device can never materialize.
+            return Ok(missing_required_state_result(
+                work.state,
+                work.outbound_intents,
+                work.policy,
+                work.now_ms,
+                CanonicalizationError::MissingOwnCommitCheckpoint,
+            ));
+        }
+        Err(error) => return Err(error),
+    };
 
     let has_pending_apps = pending_messages_contain_application(&work.pending_messages)?;
     let can_reuse_materialized = can_reuse_bfs_materialization(
@@ -1346,6 +1368,22 @@ fn missing_retained_anchor_result(
     policy: CanonicalizationPolicy,
     now_ms: u64,
 ) -> CanonicalizationResult {
+    missing_required_state_result(
+        state,
+        outbound_intents,
+        policy,
+        now_ms,
+        CanonicalizationError::MissingRetainedAnchor,
+    )
+}
+
+fn missing_required_state_result(
+    state: CanonicalizationState,
+    outbound_intents: Vec<OutboundIntent>,
+    policy: CanonicalizationPolicy,
+    now_ms: u64,
+    error: CanonicalizationError,
+) -> CanonicalizationResult {
     let elapsed = now_ms.saturating_sub(state.last_convergence_relevant_input_ms);
     let convergence_status = if elapsed >= policy.settlement_quiescence_ms {
         ConvergenceStatus::Blocked
@@ -1369,7 +1407,7 @@ fn missing_retained_anchor_result(
         already_seen: Vec::new(),
         queued_outbound_intents: outbound_intents,
         publishable_outbound_messages: Vec::new(),
-        errors: vec![CanonicalizationError::MissingRetainedAnchor],
+        errors: vec![error],
         #[cfg(feature = "test-conformance-snapshot")]
         replay_probe_count: 0,
         selection_trace: None,
@@ -1673,30 +1711,37 @@ pub(crate) fn apply_openmls_canonicalization_result_with_profile_policy<S: Stora
     // run's final resulting epoch — the exact post-merge state its last own
     // commit produced.
     let own_checkpoint_prefix =
-        checkpoint_realizable_own_commit_prefix(storage, group_id, result, &applied_prefix)?;
+        checkpoint_realizable_own_commit_prefix(storage, result, &applied_prefix)?;
     let mut skipped_prefix = applied_prefix;
     skipped_prefix.extend(own_checkpoint_prefix.commit_ids.iter().cloned());
-    let apply_start_epoch = match own_checkpoint_prefix.resulting_epoch {
-        Some(epoch) => epoch,
+    let apply_start_epoch = match own_checkpoint_prefix.realized.as_ref() {
+        Some(realized) => realized.resulting_epoch,
         None => apply_start_epoch_for_canonicalization_result(storage, result, &skipped_prefix)?
             .unwrap_or(current_epoch),
     };
     // The own-checkpoint case must restore even when its epoch equals the live
     // tip: the live tip may be a different branch's state at that epoch.
     let rewind_to_retained_anchor = apply_start_epoch < current_epoch;
-    let restore_own_checkpoint = own_checkpoint_prefix.checkpoint_id.is_some();
+    let restore_own_checkpoint = own_checkpoint_prefix.realized.is_some();
     let replay_messages = replay_messages_for_canonicalization_result(
         storage,
         result,
         &skipped_prefix,
         apply_start_epoch,
     )?;
-    let live_message_records = storage
-        .list_messages(group_id, EpochId(0))
-        .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
-    let live_queued_outbound = storage
-        .list_queued_outbound_intents(group_id)
-        .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
+    let (live_message_records, live_queued_outbound) =
+        if rewind_to_retained_anchor && !restore_own_checkpoint {
+            (
+                storage
+                    .list_messages(group_id, EpochId(0))
+                    .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?,
+                storage
+                    .list_queued_outbound_intents(group_id)
+                    .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?,
+            )
+        } else {
+            (Vec::new(), Vec::new())
+        };
     let snapshot = apply_snapshot_name(group_id, result);
     storage
         .create_group_snapshot(group_id, &snapshot)
@@ -1704,12 +1749,12 @@ pub(crate) fn apply_openmls_canonicalization_result_with_profile_policy<S: Stora
 
     // Refresh the current-epoch anchor only in the case that always did:
     // there are new commits AND the apply starts at the live tip. The extra
-    // `own_checkpoint_prefix.resulting_epoch.is_none()` term avoids an
+    // `own_checkpoint_prefix.realized.is_none()` term avoids an
     // unnecessary epoch-anchor refresh before restoring exact checkpoint
     // state. `apply_start_epoch > current_epoch` stays skipped as before.
     let prepare_result = if has_new_commits
         && apply_start_epoch == current_epoch
-        && own_checkpoint_prefix.resulting_epoch.is_none()
+        && own_checkpoint_prefix.realized.is_none()
     {
         retain_current_group_epoch_snapshot(storage, group_id, max_retained_anchor_rewind)
     } else {
@@ -1726,25 +1771,15 @@ pub(crate) fn apply_openmls_canonicalization_result_with_profile_policy<S: Stora
     // therefore returns to the pre-apply live state instead of committing an
     // older message/queue image and rebuilding it row by row.
     let apply_result = storage.with_transaction(|storage| {
-        if let Some(checkpoint_id) = own_checkpoint_prefix.checkpoint_id.as_deref() {
+        if let Some(realized) = own_checkpoint_prefix.realized.as_ref() {
             storage
-                .restore_group_state_checkpoint(group_id, checkpoint_id)
+                .restore_group_state_checkpoint(group_id, &realized.id)
                 .map_err(|e| OpenMlsProjectionError::Snapshot(format!("{e:?}")))?;
             verify_restored_own_checkpoint(
                 storage,
                 group_id,
-                own_checkpoint_prefix
-                    .resulting_epoch
-                    .expect("checkpoint prefix has resulting epoch"),
-                own_checkpoint_prefix
-                    .expected_epoch_authenticator
-                    .as_deref()
-                    .expect("checkpoint prefix has epoch authenticator"),
-            )?;
-            restore_live_message_and_queue_records(
-                storage,
-                &live_message_records,
-                &live_queued_outbound,
+                realized.resulting_epoch,
+                &realized.expected_epoch_authenticator,
             )?;
         } else if rewind_to_retained_anchor {
             let anchor_snapshot = retained_anchor_snapshot_name(apply_start_epoch);
@@ -1889,10 +1924,13 @@ struct CheckpointRealizableOwnPrefix {
     /// Selected-branch commit ids (hex) realized via an exact checkpoint
     /// instead of replay.
     commit_ids: BTreeSet<String>,
-    /// Resulting epoch of the run's last own commit.
-    resulting_epoch: Option<u64>,
-    checkpoint_id: Option<String>,
-    expected_epoch_authenticator: Option<String>,
+    realized: Option<RealizedCheckpoint>,
+}
+
+struct RealizedCheckpoint {
+    resulting_epoch: u64,
+    id: String,
+    expected_epoch_authenticator: String,
 }
 
 /// The leading run — after the already-applied prefix — of this device's own
@@ -1909,14 +1947,10 @@ struct CheckpointRealizableOwnPrefix {
 /// apply transaction.
 fn checkpoint_realizable_own_commit_prefix<S: StorageProvider>(
     storage: &S,
-    group_id: &GroupId,
     result: &CanonicalizationResult,
     applied_prefix: &BTreeSet<String>,
 ) -> Result<CheckpointRealizableOwnPrefix, OpenMlsProjectionError> {
     let mut prefix = CheckpointRealizableOwnPrefix::default();
-    let checkpoints = storage
-        .list_group_state_checkpoints(group_id)
-        .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
     for commit_id in result
         .accepted_commits
         .iter()
@@ -1941,16 +1975,12 @@ fn checkpoint_realizable_own_commit_prefix<S: StorageProvider>(
             break;
         };
         let resulting_epoch = record.epoch.0.saturating_add(1);
-        let retained = checkpoints.iter().any(|checkpoint| {
-            checkpoint.id == checkpoint_id && checkpoint.resulting_epoch.0 == resulting_epoch
-        });
-        if !retained {
-            break;
-        }
         prefix.commit_ids.insert(commit_id.clone());
-        prefix.resulting_epoch = Some(resulting_epoch);
-        prefix.checkpoint_id = Some(checkpoint_id);
-        prefix.expected_epoch_authenticator = Some(expected_authenticator);
+        prefix.realized = Some(RealizedCheckpoint {
+            resulting_epoch,
+            id: checkpoint_id,
+            expected_epoch_authenticator: expected_authenticator,
+        });
     }
     Ok(prefix)
 }
@@ -2064,7 +2094,7 @@ fn prune_group_state_checkpoints<S: StorageProvider>(
     retained_epoch: u64,
     max_retained_anchor_rewind: u64,
 ) -> Result<(), OpenMlsProjectionError> {
-    let oldest_retained_epoch = retained_epoch.saturating_sub(max_retained_anchor_rewind);
+    let oldest_retained_epoch = oldest_retained_epoch(retained_epoch, max_retained_anchor_rewind);
     for checkpoint in storage
         .list_group_state_checkpoints(group_id)
         .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?
@@ -2085,7 +2115,7 @@ fn prune_retained_anchor_snapshots<S: StorageProvider>(
     retained_epoch: u64,
     max_retained_anchor_rewind: u64,
 ) -> Result<(), OpenMlsProjectionError> {
-    let oldest_retained_epoch = retained_epoch.saturating_sub(max_retained_anchor_rewind);
+    let oldest_retained_epoch = oldest_retained_epoch(retained_epoch, max_retained_anchor_rewind);
     let snapshots = storage
         .list_group_snapshots(group_id)
         .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
@@ -2104,6 +2134,10 @@ fn prune_retained_anchor_snapshots<S: StorageProvider>(
     }
 
     Ok(())
+}
+
+fn oldest_retained_epoch(retained_epoch: u64, max_retained_anchor_rewind: u64) -> u64 {
+    retained_epoch.saturating_sub(max_retained_anchor_rewind)
 }
 
 fn apply_openmls_canonicalization_result_inner<S: StorageProvider>(
@@ -2622,13 +2656,17 @@ fn process_openmls_messages_inner<S: StorageProvider>(
                 stamp.checkpoint_id.as_deref(),
                 stamp.resulting_epoch_authenticator.as_deref(),
             ) else {
-                return Err(OpenMlsProjectionError::Replay(
-                    "own commit has no branch checkpoint".into(),
-                ));
+                return Err(OpenMlsProjectionError::MissingOwnCommitCheckpoint);
             };
-            storage
-                .restore_group_state_checkpoint(group_id, checkpoint_id)
-                .map_err(|e| OpenMlsProjectionError::Snapshot(format!("{e:?}")))?;
+            match storage.restore_group_state_checkpoint(group_id, checkpoint_id) {
+                Ok(()) => {}
+                Err(StorageError::SnapshotMissing(_)) => {
+                    return Err(OpenMlsProjectionError::MissingOwnCommitCheckpoint);
+                }
+                Err(error) => {
+                    return Err(OpenMlsProjectionError::Snapshot(format!("{error:?}")));
+                }
+            }
             mls_group = MlsGroup::load(provider.storage(), &mls_group_id)
                 .map_err(|e| OpenMlsProjectionError::Replay(format!("checkpoint reload: {e:?}")))?
                 .ok_or(OpenMlsProjectionError::MissingGroup)?;
@@ -3241,7 +3279,7 @@ mod reuse_scope_tests {
 
 #[cfg(test)]
 mod checkpoint_prefix_tests {
-    use super::{CheckpointRealizableOwnPrefix, checkpoint_realizable_own_commit_prefix};
+    use super::checkpoint_realizable_own_commit_prefix;
     use crate::canonicalization::{CanonicalizationResult, ConvergenceStatus};
     use cgka_traits::engine::CommitOrderingPriority;
     use cgka_traits::group::{Group, ProtocolProfile};
@@ -3369,17 +3407,17 @@ mod checkpoint_prefix_tests {
 
         let prefix = checkpoint_realizable_own_commit_prefix(
             &storage,
-            &group_id(),
             &result_accepting(&[b"commit-a"]),
             &BTreeSet::new(),
         )
         .unwrap();
-        assert_eq!(prefix.resulting_epoch, Some(2));
+        let realized = prefix.realized.expect("checkpoint should be realizable");
+        assert_eq!(realized.resulting_epoch, 2);
         assert!(prefix.commit_ids.contains(&hex::encode(b"commit-a")));
-        assert_eq!(prefix.checkpoint_id, Some(checkpoint_id_for(b"commit-a")));
+        assert_eq!(realized.id, checkpoint_id_for(b"commit-a"));
         assert_eq!(
-            prefix.expected_epoch_authenticator,
-            Some(authenticator_for(b"commit-a"))
+            realized.expected_epoch_authenticator,
+            authenticator_for(b"commit-a")
         );
     }
 
@@ -3392,21 +3430,18 @@ mod checkpoint_prefix_tests {
 
         let prefix = checkpoint_realizable_own_commit_prefix(
             &storage,
-            &group_id(),
             &result_accepting(&[b"commit-a"]),
             &BTreeSet::new(),
         )
         .unwrap();
-        assert_eq!(
-            prefix.resulting_epoch,
-            CheckpointRealizableOwnPrefix::default().resulting_epoch,
+        assert!(
+            prefix.realized.is_none(),
             "a commit without a checkpoint must not yield a restore target"
         );
         assert!(
             prefix.commit_ids.is_empty(),
             "a commit without a checkpoint must not realize any commit"
         );
-        assert!(prefix.checkpoint_id.is_none());
     }
 
     #[test]
@@ -3433,17 +3468,16 @@ mod checkpoint_prefix_tests {
 
         let prefix = checkpoint_realizable_own_commit_prefix(
             &storage,
-            &group_id(),
             &result_accepting(&[b"commit-a", b"commit-a-next"]),
             &BTreeSet::new(),
         )
         .unwrap();
         assert_eq!(prefix.commit_ids.len(), 2);
-        assert_eq!(prefix.resulting_epoch, Some(3));
-        assert_eq!(
-            prefix.checkpoint_id,
-            Some(checkpoint_id_for(b"commit-a-next"))
-        );
+        let realized = prefix
+            .realized
+            .expect("last checkpoint should realize the run");
+        assert_eq!(realized.resulting_epoch, 3);
+        assert_eq!(realized.id, checkpoint_id_for(b"commit-a-next"));
     }
 
     #[test]
@@ -3458,12 +3492,12 @@ mod checkpoint_prefix_tests {
 
         let prefix = checkpoint_realizable_own_commit_prefix(
             &storage,
-            &group_id(),
             &result_accepting(&[b"commit-a"]),
             &BTreeSet::new(),
         )
         .unwrap();
-        assert_eq!(prefix.resulting_epoch, Some(2));
-        assert_eq!(prefix.checkpoint_id, Some(checkpoint_id_for(b"commit-a")));
+        let realized = prefix.realized.expect("selected sibling should be exact");
+        assert_eq!(realized.resulting_epoch, 2);
+        assert_eq!(realized.id, checkpoint_id_for(b"commit-a"));
     }
 }

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -338,13 +338,11 @@ pub enum OpenMlsProjectionError {
     Storage(String),
     InvalidPolicy(String),
     ReplayBudgetExceeded,
-    /// A retained-anchor rewind meant to realize a parked own commit landed on
-    /// state that does not match the fingerprint that commit stamped at
-    /// confirm time: the name-keyed anchor was replaced by another branch's
-    /// capture at the same epoch. The apply is aborted and rolled back rather
-    /// than installing the wrong lineage. See
-    /// [`verify_rewound_anchor_lineage`] for the liveness consequence.
-    AnchorLineageMismatch,
+    /// A branch-addressed own-commit checkpoint restored state that does not
+    /// match the resulting epoch and epoch authenticator stamped at confirm
+    /// time. The apply is aborted and rolled back rather than installing an
+    /// unverified lineage.
+    CheckpointStateMismatch,
 }
 
 impl std::fmt::Display for OpenMlsProjectionError {
@@ -389,10 +387,10 @@ impl std::fmt::Display for OpenMlsProjectionError {
             OpenMlsProjectionError::ReplayBudgetExceeded => {
                 write!(f, "convergence replay budget exceeded")
             }
-            OpenMlsProjectionError::AnchorLineageMismatch => {
+            OpenMlsProjectionError::CheckpointStateMismatch => {
                 write!(
                     f,
-                    "retained anchor does not hold the parked own commit's post-merge state"
+                    "own-commit checkpoint does not match its stamped post-merge state"
                 )
             }
         }
@@ -416,10 +414,9 @@ impl From<StorageError> for OpenMlsProjectionError {
 /// branch would silently drop out of branch selection and the device could be
 /// reorged onto a losing sibling (or, with two restarted committers, the group
 /// could fork permanently). Instead, an own `Processed` commit whose ordering
-/// stamp was persisted at confirm time is realized by rolling the group
-/// forward to the retained anchor snapshot at its resulting epoch — the exact
-/// post-merge state the commit produced — and synthesizing its
-/// `CommitStaged` observation from the stamp.
+/// stamp was persisted at confirm time is realized from its immutable,
+/// commit-addressed canonical-state checkpoint, and its `CommitStaged`
+/// observation is synthesized from that stamp.
 #[derive(Clone, Debug, Default)]
 pub(crate) struct PrevalidatedOwnCommits {
     /// Confirm-stamped own `Processed` commits, keyed by wire-bytes digest.
@@ -457,10 +454,8 @@ impl PrevalidatedOwnCommits {
 /// while the staged commit is still attached (confirm time). See
 /// [`cgka_traits::message::OwnCommitConvergenceStamp`].
 ///
-/// `post_commit_tree_marker` is left `None` here and filled in by the caller
-/// once the staged commit has been MERGED: the marker fingerprints the state
-/// the commit PRODUCES, which does not exist yet while the commit is merely
-/// staged. See [`own_commit_post_merge_tree_marker`].
+/// Checkpoint identity and resulting epoch authentication are filled in by the
+/// confirm path after the commit is merged.
 pub(crate) fn own_commit_stamp(
     staged: &openmls::group::StagedCommit,
     committer: MemberId,
@@ -477,22 +472,38 @@ pub(crate) fn own_commit_stamp(
         committer,
         priority,
         consumed_proposal_refs,
-        post_commit_tree_marker: None,
+        checkpoint_id: None,
+        resulting_epoch_authenticator: None,
     })
 }
 
-/// Fingerprint the state an own commit produced, for
-/// [`cgka_traits::message::OwnCommitConvergenceStamp::post_commit_tree_marker`].
-///
-/// Call with the group AFTER `merge_pending_commit`. The ciphersuite is read
-/// from the group itself so the value recomputed at rewind time (which has no
-/// engine handle) is derived from exactly the same inputs.
-pub(crate) fn own_commit_post_merge_tree_marker(
-    merged: &MlsGroup,
+pub(crate) fn own_commit_checkpoint_id<S: StorageProvider>(
+    storage: &S,
+    message_id: &MessageId,
 ) -> Result<String, cgka_traits::error::EngineError> {
-    Ok(hex::encode(
-        crate::group_lifecycle::compute_validated_tree_marker(merged, merged.ciphersuite())?,
+    let record = storage.get_message(message_id)?;
+    let payload = StoredMessagePayload::decode(&record.payload)
+        .map_err(|error| cgka_traits::error::EngineError::Serialize(error.to_string()))?;
+    let wire = payload.as_openmls_wire().ok_or_else(|| {
+        cgka_traits::error::EngineError::Serialize(
+            "own commit record does not contain OpenMLS wire bytes".into(),
+        )
+    })?;
+    let projection = project_mls_message(&wire.payload)
+        .map_err(|error| cgka_traits::error::EngineError::Serialize(error.to_string()))?;
+    if projection.kind != OpenMlsContentKind::Commit {
+        return Err(cgka_traits::error::EngineError::Serialize(
+            "own commit record is not a commit".into(),
+        ));
+    }
+    Ok(format!(
+        "openmls-own-commit-v1-{}",
+        hex::encode(projection.message_digest)
     ))
+}
+
+pub(crate) fn own_commit_post_merge_epoch_authenticator(merged: &MlsGroup) -> String {
+    hex::encode(merged.epoch_authenticator().as_slice())
 }
 
 /// Give retained proposal rows the same terminal disposition when a local
@@ -1661,21 +1672,19 @@ pub(crate) fn apply_openmls_canonicalization_result_with_profile_policy<S: Stora
     // step: skip it from the replay and rewind to the retained anchor at the
     // run's final resulting epoch — the exact post-merge state its last own
     // commit produced.
-    let own_anchor_prefix =
-        anchor_realizable_own_commit_prefix(storage, group_id, result, &applied_prefix)?;
+    let own_checkpoint_prefix =
+        checkpoint_realizable_own_commit_prefix(storage, group_id, result, &applied_prefix)?;
     let mut skipped_prefix = applied_prefix;
-    skipped_prefix.extend(own_anchor_prefix.commit_ids.iter().cloned());
-    let apply_start_epoch = match own_anchor_prefix.resulting_epoch {
+    skipped_prefix.extend(own_checkpoint_prefix.commit_ids.iter().cloned());
+    let apply_start_epoch = match own_checkpoint_prefix.resulting_epoch {
         Some(epoch) => epoch,
         None => apply_start_epoch_for_canonicalization_result(storage, result, &skipped_prefix)?
             .unwrap_or(current_epoch),
     };
-    // The own-anchor case must rewind even when the anchor epoch equals the
-    // live tip epoch: the live tip is a DIFFERENT branch's state at that
-    // epoch (that is what displaced the own incumbent), while the retained
-    // anchor holds the own commit's post-merge state.
-    let rewind_to_retained_anchor =
-        apply_start_epoch < current_epoch || own_anchor_prefix.resulting_epoch.is_some();
+    // The own-checkpoint case must restore even when its epoch equals the live
+    // tip: the live tip may be a different branch's state at that epoch.
+    let rewind_to_retained_anchor = apply_start_epoch < current_epoch;
+    let restore_own_checkpoint = own_checkpoint_prefix.checkpoint_id.is_some();
     let replay_messages = replay_messages_for_canonicalization_result(
         storage,
         result,
@@ -1695,15 +1704,12 @@ pub(crate) fn apply_openmls_canonicalization_result_with_profile_policy<S: Stora
 
     // Refresh the current-epoch anchor only in the case that always did:
     // there are new commits AND the apply starts at the live tip. The extra
-    // `own_anchor_prefix.resulting_epoch.is_none()` term is what this branch
-    // adds, and only that: in the own-anchor case the live tip and the rewind
-    // target share an epoch number, so retaining here would overwrite the own
-    // commit's post-merge state with the displacing branch's state before the
-    // rollback reads it. `apply_start_epoch > current_epoch` stays skipped,
-    // exactly as before.
+    // `own_checkpoint_prefix.resulting_epoch.is_none()` term avoids an
+    // unnecessary epoch-anchor refresh before restoring exact checkpoint
+    // state. `apply_start_epoch > current_epoch` stays skipped as before.
     let prepare_result = if has_new_commits
         && apply_start_epoch == current_epoch
-        && own_anchor_prefix.resulting_epoch.is_none()
+        && own_checkpoint_prefix.resulting_epoch.is_none()
     {
         retain_current_group_epoch_snapshot(storage, group_id, max_retained_anchor_rewind)
     } else {
@@ -1720,24 +1726,31 @@ pub(crate) fn apply_openmls_canonicalization_result_with_profile_policy<S: Stora
     // therefore returns to the pre-apply live state instead of committing an
     // older message/queue image and rebuilding it row by row.
     let apply_result = storage.with_transaction(|storage| {
-        if rewind_to_retained_anchor {
+        if let Some(checkpoint_id) = own_checkpoint_prefix.checkpoint_id.as_deref() {
+            storage
+                .restore_group_state_checkpoint(group_id, checkpoint_id)
+                .map_err(|e| OpenMlsProjectionError::Snapshot(format!("{e:?}")))?;
+            verify_restored_own_checkpoint(
+                storage,
+                group_id,
+                own_checkpoint_prefix
+                    .resulting_epoch
+                    .expect("checkpoint prefix has resulting epoch"),
+                own_checkpoint_prefix
+                    .expected_epoch_authenticator
+                    .as_deref()
+                    .expect("checkpoint prefix has epoch authenticator"),
+            )?;
+            restore_live_message_and_queue_records(
+                storage,
+                &live_message_records,
+                &live_queued_outbound,
+            )?;
+        } else if rewind_to_retained_anchor {
             let anchor_snapshot = retained_anchor_snapshot_name(apply_start_epoch);
             storage
                 .rollback_group_to_snapshot(group_id, &anchor_snapshot)
                 .map_err(|e| OpenMlsProjectionError::Snapshot(format!("{e:?}")))?;
-            // Positive proof that the anchor held the parked own commit's
-            // post-merge state, taken only now — nothing before the rewind can
-            // distinguish a clobbered anchor from a good one (the anchor name
-            // encodes only the epoch). This runs inside the apply transaction
-            // and BEFORE any replay, so a mismatch unwinds the rewind with the
-            // live state untouched; the caller additionally rolls back to the
-            // pre-apply snapshot.
-            if let Some(expected_marker) = own_anchor_prefix
-                .expected_post_commit_tree_marker
-                .as_deref()
-            {
-                verify_rewound_anchor_lineage(storage, group_id, expected_marker)?;
-            }
             restore_live_message_and_queue_records(
                 storage,
                 &live_message_records,
@@ -1752,7 +1765,7 @@ pub(crate) fn apply_openmls_canonicalization_result_with_profile_policy<S: Stora
             &replay_messages,
             profile_policy,
         )?;
-        if apply_start_epoch < current_epoch {
+        if apply_start_epoch < current_epoch || restore_own_checkpoint {
             crate::test_crash_hooks::pause_if_requested("historical-apply-before-commit");
         }
         storage
@@ -1872,54 +1885,38 @@ fn apply_start_epoch_for_canonicalization_result<S: StorageProvider>(
 }
 
 #[derive(Default)]
-struct AnchorRealizableOwnPrefix {
-    /// Selected-branch commit ids (hex) realized via the retained anchor
+struct CheckpointRealizableOwnPrefix {
+    /// Selected-branch commit ids (hex) realized via an exact checkpoint
     /// instead of replay.
     commit_ids: BTreeSet<String>,
-    /// Resulting epoch of the run's last own commit — the retained-anchor
-    /// rewind target that realizes the whole run.
+    /// Resulting epoch of the run's last own commit.
     resulting_epoch: Option<u64>,
-    /// Hex `post_commit_tree_marker` stamped by the run's LAST own commit:
-    /// the fingerprint the rewound state must reproduce for the rewind to be
-    /// proven on that commit's lineage. `Some` exactly when
-    /// `resulting_epoch` is `Some` — the scan refuses to extend the run past a
-    /// commit whose stamp carries no marker.
-    expected_post_commit_tree_marker: Option<String>,
+    checkpoint_id: Option<String>,
+    expected_epoch_authenticator: Option<String>,
 }
 
 /// The leading run — after the already-applied prefix — of this device's own
 /// confirm-stamped commits on the selected branch, bounded to those whose
-/// resulting-epoch retained anchor still exists. Such commits reach the apply
+/// commit-addressed checkpoint still exists. Such commits reach the apply
 /// stage outside the applied prefix when a pairwise CandidateWins resolution
 /// parked a displaced own incumbent `ConvergenceDeferred` (see
 /// `fork_recovery`) and convergence later selected its regrown branch. MLS
 /// refuses to re-process own commits, so the apply realizes the run by
-/// rewinding to the retained anchor at its final resulting epoch — the exact
-/// post-merge state captured when the commit confirmed — mirroring the
-/// selection stage's stamp rollforward (`PrevalidatedOwnCommits`). The first
-/// commit that is not an anchor-realizable own commit ends the run; anything
-/// after it replays normally from that state.
-///
-/// ## Anchor identity is NOT established here
-///
-/// Retained anchors are named by resulting epoch ALONE
-/// (`openmls-retained-anchor-<N>`) and every `retain_current_group_epoch_snapshot`
-/// call at that epoch REPLACES the previous one (`INSERT OR REPLACE`). Those
-/// callers include every inbound-commit merge, so a PEER commit that merely
-/// lands on epoch N silently clobbers an own commit's anchor while leaving no
-/// own-stamped row behind. No scan over stored rows can detect that, so this
-/// function does not try: it only assembles the CANDIDATE run and the
-/// fingerprint the rewound state must reproduce. The binding check is
-/// [`verify_rewound_anchor_lineage`], run after the rewind, inside the apply
-/// transaction.
-fn anchor_realizable_own_commit_prefix<S: StorageProvider>(
+/// restoring the final commit's immutable checkpoint — the exact canonical
+/// state captured when it confirmed. The first commit without a retained
+/// checkpoint ends the run; anything after it replays normally from that
+/// state. The restored epoch and epoch authenticator are verified inside the
+/// apply transaction.
+fn checkpoint_realizable_own_commit_prefix<S: StorageProvider>(
     storage: &S,
     group_id: &GroupId,
     result: &CanonicalizationResult,
     applied_prefix: &BTreeSet<String>,
-) -> Result<AnchorRealizableOwnPrefix, OpenMlsProjectionError> {
-    let mut prefix = AnchorRealizableOwnPrefix::default();
-    let mut snapshots: Option<Vec<String>> = None;
+) -> Result<CheckpointRealizableOwnPrefix, OpenMlsProjectionError> {
+    let mut prefix = CheckpointRealizableOwnPrefix::default();
+    let checkpoints = storage
+        .list_group_state_checkpoints(group_id)
+        .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
     for commit_id in result
         .accepted_commits
         .iter()
@@ -1934,83 +1931,51 @@ fn anchor_realizable_own_commit_prefix<S: StorageProvider>(
         let Ok(payload) = StoredMessagePayload::decode(&record.payload) else {
             break;
         };
-        // The stamp must carry the post-merge fingerprint of the state this
-        // commit produced. Rows stamped before that field existed cannot be
-        // proven against the anchor, so they end the run and fall back to
-        // normal replay (which fails closed on an own commit).
-        let Some(expected_marker) = payload
-            .own_commit_stamp()
-            .and_then(|stamp| stamp.post_commit_tree_marker.clone())
-        else {
+        let Some(stamp) = payload.own_commit_stamp() else {
+            break;
+        };
+        let (Some(checkpoint_id), Some(expected_authenticator)) = (
+            stamp.checkpoint_id.clone(),
+            stamp.resulting_epoch_authenticator.clone(),
+        ) else {
             break;
         };
         let resulting_epoch = record.epoch.0.saturating_add(1);
-        if snapshots.is_none() {
-            snapshots = Some(
-                storage
-                    .list_group_snapshots(group_id)
-                    .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?,
-            );
-        }
-        let retained = snapshots
-            .as_ref()
-            .is_some_and(|names| names.contains(&retained_anchor_snapshot_name(resulting_epoch)));
+        let retained = checkpoints.iter().any(|checkpoint| {
+            checkpoint.id == checkpoint_id && checkpoint.resulting_epoch.0 == resulting_epoch
+        });
         if !retained {
             break;
         }
         prefix.commit_ids.insert(commit_id.clone());
         prefix.resulting_epoch = Some(resulting_epoch);
-        prefix.expected_post_commit_tree_marker = Some(expected_marker);
+        prefix.checkpoint_id = Some(checkpoint_id);
+        prefix.expected_epoch_authenticator = Some(expected_authenticator);
     }
     Ok(prefix)
 }
 
-/// Prove that a completed retained-anchor rewind landed on the lineage of the
-/// own commit the rewind was meant to realize.
-///
-/// Anchors are name-keyed by resulting epoch and are replaced by EVERY capture
-/// at that epoch — `retain_current_group_epoch_snapshot` runs before each
-/// inbound-commit merge, after each apply, and on each own confirm — so the
-/// anchor named for epoch N may hold a rival branch's state instead. Nothing
-/// observable before the rewind distinguishes the two cases, so this is a
-/// POSITIVE identity check taken after it: recompute the content-bound tree
-/// marker over the rewound group and require it to equal the fingerprint the
-/// parked commit stamped at confirm time. Only the exact ratchet tree that
-/// commit produced can match.
-///
-/// Must be called INSIDE the apply transaction: a mismatch returns `Err`, the
-/// transaction (which the SQLite snapshot rollback joins) unwinds, and the
-/// caller additionally rolls the group back to the pre-apply snapshot — so a
-/// failed proof leaves live state untouched.
-///
-/// LIVENESS LIMITATION (deliberate, not papered over): when the anchor HAS
-/// been clobbered, the parked own commit can no longer be realized AT ALL. The
-/// anchor rewind is its only route — MLS `process_message` refuses this
-/// device's own commits, so normal replay cannot materialize it either. This
-/// node therefore fails closed and stays diverged from the branch the rest of
-/// the fleet selected until the rewind horizon retires the parked row
-/// (`BeyondRollbackHorizon` / `beyond_retained_anchor`), after which it
-/// reorgs onto whatever remains selectable. Correctness is preserved — no
-/// wrong lineage is ever installed — but liveness inside that window is not.
-/// Restoring it requires re-keying retained anchors by content rather than by
-/// epoch, which is shared with the convergence engine and out of scope here.
-fn verify_rewound_anchor_lineage<S: StorageProvider>(
+/// Verify the exact own-commit checkpoint after restoring it. This runs inside
+/// the apply transaction so any mismatch rolls back to the pre-apply state.
+fn verify_restored_own_checkpoint<S: StorageProvider>(
     storage: &S,
     group_id: &GroupId,
-    expected_marker: &str,
+    resulting_epoch: u64,
+    expected_authenticator: &str,
 ) -> Result<(), OpenMlsProjectionError> {
     let crypto = RustCrypto::default();
     let provider = EngineOpenMlsProvider::<S>::new(&crypto, storage.mls_storage());
     let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
     let mls_group = MlsGroup::load(provider.storage(), &mls_gid)
-        .map_err(|e| OpenMlsProjectionError::Snapshot(format!("load rewound anchor group: {e:?}")))?
+        .map_err(|e| {
+            OpenMlsProjectionError::Snapshot(format!("load restored checkpoint group: {e:?}"))
+        })?
         .ok_or(OpenMlsProjectionError::MissingGroup)?;
-    let actual = own_commit_post_merge_tree_marker(&mls_group)
-        .map_err(|e| OpenMlsProjectionError::Snapshot(format!("{e}")))?;
-    if actual == expected_marker {
+    let actual = own_commit_post_merge_epoch_authenticator(&mls_group);
+    if mls_group.epoch().as_u64() == resulting_epoch && actual == expected_authenticator {
         return Ok(());
     }
-    Err(OpenMlsProjectionError::AnchorLineageMismatch)
+    Err(OpenMlsProjectionError::CheckpointStateMismatch)
 }
 
 fn rollback_and_release_group_snapshot<S: StorageProvider>(
@@ -2089,7 +2054,29 @@ pub(crate) fn retain_current_group_epoch_snapshot<S: StorageProvider>(
     storage
         .create_group_snapshot(group_id, &retained_anchor_snapshot_name(epoch))
         .map_err(|e| OpenMlsProjectionError::Snapshot(format!("{e:?}")))?;
-    prune_retained_anchor_snapshots(storage, group_id, epoch, max_retained_anchor_rewind)
+    prune_retained_anchor_snapshots(storage, group_id, epoch, max_retained_anchor_rewind)?;
+    prune_group_state_checkpoints(storage, group_id, epoch, max_retained_anchor_rewind)
+}
+
+fn prune_group_state_checkpoints<S: StorageProvider>(
+    storage: &S,
+    group_id: &GroupId,
+    retained_epoch: u64,
+    max_retained_anchor_rewind: u64,
+) -> Result<(), OpenMlsProjectionError> {
+    let oldest_retained_epoch = retained_epoch.saturating_sub(max_retained_anchor_rewind);
+    for checkpoint in storage
+        .list_group_state_checkpoints(group_id)
+        .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?
+    {
+        if checkpoint.resulting_epoch.0 >= oldest_retained_epoch {
+            continue;
+        }
+        storage
+            .release_group_state_checkpoint(group_id, &checkpoint.id)
+            .map_err(|e| OpenMlsProjectionError::Snapshot(format!("{e:?}")))?;
+    }
+    Ok(())
 }
 
 fn prune_retained_anchor_snapshots<S: StorageProvider>(
@@ -2142,9 +2129,9 @@ fn apply_openmls_canonicalization_result_inner<S: StorageProvider>(
         // No pre-validated own commits here: snapshot rollforward cannot nest
         // inside this transaction, and every own commit on the accepted
         // branch was excluded from `replay_messages` before this call —
-        // either as part of the already-applied prefix or as an
-        // anchor-realizable own-commit run whose retained-anchor rewind the
-        // caller performs itself (`anchor_realizable_own_commit_prefix`).
+        // either as part of the already-applied prefix or as a
+        // checkpoint-realizable own-commit run whose exact restore the
+        // caller performs itself (`checkpoint_realizable_own_commit_prefix`).
         let output = process_openmls_messages_inner(
             storage,
             group_id,
@@ -2620,12 +2607,10 @@ fn process_openmls_messages_inner<S: StorageProvider>(
             && prefix_canonical
             && let Some(stamp) = own_commits.stamp(&projection.message_digest)
         {
-            // MLS cannot process this device's own commit; realize its
-            // pre-validated result by rolling the group forward to the
-            // retained anchor snapshot the confirm path captured at its
-            // resulting epoch, and synthesize the CommitStaged observation
-            // from the confirm-time stamp. Any failure prunes this branch
-            // (the pre-fix behavior) rather than failing the pass.
+            // MLS cannot process this device's path-bearing own commit from
+            // the public wire echo after its pending state is gone. Restore
+            // the immutable post-merge checkpoint captured for this exact
+            // commit instead.
             let group_epoch = mls_group.epoch().as_u64();
             if group_epoch != source_epoch {
                 return Err(OpenMlsProjectionError::Replay(format!(
@@ -2633,27 +2618,26 @@ fn process_openmls_messages_inner<S: StorageProvider>(
                 )));
             }
             let resulting_epoch = source_epoch.saturating_add(1);
-            match storage.rollback_group_to_snapshot(
-                group_id,
-                &retained_anchor_snapshot_name(resulting_epoch),
-            ) {
-                Ok(()) => {}
-                Err(StorageError::SnapshotMissing(_)) => {
-                    return Err(OpenMlsProjectionError::Replay(format!(
-                        "own commit anchor snapshot missing at epoch {resulting_epoch}"
-                    )));
-                }
-                Err(e) => return Err(OpenMlsProjectionError::Snapshot(format!("{e:?}"))),
-            }
+            let (Some(checkpoint_id), Some(expected_authenticator)) = (
+                stamp.checkpoint_id.as_deref(),
+                stamp.resulting_epoch_authenticator.as_deref(),
+            ) else {
+                return Err(OpenMlsProjectionError::Replay(
+                    "own commit has no branch checkpoint".into(),
+                ));
+            };
+            storage
+                .restore_group_state_checkpoint(group_id, checkpoint_id)
+                .map_err(|e| OpenMlsProjectionError::Snapshot(format!("{e:?}")))?;
             mls_group = MlsGroup::load(provider.storage(), &mls_group_id)
-                .map_err(|e| OpenMlsProjectionError::Replay(format!("anchor reload: {e:?}")))?
+                .map_err(|e| OpenMlsProjectionError::Replay(format!("checkpoint reload: {e:?}")))?
                 .ok_or(OpenMlsProjectionError::MissingGroup)?;
-            let anchor_epoch = mls_group.epoch().as_u64();
-            if anchor_epoch != resulting_epoch {
-                return Err(OpenMlsProjectionError::Replay(format!(
-                    "own commit anchor epoch {anchor_epoch} does not match resulting epoch {resulting_epoch}"
-                )));
-            }
+            verify_restored_own_checkpoint(
+                storage,
+                group_id,
+                resulting_epoch,
+                expected_authenticator,
+            )?;
             observations.push(OpenMlsReplayObservation::CommitStaged {
                 message_id,
                 source_epoch,
@@ -3256,18 +3240,15 @@ mod reuse_scope_tests {
 }
 
 #[cfg(test)]
-mod anchor_prefix_lineage_tests {
-    use super::{
-        AnchorRealizableOwnPrefix, anchor_realizable_own_commit_prefix,
-        retained_anchor_snapshot_name,
-    };
+mod checkpoint_prefix_tests {
+    use super::{CheckpointRealizableOwnPrefix, checkpoint_realizable_own_commit_prefix};
     use crate::canonicalization::{CanonicalizationResult, ConvergenceStatus};
     use cgka_traits::engine::CommitOrderingPriority;
     use cgka_traits::group::{Group, ProtocolProfile};
     use cgka_traits::message::{
         MessageRecord, MessageState, OwnCommitConvergenceStamp, StoredMessagePayload,
     };
-    use cgka_traits::storage::{GroupStorage, MessageStorage};
+    use cgka_traits::storage::{GroupStateCheckpointRef, GroupStorage, MessageStorage};
     use cgka_traits::transport::{Timestamp, TransportEnvelope, TransportMessage, TransportSource};
     use cgka_traits::types::{EpochId, GroupId, MemberId, MessageId};
     use std::collections::BTreeSet;
@@ -3277,22 +3258,22 @@ mod anchor_prefix_lineage_tests {
         GroupId::new(vec![7u8; 32])
     }
 
-    /// Marker string a row claims its post-merge state fingerprints to. The
-    /// scan only propagates it; the value is proven against the real rewound
-    /// tree in `verify_rewound_anchor_lineage` (covered end-to-end by the
-    /// `fork_detection` integration tests, which need a real MLS group).
-    fn marker_for(id: &[u8]) -> String {
-        format!("marker-{}", hex::encode(id))
+    fn checkpoint_id_for(id: &[u8]) -> String {
+        format!("openmls-own-commit-v1-{}", hex::encode(id))
+    }
+
+    fn authenticator_for(id: &[u8]) -> String {
+        format!("auth-{}", hex::encode(id))
     }
 
     fn own_commit_row(id: &[u8], source_epoch: u64) -> MessageRecord {
-        own_commit_row_with_marker(id, source_epoch, Some(marker_for(id)))
+        own_commit_row_with_checkpoint(id, source_epoch, true)
     }
 
-    fn own_commit_row_with_marker(
+    fn own_commit_row_with_checkpoint(
         id: &[u8],
         source_epoch: u64,
-        post_commit_tree_marker: Option<String>,
+        present: bool,
     ) -> MessageRecord {
         let message = TransportMessage {
             id: MessageId::new(id.to_vec()),
@@ -3310,7 +3291,8 @@ mod anchor_prefix_lineage_tests {
             committer: MemberId::new(vec![1u8; 32]),
             priority: CommitOrderingPriority::Privileged,
             consumed_proposal_refs: Vec::new(),
-            post_commit_tree_marker,
+            checkpoint_id: present.then(|| checkpoint_id_for(id)),
+            resulting_epoch_authenticator: present.then(|| authenticator_for(id)),
         };
         MessageRecord {
             id: MessageId::new(id.to_vec()),
@@ -3349,14 +3331,14 @@ mod anchor_prefix_lineage_tests {
         }
     }
 
-    fn storage_with_anchor_at_epoch_2() -> SqliteAccountStorage {
+    fn storage_with_checkpoint(id: &[u8], resulting_epoch: u64) -> SqliteAccountStorage {
         let storage = SqliteAccountStorage::in_memory().unwrap();
         storage
             .put_group(&Group {
                 id: group_id(),
-                name: "anchor-lineage".into(),
+                name: "checkpoint-prefix".into(),
                 description: String::new(),
-                epoch: EpochId(2),
+                epoch: EpochId(resulting_epoch),
                 members: Vec::new(),
                 required_capabilities: Default::default(),
                 protocol_profile: ProtocolProfile::Legacy,
@@ -3367,23 +3349,25 @@ mod anchor_prefix_lineage_tests {
             })
             .unwrap();
         storage
-            .create_group_snapshot(&group_id(), &retained_anchor_snapshot_name(2))
+            .create_group_state_checkpoint(
+                &group_id(),
+                &GroupStateCheckpointRef {
+                    id: checkpoint_id_for(id),
+                    resulting_epoch: EpochId(resulting_epoch),
+                },
+            )
             .unwrap();
         storage
     }
 
     #[test]
-    fn stamped_own_commit_proposes_the_anchor_fast_path_with_its_marker() {
-        // A confirm-stamped own commit whose stamp carries the post-merge tree
-        // marker is a fast-path CANDIDATE: the scan proposes the rewind target
-        // and hands the apply the fingerprint it must reproduce after the
-        // rewind. The scan itself never claims the anchor is the right one.
-        let storage = storage_with_anchor_at_epoch_2();
+    fn stamped_own_commit_selects_its_exact_checkpoint() {
+        let storage = storage_with_checkpoint(b"commit-a", 2);
         storage
             .put_message(&own_commit_row(b"commit-a", 1))
             .unwrap();
 
-        let prefix = anchor_realizable_own_commit_prefix(
+        let prefix = checkpoint_realizable_own_commit_prefix(
             &storage,
             &group_id(),
             &result_accepting(&[b"commit-a"]),
@@ -3392,27 +3376,21 @@ mod anchor_prefix_lineage_tests {
         .unwrap();
         assert_eq!(prefix.resulting_epoch, Some(2));
         assert!(prefix.commit_ids.contains(&hex::encode(b"commit-a")));
+        assert_eq!(prefix.checkpoint_id, Some(checkpoint_id_for(b"commit-a")));
         assert_eq!(
-            prefix.expected_post_commit_tree_marker,
-            Some(marker_for(b"commit-a")),
-            "the apply must be given the marker to verify the rewind against"
+            prefix.expected_epoch_authenticator,
+            Some(authenticator_for(b"commit-a"))
         );
     }
 
     #[test]
-    fn own_commit_without_a_post_merge_marker_refuses_the_anchor_fast_path() {
-        // Rows stamped by engine versions that predate
-        // `post_commit_tree_marker` carry no fingerprint, so a rewind to the
-        // name-keyed anchor could never be PROVEN to land on their lineage.
-        // Refuse the fast path outright: the apply falls back to normal
-        // replay, which fails closed on an own commit
-        // (`process_message` refuses them) and lets convergence prune.
-        let storage = storage_with_anchor_at_epoch_2();
+    fn own_commit_without_a_checkpoint_refuses_the_fast_path() {
+        let storage = storage_with_checkpoint(b"commit-a", 2);
         storage
-            .put_message(&own_commit_row_with_marker(b"commit-a", 1, None))
+            .put_message(&own_commit_row_with_checkpoint(b"commit-a", 1, false))
             .unwrap();
 
-        let prefix = anchor_realizable_own_commit_prefix(
+        let prefix = checkpoint_realizable_own_commit_prefix(
             &storage,
             &group_id(),
             &result_accepting(&[b"commit-a"]),
@@ -3421,24 +3399,30 @@ mod anchor_prefix_lineage_tests {
         .unwrap();
         assert_eq!(
             prefix.resulting_epoch,
-            AnchorRealizableOwnPrefix::default().resulting_epoch,
-            "an unprovable anchor must not yield a rewind target"
+            CheckpointRealizableOwnPrefix::default().resulting_epoch,
+            "a commit without a checkpoint must not yield a restore target"
         );
         assert!(
             prefix.commit_ids.is_empty(),
-            "an unprovable anchor must not realize any commit"
+            "a commit without a checkpoint must not realize any commit"
         );
-        assert!(prefix.expected_post_commit_tree_marker.is_none());
+        assert!(prefix.checkpoint_id.is_none());
     }
 
     #[test]
-    fn a_run_of_own_commits_verifies_against_the_last_ones_marker() {
-        // The whole run is realized by a single rewind to the LAST own
-        // commit's resulting epoch, so that commit's marker — not the first's
-        // — is what the rewound state must reproduce.
-        let storage = storage_with_anchor_at_epoch_2();
+    fn a_run_of_own_commits_uses_the_last_checkpoint() {
+        let storage = storage_with_checkpoint(b"commit-a", 2);
+        let mut group = storage.get_group(&group_id()).unwrap();
+        group.epoch = EpochId(3);
+        storage.put_group(&group).unwrap();
         storage
-            .create_group_snapshot(&group_id(), &retained_anchor_snapshot_name(3))
+            .create_group_state_checkpoint(
+                &group_id(),
+                &GroupStateCheckpointRef {
+                    id: checkpoint_id_for(b"commit-a-next"),
+                    resulting_epoch: EpochId(3),
+                },
+            )
             .unwrap();
         storage
             .put_message(&own_commit_row(b"commit-a", 1))
@@ -3447,7 +3431,7 @@ mod anchor_prefix_lineage_tests {
             .put_message(&own_commit_row(b"commit-a-next", 2))
             .unwrap();
 
-        let prefix = anchor_realizable_own_commit_prefix(
+        let prefix = checkpoint_realizable_own_commit_prefix(
             &storage,
             &group_id(),
             &result_accepting(&[b"commit-a", b"commit-a-next"]),
@@ -3457,24 +3441,14 @@ mod anchor_prefix_lineage_tests {
         assert_eq!(prefix.commit_ids.len(), 2);
         assert_eq!(prefix.resulting_epoch, Some(3));
         assert_eq!(
-            prefix.expected_post_commit_tree_marker,
-            Some(marker_for(b"commit-a-next"))
+            prefix.checkpoint_id,
+            Some(checkpoint_id_for(b"commit-a-next"))
         );
     }
 
     #[test]
-    fn a_second_own_row_at_the_same_epoch_no_longer_gates_the_scan() {
-        // Deliberate behavior change. An earlier revision refused the fast
-        // path whenever more than one own confirm-stamped row shared a source
-        // epoch, on the theory that a second own confirm may have clobbered
-        // the name-keyed anchor. That under-approximation was unsound in both
-        // directions: a PEER commit that merely lands on the epoch also
-        // replaces the anchor (`retain_current_group_epoch_snapshot` runs
-        // before every inbound merge) while leaving no own row behind, so
-        // row-counting missed the real clobber — and it refused provable cases
-        // like this one for nothing. The scan now stays permissive and the
-        // apply proves anchor identity positively after the rewind.
-        let storage = storage_with_anchor_at_epoch_2();
+    fn sibling_own_rows_at_the_same_epoch_do_not_alias() {
+        let storage = storage_with_checkpoint(b"commit-a", 2);
         storage
             .put_message(&own_commit_row(b"commit-a", 1))
             .unwrap();
@@ -3482,7 +3456,7 @@ mod anchor_prefix_lineage_tests {
             .put_message(&own_commit_row(b"commit-a2", 1))
             .unwrap();
 
-        let prefix = anchor_realizable_own_commit_prefix(
+        let prefix = checkpoint_realizable_own_commit_prefix(
             &storage,
             &group_id(),
             &result_accepting(&[b"commit-a"]),
@@ -3490,10 +3464,6 @@ mod anchor_prefix_lineage_tests {
         )
         .unwrap();
         assert_eq!(prefix.resulting_epoch, Some(2));
-        assert_eq!(
-            prefix.expected_post_commit_tree_marker,
-            Some(marker_for(b"commit-a")),
-            "identity is decided by commit-a's own marker, not by row counts"
-        );
+        assert_eq!(prefix.checkpoint_id, Some(checkpoint_id_for(b"commit-a")));
     }
 }

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -3487,17 +3487,19 @@ mod checkpoint_prefix_tests {
             .put_message(&own_commit_row(b"commit-a", 1))
             .unwrap();
         storage
-            .put_message(&own_commit_row(b"commit-a2", 1))
+            .put_message(&own_commit_row_with_checkpoint(b"commit-a2", 1, false))
             .unwrap();
 
         let prefix = checkpoint_realizable_own_commit_prefix(
             &storage,
-            &result_accepting(&[b"commit-a"]),
+            &result_accepting(&[b"commit-a2"]),
             &BTreeSet::new(),
         )
         .unwrap();
-        let realized = prefix.realized.expect("selected sibling should be exact");
-        assert_eq!(realized.resulting_epoch, 2);
-        assert_eq!(realized.id, checkpoint_id_for(b"commit-a"));
+        assert!(
+            prefix.realized.is_none(),
+            "a sibling at the same epoch must not resolve to another commit's checkpoint"
+        );
+        assert!(prefix.commit_ids.is_empty());
     }
 }

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -969,9 +969,17 @@ pub(crate) fn canonicalize_stored_openmls_messages_with_profile_policy<S: Storag
                 }
                 if record.state == MessageState::Processed {
                     own_commits.insert_canonical(projection.message_digest);
-                    if let Some(stamp) = own_commit_stamp {
-                        own_commits.insert_stamped(projection.message_digest, stamp);
-                    }
+                }
+                // The stamp is written only at confirm time, so its presence
+                // alone proves this is an own commit MLS cannot re-process.
+                // Register it independently of `Processed`: a pairwise
+                // CandidateWins resolution parks the displaced own incumbent
+                // `ConvergenceDeferred` (see `fork_recovery`), and replaying
+                // its branch still needs the stamp — the prefix-canonical
+                // guard at the stamp's use site keeps a diverging prefix from
+                // mis-realizing it.
+                if let Some(stamp) = own_commit_stamp {
+                    own_commits.insert_stamped(projection.message_digest, stamp);
                 }
                 commit_messages.push(StoredCommitMessage {
                     message,
@@ -1611,13 +1619,34 @@ pub(crate) fn apply_openmls_canonicalization_result_with_profile_policy<S: Stora
     // apply at all (MLS cannot re-process own commits), and it avoids
     // re-replaying history the live state already reflects.
     let applied_prefix = already_applied_commit_prefix(storage, result, current_epoch)?;
-    let apply_start_epoch =
-        apply_start_epoch_for_canonicalization_result(storage, result, &applied_prefix)?
-            .unwrap_or(current_epoch);
+    let has_new_commits = result.accepted_commits.len() > applied_prefix.len();
+    // A displaced own commit parked `ConvergenceDeferred` by a pairwise
+    // CandidateWins resolution (see `fork_recovery`) can head the selected
+    // branch WITHOUT being in the already-applied prefix. MLS cannot
+    // re-process own commits and this apply cannot nest the selection stage's
+    // per-commit anchor rollforward, so realize such a leading run in one
+    // step: skip it from the replay and rewind to the retained anchor at the
+    // run's final resulting epoch — the exact post-merge state its last own
+    // commit produced.
+    let own_anchor_prefix =
+        anchor_realizable_own_commit_prefix(storage, group_id, result, &applied_prefix)?;
+    let mut skipped_prefix = applied_prefix;
+    skipped_prefix.extend(own_anchor_prefix.commit_ids.iter().cloned());
+    let apply_start_epoch = match own_anchor_prefix.resulting_epoch {
+        Some(epoch) => epoch,
+        None => apply_start_epoch_for_canonicalization_result(storage, result, &skipped_prefix)?
+            .unwrap_or(current_epoch),
+    };
+    // The own-anchor case must rewind even when the anchor epoch equals the
+    // live tip epoch: the live tip is a DIFFERENT branch's state at that
+    // epoch (that is what displaced the own incumbent), while the retained
+    // anchor holds the own commit's post-merge state.
+    let rewind_to_retained_anchor =
+        apply_start_epoch < current_epoch || own_anchor_prefix.resulting_epoch.is_some();
     let replay_messages = replay_messages_for_canonicalization_result(
         storage,
         result,
-        &applied_prefix,
+        &skipped_prefix,
         apply_start_epoch,
     )?;
     let live_message_records = storage
@@ -1626,13 +1655,17 @@ pub(crate) fn apply_openmls_canonicalization_result_with_profile_policy<S: Stora
     let live_queued_outbound = storage
         .list_queued_outbound_intents(group_id)
         .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
-    let has_new_commits = result.accepted_commits.len() > applied_prefix.len();
     let snapshot = apply_snapshot_name(group_id, result);
     storage
         .create_group_snapshot(group_id, &snapshot)
         .map_err(|e| OpenMlsProjectionError::Snapshot(format!("{e:?}")))?;
 
-    let prepare_result = if has_new_commits && apply_start_epoch == current_epoch {
+    // Never refresh the current-epoch anchor when this apply is about to
+    // rewind to a retained anchor: in the own-anchor case the live tip and
+    // the rewind target share an epoch number, and retaining here would
+    // overwrite the own commit's post-merge state with the displacing
+    // branch's state before the rollback reads it.
+    let prepare_result = if has_new_commits && !rewind_to_retained_anchor {
         retain_current_group_epoch_snapshot(storage, group_id, max_retained_anchor_rewind)
     } else {
         Ok(())
@@ -1648,7 +1681,7 @@ pub(crate) fn apply_openmls_canonicalization_result_with_profile_policy<S: Stora
     // therefore returns to the pre-apply live state instead of committing an
     // older message/queue image and rebuilding it row by row.
     let apply_result = storage.with_transaction(|storage| {
-        if apply_start_epoch < current_epoch {
+        if rewind_to_retained_anchor {
             let anchor_snapshot = retained_anchor_snapshot_name(apply_start_epoch);
             storage
                 .rollback_group_to_snapshot(group_id, &anchor_snapshot)
@@ -1786,6 +1819,73 @@ fn apply_start_epoch_for_canonicalization_result<S: StorageProvider>(
     Ok(Some(record.epoch.0))
 }
 
+#[derive(Default)]
+struct AnchorRealizableOwnPrefix {
+    /// Selected-branch commit ids (hex) realized via the retained anchor
+    /// instead of replay.
+    commit_ids: BTreeSet<String>,
+    /// Resulting epoch of the run's last own commit — the retained-anchor
+    /// rewind target that realizes the whole run.
+    resulting_epoch: Option<u64>,
+}
+
+/// The leading run — after the already-applied prefix — of this device's own
+/// confirm-stamped commits on the selected branch, bounded to those whose
+/// resulting-epoch retained anchor still exists. Such commits reach the apply
+/// stage outside the applied prefix when a pairwise CandidateWins resolution
+/// parked a displaced own incumbent `ConvergenceDeferred` (see
+/// `fork_recovery`) and convergence later selected its regrown branch. MLS
+/// refuses to re-process own commits, so the apply realizes the run by
+/// rewinding to the retained anchor at its final resulting epoch — the exact
+/// post-merge state captured when the commit confirmed — mirroring the
+/// selection stage's stamp rollforward (`PrevalidatedOwnCommits`). The first
+/// commit that is not an anchor-realizable own commit ends the run; anything
+/// after it replays normally from that state.
+fn anchor_realizable_own_commit_prefix<S: StorageProvider>(
+    storage: &S,
+    group_id: &GroupId,
+    result: &CanonicalizationResult,
+    applied_prefix: &BTreeSet<String>,
+) -> Result<AnchorRealizableOwnPrefix, OpenMlsProjectionError> {
+    let mut prefix = AnchorRealizableOwnPrefix::default();
+    let mut snapshots: Option<Vec<String>> = None;
+    for commit_id in result
+        .accepted_commits
+        .iter()
+        .filter(|commit_id| !applied_prefix.contains(*commit_id))
+    {
+        let message_id = message_id_from_hex(commit_id)?;
+        let record = match storage.get_message(&message_id) {
+            Ok(record) => record,
+            Err(StorageError::NotFound) => break,
+            Err(e) => return Err(OpenMlsProjectionError::Storage(format!("{e:?}"))),
+        };
+        let Ok(payload) = StoredMessagePayload::decode(&record.payload) else {
+            break;
+        };
+        if payload.own_commit_stamp().is_none() {
+            break;
+        }
+        let resulting_epoch = record.epoch.0.saturating_add(1);
+        if snapshots.is_none() {
+            snapshots = Some(
+                storage
+                    .list_group_snapshots(group_id)
+                    .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?,
+            );
+        }
+        let retained = snapshots
+            .as_ref()
+            .is_some_and(|names| names.contains(&retained_anchor_snapshot_name(resulting_epoch)));
+        if !retained {
+            break;
+        }
+        prefix.commit_ids.insert(commit_id.clone());
+        prefix.resulting_epoch = Some(resulting_epoch);
+    }
+    Ok(prefix)
+}
+
 fn rollback_and_release_group_snapshot<S: StorageProvider>(
     storage: &S,
     group_id: &GroupId,
@@ -1913,9 +2013,11 @@ fn apply_openmls_canonicalization_result_inner<S: StorageProvider>(
     // transaction guards hard crashes mid-merge.
     storage.with_transaction(|storage| {
         // No pre-validated own commits here: snapshot rollforward cannot nest
-        // inside this transaction, and the already-applied prefix (which is
-        // where own commits can appear on an accepted branch) was excluded
-        // from `replay_messages` before this call.
+        // inside this transaction, and every own commit on the accepted
+        // branch was excluded from `replay_messages` before this call —
+        // either as part of the already-applied prefix or as an
+        // anchor-realizable own-commit run whose retained-anchor rewind the
+        // caller performs itself (`anchor_realizable_own_commit_prefix`).
         let output = process_openmls_messages_inner(
             storage,
             group_id,

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -1849,6 +1849,7 @@ fn anchor_realizable_own_commit_prefix<S: StorageProvider>(
 ) -> Result<AnchorRealizableOwnPrefix, OpenMlsProjectionError> {
     let mut prefix = AnchorRealizableOwnPrefix::default();
     let mut snapshots: Option<Vec<String>> = None;
+    let mut own_stamped_commit_ids_by_source_epoch: Option<BTreeMap<u64, Vec<Vec<u8>>>> = None;
     for commit_id in result
         .accepted_commits
         .iter()
@@ -1880,10 +1881,69 @@ fn anchor_realizable_own_commit_prefix<S: StorageProvider>(
         if !retained {
             break;
         }
+        // Retained anchors are keyed by resulting epoch ALONE
+        // (`openmls-retained-anchor-<epoch>`) and `create_group_snapshot`
+        // replaces a same-named snapshot. So a name match does not prove the
+        // anchor holds THIS commit's post-merge state: if a second own commit
+        // was later confirmed at the same resulting epoch — e.g. on the branch
+        // that displaced this one — its confirm overwrote the anchor, and
+        // rewinding here would install the wrong state while skipping replay.
+        // Re-keying the anchor scheme is out of scope (it is shared with the
+        // convergence engine), so resolve the ambiguity conservatively: when
+        // more than one own confirm-stamped commit row could have produced an
+        // anchor at this resulting epoch, refuse the fast path and end the
+        // run. The commit then replays normally, which fails closed and lets
+        // convergence prune. A missed fast path is far cheaper than a wrong
+        // rewind.
+        if own_stamped_commit_ids_by_source_epoch.is_none() {
+            own_stamped_commit_ids_by_source_epoch = Some(
+                own_stamped_commit_ids_by_source_epoch_map(storage, group_id)?,
+            );
+        }
+        let ambiguous_anchor_lineage =
+            own_stamped_commit_ids_by_source_epoch
+                .as_ref()
+                .is_some_and(|by_source_epoch| {
+                    by_source_epoch.get(&record.epoch.0).is_some_and(|ids| {
+                        ids.iter().any(|id| id.as_slice() != message_id.as_slice())
+                    })
+                });
+        if ambiguous_anchor_lineage {
+            break;
+        }
         prefix.commit_ids.insert(commit_id.clone());
         prefix.resulting_epoch = Some(resulting_epoch);
     }
     Ok(prefix)
+}
+
+/// Every stored own confirm-stamped commit row for the group, indexed by the
+/// row's source epoch (its resulting epoch minus one — the key a retained
+/// anchor is named after). Used to detect anchor-lineage ambiguity in
+/// [`anchor_realizable_own_commit_prefix`]. Rows are counted regardless of
+/// state: the retained anchor is written at CONFIRM time, so even a row that
+/// convergence later parked or invalidated may have overwritten it.
+fn own_stamped_commit_ids_by_source_epoch_map<S: StorageProvider>(
+    storage: &S,
+    group_id: &GroupId,
+) -> Result<BTreeMap<u64, Vec<Vec<u8>>>, OpenMlsProjectionError> {
+    let mut by_source_epoch: BTreeMap<u64, Vec<Vec<u8>>> = BTreeMap::new();
+    let records = storage
+        .list_messages(group_id, EpochId(0))
+        .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
+    for record in records {
+        let Ok(payload) = StoredMessagePayload::decode(&record.payload) else {
+            continue;
+        };
+        if payload.own_commit_stamp().is_none() {
+            continue;
+        }
+        by_source_epoch
+            .entry(record.epoch.0)
+            .or_default()
+            .push(record.id.as_slice().to_vec());
+    }
+    Ok(by_source_epoch)
 }
 
 fn rollback_and_release_group_snapshot<S: StorageProvider>(
@@ -3125,5 +3185,191 @@ mod reuse_scope_tests {
         // Reuse also requires the BFS to have materialized every candidate path;
         // a partial materialization falls back to a full replay even app-free.
         assert!(!can_reuse_bfs_materialization(false, 2, 3));
+    }
+}
+
+#[cfg(test)]
+mod anchor_prefix_lineage_tests {
+    use super::{
+        AnchorRealizableOwnPrefix, anchor_realizable_own_commit_prefix,
+        retained_anchor_snapshot_name,
+    };
+    use crate::canonicalization::{CanonicalizationResult, ConvergenceStatus};
+    use cgka_traits::engine::CommitOrderingPriority;
+    use cgka_traits::group::{Group, ProtocolProfile};
+    use cgka_traits::message::{
+        MessageRecord, MessageState, OwnCommitConvergenceStamp, StoredMessagePayload,
+    };
+    use cgka_traits::storage::{GroupStorage, MessageStorage};
+    use cgka_traits::transport::{Timestamp, TransportEnvelope, TransportMessage, TransportSource};
+    use cgka_traits::types::{EpochId, GroupId, MemberId, MessageId};
+    use std::collections::BTreeSet;
+    use storage_sqlite::SqliteAccountStorage;
+
+    fn group_id() -> GroupId {
+        GroupId::new(vec![7u8; 32])
+    }
+
+    fn own_commit_row(id: &[u8], source_epoch: u64) -> MessageRecord {
+        let message = TransportMessage {
+            id: MessageId::new(id.to_vec()),
+            // The prefix scan never parses MLS bytes; only the stored
+            // envelope's stamp presence and the row's epoch matter here.
+            payload: id.to_vec(),
+            timestamp: Timestamp(0),
+            causal_deps: Vec::new(),
+            source: TransportSource("test".into()),
+            envelope: TransportEnvelope::GroupMessage {
+                transport_group_id: group_id().as_slice().to_vec(),
+            },
+        };
+        let stamp = OwnCommitConvergenceStamp {
+            committer: MemberId::new(vec![1u8; 32]),
+            priority: CommitOrderingPriority::Privileged,
+            consumed_proposal_refs: Vec::new(),
+        };
+        MessageRecord {
+            id: MessageId::new(id.to_vec()),
+            group_id: group_id(),
+            epoch: EpochId(source_epoch),
+            state: MessageState::ConvergenceDeferred,
+            payload: StoredMessagePayload::own_commit_wire(message, stamp)
+                .encode()
+                .unwrap(),
+            deferred_peel: None,
+        }
+    }
+
+    fn result_accepting(commit_ids: &[&[u8]]) -> CanonicalizationResult {
+        CanonicalizationResult {
+            previous_tip: 2,
+            selected_tip: Some(2),
+            selected_fork_epoch: Some(1),
+            selected_branch_id: Some("branch".into()),
+            candidate_count: 1,
+            eligible_count: 1,
+            convergence_status: ConvergenceStatus::Settled,
+            accepted_commits: commit_ids.iter().map(hex::encode).collect(),
+            accepted_proposals: Vec::new(),
+            accepted_app_messages: Vec::new(),
+            deferred_messages: Vec::new(),
+            invalidated_app_messages: Vec::new(),
+            dropped_messages: Vec::new(),
+            already_seen: Vec::new(),
+            queued_outbound_intents: Vec::new(),
+            publishable_outbound_messages: Vec::new(),
+            errors: Vec::new(),
+            #[cfg(feature = "test-conformance-snapshot")]
+            replay_probe_count: 0,
+            selection_trace: None,
+        }
+    }
+
+    fn storage_with_anchor_at_epoch_2() -> SqliteAccountStorage {
+        let storage = SqliteAccountStorage::in_memory().unwrap();
+        storage
+            .put_group(&Group {
+                id: group_id(),
+                name: "anchor-lineage".into(),
+                description: String::new(),
+                epoch: EpochId(2),
+                members: Vec::new(),
+                required_capabilities: Default::default(),
+                protocol_profile: ProtocolProfile::Legacy,
+                removed: false,
+                unrecoverable: false,
+                disbanded: None,
+                join_epoch: EpochId(0),
+            })
+            .unwrap();
+        storage
+            .create_group_snapshot(&group_id(), &retained_anchor_snapshot_name(2))
+            .unwrap();
+        storage
+    }
+
+    #[test]
+    fn unambiguous_own_commit_uses_the_retained_anchor_fast_path() {
+        // Baseline for the regression below: exactly one own confirm-stamped
+        // commit row at source epoch 1, so the `openmls-retained-anchor-2`
+        // snapshot can only hold THAT commit's post-merge state.
+        let storage = storage_with_anchor_at_epoch_2();
+        storage
+            .put_message(&own_commit_row(b"commit-a", 1))
+            .unwrap();
+
+        let prefix = anchor_realizable_own_commit_prefix(
+            &storage,
+            &group_id(),
+            &result_accepting(&[b"commit-a"]),
+            &BTreeSet::new(),
+        )
+        .unwrap();
+        assert_eq!(prefix.resulting_epoch, Some(2));
+        assert!(prefix.commit_ids.contains(&hex::encode(b"commit-a")));
+    }
+
+    #[test]
+    fn same_epoch_own_commit_overwrite_refuses_the_anchor_fast_path() {
+        // Retained anchors are named by resulting epoch alone and
+        // `create_group_snapshot` REPLACES a same-named snapshot. When a
+        // second own commit is confirmed at the same resulting epoch — e.g.
+        // the displacing branch's own commit after the first was parked by a
+        // pairwise CandidateWins — `openmls-retained-anchor-2` no longer
+        // provably holds commit-a's post-merge state.
+        //
+        // Safe outcome asserted here: the fast path REFUSES the anchor (empty
+        // prefix, no resulting epoch), so the apply falls back to pre-existing
+        // behavior — normal replay, which fails closed on an own commit and
+        // lets convergence prune the branch. The unsafe outcome this guards
+        // against is a silent rewind to the OTHER commit's state with replay
+        // skipped.
+        let storage = storage_with_anchor_at_epoch_2();
+        storage
+            .put_message(&own_commit_row(b"commit-a", 1))
+            .unwrap();
+        storage
+            .put_message(&own_commit_row(b"commit-a2", 1))
+            .unwrap();
+
+        let prefix = anchor_realizable_own_commit_prefix(
+            &storage,
+            &group_id(),
+            &result_accepting(&[b"commit-a"]),
+            &BTreeSet::new(),
+        )
+        .unwrap();
+        assert_eq!(
+            prefix.resulting_epoch,
+            AnchorRealizableOwnPrefix::default().resulting_epoch,
+            "ambiguous anchor lineage must not yield a rewind target"
+        );
+        assert!(
+            prefix.commit_ids.is_empty(),
+            "ambiguous anchor lineage must not realize any commit via the anchor"
+        );
+    }
+
+    #[test]
+    fn own_commit_at_a_different_source_epoch_does_not_create_ambiguity() {
+        // Only rows that could have produced an anchor at the SAME resulting
+        // epoch are ambiguous; an own commit from another epoch names a
+        // different anchor and must not disable the fast path.
+        let storage = storage_with_anchor_at_epoch_2();
+        storage
+            .put_message(&own_commit_row(b"commit-a", 1))
+            .unwrap();
+        storage
+            .put_message(&own_commit_row(b"commit-b", 5))
+            .unwrap();
+
+        let prefix = anchor_realizable_own_commit_prefix(
+            &storage,
+            &group_id(),
+            &result_accepting(&[b"commit-a"]),
+            &BTreeSet::new(),
+        )
+        .unwrap();
+        assert_eq!(prefix.resulting_epoch, Some(2));
     }
 }

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -1706,10 +1706,9 @@ pub(crate) fn apply_openmls_canonicalization_result_with_profile_policy<S: Stora
     // CandidateWins resolution (see `fork_recovery`) can head the selected
     // branch WITHOUT being in the already-applied prefix. MLS cannot
     // re-process own commits and this apply cannot nest the selection stage's
-    // per-commit anchor rollforward, so realize such a leading run in one
-    // step: skip it from the replay and rewind to the retained anchor at the
-    // run's final resulting epoch — the exact post-merge state its last own
-    // commit produced.
+    // per-commit checkpoint rollforward, so realize such a leading run in one
+    // step: skip it from the replay and restore the commit-addressed checkpoint
+    // for the run's final own commit — the exact post-merge state it produced.
     let own_checkpoint_prefix =
         checkpoint_realizable_own_commit_prefix(storage, result, &applied_prefix)?;
     let mut skipped_prefix = applied_prefix;
@@ -2102,9 +2101,10 @@ fn prune_group_state_checkpoints<S: StorageProvider>(
         if checkpoint.resulting_epoch.0 >= oldest_retained_epoch {
             continue;
         }
-        storage
-            .release_group_state_checkpoint(group_id, &checkpoint.id)
-            .map_err(|e| OpenMlsProjectionError::Snapshot(format!("{e:?}")))?;
+        match storage.release_group_state_checkpoint(group_id, &checkpoint.id) {
+            Ok(()) | Err(StorageError::SnapshotMissing(_)) => {}
+            Err(e) => return Err(OpenMlsProjectionError::Snapshot(format!("{e:?}"))),
+        }
     }
     Ok(())
 }

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -338,6 +338,13 @@ pub enum OpenMlsProjectionError {
     Storage(String),
     InvalidPolicy(String),
     ReplayBudgetExceeded,
+    /// A retained-anchor rewind meant to realize a parked own commit landed on
+    /// state that does not match the fingerprint that commit stamped at
+    /// confirm time: the name-keyed anchor was replaced by another branch's
+    /// capture at the same epoch. The apply is aborted and rolled back rather
+    /// than installing the wrong lineage. See
+    /// [`verify_rewound_anchor_lineage`] for the liveness consequence.
+    AnchorLineageMismatch,
 }
 
 impl std::fmt::Display for OpenMlsProjectionError {
@@ -381,6 +388,12 @@ impl std::fmt::Display for OpenMlsProjectionError {
             }
             OpenMlsProjectionError::ReplayBudgetExceeded => {
                 write!(f, "convergence replay budget exceeded")
+            }
+            OpenMlsProjectionError::AnchorLineageMismatch => {
+                write!(
+                    f,
+                    "retained anchor does not hold the parked own commit's post-merge state"
+                )
             }
         }
     }
@@ -443,6 +456,11 @@ impl PrevalidatedOwnCommits {
 /// Build the convergence ordering stamp for a staged local commit, captured
 /// while the staged commit is still attached (confirm time). See
 /// [`cgka_traits::message::OwnCommitConvergenceStamp`].
+///
+/// `post_commit_tree_marker` is left `None` here and filled in by the caller
+/// once the staged commit has been MERGED: the marker fingerprints the state
+/// the commit PRODUCES, which does not exist yet while the commit is merely
+/// staged. See [`own_commit_post_merge_tree_marker`].
 pub(crate) fn own_commit_stamp(
     staged: &openmls::group::StagedCommit,
     committer: MemberId,
@@ -459,7 +477,22 @@ pub(crate) fn own_commit_stamp(
         committer,
         priority,
         consumed_proposal_refs,
+        post_commit_tree_marker: None,
     })
+}
+
+/// Fingerprint the state an own commit produced, for
+/// [`cgka_traits::message::OwnCommitConvergenceStamp::post_commit_tree_marker`].
+///
+/// Call with the group AFTER `merge_pending_commit`. The ciphersuite is read
+/// from the group itself so the value recomputed at rewind time (which has no
+/// engine handle) is derived from exactly the same inputs.
+pub(crate) fn own_commit_post_merge_tree_marker(
+    merged: &MlsGroup,
+) -> Result<String, cgka_traits::error::EngineError> {
+    Ok(hex::encode(
+        crate::group_lifecycle::compute_validated_tree_marker(merged, merged.ciphersuite())?,
+    ))
 }
 
 /// Give retained proposal rows the same terminal disposition when a local
@@ -1660,12 +1693,18 @@ pub(crate) fn apply_openmls_canonicalization_result_with_profile_policy<S: Stora
         .create_group_snapshot(group_id, &snapshot)
         .map_err(|e| OpenMlsProjectionError::Snapshot(format!("{e:?}")))?;
 
-    // Never refresh the current-epoch anchor when this apply is about to
-    // rewind to a retained anchor: in the own-anchor case the live tip and
-    // the rewind target share an epoch number, and retaining here would
-    // overwrite the own commit's post-merge state with the displacing
-    // branch's state before the rollback reads it.
-    let prepare_result = if has_new_commits && !rewind_to_retained_anchor {
+    // Refresh the current-epoch anchor only in the case that always did:
+    // there are new commits AND the apply starts at the live tip. The extra
+    // `own_anchor_prefix.resulting_epoch.is_none()` term is what this branch
+    // adds, and only that: in the own-anchor case the live tip and the rewind
+    // target share an epoch number, so retaining here would overwrite the own
+    // commit's post-merge state with the displacing branch's state before the
+    // rollback reads it. `apply_start_epoch > current_epoch` stays skipped,
+    // exactly as before.
+    let prepare_result = if has_new_commits
+        && apply_start_epoch == current_epoch
+        && own_anchor_prefix.resulting_epoch.is_none()
+    {
         retain_current_group_epoch_snapshot(storage, group_id, max_retained_anchor_rewind)
     } else {
         Ok(())
@@ -1686,6 +1725,19 @@ pub(crate) fn apply_openmls_canonicalization_result_with_profile_policy<S: Stora
             storage
                 .rollback_group_to_snapshot(group_id, &anchor_snapshot)
                 .map_err(|e| OpenMlsProjectionError::Snapshot(format!("{e:?}")))?;
+            // Positive proof that the anchor held the parked own commit's
+            // post-merge state, taken only now — nothing before the rewind can
+            // distinguish a clobbered anchor from a good one (the anchor name
+            // encodes only the epoch). This runs inside the apply transaction
+            // and BEFORE any replay, so a mismatch unwinds the rewind with the
+            // live state untouched; the caller additionally rolls back to the
+            // pre-apply snapshot.
+            if let Some(expected_marker) = own_anchor_prefix
+                .expected_post_commit_tree_marker
+                .as_deref()
+            {
+                verify_rewound_anchor_lineage(storage, group_id, expected_marker)?;
+            }
             restore_live_message_and_queue_records(
                 storage,
                 &live_message_records,
@@ -1827,6 +1879,12 @@ struct AnchorRealizableOwnPrefix {
     /// Resulting epoch of the run's last own commit — the retained-anchor
     /// rewind target that realizes the whole run.
     resulting_epoch: Option<u64>,
+    /// Hex `post_commit_tree_marker` stamped by the run's LAST own commit:
+    /// the fingerprint the rewound state must reproduce for the rewind to be
+    /// proven on that commit's lineage. `Some` exactly when
+    /// `resulting_epoch` is `Some` — the scan refuses to extend the run past a
+    /// commit whose stamp carries no marker.
+    expected_post_commit_tree_marker: Option<String>,
 }
 
 /// The leading run — after the already-applied prefix — of this device's own
@@ -1841,6 +1899,19 @@ struct AnchorRealizableOwnPrefix {
 /// selection stage's stamp rollforward (`PrevalidatedOwnCommits`). The first
 /// commit that is not an anchor-realizable own commit ends the run; anything
 /// after it replays normally from that state.
+///
+/// ## Anchor identity is NOT established here
+///
+/// Retained anchors are named by resulting epoch ALONE
+/// (`openmls-retained-anchor-<N>`) and every `retain_current_group_epoch_snapshot`
+/// call at that epoch REPLACES the previous one (`INSERT OR REPLACE`). Those
+/// callers include every inbound-commit merge, so a PEER commit that merely
+/// lands on epoch N silently clobbers an own commit's anchor while leaving no
+/// own-stamped row behind. No scan over stored rows can detect that, so this
+/// function does not try: it only assembles the CANDIDATE run and the
+/// fingerprint the rewound state must reproduce. The binding check is
+/// [`verify_rewound_anchor_lineage`], run after the rewind, inside the apply
+/// transaction.
 fn anchor_realizable_own_commit_prefix<S: StorageProvider>(
     storage: &S,
     group_id: &GroupId,
@@ -1849,7 +1920,6 @@ fn anchor_realizable_own_commit_prefix<S: StorageProvider>(
 ) -> Result<AnchorRealizableOwnPrefix, OpenMlsProjectionError> {
     let mut prefix = AnchorRealizableOwnPrefix::default();
     let mut snapshots: Option<Vec<String>> = None;
-    let mut own_stamped_commit_ids_by_source_epoch: Option<BTreeMap<u64, Vec<Vec<u8>>>> = None;
     for commit_id in result
         .accepted_commits
         .iter()
@@ -1864,9 +1934,16 @@ fn anchor_realizable_own_commit_prefix<S: StorageProvider>(
         let Ok(payload) = StoredMessagePayload::decode(&record.payload) else {
             break;
         };
-        if payload.own_commit_stamp().is_none() {
+        // The stamp must carry the post-merge fingerprint of the state this
+        // commit produced. Rows stamped before that field existed cannot be
+        // proven against the anchor, so they end the run and fall back to
+        // normal replay (which fails closed on an own commit).
+        let Some(expected_marker) = payload
+            .own_commit_stamp()
+            .and_then(|stamp| stamp.post_commit_tree_marker.clone())
+        else {
             break;
-        }
+        };
         let resulting_epoch = record.epoch.0.saturating_add(1);
         if snapshots.is_none() {
             snapshots = Some(
@@ -1881,69 +1958,59 @@ fn anchor_realizable_own_commit_prefix<S: StorageProvider>(
         if !retained {
             break;
         }
-        // Retained anchors are keyed by resulting epoch ALONE
-        // (`openmls-retained-anchor-<epoch>`) and `create_group_snapshot`
-        // replaces a same-named snapshot. So a name match does not prove the
-        // anchor holds THIS commit's post-merge state: if a second own commit
-        // was later confirmed at the same resulting epoch — e.g. on the branch
-        // that displaced this one — its confirm overwrote the anchor, and
-        // rewinding here would install the wrong state while skipping replay.
-        // Re-keying the anchor scheme is out of scope (it is shared with the
-        // convergence engine), so resolve the ambiguity conservatively: when
-        // more than one own confirm-stamped commit row could have produced an
-        // anchor at this resulting epoch, refuse the fast path and end the
-        // run. The commit then replays normally, which fails closed and lets
-        // convergence prune. A missed fast path is far cheaper than a wrong
-        // rewind.
-        if own_stamped_commit_ids_by_source_epoch.is_none() {
-            own_stamped_commit_ids_by_source_epoch = Some(
-                own_stamped_commit_ids_by_source_epoch_map(storage, group_id)?,
-            );
-        }
-        let ambiguous_anchor_lineage =
-            own_stamped_commit_ids_by_source_epoch
-                .as_ref()
-                .is_some_and(|by_source_epoch| {
-                    by_source_epoch.get(&record.epoch.0).is_some_and(|ids| {
-                        ids.iter().any(|id| id.as_slice() != message_id.as_slice())
-                    })
-                });
-        if ambiguous_anchor_lineage {
-            break;
-        }
         prefix.commit_ids.insert(commit_id.clone());
         prefix.resulting_epoch = Some(resulting_epoch);
+        prefix.expected_post_commit_tree_marker = Some(expected_marker);
     }
     Ok(prefix)
 }
 
-/// Every stored own confirm-stamped commit row for the group, indexed by the
-/// row's source epoch (its resulting epoch minus one — the key a retained
-/// anchor is named after). Used to detect anchor-lineage ambiguity in
-/// [`anchor_realizable_own_commit_prefix`]. Rows are counted regardless of
-/// state: the retained anchor is written at CONFIRM time, so even a row that
-/// convergence later parked or invalidated may have overwritten it.
-fn own_stamped_commit_ids_by_source_epoch_map<S: StorageProvider>(
+/// Prove that a completed retained-anchor rewind landed on the lineage of the
+/// own commit the rewind was meant to realize.
+///
+/// Anchors are name-keyed by resulting epoch and are replaced by EVERY capture
+/// at that epoch — `retain_current_group_epoch_snapshot` runs before each
+/// inbound-commit merge, after each apply, and on each own confirm — so the
+/// anchor named for epoch N may hold a rival branch's state instead. Nothing
+/// observable before the rewind distinguishes the two cases, so this is a
+/// POSITIVE identity check taken after it: recompute the content-bound tree
+/// marker over the rewound group and require it to equal the fingerprint the
+/// parked commit stamped at confirm time. Only the exact ratchet tree that
+/// commit produced can match.
+///
+/// Must be called INSIDE the apply transaction: a mismatch returns `Err`, the
+/// transaction (which the SQLite snapshot rollback joins) unwinds, and the
+/// caller additionally rolls the group back to the pre-apply snapshot — so a
+/// failed proof leaves live state untouched.
+///
+/// LIVENESS LIMITATION (deliberate, not papered over): when the anchor HAS
+/// been clobbered, the parked own commit can no longer be realized AT ALL. The
+/// anchor rewind is its only route — MLS `process_message` refuses this
+/// device's own commits, so normal replay cannot materialize it either. This
+/// node therefore fails closed and stays diverged from the branch the rest of
+/// the fleet selected until the rewind horizon retires the parked row
+/// (`BeyondRollbackHorizon` / `beyond_retained_anchor`), after which it
+/// reorgs onto whatever remains selectable. Correctness is preserved — no
+/// wrong lineage is ever installed — but liveness inside that window is not.
+/// Restoring it requires re-keying retained anchors by content rather than by
+/// epoch, which is shared with the convergence engine and out of scope here.
+fn verify_rewound_anchor_lineage<S: StorageProvider>(
     storage: &S,
     group_id: &GroupId,
-) -> Result<BTreeMap<u64, Vec<Vec<u8>>>, OpenMlsProjectionError> {
-    let mut by_source_epoch: BTreeMap<u64, Vec<Vec<u8>>> = BTreeMap::new();
-    let records = storage
-        .list_messages(group_id, EpochId(0))
-        .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
-    for record in records {
-        let Ok(payload) = StoredMessagePayload::decode(&record.payload) else {
-            continue;
-        };
-        if payload.own_commit_stamp().is_none() {
-            continue;
-        }
-        by_source_epoch
-            .entry(record.epoch.0)
-            .or_default()
-            .push(record.id.as_slice().to_vec());
+    expected_marker: &str,
+) -> Result<(), OpenMlsProjectionError> {
+    let crypto = RustCrypto::default();
+    let provider = EngineOpenMlsProvider::<S>::new(&crypto, storage.mls_storage());
+    let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
+    let mls_group = MlsGroup::load(provider.storage(), &mls_gid)
+        .map_err(|e| OpenMlsProjectionError::Snapshot(format!("load rewound anchor group: {e:?}")))?
+        .ok_or(OpenMlsProjectionError::MissingGroup)?;
+    let actual = own_commit_post_merge_tree_marker(&mls_group)
+        .map_err(|e| OpenMlsProjectionError::Snapshot(format!("{e}")))?;
+    if actual == expected_marker {
+        return Ok(());
     }
-    Ok(by_source_epoch)
+    Err(OpenMlsProjectionError::AnchorLineageMismatch)
 }
 
 fn rollback_and_release_group_snapshot<S: StorageProvider>(
@@ -3210,11 +3277,27 @@ mod anchor_prefix_lineage_tests {
         GroupId::new(vec![7u8; 32])
     }
 
+    /// Marker string a row claims its post-merge state fingerprints to. The
+    /// scan only propagates it; the value is proven against the real rewound
+    /// tree in `verify_rewound_anchor_lineage` (covered end-to-end by the
+    /// `fork_detection` integration tests, which need a real MLS group).
+    fn marker_for(id: &[u8]) -> String {
+        format!("marker-{}", hex::encode(id))
+    }
+
     fn own_commit_row(id: &[u8], source_epoch: u64) -> MessageRecord {
+        own_commit_row_with_marker(id, source_epoch, Some(marker_for(id)))
+    }
+
+    fn own_commit_row_with_marker(
+        id: &[u8],
+        source_epoch: u64,
+        post_commit_tree_marker: Option<String>,
+    ) -> MessageRecord {
         let message = TransportMessage {
             id: MessageId::new(id.to_vec()),
             // The prefix scan never parses MLS bytes; only the stored
-            // envelope's stamp presence and the row's epoch matter here.
+            // envelope's stamp and the row's epoch matter here.
             payload: id.to_vec(),
             timestamp: Timestamp(0),
             causal_deps: Vec::new(),
@@ -3227,6 +3310,7 @@ mod anchor_prefix_lineage_tests {
             committer: MemberId::new(vec![1u8; 32]),
             priority: CommitOrderingPriority::Privileged,
             consumed_proposal_refs: Vec::new(),
+            post_commit_tree_marker,
         };
         MessageRecord {
             id: MessageId::new(id.to_vec()),
@@ -3289,10 +3373,11 @@ mod anchor_prefix_lineage_tests {
     }
 
     #[test]
-    fn unambiguous_own_commit_uses_the_retained_anchor_fast_path() {
-        // Baseline for the regression below: exactly one own confirm-stamped
-        // commit row at source epoch 1, so the `openmls-retained-anchor-2`
-        // snapshot can only hold THAT commit's post-merge state.
+    fn stamped_own_commit_proposes_the_anchor_fast_path_with_its_marker() {
+        // A confirm-stamped own commit whose stamp carries the post-merge tree
+        // marker is a fast-path CANDIDATE: the scan proposes the rewind target
+        // and hands the apply the fingerprint it must reproduce after the
+        // rewind. The scan itself never claims the anchor is the right one.
         let storage = storage_with_anchor_at_epoch_2();
         storage
             .put_message(&own_commit_row(b"commit-a", 1))
@@ -3307,23 +3392,88 @@ mod anchor_prefix_lineage_tests {
         .unwrap();
         assert_eq!(prefix.resulting_epoch, Some(2));
         assert!(prefix.commit_ids.contains(&hex::encode(b"commit-a")));
+        assert_eq!(
+            prefix.expected_post_commit_tree_marker,
+            Some(marker_for(b"commit-a")),
+            "the apply must be given the marker to verify the rewind against"
+        );
     }
 
     #[test]
-    fn same_epoch_own_commit_overwrite_refuses_the_anchor_fast_path() {
-        // Retained anchors are named by resulting epoch alone and
-        // `create_group_snapshot` REPLACES a same-named snapshot. When a
-        // second own commit is confirmed at the same resulting epoch — e.g.
-        // the displacing branch's own commit after the first was parked by a
-        // pairwise CandidateWins — `openmls-retained-anchor-2` no longer
-        // provably holds commit-a's post-merge state.
-        //
-        // Safe outcome asserted here: the fast path REFUSES the anchor (empty
-        // prefix, no resulting epoch), so the apply falls back to pre-existing
-        // behavior — normal replay, which fails closed on an own commit and
-        // lets convergence prune the branch. The unsafe outcome this guards
-        // against is a silent rewind to the OTHER commit's state with replay
-        // skipped.
+    fn own_commit_without_a_post_merge_marker_refuses_the_anchor_fast_path() {
+        // Rows stamped by engine versions that predate
+        // `post_commit_tree_marker` carry no fingerprint, so a rewind to the
+        // name-keyed anchor could never be PROVEN to land on their lineage.
+        // Refuse the fast path outright: the apply falls back to normal
+        // replay, which fails closed on an own commit
+        // (`process_message` refuses them) and lets convergence prune.
+        let storage = storage_with_anchor_at_epoch_2();
+        storage
+            .put_message(&own_commit_row_with_marker(b"commit-a", 1, None))
+            .unwrap();
+
+        let prefix = anchor_realizable_own_commit_prefix(
+            &storage,
+            &group_id(),
+            &result_accepting(&[b"commit-a"]),
+            &BTreeSet::new(),
+        )
+        .unwrap();
+        assert_eq!(
+            prefix.resulting_epoch,
+            AnchorRealizableOwnPrefix::default().resulting_epoch,
+            "an unprovable anchor must not yield a rewind target"
+        );
+        assert!(
+            prefix.commit_ids.is_empty(),
+            "an unprovable anchor must not realize any commit"
+        );
+        assert!(prefix.expected_post_commit_tree_marker.is_none());
+    }
+
+    #[test]
+    fn a_run_of_own_commits_verifies_against_the_last_ones_marker() {
+        // The whole run is realized by a single rewind to the LAST own
+        // commit's resulting epoch, so that commit's marker — not the first's
+        // — is what the rewound state must reproduce.
+        let storage = storage_with_anchor_at_epoch_2();
+        storage
+            .create_group_snapshot(&group_id(), &retained_anchor_snapshot_name(3))
+            .unwrap();
+        storage
+            .put_message(&own_commit_row(b"commit-a", 1))
+            .unwrap();
+        storage
+            .put_message(&own_commit_row(b"commit-a-next", 2))
+            .unwrap();
+
+        let prefix = anchor_realizable_own_commit_prefix(
+            &storage,
+            &group_id(),
+            &result_accepting(&[b"commit-a", b"commit-a-next"]),
+            &BTreeSet::new(),
+        )
+        .unwrap();
+        assert_eq!(prefix.commit_ids.len(), 2);
+        assert_eq!(prefix.resulting_epoch, Some(3));
+        assert_eq!(
+            prefix.expected_post_commit_tree_marker,
+            Some(marker_for(b"commit-a-next"))
+        );
+    }
+
+    #[test]
+    fn a_second_own_row_at_the_same_epoch_no_longer_gates_the_scan() {
+        // Deliberate behavior change. An earlier revision refused the fast
+        // path whenever more than one own confirm-stamped row shared a source
+        // epoch, on the theory that a second own confirm may have clobbered
+        // the name-keyed anchor. That under-approximation was unsound in both
+        // directions: a PEER commit that merely lands on the epoch also
+        // replaces the anchor (`retain_current_group_epoch_snapshot` runs
+        // before every inbound merge) while leaving no own row behind, so
+        // row-counting missed the real clobber — and it refused provable cases
+        // like this one for nothing. The scan now stays permissive and the
+        // apply proves anchor identity positively after the rewind.
         let storage = storage_with_anchor_at_epoch_2();
         storage
             .put_message(&own_commit_row(b"commit-a", 1))
@@ -3339,37 +3489,11 @@ mod anchor_prefix_lineage_tests {
             &BTreeSet::new(),
         )
         .unwrap();
-        assert_eq!(
-            prefix.resulting_epoch,
-            AnchorRealizableOwnPrefix::default().resulting_epoch,
-            "ambiguous anchor lineage must not yield a rewind target"
-        );
-        assert!(
-            prefix.commit_ids.is_empty(),
-            "ambiguous anchor lineage must not realize any commit via the anchor"
-        );
-    }
-
-    #[test]
-    fn own_commit_at_a_different_source_epoch_does_not_create_ambiguity() {
-        // Only rows that could have produced an anchor at the SAME resulting
-        // epoch are ambiguous; an own commit from another epoch names a
-        // different anchor and must not disable the fast path.
-        let storage = storage_with_anchor_at_epoch_2();
-        storage
-            .put_message(&own_commit_row(b"commit-a", 1))
-            .unwrap();
-        storage
-            .put_message(&own_commit_row(b"commit-b", 5))
-            .unwrap();
-
-        let prefix = anchor_realizable_own_commit_prefix(
-            &storage,
-            &group_id(),
-            &result_accepting(&[b"commit-a"]),
-            &BTreeSet::new(),
-        )
-        .unwrap();
         assert_eq!(prefix.resulting_epoch, Some(2));
+        assert_eq!(
+            prefix.expected_post_commit_tree_marker,
+            Some(marker_for(b"commit-a")),
+            "identity is decided by commit-a's own marker, not by row counts"
+        );
     }
 }

--- a/crates/cgka-engine/src/publish.rs
+++ b/crates/cgka-engine/src/publish.rs
@@ -159,6 +159,21 @@ impl<S: StorageProvider> Engine<S> {
                         .merge_pending_commit(&tx_provider)
                         .map_err(|e| EngineError::Backend(format!("merge_pending: {e:?}")))?;
                     crate::app_components::validate_current_profile_group_invariants(&mls_group)?;
+                    // Fingerprint the state this commit just PRODUCED. The
+                    // retained anchor captured below is name-keyed by resulting
+                    // epoch and is REPLACED by every later capture at that
+                    // epoch, so an anchor's name never proves whose post-merge
+                    // state it holds. This marker is what lets a later
+                    // retained-anchor rewind positively verify it landed on
+                    // this commit's lineage
+                    // (`openmls_projection::verify_rewound_anchor_lineage`).
+                    if let Some(stamp) = own_commit_stamp.as_mut() {
+                        stamp.post_commit_tree_marker = Some(
+                            crate::openmls_projection::own_commit_post_merge_tree_marker(
+                                &mls_group,
+                            )?,
+                        );
+                    }
                 }
 
                 // Now the MLS group is at the new epoch. Mirror the Marmot

--- a/crates/cgka-engine/src/publish.rs
+++ b/crates/cgka-engine/src/publish.rs
@@ -140,6 +140,14 @@ impl<S: StorageProvider> Engine<S> {
                             staged,
                             self.identity.self_id().clone(),
                         )?);
+                        if let (Some(stamp), Some(message_id)) =
+                            (own_commit_stamp.as_mut(), origin_commit_id.as_ref())
+                        {
+                            stamp.checkpoint_id =
+                                Some(crate::openmls_projection::own_commit_checkpoint_id(
+                                    storage, message_id,
+                                )?);
+                        }
                     }
                     let source_epoch = EpochId(mls_group.epoch().as_u64());
                     crate::openmls_projection::mark_consumed_proposal_records_processed(
@@ -159,19 +167,11 @@ impl<S: StorageProvider> Engine<S> {
                         .merge_pending_commit(&tx_provider)
                         .map_err(|e| EngineError::Backend(format!("merge_pending: {e:?}")))?;
                     crate::app_components::validate_current_profile_group_invariants(&mls_group)?;
-                    // Fingerprint the state this commit just PRODUCED. The
-                    // retained anchor captured below is name-keyed by resulting
-                    // epoch and is REPLACED by every later capture at that
-                    // epoch, so an anchor's name never proves whose post-merge
-                    // state it holds. This marker is what lets a later
-                    // retained-anchor rewind positively verify it landed on
-                    // this commit's lineage
-                    // (`openmls_projection::verify_rewound_anchor_lineage`).
                     if let Some(stamp) = own_commit_stamp.as_mut() {
-                        stamp.post_commit_tree_marker = Some(
-                            crate::openmls_projection::own_commit_post_merge_tree_marker(
+                        stamp.resulting_epoch_authenticator = Some(
+                            crate::openmls_projection::own_commit_post_merge_epoch_authenticator(
                                 &mls_group,
-                            )?,
+                            ),
                         );
                     }
                 }
@@ -199,6 +199,17 @@ impl<S: StorageProvider> Engine<S> {
                     self.identity.self_id(),
                     self.ciphersuite,
                 )?;
+                if let Some(stamp) = own_commit_stamp.as_ref()
+                    && let Some(checkpoint_id) = stamp.checkpoint_id.as_ref()
+                {
+                    storage.create_group_state_checkpoint(
+                        &group_id,
+                        &cgka_traits::storage::GroupStateCheckpointRef {
+                            id: checkpoint_id.clone(),
+                            resulting_epoch: EpochId(mls_group.epoch().as_u64()),
+                        },
+                    )?;
+                }
                 if let Some(message_id) = origin_commit_id.as_ref() {
                     // Enrich the stored wire record with the convergence stamp
                     // (when one was captured above) in the same write that marks

--- a/crates/cgka-engine/tests/auto_commit_atomicity.rs
+++ b/crates/cgka-engine/tests/auto_commit_atomicity.rs
@@ -33,10 +33,11 @@ use cgka_traits::peeler::TransportPeeler;
 use cgka_traits::storage::{
     AccountDeviceSignerBinding, AccountDeviceSignerStorage, CapabilityStorage,
     ConvergencePassStorage, ConvergencePolicyStorage, DisbandCandidate, DisbandCandidateStorage,
-    DisbandRequest, DisbandRequestStorage, DisbandTombstoneStorage, GroupStorage,
-    KeyPackageBundleStorage, LeaveRequest, LeaveRequestStorage, MemberValidationCacheStorage,
-    MessageStorage, OutboundFanoutStorage, OutboundIntentStorage, QueuedOutboundIntent,
-    StorageError, StorageProvider, StorageResult, StoredKeyPackageBundle, WelcomeStorage,
+    DisbandRequest, DisbandRequestStorage, DisbandTombstoneStorage, GroupStateCheckpointRef,
+    GroupStorage, KeyPackageBundleStorage, LeaveRequest, LeaveRequestStorage,
+    MemberValidationCacheStorage, MessageStorage, OutboundFanoutStorage, OutboundIntentStorage,
+    QueuedOutboundIntent, StorageError, StorageProvider, StorageResult, StoredKeyPackageBundle,
+    WelcomeStorage,
 };
 use cgka_traits::transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
@@ -274,6 +275,36 @@ impl MessageStorage for FaultStorage {
     }
     fn release_group_snapshot(&self, group_id: &GroupId, name: &str) -> StorageResult<()> {
         self.inner.release_group_snapshot(group_id, name)
+    }
+    fn create_group_state_checkpoint(
+        &self,
+        group_id: &GroupId,
+        checkpoint: &GroupStateCheckpointRef,
+    ) -> StorageResult<()> {
+        self.inner
+            .create_group_state_checkpoint(group_id, checkpoint)
+    }
+    fn restore_group_state_checkpoint(
+        &self,
+        group_id: &GroupId,
+        checkpoint_id: &str,
+    ) -> StorageResult<()> {
+        self.inner
+            .restore_group_state_checkpoint(group_id, checkpoint_id)
+    }
+    fn list_group_state_checkpoints(
+        &self,
+        group_id: &GroupId,
+    ) -> StorageResult<Vec<GroupStateCheckpointRef>> {
+        self.inner.list_group_state_checkpoints(group_id)
+    }
+    fn release_group_state_checkpoint(
+        &self,
+        group_id: &GroupId,
+        checkpoint_id: &str,
+    ) -> StorageResult<()> {
+        self.inner
+            .release_group_state_checkpoint(group_id, checkpoint_id)
     }
 }
 

--- a/crates/cgka-engine/tests/fork_detection.rs
+++ b/crates/cgka-engine/tests/fork_detection.rs
@@ -178,6 +178,19 @@ fn reopen_current_client(id: &[u8], storage: SqliteAccountStorage) -> Engine<Sql
     engine
 }
 
+fn reopen_legacy_client(id: &[u8], storage: SqliteAccountStorage) -> Engine<SqliteAccountStorage> {
+    let mut engine = EngineBuilder::new(storage)
+        .legacy_compatibility_profile()
+        .identity(pad32(id))
+        .account_identity_proof_signer(proof_signer(id))
+        .feature_registry(selfremove_registry())
+        .peeler(Box::new(MockPeeler))
+        .build()
+        .unwrap();
+    engine.hydrate_stable_groups_from_storage().unwrap();
+    engine
+}
+
 fn raw_self_update_commit(
     storage: &SqliteAccountStorage,
     sender: &MemberId,
@@ -1833,35 +1846,12 @@ async fn pairwise_candidate_win_leaves_old_incumbent_reconsiderable() {
 }
 
 #[tokio::test]
-async fn pairwise_candidate_win_with_rival_follow_on_fails_closed_not_wrong_lineage() {
-    // Variant of `pairwise_candidate_win_leaves_old_incumbent_reconsiderable`
-    // with ONE extra commit on the winning (rival) branch between the
-    // displacement and the A-branch follow-on. That single commit is what
-    // breaks the retained-anchor fast path, because retained anchors are
-    // name-keyed by resulting epoch (`openmls-retained-anchor-<N>`) and every
-    // capture at that epoch REPLACES the previous one — including the captures
-    // `ingest` takes around each inbound merge. Applying the rival's follow-on
-    // therefore overwrites the anchor that held X's parked own commit A's
-    // post-merge state, with no own-stamped row left behind to notice it.
-    //
-    // What this test pins down is the SAFE outcome. The apply rewinds to the
-    // anchor, recomputes the content-bound tree marker, finds it does not match
-    // the marker A stamped at confirm time, and aborts — the rewind is rolled
-    // back and X keeps its existing (rival-branch) state. The unsafe outcome
-    // this guards against is the one the positive check replaced: silently
-    // adopting whatever the clobbered anchor happens to hold, i.e. installing a
-    // lineage that never existed on any node.
-    //
-    // NOTE — this is the clobbered-anchor LIVENESS limitation, not a
-    // silent-corruption path. Once the anchor is gone, the parked own commit
-    // cannot be realized at all: the anchor rewind is its only route, since MLS
-    // `process_message` refuses this device's own commits, so normal replay
-    // cannot materialize it either. X therefore fails closed and stays on its
-    // own branch, diverged from the fleet, until the rewind horizon retires the
-    // parked row and it reorgs onto whatever remains selectable. Correctness is
-    // preserved; liveness inside that window is not. Restoring it needs
-    // content-keyed retained anchors, which is shared with the convergence
-    // engine and out of scope for this fix.
+async fn own_commit_checkpoint_survives_rival_anchor_overwrite_and_restart() {
+    // X confirms A, loses pairwise to B, and advances B far enough to replace
+    // every epoch-named anchor that previously described A.  After a restart,
+    // A grows deeper. X must cross its own path-bearing commit without asking
+    // OpenMLS to process the wire echo: the immutable commit-addressed
+    // checkpoint restores A's exact post-merge state and replay continues.
     use cgka_traits::ingest::IngestOutcome;
 
     let first = b"cwrf-first".as_slice();
@@ -2006,6 +1996,18 @@ async fn pairwise_candidate_win_with_rival_follow_on_fails_closed_not_wrong_line
         3,
         "X must apply the rival's follow-on on the branch it rolled onto"
     );
+    assert_eq!(
+        x_storage
+            .list_group_state_checkpoints(&group_id)
+            .unwrap()
+            .len(),
+        1,
+        "the own-commit checkpoint must not alias the rival's epoch anchor"
+    );
+
+    // Prove checkpoint identity and the own-commit stamp survive hydration.
+    drop(x);
+    let mut x = reopen_legacy_client(x_id, x_storage.clone());
 
     // (3) Y settles A and grows the A-branch two commits deeper, so distributed
     // convergence unambiguously prefers it (depth 3 vs the rival branch's 2)
@@ -2046,9 +2048,8 @@ async fn pairwise_candidate_win_with_rival_follow_on_fails_closed_not_wrong_line
     };
     assert_eq!(y.epoch(&group_id).unwrap().0, 4);
 
-    // (4) X ingests the deeper A-branch. Convergence selects it, the apply
-    // reaches the retained-anchor fast path for the parked own commit A, and
-    // the post-rewind marker check refuses it.
+    // (4) X ingests the deeper A-branch. Convergence selects it, restores A's
+    // commit-addressed checkpoint, then replays both peer-authored descendants.
     let outcome = x.ingest(route(follow_on)).await.unwrap();
     assert!(
         matches!(outcome, IngestOutcome::Buffered { .. }),
@@ -2059,38 +2060,42 @@ async fn pairwise_candidate_win_with_rival_follow_on_fails_closed_not_wrong_line
         matches!(outcome_2, IngestOutcome::Buffered { .. }),
         "the second A-branch follow-on must enter the convergence pass, got {outcome_2:?}"
     );
-    let converge = x.converge_stored_openmls_messages_at(&group_id, u64::MAX);
+    let convergence = x
+        .converge_stored_openmls_messages_at(&group_id, u64::MAX)
+        .expect("the deeper A branch must be realizable after restart");
 
-    // Whatever convergence reports, the invariant is the same: X must NOT be
-    // holding a state assembled from the clobbered anchor.
     let x_members: Vec<_> = x
         .members(&group_id)
         .unwrap()
         .iter()
         .map(|m| m.id.clone())
         .collect();
-    assert!(
-        !x_members.contains(&MemberId::new(pad32(b"cwrf-david"))),
-        "X must not silently install the A-branch it cannot prove it rewound to; \
-         members were {x_members:?}, convergence returned {converge:?}"
+    let y_members: Vec<_> = y
+        .members(&group_id)
+        .unwrap()
+        .iter()
+        .map(|m| m.id.clone())
+        .collect();
+    assert_eq!(
+        x_members,
+        y_members,
+        "X and Y must converge after restart; X epoch {:?}, result {convergence:?}",
+        x.epoch(&group_id)
     );
-    assert!(
-        x_members.contains(&MemberId::new(pad32(b"cwrf-eve")))
-            && x_members.contains(&MemberId::new(pad32(b"cwrf-heidi"))),
-        "X must keep the intact branch it was already on; members were {x_members:?}"
-    );
+    assert!(x_members.contains(&MemberId::new(pad32(b"cwrf-david"))));
+    assert!(x_members.contains(&MemberId::new(pad32(b"cwrf-frank"))));
+    assert!(x_members.contains(&MemberId::new(pad32(b"cwrf-grace"))));
+    assert!(!x_members.contains(&MemberId::new(pad32(b"cwrf-eve"))));
+    assert!(!x_members.contains(&MemberId::new(pad32(b"cwrf-heidi"))));
     assert_eq!(
         x.epoch(&group_id).unwrap().0,
-        3,
-        "the refused rewind must leave X's live epoch untouched"
+        4,
+        "X must reach the selected A-branch tip"
     );
-    // The parked own commit is still reconsiderable: nothing terminalized it,
-    // so once the horizon retires it (or a future engine key anchors by
-    // content) X is free to reorg.
-    let still_parked = x_storage.get_message(&commit_a.id).unwrap();
+    let realized = x_storage.get_message(&commit_a.id).unwrap();
     assert_eq!(
-        still_parked.state,
-        MessageState::ConvergenceDeferred,
-        "failing closed must not terminalize the parked own commit"
+        realized.state,
+        MessageState::Processed,
+        "the restored own commit must become canonical"
     );
 }

--- a/crates/cgka-engine/tests/fork_detection.rs
+++ b/crates/cgka-engine/tests/fork_detection.rs
@@ -2149,18 +2149,20 @@ async fn own_commit_checkpoint_survives_rival_anchor_overwrite_and_restart() {
         .converge_stored_openmls_messages_at(&group_id, u64::MAX)
         .expect("the deeper A branch must be realizable after restart");
 
-    let x_members: Vec<_> = x
+    let mut x_members: Vec<_> = x
         .members(&group_id)
         .unwrap()
         .iter()
         .map(|m| m.id.clone())
         .collect();
-    let y_members: Vec<_> = y
+    let mut y_members: Vec<_> = y
         .members(&group_id)
         .unwrap()
         .iter()
         .map(|m| m.id.clone())
         .collect();
+    x_members.sort_by(|a, b| a.as_slice().cmp(b.as_slice()));
+    y_members.sort_by(|a, b| a.as_slice().cmp(b.as_slice()));
     assert_eq!(
         x_members,
         y_members,

--- a/crates/cgka-engine/tests/fork_detection.rs
+++ b/crates/cgka-engine/tests/fork_detection.rs
@@ -8,7 +8,7 @@
 //! - Apply the winning commit and return to Stable
 
 use async_trait::async_trait;
-use cgka_engine::canonicalization::CanonicalizationPolicy;
+use cgka_engine::canonicalization::{CanonicalizationPolicy, ConvergenceStatus};
 use cgka_engine::convergence::ConvergencePolicy;
 use cgka_engine::feature_registry::FeatureRegistry;
 use cgka_engine::provider::EngineOpenMlsProvider;
@@ -648,10 +648,13 @@ async fn convergence_privileged_remove_beats_grinding_ordinary_self_update() {
 
 /// A peer's same-epoch commit that arrives during our own `PendingPublish`
 /// window is buffered `Retryable` before any peel. When our own commit confirms
-/// and wins the fork, replay must reclassify the buffered commit terminal: the
-/// content row lands `EpochInvalidated`, and the raw transport wrapper is
-/// retired `Processed` — not left `Retryable` to be re-peeled on every later
-/// publish-cycle replay.
+/// and wins the fork, replay must reclassify the buffered commit: the content
+/// row parks `ConvergenceDeferred` — reconsiderable, not terminal, because
+/// nodes that did not commit from that epoch resolve the same conflict through
+/// distributed convergence, where the rival branch can still win by growing
+/// deeper (see `pairwise_incumbent_defers_to_deeper_convergence_branch`) — and
+/// the raw transport wrapper is retired `Processed`, not left `Retryable` to be
+/// re-peeled on every later publish-cycle replay.
 #[tokio::test]
 async fn buffered_losing_fork_commit_raw_row_is_retired_after_confirm_replay() {
     use cgka_traits::ingest::IngestOutcome;
@@ -725,8 +728,10 @@ async fn buffered_losing_fork_commit_raw_row_is_retired_after_confirm_replay() {
 
     assert_eq!(
         alice_storage.get_message(&content_id).unwrap().state,
-        MessageState::EpochInvalidated,
-        "the losing fork commit's content row carries the real verdict"
+        MessageState::ConvergenceDeferred,
+        "the pairwise-losing fork commit's content row is parked reconsiderable \
+         (cross-seam: distributed convergence may still select its branch if it \
+         grows deeper), not terminally EpochInvalidated"
     );
     assert_eq!(
         alice_storage.get_message(&raw_id).unwrap().state,
@@ -1347,4 +1352,219 @@ async fn publish_failed_rollback_does_not_poison_fork_detection() {
         recovery_probe,
         SendResult::GroupEvolution { .. } | SendResult::Queued { .. }
     ));
+}
+
+#[tokio::test]
+async fn pairwise_incumbent_defers_to_deeper_convergence_branch() {
+    // Cross-seam divergence, as observed in multi-VM soak runs: a node that
+    // committed from epoch N resolves a same-epoch rival PAIRWISE
+    // (ForkRecoveryManager — ordering key only, depth-blind), while every
+    // node that did NOT commit from N resolves the same conflict through
+    // distributed convergence, where a deeper valid branch outranks the
+    // ordering key. If the pairwise loser is invalidated terminally, the
+    // pairwise node can never follow the fleet onto the rival branch once
+    // that branch grows — a permanent lineage split in which each side keeps
+    // decrypting only its own history.
+    //
+    // This test drives the exact sequence: the pairwise winner must first
+    // reject the rival root (incumbent wins on the ordering key), then
+    // CONVERGE onto the rival branch after a follow-on commit makes it the
+    // deeper valid branch.
+    use cgka_traits::ingest::{IngestOutcome, StaleReason};
+
+    // Fix which identity wins the pairwise race up front (privileged admin
+    // commits at the same epoch order by committer identity).
+    let first = b"seam-first".as_slice();
+    let second = b"seam-second".as_slice();
+    let (winner_id, loser_id) = if pad32(first) < pad32(second) {
+        (first, second)
+    } else {
+        (second, first)
+    };
+
+    // Concrete Engine type: the test drives the convergence pass to
+    // completion explicitly (`converge_stored_openmls_messages_at`), which is
+    // not part of the CgkaEngine trait surface.
+    let (mut winner, _winner_storage) = build_client_with_storage(winner_id); // pairwise incumbent-keeper
+    let mut loser = build_client(loser_id); //  rival whose branch grows deeper
+    let mut david = build_client(b"seam-david");
+    let mut eve = build_client(b"seam-eve");
+    let mut frank = build_client(b"seam-frank");
+
+    let loser_kp = loser.fresh_key_package().await.unwrap();
+    let (group_id, create) = winner
+        .create_group(CreateGroupRequest {
+            name: "cross-seam".into(),
+            description: String::new(),
+            members: vec![loser_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![loser.self_id()],
+        })
+        .await
+        .unwrap();
+    let welcome = match create {
+        SendResult::GroupCreated {
+            pending,
+            mut welcomes,
+        } => {
+            winner.confirm_published(pending).await.unwrap();
+            welcomes.remove(0)
+        }
+        _ => unreachable!(),
+    };
+    loser.join_welcome(welcome).await.unwrap();
+    assert_eq!(winner.epoch(&group_id).unwrap().0, 1);
+    assert_eq!(loser.epoch(&group_id).unwrap().0, 1);
+
+    let route = |msg: TransportMessage| TransportMessage {
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+        ..msg
+    };
+
+    // Rival commits from epoch 1: the winner invites david, the loser invites
+    // eve. Neither sees the other's commit yet.
+    let david_kp = david.fresh_key_package().await.unwrap();
+    let eve_kp = eve.fresh_key_package().await.unwrap();
+    let winner_invite = winner
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![david_kp],
+        })
+        .await
+        .unwrap();
+    let loser_invite = loser
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![eve_kp],
+        })
+        .await
+        .unwrap();
+    let (winner_commit, loser_root) = match (&winner_invite, &loser_invite) {
+        (
+            SendResult::GroupEvolution { msg: w, pending: wp, .. },
+            SendResult::GroupEvolution { msg: l, pending: lp, .. },
+        ) => {
+            let (w, l, wp, lp) = (w.clone(), l.clone(), *wp, *lp);
+            winner.confirm_published(wp).await.unwrap();
+            loser.confirm_published(lp).await.unwrap();
+            (w, l)
+        }
+        _ => unreachable!(),
+    };
+    let winner_key = CommitOrderingKey::from_commit_bytes(
+        EpochId(1),
+        CommitOrderingPriority::Privileged,
+        MemberId::new(pad32(winner_id)),
+        &winner_commit.payload,
+    );
+    let loser_key = CommitOrderingKey::from_commit_bytes(
+        EpochId(1),
+        CommitOrderingPriority::Privileged,
+        MemberId::new(pad32(loser_id)),
+        &loser_root.payload,
+    );
+    assert!(
+        winner_key < loser_key,
+        "identity choice must make the incumbent win the pairwise race"
+    );
+
+    // Seam 1 on the winner: the rival root LOSES the pairwise race. The
+    // winner keeps its own branch (no ForkRecovered), and — the fix under
+    // test — the loser's root must stay reconsiderable, not terminally
+    // invalidated.
+    let outcome = winner.ingest(route(loser_root.clone())).await.unwrap();
+    assert!(matches!(
+        outcome,
+        IngestOutcome::Stale {
+            reason: StaleReason::AlreadyAtEpoch { .. }
+        }
+    ));
+    let events = winner.drain_events();
+    assert!(
+        extract_fork_recovered(&events, &group_id).is_none(),
+        "incumbent-wins must not roll the winner back"
+    );
+    assert_eq!(winner.epoch(&group_id).unwrap().0, 2);
+
+    // The loser's branch grows deeper: a follow-on invite from ITS epoch 2.
+    let frank_kp = frank.fresh_key_package().await.unwrap();
+    let loser_follow_on = match loser
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![frank_kp],
+        })
+        .await
+        .unwrap()
+    {
+        SendResult::GroupEvolution { msg, pending, .. } => {
+            loser.confirm_published(pending).await.unwrap();
+            msg
+        }
+        _ => unreachable!(),
+    };
+    assert_eq!(loser.epoch(&group_id).unwrap().0, 3);
+
+    // Seam 2 on the winner: the follow-on commit routes into distributed
+    // convergence, which must now select the rival branch (valid depth 2 from
+    // the fork point vs the winner's own depth 1) and rewind the winner onto
+    // it — the same branch every convergence-only node picks. Before the fix
+    // the rival root was `EpochInvalidated` and could never be materialized,
+    // so the winner stayed on its own lineage forever.
+    let follow_on_outcome = winner.ingest(route(loser_follow_on)).await.unwrap();
+    assert!(
+        matches!(follow_on_outcome, IngestOutcome::Buffered { .. }),
+        "the rival follow-on must enter the convergence pass, got {follow_on_outcome:?}"
+    );
+    // Drive the pass past its quiescence window (production wnd gets here via
+    // the passage of time); the deeper rival branch must now be selected.
+    let result = winner
+        .converge_stored_openmls_messages_at(&group_id, u64::MAX)
+        .expect("cross-seam reorg onto the deeper rival branch");
+    assert_eq!(result.convergence_status, ConvergenceStatus::Settled);
+
+    assert_eq!(
+        winner.epoch(&group_id).unwrap().0,
+        3,
+        "winner must converge onto the deeper rival branch"
+    );
+    let winner_members: Vec<_> = winner
+        .members(&group_id)
+        .unwrap()
+        .iter()
+        .map(|m| m.id.clone())
+        .collect();
+    assert!(
+        winner_members.contains(&MemberId::new(pad32(b"seam-eve"))),
+        "rival branch's first invitee must be present after convergence"
+    );
+    assert!(
+        winner_members.contains(&MemberId::new(pad32(b"seam-frank"))),
+        "rival branch's second invitee must be present after convergence"
+    );
+    assert!(
+        !winner_members.contains(&MemberId::new(pad32(b"seam-david"))),
+        "the abandoned pairwise branch's invitee must be gone"
+    );
+    let loser_members: Vec<_> = loser
+        .members(&group_id)
+        .unwrap()
+        .iter()
+        .map(|m| m.id.clone())
+        .collect();
+    assert_eq!(
+        {
+            let mut w = winner_members.clone();
+            w.sort_by(|a, b| a.as_slice().cmp(b.as_slice()));
+            w
+        },
+        {
+            let mut l = loser_members.clone();
+            l.sort_by(|a, b| a.as_slice().cmp(b.as_slice()));
+            l
+        },
+        "both nodes must end on the identical branch"
+    );
 }

--- a/crates/cgka-engine/tests/fork_detection.rs
+++ b/crates/cgka-engine/tests/fork_detection.rs
@@ -1831,3 +1831,266 @@ async fn pairwise_candidate_win_leaves_old_incumbent_reconsiderable() {
         "X and Y must end on the identical branch"
     );
 }
+
+#[tokio::test]
+async fn pairwise_candidate_win_with_rival_follow_on_fails_closed_not_wrong_lineage() {
+    // Variant of `pairwise_candidate_win_leaves_old_incumbent_reconsiderable`
+    // with ONE extra commit on the winning (rival) branch between the
+    // displacement and the A-branch follow-on. That single commit is what
+    // breaks the retained-anchor fast path, because retained anchors are
+    // name-keyed by resulting epoch (`openmls-retained-anchor-<N>`) and every
+    // capture at that epoch REPLACES the previous one — including the captures
+    // `ingest` takes around each inbound merge. Applying the rival's follow-on
+    // therefore overwrites the anchor that held X's parked own commit A's
+    // post-merge state, with no own-stamped row left behind to notice it.
+    //
+    // What this test pins down is the SAFE outcome. The apply rewinds to the
+    // anchor, recomputes the content-bound tree marker, finds it does not match
+    // the marker A stamped at confirm time, and aborts — the rewind is rolled
+    // back and X keeps its existing (rival-branch) state. The unsafe outcome
+    // this guards against is the one the positive check replaced: silently
+    // adopting whatever the clobbered anchor happens to hold, i.e. installing a
+    // lineage that never existed on any node.
+    //
+    // NOTE — this is the clobbered-anchor LIVENESS limitation, not a
+    // silent-corruption path. Once the anchor is gone, the parked own commit
+    // cannot be realized at all: the anchor rewind is its only route, since MLS
+    // `process_message` refuses this device's own commits, so normal replay
+    // cannot materialize it either. X therefore fails closed and stays on its
+    // own branch, diverged from the fleet, until the rewind horizon retires the
+    // parked row and it reorgs onto whatever remains selectable. Correctness is
+    // preserved; liveness inside that window is not. Restoring it needs
+    // content-keyed retained anchors, which is shared with the convergence
+    // engine and out of scope for this fix.
+    use cgka_traits::ingest::IngestOutcome;
+
+    let first = b"cwrf-first".as_slice();
+    let second = b"cwrf-second".as_slice();
+    let (rival_id, x_id) = if pad32(first) < pad32(second) {
+        (first, second)
+    } else {
+        (second, first)
+    };
+
+    let (mut x, x_storage) = build_client_with_storage(x_id);
+    let mut rival = build_client(rival_id);
+    let (mut y, _y_storage) = build_client_with_storage(b"cwrf-y");
+    let mut david = build_client(b"cwrf-david");
+    let mut eve = build_client(b"cwrf-eve");
+    let mut frank = build_client(b"cwrf-frank");
+    let mut grace = build_client(b"cwrf-grace");
+    let mut heidi = build_client(b"cwrf-heidi");
+
+    let rival_kp = rival.fresh_key_package().await.unwrap();
+    let y_kp = y.fresh_key_package().await.unwrap();
+    let (group_id, create) = x
+        .create_group(CreateGroupRequest {
+            name: "candidate-win-rival-follow-on".into(),
+            description: String::new(),
+            members: vec![rival_kp, y_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![rival.self_id(), y.self_id()],
+        })
+        .await
+        .unwrap();
+    let (rival_welcome, y_welcome) = match create {
+        SendResult::GroupCreated {
+            pending,
+            mut welcomes,
+        } => {
+            x.confirm_published(pending).await.unwrap();
+            let y_welcome = welcomes.remove(1);
+            (welcomes.remove(0), y_welcome)
+        }
+        _ => unreachable!(),
+    };
+    rival.join_welcome(rival_welcome).await.unwrap();
+    y.join_welcome(y_welcome).await.unwrap();
+
+    let route = |msg: TransportMessage| TransportMessage {
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+        ..msg
+    };
+
+    // (1) X's own commit A and the rival's competing B, both from epoch 1.
+    let david_kp = david.fresh_key_package().await.unwrap();
+    let eve_kp = eve.fresh_key_package().await.unwrap();
+    let commit_a = match x
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![david_kp],
+        })
+        .await
+        .unwrap()
+    {
+        SendResult::GroupEvolution { msg, pending, .. } => {
+            x.confirm_published(pending).await.unwrap();
+            msg
+        }
+        _ => unreachable!(),
+    };
+    let commit_b = match rival
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![eve_kp],
+        })
+        .await
+        .unwrap()
+    {
+        SendResult::GroupEvolution { msg, pending, .. } => {
+            rival.confirm_published(pending).await.unwrap();
+            msg
+        }
+        _ => unreachable!(),
+    };
+    let a_key = CommitOrderingKey::from_commit_bytes(
+        EpochId(1),
+        CommitOrderingPriority::Privileged,
+        MemberId::new(pad32(x_id)),
+        &commit_a.payload,
+    );
+    let b_key = CommitOrderingKey::from_commit_bytes(
+        EpochId(1),
+        CommitOrderingPriority::Privileged,
+        MemberId::new(pad32(rival_id)),
+        &commit_b.payload,
+    );
+    assert!(
+        b_key < a_key,
+        "the inbound candidate must win the pairwise race"
+    );
+
+    // (2) B wins at X; A is parked reconsiderable at its source epoch.
+    x.ingest(route(commit_b)).await.unwrap();
+    let events = x.drain_events();
+    extract_fork_recovered(&events, &group_id).expect("candidate win must roll X back onto B");
+    assert_eq!(x.epoch(&group_id).unwrap().0, 2);
+    let parked = x_storage.get_message(&commit_a.id).unwrap();
+    assert_eq!(parked.state, MessageState::ConvergenceDeferred);
+    assert_eq!(parked.epoch, EpochId(1));
+
+    // (2b) THE EXTRA COMMIT. The rival extends its own winning branch and X
+    // applies it normally. X's merge of this commit re-captures
+    // `openmls-retained-anchor-2` at the pre-merge epoch — clobbering the
+    // capture that held A's post-merge state. Nothing about the anchor's NAME
+    // changes, and no own-stamped row records the overwrite.
+    let heidi_kp = heidi.fresh_key_package().await.unwrap();
+    let rival_follow_on = match rival
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![heidi_kp],
+        })
+        .await
+        .unwrap()
+    {
+        SendResult::GroupEvolution { msg, pending, .. } => {
+            rival.confirm_published(pending).await.unwrap();
+            msg
+        }
+        _ => unreachable!(),
+    };
+    x.ingest(route(rival_follow_on)).await.unwrap();
+    x.drain_events();
+    // The parked A row keeps a convergence pass live, so the rival's follow-on
+    // routes through convergence rather than the linear pending replay. Drive
+    // the pass: it selects the rival branch (depth 2 vs A's 1) and applies the
+    // follow-on — and THAT apply is what re-captures `openmls-retained-anchor-2`
+    // with the rival branch's state, over A's.
+    x.converge_stored_openmls_messages_at(&group_id, u64::MAX)
+        .expect("the rival follow-on settles on X's current branch");
+    assert_eq!(
+        x.epoch(&group_id).unwrap().0,
+        3,
+        "X must apply the rival's follow-on on the branch it rolled onto"
+    );
+
+    // (3) Y settles A and grows the A-branch two commits deeper, so distributed
+    // convergence unambiguously prefers it (depth 3 vs the rival branch's 2)
+    // and X is asked to reorg onto a branch rooted at its own parked commit A.
+    y.ingest(route(commit_a.clone())).await.unwrap();
+    y.converge_stored_openmls_messages_at(&group_id, u64::MAX)
+        .expect("A settles on Y through convergence");
+    assert_eq!(y.epoch(&group_id).unwrap().0, 2);
+    let frank_kp = frank.fresh_key_package().await.unwrap();
+    let follow_on = match y
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![frank_kp],
+        })
+        .await
+        .unwrap()
+    {
+        SendResult::GroupEvolution { msg, pending, .. } => {
+            y.confirm_published(pending).await.unwrap();
+            msg
+        }
+        _ => unreachable!(),
+    };
+    let grace_kp = grace.fresh_key_package().await.unwrap();
+    let follow_on_2 = match y
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![grace_kp],
+        })
+        .await
+        .unwrap()
+    {
+        SendResult::GroupEvolution { msg, pending, .. } => {
+            y.confirm_published(pending).await.unwrap();
+            msg
+        }
+        _ => unreachable!(),
+    };
+    assert_eq!(y.epoch(&group_id).unwrap().0, 4);
+
+    // (4) X ingests the deeper A-branch. Convergence selects it, the apply
+    // reaches the retained-anchor fast path for the parked own commit A, and
+    // the post-rewind marker check refuses it.
+    let outcome = x.ingest(route(follow_on)).await.unwrap();
+    assert!(
+        matches!(outcome, IngestOutcome::Buffered { .. }),
+        "the A-branch follow-on must enter the convergence pass, got {outcome:?}"
+    );
+    let outcome_2 = x.ingest(route(follow_on_2)).await.unwrap();
+    assert!(
+        matches!(outcome_2, IngestOutcome::Buffered { .. }),
+        "the second A-branch follow-on must enter the convergence pass, got {outcome_2:?}"
+    );
+    let converge = x.converge_stored_openmls_messages_at(&group_id, u64::MAX);
+
+    // Whatever convergence reports, the invariant is the same: X must NOT be
+    // holding a state assembled from the clobbered anchor.
+    let x_members: Vec<_> = x
+        .members(&group_id)
+        .unwrap()
+        .iter()
+        .map(|m| m.id.clone())
+        .collect();
+    assert!(
+        !x_members.contains(&MemberId::new(pad32(b"cwrf-david"))),
+        "X must not silently install the A-branch it cannot prove it rewound to; \
+         members were {x_members:?}, convergence returned {converge:?}"
+    );
+    assert!(
+        x_members.contains(&MemberId::new(pad32(b"cwrf-eve")))
+            && x_members.contains(&MemberId::new(pad32(b"cwrf-heidi"))),
+        "X must keep the intact branch it was already on; members were {x_members:?}"
+    );
+    assert_eq!(
+        x.epoch(&group_id).unwrap().0,
+        3,
+        "the refused rewind must leave X's live epoch untouched"
+    );
+    // The parked own commit is still reconsiderable: nothing terminalized it,
+    // so once the horizon retires it (or a future engine key anchors by
+    // content) X is free to reorg.
+    let still_parked = x_storage.get_message(&commit_a.id).unwrap();
+    assert_eq!(
+        still_parked.state,
+        MessageState::ConvergenceDeferred,
+        "failing closed must not terminalize the parked own commit"
+    );
+}

--- a/crates/cgka-engine/tests/fork_detection.rs
+++ b/crates/cgka-engine/tests/fork_detection.rs
@@ -1385,7 +1385,7 @@ async fn pairwise_incumbent_defers_to_deeper_convergence_branch() {
     // Concrete Engine type: the test drives the convergence pass to
     // completion explicitly (`converge_stored_openmls_messages_at`), which is
     // not part of the CgkaEngine trait surface.
-    let (mut winner, _winner_storage) = build_client_with_storage(winner_id); // pairwise incumbent-keeper
+    let (mut winner, winner_storage) = build_client_with_storage(winner_id); // pairwise incumbent-keeper
     let mut loser = build_client(loser_id); //  rival whose branch grows deeper
     let mut david = build_client(b"seam-david");
     let mut eve = build_client(b"seam-eve");
@@ -1496,6 +1496,25 @@ async fn pairwise_incumbent_defers_to_deeper_convergence_branch() {
         "incumbent-wins must not roll the winner back"
     );
     assert_eq!(winner.epoch(&group_id).unwrap().0, 2);
+    // The parked loser-root row IS the fix: `ConvergenceDeferred` (so branch
+    // materialization re-admits it) and keyed by its SOURCE epoch (the apply
+    // stage derives its retained-anchor rewind target from `record.epoch`; a
+    // current-epoch key would skip the rewind and fail replay).
+    let loser_root_content_id = {
+        use sha2::{Digest, Sha256};
+        MessageId::new(Sha256::digest(&loser_root.payload).to_vec())
+    };
+    let parked = winner_storage.get_message(&loser_root_content_id).unwrap();
+    assert_eq!(
+        parked.state,
+        MessageState::ConvergenceDeferred,
+        "the pairwise loser-root must be parked reconsiderable, not terminally invalidated"
+    );
+    assert_eq!(
+        parked.epoch,
+        EpochId(1),
+        "the parked loser-root must be keyed by its source epoch, not the winner's current epoch"
+    );
 
     // The loser's branch grows deeper: a follow-on invite from ITS epoch 2.
     let frank_kp = frank.fresh_key_package().await.unwrap();

--- a/crates/cgka-engine/tests/fork_detection.rs
+++ b/crates/cgka-engine/tests/fork_detection.rs
@@ -1595,3 +1595,239 @@ async fn pairwise_incumbent_defers_to_deeper_convergence_branch() {
         "both nodes must end on the identical branch"
     );
 }
+
+#[tokio::test]
+async fn pairwise_candidate_win_leaves_old_incumbent_reconsiderable() {
+    // The mirror of `pairwise_incumbent_defers_to_deeper_convergence_branch`,
+    // for the CANDIDATE-wins outcome of the pairwise race: node X's own
+    // confirmed commit A loses to an inbound rival B and X rolls back onto B
+    // (ForkRecovered). The displaced incumbent A must be parked
+    // `ConvergenceDeferred` at its SOURCE epoch — not terminally
+    // `EpochInvalidated` — because a peer that applied A and never saw B can
+    // keep extending the A-branch. Once that branch is deeper, distributed
+    // convergence selects it fleet-wide, and X can only follow if A's stored
+    // row (with its own-commit ordering stamp) is still convergence input.
+    use cgka_traits::ingest::IngestOutcome;
+
+    // Privileged same-epoch commits order by committer identity: the rival's
+    // identity must sort BEFORE X's so the inbound candidate B wins.
+    let first = b"cwin-first".as_slice();
+    let second = b"cwin-second".as_slice();
+    let (rival_id, x_id) = if pad32(first) < pad32(second) {
+        (first, second)
+    } else {
+        (second, first)
+    };
+
+    // Concrete Engine type: the test drives the convergence pass to
+    // completion explicitly (`converge_stored_openmls_messages_at`), which is
+    // not part of the CgkaEngine trait surface.
+    let (mut x, x_storage) = build_client_with_storage(x_id); // rolls back onto B, must later reorg onto A
+    let mut rival = build_client(rival_id); //                   authors the pairwise-winning B
+    let (mut y, _y_storage) = build_client_with_storage(b"cwin-y"); // applied A, never sees B
+    let mut david = build_client(b"cwin-david");
+    let mut eve = build_client(b"cwin-eve");
+    let mut frank = build_client(b"cwin-frank");
+
+    let rival_kp = rival.fresh_key_package().await.unwrap();
+    let y_kp = y.fresh_key_package().await.unwrap();
+    let (group_id, create) = x
+        .create_group(CreateGroupRequest {
+            name: "candidate-win-reconsider".into(),
+            description: String::new(),
+            members: vec![rival_kp, y_kp],
+            required_features: vec![],
+            app_components: vec![],
+            // Both peers need admin so their commits below pass the MIP-03
+            // committer guard (rival's rival root, Y's follow-on invite).
+            initial_admins: vec![rival.self_id(), y.self_id()],
+        })
+        .await
+        .unwrap();
+    let (rival_welcome, y_welcome) = match create {
+        SendResult::GroupCreated {
+            pending,
+            mut welcomes,
+        } => {
+            x.confirm_published(pending).await.unwrap();
+            let y_welcome = welcomes.remove(1);
+            (welcomes.remove(0), y_welcome)
+        }
+        _ => unreachable!(),
+    };
+    rival.join_welcome(rival_welcome).await.unwrap();
+    y.join_welcome(y_welcome).await.unwrap();
+    assert_eq!(x.epoch(&group_id).unwrap().0, 1);
+    assert_eq!(y.epoch(&group_id).unwrap().0, 1);
+
+    let route = |msg: TransportMessage| TransportMessage {
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+        ..msg
+    };
+
+    // (1) X commits from epoch 1 (commit A: invite david) and confirms — A is
+    // X's fork-recovery incumbent. (2)'s rival B (invite eve) branches from
+    // the same epoch without seeing A.
+    let david_kp = david.fresh_key_package().await.unwrap();
+    let eve_kp = eve.fresh_key_package().await.unwrap();
+    let commit_a = match x
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![david_kp],
+        })
+        .await
+        .unwrap()
+    {
+        SendResult::GroupEvolution { msg, pending, .. } => {
+            x.confirm_published(pending).await.unwrap();
+            msg
+        }
+        _ => unreachable!(),
+    };
+    let commit_b = match rival
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![eve_kp],
+        })
+        .await
+        .unwrap()
+    {
+        SendResult::GroupEvolution { msg, pending, .. } => {
+            rival.confirm_published(pending).await.unwrap();
+            msg
+        }
+        _ => unreachable!(),
+    };
+    let a_key = CommitOrderingKey::from_commit_bytes(
+        EpochId(1),
+        CommitOrderingPriority::Privileged,
+        MemberId::new(pad32(x_id)),
+        &commit_a.payload,
+    );
+    let b_key = CommitOrderingKey::from_commit_bytes(
+        EpochId(1),
+        CommitOrderingPriority::Privileged,
+        MemberId::new(pad32(rival_id)),
+        &commit_b.payload,
+    );
+    assert!(
+        b_key < a_key,
+        "identity choice must make the inbound candidate win the pairwise race"
+    );
+
+    // (2) B arrives at X and WINS: X rolls back off A onto B (ForkRecovered).
+    x.ingest(route(commit_b)).await.unwrap();
+    let events = x.drain_events();
+    let (source_epoch, recovered_epoch, winner, invalidated) =
+        extract_fork_recovered(&events, &group_id)
+            .expect("candidate win must roll X back and emit ForkRecovered");
+    assert_eq!(source_epoch.0, 1);
+    assert_eq!(recovered_epoch.0, 2);
+    assert_eq!(winner, &b_key);
+    assert_eq!(invalidated, &a_key);
+    assert_eq!(x.epoch(&group_id).unwrap().0, 2);
+
+    // The fix under test: the displaced incumbent A is parked reconsiderable
+    // at its SOURCE epoch, with its stored payload (own-commit convergence
+    // stamp) intact — not terminally `EpochInvalidated`, which would exclude
+    // it from every later convergence pass and freeze X off the A-branch.
+    let parked = x_storage.get_message(&commit_a.id).unwrap();
+    assert_eq!(
+        parked.state,
+        MessageState::ConvergenceDeferred,
+        "the pairwise-losing incumbent must be parked reconsiderable, not terminally invalidated"
+    );
+    assert_eq!(
+        parked.epoch,
+        EpochId(1),
+        "the parked incumbent must be keyed by its source epoch for the convergence rewind target"
+    );
+
+    // (3) Y applied A (and never sees B), then extends the A-branch with a
+    // follow-on invite from ITS epoch 2 — the A-branch is now depth 2. Y never
+    // committed from epoch 1, so A routes through Y's convergence pass; drive
+    // it past quiescence to settle A onto Y.
+    y.ingest(route(commit_a.clone())).await.unwrap();
+    y.converge_stored_openmls_messages_at(&group_id, u64::MAX)
+        .expect("A settles on Y through convergence");
+    assert_eq!(y.epoch(&group_id).unwrap().0, 2);
+    let frank_kp = frank.fresh_key_package().await.unwrap();
+    let follow_on = match y
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![frank_kp],
+        })
+        .await
+        .unwrap()
+    {
+        SendResult::GroupEvolution { msg, pending, .. } => {
+            y.confirm_published(pending).await.unwrap();
+            msg
+        }
+        _ => unreachable!(),
+    };
+    assert_eq!(y.epoch(&group_id).unwrap().0, 3);
+
+    // (4) X ingests the follow-on: source epoch 2 >= X's current epoch, so it
+    // routes into distributed convergence, which must select the DEEPER
+    // A-branch (depth 2 from the fork point vs B's depth 1) and reorg X onto
+    // it — the same branch every convergence-only node picks. Before the fix
+    // A's root was `EpochInvalidated` and could never be materialized, so X
+    // stayed on the B lineage forever.
+    let follow_on_outcome = x.ingest(route(follow_on)).await.unwrap();
+    assert!(
+        matches!(follow_on_outcome, IngestOutcome::Buffered { .. }),
+        "the A-branch follow-on must enter the convergence pass, got {follow_on_outcome:?}"
+    );
+    // Drive the pass past its quiescence window (production gets here via the
+    // passage of time); the deeper A-branch must now be selected.
+    let result = x
+        .converge_stored_openmls_messages_at(&group_id, u64::MAX)
+        .expect("reorg back onto the deeper A-branch");
+    assert_eq!(result.convergence_status, ConvergenceStatus::Settled);
+
+    assert_eq!(
+        x.epoch(&group_id).unwrap().0,
+        3,
+        "X must converge onto the deeper A-branch"
+    );
+    let x_members: Vec<_> = x
+        .members(&group_id)
+        .unwrap()
+        .iter()
+        .map(|m| m.id.clone())
+        .collect();
+    assert!(
+        x_members.contains(&MemberId::new(pad32(b"cwin-david"))),
+        "A-branch's first invitee must be present after convergence"
+    );
+    assert!(
+        x_members.contains(&MemberId::new(pad32(b"cwin-frank"))),
+        "A-branch's second invitee must be present after convergence"
+    );
+    assert!(
+        !x_members.contains(&MemberId::new(pad32(b"cwin-eve"))),
+        "the abandoned B-branch's invitee must be gone"
+    );
+    let y_members: Vec<_> = y
+        .members(&group_id)
+        .unwrap()
+        .iter()
+        .map(|m| m.id.clone())
+        .collect();
+    assert_eq!(
+        {
+            let mut a = x_members.clone();
+            a.sort_by(|a, b| a.as_slice().cmp(b.as_slice()));
+            a
+        },
+        {
+            let mut b = y_members.clone();
+            b.sort_by(|a, b| a.as_slice().cmp(b.as_slice()));
+            b
+        },
+        "X and Y must end on the identical branch"
+    );
+}

--- a/crates/cgka-engine/tests/fork_detection.rs
+++ b/crates/cgka-engine/tests/fork_detection.rs
@@ -8,9 +8,15 @@
 //! - Apply the winning commit and return to Stable
 
 use async_trait::async_trait;
-use cgka_engine::canonicalization::{CanonicalizationPolicy, ConvergenceStatus};
+use cgka_engine::canonicalization::{
+    CanonicalizationError, CanonicalizationPolicy, CanonicalizationState, ConvergenceStatus,
+};
 use cgka_engine::convergence::ConvergencePolicy;
 use cgka_engine::feature_registry::FeatureRegistry;
+use cgka_engine::openmls_projection::{
+    OpenMlsProjectionError, apply_openmls_canonicalization_result,
+    canonicalize_stored_openmls_messages,
+};
 use cgka_engine::provider::EngineOpenMlsProvider;
 use cgka_engine::{DEFAULT_CIPHERSUITE, Engine, EngineBuilder};
 use cgka_traits::capabilities::{Capability, CapabilityRequirement, Feature, RequirementLevel};
@@ -22,10 +28,11 @@ use cgka_traits::error::PeelerError;
 use cgka_traits::group::ProtocolProfile;
 use cgka_traits::group_context::GroupContextSnapshot;
 use cgka_traits::ingest::{PeeledContent, PeeledMessage};
-use cgka_traits::message::MessageState;
+use cgka_traits::message::{MessageState, StoredMessagePayload};
 use cgka_traits::peeler::TransportPeeler;
 use cgka_traits::storage::{
-    AccountDeviceSignerStorage, GroupStorage, MessageStorage, StorageProvider,
+    AccountDeviceSignerStorage, ConvergencePassStorage, GroupStorage, MessageStorage,
+    StorageProvider,
 };
 use cgka_traits::transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
@@ -35,6 +42,7 @@ use openmls::group::MlsGroup;
 use openmls_basic_credential::SignatureKeyPair;
 use openmls_rust_crypto::RustCrypto;
 use openmls_traits::OpenMlsProvider as _;
+use std::collections::BTreeSet;
 use storage_sqlite::SqliteAccountStorage;
 use tls_codec::Serialize as _;
 
@@ -71,6 +79,36 @@ fn hash_id(bytes: &[u8]) -> MessageId {
     let mut h = DefaultHasher::new();
     bytes.hash(&mut h);
     MessageId::new(h.finish().to_be_bytes().to_vec())
+}
+
+fn mutate_own_commit_stamp(
+    storage: &SqliteAccountStorage,
+    message_id: &MessageId,
+    mutate: impl FnOnce(&mut cgka_traits::message::OwnCommitConvergenceStamp),
+) {
+    let mut record = storage.get_message(message_id).unwrap();
+    let mut payload = StoredMessagePayload::decode(&record.payload).unwrap();
+    match &mut payload {
+        StoredMessagePayload::SignedOpenMlsWire {
+            stamp: Some(stamp), ..
+        }
+        | StoredMessagePayload::OwnCommitWire { stamp, .. } => mutate(stamp),
+        _ => panic!("expected a stamped own commit"),
+    }
+    record.payload = payload.encode().unwrap();
+    storage.put_message(&record).unwrap();
+}
+
+fn own_commit_stamp(
+    storage: &SqliteAccountStorage,
+    message_id: &MessageId,
+) -> cgka_traits::message::OwnCommitConvergenceStamp {
+    let record = storage.get_message(message_id).unwrap();
+    StoredMessagePayload::decode(&record.payload)
+        .unwrap()
+        .own_commit_stamp()
+        .expect("expected a stamped own commit")
+        .clone()
 }
 
 #[async_trait]
@@ -2060,6 +2098,53 @@ async fn own_commit_checkpoint_survives_rival_anchor_overwrite_and_restart() {
         matches!(outcome_2, IngestOutcome::Buffered { .. }),
         "the second A-branch follow-on must enter the convergence pass, got {outcome_2:?}"
     );
+
+    // Select with the valid checkpoint, then corrupt only the stamped
+    // authenticator before apply. The restore must fail closed and the apply
+    // snapshot must return canonical state to the rival branch.
+    let policy = CanonicalizationPolicy::default();
+    let selection = canonicalize_stored_openmls_messages(
+        &x_storage,
+        &group_id,
+        CanonicalizationState {
+            current_tip_epoch: 3,
+            retained_anchor_epoch: 0,
+            last_convergence_relevant_input_ms: 0,
+            seen_message_ids: BTreeSet::new(),
+        },
+        Vec::new(),
+        policy.clone(),
+        u64::MAX,
+    )
+    .expect("the deeper A branch should select with an intact checkpoint");
+    let before_failed_apply = x_storage.get_group(&group_id).unwrap();
+    let original_own_record = x_storage.get_message(&commit_a.id).unwrap();
+    mutate_own_commit_stamp(&x_storage, &commit_a.id, |stamp| {
+        stamp.resulting_epoch_authenticator = Some("mismatched-authenticator".into());
+    });
+    let error = apply_openmls_canonicalization_result(
+        &x_storage,
+        &group_id,
+        &selection,
+        policy.convergence.max_rewind_commits,
+    )
+    .expect_err("a mismatched checkpoint authenticator must abort apply");
+    assert!(matches!(
+        error,
+        OpenMlsProjectionError::CheckpointStateMismatch
+    ));
+    assert_eq!(
+        x_storage.get_group(&group_id).unwrap(),
+        before_failed_apply,
+        "failed checkpoint verification must roll back canonical state"
+    );
+    assert_eq!(
+        x_storage.get_message(&commit_a.id).unwrap().state,
+        MessageState::ConvergenceDeferred,
+        "failed apply must leave the parked root reconsiderable"
+    );
+    x_storage.put_message(&original_own_record).unwrap();
+
     let convergence = x
         .converge_stored_openmls_messages_at(&group_id, u64::MAX)
         .expect("the deeper A branch must be realizable after restart");
@@ -2097,5 +2182,57 @@ async fn own_commit_checkpoint_survives_rival_anchor_overwrite_and_restart() {
         realized.state,
         MessageState::Processed,
         "the restored own commit must become canonical"
+    );
+
+    // Model an upgrade from a pre-checkpoint database: the durable own stamp
+    // remains, but migration 42 starts with no historical checkpoint rows and
+    // the optional fields deserialize as absent. This must report missing
+    // required retained state, which the convergence coordinator turns into a
+    // durable Unrecoverable halt, rather than repeatedly selecting the branch.
+    let stamp = own_commit_stamp(&x_storage, &commit_a.id);
+    x_storage
+        .release_group_state_checkpoint(
+            &group_id,
+            stamp
+                .checkpoint_id
+                .as_deref()
+                .expect("new own commit has checkpoint id"),
+        )
+        .unwrap();
+    mutate_own_commit_stamp(&x_storage, &commit_a.id, |stamp| {
+        stamp.checkpoint_id = None;
+        stamp.resulting_epoch_authenticator = None;
+    });
+    x_storage
+        .update_message_state(&commit_a.id, MessageState::ConvergenceDeferred)
+        .unwrap();
+    let fresh_trigger = x_storage
+        .list_messages(&group_id, EpochId(3))
+        .unwrap()
+        .into_iter()
+        .find(|record| record.epoch == EpochId(3) && record.state == MessageState::Processed)
+        .expect("the selected branch has an epoch-3 descendant");
+    x_storage
+        .update_message_state(&fresh_trigger.id, MessageState::Created)
+        .unwrap();
+    x_storage.delete_convergence_pass(&group_id).unwrap();
+    let legacy_result = x
+        .converge_stored_openmls_messages_at(&group_id, u64::MAX)
+        .expect("legacy missing-checkpoint state should produce a terminal result");
+    assert_eq!(
+        legacy_result.errors,
+        vec![CanonicalizationError::MissingOwnCommitCheckpoint]
+    );
+    assert_eq!(legacy_result.convergence_status, ConvergenceStatus::Blocked);
+    assert!(
+        x_storage.get_group(&group_id).unwrap().unrecoverable,
+        "missing a required legacy own-commit checkpoint must durably halt the group"
+    );
+    assert!(
+        x.drain_events().iter().any(|event| matches!(
+            event,
+            GroupEvent::GroupUnrecoverable { group_id: halted } if halted == &group_id
+        )),
+        "the upgrade-path halt must be surfaced to the host"
     );
 }

--- a/crates/cgka-engine/tests/fork_detection.rs
+++ b/crates/cgka-engine/tests/fork_detection.rs
@@ -1444,8 +1444,16 @@ async fn pairwise_incumbent_defers_to_deeper_convergence_branch() {
         .unwrap();
     let (winner_commit, loser_root) = match (&winner_invite, &loser_invite) {
         (
-            SendResult::GroupEvolution { msg: w, pending: wp, .. },
-            SendResult::GroupEvolution { msg: l, pending: lp, .. },
+            SendResult::GroupEvolution {
+                msg: w,
+                pending: wp,
+                ..
+            },
+            SendResult::GroupEvolution {
+                msg: l,
+                pending: lp,
+                ..
+            },
         ) => {
             let (w, l, wp, lp) = (w.clone(), l.clone(), *wp, *lp);
             winner.confirm_published(wp).await.unwrap();

--- a/crates/cgka-engine/tests/hydration_quarantine.rs
+++ b/crates/cgka-engine/tests/hydration_quarantine.rs
@@ -14,10 +14,11 @@ use cgka_traits::peeler::TransportPeeler;
 use cgka_traits::storage::{
     AccountDeviceSignerBinding, AccountDeviceSignerStorage, CapabilityStorage,
     ConvergencePassStorage, ConvergencePolicyStorage, DisbandCandidate, DisbandCandidateStorage,
-    DisbandRequest, DisbandRequestStorage, DisbandTombstoneStorage, GroupStorage,
-    KeyPackageBundleStorage, LeaveRequest, LeaveRequestStorage, MemberValidationCacheStorage,
-    MessageStorage, OutboundFanoutStorage, OutboundIntentStorage, QueuedOutboundIntent,
-    StorageError, StorageProvider, StorageResult, StoredKeyPackageBundle, WelcomeStorage,
+    DisbandRequest, DisbandRequestStorage, DisbandTombstoneStorage, GroupStateCheckpointRef,
+    GroupStorage, KeyPackageBundleStorage, LeaveRequest, LeaveRequestStorage,
+    MemberValidationCacheStorage, MessageStorage, OutboundFanoutStorage, OutboundIntentStorage,
+    QueuedOutboundIntent, StorageError, StorageProvider, StorageResult, StoredKeyPackageBundle,
+    WelcomeStorage,
 };
 use cgka_traits::transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
@@ -425,6 +426,36 @@ impl MessageStorage for FlakyGroupRecordStorage {
     }
     fn release_group_snapshot(&self, group_id: &GroupId, name: &str) -> StorageResult<()> {
         self.inner.release_group_snapshot(group_id, name)
+    }
+    fn create_group_state_checkpoint(
+        &self,
+        group_id: &GroupId,
+        checkpoint: &GroupStateCheckpointRef,
+    ) -> StorageResult<()> {
+        self.inner
+            .create_group_state_checkpoint(group_id, checkpoint)
+    }
+    fn restore_group_state_checkpoint(
+        &self,
+        group_id: &GroupId,
+        checkpoint_id: &str,
+    ) -> StorageResult<()> {
+        self.inner
+            .restore_group_state_checkpoint(group_id, checkpoint_id)
+    }
+    fn list_group_state_checkpoints(
+        &self,
+        group_id: &GroupId,
+    ) -> StorageResult<Vec<GroupStateCheckpointRef>> {
+        self.inner.list_group_state_checkpoints(group_id)
+    }
+    fn release_group_state_checkpoint(
+        &self,
+        group_id: &GroupId,
+        checkpoint_id: &str,
+    ) -> StorageResult<()> {
+        self.inner
+            .release_group_state_checkpoint(group_id, checkpoint_id)
     }
 }
 

--- a/crates/cgka-engine/tests/publish_lifecycle.rs
+++ b/crates/cgka-engine/tests/publish_lifecycle.rs
@@ -36,10 +36,10 @@ use cgka_traits::storage::{
     AccountDeviceSignerBinding, AccountDeviceSignerStorage, CapabilityStorage,
     ConvergencePassStorage, ConvergencePolicyStorage, DisbandCandidate, DisbandCandidateStorage,
     DisbandRequest, DisbandRequestStatus, DisbandRequestStorage, DisbandTombstoneStorage,
-    GroupStorage, KeyPackageBundleStorage, LeaveRequest, LeaveRequestStorage, MaintenanceStorage,
-    MemberValidationCacheStorage, MessageStorage, OutboundFanoutStorage, OutboundIntentStorage,
-    QueuedOutboundIntent, StorageError, StorageProvider, StorageResult, StoredKeyPackageBundle,
-    WelcomeStorage,
+    GroupStateCheckpointRef, GroupStorage, KeyPackageBundleStorage, LeaveRequest,
+    LeaveRequestStorage, MaintenanceStorage, MemberValidationCacheStorage, MessageStorage,
+    OutboundFanoutStorage, OutboundIntentStorage, QueuedOutboundIntent, StorageError,
+    StorageProvider, StorageResult, StoredKeyPackageBundle, WelcomeStorage,
 };
 use cgka_traits::transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
@@ -1012,6 +1012,36 @@ impl MessageStorage for FaultStorage {
     }
     fn release_group_snapshot(&self, group_id: &GroupId, name: &str) -> StorageResult<()> {
         self.inner.release_group_snapshot(group_id, name)
+    }
+    fn create_group_state_checkpoint(
+        &self,
+        group_id: &GroupId,
+        checkpoint: &GroupStateCheckpointRef,
+    ) -> StorageResult<()> {
+        self.inner
+            .create_group_state_checkpoint(group_id, checkpoint)
+    }
+    fn restore_group_state_checkpoint(
+        &self,
+        group_id: &GroupId,
+        checkpoint_id: &str,
+    ) -> StorageResult<()> {
+        self.inner
+            .restore_group_state_checkpoint(group_id, checkpoint_id)
+    }
+    fn list_group_state_checkpoints(
+        &self,
+        group_id: &GroupId,
+    ) -> StorageResult<Vec<GroupStateCheckpointRef>> {
+        self.inner.list_group_state_checkpoints(group_id)
+    }
+    fn release_group_state_checkpoint(
+        &self,
+        group_id: &GroupId,
+        checkpoint_id: &str,
+    ) -> StorageResult<()> {
+        self.inner
+            .release_group_state_checkpoint(group_id, checkpoint_id)
     }
 }
 

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -65,7 +65,14 @@ versioning through the workspace version in the root `Cargo.toml`.
   keyed by its source epoch) so a later convergence pass adopts the same
   branch everywhere, and `fork_resolution` audit rows now record the kept
   incumbent's commit digest so cross-member convergence is provable from
-  forensic logs. ([#1236](https://github.com/marmot-protocol/mdk/pull/1236))
+  forensic logs. Adopting such a branch again rewinds to a retained snapshot,
+  and that rewind is now verified against a fingerprint of the state the
+  member's own commit produced, so a snapshot that a later commit on the same
+  epoch replaced can never be mistaken for it — the reorg is refused instead of
+  installing a lineage no member ever held. Displacing the losing branch is
+  also a single durable transaction now, so an interrupted resolution can no
+  longer drop it without a trace.
+  ([#1236](https://github.com/marmot-protocol/mdk/pull/1236))
 
 - `MarmotApp` now permits only one live in-memory engine session per account
   across direct clients and managed workers. Concurrent opens return the typed

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -73,6 +73,7 @@ versioning through the workspace version in the root `Cargo.toml`.
   rival branch. Checkpoints are pruned with the retained rewind horizon.
   Displacing the losing branch is also a single durable transaction now, so an
   interrupted resolution can no longer drop it without a trace.
+  ([#1285](https://github.com/marmot-protocol/mdk/pull/1285))
 
 - `MarmotApp` now permits only one live in-memory engine session per account
   across direct clients and managed workers. Concurrent opens return the typed

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -65,14 +65,14 @@ versioning through the workspace version in the root `Cargo.toml`.
   keyed by its source epoch) so a later convergence pass adopts the same
   branch everywhere, and `fork_resolution` audit rows now record the kept
   incumbent's commit digest so cross-member convergence is provable from
-  forensic logs. Adopting such a branch again rewinds to a retained snapshot,
-  and that rewind is now verified against a fingerprint of the state the
-  member's own commit produced, so a snapshot that a later commit on the same
-  epoch replaced can never be mistaken for it — the reorg is refused instead of
-  installing a lineage no member ever held. Displacing the losing branch is
-  also a single durable transaction now, so an interrupted resolution can no
-  longer drop it without a trace.
-  ([#1236](https://github.com/marmot-protocol/mdk/pull/1236))
+  forensic logs. Because OpenMLS cannot process a device's own Commit from the
+  network, confirmation now atomically retains an immutable, commit-addressed
+  checkpoint of the canonical MLS/Marmot state. A later reorg can restore that
+  exact branch after restart, verify its epoch authenticator, and replay its
+  descendants even when an epoch-keyed rollback anchor has been replaced by a
+  rival branch. Checkpoints are pruned with the retained rewind horizon.
+  Displacing the losing branch is also a single durable transaction now, so an
+  interrupted resolution can no longer drop it without a trace.
 
 - `MarmotApp` now permits only one live in-memory engine session per account
   across direct clients and managed workers. Concurrent opens return the typed

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -55,6 +55,18 @@ versioning through the workspace version in the root `Cargo.toml`.
   avoiding false failures when unrelated startup work is delayed under loaded
   `nextest` shards.
 
+- Same-epoch commit races now converge every member onto the same branch. A
+  member that had committed from the contested epoch resolved the race through
+  pairwise fork recovery and invalidated the losing commit terminally, while
+  everyone else resolved it through distributed convergence, where a deeper
+  valid branch can win later — so honest members could keep different lineages
+  forever and silently lose every application message sent on the other side.
+  The pairwise loser is now parked reconsiderable (`ConvergenceDeferred`,
+  keyed by its source epoch) so a later convergence pass adopts the same
+  branch everywhere, and `fork_resolution` audit rows now record the kept
+  incumbent's commit digest so cross-member convergence is provable from
+  forensic logs. ([#1236](https://github.com/marmot-protocol/mdk/pull/1236))
+
 - `MarmotApp` now permits only one live in-memory engine session per account
   across direct clients and managed workers. Concurrent opens return the typed
   `AccountSessionBusy` error, and worker reconnect drops the failed session

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -80,6 +80,8 @@ mod migration_0039_chat_pin_positions;
 mod migration_0040_disband_requests;
 #[path = "migrations/0041_secure_delete_checkpoint_intents.rs"]
 mod migration_0041_secure_delete_checkpoint_intents;
+#[path = "migrations/0042_group_state_checkpoints.rs"]
+mod migration_0042_group_state_checkpoints;
 
 use crate::SqliteResultExt;
 use cgka_traits::storage::{StorageError, StorageResult};
@@ -296,6 +298,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 41,
         name: "0041_secure_delete_checkpoint_intents",
         apply: migration_0041_secure_delete_checkpoint_intents::apply,
+    },
+    Migration {
+        version: 42,
+        name: "0042_group_state_checkpoints",
+        apply: migration_0042_group_state_checkpoints::apply,
     },
 ];
 

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -1320,6 +1320,7 @@ mod tests {
             ("cgka_convergence_policies", "group_id"),
             ("cgka_member_validation_cache", "group_id"),
             ("cgka_group_snapshots", "group_id"),
+            ("cgka_group_state_checkpoints", "group_id"),
         ] {
             assert_eq!(
                 foreign_key(&conn, table, column),

--- a/crates/storage-sqlite/src/migrations/0042_group_state_checkpoints.rs
+++ b/crates/storage-sqlite/src/migrations/0042_group_state_checkpoints.rs
@@ -1,0 +1,22 @@
+use crate::SqliteResultExt;
+use cgka_traits::storage::StorageResult;
+use rusqlite::Transaction;
+
+pub(crate) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
+    tx.execute_batch(
+        r#"
+CREATE TABLE cgka_group_state_checkpoints (
+    group_id BLOB NOT NULL,
+    checkpoint_id TEXT NOT NULL,
+    resulting_epoch INTEGER NOT NULL,
+    checkpoint BLOB NOT NULL,
+    PRIMARY KEY (group_id, checkpoint_id),
+    FOREIGN KEY (group_id) REFERENCES cgka_groups(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_cgka_group_state_checkpoints_epoch
+    ON cgka_group_state_checkpoints(group_id, resulting_epoch);
+"#,
+    )
+    .storage()
+}

--- a/crates/storage-sqlite/src/storage/messages.rs
+++ b/crates/storage-sqlite/src/storage/messages.rs
@@ -5,7 +5,7 @@ use crate::{
     serialize,
 };
 use cgka_traits::message::{MessageRecord, MessageState};
-use cgka_traits::storage::{MessageStorage, StorageError, StorageResult};
+use cgka_traits::storage::{GroupStateCheckpointRef, MessageStorage, StorageError, StorageResult};
 use cgka_traits::types::{EpochId, GroupId, MessageId};
 use rusqlite::{OptionalExtension, TransactionBehavior, params};
 
@@ -124,6 +124,37 @@ impl MessageStorage for SqliteAccountStorage {
             .collect::<Result<Vec<_>, _>>()
             .storage()?;
         records.iter().map(|record| deserialize(record)).collect()
+    }
+
+    fn create_group_state_checkpoint(
+        &self,
+        group_id: &GroupId,
+        checkpoint: &GroupStateCheckpointRef,
+    ) -> StorageResult<()> {
+        snapshots::create_group_state_checkpoint(self, group_id, checkpoint)
+    }
+
+    fn restore_group_state_checkpoint(
+        &self,
+        group_id: &GroupId,
+        checkpoint_id: &str,
+    ) -> StorageResult<()> {
+        snapshots::restore_group_state_checkpoint(self, group_id, checkpoint_id)
+    }
+
+    fn list_group_state_checkpoints(
+        &self,
+        group_id: &GroupId,
+    ) -> StorageResult<Vec<GroupStateCheckpointRef>> {
+        snapshots::list_group_state_checkpoints(self, group_id)
+    }
+
+    fn release_group_state_checkpoint(
+        &self,
+        group_id: &GroupId,
+        checkpoint_id: &str,
+    ) -> StorageResult<()> {
+        snapshots::release_group_state_checkpoint(self, group_id, checkpoint_id)
     }
 
     fn put_ingress_dedup_marker(&self, id: &MessageId) -> StorageResult<()> {

--- a/crates/storage-sqlite/src/storage/snapshots.rs
+++ b/crates/storage-sqlite/src/storage/snapshots.rs
@@ -92,8 +92,8 @@ mod tests {
     };
     use cgka_traits::capabilities::{Capability, GroupCapabilities};
     use cgka_traits::storage::{
-        CapabilityStorage, GroupStateCheckpointRef, GroupStorage, MessageStorage,
-        OutboundIntentStorage, StorageError, StorageProvider,
+        CapabilityStorage, GroupStateCheckpointRef, GroupStorage, MemberValidationCacheStorage,
+        MessageStorage, OutboundIntentStorage, StorageError, StorageProvider,
     };
     use cgka_traits::types::EpochId;
     use openmls_traits::storage::StorageProvider as OpenMlsStorageProvider;
@@ -164,6 +164,14 @@ mod tests {
             .mls_storage()
             .write_group_state(&mls_group_id, &TestGroupState(b"branch-a".to_vec()))
             .unwrap();
+        let mut branch_a_caps = GroupCapabilities::default();
+        branch_a_caps.insert(Capability::Proposal(10));
+        store
+            .save_member_capabilities(&g1.id, &g1.members[0], branch_a_caps.clone())
+            .unwrap();
+        store
+            .put_validated_tree_marker(&g1.id, b"branch-a-marker")
+            .unwrap();
         let checkpoint = GroupStateCheckpointRef {
             id: "own-commit-a".into(),
             resulting_epoch: EpochId(1),
@@ -186,6 +194,14 @@ mod tests {
             .mls_storage()
             .write_group_state(&mls_group_id, &TestGroupState(b"branch-b".to_vec()))
             .unwrap();
+        let mut branch_b_caps = GroupCapabilities::default();
+        branch_b_caps.insert(Capability::Extension(11));
+        store
+            .save_member_capabilities(&g2.id, &g2.members[0], branch_b_caps)
+            .unwrap();
+        store
+            .put_validated_tree_marker(&g2.id, b"branch-b-marker")
+            .unwrap();
 
         store
             .restore_group_state_checkpoint(&g2.id, &checkpoint.id)
@@ -194,6 +210,16 @@ mod tests {
         assert_eq!(store.get_group(&g1.id).unwrap(), g1);
         let state: Option<TestGroupState> = store.mls_storage().group_state(&mls_group_id).unwrap();
         assert_eq!(state, Some(TestGroupState(b"branch-a".to_vec())));
+        assert_eq!(
+            store
+                .member_capabilities(&g1.id, &g1.members[0].id)
+                .unwrap(),
+            Some(branch_a_caps)
+        );
+        assert_eq!(
+            store.validated_tree_marker(&g1.id).unwrap(),
+            Some(b"branch-a-marker".to_vec())
+        );
         assert_eq!(
             store.list_messages(&g1.id, EpochId(0)).unwrap(),
             vec![live_message]

--- a/crates/storage-sqlite/src/storage/snapshots.rs
+++ b/crates/storage-sqlite/src/storage/snapshots.rs
@@ -230,6 +230,28 @@ mod tests {
     }
 
     #[test]
+    fn releasing_missing_group_state_checkpoint_reports_snapshot_missing() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let group = sample_group(gid(1), 1, 1);
+        store.put_group(&group).unwrap();
+        let checkpoint = GroupStateCheckpointRef {
+            id: "own-commit-a".into(),
+            resulting_epoch: EpochId(1),
+        };
+        store
+            .create_group_state_checkpoint(&group.id, &checkpoint)
+            .unwrap();
+
+        store
+            .release_group_state_checkpoint(&group.id, &checkpoint.id)
+            .unwrap();
+        assert!(matches!(
+            store.release_group_state_checkpoint(&group.id, &checkpoint.id),
+            Err(StorageError::SnapshotMissing(id)) if id == checkpoint.id
+        ));
+    }
+
+    #[test]
     fn snapshot_rollback_joins_outer_transaction() {
         let store = SqliteAccountStorage::in_memory().unwrap();
         let anchor_group = sample_group(gid(1), 0, 1);

--- a/crates/storage-sqlite/src/storage/snapshots.rs
+++ b/crates/storage-sqlite/src/storage/snapshots.rs
@@ -1,4 +1,5 @@
 mod capture;
+mod checkpoints;
 mod lifecycle;
 mod restore;
 mod rows;
@@ -35,6 +36,37 @@ pub(super) fn release(
     lifecycle::release(store, group_id, name)
 }
 
+pub(super) fn create_group_state_checkpoint(
+    store: &SqliteAccountStorage,
+    group_id: &GroupId,
+    checkpoint: &cgka_traits::storage::GroupStateCheckpointRef,
+) -> StorageResult<()> {
+    checkpoints::create_group_state_checkpoint(store, group_id, checkpoint)
+}
+
+pub(super) fn restore_group_state_checkpoint(
+    store: &SqliteAccountStorage,
+    group_id: &GroupId,
+    checkpoint_id: &str,
+) -> StorageResult<()> {
+    checkpoints::restore_group_state_checkpoint(store, group_id, checkpoint_id)
+}
+
+pub(super) fn list_group_state_checkpoints(
+    store: &SqliteAccountStorage,
+    group_id: &GroupId,
+) -> StorageResult<Vec<cgka_traits::storage::GroupStateCheckpointRef>> {
+    checkpoints::list_group_state_checkpoints(store, group_id)
+}
+
+pub(super) fn release_group_state_checkpoint(
+    store: &SqliteAccountStorage,
+    group_id: &GroupId,
+    checkpoint_id: &str,
+) -> StorageResult<()> {
+    checkpoints::release_group_state_checkpoint(store, group_id, checkpoint_id)
+}
+
 #[cfg(feature = "test-conformance-replay")]
 pub(crate) fn export_replay(
     store: &SqliteAccountStorage,
@@ -60,8 +92,8 @@ mod tests {
     };
     use cgka_traits::capabilities::{Capability, GroupCapabilities};
     use cgka_traits::storage::{
-        CapabilityStorage, GroupStorage, MessageStorage, OutboundIntentStorage, StorageError,
-        StorageProvider,
+        CapabilityStorage, GroupStateCheckpointRef, GroupStorage, MessageStorage,
+        OutboundIntentStorage, StorageError, StorageProvider,
     };
     use cgka_traits::types::EpochId;
     use openmls_traits::storage::StorageProvider as OpenMlsStorageProvider;
@@ -120,6 +152,81 @@ mod tests {
         );
         let state: Option<TestGroupState> = store.mls_storage().group_state(&mls_group_id).unwrap();
         assert_eq!(state, Some(TestGroupState(b"epoch-0".to_vec())));
+    }
+
+    #[test]
+    fn group_state_checkpoint_restores_canonical_state_without_rewinding_live_work() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let g1 = sample_group(gid(1), 1, 1);
+        store.put_group(&g1).unwrap();
+        let mls_group_id = openmls::group::GroupId::from_slice(g1.id.as_slice());
+        store
+            .mls_storage()
+            .write_group_state(&mls_group_id, &TestGroupState(b"branch-a".to_vec()))
+            .unwrap();
+        let checkpoint = GroupStateCheckpointRef {
+            id: "own-commit-a".into(),
+            resulting_epoch: EpochId(1),
+        };
+        store
+            .create_group_state_checkpoint(&g1.id, &checkpoint)
+            .unwrap();
+        // Exact retry is idempotent.
+        store
+            .create_group_state_checkpoint(&g1.id, &checkpoint)
+            .unwrap();
+
+        let g2 = sample_group(gid(1), 2, 2);
+        store.put_group(&g2).unwrap();
+        let live_message = sample_message(mid(2), g2.id.clone(), 2);
+        let live_queue = sample_queued_intent(mid(10), g2.id.clone());
+        store.put_message(&live_message).unwrap();
+        store.put_queued_outbound_intent(&live_queue).unwrap();
+        store
+            .mls_storage()
+            .write_group_state(&mls_group_id, &TestGroupState(b"branch-b".to_vec()))
+            .unwrap();
+
+        store
+            .restore_group_state_checkpoint(&g2.id, &checkpoint.id)
+            .unwrap();
+
+        assert_eq!(store.get_group(&g1.id).unwrap(), g1);
+        let state: Option<TestGroupState> = store.mls_storage().group_state(&mls_group_id).unwrap();
+        assert_eq!(state, Some(TestGroupState(b"branch-a".to_vec())));
+        assert_eq!(
+            store.list_messages(&g1.id, EpochId(0)).unwrap(),
+            vec![live_message]
+        );
+        assert_eq!(
+            store.list_queued_outbound_intents(&g1.id).unwrap(),
+            vec![live_queue]
+        );
+    }
+
+    #[test]
+    fn group_state_checkpoint_id_is_immutable() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let g1 = sample_group(gid(1), 1, 1);
+        store.put_group(&g1).unwrap();
+        let checkpoint = GroupStateCheckpointRef {
+            id: "own-commit-a".into(),
+            resulting_epoch: EpochId(1),
+        };
+        store
+            .create_group_state_checkpoint(&g1.id, &checkpoint)
+            .unwrap();
+
+        let g2 = sample_group(gid(1), 2, 2);
+        store.put_group(&g2).unwrap();
+        assert!(matches!(
+            store.create_group_state_checkpoint(&g2.id, &checkpoint),
+            Err(StorageError::AlreadyExists)
+        ));
+        assert_eq!(
+            store.list_group_state_checkpoints(&g2.id).unwrap(),
+            vec![checkpoint]
+        );
     }
 
     #[test]

--- a/crates/storage-sqlite/src/storage/snapshots/capture.rs
+++ b/crates/storage-sqlite/src/storage/snapshots/capture.rs
@@ -1,6 +1,6 @@
 use super::rows::{
-    MemberCapabilitiesSnapshot, OpenMlsValueSnapshot, OrderedMessage, OrderedQueuedOutbound,
-    Snapshot,
+    GroupStateCheckpoint, MemberCapabilitiesSnapshot, OpenMlsValueSnapshot, OrderedMessage,
+    OrderedQueuedOutbound, Snapshot,
 };
 #[cfg(feature = "test-conformance-replay")]
 use super::rows::{REPLAY_SNAPSHOT_VERSION, ReplaySnapshot};
@@ -84,6 +84,29 @@ fn capture_snapshot(conn: &rusqlite::Connection, group_id: &GroupId) -> StorageR
     })
 }
 
+pub(super) fn capture_group_state(
+    conn: &rusqlite::Connection,
+    group_id: &GroupId,
+) -> StorageResult<GroupStateCheckpoint> {
+    let mls_group_key = mls_group_key(group_id)?;
+    let group_blob: Vec<u8> = conn
+        .query_row(
+            "SELECT record FROM cgka_groups WHERE id = ?1",
+            params![group_id.as_slice()],
+            |row| row.get(0),
+        )
+        .optional()
+        .storage()?
+        .ok_or(StorageError::NotFound)?;
+
+    Ok(GroupStateCheckpoint {
+        group: deserialize(&group_blob)?,
+        member_caps: member_capabilities(conn, group_id)?,
+        validated_tree_marker: validated_tree_marker(conn, group_id)?,
+        openmls_values: openmls_values(conn, &mls_group_key)?,
+    })
+}
+
 #[cfg(feature = "test-conformance-replay")]
 pub(super) fn export(store: &SqliteAccountStorage, group_id: &GroupId) -> StorageResult<Vec<u8>> {
     let conn = store.lock()?;
@@ -164,7 +187,8 @@ fn member_capabilities(
     let mut stmt = tx
         .prepare(
             "SELECT member_id, capabilities FROM cgka_member_capabilities
-             WHERE group_id = ?1",
+             WHERE group_id = ?1
+             ORDER BY member_id",
         )
         .storage()?;
     let rows = stmt

--- a/crates/storage-sqlite/src/storage/snapshots/checkpoints.rs
+++ b/crates/storage-sqlite/src/storage/snapshots/checkpoints.rs
@@ -144,7 +144,7 @@ pub(super) fn release_group_state_checkpoint(
     checkpoint_id: &str,
 ) -> StorageResult<()> {
     let delete = || {
-        store
+        let deleted = store
             .lock()?
             .execute(
                 "DELETE FROM cgka_group_state_checkpoints
@@ -152,6 +152,9 @@ pub(super) fn release_group_state_checkpoint(
                 params![group_id.as_slice(), checkpoint_id],
             )
             .storage()?;
+        if deleted == 0 {
+            return Err(StorageError::SnapshotMissing(checkpoint_id.to_owned()));
+        }
         Ok(())
     };
     if store.connection.is_current_thread_transaction_owner() {

--- a/crates/storage-sqlite/src/storage/snapshots/checkpoints.rs
+++ b/crates/storage-sqlite/src/storage/snapshots/checkpoints.rs
@@ -1,0 +1,162 @@
+use super::{capture, restore, rows::GroupStateCheckpoint};
+use crate::{
+    SqliteAccountStorage, SqliteResultExt,
+    codec::{SensitiveBytes, serialize_sensitive},
+    connection::retry_on_busy,
+    deserialize, epoch_to_i64,
+};
+use cgka_traits::storage::{GroupStateCheckpointRef, StorageError, StorageResult};
+use cgka_traits::types::{EpochId, GroupId};
+use rusqlite::{OptionalExtension, TransactionBehavior, params};
+
+pub(super) fn create_group_state_checkpoint(
+    store: &SqliteAccountStorage,
+    group_id: &GroupId,
+    checkpoint: &GroupStateCheckpointRef,
+) -> StorageResult<()> {
+    if store.connection.is_current_thread_transaction_owner() {
+        let conn = store.lock()?;
+        return create_on_connection(&conn, group_id, checkpoint);
+    }
+    retry_on_busy(|| {
+        let mut conn = store.lock()?;
+        let tx = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .storage()?;
+        create_on_connection(&tx, group_id, checkpoint)?;
+        tx.commit().storage()
+    })
+}
+
+fn create_on_connection(
+    conn: &rusqlite::Connection,
+    group_id: &GroupId,
+    checkpoint: &GroupStateCheckpointRef,
+) -> StorageResult<()> {
+    let state = capture::capture_group_state(conn, group_id)?;
+    let blob = serialize_sensitive(&state)?;
+    let existing = conn
+        .query_row(
+            "SELECT resulting_epoch, checkpoint
+             FROM cgka_group_state_checkpoints
+             WHERE group_id = ?1 AND checkpoint_id = ?2",
+            params![group_id.as_slice(), checkpoint.id],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, Vec<u8>>(1)?)),
+        )
+        .optional()
+        .storage()?;
+    if let Some((resulting_epoch, existing_blob)) = existing {
+        if resulting_epoch == epoch_to_i64(checkpoint.resulting_epoch)?
+            && existing_blob == blob.as_slice()
+        {
+            return Ok(());
+        }
+        return Err(StorageError::AlreadyExists);
+    }
+    conn.execute(
+        "INSERT INTO cgka_group_state_checkpoints
+            (group_id, checkpoint_id, resulting_epoch, checkpoint)
+         VALUES (?1, ?2, ?3, ?4)",
+        params![
+            group_id.as_slice(),
+            checkpoint.id,
+            epoch_to_i64(checkpoint.resulting_epoch)?,
+            blob.as_slice()
+        ],
+    )
+    .storage()?;
+    Ok(())
+}
+
+pub(super) fn restore_group_state_checkpoint(
+    store: &SqliteAccountStorage,
+    group_id: &GroupId,
+    checkpoint_id: &str,
+) -> StorageResult<()> {
+    if store.connection.is_current_thread_transaction_owner() {
+        let conn = store.lock()?;
+        return restore_on_connection(&conn, group_id, checkpoint_id);
+    }
+    retry_on_busy(|| {
+        let mut conn = store.lock()?;
+        let tx = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .storage()?;
+        restore_on_connection(&tx, group_id, checkpoint_id)?;
+        tx.commit().storage()
+    })
+}
+
+fn restore_on_connection(
+    conn: &rusqlite::Connection,
+    group_id: &GroupId,
+    checkpoint_id: &str,
+) -> StorageResult<()> {
+    let blob = SensitiveBytes::new(
+        conn.query_row(
+            "SELECT checkpoint FROM cgka_group_state_checkpoints
+             WHERE group_id = ?1 AND checkpoint_id = ?2",
+            params![group_id.as_slice(), checkpoint_id],
+            |row| row.get::<_, Vec<u8>>(0),
+        )
+        .optional()
+        .storage()?
+        .ok_or_else(|| StorageError::SnapshotMissing(checkpoint_id.to_owned()))?,
+    );
+    let checkpoint: GroupStateCheckpoint = deserialize(blob.as_slice())?;
+    restore::restore_group_state(conn, group_id, &checkpoint)
+}
+
+pub(super) fn list_group_state_checkpoints(
+    store: &SqliteAccountStorage,
+    group_id: &GroupId,
+) -> StorageResult<Vec<GroupStateCheckpointRef>> {
+    let conn = store.lock()?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT checkpoint_id, resulting_epoch
+             FROM cgka_group_state_checkpoints
+             WHERE group_id = ?1
+             ORDER BY resulting_epoch, checkpoint_id",
+        )
+        .storage()?;
+    stmt.query_map(params![group_id.as_slice()], |row| {
+        let epoch = row.get::<_, i64>(1)?;
+        Ok(GroupStateCheckpointRef {
+            id: row.get(0)?,
+            resulting_epoch: EpochId(u64::try_from(epoch).map_err(|error| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    1,
+                    rusqlite::types::Type::Integer,
+                    Box::new(error),
+                )
+            })?),
+        })
+    })
+    .storage()?
+    .collect::<Result<Vec<_>, _>>()
+    .storage()
+}
+
+pub(super) fn release_group_state_checkpoint(
+    store: &SqliteAccountStorage,
+    group_id: &GroupId,
+    checkpoint_id: &str,
+) -> StorageResult<()> {
+    let delete = || {
+        store
+            .lock()?
+            .execute(
+                "DELETE FROM cgka_group_state_checkpoints
+                 WHERE group_id = ?1 AND checkpoint_id = ?2",
+                params![group_id.as_slice(), checkpoint_id],
+            )
+            .storage()?;
+        Ok(())
+    };
+    if store.connection.is_current_thread_transaction_owner() {
+        delete()
+    } else {
+        retry_on_busy(delete)
+    }
+}

--- a/crates/storage-sqlite/src/storage/snapshots/restore.rs
+++ b/crates/storage-sqlite/src/storage/snapshots/restore.rs
@@ -1,6 +1,6 @@
 use super::rows::{
-    MemberCapabilitiesSnapshot, OpenMlsValueSnapshot, OrderedMessage, OrderedQueuedOutbound,
-    Snapshot,
+    GroupStateCheckpoint, MemberCapabilitiesSnapshot, OpenMlsValueSnapshot, OrderedMessage,
+    OrderedQueuedOutbound, Snapshot,
 };
 #[cfg(feature = "test-conformance-replay")]
 use super::rows::{REPLAY_SNAPSHOT_VERSION, ReplaySnapshot};
@@ -131,6 +131,18 @@ fn restore_snapshot(
     convergence_policy(conn, group_id, snapshot.convergence_policy.as_deref())?;
     validated_tree_marker(conn, group_id, snapshot.validated_tree_marker.as_deref())?;
     openmls_values(conn, mls_group_key, &snapshot.openmls_values)
+}
+
+pub(super) fn restore_group_state(
+    conn: &rusqlite::Connection,
+    group_id: &GroupId,
+    checkpoint: &GroupStateCheckpoint,
+) -> StorageResult<()> {
+    let mls_group_key = mls_group_key(group_id)?;
+    group(conn, group_id, &checkpoint.group)?;
+    member_capabilities(conn, group_id, &checkpoint.member_caps)?;
+    validated_tree_marker(conn, group_id, checkpoint.validated_tree_marker.as_deref())?;
+    openmls_values(conn, &mls_group_key, &checkpoint.openmls_values)
 }
 
 fn group(conn: &rusqlite::Connection, group_id: &GroupId, group: &Group) -> StorageResult<()> {

--- a/crates/storage-sqlite/src/storage/snapshots/rows.rs
+++ b/crates/storage-sqlite/src/storage/snapshots/rows.rs
@@ -19,6 +19,18 @@ pub(super) struct Snapshot {
     pub(super) openmls_values: Vec<OpenMlsValueSnapshot>,
 }
 
+/// Branch-addressed canonical state.  Unlike `Snapshot`, this deliberately
+/// excludes the mutable message ledger, outbound queue, convergence policy,
+/// and pass scheduler so selecting a historical branch cannot rewind current
+/// operational work.
+#[derive(Serialize, Deserialize)]
+pub(super) struct GroupStateCheckpoint {
+    pub(super) group: Group,
+    pub(super) member_caps: Vec<MemberCapabilitiesSnapshot>,
+    pub(super) validated_tree_marker: Option<Vec<u8>>,
+    pub(super) openmls_values: Vec<OpenMlsValueSnapshot>,
+}
+
 /// Test-only envelope for byte-exact convergence replay.
 ///
 /// Ordinary epoch rollback deliberately excludes the durable convergence pass:

--- a/crates/traits/src/message.rs
+++ b/crates/traits/src/message.rs
@@ -29,6 +29,22 @@ pub struct OwnCommitConvergenceStamp {
     pub priority: CommitOrderingPriority,
     /// Hex-encoded proposal references the commit consumed, in sorted order.
     pub consumed_proposal_refs: Vec<String>,
+    /// Hex-encoded fingerprint of the group state this commit PRODUCED,
+    /// captured immediately after the confirm-time merge:
+    /// `SHA-256(marker version || ciphersuite || TLS(exported ratchet tree))`
+    /// (see `cgka_engine::group_lifecycle::compute_validated_tree_marker`).
+    ///
+    /// This is the positive identity proof for the retained-anchor fast path.
+    /// Retained anchors (`openmls-retained-anchor-<N>`) are keyed by resulting
+    /// epoch ALONE and are replaced by every capture at that epoch, so an
+    /// anchor's NAME never proves whose post-merge state it holds. Rewinding
+    /// to the anchor and recomputing this marker does: it is content-bound to
+    /// the exact ratchet tree, so only the state this commit produced matches.
+    ///
+    /// `Option` because rows stamped by older engine versions predate the
+    /// field. Absent means "cannot be proven", and the fast path is refused.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub post_commit_tree_marker: Option<String>,
 }
 
 /// Typed envelope for the opaque bytes stored in [`MessageRecord::payload`].

--- a/crates/traits/src/message.rs
+++ b/crates/traits/src/message.rs
@@ -29,22 +29,15 @@ pub struct OwnCommitConvergenceStamp {
     pub priority: CommitOrderingPriority,
     /// Hex-encoded proposal references the commit consumed, in sorted order.
     pub consumed_proposal_refs: Vec<String>,
-    /// Hex-encoded fingerprint of the group state this commit PRODUCED,
-    /// captured immediately after the confirm-time merge:
-    /// `SHA-256(marker version || ciphersuite || TLS(exported ratchet tree))`
-    /// (see `cgka_engine::group_lifecycle::compute_validated_tree_marker`).
-    ///
-    /// This is the positive identity proof for the retained-anchor fast path.
-    /// Retained anchors (`openmls-retained-anchor-<N>`) are keyed by resulting
-    /// epoch ALONE and are replaced by every capture at that epoch, so an
-    /// anchor's NAME never proves whose post-merge state it holds. Rewinding
-    /// to the anchor and recomputing this marker does: it is content-bound to
-    /// the exact ratchet tree, so only the state this commit produced matches.
-    ///
-    /// `Option` because rows stamped by older engine versions predate the
-    /// field. Absent means "cannot be proven", and the fast path is refused.
+    /// Immutable canonical-state checkpoint produced by this commit.  The id
+    /// is derived from the MLS wire commit digest rather than the epoch, so
+    /// sibling branches can never replace one another's state.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub post_commit_tree_marker: Option<String>,
+    pub checkpoint_id: Option<String>,
+    /// Epoch authenticator of the checkpointed resulting state.  Restore
+    /// verifies this value before the checkpoint can realize an own commit.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resulting_epoch_authenticator: Option<String>,
 }
 
 /// Typed envelope for the opaque bytes stored in [`MessageRecord::payload`].

--- a/crates/traits/src/storage.rs
+++ b/crates/traits/src/storage.rs
@@ -66,6 +66,17 @@ impl StorageError {
 
 pub type StorageResult<T> = Result<T, StorageError>;
 
+/// Immutable, branch-addressed canonical group-state checkpoint.
+///
+/// The checkpoint id is derived from an authenticated MLS commit, while the
+/// resulting epoch is retained only for bounded garbage collection.  Backends
+/// must reject an attempt to replace an existing id with different contents.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GroupStateCheckpointRef {
+    pub id: String,
+    pub resulting_epoch: EpochId,
+}
+
 // ── GroupStorage ────────────────────────────────────────────────────────────
 
 /// CRUD for group metadata (no Nostr types; see `group.rs` invariants).
@@ -109,6 +120,33 @@ pub trait MessageStorage {
     fn list_group_snapshots(&self, group_id: &GroupId) -> StorageResult<Vec<String>>;
     fn rollback_group_to_snapshot(&self, group_id: &GroupId, name: &str) -> StorageResult<()>;
     fn release_group_snapshot(&self, group_id: &GroupId, name: &str) -> StorageResult<()>;
+
+    /// Capture only canonical group state: the Marmot group projection,
+    /// member-capability projection, validation marker, and every group-scoped
+    /// OpenMLS provider value. Messages, outbound queues, and convergence-pass
+    /// bookkeeping are deliberately excluded.
+    fn create_group_state_checkpoint(
+        &self,
+        group_id: &GroupId,
+        checkpoint: &GroupStateCheckpointRef,
+    ) -> StorageResult<()>;
+
+    fn restore_group_state_checkpoint(
+        &self,
+        group_id: &GroupId,
+        checkpoint_id: &str,
+    ) -> StorageResult<()>;
+
+    fn list_group_state_checkpoints(
+        &self,
+        group_id: &GroupId,
+    ) -> StorageResult<Vec<GroupStateCheckpointRef>>;
+
+    fn release_group_state_checkpoint(
+        &self,
+        group_id: &GroupId,
+        checkpoint_id: &str,
+    ) -> StorageResult<()>;
 }
 
 // ── OutboundIntentStorage ──────────────────────────────────────────────────

--- a/crates/traits/tests/snapshots.rs
+++ b/crates/traits/tests/snapshots.rs
@@ -308,6 +308,10 @@ fn stored_message_payload_own_commit_wire_round_trips_with_stamp() {
         committer: MemberId::new(vec![0xEE; 32]),
         priority: CommitOrderingPriority::Privileged,
         consumed_proposal_refs: vec!["0a0b".into()],
+        // `None` on purpose: this is the shape of every row written before
+        // `post_commit_tree_marker` existed, and `skip_serializing_if` must
+        // keep the stored bytes byte-identical for them.
+        post_commit_tree_marker: None,
     };
     let payload = StoredMessagePayload::own_commit_wire(message.clone(), stamp.clone());
 
@@ -319,6 +323,25 @@ fn stored_message_payload_own_commit_wire_round_trips_with_stamp() {
     assert_eq!(decoded.as_openmls_wire().unwrap(), &message);
     assert_eq!(decoded.own_commit_stamp().unwrap(), &stamp);
     assert!(decoded.as_raw_transport().is_none());
+
+    // With the marker present the field round-trips; and the stored bytes of
+    // the marker-less stamp above must still decode to `None`, so rows written
+    // by older engine versions stay readable (they simply cannot use the
+    // retained-anchor fast path).
+    let marked = OwnCommitConvergenceStamp {
+        post_commit_tree_marker: Some("ab".repeat(32)),
+        ..stamp.clone()
+    };
+    let marked_payload = StoredMessagePayload::own_commit_wire(message, marked.clone());
+    let decoded_marked = StoredMessagePayload::decode(&marked_payload.encode().unwrap()).unwrap();
+    assert_eq!(decoded_marked.own_commit_stamp().unwrap(), &marked);
+    assert!(
+        decoded
+            .own_commit_stamp()
+            .unwrap()
+            .post_commit_tree_marker
+            .is_none()
+    );
 }
 
 #[test]

--- a/crates/traits/tests/snapshots.rs
+++ b/crates/traits/tests/snapshots.rs
@@ -308,10 +308,8 @@ fn stored_message_payload_own_commit_wire_round_trips_with_stamp() {
         committer: MemberId::new(vec![0xEE; 32]),
         priority: CommitOrderingPriority::Privileged,
         consumed_proposal_refs: vec!["0a0b".into()],
-        // `None` on purpose: this is the shape of every row written before
-        // `post_commit_tree_marker` existed, and `skip_serializing_if` must
-        // keep the stored bytes byte-identical for them.
-        post_commit_tree_marker: None,
+        checkpoint_id: None,
+        resulting_epoch_authenticator: None,
     };
     let payload = StoredMessagePayload::own_commit_wire(message.clone(), stamp.clone());
 
@@ -324,24 +322,17 @@ fn stored_message_payload_own_commit_wire_round_trips_with_stamp() {
     assert_eq!(decoded.own_commit_stamp().unwrap(), &stamp);
     assert!(decoded.as_raw_transport().is_none());
 
-    // With the marker present the field round-trips; and the stored bytes of
-    // the marker-less stamp above must still decode to `None`, so rows written
-    // by older engine versions stay readable (they simply cannot use the
-    // retained-anchor fast path).
+    // A branch-addressed checkpoint and its resulting epoch authenticator
+    // round-trip together. Older stamp rows omit both optional fields.
     let marked = OwnCommitConvergenceStamp {
-        post_commit_tree_marker: Some("ab".repeat(32)),
+        checkpoint_id: Some(format!("openmls-own-commit-v1-{}", "ab".repeat(32))),
+        resulting_epoch_authenticator: Some("cd".repeat(32)),
         ..stamp.clone()
     };
     let marked_payload = StoredMessagePayload::own_commit_wire(message, marked.clone());
     let decoded_marked = StoredMessagePayload::decode(&marked_payload.encode().unwrap()).unwrap();
     assert_eq!(decoded_marked.own_commit_stamp().unwrap(), &marked);
-    assert!(
-        decoded
-            .own_commit_stamp()
-            .unwrap()
-            .post_commit_tree_marker
-            .is_none()
-    );
+    assert!(decoded.own_commit_stamp().unwrap().checkpoint_id.is_none());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Replaces #1236 with branch-addressed recovery for locally authored OpenMLS commits.

OpenMLS cannot process a device's own Commit after receiving it back from the network. The convergence engine therefore cannot reconstruct a selected branch containing a displaced own Commit from wire bytes alone, and the epoch-keyed retained snapshots used by #1236 can be overwritten by a rival branch at the same epoch.

This change:

- keeps both sides of a pairwise same-epoch race reconsiderable by distributed convergence, with atomic loser parking and branch-identifying audit records;
- derives an immutable checkpoint id from each confirmed own Commit's MLS wire digest;
- atomically captures the complete canonical MLS/Marmot group state after the pending Commit is merged and before its stored row becomes `Processed`;
- restores the exact commit-addressed checkpoint when that own branch wins later, verifies its resulting epoch authenticator, then replays descendants normally;
- deliberately leaves the live message ledger, outbound queues, convergence policy, and pass scheduler outside the checkpoint;
- retains checkpoints for the same bounded rewind horizon as convergence history and prunes them afterward.

If convergence needs an in-horizon locally authored commit from a pre-checkpoint database, the engine now reports `MissingOwnCommitCheckpoint`, leaves canonical state unchanged, and durably marks the group `Unrecoverable` for explicit repair. There is no safe way to reconstruct that exact historical branch from its network wire or an epoch-keyed anchor.

## Why this replaces #1236

#1236 correctly unified pairwise and convergence branch selection, but its final recovery mechanism still identified rollback state by epoch. Two sibling commits can produce the same epoch, so a later capture could replace the locally authored branch's only usable state. A ratchet-tree marker could detect the mismatch but could not recover the branch, leaving a liveness failure.

Commit-addressed immutable checkpoints remove that aliasing: the locally authored branch remains materializable after restart for as long as the convergence engine is allowed to select it.

## Validation

- `just fast-ci`
- `cargo test -p cgka-engine --features test-policy-overrides`
- `cargo test -p storage-sqlite`
- `cargo test -p cgka-traits --test snapshots`

The fork regression explicitly confirms an own Commit, lets a rival same-epoch branch overwrite the ordinary epoch anchor, restarts the original author, grows the own branch deeper, and verifies convergence onto that branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved same-epoch fork convergence so losing branches remain eligible for later reconciliation instead of becoming permanently invalid.
  * Added durable group-state checkpoints to support safe branch reorganization, restart recovery, and descendant replay.
  * Preserved winning commit ordering and expanded audit records with retained commit details.
* **Bug Fixes**
  * Prevented incorrect state restoration during fork resolution by validating recovered state before continuing.
  * Added fail-closed handling when required recovery checkpoints are unavailable.
* **Documentation**
  * Updated the unreleased changelog with convergence, checkpoint, and recovery improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
