### PR TITLE
feat: expose dial-safe profile image fetch

### DIFF
--- a/crates/cgka-conformance-simulator/src/app_runtime.rs
+++ b/crates/cgka-conformance-simulator/src/app_runtime.rs
@@ -1065,6 +1065,7 @@ fn app_error(error: AppError) -> SubjectError {
         | AppError::InvalidGroupAvatarUrl(_)
         | AppError::InvalidAgentTextStreamPolicy(_)
         | AppError::InvalidEncryptedMedia(_)
+        | AppError::UnsafeMediaFetch(_)
         | AppError::InvalidAppMessagePayload(_)
         | AppError::InvalidPushToken(_)
         | AppError::InvalidPushServer(_)

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -50,6 +50,11 @@ versioning through the workspace version in the root `Cargo.toml`.
   extensions can return bounded fallback content instead of creating a second
   stateful writer.
   
+- MarmotKit exposes `downloadProfileImage` for dial-safe fetching of untrusted
+  kind:0 profile `picture` URLs (HTTPS-only, pinned public resolution, bounded
+  redirects, and streaming limits) so Android and Swift hosts do not maintain a
+  separate SSRF stack for public avatars.
+
 - Outbound messages waiting in a group's durable queue are now bounded at 256
   per group. The bound covers every reason a message waits: a group resolving a
   stalled publication, convergence input that has not settled, and messages

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -51,9 +51,9 @@ versioning through the workspace version in the root `Cargo.toml`.
   stateful writer.
   
 - MarmotKit exposes `downloadProfileImage` for dial-safe fetching of untrusted
-  kind:0 profile `picture` URLs (HTTPS-only, pinned public resolution, bounded
-  redirects, and streaming limits) so Android and Swift hosts do not maintain a
-  separate SSRF stack for public avatars
+  kind:0 profile `picture` URLs (HTTPS-only, proxy-disabled pinned public
+  resolution, bounded redirects, and streaming limits) so Android and Swift
+  hosts do not maintain a separate SSRF stack for public avatars
   ([#1288](https://github.com/marmot-protocol/mdk/pull/1288)).
 
 - Outbound messages waiting in a group's durable queue are now bounded at 256

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -53,7 +53,8 @@ versioning through the workspace version in the root `Cargo.toml`.
 - MarmotKit exposes `downloadProfileImage` for dial-safe fetching of untrusted
   kind:0 profile `picture` URLs (HTTPS-only, pinned public resolution, bounded
   redirects, and streaming limits) so Android and Swift hosts do not maintain a
-  separate SSRF stack for public avatars.
+  separate SSRF stack for public avatars
+  ([#1288](https://github.com/marmot-protocol/mdk/pull/1288)).
 
 - Outbound messages waiting in a group's durable queue are now bounded at 256
   per group. The bound covers every reason a message waits: a group resolving a

--- a/crates/marmot-app/src/client/projection.rs
+++ b/crates/marmot-app/src/client/projection.rs
@@ -579,6 +579,7 @@ fn read_marker_error_code(error: &AppError) -> &'static str {
         }
         AppError::InvalidEncryptedMedia(_) => "read_marker_failed:invalid_encrypted_media",
         AppError::BlobStore(_) => "read_marker_failed:blob_store",
+        AppError::UnsafeMediaFetch(_) => "read_marker_failed:unsafe_media_fetch",
         AppError::InvalidAppMessagePayload(_) => "read_marker_failed:invalid_app_message_payload",
         AppError::InvalidPushToken(_) => "read_marker_failed:invalid_push_token",
         AppError::InvalidPushServer(_) => "read_marker_failed:invalid_push_server",

--- a/crates/marmot-app/src/error.rs
+++ b/crates/marmot-app/src/error.rs
@@ -94,6 +94,9 @@ pub enum AppError {
     InvalidEncryptedMedia(String),
     #[error("blob store request failed: {0}")]
     BlobStore(String),
+    /// Pre-dial rejection for untrusted profile/media fetch URLs (SSRF boundary).
+    #[error("unsafe media fetch: {0}")]
+    UnsafeMediaFetch(String),
     #[error("invalid app message payload: {0}")]
     InvalidAppMessagePayload(String),
     #[error("invalid push token")]
@@ -208,6 +211,7 @@ impl AppError {
             Self::InvalidAgentTextStreamPolicy(_) => "invalid_agent_text_stream_policy",
             Self::InvalidEncryptedMedia(_) => "invalid_encrypted_media",
             Self::BlobStore(_) => "blob_store",
+            Self::UnsafeMediaFetch(_) => "unsafe_media_fetch",
             Self::InvalidAppMessagePayload(_) => "invalid_app_message_payload",
             Self::InvalidPushToken(_) => "invalid_push_token",
             Self::InvalidPushServer(_) => "invalid_push_server",

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -166,7 +166,7 @@ pub use media::{
     DEFAULT_BLOSSOM_SERVER_URL, DEFAULT_BLOSSOM_SERVER_URLS, ENCRYPTED_MEDIA_VERSION,
     EncryptedMediaVersion, MediaAttachmentReference, MediaDownloadResult, MediaLocator,
     MediaUploadAttachmentRequest, MediaUploadAttachmentResult, MediaUploadRequest,
-    MediaUploadResult, media_attachment_from_imeta_tag,
+    MediaUploadResult, download_profile_image, media_attachment_from_imeta_tag,
 };
 pub use messages::{is_stream_final_event, tag_value, tag_values};
 pub use nostr_secret::is_nostr_secret;

--- a/crates/marmot-app/src/media/blossom.rs
+++ b/crates/marmot-app/src/media/blossom.rs
@@ -8,10 +8,13 @@ use serde::Deserialize;
 use url::{Host, Url};
 
 use super::host_safety::{
-    is_loopback_host, reject_non_public_ip, validate_blossom_fetch_url,
-    validate_profile_image_fetch_url,
+    is_loopback_host, parse_profile_image_fetch_url, parse_profile_image_redirect_url,
+    reject_non_public_ip, validate_blossom_fetch_url,
 };
 use crate::{AppError, unix_now_seconds};
+
+#[cfg(test)]
+use cgka_traits::app_components::ENCRYPTED_MEDIA_ENDPOINT_URL_MAX_LEN;
 
 const BLOSSOM_UPLOAD_AUTH_TTL: Duration = Duration::from_secs(10 * 60);
 const BLOSSOM_UPLOAD_CONTENT_TYPE: &str = "application/octet-stream";
@@ -171,107 +174,118 @@ pub(crate) async fn fetch_blossom_blob(
     url: &str,
     allow_loopback_http: bool,
 ) -> Result<Vec<u8>, AppError> {
-    let mut current = Url::parse(url)
+    let current = Url::parse(url)
         .map_err(|_| AppError::InvalidEncryptedMedia("media URL is invalid".into()))?;
     validate_blossom_fetch_url(&current, allow_loopback_http)
         .map_err(|err| AppError::BlobStore(format!("unsafe Blossom URL: {err}")))?;
-    let mut redirects = 0_usize;
-
-    loop {
-        let client = media_http_client_for_url(&current, allow_loopback_http).await?;
-        let response = client
-            .get(current.clone())
-            .send()
-            .await
-            .map_err(reqwest_blob_error)?;
-        let status = response.status();
-        if status.is_success() {
-            return read_limited_blossom_body(response, MAX_ENCRYPTED_MEDIA_BLOB_BYTES).await;
-        }
-        if !status.is_redirection() {
-            return Err(AppError::BlobStore(format!(
-                "download returned HTTP {}",
-                status.as_u16()
-            )));
-        }
-
-        if redirects >= BLOSSOM_REDIRECT_LIMIT {
-            return Err(AppError::BlobStore(format!(
-                "media redirect chain exceeded {BLOSSOM_REDIRECT_LIMIT} hops"
-            )));
-        }
-        let location = response
-            .headers()
-            .get(reqwest::header::LOCATION)
-            .ok_or_else(|| {
-                AppError::BlobStore("redirect response did not include Location".into())
-            })?
-            .to_str()
-            .map_err(|_| AppError::BlobStore("redirect Location header is invalid".into()))?;
-        let next = current.join(location).map_err(|_| {
-            AppError::BlobStore("redirect Location header is not a valid URL".into())
-        })?;
-        validate_blossom_redirect_target(&current, &next, allow_loopback_http)?;
-        current = next;
-        redirects += 1;
-    }
-}
-
-pub(crate) async fn fetch_profile_image(url: &str, max_bytes: u64) -> Result<Vec<u8>, AppError> {
-    profile_operation_timeout(
-        MEDIA_HTTP_TOTAL_TIMEOUT,
-        fetch_profile_image_impl(url, max_bytes, ProfileResolveMode::Production),
+    fetch_http_with_bounded_redirects(
+        current,
+        MAX_ENCRYPTED_MEDIA_BLOB_BYTES,
+        move |url| {
+            let allow_loopback_http = allow_loopback_http;
+            async move { media_http_client_for_url(&url, allow_loopback_http).await }
+        },
+        move |current, location| {
+            let next = current.join(location).map_err(|_| {
+                AppError::BlobStore("redirect Location header is not a valid URL".into())
+            })?;
+            validate_blossom_redirect_target(current, &next, allow_loopback_http)?;
+            Ok(next)
+        },
     )
     .await
 }
 
+pub(crate) async fn fetch_profile_image(url: &str, max_bytes: u64) -> Result<Vec<u8>, AppError> {
+    profile_operation_timeout(fetch_profile_image_impl(url, max_bytes)).await
+}
+
 #[cfg(test)]
-pub(crate) async fn fetch_profile_image_with_injected_addrs(
+pub(crate) async fn fetch_profile_image_with_loopback(
     url: &str,
     max_bytes: u64,
-    injected_addrs: Vec<SocketAddr>,
 ) -> Result<Vec<u8>, AppError> {
-    profile_operation_timeout(
-        MEDIA_HTTP_TOTAL_TIMEOUT,
-        fetch_profile_image_impl(url, max_bytes, ProfileResolveMode::Injected(injected_addrs)),
-    )
+    let raw = url.trim();
+    if raw.len() > ENCRYPTED_MEDIA_ENDPOINT_URL_MAX_LEN {
+        return Err(AppError::UnsafeMediaFetch(format!(
+            "profile image URL exceeds {ENCRYPTED_MEDIA_ENDPOINT_URL_MAX_LEN} bytes"
+        )));
+    }
+    let current = Url::parse(raw).map_err(|err| {
+        AppError::UnsafeMediaFetch(format!("profile image URL is invalid: {err}"))
+    })?;
+    validate_blossom_fetch_url(&current, true).map_err(AppError::UnsafeMediaFetch)?;
+    profile_operation_timeout(fetch_http_with_bounded_redirects(
+        current,
+        max_bytes,
+        move |url| async move { media_http_client_for_url(&url, true).await },
+        move |current, location| {
+            let raw_location = location.trim();
+            if raw_location.len() > ENCRYPTED_MEDIA_ENDPOINT_URL_MAX_LEN {
+                return Err(AppError::UnsafeMediaFetch(format!(
+                    "profile image redirect URL exceeds {ENCRYPTED_MEDIA_ENDPOINT_URL_MAX_LEN} bytes"
+                )));
+            }
+            let next = current.join(raw_location).map_err(|err| {
+                AppError::UnsafeMediaFetch(format!(
+                    "profile image redirect URL is invalid: {err}"
+                ))
+            })?;
+            validate_blossom_fetch_url(&next, true).map_err(AppError::UnsafeMediaFetch)?;
+            Ok(next)
+        },
+    ))
     .await
 }
 
 async fn profile_operation_timeout<T>(
-    timeout: Duration,
     operation: impl std::future::Future<Output = Result<T, AppError>>,
 ) -> Result<T, AppError> {
-    tokio::time::timeout(timeout, operation)
+    tokio::time::timeout(MEDIA_HTTP_TOTAL_TIMEOUT, operation)
         .await
         .map_err(|_| AppError::BlobStore("request timed out".into()))?
 }
 
-#[cfg(test)]
-pub(super) async fn profile_operation_timeout_for_test(timeout: Duration) -> Result<(), AppError> {
-    profile_operation_timeout(timeout, std::future::pending()).await
+async fn fetch_profile_image_impl(url: &str, max_bytes: u64) -> Result<Vec<u8>, AppError> {
+    let current = parse_profile_image_fetch_url(url).map_err(AppError::UnsafeMediaFetch)?;
+    fetch_http_with_bounded_redirects(
+        current,
+        max_bytes,
+        move |url| async move { media_http_client_for_profile(&url).await },
+        move |current, location| {
+            parse_profile_image_redirect_url(current, location).map_err(AppError::UnsafeMediaFetch)
+        },
+    )
+    .await
 }
 
-enum ProfileResolveMode {
-    Production,
-    #[cfg(test)]
-    Injected(Vec<SocketAddr>),
+/// Vet every DNS answer before pinning a profile-image fetch.
+pub(crate) fn vet_profile_fetch_resolved_addresses(addrs: &[SocketAddr]) -> Result<(), AppError> {
+    for addr in addrs {
+        reject_non_public_ip(addr.ip(), false).map_err(|err| {
+            AppError::UnsafeMediaFetch(format!("unsafe profile image host address: {err}"))
+        })?;
+    }
+    Ok(())
 }
 
-async fn fetch_profile_image_impl(
-    url: &str,
-    max_bytes: u64,
-    resolve_mode: ProfileResolveMode,
-) -> Result<Vec<u8>, AppError> {
-    let mut current = Url::parse(url)
-        .map_err(|_| AppError::InvalidAppMessagePayload("profile image URL is invalid".into()))?;
-    validate_profile_image_fetch_url(&current).map_err(|err| {
-        AppError::InvalidAppMessagePayload(format!("unsafe profile image URL: {err}"))
-    })?;
+/// Shared manual redirect loop for Blossom blob and profile-image fetches.
+/// Keep policy differences in the caller-supplied client and redirect validators.
+async fn fetch_http_with_bounded_redirects<C, CFut, R>(
+    mut current: Url,
+    max_body_bytes: u64,
+    mut client_for_url: C,
+    mut redirect_target: R,
+) -> Result<Vec<u8>, AppError>
+where
+    C: FnMut(Url) -> CFut,
+    CFut: std::future::Future<Output = Result<reqwest::Client, AppError>>,
+    R: FnMut(&Url, &str) -> Result<Url, AppError>,
+{
     let mut redirects = 0_usize;
 
     loop {
-        let client = media_http_client_for_profile(&current, &resolve_mode).await?;
+        let client = client_for_url(current.clone()).await?;
         let response = client
             .get(current.clone())
             .send()
@@ -279,7 +293,7 @@ async fn fetch_profile_image_impl(
             .map_err(reqwest_blob_error)?;
         let status = response.status();
         if status.is_success() {
-            return read_limited_blossom_body(response, max_bytes).await;
+            return read_limited_blossom_body(response, max_body_bytes).await;
         }
         if !status.is_redirection() {
             return Err(AppError::BlobStore(format!(
@@ -301,28 +315,8 @@ async fn fetch_profile_image_impl(
             })?
             .to_str()
             .map_err(|_| AppError::BlobStore("redirect Location header is invalid".into()))?;
-        let next = current.join(location).map_err(|_| {
-            AppError::BlobStore("redirect Location header is not a valid URL".into())
-        })?;
-        validate_profile_image_fetch_url(&next).map_err(|err| {
-            AppError::InvalidAppMessagePayload(format!("unsafe profile image redirect URL: {err}"))
-        })?;
-        current = next;
+        current = redirect_target(&current, location)?;
         redirects += 1;
-    }
-}
-
-#[cfg(test)]
-pub(super) fn plan_profile_image_pin(
-    url: &Url,
-    injected_addrs: &[SocketAddr],
-) -> Result<Option<(String, Vec<SocketAddr>)>, AppError> {
-    match url
-        .host()
-        .ok_or_else(|| AppError::BlobStore("media URL is missing a host".into()))?
-    {
-        Host::Domain(domain) => validated_media_domain_pin(domain, injected_addrs, false).map(Some),
-        _ => Ok(None),
     }
 }
 
@@ -343,23 +337,47 @@ fn validated_media_domain_pin(
     Ok((domain.to_ascii_lowercase(), addrs.to_vec()))
 }
 
-async fn profile_media_pin(
-    url: &Url,
-    resolve_mode: &ProfileResolveMode,
-) -> Result<Option<(String, Vec<SocketAddr>)>, AppError> {
-    match resolve_mode {
-        ProfileResolveMode::Production => resolve_media_host(url, false).await,
-        #[cfg(test)]
-        ProfileResolveMode::Injected(addrs) => plan_profile_image_pin(url, addrs),
-    }
+async fn media_http_client_for_profile(url: &Url) -> Result<reqwest::Client, AppError> {
+    let pin = resolve_media_host_for_profile(url).await?;
+    build_pinned_media_http_client(pin)
 }
 
-async fn media_http_client_for_profile(
+async fn resolve_media_host_for_profile(
     url: &Url,
-    resolve_mode: &ProfileResolveMode,
-) -> Result<reqwest::Client, AppError> {
-    let pin = profile_media_pin(url, resolve_mode).await?;
-    build_pinned_media_http_client(MEDIA_HTTP_TOTAL_TIMEOUT, pin)
+) -> Result<Option<(String, Vec<SocketAddr>)>, AppError> {
+    match url
+        .host()
+        .ok_or_else(|| AppError::UnsafeMediaFetch("profile image URL is missing a host".into()))?
+    {
+        Host::Domain(domain) => {
+            let port = url.port_or_known_default().ok_or_else(|| {
+                AppError::UnsafeMediaFetch("profile image URL is missing a fetch port".into())
+            })?;
+            let addrs = tokio::net::lookup_host((domain, port))
+                .await
+                .map_err(|_| AppError::BlobStore("media host DNS lookup failed".into()))?
+                .collect::<Vec<_>>();
+            if addrs.is_empty() {
+                return Err(AppError::BlobStore(
+                    "media host DNS lookup returned no addresses".into(),
+                ));
+            }
+            vet_profile_fetch_resolved_addresses(&addrs)?;
+            Ok(Some((domain.to_ascii_lowercase(), addrs)))
+        }
+        Host::Ipv4(addr) => {
+            reject_non_public_ip(IpAddr::V4(addr), false).map_err(|err| {
+                AppError::UnsafeMediaFetch(format!("unsafe profile image host address: {err}"))
+            })?;
+            Ok(None)
+        }
+        Host::Ipv6(addr) => {
+            reject_non_public_ip(IpAddr::V6(addr), false).map_err(|err| {
+                AppError::UnsafeMediaFetch(format!("unsafe profile image host address: {err}"))
+            })?;
+            Ok(None)
+        }
+    }
 }
 
 pub(super) fn validate_blossom_redirect_target(
@@ -421,20 +439,17 @@ async fn media_http_client_for_url(
         && allow_loopback_http
         && url.host().map(is_loopback_host).unwrap_or(false);
     let pin = resolve_media_host(url, allow_loopback).await?;
-    build_pinned_media_http_client(MEDIA_HTTP_TOTAL_TIMEOUT, pin)
+    build_pinned_media_http_client(pin)
 }
 
 fn build_pinned_media_http_client(
-    operation_timeout: Duration,
     pin: Option<(String, Vec<SocketAddr>)>,
 ) -> Result<reqwest::Client, AppError> {
-    let connect_timeout = operation_timeout.min(MEDIA_HTTP_CONNECT_TIMEOUT);
-    let read_timeout = operation_timeout.min(MEDIA_HTTP_READ_TIMEOUT);
     let mut builder = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
-        .connect_timeout(connect_timeout)
-        .read_timeout(read_timeout)
-        .timeout(operation_timeout)
+        .connect_timeout(MEDIA_HTTP_CONNECT_TIMEOUT)
+        .read_timeout(MEDIA_HTTP_READ_TIMEOUT)
+        .timeout(MEDIA_HTTP_TOTAL_TIMEOUT)
         .no_proxy()
         .no_gzip()
         .no_brotli()

--- a/crates/marmot-app/src/media/blossom.rs
+++ b/crates/marmot-app/src/media/blossom.rs
@@ -7,7 +7,10 @@ use nostr::{EventBuilder, JsonUtil, Kind, NostrSigner, Tag, Timestamp as NostrTi
 use serde::Deserialize;
 use url::{Host, Url};
 
-use super::host_safety::{is_loopback_host, reject_non_public_ip, validate_blossom_fetch_url};
+use super::host_safety::{
+    is_loopback_host, reject_non_public_ip, validate_blossom_fetch_url,
+    validate_profile_image_fetch_url,
+};
 use crate::{AppError, unix_now_seconds};
 
 const BLOSSOM_UPLOAD_AUTH_TTL: Duration = Duration::from_secs(10 * 60);
@@ -214,6 +217,151 @@ pub(crate) async fn fetch_blossom_blob(
     }
 }
 
+pub(crate) async fn fetch_profile_image(url: &str, max_bytes: u64) -> Result<Vec<u8>, AppError> {
+    profile_operation_timeout(
+        MEDIA_HTTP_TOTAL_TIMEOUT,
+        fetch_profile_image_impl(url, max_bytes, ProfileResolveMode::Production),
+    )
+    .await
+}
+
+#[cfg(test)]
+pub(crate) async fn fetch_profile_image_with_injected_addrs(
+    url: &str,
+    max_bytes: u64,
+    injected_addrs: Vec<SocketAddr>,
+) -> Result<Vec<u8>, AppError> {
+    profile_operation_timeout(
+        MEDIA_HTTP_TOTAL_TIMEOUT,
+        fetch_profile_image_impl(url, max_bytes, ProfileResolveMode::Injected(injected_addrs)),
+    )
+    .await
+}
+
+async fn profile_operation_timeout<T>(
+    timeout: Duration,
+    operation: impl std::future::Future<Output = Result<T, AppError>>,
+) -> Result<T, AppError> {
+    tokio::time::timeout(timeout, operation)
+        .await
+        .map_err(|_| AppError::BlobStore("request timed out".into()))?
+}
+
+#[cfg(test)]
+pub(super) async fn profile_operation_timeout_for_test(timeout: Duration) -> Result<(), AppError> {
+    profile_operation_timeout(timeout, std::future::pending()).await
+}
+
+enum ProfileResolveMode {
+    Production,
+    #[cfg(test)]
+    Injected(Vec<SocketAddr>),
+}
+
+async fn fetch_profile_image_impl(
+    url: &str,
+    max_bytes: u64,
+    resolve_mode: ProfileResolveMode,
+) -> Result<Vec<u8>, AppError> {
+    let mut current = Url::parse(url)
+        .map_err(|_| AppError::InvalidAppMessagePayload("profile image URL is invalid".into()))?;
+    validate_profile_image_fetch_url(&current).map_err(|err| {
+        AppError::InvalidAppMessagePayload(format!("unsafe profile image URL: {err}"))
+    })?;
+    let mut redirects = 0_usize;
+
+    loop {
+        let client = media_http_client_for_profile(&current, &resolve_mode).await?;
+        let response = client
+            .get(current.clone())
+            .send()
+            .await
+            .map_err(reqwest_blob_error)?;
+        let status = response.status();
+        if status.is_success() {
+            return read_limited_blossom_body(response, max_bytes).await;
+        }
+        if !status.is_redirection() {
+            return Err(AppError::BlobStore(format!(
+                "download returned HTTP {}",
+                status.as_u16()
+            )));
+        }
+
+        if redirects >= BLOSSOM_REDIRECT_LIMIT {
+            return Err(AppError::BlobStore(format!(
+                "media redirect chain exceeded {BLOSSOM_REDIRECT_LIMIT} hops"
+            )));
+        }
+        let location = response
+            .headers()
+            .get(reqwest::header::LOCATION)
+            .ok_or_else(|| {
+                AppError::BlobStore("redirect response did not include Location".into())
+            })?
+            .to_str()
+            .map_err(|_| AppError::BlobStore("redirect Location header is invalid".into()))?;
+        let next = current.join(location).map_err(|_| {
+            AppError::BlobStore("redirect Location header is not a valid URL".into())
+        })?;
+        validate_profile_image_fetch_url(&next).map_err(|err| {
+            AppError::InvalidAppMessagePayload(format!("unsafe profile image redirect URL: {err}"))
+        })?;
+        current = next;
+        redirects += 1;
+    }
+}
+
+#[cfg(test)]
+pub(super) fn plan_profile_image_pin(
+    url: &Url,
+    injected_addrs: &[SocketAddr],
+) -> Result<Option<(String, Vec<SocketAddr>)>, AppError> {
+    match url
+        .host()
+        .ok_or_else(|| AppError::BlobStore("media URL is missing a host".into()))?
+    {
+        Host::Domain(domain) => validated_media_domain_pin(domain, injected_addrs, false).map(Some),
+        _ => Ok(None),
+    }
+}
+
+fn validated_media_domain_pin(
+    domain: &str,
+    addrs: &[SocketAddr],
+    allow_loopback: bool,
+) -> Result<(String, Vec<SocketAddr>), AppError> {
+    if addrs.is_empty() {
+        return Err(AppError::BlobStore(
+            "media host DNS lookup returned no addresses".into(),
+        ));
+    }
+    for addr in addrs {
+        reject_non_public_ip(addr.ip(), allow_loopback)
+            .map_err(|err| AppError::BlobStore(format!("unsafe media host address: {err}")))?;
+    }
+    Ok((domain.to_ascii_lowercase(), addrs.to_vec()))
+}
+
+async fn profile_media_pin(
+    url: &Url,
+    resolve_mode: &ProfileResolveMode,
+) -> Result<Option<(String, Vec<SocketAddr>)>, AppError> {
+    match resolve_mode {
+        ProfileResolveMode::Production => resolve_media_host(url, false).await,
+        #[cfg(test)]
+        ProfileResolveMode::Injected(addrs) => plan_profile_image_pin(url, addrs),
+    }
+}
+
+async fn media_http_client_for_profile(
+    url: &Url,
+    resolve_mode: &ProfileResolveMode,
+) -> Result<reqwest::Client, AppError> {
+    let pin = profile_media_pin(url, resolve_mode).await?;
+    build_pinned_media_http_client(MEDIA_HTTP_TOTAL_TIMEOUT, pin)
+}
+
 pub(super) fn validate_blossom_redirect_target(
     current: &Url,
     next: &Url,
@@ -269,17 +417,30 @@ async fn media_http_client_for_url(
 ) -> Result<reqwest::Client, AppError> {
     validate_blossom_fetch_url(url, allow_loopback_http)
         .map_err(|err| AppError::BlobStore(format!("unsafe Blossom URL: {err}")))?;
+    let allow_loopback = url.scheme() == "http"
+        && allow_loopback_http
+        && url.host().map(is_loopback_host).unwrap_or(false);
+    let pin = resolve_media_host(url, allow_loopback).await?;
+    build_pinned_media_http_client(MEDIA_HTTP_TOTAL_TIMEOUT, pin)
+}
+
+fn build_pinned_media_http_client(
+    operation_timeout: Duration,
+    pin: Option<(String, Vec<SocketAddr>)>,
+) -> Result<reqwest::Client, AppError> {
+    let connect_timeout = operation_timeout.min(MEDIA_HTTP_CONNECT_TIMEOUT);
+    let read_timeout = operation_timeout.min(MEDIA_HTTP_READ_TIMEOUT);
     let mut builder = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
-        .connect_timeout(MEDIA_HTTP_CONNECT_TIMEOUT)
-        .read_timeout(MEDIA_HTTP_READ_TIMEOUT)
-        .timeout(MEDIA_HTTP_TOTAL_TIMEOUT)
+        .connect_timeout(connect_timeout)
+        .read_timeout(read_timeout)
+        .timeout(operation_timeout)
         .no_proxy()
         .no_gzip()
         .no_brotli()
         .no_zstd()
         .no_deflate();
-    if let Some((domain, addrs)) = resolve_media_host(url, allow_loopback_http).await? {
+    if let Some((domain, addrs)) = pin {
         builder = builder.resolve_to_addrs(&domain, &addrs);
     }
     builder
@@ -289,11 +450,8 @@ async fn media_http_client_for_url(
 
 async fn resolve_media_host(
     url: &Url,
-    allow_loopback_http: bool,
+    allow_loopback: bool,
 ) -> Result<Option<(String, Vec<SocketAddr>)>, AppError> {
-    let allow_loopback = url.scheme() == "http"
-        && allow_loopback_http
-        && url.host().map(is_loopback_host).unwrap_or(false);
     match url
         .host()
         .ok_or_else(|| AppError::BlobStore("Blossom URL is missing a host".into()))?
@@ -306,17 +464,7 @@ async fn resolve_media_host(
                 .await
                 .map_err(|_| AppError::BlobStore("media host DNS lookup failed".into()))?
                 .collect::<Vec<_>>();
-            if addrs.is_empty() {
-                return Err(AppError::BlobStore(
-                    "media host DNS lookup returned no addresses".into(),
-                ));
-            }
-            for addr in &addrs {
-                reject_non_public_ip(addr.ip(), allow_loopback).map_err(|err| {
-                    AppError::BlobStore(format!("unsafe media host address: {err}"))
-                })?;
-            }
-            Ok(Some((domain.to_ascii_lowercase(), addrs)))
+            validated_media_domain_pin(domain, &addrs, allow_loopback).map(Some)
         }
         Host::Ipv4(addr) => {
             reject_non_public_ip(IpAddr::V4(addr), allow_loopback)

--- a/crates/marmot-app/src/media/blossom.rs
+++ b/crates/marmot-app/src/media/blossom.rs
@@ -445,7 +445,14 @@ async fn media_http_client_for_url(
 fn build_pinned_media_http_client(
     pin: Option<(String, Vec<SocketAddr>)>,
 ) -> Result<reqwest::Client, AppError> {
-    let mut builder = reqwest::Client::builder()
+    build_pinned_media_http_client_from_builder(reqwest::Client::builder(), pin)
+}
+
+fn build_pinned_media_http_client_from_builder(
+    builder: reqwest::ClientBuilder,
+    pin: Option<(String, Vec<SocketAddr>)>,
+) -> Result<reqwest::Client, AppError> {
+    let mut builder = builder
         .redirect(reqwest::redirect::Policy::none())
         .connect_timeout(MEDIA_HTTP_CONNECT_TIMEOUT)
         .read_timeout(MEDIA_HTTP_READ_TIMEOUT)
@@ -461,6 +468,16 @@ fn build_pinned_media_http_client(
     builder
         .build()
         .map_err(|_| AppError::BlobStore("failed to build HTTP client".into()))
+}
+
+#[cfg(test)]
+pub(super) fn build_pinned_media_http_client_with_proxy_for_test(
+    pin: Option<(String, Vec<SocketAddr>)>,
+    proxy_url: &str,
+) -> Result<reqwest::Client, AppError> {
+    let proxy = reqwest::Proxy::all(proxy_url)
+        .map_err(|_| AppError::BlobStore("failed to configure test HTTP proxy".into()))?;
+    build_pinned_media_http_client_from_builder(reqwest::Client::builder().proxy(proxy), pin)
 }
 
 async fn resolve_media_host(

--- a/crates/marmot-app/src/media/host_safety.rs
+++ b/crates/marmot-app/src/media/host_safety.rs
@@ -69,6 +69,41 @@ pub(crate) fn validate_profile_image_fetch_url(url: &Url) -> Result<(), String> 
     Ok(())
 }
 
+/// Trim and bound-check the raw profile-image URL before WHATWG parse
+/// normalization can collapse an over-limit dot-segment path.
+pub(crate) fn parse_profile_image_fetch_url(raw: &str) -> Result<Url, String> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return Err("profile image URL must not be empty".into());
+    }
+    if raw.len() > ENCRYPTED_MEDIA_ENDPOINT_URL_MAX_LEN {
+        return Err(format!(
+            "profile image URL exceeds {ENCRYPTED_MEDIA_ENDPOINT_URL_MAX_LEN} bytes"
+        ));
+    }
+    let url = Url::parse(raw).map_err(|e| format!("profile image URL is invalid: {e}"))?;
+    validate_profile_image_fetch_url(&url)?;
+    Ok(url)
+}
+
+/// Resolve one profile-image redirect only after bounding its raw `Location`.
+pub(crate) fn parse_profile_image_redirect_url(
+    current: &Url,
+    raw_location: &str,
+) -> Result<Url, String> {
+    let raw_location = raw_location.trim();
+    if raw_location.len() > ENCRYPTED_MEDIA_ENDPOINT_URL_MAX_LEN {
+        return Err(format!(
+            "profile image redirect URL exceeds {ENCRYPTED_MEDIA_ENDPOINT_URL_MAX_LEN} bytes"
+        ));
+    }
+    let url = current
+        .join(raw_location)
+        .map_err(|e| format!("profile image redirect URL is invalid: {e}"))?;
+    validate_profile_image_fetch_url(&url)?;
+    Ok(url)
+}
+
 pub(crate) fn validate_blossom_fetch_url(
     url: &Url,
     allow_loopback_http: bool,

--- a/crates/marmot-app/src/media/host_safety.rs
+++ b/crates/marmot-app/src/media/host_safety.rs
@@ -56,6 +56,19 @@ pub(crate) fn validate_locator(
     Ok(())
 }
 
+/// HTTPS-only profile-image fetch URLs: default port 443, no credentials or
+/// fragments, and no loopback/private/special-use literal hosts. Unlike Blossom
+/// media locators, explicit non-default HTTPS ports are rejected.
+pub(crate) fn validate_profile_image_fetch_url(url: &Url) -> Result<(), String> {
+    validate_blossom_fetch_url(url, false)?;
+    if let Some(port) = url.port()
+        && port != 443
+    {
+        return Err("URL must use the default HTTPS port".into());
+    }
+    Ok(())
+}
+
 pub(crate) fn validate_blossom_fetch_url(
     url: &Url,
     allow_loopback_http: bool,

--- a/crates/marmot-app/src/media/host_safety.rs
+++ b/crates/marmot-app/src/media/host_safety.rs
@@ -72,14 +72,14 @@ pub(crate) fn validate_profile_image_fetch_url(url: &Url) -> Result<(), String> 
 /// Trim and bound-check the raw profile-image URL before WHATWG parse
 /// normalization can collapse an over-limit dot-segment path.
 pub(crate) fn parse_profile_image_fetch_url(raw: &str) -> Result<Url, String> {
-    let raw = raw.trim();
-    if raw.is_empty() {
-        return Err("profile image URL must not be empty".into());
-    }
     if raw.len() > ENCRYPTED_MEDIA_ENDPOINT_URL_MAX_LEN {
         return Err(format!(
             "profile image URL exceeds {ENCRYPTED_MEDIA_ENDPOINT_URL_MAX_LEN} bytes"
         ));
+    }
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return Err("profile image URL must not be empty".into());
     }
     let url = Url::parse(raw).map_err(|e| format!("profile image URL is invalid: {e}"))?;
     validate_profile_image_fetch_url(&url)?;
@@ -91,12 +91,12 @@ pub(crate) fn parse_profile_image_redirect_url(
     current: &Url,
     raw_location: &str,
 ) -> Result<Url, String> {
-    let raw_location = raw_location.trim();
     if raw_location.len() > ENCRYPTED_MEDIA_ENDPOINT_URL_MAX_LEN {
         return Err(format!(
             "profile image redirect URL exceeds {ENCRYPTED_MEDIA_ENDPOINT_URL_MAX_LEN} bytes"
         ));
     }
+    let raw_location = raw_location.trim();
     let url = current
         .join(raw_location)
         .map_err(|e| format!("profile image redirect URL is invalid: {e}"))?;

--- a/crates/marmot-app/src/media/mod.rs
+++ b/crates/marmot-app/src/media/mod.rs
@@ -95,7 +95,8 @@ pub const DEFAULT_BLOSSOM_SERVER_URL: &str = DEFAULT_BLOSSOM_SERVER_URLS[0];
 /// Public-profile images are intentionally not encrypted: their Blossom URL is
 /// published in Nostr kind:0 metadata and must be fetchable by other clients.
 pub const DEFAULT_PROFILE_IMAGE_BLOSSOM_SERVER_URL: &str = "https://blossom.primal.net";
-const MAX_PROFILE_IMAGE_BYTES: usize = 10 * 1024 * 1024;
+/// Maximum profile-image upload and dial-safe download size (10 MiB).
+pub(crate) const MAX_PROFILE_IMAGE_BYTES: usize = 10 * 1024 * 1024;
 /// Frozen legacy format label. New code chooses a version from group state.
 pub const ENCRYPTED_MEDIA_VERSION: &str = ENCRYPTED_MEDIA_FORMAT_V1;
 
@@ -191,6 +192,43 @@ pub(crate) async fn upload_profile_image_with_policy(
     host_safety::validate_blossom_fetch_url(&parsed, allow_loopback_http)
         .map_err(|_| AppError::BlobStore("upload returned an unsafe image URL".into()))?;
     Ok(url)
+}
+
+fn normalize_profile_image_max_bytes(max_bytes: u64) -> Result<u64, AppError> {
+    if max_bytes == 0 {
+        return Err(AppError::InvalidAppMessagePayload(
+            "profile image max_bytes must be positive".into(),
+        ));
+    }
+    let ceiling = MAX_PROFILE_IMAGE_BYTES as u64;
+    if max_bytes > ceiling {
+        return Err(AppError::InvalidAppMessagePayload(format!(
+            "profile image max_bytes exceeds {ceiling} byte ceiling"
+        )));
+    }
+    Ok(max_bytes)
+}
+
+/// Fetch one untrusted kind:0 profile `picture` URL with MDK dial-safe HTTPS
+/// policy (pinned public resolution, bounded redirects, and streaming limits).
+pub async fn download_profile_image(url: String, max_bytes: u64) -> Result<Vec<u8>, AppError> {
+    let max_bytes = normalize_profile_image_max_bytes(max_bytes)?;
+    blossom::fetch_profile_image(&url, max_bytes).await
+}
+
+#[cfg(test)]
+pub(crate) async fn download_profile_image_with_injected_addrs(
+    url: &str,
+    max_bytes: u64,
+    injected_addrs: Vec<std::net::SocketAddr>,
+) -> Result<Vec<u8>, AppError> {
+    let max_bytes = normalize_profile_image_max_bytes(max_bytes)?;
+    blossom::fetch_profile_image_with_injected_addrs(url, max_bytes, injected_addrs).await
+}
+
+#[cfg(test)]
+pub(crate) fn normalize_profile_image_max_bytes_for_test(max_bytes: u64) -> Result<u64, AppError> {
+    normalize_profile_image_max_bytes(max_bytes)
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -928,3 +966,5 @@ fn validate_outbound_file_name(
 
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod tests_profile_image;

--- a/crates/marmot-app/src/media/mod.rs
+++ b/crates/marmot-app/src/media/mod.rs
@@ -217,13 +217,12 @@ pub async fn download_profile_image(url: String, max_bytes: u64) -> Result<Vec<u
 }
 
 #[cfg(test)]
-pub(crate) async fn download_profile_image_with_injected_addrs(
-    url: &str,
+pub(crate) async fn download_profile_image_with_test_loopback(
+    url: String,
     max_bytes: u64,
-    injected_addrs: Vec<std::net::SocketAddr>,
 ) -> Result<Vec<u8>, AppError> {
     let max_bytes = normalize_profile_image_max_bytes(max_bytes)?;
-    blossom::fetch_profile_image_with_injected_addrs(url, max_bytes, injected_addrs).await
+    blossom::fetch_profile_image_with_loopback(&url, max_bytes).await
 }
 
 #[cfg(test)]

--- a/crates/marmot-app/src/media/tests.rs
+++ b/crates/marmot-app/src/media/tests.rs
@@ -293,7 +293,7 @@ fn spawn_http_responses(responses: Vec<Vec<u8>>) -> String {
     format!("http://{addr}")
 }
 
-fn spawn_http_response(response: Vec<u8>) -> String {
+pub(super) fn spawn_http_response(response: Vec<u8>) -> String {
     spawn_http_responses(vec![response])
 }
 
@@ -304,7 +304,7 @@ fn http_redirect_response(location: &str) -> Vec<u8> {
     .into_bytes()
 }
 
-fn http_ok_response(body: &[u8]) -> Vec<u8> {
+pub(super) fn http_ok_response(body: &[u8]) -> Vec<u8> {
     let mut response = format!(
         "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
         body.len()

--- a/crates/marmot-app/src/media/tests.rs
+++ b/crates/marmot-app/src/media/tests.rs
@@ -278,7 +278,7 @@ fn imeta_parser_rejects_duplicate_single_occurrence_field() {
     assert!(media_attachment_from_imeta_tag(&multi, None, false).is_ok());
 }
 
-fn spawn_http_responses(responses: Vec<Vec<u8>>) -> String {
+pub(super) fn spawn_http_responses(responses: Vec<Vec<u8>>) -> String {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
     let addr = listener.local_addr().expect("test server addr");
     thread::spawn(move || {
@@ -297,7 +297,7 @@ pub(super) fn spawn_http_response(response: Vec<u8>) -> String {
     spawn_http_responses(vec![response])
 }
 
-fn http_redirect_response(location: &str) -> Vec<u8> {
+pub(super) fn http_redirect_response(location: &str) -> Vec<u8> {
     format!(
         "HTTP/1.1 302 Found\r\nLocation: {location}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
     )

--- a/crates/marmot-app/src/media/tests_profile_image.rs
+++ b/crates/marmot-app/src/media/tests_profile_image.rs
@@ -3,7 +3,10 @@
 use cgka_traits::app_components::ENCRYPTED_MEDIA_ENDPOINT_URL_MAX_LEN;
 use url::Url;
 
-use super::blossom::{read_limited_blossom_body, vet_profile_fetch_resolved_addresses};
+use super::blossom::{
+    build_pinned_media_http_client_with_proxy_for_test, read_limited_blossom_body,
+    vet_profile_fetch_resolved_addresses,
+};
 use super::host_safety::{parse_profile_image_fetch_url, validate_profile_image_fetch_url};
 use super::tests::{
     http_ok_response, http_redirect_response, spawn_http_response, spawn_http_responses,
@@ -223,6 +226,34 @@ async fn download_profile_image_follows_redirect_to_local_listener() {
         .expect("profile fetch should follow one redirect to the final body");
 
     assert_eq!(bytes, b"avatar-bytes");
+}
+
+#[tokio::test]
+async fn pinned_media_client_ignores_configured_proxy() {
+    let origin_url = spawn_http_response(http_ok_response(b"direct-origin"));
+    let origin = Url::parse(&origin_url).expect("origin listener URL");
+    let origin_addr = std::net::SocketAddr::new(
+        origin.host_str().unwrap().parse().unwrap(),
+        origin.port().unwrap(),
+    );
+    let proxy_url = spawn_http_response(http_ok_response(b"proxy-used"));
+    let client = build_pinned_media_http_client_with_proxy_for_test(
+        Some(("profile-image.test".into(), vec![origin_addr])),
+        &proxy_url,
+    )
+    .expect("build pinned client with a configured proxy");
+
+    let response = client
+        .get(format!(
+            "http://profile-image.test:{}/avatar.png",
+            origin_addr.port()
+        ))
+        .send()
+        .await
+        .expect("pinned client must dial the vetted origin directly");
+    let body = response.bytes().await.expect("read origin response");
+
+    assert_eq!(body.as_ref(), b"direct-origin");
 }
 
 #[tokio::test]

--- a/crates/marmot-app/src/media/tests_profile_image.rs
+++ b/crates/marmot-app/src/media/tests_profile_image.rs
@@ -1,0 +1,256 @@
+//! Profile-image dial-safe fetch acceptance tests (mdk#1287).
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::time::Duration;
+
+use cgka_traits::app_components::ENCRYPTED_MEDIA_ENDPOINT_URL_MAX_LEN;
+use url::Url;
+
+use super::blossom::{
+    plan_profile_image_pin, profile_operation_timeout_for_test, read_limited_blossom_body,
+};
+use super::host_safety::validate_profile_image_fetch_url;
+use super::{
+    MAX_PROFILE_IMAGE_BYTES, download_profile_image, download_profile_image_with_injected_addrs,
+    normalize_profile_image_max_bytes_for_test,
+};
+
+fn public_socket_addr(byte: u8) -> SocketAddr {
+    SocketAddr::new(IpAddr::V4(Ipv4Addr::new(93, 184, 216, byte)), 443)
+}
+
+#[tokio::test]
+async fn download_profile_image_rejects_loopback_literal_before_network() {
+    let err = download_profile_image("https://127.0.0.1/avatar.png".to_owned(), 1024)
+        .await
+        .expect_err("loopback profile URL must not be dialed");
+    assert!(
+        err.to_string().contains("localhost") || err.to_string().contains("public unicast"),
+        "expected pre-dial rejection, got {err}"
+    );
+}
+
+#[test]
+fn profile_image_fetch_url_rejects_rooted_localhost_forms() {
+    for url in [
+        "https://localhost./avatar.png",
+        "https://dev.localhost./avatar.png",
+    ] {
+        let parsed = Url::parse(url).unwrap();
+        let err = validate_profile_image_fetch_url(&parsed).unwrap_err();
+        assert!(err.contains("localhost"), "url {url}: {err}");
+    }
+}
+
+#[test]
+fn profile_image_fetch_url_rejects_private_and_special_use_literals() {
+    for url in [
+        "https://127.0.0.1/avatar.png",
+        "https://localhost/avatar.png",
+        "https://sub.localhost/avatar.png",
+        "https://10.0.0.1/avatar.png",
+        "https://169.254.169.254/avatar.png",
+        "https://[::1]/avatar.png",
+        "https://[fc00::1]/avatar.png",
+        "https://[3fff::1]/avatar.png",
+    ] {
+        let parsed = Url::parse(url).unwrap();
+        let err = validate_profile_image_fetch_url(&parsed).unwrap_err();
+        assert!(
+            err.contains("localhost") || err.contains("public unicast"),
+            "url {url}: {err}"
+        );
+    }
+}
+
+#[test]
+fn profile_image_fetch_url_length_boundary_and_over_limit() {
+    let prefix = "https://media.example/";
+    let under = format!(
+        "{}{}",
+        prefix,
+        "a".repeat(ENCRYPTED_MEDIA_ENDPOINT_URL_MAX_LEN - prefix.len())
+    );
+    assert!(validate_profile_image_fetch_url(&Url::parse(&under).unwrap()).is_ok());
+
+    let over = format!(
+        "{}{}",
+        prefix,
+        "a".repeat(ENCRYPTED_MEDIA_ENDPOINT_URL_MAX_LEN - prefix.len() + 1)
+    );
+    let err = validate_profile_image_fetch_url(&Url::parse(&over).unwrap()).unwrap_err();
+    assert!(err.contains("exceeds"));
+}
+
+#[test]
+fn profile_image_fetch_url_rejects_credentials_fragments_scheme_and_custom_port() {
+    let base = "https://media.example/avatar.png";
+    for (url, needle) in [
+        ("https://user@media.example/avatar.png", "credentials"),
+        ("https://media.example/avatar.png#frag", "fragment"),
+        ("http://media.example/avatar.png", "https"),
+        (
+            "https://media.example:8443/avatar.png",
+            "default HTTPS port",
+        ),
+    ] {
+        let parsed = Url::parse(url).unwrap();
+        let err = validate_profile_image_fetch_url(&parsed).unwrap_err();
+        assert!(err.contains(needle), "url {url}: {err}");
+    }
+    assert!(validate_profile_image_fetch_url(&Url::parse(base).unwrap()).is_ok());
+}
+
+#[test]
+fn profile_image_redirect_validation_allows_cross_domain_public_targets() {
+    let current = Url::parse("https://profiles.example/a.png").unwrap();
+    let next = Url::parse("https://cdn.other.example/b.png").unwrap();
+    assert!(validate_profile_image_fetch_url(&current).is_ok());
+    assert!(validate_profile_image_fetch_url(&next).is_ok());
+    assert!(
+        super::blossom::validate_blossom_redirect_target(&current, &next, false).is_err(),
+        "Blossom must keep registrable-domain affinity"
+    );
+}
+
+#[test]
+fn profile_image_redirect_validation_rejects_unsafe_targets_before_resolve() {
+    let safe = Url::parse("https://profiles.example/a.png").unwrap();
+    for bad in [
+        "http://cdn.other.example/b.png",
+        "https://127.0.0.1/b.png",
+        "https://localhost./b.png",
+        "https://dev.localhost./b.png",
+        "https://user@cdn.other.example/b.png",
+        "https://cdn.other.example/b.png#x",
+        "https://cdn.other.example:8443/b.png",
+    ] {
+        let parsed = Url::parse(bad).unwrap();
+        assert!(
+            validate_profile_image_fetch_url(&parsed).is_err(),
+            "redirect target must be rejected: {bad}"
+        );
+    }
+    assert!(validate_profile_image_fetch_url(&safe).is_ok());
+}
+
+#[test]
+fn profile_image_max_bytes_zero_ceiling_and_exact_ceiling() {
+    assert!(
+        normalize_profile_image_max_bytes_for_test(0)
+            .unwrap_err()
+            .to_string()
+            .contains("positive")
+    );
+    assert!(
+        normalize_profile_image_max_bytes_for_test(MAX_PROFILE_IMAGE_BYTES as u64 + 1)
+            .unwrap_err()
+            .to_string()
+            .contains("ceiling")
+    );
+    assert_eq!(
+        normalize_profile_image_max_bytes_for_test(MAX_PROFILE_IMAGE_BYTES as u64).unwrap(),
+        MAX_PROFILE_IMAGE_BYTES as u64
+    );
+}
+
+#[tokio::test]
+async fn download_profile_image_rejects_injected_private_resolve_before_dial() {
+    let err = download_profile_image_with_injected_addrs(
+        "https://profile.example/avatar.png",
+        1024,
+        vec![SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 443)],
+    )
+    .await
+    .expect_err("private injected resolve");
+    assert!(err.to_string().contains("public unicast"));
+}
+
+#[test]
+fn profile_image_pin_plan_rejects_private_injected_addresses_before_dial() {
+    let url = Url::parse("https://profile.example/avatar.png").unwrap();
+    let public = public_socket_addr(34);
+    let err = plan_profile_image_pin(
+        &url,
+        &[
+            public,
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 443),
+        ],
+    )
+    .expect_err("mixed public/private inject");
+    assert!(err.to_string().contains("public unicast"));
+}
+
+#[test]
+fn profile_image_pin_plan_returns_exact_vetted_set_for_one_hop() {
+    let url = Url::parse("https://profile.example/avatar.png").unwrap();
+    let first = vec![public_socket_addr(34), public_socket_addr(35)];
+    let (domain, pinned) = plan_profile_image_pin(&url, &first)
+        .expect("pin plan")
+        .expect("domain pin");
+    assert_eq!(domain, "profile.example");
+    assert_eq!(pinned, first);
+
+    let rebound = vec![public_socket_addr(36)];
+    let (_, second_pin) = plan_profile_image_pin(&url, &rebound)
+        .expect("second plan")
+        .expect("second pin");
+    assert_eq!(second_pin, rebound);
+    assert_ne!(
+        pinned, second_pin,
+        "rebound answers must not merge across plans"
+    );
+}
+
+#[tokio::test]
+async fn profile_image_operation_deadline_covers_the_whole_future() {
+    let err = profile_operation_timeout_for_test(Duration::from_millis(1))
+        .await
+        .expect_err("pending operation must hit the overall deadline");
+    assert!(err.to_string().contains("timed out"));
+}
+
+#[tokio::test]
+async fn profile_image_shared_reader_bounds_content_length_and_chunked_to_caller_max() {
+    let caller_max = 5_u64;
+    let over_body = spawn_http_response(http_ok_response(&[0_u8; 8]));
+    let response = reqwest::Client::new()
+        .get(over_body)
+        .send()
+        .await
+        .expect("fetch test body");
+    let err = read_limited_blossom_body(response, caller_max)
+        .await
+        .expect_err("content-length overflow");
+    assert!(
+        err.to_string()
+            .contains(&format!("download exceeds {caller_max} bytes")),
+        "{err}"
+    );
+
+    let chunked = spawn_http_response(
+        b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n6\r\nabcdef\r\n0\r\n\r\n"
+            .to_vec(),
+    );
+    let response = reqwest::Client::new()
+        .get(chunked)
+        .send()
+        .await
+        .expect("fetch chunked test body");
+    let err = read_limited_blossom_body(response, caller_max)
+        .await
+        .expect_err("chunked overflow");
+    assert!(
+        err.to_string()
+            .contains(&format!("download exceeds {caller_max} bytes")),
+        "{err}"
+    );
+}
+
+fn spawn_http_response(response: Vec<u8>) -> String {
+    super::tests::spawn_http_response(response)
+}
+
+fn http_ok_response(body: &[u8]) -> Vec<u8> {
+    super::tests::http_ok_response(body)
+}

--- a/crates/marmot-app/src/media/tests_profile_image.rs
+++ b/crates/marmot-app/src/media/tests_profile_image.rs
@@ -1,22 +1,24 @@
 //! Profile-image dial-safe fetch acceptance tests (mdk#1287).
 
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::time::Duration;
-
 use cgka_traits::app_components::ENCRYPTED_MEDIA_ENDPOINT_URL_MAX_LEN;
 use url::Url;
 
-use super::blossom::{
-    plan_profile_image_pin, profile_operation_timeout_for_test, read_limited_blossom_body,
+use super::blossom::{read_limited_blossom_body, vet_profile_fetch_resolved_addresses};
+use super::host_safety::{parse_profile_image_fetch_url, validate_profile_image_fetch_url};
+use super::tests::{
+    http_ok_response, http_redirect_response, spawn_http_response, spawn_http_responses,
 };
-use super::host_safety::validate_profile_image_fetch_url;
 use super::{
-    MAX_PROFILE_IMAGE_BYTES, download_profile_image, download_profile_image_with_injected_addrs,
+    MAX_PROFILE_IMAGE_BYTES, download_profile_image, download_profile_image_with_test_loopback,
     normalize_profile_image_max_bytes_for_test,
 };
+use crate::AppError;
 
-fn public_socket_addr(byte: u8) -> SocketAddr {
-    SocketAddr::new(IpAddr::V4(Ipv4Addr::new(93, 184, 216, byte)), 443)
+fn localhost_url(raw: &str) -> String {
+    let mut url = Url::parse(raw).expect("test listener URL");
+    url.set_host(Some("localhost"))
+        .expect("replace loopback literal with localhost");
+    url.into()
 }
 
 #[tokio::test]
@@ -25,8 +27,8 @@ async fn download_profile_image_rejects_loopback_literal_before_network() {
         .await
         .expect_err("loopback profile URL must not be dialed");
     assert!(
-        err.to_string().contains("localhost") || err.to_string().contains("public unicast"),
-        "expected pre-dial rejection, got {err}"
+        matches!(err, AppError::UnsafeMediaFetch(_)),
+        "expected pre-dial safety rejection, got {err}"
     );
 }
 
@@ -79,6 +81,19 @@ fn profile_image_fetch_url_length_boundary_and_over_limit() {
         "a".repeat(ENCRYPTED_MEDIA_ENDPOINT_URL_MAX_LEN - prefix.len() + 1)
     );
     let err = validate_profile_image_fetch_url(&Url::parse(&over).unwrap()).unwrap_err();
+    assert!(err.contains("exceeds"));
+}
+
+#[test]
+fn profile_image_raw_url_length_checked_before_parse_normalization() {
+    let prefix = "https://media.example/";
+    let padding = ENCRYPTED_MEDIA_ENDPOINT_URL_MAX_LEN - prefix.len() + 64;
+    let raw = format!("{prefix}{}/avatar.png", "../".repeat(padding));
+    assert!(raw.len() > ENCRYPTED_MEDIA_ENDPOINT_URL_MAX_LEN);
+    let normalized = Url::parse(&raw).expect("url must parse");
+    assert!(normalized.as_str().len() <= ENCRYPTED_MEDIA_ENDPOINT_URL_MAX_LEN);
+
+    let err = parse_profile_image_fetch_url(&raw).unwrap_err();
     assert!(err.contains("exceeds"));
 }
 
@@ -154,60 +169,82 @@ fn profile_image_max_bytes_zero_ceiling_and_exact_ceiling() {
     );
 }
 
+#[test]
+fn profile_image_vet_resolved_addresses_rejects_private_before_dial() {
+    let err = vet_profile_fetch_resolved_addresses(&[
+        std::net::SocketAddr::from(([93, 184, 216, 34], 443)),
+        std::net::SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, 443)),
+    ])
+    .expect_err("one unsafe answer must reject the whole DNS result");
+    assert!(matches!(err, AppError::UnsafeMediaFetch(_)));
+}
+
 #[tokio::test]
-async fn download_profile_image_rejects_injected_private_resolve_before_dial() {
-    let err = download_profile_image_with_injected_addrs(
-        "https://profile.example/avatar.png",
-        1024,
-        vec![SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 443)],
-    )
-    .await
-    .expect_err("private injected resolve");
-    assert!(err.to_string().contains("public unicast"));
+async fn download_profile_image_follows_redirect_to_local_listener() {
+    let final_server = localhost_url(&spawn_http_response(http_ok_response(b"avatar-bytes")));
+    let final_url = format!("{final_server}/avatar.png");
+    let redirecting_server =
+        localhost_url(&spawn_http_response(http_redirect_response(&final_url)));
+    let url = format!("{redirecting_server}/start.png");
+
+    let bytes = download_profile_image_with_test_loopback(url, 1024)
+        .await
+        .expect("profile fetch should follow one redirect to the final body");
+
+    assert_eq!(bytes, b"avatar-bytes");
 }
 
-#[test]
-fn profile_image_pin_plan_rejects_private_injected_addresses_before_dial() {
-    let url = Url::parse("https://profile.example/avatar.png").unwrap();
-    let public = public_socket_addr(34);
-    let err = plan_profile_image_pin(
-        &url,
-        &[
-            public,
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 443),
-        ],
-    )
-    .expect_err("mixed public/private inject");
-    assert!(err.to_string().contains("public unicast"));
-}
+#[tokio::test]
+async fn download_profile_image_rejects_redirect_chain_over_limit() {
+    let responses = (0..6)
+        .map(|idx| http_redirect_response(&format!("/hop-{idx}/avatar.png")))
+        .collect::<Vec<_>>();
+    let server = localhost_url(&spawn_http_responses(responses));
+    let url = format!("{server}/start.png");
 
-#[test]
-fn profile_image_pin_plan_returns_exact_vetted_set_for_one_hop() {
-    let url = Url::parse("https://profile.example/avatar.png").unwrap();
-    let first = vec![public_socket_addr(34), public_socket_addr(35)];
-    let (domain, pinned) = plan_profile_image_pin(&url, &first)
-        .expect("pin plan")
-        .expect("domain pin");
-    assert_eq!(domain, "profile.example");
-    assert_eq!(pinned, first);
+    let err = download_profile_image_with_test_loopback(url, 1024)
+        .await
+        .expect_err("six redirects must exceed the hop cap");
 
-    let rebound = vec![public_socket_addr(36)];
-    let (_, second_pin) = plan_profile_image_pin(&url, &rebound)
-        .expect("second plan")
-        .expect("second pin");
-    assert_eq!(second_pin, rebound);
-    assert_ne!(
-        pinned, second_pin,
-        "rebound answers must not merge across plans"
+    assert!(
+        err.to_string().contains("exceeded 5 hops"),
+        "expected hop-limit error, got {err}"
     );
 }
 
 #[tokio::test]
-async fn profile_image_operation_deadline_covers_the_whole_future() {
-    let err = profile_operation_timeout_for_test(Duration::from_millis(1))
+async fn download_profile_image_classifies_unsafe_redirect_before_dial() {
+    let redirecting_server = localhost_url(&spawn_http_response(http_redirect_response(
+        "https://127.0.0.1/avatar.png",
+    )));
+    let url = format!("{redirecting_server}/start.png");
+
+    let err = download_profile_image_with_test_loopback(url, 1024)
         .await
-        .expect_err("pending operation must hit the overall deadline");
-    assert!(err.to_string().contains("timed out"));
+        .expect_err("unsafe redirect target must be rejected before its dial");
+
+    assert!(matches!(err, AppError::UnsafeMediaFetch(_)));
+}
+
+#[tokio::test]
+async fn download_profile_image_bounds_raw_redirect_before_normalization() {
+    let raw_location = format!(
+        "/{}/avatar.png",
+        "../".repeat(ENCRYPTED_MEDIA_ENDPOINT_URL_MAX_LEN)
+    );
+    assert!(raw_location.len() > ENCRYPTED_MEDIA_ENDPOINT_URL_MAX_LEN);
+
+    let server = localhost_url(&spawn_http_responses(vec![
+        http_redirect_response(&raw_location),
+        http_ok_response(b"must-not-be-fetched"),
+    ]));
+    let url = format!("{server}/start.png");
+
+    let err = download_profile_image_with_test_loopback(url, 1024)
+        .await
+        .expect_err("raw redirect target must be bounded before URL normalization");
+
+    assert!(matches!(err, AppError::UnsafeMediaFetch(_)));
 }
 
 #[tokio::test]
@@ -247,10 +284,28 @@ async fn profile_image_shared_reader_bounds_content_length_and_chunked_to_caller
     );
 }
 
-fn spawn_http_response(response: Vec<u8>) -> String {
-    super::tests::spawn_http_response(response)
+#[tokio::test]
+async fn unsafe_profile_url_maps_to_unsafe_media_fetch_not_blob_store() {
+    let err = download_profile_image("https://127.0.0.1/avatar.png".into(), 1024)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, AppError::UnsafeMediaFetch(_)));
 }
 
-fn http_ok_response(body: &[u8]) -> Vec<u8> {
-    super::tests::http_ok_response(body)
+#[tokio::test]
+async fn dns_operational_failure_stays_blob_store_for_retryable_runtime() {
+    let err = download_profile_image(
+        "https://this-host-should-not-resolve.invalid.test/avatar.png".into(),
+        1024,
+    )
+    .await
+    .unwrap_err();
+    assert!(
+        matches!(err, AppError::BlobStore(_)),
+        "DNS failure should remain operational, got {err}"
+    );
+    assert!(
+        err.to_string().contains("DNS lookup failed"),
+        "unexpected message: {err}"
+    );
 }

--- a/crates/marmot-app/src/media/tests_profile_image.rs
+++ b/crates/marmot-app/src/media/tests_profile_image.rs
@@ -98,6 +98,37 @@ fn profile_image_raw_url_length_checked_before_parse_normalization() {
 }
 
 #[test]
+fn profile_image_raw_url_length_checked_before_whitespace_trimming() {
+    let valid = "https://media.example/avatar.png";
+    let raw = format!(
+        "{}{}",
+        " ".repeat(ENCRYPTED_MEDIA_ENDPOINT_URL_MAX_LEN),
+        valid
+    );
+    assert!(raw.len() > ENCRYPTED_MEDIA_ENDPOINT_URL_MAX_LEN);
+    assert_eq!(raw.trim(), valid);
+
+    let err = parse_profile_image_fetch_url(&raw).unwrap_err();
+    assert!(err.contains("exceeds"));
+}
+
+#[test]
+fn profile_image_redirect_length_checked_before_whitespace_trimming() {
+    let current = Url::parse("https://media.example/start.png").unwrap();
+    let raw_location = format!(
+        "{}{}",
+        " ".repeat(ENCRYPTED_MEDIA_ENDPOINT_URL_MAX_LEN),
+        "/avatar.png"
+    );
+    assert!(raw_location.len() > ENCRYPTED_MEDIA_ENDPOINT_URL_MAX_LEN);
+    assert_eq!(raw_location.trim(), "/avatar.png");
+
+    let err =
+        super::host_safety::parse_profile_image_redirect_url(&current, &raw_location).unwrap_err();
+    assert!(err.contains("exceeds"));
+}
+
+#[test]
 fn profile_image_fetch_url_rejects_credentials_fragments_scheme_and_custom_port() {
     let base = "https://media.example/avatar.png";
     for (url, needle) in [

--- a/crates/marmot-uniffi/src/commands/account.rs
+++ b/crates/marmot-uniffi/src/commands/account.rs
@@ -529,6 +529,27 @@ impl Marmot {
             .upload_profile_image(&account_ref, data, &media_type, blossom_server.as_deref())
             .await?)
     }
+
+    /// Fetch one untrusted kind:0 profile `picture` URL with MDK dial-safe
+    /// HTTPS policy, address pinning, and bounded streaming.
+    pub async fn download_profile_image(
+        &self,
+        url: String,
+        max_bytes: u64,
+    ) -> Result<Vec<u8>, MarmotKitError> {
+        marmot_app::download_profile_image(url, max_bytes)
+            .await
+            .map_err(profile_image_fetch_error)
+    }
+}
+
+fn profile_image_fetch_error(error: marmot_app::AppError) -> MarmotKitError {
+    match error {
+        marmot_app::AppError::InvalidAppMessagePayload(details) => {
+            MarmotKitError::InvalidMediaReference { details }
+        }
+        other => other.into(),
+    }
 }
 
 fn ffi_discovery_relays(bootstrap_relays: &[String]) -> Vec<TransportEndpoint> {

--- a/crates/marmot-uniffi/src/commands/account.rs
+++ b/crates/marmot-uniffi/src/commands/account.rs
@@ -537,18 +537,7 @@ impl Marmot {
         url: String,
         max_bytes: u64,
     ) -> Result<Vec<u8>, MarmotKitError> {
-        marmot_app::download_profile_image(url, max_bytes)
-            .await
-            .map_err(profile_image_fetch_error)
-    }
-}
-
-fn profile_image_fetch_error(error: marmot_app::AppError) -> MarmotKitError {
-    match error {
-        marmot_app::AppError::InvalidAppMessagePayload(details) => {
-            MarmotKitError::InvalidMediaReference { details }
-        }
-        other => other.into(),
+        Ok(marmot_app::download_profile_image(url, max_bytes).await?)
     }
 }
 

--- a/crates/marmot-uniffi/src/errors.rs
+++ b/crates/marmot-uniffi/src/errors.rs
@@ -232,6 +232,7 @@ impl From<AppError> for MarmotKitError {
             // errors; map them to the typed variant so send/upload/download
             // agree with build/parse even when a call site uses `?`/`From`.
             AppError::InvalidEncryptedMedia(details) => Self::InvalidMediaReference { details },
+            AppError::UnsafeMediaFetch(details) => Self::InvalidMediaReference { details },
             AppError::Hex(err) => Self::InvalidHex {
                 details: err.to_string(),
             },
@@ -461,6 +462,13 @@ mod tests {
             matches!(ffi, MarmotKitError::Runtime { .. }),
             "InvalidTransition denotes an engine bug and stays untyped; got {ffi:?}"
         );
+    }
+
+    #[test]
+    fn unsafe_media_fetch_crosses_ffi_as_typed_media_reference() {
+        let app_err = AppError::UnsafeMediaFetch("unsafe profile image URL".into());
+        let ffi: MarmotKitError = app_err.into();
+        assert!(matches!(ffi, MarmotKitError::InvalidMediaReference { .. }));
     }
 
     #[test]

--- a/crates/marmot-uniffi/tests/smoke.rs
+++ b/crates/marmot-uniffi/tests/smoke.rs
@@ -471,6 +471,26 @@ async fn profile_image_upload_binding_is_public_and_requires_a_known_account() {
 }
 
 #[tokio::test]
+async fn profile_image_download_binding_maps_invalid_url_to_typed_error() {
+    install_mock_keyring();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let kit = Marmot::new(
+        tmp.path().to_string_lossy().into_owned(),
+        vec!["wss://relay.invalid.test".to_string()],
+    )
+    .expect("open marmot kit");
+
+    let error = kit
+        .download_profile_image("https://127.0.0.1/avatar.png".into(), 1024)
+        .await
+        .expect_err("loopback profile URL must fail before dial");
+    assert!(
+        matches!(error, MarmotKitError::InvalidMediaReference { .. }),
+        "expected InvalidMediaReference, got {error:?}"
+    );
+}
+
+#[tokio::test]
 async fn media_binding_records_are_public_and_methods_validate_group_hex() {
     install_mock_keyring();
     let tmp = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
Fixes #1287

## Summary
- Add an MDK-owned `download_profile_image(url, max_bytes)` path for untrusted kind-0 picture URLs.
- Enforce HTTPS/default-port URL policy, localhost/private/special-use rejection, per-hop DNS vetting and reqwest address pinning, bounded manual redirects, disabled proxies/decompression, caller-bounded streaming, and an operation-wide deadline.
- Export the async method through UniFFI and cover the generated Kotlin/Swift surface; add `Unreleased` changelog coverage without version churn.

## Verification
- `cargo test -p marmot-app --locked --lib profile_image` — 18 passed.
- `cargo test -p marmot-uniffi --locked profile_image` — 2 passed.
- `just fast-ci` — passed (format, naming/ledger gates, workspace all-target checks, clippy with/without OTLP, convergence policy tests).
- Generated host Kotlin and Swift bindings with `uniffi-bindgen`; both contain `downloadProfileImage(url, maxBytes)`.
- Independent Composer security review — passed with no security or logic findings.

## Baseline recheck
- Rebased onto current `master` (`bca10777`).
- `cold_reopen_recovers_quiet_offline_history_without_a_live_trigger` now passes with the valid package-scoped feature set.
- Current `master` has a fully green GitHub CI matrix, including `Simulator and vectors`.
- The earlier blocker was stale; one attempted package-scoped reproduction also used an invalid cross-package feature flag and was not test evidence.

## Sensitive paths
- `crates/marmot-app/src/media/blossom.rs`
- `crates/marmot-app/src/media/host_safety.rs`

These implement the SSRF/dial-safety trust boundary and DNS pinning for untrusted profile-image URLs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added profile-image downloading through the public MarmotKit API.
  - Supports caller-defined download limits up to 10 MiB.
  - Added safeguards for HTTPS URLs, public destinations, bounded redirects, DNS resolution, timeouts, and response sizes.
  - Added clear errors for invalid or unsafe media references.

- **Documentation**
  - Documented the profile-image download API and its security protections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->