### PR TITLE
Add transcript and secrecy scenario vectors from the multi-VM catalog

### DIFF
--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -157,6 +157,50 @@ These are the scenarios another implementation should be able to load from JSON 
 - Pressure: Bob's message is delayed, Alice restarts, and the released message is duplicated and reordered.
 - Expected: Alice hydrates the stable group after restart and receives Bob's payload once.
 
+### `conversation/v1`
+
+- File: `vectors/conversation.v1.json`
+- Provenance: ported from the external multi-VM harness scenario catalog (`conversation.rb`).
+- Setup: Alice creates a group with Bob and Carol. Three round-robin rounds where every member sends one message per
+  round.
+- Pressure: none beyond sustained turn-taking traffic. This is the transcript-completeness smoke path.
+- Expected: every client holds the exact six-payload transcript of the other members with no duplicates, all clients
+  converge at epoch 1 with three members, and no pending work remains.
+
+### `latecomer-forward-secrecy/v1`
+
+- File: `vectors/latecomer-forward-secrecy.v1.json`
+- Provenance: ported from the external multi-VM harness scenario catalog (`latecomer.rb`).
+- Setup: Alice and Bob chat two pre-join rounds, then Alice invites Carol mid-conversation, then all three chat two
+  post-join rounds. Pre-join ciphertext does reach Carol's mailbox.
+- Pressure: forward secrecy. Carol must decrypt nothing from before her join even though she holds the ciphertext.
+- Expected: originals hold pre+post transcripts; Carol's exact transcript contains only post-join payloads, and
+  `payload_count` assertions pin two pre-join payloads at zero for her. Carol legitimately retains one undecryptable
+  pre-join input as deferred transport work, so `no_pending_work` covers the original members only.
+
+### `leaver-removal-secrecy/v1`
+
+- File: `vectors/leaver-removal-secrecy.v1.json`
+- Provenance: ported from the external multi-VM harness scenario catalog (`leaver.rb`), minus the re-add leg.
+- Setup: four members chat, Alice removes Dave (transport unsubscribes him, modeled as a partition), the remaining
+  members chat a gap phase, Carol self-leaves via the witness-commit path, and Alice and Bob chat a tail phase.
+- Pressure: post-removal and post-leave secrecy plus the admin-removal and self-leave commit paths.
+- Expected: Dave never observes gap plaintext and Carol never observes tail plaintext (`payload_count` zero
+  assertions); Alice and Bob hold the full transcript minus the departed members' silence and converge at epoch 3 with
+  two members and no pending work. The original harness scenario's re-add leg (removed member rejoins via a fresh KeyPackage) is
+  deliberately absent: welcome-after-eviction currently fails in the engine harness with
+  `GroupStateError(UseAfterEviction)` and is tracked as a coverage gap.
+
+### `incremental-growth/v1`
+
+- File: `vectors/incremental-growth.v1.json`
+- Provenance: ported from the external multi-VM harness scenario catalog (`build.rb` + `growth.rb`).
+- Setup: two founders chat, then Alice grows the group one member at a time (Carol, then Dave), renaming the group and
+  running a full message round after each add.
+- Pressure: staged growth with a commit per phase, and cohort-era forward secrecy across two join boundaries.
+- Expected: each member's exact transcript starts at their own join era (`payload_count` assertions pin earlier-era
+  payloads at zero for Carol and Dave), and all four clients converge at epoch 5 with four members.
+
 ## Incident-Replay Vectors
 
 These vectors are synthesized from Goggles `agent-state.json` forensic exports by the `incident-replay` adapter, then

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -161,10 +161,11 @@ These are the scenarios another implementation should be able to load from JSON 
 
 - File: `vectors/conversation.v1.json`
 - Provenance: ported from the external multi-VM harness scenario catalog (`conversation.rb`).
-- Setup: Alice creates a group with Bob and Carol. Three round-robin rounds where every member sends one message per
-  round.
+- Setup: Alice creates a group with Bob and Carol. Two round-robin rounds where every member sends one message per
+  round. Two rounds are the minimum that pins the no-duplicate-across-rounds property; what this vector adds over
+  `three-client-message-exchange/v1` is `observe_exact` and `no_pending_work`, not round count.
 - Pressure: none beyond sustained turn-taking traffic. This is the transcript-completeness smoke path.
-- Expected: every client holds the exact six-payload transcript of the other members with no duplicates, all clients
+- Expected: every client holds the exact four-payload transcript of the other members with no duplicates, all clients
   converge at epoch 1 with three members, and no pending work remains.
 
 ### `latecomer-forward-secrecy/v1`
@@ -182,14 +183,19 @@ These are the scenarios another implementation should be able to load from JSON 
 
 - File: `vectors/leaver-removal-secrecy.v1.json`
 - Provenance: ported from the external multi-VM harness scenario catalog (`leaver.rb`), minus the re-add leg.
-- Setup: four members chat, Alice removes Dave (transport unsubscribes him, modeled as a partition), the remaining
-  members chat a gap phase, Carol self-leaves via the witness-commit path, and Alice and Bob chat a tail phase.
+- Setup: four members chat, Alice removes Dave, the remaining members chat a gap phase, Carol self-leaves via the
+  witness-commit path, and Alice and Bob chat a tail phase. Both departed members stay bus-attached with no partition:
+  the gap and tail ciphertext really lands in Dave's mailbox (and the tail ciphertext in Carol's), and both are ticked
+  after each delivery, so the zero assertions run against processed ciphertext the engine had to refuse — not against
+  an empty or unread mailbox.
 - Pressure: post-removal and post-leave secrecy plus the admin-removal and self-leave commit paths.
-- Expected: Dave never observes gap plaintext and Carol never observes tail plaintext (`payload_count` zero
-  assertions); Alice and Bob hold the full transcript minus the departed members' silence and converge at epoch 3 with
-  two members and no pending work. The original harness scenario's re-add leg (removed member rejoins via a fresh KeyPackage) is
-  deliberately absent: welcome-after-eviction currently fails in the engine harness with
-  `GroupStateError(UseAfterEviction)` and is tracked as a coverage gap.
+- Expected: Dave decrypts none of the gap or tail payloads and Carol decrypts none of the tail payloads
+  (`payload_count` zero assertions cover every post-departure payload for each departed client); Alice and Bob hold
+  the full transcript minus the departed members' silence and converge at epoch 3 with two members. `no_pending_work`
+  covers Alice and Bob only: like the latecomer vector's pre-join input, Dave and Carol legitimately retain their
+  undecryptable post-departure inputs as deferred transport work. The original harness scenario's re-add leg (removed
+  member rejoins via a fresh KeyPackage) is deliberately absent: welcome-after-eviction currently fails in the engine
+  harness with `GroupStateError(UseAfterEviction)` and is tracked as a coverage gap.
 
 ### `incremental-growth/v1`
 
@@ -199,7 +205,9 @@ These are the scenarios another implementation should be able to load from JSON 
   running a full message round after each add.
 - Pressure: staged growth with a commit per phase, and cohort-era forward secrecy across two join boundaries.
 - Expected: each member's exact transcript starts at their own join era (`payload_count` assertions pin earlier-era
-  payloads at zero for Carol and Dave), and all four clients converge at epoch 5 with four members.
+  payloads at zero for Carol and Dave), and all four clients converge at epoch 5 with four members. `no_pending_work`
+  covers the founders only: as in the latecomer vector, Carol and Dave legitimately retain their undecryptable
+  pre-join inputs as deferred transport work, so including them would fail on intended behavior.
 
 ## Incident-Replay Vectors
 

--- a/crates/cgka-conformance-simulator/vectors/conversation.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/conversation.v1.json
@@ -6,36 +6,107 @@
   "scenario": {
     "name": "conversation/v1",
     "spec_version": "2",
-    "clients": ["alice", "bob", "carol"],
+    "clients": [
+      "alice",
+      "bob",
+      "carol"
+    ],
     "steps": [
       {
         "type": "create_group",
         "creator": "alice",
         "name": "conversation",
-        "invitees": ["bob", "carol"],
+        "invitees": [
+          "bob",
+          "carol"
+        ],
         "required_features": [],
         "pending": "create"
       },
-      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
-      { "type": "deliver_all" },
-      { "type": "tick", "clients": ["bob", "carol"] },
-      { "type": "clear_events", "clients": ["alice", "bob", "carol"] },
-      { "type": "send_app_message", "sender": "alice", "payload": "conversation:r1:alice" },
-      { "type": "send_app_message", "sender": "bob", "payload": "conversation:r1:bob" },
-      { "type": "send_app_message", "sender": "carol", "payload": "conversation:r1:carol" },
-      { "type": "deliver_all" },
-      { "type": "tick", "clients": ["alice", "bob", "carol"] },
-      { "type": "send_app_message", "sender": "alice", "payload": "conversation:r2:alice" },
-      { "type": "send_app_message", "sender": "bob", "payload": "conversation:r2:bob" },
-      { "type": "send_app_message", "sender": "carol", "payload": "conversation:r2:carol" },
-      { "type": "deliver_all" },
-      { "type": "tick", "clients": ["alice", "bob", "carol"] },
-      { "type": "send_app_message", "sender": "alice", "payload": "conversation:r3:alice" },
-      { "type": "send_app_message", "sender": "bob", "payload": "conversation:r3:bob" },
-      { "type": "send_app_message", "sender": "carol", "payload": "conversation:r3:carol" },
-      { "type": "deliver_all" },
-      { "type": "tick", "clients": ["alice", "bob", "carol"] },
-      { "type": "observe_exact", "clients": ["alice", "bob", "carol"] }
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "publication": "create",
+        "outcome": "accepted"
+      },
+      {
+        "type": "deliver_all"
+      },
+      {
+        "type": "tick",
+        "clients": [
+          "bob",
+          "carol"
+        ]
+      },
+      {
+        "type": "clear_events",
+        "clients": [
+          "alice",
+          "bob",
+          "carol"
+        ]
+      },
+      {
+        "type": "send_app_message",
+        "sender": "alice",
+        "payload": "conversation:r1:alice"
+      },
+      {
+        "type": "send_app_message",
+        "sender": "bob",
+        "payload": "conversation:r1:bob"
+      },
+      {
+        "type": "send_app_message",
+        "sender": "carol",
+        "payload": "conversation:r1:carol"
+      },
+      {
+        "type": "deliver_all"
+      },
+      {
+        "type": "tick",
+        "clients": [
+          "alice",
+          "bob",
+          "carol"
+        ]
+      },
+      {
+        "type": "send_app_message",
+        "sender": "alice",
+        "payload": "conversation:r2:alice"
+      },
+      {
+        "type": "send_app_message",
+        "sender": "bob",
+        "payload": "conversation:r2:bob"
+      },
+      {
+        "type": "send_app_message",
+        "sender": "carol",
+        "payload": "conversation:r2:carol"
+      },
+      {
+        "type": "deliver_all"
+      },
+      {
+        "type": "tick",
+        "clients": [
+          "alice",
+          "bob",
+          "carol"
+        ]
+      },
+      {
+        "type": "observe_exact",
+        "clients": [
+          "alice",
+          "bob",
+          "carol"
+        ]
+      }
     ]
   },
   "expected_outcomes": [
@@ -55,9 +126,7 @@
         "conversation:r1:bob",
         "conversation:r1:carol",
         "conversation:r2:bob",
-        "conversation:r2:carol",
-        "conversation:r3:bob",
-        "conversation:r3:carol"
+        "conversation:r2:carol"
       ]
     },
     {
@@ -69,9 +138,7 @@
         "conversation:r1:alice",
         "conversation:r1:carol",
         "conversation:r2:alice",
-        "conversation:r2:carol",
-        "conversation:r3:alice",
-        "conversation:r3:carol"
+        "conversation:r2:carol"
       ]
     },
     {
@@ -83,20 +150,26 @@
         "conversation:r1:alice",
         "conversation:r1:bob",
         "conversation:r2:alice",
-        "conversation:r2:bob",
-        "conversation:r3:alice",
-        "conversation:r3:bob"
+        "conversation:r2:bob"
       ]
     },
     {
       "type": "clients_converged",
-      "clients": ["alice", "bob", "carol"],
+      "clients": [
+        "alice",
+        "bob",
+        "carol"
+      ],
       "epoch": 1,
       "member_count": 3
     },
     {
       "type": "no_pending_work",
-      "clients": ["alice", "bob", "carol"]
+      "clients": [
+        "alice",
+        "bob",
+        "carol"
+      ]
     }
   ]
 }

--- a/crates/cgka-conformance-simulator/vectors/conversation.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/conversation.v1.json
@@ -1,0 +1,102 @@
+{
+  "scenario_name": "conversation/v1",
+  "vector_version": "1",
+  "conformance_version": "0.9.10",
+  "seed": null,
+  "scenario": {
+    "name": "conversation/v1",
+    "spec_version": "2",
+    "clients": ["alice", "bob", "carol"],
+    "steps": [
+      {
+        "type": "create_group",
+        "creator": "alice",
+        "name": "conversation",
+        "invitees": ["bob", "carol"],
+        "required_features": [],
+        "pending": "create"
+      },
+      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
+      { "type": "deliver_all" },
+      { "type": "tick", "clients": ["bob", "carol"] },
+      { "type": "clear_events", "clients": ["alice", "bob", "carol"] },
+      { "type": "send_app_message", "sender": "alice", "payload": "conversation:r1:alice" },
+      { "type": "send_app_message", "sender": "bob", "payload": "conversation:r1:bob" },
+      { "type": "send_app_message", "sender": "carol", "payload": "conversation:r1:carol" },
+      { "type": "deliver_all" },
+      { "type": "tick", "clients": ["alice", "bob", "carol"] },
+      { "type": "send_app_message", "sender": "alice", "payload": "conversation:r2:alice" },
+      { "type": "send_app_message", "sender": "bob", "payload": "conversation:r2:bob" },
+      { "type": "send_app_message", "sender": "carol", "payload": "conversation:r2:carol" },
+      { "type": "deliver_all" },
+      { "type": "tick", "clients": ["alice", "bob", "carol"] },
+      { "type": "send_app_message", "sender": "alice", "payload": "conversation:r3:alice" },
+      { "type": "send_app_message", "sender": "bob", "payload": "conversation:r3:bob" },
+      { "type": "send_app_message", "sender": "carol", "payload": "conversation:r3:carol" },
+      { "type": "deliver_all" },
+      { "type": "tick", "clients": ["alice", "bob", "carol"] },
+      { "type": "observe_exact", "clients": ["alice", "bob", "carol"] }
+    ]
+  },
+  "expected_outcomes": [
+    {
+      "type": "pending_resolution",
+      "step_index": 1,
+      "client": "alice",
+      "pending": "create",
+      "resolution": "confirmed"
+    },
+    {
+      "type": "client_state",
+      "client": "alice",
+      "epoch": 1,
+      "member_count": 3,
+      "received_payloads": [
+        "conversation:r1:bob",
+        "conversation:r1:carol",
+        "conversation:r2:bob",
+        "conversation:r2:carol",
+        "conversation:r3:bob",
+        "conversation:r3:carol"
+      ]
+    },
+    {
+      "type": "client_state",
+      "client": "bob",
+      "epoch": 1,
+      "member_count": 3,
+      "received_payloads": [
+        "conversation:r1:alice",
+        "conversation:r1:carol",
+        "conversation:r2:alice",
+        "conversation:r2:carol",
+        "conversation:r3:alice",
+        "conversation:r3:carol"
+      ]
+    },
+    {
+      "type": "client_state",
+      "client": "carol",
+      "epoch": 1,
+      "member_count": 3,
+      "received_payloads": [
+        "conversation:r1:alice",
+        "conversation:r1:bob",
+        "conversation:r2:alice",
+        "conversation:r2:bob",
+        "conversation:r3:alice",
+        "conversation:r3:bob"
+      ]
+    },
+    {
+      "type": "clients_converged",
+      "clients": ["alice", "bob", "carol"],
+      "epoch": 1,
+      "member_count": 3
+    },
+    {
+      "type": "no_pending_work",
+      "clients": ["alice", "bob", "carol"]
+    }
+  ]
+}

--- a/crates/cgka-conformance-simulator/vectors/incremental-growth.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incremental-growth.v1.json
@@ -1,0 +1,197 @@
+{
+  "scenario_name": "incremental-growth/v1",
+  "vector_version": "1",
+  "conformance_version": "0.9.10",
+  "seed": null,
+  "scenario": {
+    "name": "incremental-growth/v1",
+    "spec_version": "2",
+    "clients": ["alice", "bob", "carol", "dave"],
+    "steps": [
+      {
+        "type": "create_group",
+        "creator": "alice",
+        "name": "growth-2",
+        "invitees": ["bob"],
+        "required_features": [],
+        "pending": "create"
+      },
+      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
+      { "type": "deliver_all" },
+      { "type": "tick", "clients": ["bob"] },
+      { "type": "clear_events", "clients": ["alice", "bob", "carol", "dave"] },
+      { "type": "send_app_message", "sender": "alice", "payload": "growth:p0:alice" },
+      { "type": "send_app_message", "sender": "bob", "payload": "growth:p0:bob" },
+      { "type": "deliver_all" },
+      { "type": "tick", "clients": ["alice", "bob"] },
+      {
+        "type": "invite_members",
+        "inviter": "alice",
+        "invitees": ["carol"],
+        "pending": "invite-carol"
+      },
+      { "type": "acknowledge_outbound", "client": "alice", "publication": "invite-carol", "outcome": "accepted" },
+      { "type": "deliver_all" },
+      { "type": "tick", "clients": ["bob", "carol"] },
+      {
+        "type": "update_group_data",
+        "client": "alice",
+        "name": "growth-3",
+        "pending": "rename-3"
+      },
+      { "type": "acknowledge_outbound", "client": "alice", "publication": "rename-3", "outcome": "accepted" },
+      { "type": "deliver_all" },
+      { "type": "tick", "clients": ["bob", "carol"] },
+      { "type": "send_app_message", "sender": "alice", "payload": "growth:p1:alice" },
+      { "type": "send_app_message", "sender": "bob", "payload": "growth:p1:bob" },
+      { "type": "send_app_message", "sender": "carol", "payload": "growth:p1:carol" },
+      { "type": "deliver_all" },
+      { "type": "tick", "clients": ["alice", "bob", "carol"] },
+      {
+        "type": "invite_members",
+        "inviter": "alice",
+        "invitees": ["dave"],
+        "pending": "invite-dave"
+      },
+      { "type": "acknowledge_outbound", "client": "alice", "publication": "invite-dave", "outcome": "accepted" },
+      { "type": "deliver_all" },
+      { "type": "tick", "clients": ["bob", "carol", "dave"] },
+      {
+        "type": "update_group_data",
+        "client": "alice",
+        "name": "growth-4",
+        "pending": "rename-4"
+      },
+      { "type": "acknowledge_outbound", "client": "alice", "publication": "rename-4", "outcome": "accepted" },
+      { "type": "deliver_all" },
+      { "type": "tick", "clients": ["bob", "carol", "dave"] },
+      { "type": "send_app_message", "sender": "alice", "payload": "growth:p2:alice" },
+      { "type": "send_app_message", "sender": "bob", "payload": "growth:p2:bob" },
+      { "type": "send_app_message", "sender": "carol", "payload": "growth:p2:carol" },
+      { "type": "send_app_message", "sender": "dave", "payload": "growth:p2:dave" },
+      { "type": "deliver_all" },
+      { "type": "tick", "clients": ["alice", "bob", "carol", "dave"] },
+      {
+        "type": "assert",
+        "assertion": {
+          "mode": "exactly",
+          "predicate": { "type": "payload_count", "client": "carol", "payload": "growth:p0:alice", "count": 0 }
+        }
+      },
+      {
+        "type": "assert",
+        "assertion": {
+          "mode": "exactly",
+          "predicate": { "type": "payload_count", "client": "dave", "payload": "growth:p0:alice", "count": 0 }
+        }
+      },
+      {
+        "type": "assert",
+        "assertion": {
+          "mode": "exactly",
+          "predicate": { "type": "payload_count", "client": "dave", "payload": "growth:p1:alice", "count": 0 }
+        }
+      },
+      { "type": "observe_exact", "clients": ["alice", "bob", "carol", "dave"] }
+    ]
+  },
+  "expected_outcomes": [
+    {
+      "type": "pending_resolution",
+      "step_index": 1,
+      "client": "alice",
+      "pending": "create",
+      "resolution": "confirmed"
+    },
+    {
+      "type": "pending_resolution",
+      "step_index": 10,
+      "client": "alice",
+      "pending": "invite-carol",
+      "resolution": "confirmed"
+    },
+    {
+      "type": "pending_resolution",
+      "step_index": 14,
+      "client": "alice",
+      "pending": "rename-3",
+      "resolution": "confirmed"
+    },
+    {
+      "type": "pending_resolution",
+      "step_index": 23,
+      "client": "alice",
+      "pending": "invite-dave",
+      "resolution": "confirmed"
+    },
+    {
+      "type": "pending_resolution",
+      "step_index": 27,
+      "client": "alice",
+      "pending": "rename-4",
+      "resolution": "confirmed"
+    },
+    {
+      "type": "client_state",
+      "client": "alice",
+      "epoch": 5,
+      "member_count": 4,
+      "received_payloads": [
+        "growth:p0:bob",
+        "growth:p1:bob",
+        "growth:p1:carol",
+        "growth:p2:bob",
+        "growth:p2:carol",
+        "growth:p2:dave"
+      ]
+    },
+    {
+      "type": "client_state",
+      "client": "bob",
+      "epoch": 5,
+      "member_count": 4,
+      "received_payloads": [
+        "growth:p0:alice",
+        "growth:p1:alice",
+        "growth:p1:carol",
+        "growth:p2:alice",
+        "growth:p2:carol",
+        "growth:p2:dave"
+      ]
+    },
+    {
+      "type": "client_state",
+      "client": "carol",
+      "epoch": 5,
+      "member_count": 4,
+      "received_payloads": [
+        "growth:p1:alice",
+        "growth:p1:bob",
+        "growth:p2:alice",
+        "growth:p2:bob",
+        "growth:p2:dave"
+      ]
+    },
+    {
+      "type": "client_state",
+      "client": "dave",
+      "epoch": 5,
+      "member_count": 4,
+      "received_payloads": [
+        "growth:p2:alice",
+        "growth:p2:bob",
+        "growth:p2:carol"
+      ]
+    },
+    {
+      "type": "clients_converged",
+      "clients": ["alice", "bob", "carol", "dave"],
+      "epoch": 5,
+      "member_count": 4
+    },
+    {
+      "type": "no_pending_work",
+      "clients": ["alice", "bob"]
+    }
+  ]
+}

--- a/crates/cgka-conformance-simulator/vectors/incremental-growth.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incremental-growth.v1.json
@@ -6,93 +6,264 @@
   "scenario": {
     "name": "incremental-growth/v1",
     "spec_version": "2",
-    "clients": ["alice", "bob", "carol", "dave"],
+    "clients": [
+      "alice",
+      "bob",
+      "carol",
+      "dave"
+    ],
     "steps": [
       {
         "type": "create_group",
         "creator": "alice",
         "name": "growth-2",
-        "invitees": ["bob"],
+        "invitees": [
+          "bob"
+        ],
         "required_features": [],
         "pending": "create"
       },
-      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
-      { "type": "deliver_all" },
-      { "type": "tick", "clients": ["bob"] },
-      { "type": "clear_events", "clients": ["alice", "bob", "carol", "dave"] },
-      { "type": "send_app_message", "sender": "alice", "payload": "growth:p0:alice" },
-      { "type": "send_app_message", "sender": "bob", "payload": "growth:p0:bob" },
-      { "type": "deliver_all" },
-      { "type": "tick", "clients": ["alice", "bob"] },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "publication": "create",
+        "outcome": "accepted"
+      },
+      {
+        "type": "deliver_all"
+      },
+      {
+        "type": "tick",
+        "clients": [
+          "bob"
+        ]
+      },
+      {
+        "type": "clear_events",
+        "clients": [
+          "alice",
+          "bob",
+          "carol",
+          "dave"
+        ]
+      },
+      {
+        "type": "send_app_message",
+        "sender": "alice",
+        "payload": "growth:p0:alice"
+      },
+      {
+        "type": "send_app_message",
+        "sender": "bob",
+        "payload": "growth:p0:bob"
+      },
+      {
+        "type": "deliver_all"
+      },
+      {
+        "type": "tick",
+        "clients": [
+          "alice",
+          "bob"
+        ]
+      },
       {
         "type": "invite_members",
         "inviter": "alice",
-        "invitees": ["carol"],
+        "invitees": [
+          "carol"
+        ],
         "pending": "invite-carol"
       },
-      { "type": "acknowledge_outbound", "client": "alice", "publication": "invite-carol", "outcome": "accepted" },
-      { "type": "deliver_all" },
-      { "type": "tick", "clients": ["bob", "carol"] },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "publication": "invite-carol",
+        "outcome": "accepted"
+      },
+      {
+        "type": "deliver_all"
+      },
+      {
+        "type": "tick",
+        "clients": [
+          "bob",
+          "carol"
+        ]
+      },
       {
         "type": "update_group_data",
         "client": "alice",
         "name": "growth-3",
         "pending": "rename-3"
       },
-      { "type": "acknowledge_outbound", "client": "alice", "publication": "rename-3", "outcome": "accepted" },
-      { "type": "deliver_all" },
-      { "type": "tick", "clients": ["bob", "carol"] },
-      { "type": "send_app_message", "sender": "alice", "payload": "growth:p1:alice" },
-      { "type": "send_app_message", "sender": "bob", "payload": "growth:p1:bob" },
-      { "type": "send_app_message", "sender": "carol", "payload": "growth:p1:carol" },
-      { "type": "deliver_all" },
-      { "type": "tick", "clients": ["alice", "bob", "carol"] },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "publication": "rename-3",
+        "outcome": "accepted"
+      },
+      {
+        "type": "deliver_all"
+      },
+      {
+        "type": "tick",
+        "clients": [
+          "bob",
+          "carol"
+        ]
+      },
+      {
+        "type": "send_app_message",
+        "sender": "alice",
+        "payload": "growth:p1:alice"
+      },
+      {
+        "type": "send_app_message",
+        "sender": "bob",
+        "payload": "growth:p1:bob"
+      },
+      {
+        "type": "send_app_message",
+        "sender": "carol",
+        "payload": "growth:p1:carol"
+      },
+      {
+        "type": "deliver_all"
+      },
+      {
+        "type": "tick",
+        "clients": [
+          "alice",
+          "bob",
+          "carol"
+        ]
+      },
       {
         "type": "invite_members",
         "inviter": "alice",
-        "invitees": ["dave"],
+        "invitees": [
+          "dave"
+        ],
         "pending": "invite-dave"
       },
-      { "type": "acknowledge_outbound", "client": "alice", "publication": "invite-dave", "outcome": "accepted" },
-      { "type": "deliver_all" },
-      { "type": "tick", "clients": ["bob", "carol", "dave"] },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "publication": "invite-dave",
+        "outcome": "accepted"
+      },
+      {
+        "type": "deliver_all"
+      },
+      {
+        "type": "tick",
+        "clients": [
+          "bob",
+          "carol",
+          "dave"
+        ]
+      },
       {
         "type": "update_group_data",
         "client": "alice",
         "name": "growth-4",
         "pending": "rename-4"
       },
-      { "type": "acknowledge_outbound", "client": "alice", "publication": "rename-4", "outcome": "accepted" },
-      { "type": "deliver_all" },
-      { "type": "tick", "clients": ["bob", "carol", "dave"] },
-      { "type": "send_app_message", "sender": "alice", "payload": "growth:p2:alice" },
-      { "type": "send_app_message", "sender": "bob", "payload": "growth:p2:bob" },
-      { "type": "send_app_message", "sender": "carol", "payload": "growth:p2:carol" },
-      { "type": "send_app_message", "sender": "dave", "payload": "growth:p2:dave" },
-      { "type": "deliver_all" },
-      { "type": "tick", "clients": ["alice", "bob", "carol", "dave"] },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "publication": "rename-4",
+        "outcome": "accepted"
+      },
+      {
+        "type": "deliver_all"
+      },
+      {
+        "type": "tick",
+        "clients": [
+          "bob",
+          "carol",
+          "dave"
+        ]
+      },
+      {
+        "type": "send_app_message",
+        "sender": "alice",
+        "payload": "growth:p2:alice"
+      },
+      {
+        "type": "send_app_message",
+        "sender": "bob",
+        "payload": "growth:p2:bob"
+      },
+      {
+        "type": "send_app_message",
+        "sender": "carol",
+        "payload": "growth:p2:carol"
+      },
+      {
+        "type": "send_app_message",
+        "sender": "dave",
+        "payload": "growth:p2:dave"
+      },
+      {
+        "type": "deliver_all"
+      },
+      {
+        "type": "tick",
+        "clients": [
+          "alice",
+          "bob",
+          "carol",
+          "dave"
+        ]
+      },
       {
         "type": "assert",
         "assertion": {
           "mode": "exactly",
-          "predicate": { "type": "payload_count", "client": "carol", "payload": "growth:p0:alice", "count": 0 }
+          "predicate": {
+            "type": "payload_count",
+            "client": "carol",
+            "payload": "growth:p0:alice",
+            "count": 0
+          }
         }
       },
       {
         "type": "assert",
         "assertion": {
           "mode": "exactly",
-          "predicate": { "type": "payload_count", "client": "dave", "payload": "growth:p0:alice", "count": 0 }
+          "predicate": {
+            "type": "payload_count",
+            "client": "dave",
+            "payload": "growth:p0:alice",
+            "count": 0
+          }
         }
       },
       {
         "type": "assert",
         "assertion": {
           "mode": "exactly",
-          "predicate": { "type": "payload_count", "client": "dave", "payload": "growth:p1:alice", "count": 0 }
+          "predicate": {
+            "type": "payload_count",
+            "client": "dave",
+            "payload": "growth:p1:alice",
+            "count": 0
+          }
         }
       },
-      { "type": "observe_exact", "clients": ["alice", "bob", "carol", "dave"] }
+      {
+        "type": "observe_exact",
+        "clients": [
+          "alice",
+          "bob",
+          "carol",
+          "dave"
+        ]
+      }
     ]
   },
   "expected_outcomes": [
@@ -185,13 +356,21 @@
     },
     {
       "type": "clients_converged",
-      "clients": ["alice", "bob", "carol", "dave"],
+      "clients": [
+        "alice",
+        "bob",
+        "carol",
+        "dave"
+      ],
       "epoch": 5,
       "member_count": 4
     },
     {
       "type": "no_pending_work",
-      "clients": ["alice", "bob"]
+      "clients": [
+        "alice",
+        "bob"
+      ]
     }
   ]
 }

--- a/crates/cgka-conformance-simulator/vectors/latecomer-forward-secrecy.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/latecomer-forward-secrecy.v1.json
@@ -6,62 +6,193 @@
   "scenario": {
     "name": "latecomer-forward-secrecy/v1",
     "spec_version": "2",
-    "clients": ["alice", "bob", "carol"],
+    "clients": [
+      "alice",
+      "bob",
+      "carol"
+    ],
     "steps": [
       {
         "type": "create_group",
         "creator": "alice",
         "name": "latecomer",
-        "invitees": ["bob"],
+        "invitees": [
+          "bob"
+        ],
         "required_features": [],
         "pending": "create"
       },
-      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
-      { "type": "deliver_all" },
-      { "type": "tick", "clients": ["bob"] },
-      { "type": "clear_events", "clients": ["alice", "bob", "carol"] },
-      { "type": "send_app_message", "sender": "alice", "payload": "latecomer:pre:r1:alice" },
-      { "type": "send_app_message", "sender": "bob", "payload": "latecomer:pre:r1:bob" },
-      { "type": "deliver_all" },
-      { "type": "tick", "clients": ["alice", "bob"] },
-      { "type": "send_app_message", "sender": "alice", "payload": "latecomer:pre:r2:alice" },
-      { "type": "send_app_message", "sender": "bob", "payload": "latecomer:pre:r2:bob" },
-      { "type": "deliver_all" },
-      { "type": "tick", "clients": ["alice", "bob"] },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "publication": "create",
+        "outcome": "accepted"
+      },
+      {
+        "type": "deliver_all"
+      },
+      {
+        "type": "tick",
+        "clients": [
+          "bob"
+        ]
+      },
+      {
+        "type": "clear_events",
+        "clients": [
+          "alice",
+          "bob",
+          "carol"
+        ]
+      },
+      {
+        "type": "send_app_message",
+        "sender": "alice",
+        "payload": "latecomer:pre:r1:alice"
+      },
+      {
+        "type": "send_app_message",
+        "sender": "bob",
+        "payload": "latecomer:pre:r1:bob"
+      },
+      {
+        "type": "deliver_all"
+      },
+      {
+        "type": "tick",
+        "clients": [
+          "alice",
+          "bob"
+        ]
+      },
+      {
+        "type": "send_app_message",
+        "sender": "alice",
+        "payload": "latecomer:pre:r2:alice"
+      },
+      {
+        "type": "send_app_message",
+        "sender": "bob",
+        "payload": "latecomer:pre:r2:bob"
+      },
+      {
+        "type": "deliver_all"
+      },
+      {
+        "type": "tick",
+        "clients": [
+          "alice",
+          "bob"
+        ]
+      },
       {
         "type": "invite_members",
         "inviter": "alice",
-        "invitees": ["carol"],
+        "invitees": [
+          "carol"
+        ],
         "pending": "invite-carol"
       },
-      { "type": "acknowledge_outbound", "client": "alice", "publication": "invite-carol", "outcome": "accepted" },
-      { "type": "deliver_all" },
-      { "type": "tick", "clients": ["bob", "carol"] },
-      { "type": "send_app_message", "sender": "alice", "payload": "latecomer:post:r1:alice" },
-      { "type": "send_app_message", "sender": "bob", "payload": "latecomer:post:r1:bob" },
-      { "type": "send_app_message", "sender": "carol", "payload": "latecomer:post:r1:carol" },
-      { "type": "deliver_all" },
-      { "type": "tick", "clients": ["alice", "bob", "carol"] },
-      { "type": "send_app_message", "sender": "alice", "payload": "latecomer:post:r2:alice" },
-      { "type": "send_app_message", "sender": "bob", "payload": "latecomer:post:r2:bob" },
-      { "type": "send_app_message", "sender": "carol", "payload": "latecomer:post:r2:carol" },
-      { "type": "deliver_all" },
-      { "type": "tick", "clients": ["alice", "bob", "carol"] },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "publication": "invite-carol",
+        "outcome": "accepted"
+      },
+      {
+        "type": "deliver_all"
+      },
+      {
+        "type": "tick",
+        "clients": [
+          "bob",
+          "carol"
+        ]
+      },
+      {
+        "type": "send_app_message",
+        "sender": "alice",
+        "payload": "latecomer:post:r1:alice"
+      },
+      {
+        "type": "send_app_message",
+        "sender": "bob",
+        "payload": "latecomer:post:r1:bob"
+      },
+      {
+        "type": "send_app_message",
+        "sender": "carol",
+        "payload": "latecomer:post:r1:carol"
+      },
+      {
+        "type": "deliver_all"
+      },
+      {
+        "type": "tick",
+        "clients": [
+          "alice",
+          "bob",
+          "carol"
+        ]
+      },
+      {
+        "type": "send_app_message",
+        "sender": "alice",
+        "payload": "latecomer:post:r2:alice"
+      },
+      {
+        "type": "send_app_message",
+        "sender": "bob",
+        "payload": "latecomer:post:r2:bob"
+      },
+      {
+        "type": "send_app_message",
+        "sender": "carol",
+        "payload": "latecomer:post:r2:carol"
+      },
+      {
+        "type": "deliver_all"
+      },
+      {
+        "type": "tick",
+        "clients": [
+          "alice",
+          "bob",
+          "carol"
+        ]
+      },
       {
         "type": "assert",
         "assertion": {
           "mode": "exactly",
-          "predicate": { "type": "payload_count", "client": "carol", "payload": "latecomer:pre:r1:alice", "count": 0 }
+          "predicate": {
+            "type": "payload_count",
+            "client": "carol",
+            "payload": "latecomer:pre:r1:alice",
+            "count": 0
+          }
         }
       },
       {
         "type": "assert",
         "assertion": {
           "mode": "exactly",
-          "predicate": { "type": "payload_count", "client": "carol", "payload": "latecomer:pre:r2:bob", "count": 0 }
+          "predicate": {
+            "type": "payload_count",
+            "client": "carol",
+            "payload": "latecomer:pre:r2:bob",
+            "count": 0
+          }
         }
       },
-      { "type": "observe_exact", "clients": ["alice", "bob", "carol"] }
+      {
+        "type": "observe_exact",
+        "clients": [
+          "alice",
+          "bob",
+          "carol"
+        ]
+      }
     ]
   },
   "expected_outcomes": [
@@ -121,13 +252,20 @@
     },
     {
       "type": "clients_converged",
-      "clients": ["alice", "bob", "carol"],
+      "clients": [
+        "alice",
+        "bob",
+        "carol"
+      ],
       "epoch": 2,
       "member_count": 3
     },
     {
       "type": "no_pending_work",
-      "clients": ["alice", "bob"]
+      "clients": [
+        "alice",
+        "bob"
+      ]
     }
   ]
 }

--- a/crates/cgka-conformance-simulator/vectors/latecomer-forward-secrecy.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/latecomer-forward-secrecy.v1.json
@@ -1,0 +1,133 @@
+{
+  "scenario_name": "latecomer-forward-secrecy/v1",
+  "vector_version": "1",
+  "conformance_version": "0.9.10",
+  "seed": null,
+  "scenario": {
+    "name": "latecomer-forward-secrecy/v1",
+    "spec_version": "2",
+    "clients": ["alice", "bob", "carol"],
+    "steps": [
+      {
+        "type": "create_group",
+        "creator": "alice",
+        "name": "latecomer",
+        "invitees": ["bob"],
+        "required_features": [],
+        "pending": "create"
+      },
+      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
+      { "type": "deliver_all" },
+      { "type": "tick", "clients": ["bob"] },
+      { "type": "clear_events", "clients": ["alice", "bob", "carol"] },
+      { "type": "send_app_message", "sender": "alice", "payload": "latecomer:pre:r1:alice" },
+      { "type": "send_app_message", "sender": "bob", "payload": "latecomer:pre:r1:bob" },
+      { "type": "deliver_all" },
+      { "type": "tick", "clients": ["alice", "bob"] },
+      { "type": "send_app_message", "sender": "alice", "payload": "latecomer:pre:r2:alice" },
+      { "type": "send_app_message", "sender": "bob", "payload": "latecomer:pre:r2:bob" },
+      { "type": "deliver_all" },
+      { "type": "tick", "clients": ["alice", "bob"] },
+      {
+        "type": "invite_members",
+        "inviter": "alice",
+        "invitees": ["carol"],
+        "pending": "invite-carol"
+      },
+      { "type": "acknowledge_outbound", "client": "alice", "publication": "invite-carol", "outcome": "accepted" },
+      { "type": "deliver_all" },
+      { "type": "tick", "clients": ["bob", "carol"] },
+      { "type": "send_app_message", "sender": "alice", "payload": "latecomer:post:r1:alice" },
+      { "type": "send_app_message", "sender": "bob", "payload": "latecomer:post:r1:bob" },
+      { "type": "send_app_message", "sender": "carol", "payload": "latecomer:post:r1:carol" },
+      { "type": "deliver_all" },
+      { "type": "tick", "clients": ["alice", "bob", "carol"] },
+      { "type": "send_app_message", "sender": "alice", "payload": "latecomer:post:r2:alice" },
+      { "type": "send_app_message", "sender": "bob", "payload": "latecomer:post:r2:bob" },
+      { "type": "send_app_message", "sender": "carol", "payload": "latecomer:post:r2:carol" },
+      { "type": "deliver_all" },
+      { "type": "tick", "clients": ["alice", "bob", "carol"] },
+      {
+        "type": "assert",
+        "assertion": {
+          "mode": "exactly",
+          "predicate": { "type": "payload_count", "client": "carol", "payload": "latecomer:pre:r1:alice", "count": 0 }
+        }
+      },
+      {
+        "type": "assert",
+        "assertion": {
+          "mode": "exactly",
+          "predicate": { "type": "payload_count", "client": "carol", "payload": "latecomer:pre:r2:bob", "count": 0 }
+        }
+      },
+      { "type": "observe_exact", "clients": ["alice", "bob", "carol"] }
+    ]
+  },
+  "expected_outcomes": [
+    {
+      "type": "pending_resolution",
+      "step_index": 1,
+      "client": "alice",
+      "pending": "create",
+      "resolution": "confirmed"
+    },
+    {
+      "type": "pending_resolution",
+      "step_index": 14,
+      "client": "alice",
+      "pending": "invite-carol",
+      "resolution": "confirmed"
+    },
+    {
+      "type": "client_state",
+      "client": "alice",
+      "epoch": 2,
+      "member_count": 3,
+      "received_payloads": [
+        "latecomer:pre:r1:bob",
+        "latecomer:pre:r2:bob",
+        "latecomer:post:r1:bob",
+        "latecomer:post:r1:carol",
+        "latecomer:post:r2:bob",
+        "latecomer:post:r2:carol"
+      ]
+    },
+    {
+      "type": "client_state",
+      "client": "bob",
+      "epoch": 2,
+      "member_count": 3,
+      "received_payloads": [
+        "latecomer:pre:r1:alice",
+        "latecomer:pre:r2:alice",
+        "latecomer:post:r1:alice",
+        "latecomer:post:r1:carol",
+        "latecomer:post:r2:alice",
+        "latecomer:post:r2:carol"
+      ]
+    },
+    {
+      "type": "client_state",
+      "client": "carol",
+      "epoch": 2,
+      "member_count": 3,
+      "received_payloads": [
+        "latecomer:post:r1:alice",
+        "latecomer:post:r1:bob",
+        "latecomer:post:r2:alice",
+        "latecomer:post:r2:bob"
+      ]
+    },
+    {
+      "type": "clients_converged",
+      "clients": ["alice", "bob", "carol"],
+      "epoch": 2,
+      "member_count": 3
+    },
+    {
+      "type": "no_pending_work",
+      "clients": ["alice", "bob"]
+    }
+  ]
+}

--- a/crates/cgka-conformance-simulator/vectors/leaver-removal-secrecy.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/leaver-removal-secrecy.v1.json
@@ -1,0 +1,134 @@
+{
+  "scenario_name": "leaver-removal-secrecy/v1",
+  "vector_version": "1",
+  "conformance_version": "0.9.10",
+  "seed": null,
+  "scenario": {
+    "name": "leaver-removal-secrecy/v1",
+    "spec_version": "2",
+    "clients": ["alice", "bob", "carol", "dave"],
+    "steps": [
+      {
+        "type": "create_group",
+        "creator": "alice",
+        "name": "leaver",
+        "invitees": ["bob", "carol", "dave"],
+        "required_features": [],
+        "pending": "create"
+      },
+      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
+      { "type": "deliver_all" },
+      { "type": "tick", "clients": ["bob", "carol", "dave"] },
+      { "type": "clear_events", "clients": ["alice", "bob", "carol", "dave"] },
+      { "type": "send_app_message", "sender": "alice", "payload": "leaver:pre:alice" },
+      { "type": "send_app_message", "sender": "bob", "payload": "leaver:pre:bob" },
+      { "type": "send_app_message", "sender": "carol", "payload": "leaver:pre:carol" },
+      { "type": "send_app_message", "sender": "dave", "payload": "leaver:pre:dave" },
+      { "type": "deliver_all" },
+      { "type": "tick", "clients": ["alice", "bob", "carol", "dave"] },
+      {
+        "type": "remove_members",
+        "remover": "alice",
+        "members": ["dave"],
+        "pending": "remove-dave"
+      },
+      { "type": "acknowledge_outbound", "client": "alice", "publication": "remove-dave", "outcome": "accepted" },
+      { "type": "deliver_all" },
+      { "type": "tick", "clients": ["bob", "carol", "dave"] },
+      { "type": "set_partition", "allow": ["alice", "bob", "carol"] },
+      { "type": "send_app_message", "sender": "alice", "payload": "leaver:gap:alice" },
+      { "type": "send_app_message", "sender": "bob", "payload": "leaver:gap:bob" },
+      { "type": "send_app_message", "sender": "carol", "payload": "leaver:gap:carol" },
+      { "type": "deliver_all" },
+      { "type": "tick", "clients": ["alice", "bob", "carol"] },
+      { "type": "leave", "client": "carol" },
+      { "type": "deliver_all" },
+      { "type": "tick", "clients": ["alice"] },
+      { "type": "acknowledge_outbound", "client": "alice", "outcome": "accepted" },
+      { "type": "deliver_all" },
+      { "type": "tick", "clients": ["bob", "carol"] },
+      { "type": "send_app_message", "sender": "alice", "payload": "leaver:tail:alice" },
+      { "type": "send_app_message", "sender": "bob", "payload": "leaver:tail:bob" },
+      { "type": "deliver_all" },
+      { "type": "tick", "clients": ["alice", "bob"] },
+      {
+        "type": "assert",
+        "assertion": {
+          "mode": "exactly",
+          "predicate": { "type": "payload_count", "client": "dave", "payload": "leaver:gap:alice", "count": 0 }
+        }
+      },
+      {
+        "type": "assert",
+        "assertion": {
+          "mode": "exactly",
+          "predicate": { "type": "payload_count", "client": "dave", "payload": "leaver:gap:bob", "count": 0 }
+        }
+      },
+      {
+        "type": "assert",
+        "assertion": {
+          "mode": "exactly",
+          "predicate": { "type": "payload_count", "client": "carol", "payload": "leaver:tail:alice", "count": 0 }
+        }
+      },
+      { "type": "observe_exact", "clients": ["alice", "bob"] }
+    ]
+  },
+  "expected_outcomes": [
+    {
+      "type": "pending_resolution",
+      "step_index": 1,
+      "client": "alice",
+      "pending": "create",
+      "resolution": "confirmed"
+    },
+    {
+      "type": "pending_resolution",
+      "step_index": 12,
+      "client": "alice",
+      "pending": "remove-dave",
+      "resolution": "confirmed"
+    },
+    {
+      "type": "client_state",
+      "client": "alice",
+      "epoch": 3,
+      "member_count": 2,
+      "received_payloads": [
+        "leaver:pre:bob",
+        "leaver:pre:carol",
+        "leaver:pre:dave",
+        "leaver:gap:bob",
+        "leaver:gap:carol",
+        "leaver:tail:bob"
+      ],
+      "removed_members": ["dave", "carol"]
+    },
+    {
+      "type": "client_state",
+      "client": "bob",
+      "epoch": 3,
+      "member_count": 2,
+      "received_payloads": [
+        "leaver:pre:alice",
+        "leaver:pre:carol",
+        "leaver:pre:dave",
+        "leaver:gap:alice",
+        "leaver:gap:carol",
+        "leaver:tail:alice"
+      ],
+      "removed_members": ["dave", "carol"]
+    },
+    {
+      "type": "clients_converged",
+      "clients": ["alice", "bob"],
+      "epoch": 3,
+      "member_count": 2
+    },
+    {
+      "type": "no_pending_work",
+      "clients": ["alice", "bob"]
+    }
+  ]
+}

--- a/crates/cgka-conformance-simulator/vectors/leaver-removal-secrecy.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/leaver-removal-secrecy.v1.json
@@ -6,73 +6,276 @@
   "scenario": {
     "name": "leaver-removal-secrecy/v1",
     "spec_version": "2",
-    "clients": ["alice", "bob", "carol", "dave"],
+    "clients": [
+      "alice",
+      "bob",
+      "carol",
+      "dave"
+    ],
     "steps": [
       {
         "type": "create_group",
         "creator": "alice",
         "name": "leaver",
-        "invitees": ["bob", "carol", "dave"],
+        "invitees": [
+          "bob",
+          "carol",
+          "dave"
+        ],
         "required_features": [],
         "pending": "create"
       },
-      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
-      { "type": "deliver_all" },
-      { "type": "tick", "clients": ["bob", "carol", "dave"] },
-      { "type": "clear_events", "clients": ["alice", "bob", "carol", "dave"] },
-      { "type": "send_app_message", "sender": "alice", "payload": "leaver:pre:alice" },
-      { "type": "send_app_message", "sender": "bob", "payload": "leaver:pre:bob" },
-      { "type": "send_app_message", "sender": "carol", "payload": "leaver:pre:carol" },
-      { "type": "send_app_message", "sender": "dave", "payload": "leaver:pre:dave" },
-      { "type": "deliver_all" },
-      { "type": "tick", "clients": ["alice", "bob", "carol", "dave"] },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "publication": "create",
+        "outcome": "accepted"
+      },
+      {
+        "type": "deliver_all"
+      },
+      {
+        "type": "tick",
+        "clients": [
+          "bob",
+          "carol",
+          "dave"
+        ]
+      },
+      {
+        "type": "clear_events",
+        "clients": [
+          "alice",
+          "bob",
+          "carol",
+          "dave"
+        ]
+      },
+      {
+        "type": "send_app_message",
+        "sender": "alice",
+        "payload": "leaver:pre:alice"
+      },
+      {
+        "type": "send_app_message",
+        "sender": "bob",
+        "payload": "leaver:pre:bob"
+      },
+      {
+        "type": "send_app_message",
+        "sender": "carol",
+        "payload": "leaver:pre:carol"
+      },
+      {
+        "type": "send_app_message",
+        "sender": "dave",
+        "payload": "leaver:pre:dave"
+      },
+      {
+        "type": "deliver_all"
+      },
+      {
+        "type": "tick",
+        "clients": [
+          "alice",
+          "bob",
+          "carol",
+          "dave"
+        ]
+      },
       {
         "type": "remove_members",
         "remover": "alice",
-        "members": ["dave"],
+        "members": [
+          "dave"
+        ],
         "pending": "remove-dave"
       },
-      { "type": "acknowledge_outbound", "client": "alice", "publication": "remove-dave", "outcome": "accepted" },
-      { "type": "deliver_all" },
-      { "type": "tick", "clients": ["bob", "carol", "dave"] },
-      { "type": "set_partition", "allow": ["alice", "bob", "carol"] },
-      { "type": "send_app_message", "sender": "alice", "payload": "leaver:gap:alice" },
-      { "type": "send_app_message", "sender": "bob", "payload": "leaver:gap:bob" },
-      { "type": "send_app_message", "sender": "carol", "payload": "leaver:gap:carol" },
-      { "type": "deliver_all" },
-      { "type": "tick", "clients": ["alice", "bob", "carol"] },
-      { "type": "leave", "client": "carol" },
-      { "type": "deliver_all" },
-      { "type": "tick", "clients": ["alice"] },
-      { "type": "acknowledge_outbound", "client": "alice", "outcome": "accepted" },
-      { "type": "deliver_all" },
-      { "type": "tick", "clients": ["bob", "carol"] },
-      { "type": "send_app_message", "sender": "alice", "payload": "leaver:tail:alice" },
-      { "type": "send_app_message", "sender": "bob", "payload": "leaver:tail:bob" },
-      { "type": "deliver_all" },
-      { "type": "tick", "clients": ["alice", "bob"] },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "publication": "remove-dave",
+        "outcome": "accepted"
+      },
+      {
+        "type": "deliver_all"
+      },
+      {
+        "type": "tick",
+        "clients": [
+          "bob",
+          "carol",
+          "dave"
+        ]
+      },
+      {
+        "type": "send_app_message",
+        "sender": "alice",
+        "payload": "leaver:gap:alice"
+      },
+      {
+        "type": "send_app_message",
+        "sender": "bob",
+        "payload": "leaver:gap:bob"
+      },
+      {
+        "type": "send_app_message",
+        "sender": "carol",
+        "payload": "leaver:gap:carol"
+      },
+      {
+        "type": "deliver_all"
+      },
+      {
+        "type": "tick",
+        "clients": [
+          "alice",
+          "bob",
+          "carol",
+          "dave"
+        ]
+      },
+      {
+        "type": "leave",
+        "client": "carol"
+      },
+      {
+        "type": "deliver_all"
+      },
+      {
+        "type": "tick",
+        "clients": [
+          "alice"
+        ]
+      },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "outcome": "accepted"
+      },
+      {
+        "type": "deliver_all"
+      },
+      {
+        "type": "tick",
+        "clients": [
+          "bob",
+          "carol"
+        ]
+      },
+      {
+        "type": "send_app_message",
+        "sender": "alice",
+        "payload": "leaver:tail:alice"
+      },
+      {
+        "type": "send_app_message",
+        "sender": "bob",
+        "payload": "leaver:tail:bob"
+      },
+      {
+        "type": "deliver_all"
+      },
+      {
+        "type": "tick",
+        "clients": [
+          "alice",
+          "bob",
+          "carol",
+          "dave"
+        ]
+      },
       {
         "type": "assert",
         "assertion": {
           "mode": "exactly",
-          "predicate": { "type": "payload_count", "client": "dave", "payload": "leaver:gap:alice", "count": 0 }
+          "predicate": {
+            "type": "payload_count",
+            "client": "dave",
+            "payload": "leaver:gap:alice",
+            "count": 0
+          }
         }
       },
       {
         "type": "assert",
         "assertion": {
           "mode": "exactly",
-          "predicate": { "type": "payload_count", "client": "dave", "payload": "leaver:gap:bob", "count": 0 }
+          "predicate": {
+            "type": "payload_count",
+            "client": "dave",
+            "payload": "leaver:gap:bob",
+            "count": 0
+          }
         }
       },
       {
         "type": "assert",
         "assertion": {
           "mode": "exactly",
-          "predicate": { "type": "payload_count", "client": "carol", "payload": "leaver:tail:alice", "count": 0 }
+          "predicate": {
+            "type": "payload_count",
+            "client": "dave",
+            "payload": "leaver:gap:carol",
+            "count": 0
+          }
         }
       },
-      { "type": "observe_exact", "clients": ["alice", "bob"] }
+      {
+        "type": "assert",
+        "assertion": {
+          "mode": "exactly",
+          "predicate": {
+            "type": "payload_count",
+            "client": "dave",
+            "payload": "leaver:tail:alice",
+            "count": 0
+          }
+        }
+      },
+      {
+        "type": "assert",
+        "assertion": {
+          "mode": "exactly",
+          "predicate": {
+            "type": "payload_count",
+            "client": "dave",
+            "payload": "leaver:tail:bob",
+            "count": 0
+          }
+        }
+      },
+      {
+        "type": "assert",
+        "assertion": {
+          "mode": "exactly",
+          "predicate": {
+            "type": "payload_count",
+            "client": "carol",
+            "payload": "leaver:tail:alice",
+            "count": 0
+          }
+        }
+      },
+      {
+        "type": "assert",
+        "assertion": {
+          "mode": "exactly",
+          "predicate": {
+            "type": "payload_count",
+            "client": "carol",
+            "payload": "leaver:tail:bob",
+            "count": 0
+          }
+        }
+      },
+      {
+        "type": "observe_exact",
+        "clients": [
+          "alice",
+          "bob"
+        ]
+      }
     ]
   },
   "expected_outcomes": [
@@ -103,7 +306,10 @@
         "leaver:gap:carol",
         "leaver:tail:bob"
       ],
-      "removed_members": ["dave", "carol"]
+      "removed_members": [
+        "dave",
+        "carol"
+      ]
     },
     {
       "type": "client_state",
@@ -118,17 +324,26 @@
         "leaver:gap:carol",
         "leaver:tail:alice"
       ],
-      "removed_members": ["dave", "carol"]
+      "removed_members": [
+        "dave",
+        "carol"
+      ]
     },
     {
       "type": "clients_converged",
-      "clients": ["alice", "bob"],
+      "clients": [
+        "alice",
+        "bob"
+      ],
       "epoch": 3,
       "member_count": 2
     },
     {
       "type": "no_pending_work",
-      "clients": ["alice", "bob"]
+      "clients": [
+        "alice",
+        "bob"
+      ]
     }
   ]
 }

--- a/crates/cgka-conformance-simulator/vectors/manifest.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/manifest.v1.json
@@ -402,9 +402,9 @@
       "artifact": "leaver-removal-secrecy.v1.json",
       "coverage": [
         "admin removal commit",
-        "post-removal secrecy for the removed member",
+        "post-removal secrecy: removed member receives and processes all post-removal ciphertext, decrypts none",
         "self-leave witness commit",
-        "post-leave secrecy for the departed member"
+        "post-leave secrecy: departed member receives and processes all post-leave ciphertext, decrypts none"
       ],
       "next": "Add the removed-member re-add leg once welcome-after-eviction is supported by the engine harness."
     },

--- a/crates/cgka-conformance-simulator/vectors/manifest.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/manifest.v1.json
@@ -368,6 +368,58 @@
         "duplicate relay rejection"
       ],
       "next": "Add unsorted, malformed URL, and oversized relay-list vectors."
+    },
+    {
+      "id": "conversation/v1",
+      "kind": "scenario_vector",
+      "status": "portable",
+      "artifact": "conversation.v1.json",
+      "coverage": [
+        "multi-round turn-taking application traffic",
+        "exact per-client transcript completeness",
+        "no duplicate delivery across rounds",
+        "cross-client convergence with no pending work"
+      ],
+      "next": "Extend rounds or member count if turn-taking regressions appear."
+    },
+    {
+      "id": "latecomer-forward-secrecy/v1",
+      "kind": "scenario_vector",
+      "status": "portable",
+      "artifact": "latecomer-forward-secrecy.v1.json",
+      "coverage": [
+        "mid-conversation invite",
+        "forward secrecy: latecomer never observes pre-join plaintext",
+        "pre-join ciphertext retained as deferred transport input",
+        "post-join transcript completeness for all members"
+      ],
+      "next": "Add a multi-epoch pre-join history variant once deferred-input expiry is modeled."
+    },
+    {
+      "id": "leaver-removal-secrecy/v1",
+      "kind": "scenario_vector",
+      "status": "portable",
+      "artifact": "leaver-removal-secrecy.v1.json",
+      "coverage": [
+        "admin removal commit",
+        "post-removal secrecy for the removed member",
+        "self-leave witness commit",
+        "post-leave secrecy for the departed member"
+      ],
+      "next": "Add the removed-member re-add leg once welcome-after-eviction is supported by the engine harness."
+    },
+    {
+      "id": "incremental-growth/v1",
+      "kind": "scenario_vector",
+      "status": "portable",
+      "artifact": "incremental-growth.v1.json",
+      "coverage": [
+        "one-member-at-a-time growth",
+        "group-data rename per growth phase",
+        "cohort-era forward secrecy: each joiner sees only its era onward",
+        "full-group convergence at final epoch"
+      ],
+      "next": "Scale the cohort schedule into a generated family for larger rosters."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Ports four scenarios from the external multi-VM harness catalog into portable ScenarioSpec v2 vector fixtures. Marmots now prove not only who heard what, but who never could.

- `conversation/v1`: multi-round turn-taking chat with exact per-client transcripts, convergence, and no pending work
- `latecomer-forward-secrecy/v1`: the simulator's first forward-secrecy check. The latecomer holds pre-join ciphertext and must never observe pre-join plaintext.
- `leaver-removal-secrecy/v1`: the first `remove_members` vector. Post-removal and post-self-leave secrecy are pinned with `payload_count` zero assertions.
- `incremental-growth/v1`: grows a group one member per phase with a rename per phase, and pins cohort-era secrecy across two join boundaries
- registers all four in `vectors/manifest.v1.json` and `SCENARIOS.md`

## Stack

Continues the #1250 extraction series: #1270 (merged), #1271 (merged), #1272 (base of this PR). This PR targets `codex/convergence-failure-corpus` and re-targets `master` once #1272 merges. Planned follow-ups in this series: isolation and catch-up vectors, then a seeded churn family.

## Scope boundary

No production code changes; this PR adds JSON fixtures and docs only. The catalog's re-add leg (a removed member rejoins with a fresh KeyPackage) is absent on purpose: welcome-after-eviction fails in the engine harness with `GroupStateError(UseAfterEviction)`. SCENARIOS.md records that gap so the leg can land once the harness supports it.

## Verification

- `cargo test -p cgka-conformance-simulator --locked --test canonical_scenarios canonical_vector_fixtures_match_generated_traces`
- `cargo test -p cgka-conformance-simulator --locked --test vector_artifacts`
- `cargo test -p cgka-conformance-simulator --locked --test scenario_ir`
- `just fast-ci` (one caveat: `convergence-campaign-runner/src/manifest.rs:469` on the base branch trips clippy 1.97's `unneeded_wildcard_pattern`; CI pins 1.95, where it does not fire)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added portable conformance scenarios for multi-round conversations, incremental group growth, latecomer forward secrecy, and member-removal secrecy.
  * Added coverage for invitations, renames, membership changes, message delivery, and multi-epoch group evolution.
  * Added expected results for payload visibility, state convergence, confirmed operations, and completion without pending work.
  * Updated the scenario manifest to include all four new vectors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->