### PR TITLE
Add the admin-churn/v1 generated scenario family

### DIFF
--- a/crates/cgka-conformance-simulator/AGENTS.md
+++ b/crates/cgka-conformance-simulator/AGENTS.md
@@ -330,7 +330,8 @@ Keep these aligned with [`README.md`](README.md), [`SCENARIOS.md`](SCENARIOS.md)
   storms, mixed message/commit storms, and restart plus duplicate delivery. `admin-churn/v1` covers seeded admin-set
   churn, competing same-epoch admin-policy commits, restart between publish and delivery, and latecomer joins under
   commit pressure. Storage-loss families are still future work. A welcome-joined member retains its own join commit as
-  a permanently deferred transport input; latecomer arms scope their pending-work oracle to the founders until that is
+  a permanently deferred transport input; latecomer arms scope their strict pending-work oracle to the founders and
+  pin the joiner to exactly that retained artifact (`no_pending_work_except_retained_join_commit`) until that is
   resolved.
 - **Stateful chat journeys serialize commits by construction.** Each commit is acknowledged and delivered before the
   next state-changing action, and restart is a terminal checkpoint. Mutation-after-reopen plus concurrent and racing

--- a/crates/cgka-conformance-simulator/AGENTS.md
+++ b/crates/cgka-conformance-simulator/AGENTS.md
@@ -57,7 +57,8 @@ the property-test registry. This file is the agent-facing model.
 
 - **Module:** `src/family.rs`
   - **Role:** Deterministic generated scenario families. `generate_send_leave_family`,
-    `generate_convergence_e2e_delivery_family`, and `generate_convergence_chaos_family` record family name, generator
+    `generate_convergence_e2e_delivery_family`, `generate_convergence_chaos_family`, and
+    `generate_admin_churn_family` record family name, generator
     version, seed, case index, runnable `ScenarioSpec`, and optional semantic expectations. `run_generated_case_report`
     adds generated metadata to report artifacts. Reliability families append a final global drain, exact canonical
     observation, and pending-work assertion; do not remove a red strict result merely because an earlier legacy
@@ -326,7 +327,11 @@ Keep these aligned with [`README.md`](README.md), [`SCENARIOS.md`](SCENARIOS.md)
   metadata, `convergence-e2e-delivery/v1` mutates the convergence E2E bridge with duplicate/delay/reorder delivery, and
   `convergence-chaos/v1` covers invite races, group-data races, publish rollback, partitions, leaves, delayed past-epoch
   app delivery, queue faults, 20+ client message storms, partitioned large-group storms, multi-committer group-data
-  storms, mixed message/commit storms, and restart plus duplicate delivery. Storage-loss families are still future work.
+  storms, mixed message/commit storms, and restart plus duplicate delivery. `admin-churn/v1` covers seeded admin-set
+  churn, competing same-epoch admin-policy commits, restart between publish and delivery, and latecomer joins under
+  commit pressure. Storage-loss families are still future work. A welcome-joined member retains its own join commit as
+  a permanently deferred transport input; latecomer arms scope their pending-work oracle to the founders until that is
+  resolved.
 - **Stateful chat journeys serialize commits by construction.** Each commit is acknowledged and delivered before the
   next state-changing action, and restart is a terminal checkpoint. Mutation-after-reopen plus concurrent and racing
   commit coverage remains owned by `convergence-chaos/v1`.

--- a/crates/cgka-conformance-simulator/README.md
+++ b/crates/cgka-conformance-simulator/README.md
@@ -551,6 +551,17 @@ cargo run -p cgka-conformance-simulator --bin cgka-conformance-simulator-report 
   --out target/cgka-conformance-simulator-reports
 ```
 
+To drill the admin-churn catalog (sequential churn, competing admin-policy commits, restart recovery, and latecomer
+joins under commit pressure):
+
+```sh
+cargo run -p cgka-conformance-simulator --bin cgka-conformance-simulator-report -- \
+  --family admin-churn/v1 \
+  --seed 42 \
+  --cases 8 \
+  --out target/cgka-conformance-simulator-reports
+```
+
 Reports are written as one file per case, for example
 `target/cgka-conformance-simulator-reports/send-leave-v1-seed-42-case-0.json`. Generated family runs also write fixture
 candidates such as `target/cgka-conformance-simulator-reports/convergence-chaos-v1-seed-42-case-0-fixture.v1.json`.

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -506,10 +506,13 @@ regression, covers a new semantic edge, or is the smallest readable example of a
 #### Admin-Churn Arm `1`: Competing Admin-Policy Commits
 
 - Setup: two admins race admin-policy commits from the same epoch; the delivery order of the two commits is drawn from
-  the seed.
+  the seed. After the race settles, an admin retained under both candidate outcomes pins the admin set with a
+  follow-up policy commit.
 - Pressure: same-epoch admin-authority race, the admin-set analog of the chaos group-data fork.
-- Expected: all clients converge one epoch past the race and the group stays usable (exact post-race probe
-  transcripts). The winning admin set is deliberately not asserted; it is schedule-dependent.
+- Expected: the race winner stays schedule-dependent and unasserted, but authority is enforced afterward: the
+  retained admin's pinning commit must succeed, both non-admins' privileged updates must be rejected in place
+  (`not_group_admin`), and every client observes the pinned admin set. All clients converge two epochs past the race
+  with exact post-race probe transcripts.
 
 #### Admin-Churn Arm `2`: Restart Between Publish and Delivery
 
@@ -521,14 +524,17 @@ regression, covers a new semantic edge, or is the smallest readable example of a
 
 #### Admin-Churn Arm `3`: Latecomer Under Commit Pressure
 
-- Setup: the founder keeps rename pressure up, then invites a fourth member and immediately renames again; all four
-  then exchange traffic. Pre-join traffic is partitioned away from the latecomer's process (ciphertext-exposure
-  forward secrecy is the `latecomer-forward-secrecy/v1` vector's job).
-- Pressure: a join racing sustained commit pressure.
-- Expected: the latecomer never observes pre-join plaintext (zero-count assertions), holds the exact post-join
-  transcript, and every client converges. The pending-work assertion is scoped to the founders: a welcome-joined
-  member currently retains its own join commit as a permanently deferred transport input, which is tracked as a
-  harness coverage gap.
+- Setup: the founder keeps rename pressure up, then invites a fourth member and publishes another rename before the
+  delivery round that completes the join, so the welcome and the next commit travel in the same flight; all four then
+  exchange traffic. Pre-join traffic is partitioned away from the latecomer's process (ciphertext-exposure forward
+  secrecy is the `latecomer-forward-secrecy/v1` vector's job).
+- Pressure: a join genuinely racing sustained commit pressure.
+- Expected: the latecomer never observes pre-join plaintext (zero-count assertions), every member holds its exact
+  transcript (founders carry pre-join and post-join traffic), and every client converges. The strict pending-work
+  assertion is scoped to the founders, and the joiner carries a
+  `no_pending_work_except_retained_join_commit` assertion: a welcome-joined member currently retains exactly its own
+  join commit as a permanently deferred transport input, and any other pending work still fails the case. The
+  retained join commit itself is tracked as a harness coverage gap.
 
 ### `convergence-chaos/v1`
 

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -487,6 +487,49 @@ regression, covers a new semantic edge, or is the smallest readable example of a
 - Pressure: duplicate, delay, release, and reorder before observer clients tick.
 - Expected: observers converge on one selected branch and emit only the selected branch payload.
 
+### `admin-churn/v1`
+
+- Generator: `generate_admin_churn_family` (generator version `1`).
+- Provenance: ported from the external multi-VM harness scenario catalog (`cheeky.rb`, `committy.rb`, `crashy.rb`
+  essences, without their wall-clock scheduling).
+- Setup: the family rotates through four arms.
+- Expected: each arm carries semantic expectations for convergence, exact transcripts, and pending work, then performs
+  the final drain with exact-state assertions.
+
+#### Admin-Churn Arm `0`: Seeded Sequential Churn
+
+- Setup: four members, all promoted to admin. Four rounds where a seeded admin either renames or toggles a non-founder
+  in or out of the admin set, with a full message round after each commit.
+- Pressure: sustained admin-set and metadata churn with traffic between commits.
+- Expected: all clients converge at the deterministic final epoch with exact per-client transcripts.
+
+#### Admin-Churn Arm `1`: Competing Admin-Policy Commits
+
+- Setup: two admins race admin-policy commits from the same epoch; the delivery order of the two commits is drawn from
+  the seed.
+- Pressure: same-epoch admin-authority race, the admin-set analog of the chaos group-data fork.
+- Expected: all clients converge one epoch past the race and the group stays usable (exact post-race probe
+  transcripts). The winning admin set is deliberately not asserted; it is schedule-dependent.
+
+#### Admin-Churn Arm `2`: Restart Between Publish and Delivery
+
+- Setup: a seeded admin publishes a rename commit and restarts before delivery; every member then sends into the
+  recovered group.
+- Pressure: crash-shaped interruption between commit publish and delivery.
+- Expected: the restarted client hydrates the stable group, its post-restart send lands everywhere, and all clients
+  converge with exact transcripts.
+
+#### Admin-Churn Arm `3`: Latecomer Under Commit Pressure
+
+- Setup: the founder keeps rename pressure up, then invites a fourth member and immediately renames again; all four
+  then exchange traffic. Pre-join traffic is partitioned away from the latecomer's process (ciphertext-exposure
+  forward secrecy is the `latecomer-forward-secrecy/v1` vector's job).
+- Pressure: a join racing sustained commit pressure.
+- Expected: the latecomer never observes pre-join plaintext (zero-count assertions), holds the exact post-join
+  transcript, and every client converges. The pending-work assertion is scoped to the founders: a welcome-joined
+  member currently retains its own join commit as a permanently deferred transport input, which is tracked as a
+  harness coverage gap.
+
 ### `convergence-chaos/v1`
 
 - Generator: `generate_convergence_chaos_family` (generator version `6`).

--- a/crates/cgka-conformance-simulator/src/family.rs
+++ b/crates/cgka-conformance-simulator/src/family.rs
@@ -180,7 +180,7 @@ pub fn generate_convergence_chaos_family(seed: u64, cases: usize) -> Vec<Generat
 /// scenario catalog (cheeky, committy, crashy essences). Case indices rotate
 /// through four arms: seeded sequential admin churn, competing same-epoch
 /// admin-policy commits, restart during a commit burst, and a latecomer added
-/// under commit pressure with a forward-secrecy check.
+/// under commit pressure with a pre-join mailbox-isolation check.
 pub fn generate_admin_churn_family(seed: u64, cases: usize) -> Vec<GeneratedScenarioCase> {
     let mut out = Vec::with_capacity(cases);
     for case_index in 0..cases {

--- a/crates/cgka-conformance-simulator/src/family.rs
+++ b/crates/cgka-conformance-simulator/src/family.rs
@@ -194,8 +194,13 @@ pub fn generate_admin_churn_family(seed: u64, cases: usize) -> Vec<GeneratedScen
             add_scoped_reliability_oracle(
                 &mut scenario,
                 &mut expected_outcomes,
-                labels(["alice", "bob", "carol"]),
+                admin_churn_core_labels(),
             );
+            // The joiner is not exempt from pending-work coverage: it must
+            // retain exactly its own deferred join commit and nothing else.
+            expected_outcomes.push(TraceExpectation::NoPendingWorkExceptRetainedJoinCommit {
+                client: "dave".into(),
+            });
         } else {
             add_strict_reliability_oracle(&mut scenario, &mut expected_outcomes);
         }
@@ -1440,6 +1445,13 @@ fn admin_churn_case(rng: &mut StdRng, case_index: u64) -> (ScenarioSpec, Vec<Tra
     }
 }
 
+/// Founders shared by the admin-churn latecomer arm and its scoped
+/// pending-work oracle. Keeping one source prevents the oracle scope from
+/// silently diverging if the arm's core roster changes.
+fn admin_churn_core_labels() -> Vec<String> {
+    labels(["alice", "bob", "carol"])
+}
+
 fn admin_policy_step(client: &str, admins: Vec<String>, pending: &str) -> ScenarioStep {
     ScenarioStep::UpdateAdminPolicy {
         client: client.into(),
@@ -1616,6 +1628,33 @@ fn admin_churn_competing_admin_commits(
     steps.push(ScenarioStep::DeliverAll);
     steps.push(tick_vec(clients.clone()));
 
+    // The same-epoch race winner is schedule-dependent, so pin the admin set
+    // deterministically before asserting authority: bob is an admin under both
+    // candidate outcomes, so his follow-up policy commit must succeed and
+    // reconverge everyone on a known set.
+    steps.push(admin_policy_step(
+        "bob",
+        labels(["alice", "bob"]),
+        "pin-core",
+    ));
+    push_confirmed(&mut steps, &mut expected, "bob", "pin-core");
+    steps.push(ScenarioStep::DeliverAll);
+    steps.push(tick_vec(clients.clone()));
+
+    // Authority enforcement: under the pinned set, carol and dave are
+    // non-admins regardless of which racer won, so their privileged updates
+    // must be rejected in place.
+    steps.push(ScenarioStep::ExpectUpdateAdminPolicyError {
+        client: "carol".into(),
+        admins: labels(["alice", "bob", "carol"]),
+        error: "not_group_admin".into(),
+    });
+    steps.push(ScenarioStep::ExpectUpdateAdminPolicyError {
+        client: "dave".into(),
+        admins: labels(["alice", "bob", "dave"]),
+        error: "not_group_admin".into(),
+    });
+
     for sender in &clients {
         steps.push(ScenarioStep::SendAppMessage {
             sender: sender.clone(),
@@ -1624,20 +1663,27 @@ fn admin_churn_competing_admin_commits(
     }
     steps.push(ScenarioStep::DeliverAll);
     steps.push(tick_vec(clients.clone()));
+    steps.push(ScenarioStep::ObserveAdminPolicy {
+        clients: clients.clone(),
+    });
     steps.push(observe_vec(clients.clone()));
 
     expected.push(clients_converged_vec(
         clients.clone(),
-        Some(3),
+        Some(4),
         Some(clients.len()),
     ));
     for client in &clients {
+        expected.push(TraceExpectation::AdminPolicy {
+            client: client.clone(),
+            admins: labels(["alice", "bob"]),
+        });
         let received = clients
             .iter()
             .filter(|sender| *sender != client)
             .map(|sender| format!("admin-churn:{case_index}:probe:{sender}"))
             .collect();
-        expected.push(client_state(client, 3, clients.len(), received));
+        expected.push(client_state(client, 4, clients.len(), received));
     }
 
     let scenario = ScenarioSpec {
@@ -1734,7 +1780,7 @@ fn admin_churn_restart_recovery(
 /// must never observe pre-join plaintext (committy essence).
 fn admin_churn_latecomer_under_pressure(case_index: u64) -> (ScenarioSpec, Vec<TraceExpectation>) {
     let clients = labels(["alice", "bob", "carol", "dave"]);
-    let core = labels(["alice", "bob", "carol"]);
+    let core = admin_churn_core_labels();
     let pre_payloads = [
         format!("admin-churn:{case_index}:pre:bob"),
         format!("admin-churn:{case_index}:pre:carol"),
@@ -1783,9 +1829,9 @@ fn admin_churn_latecomer_under_pressure(case_index: u64) -> (ScenarioSpec, Vec<T
     steps.push(ScenarioStep::ClearPartition);
     steps.push(invite("alice", ["dave"], "invite-late"));
     push_confirmed(&mut steps, &mut expected, "alice", "invite-late");
-    steps.push(ScenarioStep::DeliverAll);
-    steps.push(tick_vec(clients[1..].to_vec()));
-
+    // Publish the rename before the delivery round that completes Dave's
+    // join: his welcome and the founder's next commit travel in the same
+    // flight, so the join genuinely races the ongoing commit pressure.
     steps.push(ScenarioStep::UpdateGroupData {
         client: "alice".into(),
         name: format!("admin-late-{case_index}-post"),
@@ -1838,6 +1884,19 @@ fn admin_churn_latecomer_under_pressure(case_index: u64) -> (ScenarioSpec, Vec<T
         clients.len(),
         alice_received,
     ));
+    // Bob and Carol carry both pre-join and post-join traffic; exact
+    // transcripts for them catch missing, duplicated, or unexpected payloads
+    // that canonical-state equivalence alone cannot.
+    for (member, other_pre) in [("bob", &pre_payloads[1]), ("carol", &pre_payloads[0])] {
+        let mut received = vec![other_pre.clone()];
+        received.extend(
+            clients
+                .iter()
+                .filter(|sender| *sender != member)
+                .map(|sender| format!("admin-churn:{case_index}:post:{sender}")),
+        );
+        expected.push(client_state(member, final_epoch, clients.len(), received));
+    }
 
     let scenario = ScenarioSpec {
         name: format!("admin-churn/v1/case-{case_index}"),
@@ -3310,6 +3369,31 @@ fn add_strict_reliability_oracle(
     scenario: &mut ScenarioSpec,
     expected: &mut Vec<TraceExpectation>,
 ) {
+    add_reliability_oracle(scenario, expected, None);
+}
+
+/// Strict-oracle variant with an explicit pending-work scope. Appends the same
+/// drain / acknowledge / exact-observation tail as
+/// [`add_strict_reliability_oracle`], asserts exact equivalence across every
+/// expectation-derived client, but limits the no-pending-work assertion to
+/// `pending_scope`. Use only when a client is known to retain a documented
+/// terminal input (for example a welcome-joined member's own join commit).
+fn add_scoped_reliability_oracle(
+    scenario: &mut ScenarioSpec,
+    expected: &mut Vec<TraceExpectation>,
+    pending_scope: Vec<String>,
+) {
+    add_reliability_oracle(scenario, expected, Some(pending_scope));
+}
+
+/// Shared oracle tail: drain, acknowledge, exact-observe, and assert. The
+/// no-pending-work assertion covers every expectation-derived client unless an
+/// explicit `pending_scope` narrows it.
+fn add_reliability_oracle(
+    scenario: &mut ScenarioSpec,
+    expected: &mut Vec<TraceExpectation>,
+    pending_scope: Option<Vec<String>>,
+) {
     let exact_clients = expected
         .iter()
         .flat_map(|expectation| match expectation {
@@ -3368,57 +3452,7 @@ fn add_strict_reliability_oracle(
         });
     }
     expected.push(TraceExpectation::NoPendingWork {
-        clients: exact_clients,
-    });
-}
-
-/// Strict-oracle variant with an explicit pending-work scope. Appends the same
-/// drain / acknowledge / exact-observation tail as
-/// [`add_strict_reliability_oracle`], asserts exact equivalence across every
-/// expectation-derived client, but limits the no-pending-work assertion to
-/// `pending_scope`. Use only when a client is known to retain a documented
-/// terminal input (for example a welcome-joined member's own join commit).
-fn add_scoped_reliability_oracle(
-    scenario: &mut ScenarioSpec,
-    expected: &mut Vec<TraceExpectation>,
-    pending_scope: Vec<String>,
-) {
-    let exact_clients = expected
-        .iter()
-        .flat_map(|expectation| match expectation {
-            TraceExpectation::ClientsConverged { clients, .. } => clients.clone(),
-            TraceExpectation::ClientState { client, .. } => vec![client.clone()],
-            _ => Vec::new(),
-        })
-        .collect::<BTreeSet<_>>()
-        .into_iter()
-        .collect::<Vec<_>>();
-    if exact_clients.is_empty() {
-        return;
-    }
-
-    scenario.steps.push(ScenarioStep::DeliverAll);
-    scenario.steps.push(ScenarioStep::Tick {
-        clients: scenario.clients.clone(),
-    });
-    for client in &scenario.clients {
-        scenario.steps.push(accept_all_outbound(client));
-    }
-    scenario.steps.push(ScenarioStep::DeliverAll);
-    scenario.steps.push(ScenarioStep::Tick {
-        clients: scenario.clients.clone(),
-    });
-    scenario.steps.push(ScenarioStep::ObserveExact {
-        clients: exact_clients.clone(),
-    });
-
-    if exact_clients.len() >= 2 {
-        expected.push(TraceExpectation::ClientsExactlyEquivalent {
-            clients: exact_clients,
-        });
-    }
-    expected.push(TraceExpectation::NoPendingWork {
-        clients: pending_scope,
+        clients: pending_scope.unwrap_or(exact_clients),
     });
 }
 

--- a/crates/cgka-conformance-simulator/src/family.rs
+++ b/crates/cgka-conformance-simulator/src/family.rs
@@ -176,6 +176,42 @@ pub fn generate_convergence_chaos_family(seed: u64, cases: usize) -> Vec<Generat
     out
 }
 
+/// Generate the admin-churn catalog ported from the external multi-VM harness
+/// scenario catalog (cheeky, committy, crashy essences). Case indices rotate
+/// through four arms: seeded sequential admin churn, competing same-epoch
+/// admin-policy commits, restart during a commit burst, and a latecomer added
+/// under commit pressure with a forward-secrecy check.
+pub fn generate_admin_churn_family(seed: u64, cases: usize) -> Vec<GeneratedScenarioCase> {
+    let mut out = Vec::with_capacity(cases);
+    for case_index in 0..cases {
+        let mut rng = StdRng::seed_from_u64(seed ^ 0xAD41_C4B2 ^ ((case_index as u64) << 32));
+        let (mut scenario, mut expected_outcomes) = admin_churn_case(&mut rng, case_index as u64);
+        if case_index % 4 == 3 {
+            // The latecomer arm scopes the pending-work oracle away from the
+            // joiner: a welcome-joined member currently retains its own join
+            // commit as a permanently deferred transport input, so the strict
+            // whole-roster oracle would flag every latecomer scenario.
+            add_scoped_reliability_oracle(
+                &mut scenario,
+                &mut expected_outcomes,
+                labels(["alice", "bob", "carol"]),
+            );
+        } else {
+            add_strict_reliability_oracle(&mut scenario, &mut expected_outcomes);
+        }
+        out.push(GeneratedScenarioCase {
+            family_name: "admin-churn/v1".into(),
+            generator_version: "1".into(),
+            seed,
+            case_index: case_index as u64,
+            subject: GeneratedSubjectKind::Engine,
+            scenario,
+            expected_outcomes,
+        });
+    }
+    out
+}
+
 /// Generate the adversarial reliability catalog. Case indices rotate through
 /// every required workload family; requesting more than twelve cases repeats
 /// the catalog with a new deterministic case id and schedule seed.
@@ -1395,6 +1431,424 @@ fn convergence_chaos_restart_delivery_faults(
 }
 
 /// Select one of the twelve adversarial workload shapes by stable case index.
+fn admin_churn_case(rng: &mut StdRng, case_index: u64) -> (ScenarioSpec, Vec<TraceExpectation>) {
+    match case_index % 4 {
+        0 => admin_churn_seeded_churn(rng, case_index),
+        1 => admin_churn_competing_admin_commits(rng, case_index),
+        2 => admin_churn_restart_recovery(rng, case_index),
+        _ => admin_churn_latecomer_under_pressure(case_index),
+    }
+}
+
+fn admin_policy_step(client: &str, admins: Vec<String>, pending: &str) -> ScenarioStep {
+    ScenarioStep::UpdateAdminPolicy {
+        client: client.into(),
+        admins,
+        pending: pending.into(),
+    }
+}
+
+fn payload_absent_assert(client: &str, payload: &str) -> ScenarioStep {
+    ScenarioStep::Assert {
+        assertion: crate::ScenarioAssertionV2::Exactly {
+            predicate: crate::ScenarioPredicateV2::PayloadCount {
+                client: client.into(),
+                payload: payload.into(),
+                count: 0,
+            },
+        },
+    }
+}
+
+/// Push an acknowledge step for `pending` and record its confirmed
+/// pending-resolution expectation at the acknowledge step's index.
+fn push_confirmed(
+    steps: &mut Vec<ScenarioStep>,
+    expected: &mut Vec<TraceExpectation>,
+    client: &str,
+    pending: &str,
+) {
+    expected.push(confirmed(steps.len(), client, pending));
+    steps.push(confirmed_step(client, pending));
+}
+
+/// Sequential admin churn: every commit settles before the next, but the
+/// actor, action, and admin-set evolution are drawn from the seed
+/// (cheeky essence without wall-clock randomness).
+fn admin_churn_seeded_churn(
+    rng: &mut StdRng,
+    case_index: u64,
+) -> (ScenarioSpec, Vec<TraceExpectation>) {
+    let clients = labels(["alice", "bob", "carol", "dave"]);
+    let rounds = 4_u64;
+    let mut expected = Vec::new();
+    let mut steps = vec![create_group_vec(
+        "alice",
+        format!("admin-churn-{case_index}"),
+        clients[1..].to_vec(),
+        "create",
+    )];
+    push_confirmed(&mut steps, &mut expected, "alice", "create");
+    steps.push(ScenarioStep::DeliverAll);
+    steps.push(tick_vec(clients[1..].to_vec()));
+    steps.push(clear_vec(clients.clone()));
+
+    steps.push(admin_policy_step("alice", clients.clone(), "promote-all"));
+    push_confirmed(&mut steps, &mut expected, "alice", "promote-all");
+    steps.push(ScenarioStep::DeliverAll);
+    steps.push(tick_vec(clients[1..].to_vec()));
+
+    let mut admins: Vec<String> = clients.clone();
+    for round in 0..rounds {
+        let actor = admins[rng.gen_range(0..admins.len())].clone();
+        let pending = format!("churn-{round}");
+        if rng.gen_range(0..100_u32) < 50 || admins.len() == 1 {
+            steps.push(ScenarioStep::UpdateGroupData {
+                client: actor.clone(),
+                name: format!("admin-churn-{case_index}-r{round}"),
+                pending: pending.clone(),
+            });
+        } else {
+            // Toggle a non-alice member in or out of the admin set so alice
+            // always retains authority and the set never empties.
+            let candidates: Vec<String> =
+                clients.iter().filter(|c| *c != "alice").cloned().collect();
+            let target = candidates[rng.gen_range(0..candidates.len())].clone();
+            if admins.contains(&target) {
+                admins.retain(|admin| admin != &target);
+            } else {
+                let position = clients.iter().position(|c| c == &target).unwrap_or(0);
+                admins.insert(admins.len().min(position), target);
+            }
+            // The actor may have demoted itself; the commit is still issued
+            // from its pre-commit authority.
+            steps.push(admin_policy_step(&actor, admins.clone(), &pending));
+        }
+        push_confirmed(&mut steps, &mut expected, &actor, &pending);
+        steps.push(ScenarioStep::DeliverAll);
+        steps.push(tick_vec(clients.clone()));
+
+        for sender in &clients {
+            steps.push(ScenarioStep::SendAppMessage {
+                sender: sender.clone(),
+                payload: format!("admin-churn:{case_index}:r{round}:{sender}"),
+            });
+        }
+        steps.push(ScenarioStep::DeliverAll);
+        steps.push(tick_vec(clients.clone()));
+    }
+    steps.push(observe_vec(clients.clone()));
+
+    let final_epoch = 2 + rounds;
+    expected.push(clients_converged_vec(
+        clients.clone(),
+        Some(final_epoch),
+        Some(clients.len()),
+    ));
+    for client in &clients {
+        let received = (0..rounds)
+            .flat_map(|round| {
+                clients
+                    .iter()
+                    .filter(|sender| *sender != client)
+                    .map(move |sender| format!("admin-churn:{case_index}:r{round}:{sender}"))
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+        expected.push(client_state(client, final_epoch, clients.len(), received));
+    }
+
+    let scenario = ScenarioSpec {
+        name: format!("admin-churn/v1/case-{case_index}"),
+        spec_version: "2".into(),
+        topology: Default::default(),
+        clients,
+        steps,
+    };
+    (scenario, expected)
+}
+
+/// Two admins race admin-policy commits from the same epoch; delivery order is
+/// drawn from the seed. Convergence and post-race usability are
+/// schedule-invariant; the winning admin set is not asserted.
+fn admin_churn_competing_admin_commits(
+    rng: &mut StdRng,
+    case_index: u64,
+) -> (ScenarioSpec, Vec<TraceExpectation>) {
+    let clients = labels(["alice", "bob", "carol", "dave"]);
+    let mut expected = Vec::new();
+    let mut steps = vec![create_group_vec(
+        "alice",
+        format!("admin-race-{case_index}"),
+        clients[1..].to_vec(),
+        "create",
+    )];
+    push_confirmed(&mut steps, &mut expected, "alice", "create");
+    steps.push(ScenarioStep::DeliverAll);
+    steps.push(tick_vec(clients[1..].to_vec()));
+
+    steps.push(admin_policy_step(
+        "alice",
+        labels(["alice", "bob"]),
+        "promote-core",
+    ));
+    push_confirmed(&mut steps, &mut expected, "alice", "promote-core");
+    steps.push(ScenarioStep::DeliverAll);
+    steps.push(tick_vec(clients[1..].to_vec()));
+    steps.push(clear_vec(clients.clone()));
+
+    steps.push(admin_policy_step(
+        "alice",
+        labels(["alice", "bob", "carol"]),
+        "alice-race",
+    ));
+    steps.push(admin_policy_step(
+        "bob",
+        labels(["alice", "bob", "dave"]),
+        "bob-race",
+    ));
+    push_confirmed(&mut steps, &mut expected, "alice", "alice-race");
+    push_confirmed(&mut steps, &mut expected, "bob", "bob-race");
+    let racers = [commit_selector("alice"), commit_selector("bob")];
+    steps.push(ScenarioStep::ReorderMessages {
+        order: reorder_selectors(&racers, &shuffled_order(rng, racers.len())),
+    });
+    steps.push(ScenarioStep::DeliverAll);
+    steps.push(tick_vec(clients.clone()));
+
+    for sender in &clients {
+        steps.push(ScenarioStep::SendAppMessage {
+            sender: sender.clone(),
+            payload: format!("admin-churn:{case_index}:probe:{sender}"),
+        });
+    }
+    steps.push(ScenarioStep::DeliverAll);
+    steps.push(tick_vec(clients.clone()));
+    steps.push(observe_vec(clients.clone()));
+
+    expected.push(clients_converged_vec(
+        clients.clone(),
+        Some(3),
+        Some(clients.len()),
+    ));
+    for client in &clients {
+        let received = clients
+            .iter()
+            .filter(|sender| *sender != client)
+            .map(|sender| format!("admin-churn:{case_index}:probe:{sender}"))
+            .collect();
+        expected.push(client_state(client, 3, clients.len(), received));
+    }
+
+    let scenario = ScenarioSpec {
+        name: format!("admin-churn/v1/case-{case_index}"),
+        spec_version: "2".into(),
+        topology: Default::default(),
+        clients,
+        steps,
+    };
+    (scenario, expected)
+}
+
+/// A seeded victim restarts between publishing a rename commit and its
+/// delivery, then must accept new traffic into the recovered group
+/// (crashy essence).
+fn admin_churn_restart_recovery(
+    rng: &mut StdRng,
+    case_index: u64,
+) -> (ScenarioSpec, Vec<TraceExpectation>) {
+    let clients = labels(["alice", "bob", "carol"]);
+    let victim = clients[rng.gen_range(0..clients.len())].clone();
+    let mut expected = Vec::new();
+    let mut steps = vec![create_group_vec(
+        "alice",
+        format!("admin-restart-{case_index}"),
+        clients[1..].to_vec(),
+        "create",
+    )];
+    push_confirmed(&mut steps, &mut expected, "alice", "create");
+    steps.push(ScenarioStep::DeliverAll);
+    steps.push(tick_vec(clients[1..].to_vec()));
+    steps.push(clear_vec(clients.clone()));
+
+    steps.push(admin_policy_step("alice", clients.clone(), "promote-all"));
+    push_confirmed(&mut steps, &mut expected, "alice", "promote-all");
+    steps.push(ScenarioStep::DeliverAll);
+    steps.push(tick_vec(clients[1..].to_vec()));
+
+    steps.push(ScenarioStep::UpdateGroupData {
+        client: victim.clone(),
+        name: format!("admin-restart-{case_index}-renamed"),
+        pending: "victim-rename".into(),
+    });
+    push_confirmed(&mut steps, &mut expected, &victim, "victim-rename");
+    steps.push(ScenarioStep::RestartClient {
+        client: victim.clone(),
+    });
+    steps.push(ScenarioStep::DeliverAll);
+    steps.push(tick_vec(clients.clone()));
+
+    steps.push(ScenarioStep::SendAppMessage {
+        sender: victim.clone(),
+        payload: format!("admin-churn:{case_index}:recovered:{victim}"),
+    });
+    for sender in clients.iter().filter(|sender| **sender != victim) {
+        steps.push(ScenarioStep::SendAppMessage {
+            sender: sender.clone(),
+            payload: format!("admin-churn:{case_index}:after:{sender}"),
+        });
+    }
+    steps.push(ScenarioStep::DeliverAll);
+    steps.push(tick_vec(clients.clone()));
+    steps.push(observe_vec(clients.clone()));
+
+    expected.push(clients_converged_vec(
+        clients.clone(),
+        Some(3),
+        Some(clients.len()),
+    ));
+    for client in &clients {
+        let mut received = Vec::new();
+        if *client != victim {
+            received.push(format!("admin-churn:{case_index}:recovered:{victim}"));
+        }
+        for sender in clients.iter().filter(|sender| **sender != victim) {
+            if sender != client {
+                received.push(format!("admin-churn:{case_index}:after:{sender}"));
+            }
+        }
+        expected.push(client_state(client, 3, clients.len(), received));
+    }
+
+    let scenario = ScenarioSpec {
+        name: format!("admin-churn/v1/case-{case_index}"),
+        spec_version: "2".into(),
+        topology: Default::default(),
+        clients,
+        steps,
+    };
+    (scenario, expected)
+}
+
+/// A latecomer joins while the founder keeps commit pressure up; the latecomer
+/// must never observe pre-join plaintext (committy essence).
+fn admin_churn_latecomer_under_pressure(case_index: u64) -> (ScenarioSpec, Vec<TraceExpectation>) {
+    let clients = labels(["alice", "bob", "carol", "dave"]);
+    let core = labels(["alice", "bob", "carol"]);
+    let pre_payloads = [
+        format!("admin-churn:{case_index}:pre:bob"),
+        format!("admin-churn:{case_index}:pre:carol"),
+    ];
+    let mut expected = Vec::new();
+    let mut steps = vec![create_group_vec(
+        "alice",
+        format!("admin-late-{case_index}"),
+        core[1..].to_vec(),
+        "create",
+    )];
+    push_confirmed(&mut steps, &mut expected, "alice", "create");
+    steps.push(ScenarioStep::DeliverAll);
+    steps.push(tick_vec(core[1..].to_vec()));
+    steps.push(clear_vec(clients.clone()));
+    // The latecomer's process is not subscribed before its invite; pre-join
+    // traffic must not accumulate in its mailbox. Ciphertext-exposure forward
+    // secrecy is covered by the latecomer-forward-secrecy/v1 vector.
+    steps.push(ScenarioStep::SetPartition {
+        allow: core.clone(),
+    });
+
+    steps.push(ScenarioStep::SendAppMessage {
+        sender: "bob".into(),
+        payload: pre_payloads[0].clone(),
+    });
+    steps.push(ScenarioStep::SendAppMessage {
+        sender: "carol".into(),
+        payload: pre_payloads[1].clone(),
+    });
+    steps.push(ScenarioStep::DeliverAll);
+    steps.push(tick_vec(core.clone()));
+
+    for sprint in 0..2_u64 {
+        let pending = format!("sprint-{sprint}");
+        steps.push(ScenarioStep::UpdateGroupData {
+            client: "alice".into(),
+            name: format!("admin-late-{case_index}-s{sprint}"),
+            pending: pending.clone(),
+        });
+        push_confirmed(&mut steps, &mut expected, "alice", &pending);
+        steps.push(ScenarioStep::DeliverAll);
+        steps.push(tick_vec(core[1..].to_vec()));
+    }
+
+    steps.push(ScenarioStep::ClearPartition);
+    steps.push(invite("alice", ["dave"], "invite-late"));
+    push_confirmed(&mut steps, &mut expected, "alice", "invite-late");
+    steps.push(ScenarioStep::DeliverAll);
+    steps.push(tick_vec(clients[1..].to_vec()));
+
+    steps.push(ScenarioStep::UpdateGroupData {
+        client: "alice".into(),
+        name: format!("admin-late-{case_index}-post"),
+        pending: "post-invite-rename".into(),
+    });
+    push_confirmed(&mut steps, &mut expected, "alice", "post-invite-rename");
+    steps.push(ScenarioStep::DeliverAll);
+    steps.push(tick_vec(clients[1..].to_vec()));
+
+    for sender in &clients {
+        steps.push(ScenarioStep::SendAppMessage {
+            sender: sender.clone(),
+            payload: format!("admin-churn:{case_index}:post:{sender}"),
+        });
+    }
+    steps.push(ScenarioStep::DeliverAll);
+    steps.push(tick_vec(clients.clone()));
+    for pre in &pre_payloads {
+        steps.push(payload_absent_assert("dave", pre));
+    }
+    steps.push(observe_vec(clients.clone()));
+
+    let final_epoch = 5;
+    expected.push(clients_converged_vec(
+        clients.clone(),
+        Some(final_epoch),
+        Some(clients.len()),
+    ));
+    let dave_received = clients
+        .iter()
+        .filter(|sender| *sender != "dave")
+        .map(|sender| format!("admin-churn:{case_index}:post:{sender}"))
+        .collect();
+    expected.push(client_state(
+        "dave",
+        final_epoch,
+        clients.len(),
+        dave_received,
+    ));
+    let mut alice_received = pre_payloads.to_vec();
+    alice_received.extend(
+        clients
+            .iter()
+            .filter(|sender| *sender != "alice")
+            .map(|sender| format!("admin-churn:{case_index}:post:{sender}")),
+    );
+    expected.push(client_state(
+        "alice",
+        final_epoch,
+        clients.len(),
+        alice_received,
+    ));
+
+    let scenario = ScenarioSpec {
+        name: format!("admin-churn/v1/case-{case_index}"),
+        spec_version: "2".into(),
+        topology: Default::default(),
+        clients,
+        steps,
+    };
+    (scenario, expected)
+}
+
 fn adversarial_reliability_case(
     rng: &mut StdRng,
     case_index: u64,
@@ -2915,6 +3369,56 @@ fn add_strict_reliability_oracle(
     }
     expected.push(TraceExpectation::NoPendingWork {
         clients: exact_clients,
+    });
+}
+
+/// Strict-oracle variant with an explicit pending-work scope. Appends the same
+/// drain / acknowledge / exact-observation tail as
+/// [`add_strict_reliability_oracle`], asserts exact equivalence across every
+/// expectation-derived client, but limits the no-pending-work assertion to
+/// `pending_scope`. Use only when a client is known to retain a documented
+/// terminal input (for example a welcome-joined member's own join commit).
+fn add_scoped_reliability_oracle(
+    scenario: &mut ScenarioSpec,
+    expected: &mut Vec<TraceExpectation>,
+    pending_scope: Vec<String>,
+) {
+    let exact_clients = expected
+        .iter()
+        .flat_map(|expectation| match expectation {
+            TraceExpectation::ClientsConverged { clients, .. } => clients.clone(),
+            TraceExpectation::ClientState { client, .. } => vec![client.clone()],
+            _ => Vec::new(),
+        })
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    if exact_clients.is_empty() {
+        return;
+    }
+
+    scenario.steps.push(ScenarioStep::DeliverAll);
+    scenario.steps.push(ScenarioStep::Tick {
+        clients: scenario.clients.clone(),
+    });
+    for client in &scenario.clients {
+        scenario.steps.push(accept_all_outbound(client));
+    }
+    scenario.steps.push(ScenarioStep::DeliverAll);
+    scenario.steps.push(ScenarioStep::Tick {
+        clients: scenario.clients.clone(),
+    });
+    scenario.steps.push(ScenarioStep::ObserveExact {
+        clients: exact_clients.clone(),
+    });
+
+    if exact_clients.len() >= 2 {
+        expected.push(TraceExpectation::ClientsExactlyEquivalent {
+            clients: exact_clients,
+        });
+    }
+    expected.push(TraceExpectation::NoPendingWork {
+        clients: pending_scope,
     });
 }
 

--- a/crates/cgka-conformance-simulator/src/lib.rs
+++ b/crates/cgka-conformance-simulator/src/lib.rs
@@ -91,7 +91,7 @@ pub use failure_capsule::{
 };
 pub use family::{
     GENERATED_SCENARIO_INPUT_SCHEMA_VERSION, GeneratedScenarioCase, GeneratedScenarioInputV1,
-    GeneratedSubjectKind, generate_adversarial_reliability_case,
+    GeneratedSubjectKind, generate_admin_churn_family, generate_adversarial_reliability_case,
     generate_adversarial_reliability_family, generate_adversarial_reliability_offline_regression,
     generate_adversarial_reliability_self_update_regression,
     generate_adversarial_reliability_sustained_regression, generate_convergence_chaos_family,

--- a/crates/cgka-conformance-simulator/src/oracle.rs
+++ b/crates/cgka-conformance-simulator/src/oracle.rs
@@ -649,7 +649,8 @@ fn expectation_behaviors(expectation: &TraceExpectation) -> BTreeSet<OracleBehav
                 behaviors.insert(OracleBehavior::AppInvalidated);
             }
         }
-        TraceExpectation::NoPendingWork { .. } => {
+        TraceExpectation::NoPendingWork { .. }
+        | TraceExpectation::NoPendingWorkExceptRetainedJoinCommit { .. } => {
             behaviors.insert(OracleBehavior::NoPendingWorkObserved);
         }
         TraceExpectation::ClientsBidirectionallyDecryptable { .. } => {

--- a/crates/cgka-conformance-simulator/src/report.rs
+++ b/crates/cgka-conformance-simulator/src/report.rs
@@ -5,10 +5,11 @@ use crate::scenario_input::generated_scenario_input_provenance;
 use crate::{
     CoverageMatrixEntry, FailureCapsuleSensitivity, FailureCapsuleV1, GeneratedScenarioCase,
     GeneratedScenarioInputV1, HarnessStorageMode, ScenarioInputProvenanceV1, ScenarioReport,
-    VectorFixture, coverage_matrix_entry, generate_adversarial_reliability_family,
-    generate_convergence_chaos_family, generate_convergence_e2e_delivery_family,
-    generate_send_leave_family, generate_stateful_chat_journey_family,
-    resolve_scenario_input_bytes, run_vector_fixture_report_with_capture, write_failure_capsule,
+    VectorFixture, coverage_matrix_entry, generate_admin_churn_family,
+    generate_adversarial_reliability_family, generate_convergence_chaos_family,
+    generate_convergence_e2e_delivery_family, generate_send_leave_family,
+    generate_stateful_chat_journey_family, resolve_scenario_input_bytes,
+    run_vector_fixture_report_with_capture, write_failure_capsule,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -256,6 +257,7 @@ async fn run_generated_family_reports(
         "send-leave/v1" => generate_send_leave_family(seed, cases),
         "convergence-e2e-delivery/v1" => generate_convergence_e2e_delivery_family(seed, cases),
         "convergence-chaos/v1" => generate_convergence_chaos_family(seed, cases),
+        "admin-churn/v1" => generate_admin_churn_family(seed, cases),
         "adversarial-reliability/v1" => generate_adversarial_reliability_family(seed, cases),
         "chat-journey/v1" => generate_stateful_chat_journey_family(seed, cases),
         other => return Err(format!("unsupported family {other}").into()),
@@ -717,7 +719,7 @@ fn next_value(
 }
 
 pub fn report_usage() -> &'static str {
-    "Usage: cgka-conformance-simulator-report [--replay-capsule FILE | --generated-input FILE ... [--adapter engine|retained-relay|app-runtime] | --vectors FILE_OR_DIR ... | --family send-leave/v1|convergence-e2e-delivery/v1|convergence-chaos/v1|adversarial-reliability/v1|chat-journey/v1 --seed N --cases N] [--out DIR] [--storage memory|file] [--strict-oracle|--allow-weak-oracle] [--capture-sensitive-replay]"
+    "Usage: cgka-conformance-simulator-report [--replay-capsule FILE | --generated-input FILE ... [--adapter engine|retained-relay|app-runtime] | --vectors FILE_OR_DIR ... | --family send-leave/v1|convergence-e2e-delivery/v1|convergence-chaos/v1|admin-churn/v1|adversarial-reliability/v1|chat-journey/v1 --seed N --cases N] [--out DIR] [--storage memory|file] [--strict-oracle|--allow-weak-oracle] [--capture-sensitive-replay]"
 }
 
 #[cfg(test)]

--- a/crates/cgka-conformance-simulator/src/vector.rs
+++ b/crates/cgka-conformance-simulator/src/vector.rs
@@ -170,8 +170,10 @@ pub enum TraceExpectation {
     /// documented latecomer wart: a welcome-joined member retains its own join
     /// commit as one permanently deferred transport input (mirrored as one
     /// pending scenario input). Every other pending-work category must be
-    /// empty, so unrelated deferred commits, messages, or outbound work still
-    /// fail the expectation.
+    /// empty, and the sole unresolved ledger input must be identified as the
+    /// joiner's own transport-deferred `invite_members` commit, so unrelated
+    /// deferred commits, messages, or outbound work still fail the
+    /// expectation even when their aggregate counts coincide.
     NoPendingWorkExceptRetainedJoinCommit {
         client: String,
     },
@@ -639,6 +641,32 @@ impl TraceExpectation {
                             "pending_work": allowed,
                         }),
                         actual: json!(pending_work),
+                    });
+                    return;
+                }
+                // Aggregate counts alone cannot identify the artifact: pin the
+                // sole unresolved ledger input to the joiner's own join commit
+                // (the invite_members commit, retained as one transport-deferred
+                // ingest).
+                let unresolved = observation
+                    .scenario_input_ledger
+                    .iter()
+                    .filter(|entry| entry.pending)
+                    .collect::<Vec<_>>();
+                let is_retained_join_commit = |entry: &ScenarioInputLedgerEntry| {
+                    entry.kind == crate::ScenarioInputKind::Commit
+                        && entry.scenario_id.ends_with(":invite_members")
+                        && entry.transport_deferred == 1
+                };
+                if unresolved.len() != 1 || !is_retained_join_commit(unresolved[0]) {
+                    mismatches.push(ExpectationFailure {
+                        kind: "retained_pending_input_is_not_the_join_commit".into(),
+                        message: format!(
+                            "client {client} must retain exactly one unresolved input: its own \
+                             transport-deferred invite_members join commit"
+                        ),
+                        expected: json!(self),
+                        actual: json!(unresolved),
                     });
                 }
             }
@@ -1687,6 +1715,63 @@ mod tests {
             failures[0].message.contains("bus_delayed"),
             "failure should name the blocking subsystem: {failures:#?}"
         );
+    }
+
+    #[test]
+    fn retained_join_commit_exception_accepts_exactly_the_join_commit() {
+        let mut dave = observation("dave", 5, 4);
+        let mut pending = PendingWorkObservation::default();
+        pending.engine.stored_transport_deferred_messages = 1;
+        pending.scenario_inputs_pending = 1;
+        dave.pending_work = Some(pending);
+        dave.scenario_input_ledger = vec![ScenarioInputLedgerEntry {
+            scenario_id: "step-19:invite_members".into(),
+            kind: crate::ScenarioInputKind::Commit,
+            sender: "alice".into(),
+            transport_deferred: 1,
+            pending: true,
+            ..Default::default()
+        }];
+        let expectation = TraceExpectation::NoPendingWorkExceptRetainedJoinCommit {
+            client: "dave".into(),
+        };
+
+        let failures = compare_trace_expectations(
+            None,
+            std::slice::from_ref(&expectation),
+            &trace(vec![dave.clone()]),
+        );
+        assert!(failures.is_empty(), "unexpected failures: {failures:#?}");
+
+        // Same aggregate counts, but the unresolved input is an unrelated
+        // deferred application message, not the joiner's own join commit.
+        dave.scenario_input_ledger = vec![ScenarioInputLedgerEntry {
+            scenario_id: "step-19:send_app_message".into(),
+            kind: crate::ScenarioInputKind::Application,
+            sender: "alice".into(),
+            transport_deferred: 1,
+            pending: true,
+            ..Default::default()
+        }];
+        let failures = compare_trace_expectations(
+            None,
+            std::slice::from_ref(&expectation),
+            &trace(vec![dave.clone()]),
+        );
+        assert_eq!(failures.len(), 1);
+        assert_eq!(
+            failures[0].kind,
+            "retained_pending_input_is_not_the_join_commit"
+        );
+
+        // Any category beyond the retained join commit still fails.
+        dave.pending_work
+            .as_mut()
+            .expect("pending snapshot")
+            .bus_mailbox_messages = 1;
+        let failures = compare_trace_expectations(None, &[expectation], &trace(vec![dave]));
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].kind, "pending_work_beyond_retained_join_commit");
     }
 
     #[test]

--- a/crates/cgka-conformance-simulator/src/vector.rs
+++ b/crates/cgka-conformance-simulator/src/vector.rs
@@ -166,6 +166,15 @@ pub enum TraceExpectation {
     NoPendingWork {
         clients: Vec<String>,
     },
+    /// Like [`Self::NoPendingWork`] for one client, but permit exactly the
+    /// documented latecomer wart: a welcome-joined member retains its own join
+    /// commit as one permanently deferred transport input (mirrored as one
+    /// pending scenario input). Every other pending-work category must be
+    /// empty, so unrelated deferred commits, messages, or outbound work still
+    /// fail the expectation.
+    NoPendingWorkExceptRetainedJoinCommit {
+        client: String,
+    },
     /// Require a completed active application-message probe in every direction
     /// between the named clients.
     ClientsBidirectionallyDecryptable {
@@ -592,6 +601,45 @@ impl TraceExpectation {
                             actual: json!(pending_work),
                         });
                     }
+                }
+            }
+            TraceExpectation::NoPendingWorkExceptRetainedJoinCommit { client } => {
+                let Some(latest_observation) = client_observation(observed, client) else {
+                    missing_client(client, self, mismatches);
+                    return;
+                };
+                let Some(observation) = client_pending_work_observation(observed, client) else {
+                    mismatches.push(ExpectationFailure {
+                        kind: "missing_pending_work_observation".into(),
+                        message: format!(
+                            "client {client} was not observed with observe_client_exact"
+                        ),
+                        expected: json!(self),
+                        actual: json!(latest_observation),
+                    });
+                    return;
+                };
+                let pending_work = observation
+                    .pending_work
+                    .as_ref()
+                    .expect("pending-work observation carries pending work");
+                let mut allowed = PendingWorkObservation::default();
+                allowed.engine.stored_transport_deferred_messages = 1;
+                allowed.scenario_inputs_pending = 1;
+                if pending_work != &allowed {
+                    mismatches.push(ExpectationFailure {
+                        kind: "pending_work_beyond_retained_join_commit".into(),
+                        message: format!(
+                            "client {client} pending work is not exactly the retained join \
+                             commit; blocking subsystems {:?}",
+                            pending_work.blocking_subsystems()
+                        ),
+                        expected: json!({
+                            "client": client,
+                            "pending_work": allowed,
+                        }),
+                        actual: json!(pending_work),
+                    });
                 }
             }
             TraceExpectation::ClientsBidirectionallyDecryptable { clients } => {

--- a/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
+++ b/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
@@ -10,7 +10,7 @@ use cgka_conformance_simulator::{
     ScenarioInputDisposition, ScenarioInputKind, ScenarioInputLedgerEntry,
     ScenarioMessageSelectorV2, ScenarioReport, ScenarioSpec, ScenarioStep, ScenarioTrace,
     ScenarioTransportClass, SubjectOutboundOutcome, TraceExpectation, TransportBus, VectorFixture,
-    compare_trace_expectations, generate_convergence_chaos_family,
+    compare_trace_expectations, generate_admin_churn_family, generate_convergence_chaos_family,
     generate_convergence_e2e_delivery_family, generate_send_leave_family, observe_client,
     observe_client_exact, run_generated_case_report, run_scenario_report,
     run_scenario_report_with_outcomes, run_scenario_spec, run_vector_fixture_report,
@@ -1600,6 +1600,58 @@ fn without_strict_reliability_outcomes(mut case: GeneratedScenarioCase) -> Gener
         )
     });
     case
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn admin_churn_family_generates_deterministic_arms_that_pass() {
+    let cases = generate_admin_churn_family(123, 4);
+
+    assert_eq!(cases, generate_admin_churn_family(123, 4));
+    assert_eq!(cases.len(), 4);
+    assert!(
+        cases.iter().all(|case| !case.expected_outcomes.is_empty()),
+        "admin-churn cases should carry semantic expectations"
+    );
+    assert!(cases[..3].iter().all(|case| {
+        case.scenario
+            .steps
+            .iter()
+            .any(|step| matches!(step, ScenarioStep::UpdateAdminPolicy { .. }))
+    }));
+    assert!(
+        cases[2]
+            .scenario
+            .steps
+            .iter()
+            .any(|step| matches!(step, ScenarioStep::RestartClient { .. }))
+    );
+    assert!(
+        cases[3]
+            .scenario
+            .steps
+            .iter()
+            .any(|step| matches!(step, ScenarioStep::InviteMembers { .. }))
+    );
+    assert!(
+        cases[3]
+            .scenario
+            .steps
+            .iter()
+            .any(|step| matches!(step, ScenarioStep::Assert { .. })),
+        "the latecomer arm carries forward-secrecy zero-count assertions"
+    );
+
+    for case in &cases {
+        let report = run_generated_case_report(case, None)
+            .await
+            .expect("admin-churn case reports");
+        assert!(
+            report.expectation_failures.is_empty(),
+            "case {} failed: {:?}",
+            case.case_index,
+            report.expectation_failures
+        );
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
+++ b/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
@@ -1650,9 +1650,12 @@ async fn admin_churn_family_generates_deterministic_arms_that_pass() {
             .expect("every admin-churn case carries a no-pending-work expectation")
     };
     for case in &cases[..3] {
-        assert!(
-            pending_scope(case).contains(&"dave".to_owned())
-                || !case.scenario.clients.contains(&"dave".to_owned()),
+        let mut expected_clients = case.scenario.clients.clone();
+        expected_clients.sort();
+        let mut scoped_clients = pending_scope(case);
+        scoped_clients.sort();
+        assert_eq!(
+            scoped_clients, expected_clients,
             "non-latecomer arms keep the whole-roster pending-work oracle"
         );
     }

--- a/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
+++ b/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
@@ -1638,7 +1638,7 @@ async fn admin_churn_family_generates_deterministic_arms_that_pass() {
             .steps
             .iter()
             .any(|step| matches!(step, ScenarioStep::Assert { .. })),
-        "the latecomer arm carries forward-secrecy zero-count assertions"
+        "the latecomer arm carries pre-join mailbox-isolation zero-count assertions"
     );
 
     for case in &cases {

--- a/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
+++ b/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
@@ -1640,6 +1640,34 @@ async fn admin_churn_family_generates_deterministic_arms_that_pass() {
             .any(|step| matches!(step, ScenarioStep::Assert { .. })),
         "the latecomer arm carries pre-join mailbox-isolation zero-count assertions"
     );
+    let pending_scope = |case: &GeneratedScenarioCase| {
+        case.expected_outcomes
+            .iter()
+            .find_map(|expectation| match expectation {
+                TraceExpectation::NoPendingWork { clients } => Some(clients.clone()),
+                _ => None,
+            })
+            .expect("every admin-churn case carries a no-pending-work expectation")
+    };
+    for case in &cases[..3] {
+        assert!(
+            pending_scope(case).contains(&"dave".to_owned())
+                || !case.scenario.clients.contains(&"dave".to_owned()),
+            "non-latecomer arms keep the whole-roster pending-work oracle"
+        );
+    }
+    assert_eq!(
+        pending_scope(&cases[3]),
+        vec!["alice".to_owned(), "bob".to_owned(), "carol".to_owned()],
+        "the latecomer arm scopes strict pending work to the founders"
+    );
+    assert!(
+        cases[3].expected_outcomes.iter().any(|expectation| matches!(
+            expectation,
+            TraceExpectation::NoPendingWorkExceptRetainedJoinCommit { client } if client == "dave"
+        )),
+        "the latecomer arm pins the joiner to exactly its retained join commit"
+    );
 
     for case in &cases {
         let report = run_generated_case_report(case, None)

--- a/crates/cgka-conformance-simulator/vectors/manifest.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/manifest.v1.json
@@ -483,7 +483,7 @@
         "seeded sequential admin churn with per-round traffic",
         "competing same-epoch admin-policy commits with seeded delivery order",
         "restart between commit publish and delivery with post-restart traffic",
-        "latecomer added under commit pressure with forward-secrecy zero-count assertions"
+        "latecomer added under commit pressure with pre-join mailbox-isolation zero-count assertions (ciphertext-exposure forward secrecy stays with latecomer-forward-secrecy/v1)"
       ],
       "next": "Promote a reviewed case into vectors/ once the joiner join-commit deferral is resolved."
     }

--- a/crates/cgka-conformance-simulator/vectors/manifest.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/manifest.v1.json
@@ -474,6 +474,18 @@
         "full-group convergence including group name"
       ],
       "next": "Keep durable-relay offline recovery in the adversarial-reliability family; this vector models mailbox catch-up."
+    },
+    {
+      "id": "admin-churn/v1",
+      "kind": "generated_scenario_family",
+      "status": "generated",
+      "coverage": [
+        "seeded sequential admin churn with per-round traffic",
+        "competing same-epoch admin-policy commits with seeded delivery order",
+        "restart between commit publish and delivery with post-restart traffic",
+        "latecomer added under commit pressure with forward-secrecy zero-count assertions"
+      ],
+      "next": "Promote a reviewed case into vectors/ once the joiner join-commit deferral is resolved."
     }
   ]
 }

--- a/crates/cgka-conformance-simulator/vectors/manifest.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/manifest.v1.json
@@ -481,9 +481,9 @@
       "status": "generated",
       "coverage": [
         "seeded sequential admin churn with per-round traffic",
-        "competing same-epoch admin-policy commits with seeded delivery order",
+        "competing same-epoch admin-policy commits with seeded delivery order, post-race admin-set pinning, and non-admin rejection probes",
         "restart between commit publish and delivery with post-restart traffic",
-        "latecomer added under commit pressure with pre-join mailbox-isolation zero-count assertions (ciphertext-exposure forward secrecy stays with latecomer-forward-secrecy/v1)"
+        "latecomer joining in the same delivery flight as a rename commit, with pre-join mailbox-isolation zero-count assertions (ciphertext-exposure forward secrecy stays with latecomer-forward-secrecy/v1) and the joiner pinned to exactly its retained join commit"
       ],
       "next": "Promote a reviewed case into vectors/ once the joiner join-commit deferral is resolved."
     }


### PR DESCRIPTION
## Summary

Final slice of the multi-VM catalog port. The marmot colony now drills under fire: admin churn, authority races, crashes, and joins under pressure, all seeded and deterministic.

Adds `generate_admin_churn_family` (`admin-churn/v1`) with four arms rotating by case index:

- Arm 0: seeded sequential admin churn. A seeded admin renames or toggles admin membership each round, with a full message round between commits.
- Arm 1: competing same-epoch admin-policy commits with seeded delivery order, the admin-set analog of the chaos group-data fork. The race winner stays schedule-dependent and unpinned, but authority is enforced afterward: a retained admin pins the set with a commit that must succeed, both non-admins are rejected with `not_group_admin`, and every client asserts the pinned set.
- Arm 2: a seeded admin restarts between publishing a rename commit and its delivery, then must accept and originate traffic in the recovered group.
- Arm 3: a latecomer's welcome travels in the same delivery flight as the founder's next rename commit, so the join genuinely races commit pressure; zero-count assertions prove the latecomer never observes pre-join plaintext, and all four members carry exact transcripts.

Registered in the report CLI (`--family admin-churn/v1`), `lib.rs`, the vector manifest, `SCENARIOS.md`, and `AGENTS.md`, with a determinism-plus-execution regression test in `canonical_scenarios.rs`.

## Known gap surfaced

A welcome-joined member retains its own join commit as a permanently deferred transport input, so no latecomer scenario can pass a whole-roster pending-work oracle. Arm 3 uses a documented scoped oracle (`add_scoped_reliability_oracle`) covering the founders, and pins the joiner with a new `no_pending_work_except_retained_join_commit` expectation that allows exactly the retained join commit and fails on any other pending work. The same wart is why the slice-one latecomer and growth vectors scope their `no_pending_work` expectations. Worth an issue; it also affects the pre-existing `invite-member/v1` shape.

## Stack

Fifth slice in the #1250 series lineage: #1270, #1271 (merged), #1272, #1292, #1294 (base of this PR). Re-targets as parents merge.

## Scope boundary

Simulator-only: `family.rs`, `report.rs`, `lib.rs`, tests, and docs. No production code, no changes to existing families beyond registration lists.

## Verification

- `cargo run -p cgka-conformance-simulator --bin cgka-conformance-simulator-report -- --family admin-churn/v1 --seed 42 --cases 8` (PASS 8/8; also seed 7 with 12 cases, PASS 12/12)
- `cargo test -p cgka-conformance-simulator --locked --test canonical_scenarios` (42 tests, includes the new family regression and all vector fixtures)
- `cargo test -p cgka-conformance-simulator --locked --lib`
- `cargo clippy -p cgka-conformance-simulator --all-targets --locked -- -D warnings`
- `scripts/check_legacy_naming.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an `admin-churn/v1` scenario family covering sequential changes, competing policy updates, restart recovery, and late participant onboarding.
  - Added reporting, manifest, and pending-work validation support for these scenarios.

- **Tests**
  - Added deterministic, multi-threaded validation for authorization, convergence, secrecy, recovery, and pending-work expectations.

- **Documentation**
  - Expanded guidance on administrator churn, latecomer behavior, deferred join-commit handling, and running the new scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
