### PR TITLE
Preserve own sent messages through convergence

### DIFF
--- a/crates/cgka-engine/src/app_payload.rs
+++ b/crates/cgka-engine/src/app_payload.rs
@@ -1,4 +1,11 @@
 use cgka_traits::{EngineError, MarmotAppEvent, MemberId};
+use sha2::{Digest, Sha256};
+
+/// Stable transient reference used when convergence reports a decrypted
+/// application payload without retaining the plaintext itself.
+pub(crate) fn decrypted_payload_ref(payload: &[u8]) -> String {
+    format!("sha256:{}", hex::encode(Sha256::digest(payload)))
+}
 
 /// Shared application-payload sender validation for every inbound seam
 /// (direct ingest, stored-convergence/replay). An application message is
@@ -25,7 +32,7 @@ pub(crate) fn validate_app_payload_for_sender(
 
 #[cfg(test)]
 mod tests {
-    use super::validate_app_payload_for_sender;
+    use super::{decrypted_payload_ref, validate_app_payload_for_sender};
     use cgka_traits::{EngineError, MarmotAppEvent, MemberId};
 
     fn payload_from(pubkey: &str) -> Vec<u8> {
@@ -65,5 +72,13 @@ mod tests {
         let event =
             validate_app_payload_for_sender(&payload, &sender).expect("matching sender validates");
         assert_eq!(event.content, "hello");
+    }
+
+    #[test]
+    fn decrypted_payload_reference_format_is_stable() {
+        assert_eq!(
+            decrypted_payload_ref(b"hello"),
+            "sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        );
     }
 }

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -1336,16 +1336,20 @@ impl<S: StorageProvider> Engine<S> {
         // Snapshot their prior values first, then emit forensic transitions
         // only after that transaction commits so Goggles never observes a
         // state change that rolled back.
-        let disposition_transitions = openmls_canonicalization_dispositions(&result)?
-            .into_iter()
-            .map(|disposition| {
-                let record = self
-                    .storage
-                    .get_message(&disposition.message_id)
-                    .map_err(storage_projection_error)?;
-                Ok((disposition, record.state, record.epoch))
-            })
-            .collect::<Result<Vec<_>, OpenMlsProjectionError>>()?;
+        let disposition_transitions = if self.recorder.is_enabled() {
+            openmls_canonicalization_dispositions(&result)?
+                .into_iter()
+                .map(|disposition| {
+                    let record = self
+                        .storage
+                        .get_message(&disposition.message_id)
+                        .map_err(storage_projection_error)?;
+                    Ok((disposition, record.state, record.epoch))
+                })
+                .collect::<Result<Vec<_>, OpenMlsProjectionError>>()?
+        } else {
+            Vec::new()
+        };
         let observations = self.storage.with_transaction(|storage| {
             let observations = apply_openmls_canonicalization_result_with_profile_policy(
                 storage,

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -35,7 +35,8 @@ use crate::engine::Engine;
 use crate::openmls_projection::{
     OpenMlsContentKind, OpenMlsProjectionError, OpenMlsReplayObservation, ReplayProfilePolicy,
     StoredCanonicalizationOptions, apply_openmls_canonicalization_result_with_profile_policy,
-    canonicalize_stored_openmls_messages_with_profile_policy, project_mls_message,
+    canonicalize_stored_openmls_messages_with_profile_policy,
+    openmls_canonicalization_dispositions, project_mls_message,
     retain_current_group_epoch_snapshot, retire_stale_convergence_deferred_commits,
 };
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -1331,6 +1332,20 @@ impl<S: StorageProvider> Engine<S> {
         let mut completed_pass = pass.clone();
         completed_pass.phase = ConvergencePassPhase::Completed;
         completed_pass.fairness_slot_available = true;
+        // The disposition writes are part of the atomic convergence apply.
+        // Snapshot their prior values first, then emit forensic transitions
+        // only after that transaction commits so Goggles never observes a
+        // state change that rolled back.
+        let disposition_transitions = openmls_canonicalization_dispositions(&result)?
+            .into_iter()
+            .map(|disposition| {
+                let record = self
+                    .storage
+                    .get_message(&disposition.message_id)
+                    .map_err(storage_projection_error)?;
+                Ok((disposition, record.state, record.epoch))
+            })
+            .collect::<Result<Vec<_>, OpenMlsProjectionError>>()?;
         let observations = self.storage.with_transaction(|storage| {
             let observations = apply_openmls_canonicalization_result_with_profile_policy(
                 storage,
@@ -1342,6 +1357,21 @@ impl<S: StorageProvider> Engine<S> {
             storage.put_convergence_pass(&completed_pass)?;
             Ok::<_, OpenMlsProjectionError>(observations)
         })?;
+        for (disposition, previous_state, epoch) in disposition_transitions {
+            if previous_state == disposition.state {
+                continue;
+            }
+            self.audit_group(
+                group_id,
+                crate::audit_helpers::message_state_transition_event(
+                    hex::encode(disposition.message_id.as_slice()),
+                    Some(previous_state),
+                    disposition.state,
+                    Some(epoch),
+                    disposition.reason,
+                ),
+            );
+        }
         crate::test_crash_hooks::pause_if_requested("convergence-pass-completed-durable");
         // Diagnostic only: settling-latency telemetry for the remediation
         // plan — pass open → apply, and the gap since the previous completed

--- a/crates/cgka-engine/src/message_processor/send.rs
+++ b/crates/cgka-engine/src/message_processor/send.rs
@@ -12,6 +12,7 @@ use cgka_traits::app_components::GROUP_ADMIN_POLICY_COMPONENT_ID;
 use cgka_traits::engine::{CommitOrderingKey, GroupStateChange, SendIntent, SendResult};
 use cgka_traits::engine_state::EpochState;
 use cgka_traits::error::EngineError;
+use cgka_traits::message::OwnApplicationConvergenceStamp;
 use cgka_traits::peeler::GroupMessageMetadata;
 use cgka_traits::storage::{LeaveRequest, StorageError, StorageProvider};
 use cgka_traits::transport::{EncryptedPayload, TransportMessage};
@@ -19,6 +20,7 @@ use cgka_traits::types::{EpochId, GroupId, MemberId};
 use openmls::group::MlsGroup;
 use openmls::messages::proposals::{AppDataUpdateProposal, Proposal};
 use openmls::prelude::{BasicCredential, MlsMessageOut};
+use sha2::{Digest, Sha256};
 use std::collections::HashSet;
 use tls_codec::Serialize as _;
 
@@ -852,6 +854,14 @@ impl<S: StorageProvider> Engine<S> {
         let app_event =
             crate::app_payload::validate_app_payload_for_sender(&payload, self.identity.self_id())?;
         let source_epoch = EpochId(mls_group.epoch().as_u64());
+        let own_application_stamp = OwnApplicationConvergenceStamp {
+            sender: self.identity.self_id().clone(),
+            source_epoch_authenticator: hex::encode(mls_group.epoch_authenticator().as_slice()),
+            decrypted_payload_ref: format!(
+                "sha256:{}",
+                hex::encode(Sha256::digest(payload.as_slice()))
+            ),
+        };
         let source_retention_seconds =
             crate::app_components::message_retention_seconds_of_group(&mls_group)?;
         let retention = cgka_traits::app_event::AppMessageRetentionDecision::new(
@@ -883,7 +893,13 @@ impl<S: StorageProvider> Engine<S> {
             .map_err(EngineError::Peeler)?;
 
         let wrapped = route_wrapped_group_message(wrapped, &ctx);
-        self.record_sent_openmls_message(&wrapped, out_bytes.as_slice(), &group_id, source_epoch)?;
+        self.record_sent_openmls_application_message(
+            &wrapped,
+            out_bytes.as_slice(),
+            &group_id,
+            source_epoch,
+            own_application_stamp,
+        )?;
 
         Ok(SendResult::ApplicationMessage {
             msg: wrapped,

--- a/crates/cgka-engine/src/message_processor/send.rs
+++ b/crates/cgka-engine/src/message_processor/send.rs
@@ -20,7 +20,6 @@ use cgka_traits::types::{EpochId, GroupId, MemberId};
 use openmls::group::MlsGroup;
 use openmls::messages::proposals::{AppDataUpdateProposal, Proposal};
 use openmls::prelude::{BasicCredential, MlsMessageOut};
-use sha2::{Digest, Sha256};
 use std::collections::HashSet;
 use tls_codec::Serialize as _;
 
@@ -857,10 +856,6 @@ impl<S: StorageProvider> Engine<S> {
         let own_application_stamp = OwnApplicationConvergenceStamp {
             sender: self.identity.self_id().clone(),
             source_epoch_authenticator: hex::encode(mls_group.epoch_authenticator().as_slice()),
-            decrypted_payload_ref: format!(
-                "sha256:{}",
-                hex::encode(Sha256::digest(payload.as_slice()))
-            ),
         };
         let source_retention_seconds =
             crate::app_components::message_retention_seconds_of_group(&mls_group)?;

--- a/crates/cgka-engine/src/message_processor/store.rs
+++ b/crates/cgka-engine/src/message_processor/store.rs
@@ -221,27 +221,21 @@ impl<S: StorageProvider> Engine<S> {
             ..msg.clone()
         };
         self.storage.with_transaction(|_storage| {
-            if let Some(stamp) = application_stamp.clone() {
-                self.persist_stored_message_payload(
-                    msg.id.clone(),
-                    group_id,
-                    epoch,
-                    MessageState::Sent,
-                    StoredMessagePayload::signed_openmls_application_wire(
-                        msg.clone(),
-                        openmls_msg.clone(),
-                        stamp,
-                    ),
-                )?;
-            } else {
-                self.persist_signed_openmls_wire_message(
-                    msg,
-                    &openmls_msg,
-                    group_id,
-                    epoch,
-                    MessageState::Sent,
-                )?;
-            }
+            let payload = match application_stamp {
+                Some(stamp) => StoredMessagePayload::signed_openmls_application_wire(
+                    msg.clone(),
+                    openmls_msg.clone(),
+                    stamp,
+                ),
+                None => StoredMessagePayload::signed_openmls_wire(msg.clone(), openmls_msg.clone()),
+            };
+            self.persist_stored_message_payload(
+                msg.id.clone(),
+                group_id,
+                epoch,
+                MessageState::Sent,
+                payload,
+            )?;
             self.persist_sent_openmls_content_marker(
                 &openmls_msg,
                 content_id.clone(),
@@ -386,26 +380,6 @@ impl<S: StorageProvider> Engine<S> {
             epoch,
             state,
             StoredMessagePayload::openmls_wire(msg.clone()),
-        )
-    }
-
-    pub(crate) fn persist_signed_openmls_wire_message(
-        &self,
-        exact_message: &TransportMessage,
-        openmls_message: &TransportMessage,
-        group_id: &GroupId,
-        epoch: EpochId,
-        state: MessageState,
-    ) -> Result<(), EngineError> {
-        self.persist_stored_message_payload(
-            exact_message.id.clone(),
-            group_id,
-            epoch,
-            state,
-            StoredMessagePayload::signed_openmls_wire(
-                exact_message.clone(),
-                openmls_message.clone(),
-            ),
         )
     }
 

--- a/crates/cgka-engine/src/message_processor/store.rs
+++ b/crates/cgka-engine/src/message_processor/store.rs
@@ -7,7 +7,8 @@ use cgka_traits::engine::GroupEvent;
 use cgka_traits::error::EngineError;
 use cgka_traits::ingest::{InboundResourceLimit, IngestOutcome, InputRejectionCategory};
 use cgka_traits::message::{
-    DeferredPeelLifecycle, MessageRecord, MessageState, StoredMessagePayload,
+    DeferredPeelLifecycle, MessageRecord, MessageState, OwnApplicationConvergenceStamp,
+    StoredMessagePayload,
 };
 use cgka_traits::storage::{LeaveRequest, StorageError, StorageProvider};
 use cgka_traits::transport::TransportMessage;
@@ -179,6 +180,36 @@ impl<S: StorageProvider> Engine<S> {
         group_id: &GroupId,
         epoch: EpochId,
     ) -> Result<(), EngineError> {
+        self.record_sent_openmls_message_with_application_stamp(
+            msg, mls_bytes, group_id, epoch, None,
+        )
+    }
+
+    pub(crate) fn record_sent_openmls_application_message(
+        &mut self,
+        msg: &TransportMessage,
+        mls_bytes: &[u8],
+        group_id: &GroupId,
+        epoch: EpochId,
+        stamp: OwnApplicationConvergenceStamp,
+    ) -> Result<(), EngineError> {
+        self.record_sent_openmls_message_with_application_stamp(
+            msg,
+            mls_bytes,
+            group_id,
+            epoch,
+            Some(stamp),
+        )
+    }
+
+    fn record_sent_openmls_message_with_application_stamp(
+        &mut self,
+        msg: &TransportMessage,
+        mls_bytes: &[u8],
+        group_id: &GroupId,
+        epoch: EpochId,
+        application_stamp: Option<OwnApplicationConvergenceStamp>,
+    ) -> Result<(), EngineError> {
         // Also remember and persist the content-derived id so our own commit /
         // app message echoed back inside a freshly re-wrapped transport envelope
         // (different transport id) is still classified `OwnEcho` by the
@@ -190,13 +221,27 @@ impl<S: StorageProvider> Engine<S> {
             ..msg.clone()
         };
         self.storage.with_transaction(|_storage| {
-            self.persist_signed_openmls_wire_message(
-                msg,
-                &openmls_msg,
-                group_id,
-                epoch,
-                MessageState::Sent,
-            )?;
+            if let Some(stamp) = application_stamp.clone() {
+                self.persist_stored_message_payload(
+                    msg.id.clone(),
+                    group_id,
+                    epoch,
+                    MessageState::Sent,
+                    StoredMessagePayload::signed_openmls_application_wire(
+                        msg.clone(),
+                        openmls_msg.clone(),
+                        stamp,
+                    ),
+                )?;
+            } else {
+                self.persist_signed_openmls_wire_message(
+                    msg,
+                    &openmls_msg,
+                    group_id,
+                    epoch,
+                    MessageState::Sent,
+                )?;
+            }
             self.persist_sent_openmls_content_marker(
                 &openmls_msg,
                 content_id.clone(),

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -311,7 +311,6 @@ pub enum OpenMlsReplayObservation {
         source_epoch: u64,
         sender: Vec<u8>,
         source_epoch_authenticator: String,
-        decrypted_payload_ref: String,
     },
     Ignored {
         message_id: String,
@@ -2272,12 +2271,15 @@ fn apply_openmls_canonicalization_result_inner<S: StorageProvider>(
     // inside an open one. The snapshot guards in-process error returns; this
     // transaction guards hard crashes mid-merge.
     storage.with_transaction(|storage| {
-        // No pre-validated own commits here: snapshot rollforward cannot nest
+        // No pre-validated own messages here. Snapshot rollforward cannot nest
         // inside this transaction, and every own commit on the accepted
         // branch was excluded from `replay_messages` before this call —
         // either as part of the already-applied prefix or as a
         // checkpoint-realizable own-commit run whose exact restore the
         // caller performs itself (`checkpoint_realizable_own_commit_prefix`).
+        // Leaving own-application stamps out is also load-bearing: those apps
+        // reach OpenMLS as `OwnPrivateMessage` and remain `Ignored`, so apply
+        // replay never echoes a sender's own message as `MessageReceived`.
         let output = process_openmls_messages_inner(
             storage,
             group_id,
@@ -2617,7 +2619,7 @@ struct AppMessageBranches {
     source_epoch: u64,
     sender: Vec<u8>,
     branch_ids: BTreeSet<String>,
-    decrypted_payload_ref: String,
+    decrypted_payload_ref: Option<String>,
 }
 
 fn app_messages_by_id(
@@ -2633,13 +2635,17 @@ fn app_messages_by_id(
                     sender,
                     decrypted_payload_ref,
                     ..
-                } => (message_id, source_epoch, sender, decrypted_payload_ref),
+                } => (
+                    message_id,
+                    source_epoch,
+                    sender,
+                    Some(decrypted_payload_ref),
+                ),
                 OpenMlsReplayObservation::OwnApplicationSent {
                     message_id,
                     source_epoch,
                     sender,
                     source_epoch_authenticator,
-                    decrypted_payload_ref,
                 } => {
                     let matches_candidate = candidate
                         .epoch_authenticators
@@ -2653,7 +2659,7 @@ fn app_messages_by_id(
                     if !matches_candidate {
                         continue;
                     }
-                    (message_id, source_epoch, sender, decrypted_payload_ref)
+                    (message_id, source_epoch, sender, None)
                 }
                 _ => continue,
             };
@@ -2664,7 +2670,7 @@ fn app_messages_by_id(
                         source_epoch: *source_epoch,
                         sender: sender.clone(),
                         branch_ids: BTreeSet::new(),
-                        decrypted_payload_ref: decrypted_payload_ref.clone(),
+                        decrypted_payload_ref: decrypted_payload_ref.cloned(),
                     });
             entry.branch_ids.insert(candidate.branch_id.clone());
         }
@@ -2703,7 +2709,7 @@ fn project_pending_canonicalization_messages(
                         .map(|observed| observed.branch_ids.iter().cloned().collect())
                         .unwrap_or_default(),
                     decrypted_payload_ref: observed
-                        .map(|observed| observed.decrypted_payload_ref.clone()),
+                        .and_then(|observed| observed.decrypted_payload_ref.clone()),
                     already_delivered: already_delivered_app_ids.contains(&message_id),
                 }
             }
@@ -2788,7 +2794,6 @@ fn process_openmls_messages_inner<S: StorageProvider>(
                 source_epoch,
                 sender: stamp.sender.as_slice().to_vec(),
                 source_epoch_authenticator: stamp.source_epoch_authenticator.clone(),
-                decrypted_payload_ref: stamp.decrypted_payload_ref.clone(),
             });
             continue;
         }
@@ -3129,9 +3134,8 @@ fn process_openmls_messages_inner<S: StorageProvider>(
                             app_event.created_at,
                             retention_seconds,
                         ),
-                        decrypted_payload_ref: format!(
-                            "sha256:{}",
-                            hex::encode(message_digest(payload.as_slice()))
+                        decrypted_payload_ref: crate::app_payload::decrypted_payload_ref(
+                            payload.as_slice(),
                         ),
                     });
                 } else {

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -12,7 +12,9 @@ use crate::provider::EngineOpenMlsProvider;
 use cgka_traits::app_event::AppMessageRetentionDecision;
 use cgka_traits::engine::CommitOrderingPriority;
 use cgka_traits::group::{Member, ProtocolProfile};
-use cgka_traits::message::{MessageRecord, MessageState, StoredMessagePayload};
+use cgka_traits::message::{
+    MessageRecord, MessageState, OwnApplicationConvergenceStamp, StoredMessagePayload,
+};
 use cgka_traits::storage::{StorageError, StorageProvider};
 use cgka_traits::transport::{TransportEnvelope, TransportMessage};
 use cgka_traits::types::{EpochId, GroupId, MemberId, MessageId};
@@ -72,6 +74,10 @@ pub struct OpenMlsMaterializedCandidate {
     pub commit_message_ids: Vec<String>,
     pub consumed_proposal_refs: Vec<String>,
     pub observations: Vec<OpenMlsReplayObservation>,
+    /// Authenticated state identity at every epoch materialized while replaying
+    /// this branch. Locally authored applications use it to prove which
+    /// candidate state encrypted their otherwise undecryptable own ciphertext.
+    pub epoch_authenticators: BTreeMap<u64, String>,
 }
 
 impl OpenMlsMaterializedCandidate {
@@ -300,6 +306,13 @@ pub enum OpenMlsReplayObservation {
         retention: AppMessageRetentionDecision,
         decrypted_payload_ref: String,
     },
+    OwnApplicationSent {
+        message_id: String,
+        source_epoch: u64,
+        sender: Vec<u8>,
+        source_epoch_authenticator: String,
+        decrypted_payload_ref: String,
+    },
     Ignored {
         message_id: String,
         kind: OpenMlsContentKind,
@@ -311,6 +324,7 @@ struct OpenMlsReplayOutput {
     observations: Vec<OpenMlsReplayObservation>,
     final_epoch: u64,
     final_members: Vec<Member>,
+    epoch_authenticators: BTreeMap<u64, String>,
 }
 
 #[derive(Debug)]
@@ -433,6 +447,10 @@ pub(crate) struct PrevalidatedOwnCommits {
     /// prefix stays canonical: it was created from the canonical state at its
     /// source epoch, so on any diverging prefix it must NOT apply.
     canonical_digests: BTreeSet<[u8; 32]>,
+    /// Locally authenticated app-message stamps, keyed by their stored wire id.
+    /// These are loaded before a retained-anchor rollback because the rollback
+    /// intentionally removes rows created after that anchor.
+    application_by_id: BTreeMap<Vec<u8>, OwnApplicationConvergenceStamp>,
 }
 
 impl PrevalidatedOwnCommits {
@@ -454,6 +472,15 @@ impl PrevalidatedOwnCommits {
 
     fn is_canonical(&self, digest: &[u8; 32]) -> bool {
         self.canonical_digests.contains(digest)
+    }
+
+    fn insert_application(&mut self, message_id: MessageId, stamp: OwnApplicationConvergenceStamp) {
+        self.application_by_id
+            .insert(message_id.as_slice().to_vec(), stamp);
+    }
+
+    fn application_stamp(&self, message_id: &MessageId) -> Option<&OwnApplicationConvergenceStamp> {
+        self.application_by_id.get(message_id.as_slice())
     }
 }
 
@@ -596,11 +623,13 @@ pub(crate) fn stamp_processed_own_commit_record<S: StorageProvider>(
         StoredMessagePayload::SignedOpenMlsWire {
             exact_message,
             openmls_message,
+            own_application_stamp,
             ..
         } => StoredMessagePayload::SignedOpenMlsWire {
             exact_message,
             openmls_message,
             stamp: Some(stamp),
+            own_application_stamp,
         },
         // Raw-transport rows never enter the OpenMLS candidate graph; a plain
         // state update preserves their shape.
@@ -721,6 +750,23 @@ fn replay_openmls_messages_prevalidated<S: StorageProvider>(
     own_commits: &PrevalidatedOwnCommits,
     profile_policy: ReplayProfilePolicy,
 ) -> Result<Vec<OpenMlsReplayObservation>, OpenMlsProjectionError> {
+    replay_openmls_messages_prevalidated_output(
+        storage,
+        group_id,
+        messages,
+        own_commits,
+        profile_policy,
+    )
+    .map(|output| output.observations)
+}
+
+fn replay_openmls_messages_prevalidated_output<S: StorageProvider>(
+    storage: &S,
+    group_id: &GroupId,
+    messages: &[TransportMessage],
+    own_commits: &PrevalidatedOwnCommits,
+    profile_policy: ReplayProfilePolicy,
+) -> Result<OpenMlsReplayOutput, OpenMlsProjectionError> {
     use crate::snapshot_guard::SnapshotRollbackGuard;
     let snapshot = replay_snapshot_name(group_id, messages);
     // RAII: on any unwind path (panic during replay, early error)
@@ -732,8 +778,7 @@ fn replay_openmls_messages_prevalidated<S: StorageProvider>(
         .map_err(|e| OpenMlsProjectionError::Snapshot(format!("{e:?}")))?;
 
     let result =
-        process_openmls_messages_inner(storage, group_id, messages, own_commits, profile_policy)
-            .map(|out| out.observations);
+        process_openmls_messages_inner(storage, group_id, messages, own_commits, profile_policy);
     guard
         .commit()
         .map_err(|e| OpenMlsProjectionError::Snapshot(format!("{e:?}")))?;
@@ -771,13 +816,14 @@ fn materialize_openmls_candidate_paths_budgeted<S: StorageProvider>(
             ));
         }
         budget.consume()?;
-        let observations = replay_openmls_messages_prevalidated(
+        let replay = replay_openmls_messages_prevalidated_output(
             storage,
             group_id,
             &path.messages,
             own_commits,
             profile_policy,
         )?;
+        let observations = replay.observations;
         let mut fork_epoch: Option<u64> = None;
         let mut tip_epoch: Option<u64> = None;
         let mut tip_digest: Option<[u8; 32]> = None;
@@ -833,6 +879,7 @@ fn materialize_openmls_candidate_paths_budgeted<S: StorageProvider>(
             commit_message_ids,
             consumed_proposal_refs,
             observations,
+            epoch_authenticators: replay.epoch_authenticators,
         });
     }
     candidates.sort_by(|a, b| a.branch_id.cmp(&b.branch_id));
@@ -994,6 +1041,7 @@ pub(crate) fn canonicalize_stored_openmls_messages_with_profile_policy<S: Storag
         let payload = StoredMessagePayload::decode(&record.payload)
             .map_err(|e| OpenMlsProjectionError::Serialize(format!("{e:?}")))?;
         let own_commit_stamp = payload.own_commit_stamp().cloned();
+        let own_application_stamp = payload.own_application_stamp().cloned();
         let Some(message) = payload.as_openmls_wire().cloned() else {
             continue;
         };
@@ -1056,6 +1104,9 @@ pub(crate) fn canonicalize_stored_openmls_messages_with_profile_policy<S: Storag
                 if record_state_can_contribute_to_openmls_graph(record.state)
                     && source_epoch.is_some_and(|epoch| epoch >= state.retained_anchor_epoch) =>
             {
+                if let Some(stamp) = own_application_stamp {
+                    own_commits.insert_application(message.id.clone(), stamp);
+                }
                 if record.state == MessageState::Processed {
                     already_delivered_app_ids.insert(hex::encode(message.id.as_slice()));
                 }
@@ -1826,12 +1877,49 @@ pub fn persist_openmls_canonicalization_dispositions<S: StorageProvider>(
     storage: &S,
     result: &CanonicalizationResult,
 ) -> Result<(), OpenMlsProjectionError> {
+    for disposition in openmls_canonicalization_dispositions(result)? {
+        storage
+            .update_message_state(&disposition.message_id, disposition.state)
+            .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
+    }
+
+    Ok(())
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct OpenMlsCanonicalizationDisposition {
+    pub message_id: MessageId,
+    pub state: MessageState,
+    pub reason: &'static str,
+}
+
+pub(crate) fn openmls_canonicalization_dispositions(
+    result: &CanonicalizationResult,
+) -> Result<Vec<OpenMlsCanonicalizationDisposition>, OpenMlsProjectionError> {
     let mut state_by_message_id = BTreeMap::new();
 
     for dropped in &result.dropped_messages {
         state_by_message_id.insert(
             dropped.message_id.clone(),
-            message_state_for_dropped_reason(dropped.reason),
+            (
+                message_state_for_dropped_reason(dropped.reason),
+                match dropped.reason {
+                    DroppedMessageReason::Malformed => "canonicalization_dropped_malformed",
+                    DroppedMessageReason::UnsupportedPolicy => {
+                        "canonicalization_dropped_unsupported_policy"
+                    }
+                    DroppedMessageReason::BeyondRollbackHorizon => {
+                        "canonicalization_dropped_beyond_rollback_horizon"
+                    }
+                    DroppedMessageReason::BeyondAnchor => "canonicalization_dropped_beyond_anchor",
+                    DroppedMessageReason::BeyondAppRetention => {
+                        "canonicalization_dropped_beyond_app_retention"
+                    }
+                    DroppedMessageReason::InvalidAgainstCandidateState => {
+                        "canonicalization_dropped_invalid_candidate_state"
+                    }
+                },
+            ),
         );
     }
     // The epoch convergence settled on: the selected branch tip, or the
@@ -1840,17 +1928,36 @@ pub fn persist_openmls_canonicalization_dispositions<S: StorageProvider>(
     for invalidated in &result.invalidated_app_messages {
         state_by_message_id.insert(
             invalidated.message_id.clone(),
-            message_state_for_invalidated_reason(
-                invalidated.reason,
-                invalidated.epoch,
-                resulting_tip,
+            (
+                message_state_for_invalidated_reason(
+                    invalidated.reason,
+                    invalidated.epoch,
+                    resulting_tip,
+                ),
+                match invalidated.reason {
+                    InvalidatedAppMessageReason::LosingBranch => {
+                        "canonicalization_invalidated_losing_branch"
+                    }
+                    InvalidatedAppMessageReason::UndecryptableInCanonicalState => {
+                        "canonicalization_invalidated_undecryptable"
+                    }
+                    InvalidatedAppMessageReason::BeyondAnchor => {
+                        "canonicalization_invalidated_beyond_anchor"
+                    }
+                    InvalidatedAppMessageReason::BeyondAppRetention => {
+                        "canonicalization_invalidated_beyond_app_retention"
+                    }
+                },
             ),
         );
     }
     for deferred in &result.deferred_messages {
         state_by_message_id.insert(
             deferred.message_id.clone(),
-            MessageState::ConvergenceDeferred,
+            (
+                MessageState::ConvergenceDeferred,
+                "canonicalization_deferred",
+            ),
         );
     }
     for accepted in result
@@ -1859,17 +1966,22 @@ pub fn persist_openmls_canonicalization_dispositions<S: StorageProvider>(
         .chain(&result.accepted_proposals)
         .chain(&result.accepted_app_messages)
     {
-        state_by_message_id.insert(accepted.clone(), MessageState::Processed);
+        state_by_message_id.insert(
+            accepted.clone(),
+            (MessageState::Processed, "canonicalization_accepted"),
+        );
     }
 
-    for (hex_message_id, state) in state_by_message_id {
-        let message_id = message_id_from_hex(&hex_message_id)?;
-        storage
-            .update_message_state(&message_id, state)
-            .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
-    }
-
-    Ok(())
+    state_by_message_id
+        .into_iter()
+        .map(|(hex_message_id, (state, reason))| {
+            Ok(OpenMlsCanonicalizationDisposition {
+                message_id: message_id_from_hex(&hex_message_id)?,
+                state,
+                reason,
+            })
+        })
+        .collect()
 }
 
 /// The longest leading run of accepted commits already applied on the live
@@ -2514,15 +2626,36 @@ fn app_messages_by_id(
     let mut app_messages = BTreeMap::new();
     for candidate in candidates {
         for observation in &candidate.observations {
-            let OpenMlsReplayObservation::ApplicationProcessed {
-                message_id,
-                source_epoch,
-                sender,
-                decrypted_payload_ref,
-                ..
-            } = observation
-            else {
-                continue;
+            let (message_id, source_epoch, sender, decrypted_payload_ref) = match observation {
+                OpenMlsReplayObservation::ApplicationProcessed {
+                    message_id,
+                    source_epoch,
+                    sender,
+                    decrypted_payload_ref,
+                    ..
+                } => (message_id, source_epoch, sender, decrypted_payload_ref),
+                OpenMlsReplayObservation::OwnApplicationSent {
+                    message_id,
+                    source_epoch,
+                    sender,
+                    source_epoch_authenticator,
+                    decrypted_payload_ref,
+                } => {
+                    let matches_candidate = candidate
+                        .epoch_authenticators
+                        .get(source_epoch)
+                        .map(|candidate_authenticator| {
+                            candidate_authenticator == source_epoch_authenticator
+                        })
+                        // A source epoch older than the replay anchor is part
+                        // of every candidate's common pre-fork history.
+                        .unwrap_or(*source_epoch <= candidate.fork_epoch);
+                    if !matches_candidate {
+                        continue;
+                    }
+                    (message_id, source_epoch, sender, decrypted_payload_ref)
+                }
+                _ => continue,
             };
             let entry =
                 app_messages
@@ -2616,6 +2749,10 @@ fn process_openmls_messages_inner<S: StorageProvider>(
         .ok_or(OpenMlsProjectionError::MissingGroup)?;
 
     let mut observations = Vec::new();
+    let mut epoch_authenticators = BTreeMap::from([(
+        mls_group.epoch().as_u64(),
+        own_commit_post_merge_epoch_authenticator(&mls_group),
+    )]);
     // An own commit is pre-validated only while every commit replayed before
     // it was canonical (`Processed`): it was created from the canonical state
     // at its source epoch, so on a diverging prefix its anchor state would
@@ -2637,6 +2774,24 @@ fn process_openmls_messages_inner<S: StorageProvider>(
                 .ok_or(OpenMlsProjectionError::UnsupportedMessageKind(
                     projection.kind,
                 ))?;
+        if projection.kind == OpenMlsContentKind::Application
+            && let Some(stamp) = own_commits.application_stamp(&message.id)
+        {
+            // A locally authored private message cannot be authenticated by
+            // replaying its ciphertext: MLS sender ratchets are encryption-
+            // only. Carry the durable send-time evidence forward and let the
+            // candidate epoch-authenticator comparison below decide whether
+            // this branch may claim it. Do not consult OpenMLS's unauthenticated
+            // OwnPrivateMessage classification.
+            observations.push(OpenMlsReplayObservation::OwnApplicationSent {
+                message_id,
+                source_epoch,
+                sender: stamp.sender.as_slice().to_vec(),
+                source_epoch_authenticator: stamp.source_epoch_authenticator.clone(),
+                decrypted_payload_ref: stamp.decrypted_payload_ref.clone(),
+            });
+            continue;
+        }
         if projection.kind == OpenMlsContentKind::Commit
             && prefix_canonical
             && let Some(stamp) = own_commits.stamp(&projection.message_digest)
@@ -2676,6 +2831,10 @@ fn process_openmls_messages_inner<S: StorageProvider>(
                 resulting_epoch,
                 expected_authenticator,
             )?;
+            epoch_authenticators.insert(
+                mls_group.epoch().as_u64(),
+                own_commit_post_merge_epoch_authenticator(&mls_group),
+            );
             observations.push(OpenMlsReplayObservation::CommitStaged {
                 message_id,
                 source_epoch,
@@ -2920,6 +3079,10 @@ fn process_openmls_messages_inner<S: StorageProvider>(
                     .map_err(|e| {
                         OpenMlsProjectionError::Replay(format!("merge_staged_commit: {e:?}"))
                     })?;
+                epoch_authenticators.insert(
+                    mls_group.epoch().as_u64(),
+                    own_commit_post_merge_epoch_authenticator(&mls_group),
+                );
                 crate::app_components::validate_current_profile_group_invariants(&mls_group)
                     .map_err(|error| OpenMlsProjectionError::InvalidCommit {
                         message_id,
@@ -2986,10 +3149,11 @@ fn process_openmls_messages_inner<S: StorageProvider>(
             }
             ProcessedMessageContent::OwnPendingCommit
             | ProcessedMessageContent::OwnPrivateMessage => {
-                // Own sends are replay evidence only. In particular, never
-                // merge an OwnPendingCommit here: MDK realizes confirmed own
-                // commits from retained anchor snapshots above, preserving
-                // the publish-before-apply lifecycle.
+                // Never merge an OwnPendingCommit here: MDK realizes confirmed
+                // own commits from retained anchor snapshots above, preserving
+                // the publish-before-apply lifecycle. A stamped own private
+                // message was handled before OpenMLS processing above; an
+                // unstamped OwnPrivateMessage is not trusted as provenance.
                 observations.push(OpenMlsReplayObservation::Ignored {
                     message_id,
                     kind: projection.kind,
@@ -3010,6 +3174,7 @@ fn process_openmls_messages_inner<S: StorageProvider>(
         observations,
         final_epoch: mls_group.epoch().as_u64(),
         final_members: marmot_members(&mls_group),
+        epoch_authenticators,
     })
 }
 

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -31,6 +31,7 @@ use cgka_traits::transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
 };
 use cgka_traits::types::{EpochId, GroupId, MemberId, MessageId};
+use marmot_forensics::{AuditEvent, AuditEventKind, JsonlRecorder};
 use openmls::component::ComponentData;
 use openmls::extensions::{AppDataDictionary, AppDataDictionaryExtension, Extension, Extensions};
 use openmls::group::{
@@ -289,6 +290,22 @@ fn build_client_with_storage(
         .account_identity_proof_signer(proof_signer(id))
         .feature_registry(selfremove_registry())
         .peeler(Box::new(MockPeeler))
+        .build()
+        .unwrap()
+}
+
+fn build_client_with_storage_and_recorder(
+    id: &[u8],
+    storage: SqliteAccountStorage,
+    recorder: JsonlRecorder,
+) -> Engine<SqliteAccountStorage> {
+    EngineBuilder::new(storage)
+        .legacy_compatibility_profile()
+        .identity(pad32(id))
+        .account_identity_proof_signer(proof_signer(id))
+        .feature_registry(selfremove_registry())
+        .peeler(Box::new(MockPeeler))
+        .recorder(Box::new(recorder))
         .build()
         .unwrap()
 }
@@ -839,6 +856,257 @@ async fn engine_converges_stored_openmls_messages_to_selected_branch() {
             .expect("pending convergence query succeeds"),
         "the epoch-invalidated loser must not keep gating ordinary app traffic"
     );
+}
+
+/// Regression for the Android-visible "This message is no longer valid"
+/// banner on a device's own sent message. OpenMLS cannot decrypt an own
+/// private-message ciphertext during candidate replay, so convergence must use
+/// the authenticated send-time stamp retained with the `Sent` row instead of
+/// classifying the message as undecryptable.
+#[tokio::test]
+async fn rebuilt_sender_keeps_own_sent_app_valid_through_convergence() {
+    let audit_dir = tempfile::TempDir::new().unwrap();
+    let audit_path = audit_dir.path().join("own-sent-convergence.jsonl");
+    let (mut alice, _alice_storage) = build_client(b"alice");
+    let (mut carol, carol_storage) = build_client(b"carol");
+    let (mut david, _david_storage) = build_client(b"david");
+
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "own-sent-app-convergence".into(),
+            description: "".into(),
+            members: vec![carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![alice.self_id()],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    carol
+        .join_welcome(welcome_for(&welcomes, b"carol"))
+        .await
+        .unwrap();
+    carol.drain_events();
+
+    let own_app = send_app(
+        &mut carol,
+        &group_id,
+        b"must remain valid on the sender".to_vec(),
+    )
+    .await;
+    let stored_before_restart = carol_storage
+        .get_message(&own_app.id)
+        .expect("own sent row is durable");
+    assert_eq!(stored_before_restart.state, MessageState::Sent);
+    let payload = StoredMessagePayload::decode(&stored_before_restart.payload)
+        .expect("own sent payload decodes");
+    assert!(
+        payload.own_application_stamp().is_some(),
+        "own application provenance must survive in the durable Sent row"
+    );
+
+    let invite = alice
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![david.fresh_key_package().await.unwrap()],
+        })
+        .await
+        .unwrap();
+    let (commit, _pending) = evolution(invite);
+    carol
+        .buffer_openmls_convergence_message_at(&group_id, route(commit, &group_id), 1_000)
+        .expect("commit buffered alongside own Sent row");
+
+    drop(carol);
+    let recorder = JsonlRecorder::open(&audit_path, "own-sent-regression".into()).unwrap();
+    let mut restarted =
+        build_client_with_storage_and_recorder(b"carol", carol_storage.clone(), recorder);
+    restarted
+        .hydrate_stable_groups_from_storage()
+        .expect("restart hydrates the persisted group");
+    let result = restarted
+        .converge_stored_openmls_messages_at(&group_id, u64::MAX)
+        .expect("rebuilt sender converges stored messages");
+
+    let own_app_id = hex::encode(own_app.id.as_slice());
+    assert_eq!(result.convergence_status, ConvergenceStatus::Settled);
+    assert_eq!(
+        result.accepted_app_messages,
+        vec![own_app_id.clone()],
+        "own app was not credited to its branch: {result:?}"
+    );
+    assert!(
+        result
+            .invalidated_app_messages
+            .iter()
+            .all(|invalidated| invalidated.message_id != own_app_id),
+        "own sent message must not be invalidated: {:?}",
+        result.invalidated_app_messages
+    );
+    assert_eq!(
+        carol_storage
+            .get_message(&own_app.id)
+            .expect("own sent row remains stored")
+            .state,
+        MessageState::Processed
+    );
+    let events = restarted.drain_events();
+    assert!(
+        events.iter().all(|event| !matches!(
+            event,
+            GroupEvent::AppMessageInvalidated { message_id, .. } if *message_id == own_app.id
+        )),
+        "sender must not receive an invalidation for its own message: {events:?}"
+    );
+    assert!(
+        events.iter().all(|event| !matches!(
+            event,
+            GroupEvent::MessageReceived { group_id: event_group, .. } if *event_group == group_id
+        )),
+        "convergence must not echo the sender's own app back as received: {events:?}"
+    );
+    drop(restarted);
+    let audit_events: Vec<AuditEvent> = std::fs::read_to_string(&audit_path)
+        .expect("read convergence audit")
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("parse convergence audit event"))
+        .collect();
+    assert!(
+        audit_events.iter().any(|event| matches!(
+            &event.kind,
+            AuditEventKind::MessageStateChanged {
+                previous_state: Some(previous_state),
+                new_state,
+                reason,
+                ..
+            } if previous_state == "sent"
+                && new_state == "processed"
+                && reason == "canonicalization_accepted"
+        )),
+        "forensic audit must expose the atomic Sent -> Processed convergence disposition"
+    );
+}
+
+/// A locally authored app is a witness only for the branch whose authenticated
+/// source state created it. Choose the branch that would lose the deterministic
+/// commit tie-break, then prove the own-message stamp credits only that branch
+/// and lets its real app witness win selection.
+#[tokio::test]
+async fn own_sent_app_witnesses_only_its_matching_fork_branch() {
+    let (mut alice, alice_storage) = build_client(b"alice");
+    let (mut bob, bob_storage) = build_client(b"bob");
+    let (mut david, _david_storage) = build_client(b"david");
+    let (mut eve, _eve_storage) = build_client(b"eve");
+
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "own-app-fork-provenance".into(),
+            description: "".into(),
+            members: vec![bob_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![bob.self_id()],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    bob.join_welcome(welcome_for(&welcomes, b"bob"))
+        .await
+        .unwrap();
+
+    let alice_invite = alice
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![david.fresh_key_package().await.unwrap()],
+        })
+        .await
+        .unwrap();
+    let bob_invite = bob
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![eve.fresh_key_package().await.unwrap()],
+        })
+        .await
+        .unwrap();
+    let (alice_commit, alice_pending) = evolution(alice_invite);
+    let (bob_commit, bob_pending) = evolution(bob_invite);
+    let commits = [route(alice_commit, &group_id), route(bob_commit, &group_id)];
+    let own_branch = 1 - commit_tiebreak_winner_index(&alice.self_id(), &bob.self_id());
+
+    let (own_app, sender_storage, events) = if own_branch == 0 {
+        alice.confirm_published(alice_pending).await.unwrap();
+        let own_app = send_app(
+            &mut alice,
+            &group_id,
+            b"alice own app selects matching branch".to_vec(),
+        )
+        .await;
+        alice
+            .buffer_openmls_convergence_message_at(&group_id, commits[1].clone(), 1_000)
+            .expect("competing Bob commit buffered");
+        let result = alice
+            .converge_stored_openmls_messages_at(&group_id, u64::MAX)
+            .expect("Alice converges the fork");
+        let events = alice.drain_events();
+        (own_app, alice_storage, (result, events))
+    } else {
+        bob.confirm_published(bob_pending).await.unwrap();
+        let own_app = send_app(
+            &mut bob,
+            &group_id,
+            b"bob own app selects matching branch".to_vec(),
+        )
+        .await;
+        bob.buffer_openmls_convergence_message_at(&group_id, commits[0].clone(), 1_000)
+            .expect("competing Alice commit buffered");
+        let result = bob
+            .converge_stored_openmls_messages_at(&group_id, u64::MAX)
+            .expect("Bob converges the fork");
+        let events = bob.drain_events();
+        (own_app, bob_storage, (result, events))
+    };
+    let (result, events) = events;
+    let own_app_id = hex::encode(own_app.id.as_slice());
+
+    assert_eq!(result.convergence_status, ConvergenceStatus::Settled);
+    assert_eq!(
+        result.accepted_app_messages,
+        vec![own_app_id.clone()],
+        "own app was not credited to its branch: {result:?}"
+    );
+    assert!(
+        result
+            .accepted_commits
+            .iter()
+            .any(|message_id| message_id == &hex::encode(commits[own_branch].id.as_slice())),
+        "the own app witness must select its matching branch: {result:?}"
+    );
+    assert!(result.invalidated_app_messages.iter().all(|invalidated| {
+        invalidated.message_id != own_app_id
+            && invalidated.reason != InvalidatedAppMessageReason::UndecryptableInCanonicalState
+    }));
+    assert_eq!(
+        sender_storage
+            .get_message(&own_app.id)
+            .expect("own app remains durable")
+            .state,
+        MessageState::Processed
+    );
+    assert!(events.iter().all(|event| !matches!(
+        event,
+        GroupEvent::AppMessageInvalidated { message_id, .. } if *message_id == own_app.id
+    )));
 }
 
 #[tokio::test]

--- a/crates/marmot-forensics/src/audit.rs
+++ b/crates/marmot-forensics/src/audit.rs
@@ -1165,6 +1165,15 @@ pub enum PeelerOutcomeKind {
 pub trait ForensicRecorder: Send + Sync {
     fn record(&self, record: AuditRecord);
 
+    /// Whether this recorder consumes audit events.
+    ///
+    /// Producers may use this to skip audit-only data loads on hot paths. The
+    /// default is enabled so custom recorders remain observable without code
+    /// changes; [`NoopRecorder`] is the sole disabled implementation.
+    fn is_enabled(&self) -> bool {
+        true
+    }
+
     fn health_snapshot(&self) -> AuditRecorderHealthSnapshot {
         AuditRecorderHealthSnapshot::default()
     }
@@ -1214,6 +1223,10 @@ pub struct NoopRecorder;
 
 impl ForensicRecorder for NoopRecorder {
     fn record(&self, _record: AuditRecord) {}
+
+    fn is_enabled(&self) -> bool {
+        false
+    }
 }
 
 /// JSONL recorder. Appends one JSON line per event to the configured path.

--- a/crates/marmot-forensics/src/audit/tests.rs
+++ b/crates/marmot-forensics/src/audit/tests.rs
@@ -22,6 +22,7 @@ fn jsonl_recorder_appends_events_with_monotonic_seq() {
     let dir = TempDir::new().unwrap();
     let path = default_jsonl_path(dir.path(), "engine-abc");
     let recorder = JsonlRecorder::open(&path, "engine-abc".to_string()).unwrap();
+    assert!(recorder.is_enabled());
     recorder.record(AuditRecord::new(
         None,
         AuditEventKind::SendEntry {
@@ -141,6 +142,7 @@ fn jsonl_recorder_rotate_discards_old_lines_and_keeps_recording() {
 #[test]
 fn noop_recorder_has_no_path_and_rotate_is_a_no_op() {
     let recorder = NoopRecorder;
+    assert!(!recorder.is_enabled());
     assert!(recorder.audit_log_path().is_none());
     recorder.rotate().unwrap();
 }

--- a/crates/traits/src/lib.rs
+++ b/crates/traits/src/lib.rs
@@ -94,7 +94,10 @@ pub use maintenance::{
     SendMaintenanceDisposition, SignedPublicationArtifact, TransportFanoutAttemptState,
     TransportFanoutTarget, WallClock,
 };
-pub use message::{MessageRecord, MessageState, OwnCommitConvergenceStamp, StoredMessagePayload};
+pub use message::{
+    MessageRecord, MessageState, OwnApplicationConvergenceStamp, OwnCommitConvergenceStamp,
+    StoredMessagePayload,
+};
 pub use peeler::{GroupMessageMetadata, TransportPeeler};
 pub use storage::{
     CapabilityStorage, ConvergencePassStorage, DisbandCandidate, DisbandCandidateStorage,

--- a/crates/traits/src/message.rs
+++ b/crates/traits/src/message.rs
@@ -40,6 +40,24 @@ pub struct OwnCommitConvergenceStamp {
     pub resulting_epoch_authenticator: Option<String>,
 }
 
+/// Branch provenance for an application message authored by this device.
+///
+/// MLS sender ratchets are encryption-only, so a device cannot later decrypt
+/// and authenticate its own private-message ciphertext during candidate
+/// replay. The send path therefore captures the authenticated local source
+/// state while it still owns it. Stored convergence may credit the message
+/// only to candidate states whose epoch authenticator matches this stamp.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OwnApplicationConvergenceStamp {
+    /// This device's authenticated Marmot member identity at send time.
+    pub sender: MemberId,
+    /// Hex-encoded MLS epoch authenticator of the state that encrypted the
+    /// application message.
+    pub source_epoch_authenticator: String,
+    /// Stable local reference to the validated plaintext payload.
+    pub decrypted_payload_ref: String,
+}
+
 /// Typed envelope for the opaque bytes stored in [`MessageRecord::payload`].
 ///
 /// The database column remains a byte blob so backends do not need a schema
@@ -54,11 +72,12 @@ pub struct OwnCommitConvergenceStamp {
 ///   recovery find only delivery obligations created by versions that track
 ///   their completion.
 /// - `OpenMlsWire`: transport metadata plus payload replaced with peeled MLS
-///   wire bytes. Only this variant and `OwnCommitWire` are eligible for
-///   OpenMLS projection and convergence replay.
+///   wire bytes. This variant, `SignedOpenMlsWire`, and `OwnCommitWire` are
+///   eligible for OpenMLS projection and convergence replay.
 /// - `SignedOpenMlsWire`: the exact signed outer transport message alongside
 ///   the projection-friendly MLS wire message. This is the current outbound
-///   representation and supports byte-identical retry after restart.
+///   representation and supports byte-identical retry after restart. Locally
+///   authored applications also carry [`OwnApplicationConvergenceStamp`].
 /// - `OwnCommitWire`: an `OpenMlsWire` commit this device published and
 ///   confirmed, enriched with its [`OwnCommitConvergenceStamp`] so stored
 ///   convergence can treat it as a pre-validated candidate branch after a
@@ -74,6 +93,8 @@ pub enum StoredMessagePayload {
         openmls_message: TransportMessage,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         stamp: Option<OwnCommitConvergenceStamp>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        own_application_stamp: Option<Box<OwnApplicationConvergenceStamp>>,
     },
     OwnCommitWire {
         message: TransportMessage,
@@ -102,6 +123,20 @@ impl StoredMessagePayload {
             exact_message,
             openmls_message,
             stamp: None,
+            own_application_stamp: None,
+        }
+    }
+
+    pub fn signed_openmls_application_wire(
+        exact_message: TransportMessage,
+        openmls_message: TransportMessage,
+        own_application_stamp: OwnApplicationConvergenceStamp,
+    ) -> Self {
+        Self::SignedOpenMlsWire {
+            exact_message,
+            openmls_message,
+            stamp: None,
+            own_application_stamp: Some(Box::new(own_application_stamp)),
         }
     }
 
@@ -169,6 +204,20 @@ impl StoredMessagePayload {
             Self::RawTransport(_) | Self::OutboundWelcome(_) | Self::OpenMlsWire(_) => None,
             Self::SignedOpenMlsWire { stamp, .. } => stamp.as_ref(),
             Self::OwnCommitWire { stamp, .. } => Some(stamp),
+        }
+    }
+
+    /// Send-time branch provenance for a locally authored application message.
+    pub fn own_application_stamp(&self) -> Option<&OwnApplicationConvergenceStamp> {
+        match self {
+            Self::SignedOpenMlsWire {
+                own_application_stamp,
+                ..
+            } => own_application_stamp.as_deref(),
+            Self::RawTransport(_)
+            | Self::OutboundWelcome(_)
+            | Self::OpenMlsWire(_)
+            | Self::OwnCommitWire { .. } => None,
         }
     }
 

--- a/crates/traits/src/message.rs
+++ b/crates/traits/src/message.rs
@@ -54,8 +54,6 @@ pub struct OwnApplicationConvergenceStamp {
     /// Hex-encoded MLS epoch authenticator of the state that encrypted the
     /// application message.
     pub source_epoch_authenticator: String,
-    /// Stable local reference to the validated plaintext payload.
-    pub decrypted_payload_ref: String,
 }
 
 /// Typed envelope for the opaque bytes stored in [`MessageRecord::payload`].

--- a/crates/traits/tests/snapshots.rs
+++ b/crates/traits/tests/snapshots.rs
@@ -336,6 +336,53 @@ fn stored_message_payload_own_commit_wire_round_trips_with_stamp() {
 }
 
 #[test]
+fn stored_signed_application_payload_round_trips_and_old_rows_default_to_unstamped() {
+    use cgka_traits::message::OwnApplicationConvergenceStamp;
+
+    let exact = TransportMessage {
+        id: mid(),
+        payload: vec![0x01, 0x02],
+        timestamp: Timestamp(1717171717),
+        causal_deps: vec![],
+        source: TransportSource("nostr".into()),
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: vec![0xCC; 4],
+        },
+    };
+    let openmls = TransportMessage {
+        payload: vec![0xAB, 0xCD],
+        ..exact.clone()
+    };
+    let stamp = OwnApplicationConvergenceStamp {
+        sender: MemberId::new(vec![0xEE; 32]),
+        source_epoch_authenticator: "ab".repeat(32),
+        decrypted_payload_ref: format!("sha256:{}", "cd".repeat(32)),
+    };
+    let payload = StoredMessagePayload::signed_openmls_application_wire(
+        exact.clone(),
+        openmls.clone(),
+        stamp.clone(),
+    );
+    let decoded = StoredMessagePayload::decode(&payload.encode().unwrap()).unwrap();
+    assert_eq!(decoded.as_exact_transport(), Some(&exact));
+    assert_eq!(decoded.as_openmls_wire(), Some(&openmls));
+    assert_eq!(decoded.own_application_stamp(), Some(&stamp));
+
+    // The new field is serde-defaulted and omitted when absent, so every
+    // pre-upgrade SignedOpenMlsWire row remains decodable.
+    let legacy_signed = StoredMessagePayload::signed_openmls_wire(exact, openmls);
+    let legacy_json = serde_json::to_value(&legacy_signed).unwrap();
+    assert!(
+        legacy_json["message"]
+            .get("own_application_stamp")
+            .is_none()
+    );
+    let decoded_legacy =
+        StoredMessagePayload::decode(&serde_json::to_vec(&legacy_json).unwrap()).unwrap();
+    assert!(decoded_legacy.own_application_stamp().is_none());
+}
+
+#[test]
 fn stored_message_payload_decodes_legacy_transport_message_as_openmls_wire() {
     let legacy = TransportMessage {
         id: mid(),

--- a/crates/traits/tests/snapshots.rs
+++ b/crates/traits/tests/snapshots.rs
@@ -356,7 +356,6 @@ fn stored_signed_application_payload_round_trips_and_old_rows_default_to_unstamp
     let stamp = OwnApplicationConvergenceStamp {
         sender: MemberId::new(vec![0xEE; 32]),
         source_epoch_authenticator: "ab".repeat(32),
-        decrypted_payload_ref: format!("sha256:{}", "cd".repeat(32)),
     };
     let payload = StoredMessagePayload::signed_openmls_application_wire(
         exact.clone(),


### PR DESCRIPTION
## Summary

Prevent locally authored application messages from being reclassified as invalid when they are included in Android's stored-convergence pass.

The send path now persists a minimal local convergence stamp containing only the authenticated sender and MLS source-epoch authenticator. Candidate replay carries that stamp across retained-anchor rollback and credits an own message only to candidate branches whose authenticated epoch state matches the send-time stamp.

## Root cause

OpenMLS sender ratchets are encryption-only. During replay, a device cannot decrypt and authenticate its own private-message ciphertext, and OpenMLS reports `OwnPrivateMessage` without authenticated branch provenance.

MDK previously converted that result to `Ignored`. Canonicalization then saw no branch that could decrypt the stored `Sent` row, classified it as `UndecryptableInCanonicalState`, persisted `EpochInvalidated`, and emitted `AppMessageInvalidated`. Android rendered that event as the “This message is no longer valid” banner on the sender's own message.

## Changes

- persist backward-compatible own-application provenance with signed outbound OpenMLS rows
- retain only sender and epoch-authenticator provenance; plaintext-derived payload references remain transient
- preload provenance before retained-anchor rollback so restart and historical replay retain it
- track epoch authenticators for each materialized candidate
- accept an own app only on its matching branch, including contested forks
- transition accepted own rows from `Sent` to `Processed` without emitting a duplicate received event
- emit canonicalization message-state audit transitions only after the atomic convergence apply commits
- skip audit-only message-row reads when the no-op recorder is installed
- preserve decoding of pre-existing unstamped rows

This prevents new occurrences of the original `UndecryptableInCanonicalState` misclassification for messages sent through the upgraded MDK. A locally sent message on a genuinely losing fork can still be invalidated with `LosingBranch`; Android may correctly render the same banner in that case. The change does not retroactively clear an invalidation already projected into an existing application timeline.

## Validation

- `just fast-ci`
- `cargo test -p cgka-engine --features test-policy-overrides --test distributed_convergence` — 83 passed
- `cargo test -p cgka-traits`
- `cargo test -p marmot-forensics` — 28 passed
- focused restart, matching-fork provenance, no-echo, audit-transition, recorder gating, payload-reference format, and legacy serialization regressions
