### PR TITLE
Bump pinned Rust toolchain to 1.97.1

### DIFF
--- a/Dockerfile.convergence-campaign
+++ b/Dockerfile.convergence-campaign
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM rust:1.95.0-bookworm@sha256:6258907abe69656e41cd992e0b705cdcfabcbbe3db374f92ed2d47121282d4a1 AS builder
+FROM rust:1.97.1-bookworm@sha256:14bc9c5966e7b3a385794b3d5389a8765668342025fbcc7b2e3d2866ac4bd8c3 AS builder
 
 WORKDIR /workspace
 COPY Cargo.toml Cargo.lock rust-toolchain.toml ./

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -113,8 +113,8 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 - The bundled SQLCipher stack now uses rusqlite 0.40.1/libsqlite3-sys 0.38.1,
   providing SQLCipher 4.14.0 and SQLite 3.51.3 with SQLite's WAL-reset
-  corruption fix. The pinned Rust toolchain is now 1.95.0, the minimum release
-  that supports this libsqlite3-sys build.
+  corruption fix. Rust 1.95.0 is the minimum release that supports this
+  libsqlite3-sys build; the pinned toolchain moved on to 1.97.1 below.
 
 - The pinned Rust toolchain is now 1.97.1, and the convergence-campaign
   builder image is digest-pinned to the matching `rust:1.97.1-bookworm`.

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -116,6 +116,12 @@ versioning through the workspace version in the root `Cargo.toml`.
   corruption fix. The pinned Rust toolchain is now 1.95.0, the minimum release
   that supports this libsqlite3-sys build.
 
+- The pinned Rust toolchain is now 1.97.1, and the convergence-campaign
+  builder image is digest-pinned to the matching `rust:1.97.1-bookworm`.
+  Rust 1.97's new `unneeded_wildcard_pattern` clippy lint required removing
+  two redundant field bindings in the campaign runner's fault validation.
+  ([#1303](https://github.com/marmot-protocol/mdk/pull/1303))
+
 ## [0.9.10] - 2026-07-29
 
 ### Added

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -120,7 +120,7 @@ versioning through the workspace version in the root `Cargo.toml`.
   builder image is digest-pinned to the matching `rust:1.97.1-bookworm`.
   Rust 1.97's new `unneeded_wildcard_pattern` clippy lint required removing
   two redundant field bindings in the campaign runner's fault validation.
-  ([#1303](https://github.com/marmot-protocol/mdk/pull/1303))
+  ([#1305](https://github.com/marmot-protocol/mdk/pull/1305))
 
 ## [0.9.10] - 2026-07-29
 

--- a/crates/convergence-campaign-runner/src/manifest.rs
+++ b/crates/convergence-campaign-runner/src/manifest.rs
@@ -464,13 +464,8 @@ impl DistributedFaultV1 {
                 ))
             }
             Self::FillDisk { bytes: 0, .. }
+            | Self::DatabaseContention { workers: 0, .. }
             | Self::DatabaseContention {
-                workers: 0,
-                bytes_per_worker: _,
-                ..
-            }
-            | Self::DatabaseContention {
-                workers: _,
                 bytes_per_worker: 0,
                 ..
             }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.97.1"
 components = ["rustfmt", "clippy"]
 profile = "default"


### PR DESCRIPTION
Bumps the pinned Rust toolchain from 1.95.0 to 1.97.1 so every marmot burrow builds with the same compiler: rolling-release machines already run 1.97, where clippy's new default-on `unneeded_wildcard_pattern` lint turns `just fast-ci` red on code that CI still accepts under 1.95.

Changes:

- `rust-toolchain.toml`: channel 1.95.0 to 1.97.1. All CI workflows and the campaign toolchain gate read their version from this file.
- `Dockerfile.convergence-campaign`: builder image digest-pinned to `rust:1.97.1-bookworm` so `scripts/check_campaign_toolchain.sh` stays green.
- `crates/convergence-campaign-runner/src/manifest.rs`: removed two redundant field bindings in the `DatabaseContention` validation arms; the trailing `..` already covers them. This is the only place the new lint fires in the workspace.

Verified on 1.97.1: `just fast-ci` passes end to end (it failed on the lint before), `cargo test -p convergence-campaign-runner` passes, and the campaign toolchain gate reports 1.97.1.

Header image owed: the PPQ forge is out of fuel; a pixel marmot swapping gears arrives once it is refueled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated the Rust toolchain to version 1.97.1.
  * Updated the convergence campaign build environment to use the matching Rust release.
  * Refined validation handling for database contention settings while preserving rejection of invalid zero-value configurations.

* **Documentation**
  * Updated the unreleased changelog with toolchain and build environment details.
  * Documented lint-related cleanup and the minimum Rust version required for SQLCipher builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->