### PR TITLE
Add engine two-phase hydration with fail-closed unhydrated state

### DIFF
--- a/crates/cgka-conformance-simulator/src/client.rs
+++ b/crates/cgka-conformance-simulator/src/client.rs
@@ -711,7 +711,7 @@ impl HarnessClient {
             },
         );
         engine
-            .hydrate_stable_groups_from_storage()
+            .hydrate_all_stored_groups()
             .expect("engine hydrates from storage");
         self.storage = Some(storage);
         self.engine = Some(engine);

--- a/crates/cgka-conformance-simulator/src/subject.rs
+++ b/crates/cgka-conformance-simulator/src/subject.rs
@@ -2039,6 +2039,7 @@ pub(crate) fn classify_engine_error(error: &EngineError) -> (SubjectFailureCateg
         | EngineError::InvalidWelcome
         | EngineError::WelcomeAlreadyProcessed
         | EngineError::UnknownGroup(_)
+        | EngineError::GroupNotHydrated(_)
         | EngineError::UnknownMember { .. }
         | EngineError::NotAMember { .. }
         | EngineError::MissingRequiredCapabilities { .. }
@@ -2093,6 +2094,7 @@ fn observe_engine_error(error: &EngineError) -> String {
         EngineError::WelcomeAlreadyProcessed => "welcome_already_processed",
         EngineError::InvalidTransition(_) => "invalid_transition",
         EngineError::UnknownGroup(_) => "unknown_group",
+        EngineError::GroupNotHydrated(_) => "group_not_hydrated",
         EngineError::UnknownMember { .. } => "unknown_member",
         EngineError::NotAMember { .. } => "not_a_member",
         EngineError::Other(_) => "other",

--- a/crates/cgka-engine/AGENTS.md
+++ b/crates/cgka-engine/AGENTS.md
@@ -375,9 +375,15 @@ shapes. Tests: `tests/fork_detection.rs` plus the harness `deliberate_fork_via_h
   `&mut` entry points (send, ingest, convergence drains) call `ensure_hydrated` first, which retracts the provisional
   seed, runs the full per-group hydration, and on failure quarantines with exact open-time parity (including removing
   the epoch entry — a quarantined group must never hold one). `hydrate_all_stored_groups` is the eager compatibility
-  path (seed + drain-all) used by `AccountDeviceSession::open` until the app-layer background pipeline lands. Groups
-  without a durable route row sit in `route_backfill_pending`; ingest backfills each with one MLS load ever
-  (amortized preservation of the mdk#740 attacker-paced-scan bound).
+  path (seed + drain-all) used by `AccountDeviceSession::open` until the app-layer background pipeline lands, and it
+  drains every seeded group — including unrecoverable ones, whose halt re-emits from full hydration exactly once per
+  open. Durable route rows carry a `source_epoch` stamp refreshed at every commit apply: the seed trusts a group's
+  route set only when a stamp matches the record epoch (a lagging stamp means a crash or write failure between the
+  commit and the route refresh), and stale/route-less groups sit in `route_backfill_pending`. Ingest probes at most
+  `ROUTE_BACKFILL_PROBES_PER_MISS` pending groups per unknown route (bounded per event — mdk#408's O(groups)
+  amplification stays closed), removing an id only on successful indexing or the terminal no-routing-component
+  disposition; MLS-load failures stay owned by hydration/quarantine. Route refreshes also retire durable rows the
+  retained-history window (pinned v1 `max_rewind_commits`) has moved past, per routing-v1's overlap rule.
 - **The durable `Group::epoch` is a mirror of the epoch manager, and hydration seeds the epoch manager from it.**
   Because those two stores read each other across a restart, every mirror write belongs to the same durable unit as the
   MLS state change it projects, and every mirror failure propagates — never best-effort. Write the record inside the

--- a/crates/cgka-engine/AGENTS.md
+++ b/crates/cgka-engine/AGENTS.md
@@ -366,6 +366,18 @@ shapes. Tests: `tests/fork_detection.rs` plus the harness `deliberate_fork_via_h
   path that reads group state, add the gate — a path that bypasses it can silently un-quarantine a group via
   `set_stable`. Quarantine clears only through `retry_hydrate_quarantined_group` or an authenticated re-join welcome,
   both of which schedule retained input for replay.
+- **Two-phase hydration (mdk#1161): session open seeds, full hydration promotes.**
+  `hydrate_stable_groups_from_storage` is the cheap seed pass: per stored group it reads only the durable record —
+  no MLS load, snapshot list, or message scan — seeds a provisional `Stable(record.epoch)` entry so `live_group_ids`
+  keeps listing the group, restores disband/unrecoverable terminal state, seeds the inbound routing index from the
+  durable `transport_group_routes` table, and adds the group to `unhydrated_groups`. An unhydrated group fails closed
+  through the same `ensure_group_live` chokepoint with the retryable `GroupNotHydrated` (never a partial view);
+  `&mut` entry points (send, ingest, convergence drains) call `ensure_hydrated` first, which retracts the provisional
+  seed, runs the full per-group hydration, and on failure quarantines with exact open-time parity (including removing
+  the epoch entry — a quarantined group must never hold one). `hydrate_all_stored_groups` is the eager compatibility
+  path (seed + drain-all) used by `AccountDeviceSession::open` until the app-layer background pipeline lands. Groups
+  without a durable route row sit in `route_backfill_pending`; ingest backfills each with one MLS load ever
+  (amortized preservation of the mdk#740 attacker-paced-scan bound).
 - **The durable `Group::epoch` is a mirror of the epoch manager, and hydration seeds the epoch manager from it.**
   Because those two stores read each other across a restart, every mirror write belongs to the same durable unit as the
   MLS state change it projects, and every mirror failure propagates — never best-effort. Write the record inside the

--- a/crates/cgka-engine/src/audit_helpers.rs
+++ b/crates/cgka-engine/src/audit_helpers.rs
@@ -642,6 +642,7 @@ pub(crate) fn create_group_outcome_event(result: &SendResult) -> AuditEventKind 
 pub(crate) fn engine_error_kind(err: &EngineError) -> &'static str {
     match err {
         EngineError::UnknownGroup(_) => "unknown_group",
+        EngineError::GroupNotHydrated(_) => "group_not_hydrated",
         EngineError::UnknownPending => "unknown_pending",
         EngineError::NotAMember { .. } => "not_a_member",
         EngineError::NotGroupAdmin { .. } => "not_group_admin",

--- a/crates/cgka-engine/src/disband.rs
+++ b/crates/cgka-engine/src/disband.rs
@@ -609,6 +609,13 @@ impl<S: StorageProvider> Engine<S> {
 
         self.transport_group_id_index
             .retain(|_, mapped_group| mapped_group != group_id);
+        // A disbanded group must be unroutable across restarts too; the
+        // durable delete shares the in-memory retain's best-effort policy
+        // (the tombstone keeps inbound handling terminal either way).
+        let _ = self
+            .storage
+            .delete_transport_group_routes_for_group(group_id);
+        self.route_backfill_pending.remove(group_id);
         self.pending_convergence_groups.remove(group_id);
         self.engine_metrics.forget_group(group_id);
         self.leaving_groups.remove(group_id);

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -374,7 +374,7 @@ impl<S: StorageProvider> Engine<S> {
         monotonic_ms: u64,
     ) -> Result<(), OpenMlsProjectionError> {
         // See `buffer_openmls_convergence_message` (mdk#1161).
-        let _ = self.ensure_hydrated(group_id);
+        self.ensure_hydrated_for_convergence(group_id)?;
         self.buffer_openmls_convergence_message_with_time(
             group_id,
             message,
@@ -394,8 +394,27 @@ impl<S: StorageProvider> Engine<S> {
         // Promote a seeded-but-unhydrated group before persisting convergence
         // input against it (mdk#1161): the group's interrupted probe/apply
         // recovery must run before any of its stored state is extended.
-        let _ = self.ensure_hydrated(group_id);
+        self.ensure_hydrated_for_convergence(group_id)?;
         self.buffer_openmls_convergence_message_with_time(group_id, message, self.convergence_now())
+    }
+
+    /// Fail-closed hydration promotion for the public convergence-buffering
+    /// entry points (mdk#1161): a failed promotion quarantines the group and
+    /// retracts its provisional epoch state, so continuing would take the
+    /// no-epoch-state admission branch and durably retain a convergence row
+    /// for a group validation just rejected. Propagate instead — the caller
+    /// observes the same missing-group view every quarantined group presents,
+    /// and no durable state is extended.
+    fn ensure_hydrated_for_convergence(
+        &mut self,
+        group_id: &GroupId,
+    ) -> Result<(), OpenMlsProjectionError> {
+        self.ensure_hydrated(group_id).map_err(|e| match e {
+            cgka_traits::error::EngineError::UnknownGroup(_) => {
+                OpenMlsProjectionError::MissingGroup
+            }
+            other => OpenMlsProjectionError::Storage(format!("{other}")),
+        })
     }
 
     pub(crate) fn buffer_openmls_convergence_message_with_time(

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -199,6 +199,10 @@ impl<S: StorageProvider> Engine<S> {
         &mut self,
         group_id: &GroupId,
     ) -> Result<Option<u64>, OpenMlsProjectionError> {
+        // Convergence scheduling for a seeded-but-unhydrated group promotes
+        // it first (mdk#1161); a hydration failure quarantines it and the
+        // gate below reports no work.
+        let _ = self.ensure_hydrated(group_id);
         if self.ensure_group_live(group_id).is_err() {
             return Ok(None);
         }
@@ -967,6 +971,10 @@ impl<S: StorageProvider> Engine<S> {
         now: ConvergenceTime,
     ) -> Result<CanonicalizationResult, OpenMlsProjectionError> {
         let now_ms = now.monotonic_ms;
+        // A convergence pass over a seeded-but-unhydrated group promotes it
+        // first (mdk#1161); a hydration failure quarantines it and the gate
+        // below reports the blocked run.
+        let _ = self.ensure_hydrated(group_id);
         // A hydration-quarantined group is frozen until explicit repair: no
         // canonicalization pass may read or mutate its state, and no
         // set_stable may re-activate it out of band (mdk#364). Check this

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -248,6 +248,11 @@ impl<S: StorageProvider> Engine<S> {
         group_id: &GroupId,
         policy: CanonicalizationPolicy,
     ) -> Result<(), OpenMlsProjectionError> {
+        // Promote a seeded-but-unhydrated group first (mdk#1161) so the audit
+        // context snapshot below reads validated state; a hydration failure
+        // quarantines and the write proceeds as it does for quarantined
+        // groups today (the policy is durable config, not group state).
+        let _ = self.ensure_hydrated(group_id);
         self.accept_convergence_policy(&policy)?;
         self.storage
             .put_convergence_policy(group_id, &encode_convergence_policy(&policy)?)
@@ -368,6 +373,8 @@ impl<S: StorageProvider> Engine<S> {
         message: TransportMessage,
         monotonic_ms: u64,
     ) -> Result<(), OpenMlsProjectionError> {
+        // See `buffer_openmls_convergence_message` (mdk#1161).
+        let _ = self.ensure_hydrated(group_id);
         self.buffer_openmls_convergence_message_with_time(
             group_id,
             message,
@@ -384,6 +391,10 @@ impl<S: StorageProvider> Engine<S> {
         group_id: &GroupId,
         message: TransportMessage,
     ) -> Result<(), OpenMlsProjectionError> {
+        // Promote a seeded-but-unhydrated group before persisting convergence
+        // input against it (mdk#1161): the group's interrupted probe/apply
+        // recovery must run before any of its stored state is extended.
+        let _ = self.ensure_hydrated(group_id);
         self.buffer_openmls_convergence_message_with_time(group_id, message, self.convergence_now())
     }
 

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -285,6 +285,25 @@ pub struct Engine<S: StorageProvider> {
     /// successful [`Self::retry_hydrate_quarantined_group`].
     pub(crate) quarantined_groups: HashMap<GroupId, GroupHydrationQuarantineReason>,
 
+    /// Groups seeded by the session-open cheap pass whose full per-group
+    /// hydration (MLS load, validation, pending-commit recovery) has not run
+    /// yet (mdk#1161). The seed grants each group a provisional
+    /// `Stable(record.epoch)` epoch entry — so `live_group_ids` and the app
+    /// projection keep listing it — while [`Self::ensure_group_live`] fails
+    /// closed with [`EngineError::GroupNotHydrated`] on every gated surface.
+    /// Membership leaves this set only through [`Self::ensure_hydrated`]:
+    /// success promotes the group to live, failure moves it to
+    /// [`Self::quarantined_groups`] exactly like an open-time quarantine.
+    pub(crate) unhydrated_groups: HashSet<GroupId>,
+
+    /// Seeded, non-disbanded groups with no durable transport-route row yet
+    /// (records predating migration 0043, or a provider without a route
+    /// store). While non-empty, a routing-index miss cannot be trusted:
+    /// ingest backfills these groups' routes on demand — each group leaves
+    /// this set permanently after one MLS load, preserving mdk#740's
+    /// attacker-paced-scan bound in amortized form.
+    pub(crate) route_backfill_pending: HashSet<GroupId>,
+
     /// Authoritative `transport_group_id -> GroupId` resolver for inbound
     /// routing (#740). A Nostr-routed group's `transport_group_id`
     /// (`nostr_group_id`) differs from its MLS group id, so the direct
@@ -578,6 +597,8 @@ impl<S: StorageProvider> EngineBuilder<S> {
             audit_operation_counter: 0,
             current_audit_context: None,
             quarantined_groups: HashMap::new(),
+            unhydrated_groups: HashSet::new(),
+            route_backfill_pending: HashSet::new(),
             transport_group_id_index: HashMap::new(),
             seen_message_ids_hex_cache: None,
             deferred_peel: HashMap::new(),
@@ -739,9 +760,13 @@ impl<S: StorageProvider> Engine<S> {
             .list_outbound_fanouts()?
             .into_iter()
             .filter(|fanout| {
-                fanout
-                    .group_id()
-                    .is_none_or(|group_id| !self.quarantined_groups.contains_key(group_id))
+                fanout.group_id().is_none_or(|group_id| {
+                    // Unhydrated groups' fanouts stay frozen until full
+                    // hydration restores their pending lifecycle (mdk#1161);
+                    // quarantined groups' fanouts are hidden as before.
+                    !self.quarantined_groups.contains_key(group_id)
+                        && !self.unhydrated_groups.contains(group_id)
+                })
             })
             .collect())
     }
@@ -1176,6 +1201,23 @@ impl<S: StorageProvider> Engine<S> {
     /// `MlsGroup::load` is cost-appropriate. Best-effort: a load / routing-read
     /// failure just forfeits the fast path for this group (inbound would fall to
     /// the unknown-group disposition), never fails the merge.
+    /// Insert one transport route into the in-memory resolver AND the durable
+    /// route table (mdk#1161). The durable write is best-effort with the same
+    /// policy as every route refresh: a failure only forfeits the next
+    /// cold-start route seed, never routing correctness — the in-memory
+    /// insert stays authoritative for this session.
+    pub(crate) fn index_transport_group_route(
+        &mut self,
+        transport_group_id: Vec<u8>,
+        group_id: &GroupId,
+    ) {
+        self.transport_group_id_index
+            .insert(transport_group_id.clone(), group_id.clone());
+        let _ = self
+            .storage
+            .put_transport_group_route(&transport_group_id, group_id);
+    }
+
     pub(crate) fn reindex_transport_group_id(&mut self, group_id: &GroupId) {
         let mls_group = {
             let provider = crate::provider::EngineOpenMlsProvider::<S>::new(
@@ -1196,23 +1238,179 @@ impl<S: StorageProvider> Engine<S> {
         if let Ok(transport_group_id) =
             crate::app_components::transport_group_id_of_group(&mls_group)
         {
-            self.transport_group_id_index
-                .insert(transport_group_id, group_id.clone());
+            self.index_transport_group_route(transport_group_id, group_id);
         }
     }
 
+    /// Session-open cheap pass (mdk#1161): seed every stored group's epoch
+    /// entry, terminal markers, and transport route from durable records —
+    /// without loading MLS state, listing snapshots, or scanning messages —
+    /// so open cost stays flat in stored group count.
+    ///
+    /// Seeded groups enter [`Self::unhydrated_groups`] and fail closed with
+    /// [`EngineError::GroupNotHydrated`] on every gated surface until
+    /// [`Self::ensure_hydrated`] runs their full hydration (on demand from a
+    /// `&mut` entry point, or from the embedder's background pipeline over
+    /// [`Self::unhydrated_group_ids`]). Disbanded and unrecoverable groups
+    /// restore their terminal state here exactly as before, including the
+    /// every-open `GroupUnrecoverable` re-emit. Idempotent: groups that
+    /// already hold an epoch entry or a quarantine entry are left untouched,
+    /// so a second call never demotes a live group.
     pub fn hydrate_stable_groups_from_storage(&mut self) -> Result<(), EngineError> {
-        let stored_groups = self.storage.list_groups()?;
-        let stored_group_ids = stored_groups.iter().cloned().collect::<HashSet<_>>();
-        for group_id in stored_groups {
-            if let Err(reason) = self.hydrate_one_stored_group(&group_id) {
-                self.quarantine_stored_group_on_hydrate(&group_id, reason);
+        // One unreadable record must quarantine that one group, never abort
+        // the whole account open (mdk#151 / #417). The bulk read is the fast
+        // path; if it fails, re-read per group and carry each failure as the
+        // group id it belongs to.
+        let records: Vec<Result<Group, GroupId>> = match self.storage.list_group_records() {
+            Ok(records) => records.into_iter().map(Ok).collect(),
+            Err(_) => self
+                .storage
+                .list_groups()?
+                .into_iter()
+                .map(|group_id| self.storage.get_group(&group_id).map_err(|_| group_id))
+                .collect(),
+        };
+        let mut tombstones: HashMap<GroupId, cgka_traits::DisbandTombstone> = self
+            .storage
+            .list_disband_tombstones()?
+            .into_iter()
+            .collect();
+        let mut stored_group_ids = HashSet::with_capacity(records.len());
+        let mut seedable_group_ids = HashSet::new();
+        for record in records {
+            let group = match record {
+                Ok(group) => group,
+                Err(group_id) => {
+                    stored_group_ids.insert(group_id.clone());
+                    if self.epoch_manager.state(&group_id).is_none()
+                        && !self.quarantined_groups.contains_key(&group_id)
+                    {
+                        self.quarantine_stored_group_on_hydrate(
+                            &group_id,
+                            GroupHydrationQuarantineReason::GroupRecordLoadFailed,
+                        );
+                    }
+                    continue;
+                }
+            };
+            stored_group_ids.insert(group.id.clone());
+            if self.epoch_manager.state(&group.id).is_some()
+                || self.quarantined_groups.contains_key(&group.id)
+            {
+                continue;
+            }
+            let tombstone = group
+                .disbanded
+                .clone()
+                .or_else(|| tombstones.remove(&group.id));
+            if let Some(tombstone) = tombstone {
+                // Reconcile the single deterministic system row after a
+                // crash. The application projection canonicalizes this event,
+                // so replaying it on open is idempotent.
+                self.restore_disband_tombstone(group.id, tombstone)?;
+                continue;
+            }
+            if group.unrecoverable {
+                // mdk#971: a durable Unrecoverable halt must survive process
+                // restart, and the durable lifecycle marker is also an
+                // application-facing repair requirement — re-emit it on every
+                // session open because the original transition event belonged
+                // to the prior process. Terminal until a verified repair path
+                // (re-join welcome) clears the marker, so the group is NOT
+                // queued for lazy hydration.
+                self.epoch_manager
+                    .restore_unrecoverable(group.id.clone(), group.epoch);
+                self.audit_group(
+                    &group.id,
+                    crate::audit_helpers::epoch_state_changed_event(
+                        None,
+                        "unrecoverable",
+                        group.epoch,
+                        "hydrate_unrecoverable_group",
+                        None,
+                        None,
+                    ),
+                );
+                self.events_buf.push_back(GroupEvent::GroupUnrecoverable {
+                    group_id: group.id.clone(),
+                });
+                seedable_group_ids.insert(group.id);
+                continue;
+            }
+            // Provisional seed: the durable record's epoch mirror keeps
+            // `live_group_ids` and the app projection listing this group
+            // while full hydration is outstanding. A crash mid-probe may
+            // have left the record rewound; the interrupted-probe rollback
+            // runs inside `ensure_hydrated` before any gated read, and the
+            // only pre-rollback reads are these display-provisional record
+            // fields, which full hydration re-derives.
+            self.epoch_manager.set_stable(group.id.clone(), group.epoch);
+            self.audit_group(
+                &group.id,
+                crate::audit_helpers::epoch_state_changed_event(
+                    None,
+                    "seeded",
+                    group.epoch,
+                    "hydrate_seed_group",
+                    None,
+                    None,
+                ),
+            );
+            self.unhydrated_groups.insert(group.id.clone());
+            seedable_group_ids.insert(group.id);
+        }
+
+        // Seed inbound routing from the durable route table so unhydrated
+        // groups still resolve (mdk#740 semantics preserved: many-to-one,
+        // rotation overlap retained). Groups without a durable route —
+        // records predating migration 0043 or a provider without a route
+        // store — go to the backfill set: ingest re-derives their route from
+        // one MLS load on demand, and the background pipeline orders them
+        // first.
+        let mut routed_group_ids = HashSet::new();
+        for (transport_group_id, group_id) in self.storage.list_transport_group_routes()? {
+            if stored_group_ids.contains(&group_id) {
+                routed_group_ids.insert(group_id.clone());
+                self.transport_group_id_index
+                    .insert(transport_group_id, group_id);
             }
         }
-        for (group_id, tombstone) in self.storage.list_disband_tombstones()? {
-            if !stored_group_ids.contains(&group_id) {
+        for group_id in seedable_group_ids {
+            if !routed_group_ids.contains(&group_id) {
+                self.route_backfill_pending.insert(group_id);
+            }
+        }
+
+        for (group_id, tombstone) in tombstones {
+            if !stored_group_ids.contains(&group_id)
+                && self.epoch_manager.state(&group_id).is_none()
+            {
                 self.restore_disband_tombstone(group_id, tombstone)?;
             }
+        }
+        let stored_group_count = stored_group_ids.len();
+        tracing::debug!(
+            target: "cgka_engine::hydrate",
+            method = "hydrate_stable_groups_from_storage",
+            stored_groups = stored_group_count,
+            unhydrated_groups = self.unhydrated_groups.len(),
+            route_backfill_pending = self.route_backfill_pending.len(),
+            "seeded stored groups without full hydration"
+        );
+        Ok(())
+    }
+
+    /// Eager-compatibility hydration: run the cheap pass, then drain every
+    /// seeded group through full hydration immediately, swallowing per-group
+    /// quarantines exactly like the pre-mdk#1161 all-groups open loop. For
+    /// tests and embedders that want every group live (or quarantined) before
+    /// the session serves work.
+    pub fn hydrate_all_stored_groups(&mut self) -> Result<(), EngineError> {
+        self.hydrate_stable_groups_from_storage()?;
+        for group_id in self.unhydrated_group_ids() {
+            // A failed hydration quarantines the group inside
+            // `ensure_hydrated`; the rest of the account still opens.
+            let _ = self.ensure_hydrated(&group_id);
         }
         Ok(())
     }
@@ -1313,9 +1511,9 @@ impl<S: StorageProvider> Engine<S> {
         if let Ok(transport_group_id) =
             crate::app_components::transport_group_id_of_group(&mls_group)
         {
-            self.transport_group_id_index
-                .insert(transport_group_id, group_id.clone());
+            self.index_transport_group_route(transport_group_id, group_id);
         }
+        self.route_backfill_pending.remove(group_id);
         let wire_protocol_profile =
             crate::account_identity_proof::protocol_profile_of_group(&mls_group)
                 .map_err(|_| GroupHydrationQuarantineReason::MemberValidationFailed)?;
@@ -1528,11 +1726,7 @@ impl<S: StorageProvider> Engine<S> {
             .map_err(|_| GroupHydrationQuarantineReason::GroupRecordLoadFailed)?
             .is_empty();
         let has_convergence_inputs = self
-            .has_unresolved_convergence_inputs_in_records(
-                group_id,
-                &group,
-                &stored_message_records,
-            )
+            .has_unresolved_convergence_inputs_in_records(group_id, &group, &stored_message_records)
             .map_err(|_| GroupHydrationQuarantineReason::GroupRecordLoadFailed)?;
         let has_deferred_peels = stored_message_records
             .iter()
@@ -2022,6 +2216,11 @@ impl<S: StorageProvider> Engine<S> {
             group_digest,
             reason: reason_tag.to_string(),
         });
+        // A quarantined group must not retain an epoch entry: the cheap-pass
+        // seed (and any partial transition applied before the failure) would
+        // otherwise keep it listed in `live_group_ids` while every accessor
+        // rejects it (mdk#1161).
+        self.epoch_manager.clear_group_state(group_id);
         self.quarantined_groups.insert(group_id.clone(), reason);
         self.events_buf
             .push_back(GroupEvent::GroupHydrationQuarantined {
@@ -2077,7 +2276,68 @@ impl<S: StorageProvider> Engine<S> {
         if self.quarantined_groups.contains_key(group_id) {
             return Err(EngineError::UnknownGroup(group_id.clone()));
         }
+        // Seeded-but-unhydrated groups fail closed with the retryable variant
+        // (mdk#1161): full hydration has not validated this group yet, so no
+        // accessor, send, or convergence path may treat it as live. `&mut`
+        // entry points call [`Self::ensure_hydrated`] first to promote the
+        // group instead of failing.
+        if self.unhydrated_groups.contains(group_id) {
+            return Err(EngineError::GroupNotHydrated(group_id.clone()));
+        }
         Ok(())
+    }
+
+    /// Run full per-group hydration for a group the session-open cheap pass
+    /// only seeded (mdk#1161). No-op for live, quarantined, disbanded, or
+    /// unknown groups — callers keep their existing handling for those.
+    ///
+    /// On success the group is promoted to live: its recovery events
+    /// (`PendingCommitRecovered`, leave-request restore) and convergence
+    /// scheduling fire now. On failure the group moves to the quarantine
+    /// surface exactly as an open-time hydration failure would, and the
+    /// caller observes `UnknownGroup` — the same view a quarantined group
+    /// has always presented.
+    pub fn ensure_hydrated(&mut self, group_id: &GroupId) -> Result<(), EngineError> {
+        if !self.unhydrated_groups.contains(group_id) {
+            return Ok(());
+        }
+        self.unhydrated_groups.remove(group_id);
+        // Retract the provisional seed so full hydration derives the real
+        // epoch entry from the same entry-absent conditions the open-time
+        // loop always had. The record's epoch mirror is projected forward
+        // over a pending evolution, so leaving the seed in place would hand
+        // `restore_pending` a wrong `begin_pending` base.
+        self.epoch_manager.clear_group_state(group_id);
+        match self.hydrate_one_stored_group(group_id) {
+            Ok(_epoch) => {
+                self.route_backfill_pending.remove(group_id);
+                Ok(())
+            }
+            Err(reason) => {
+                self.route_backfill_pending.remove(group_id);
+                self.quarantine_stored_group_on_hydrate(group_id, reason);
+                Err(EngineError::UnknownGroup(group_id.clone()))
+            }
+        }
+    }
+
+    /// Group ids still awaiting full hydration, route-backfill-pending groups
+    /// first (they also block trust in routing-index misses, so a background
+    /// pipeline should clear them earliest).
+    pub fn unhydrated_group_ids(&self) -> Vec<GroupId> {
+        let mut ids: Vec<GroupId> = self
+            .route_backfill_pending
+            .iter()
+            .filter(|group_id| self.unhydrated_groups.contains(*group_id))
+            .cloned()
+            .collect();
+        ids.extend(
+            self.unhydrated_groups
+                .iter()
+                .filter(|group_id| !self.route_backfill_pending.contains(*group_id))
+                .cloned(),
+        );
+        ids
     }
 
     /// Re-attempt hydration of a single quarantined group.
@@ -2879,6 +3139,11 @@ impl<S: StorageProvider + 'static> CgkaEngine for Engine<S> {
     }
 
     fn epoch(&self, group_id: &GroupId) -> Result<EpochId, EngineError> {
+        // Gate explicitly: a seeded-but-unhydrated group HOLDS a provisional
+        // epoch entry (mdk#1161), so the entry-presence check below no longer
+        // implies the group is live the way it did when quarantined groups
+        // were simply absent.
+        self.ensure_group_live(group_id)?;
         self.epoch_manager
             .epoch(group_id)
             .ok_or_else(|| EngineError::UnknownGroup(group_id.clone()))

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -1155,40 +1155,43 @@ impl<S: StorageProvider> Engine<S> {
         rows
     }
 
-    /// Restore stable epoch state for groups already present in storage.
+    /// Insert one transport route into the in-memory resolver AND the durable
+    /// route table (mdk#1161), stamped with the group epoch that observed the
+    /// route as current, then retire durable rows the retained-history window
+    /// has moved past (routing-v1: a prior address is accepted only until no
+    /// epoch using it remains in either retained window).
     ///
-    /// This is used by production session startup after opening durable
-    /// storage. The application is expected to resolve publish success/failure
-    /// (`confirm_published` / `publish_failed`) before shutdown, but a *crash*
-    /// between transport publish and that resolution violates the
-    /// precondition: OpenMLS durably persists the staged commit
-    /// (`MlsGroupState::PendingCommit`) and `MlsGroup::load` restores it, while
-    /// the in-memory `PendingStateRef` that `confirm_published` /
-    /// `publish_failed` require is gone (the `EpochManager` starts empty on
-    /// every open). Left untouched, the group is stranded: every subsequent
-    /// commit-creating operation fails with a pending-commit error forever.
-    ///
-    /// So at hydrate time we detect a surviving pending commit and clear it,
-    /// treating an unresolved pending publish as publish-failed (the same
-    /// rewind `do_publish_failed` performs). The MLS group returns to its
-    /// pre-stage epoch, we re-derive the Marmot record from that cleared
-    /// state, and we surface a typed `PendingCommitRecovered` event so the
-    /// application can run a recovery / resync path — if relays accepted the
-    /// commit before the crash, this device is now behind and must catch up.
-    ///
-    /// **Member-removing commits are deliberately left untouched.** A surviving
-    /// pending commit is NOT a reliable crash signal on its own: a deferred
-    /// SelfRemove-only commit (the MIP-03 leave path) legitimately persists a
-    /// staged commit across process boundaries — a remaining member stages the
-    /// commit, projects the departing member out of the Marmot record
-    /// *forward*, and a later run publishes + confirms it. Rolling that
-    /// back re-derives the record from the pre-stage MLS state and so re-adds a
-    /// member who already left, forking convergence (the remaining members
-    /// advance past the leave while this device silently rewinds it). Clearing
-    /// an additive (invite) commit is safe — it only drops an invitee who never
-    /// actually joined — but clearing a Remove/SelfRemove is not. We therefore
-    /// scope crash-recovery to staged commits that remove no members, matching
-    /// the prior (pre-recovery) behaviour for removal-bearing commits.
+    /// The durable writes are best-effort with the same policy as every route
+    /// refresh: a failure only forfeits the next cold-start route seed, never
+    /// routing correctness — the in-memory insert stays authoritative for
+    /// this session, and the session-open seed detects the resulting stale
+    /// epoch stamp and schedules a backfill repair.
+    pub(crate) fn index_transport_group_route(
+        &mut self,
+        transport_group_id: Vec<u8>,
+        group_id: &GroupId,
+        source_epoch: EpochId,
+    ) {
+        self.transport_group_id_index
+            .insert(transport_group_id.clone(), group_id.clone());
+        let _ = self
+            .storage
+            .put_transport_group_route(&transport_group_id, group_id, source_epoch);
+        // Durable retirement: rows last observed current before the retained
+        // horizon can no longer carry acceptable traffic. (The in-memory map
+        // stays session-scoped; its growth is tracked separately as #896.)
+        if let Ok(policy) = self.convergence_policy_for_group_ungated(group_id) {
+            let cutoff = EpochId(
+                source_epoch
+                    .0
+                    .saturating_sub(policy.convergence.max_rewind_commits),
+            );
+            let _ = self
+                .storage
+                .delete_transport_group_routes_below_epoch(group_id, cutoff);
+        }
+    }
+
     /// Additively refresh a group's `transport_group_id_index` entry from live
     /// MLS state after a commit that may have changed the Nostr routing
     /// component (#740 rotation). Inserts the group's CURRENT `transport_group_id`;
@@ -1200,24 +1203,10 @@ impl<S: StorageProvider> Engine<S> {
     /// only fire on commit application, not per app message, so the extra
     /// `MlsGroup::load` is cost-appropriate. Best-effort: a load / routing-read
     /// failure just forfeits the fast path for this group (inbound would fall to
-    /// the unknown-group disposition), never fails the merge.
-    /// Insert one transport route into the in-memory resolver AND the durable
-    /// route table (mdk#1161). The durable write is best-effort with the same
-    /// policy as every route refresh: a failure only forfeits the next
-    /// cold-start route seed, never routing correctness — the in-memory
-    /// insert stays authoritative for this session.
-    pub(crate) fn index_transport_group_route(
-        &mut self,
-        transport_group_id: Vec<u8>,
-        group_id: &GroupId,
-    ) {
-        self.transport_group_id_index
-            .insert(transport_group_id.clone(), group_id.clone());
-        let _ = self
-            .storage
-            .put_transport_group_route(&transport_group_id, group_id);
-    }
-
+    /// the unknown-group disposition), never fails the merge — and because this
+    /// runs after the commit transaction, the durable route row can lag the
+    /// record epoch; the session-open seed treats that lag as a stale route
+    /// set and schedules a backfill repair (mdk#1161).
     pub(crate) fn reindex_transport_group_id(&mut self, group_id: &GroupId) {
         let mls_group = {
             let provider = crate::provider::EngineOpenMlsProvider::<S>::new(
@@ -1238,7 +1227,8 @@ impl<S: StorageProvider> Engine<S> {
         if let Ok(transport_group_id) =
             crate::app_components::transport_group_id_of_group(&mls_group)
         {
-            self.index_transport_group_route(transport_group_id, group_id);
+            let current_epoch = EpochId(mls_group.epoch().as_u64());
+            self.index_transport_group_route(transport_group_id, group_id, current_epoch);
         }
     }
 
@@ -1276,7 +1266,7 @@ impl<S: StorageProvider> Engine<S> {
             .into_iter()
             .collect();
         let mut stored_group_ids = HashSet::with_capacity(records.len());
-        let mut seedable_group_ids = HashSet::new();
+        let mut seeded_group_epochs: HashMap<GroupId, EpochId> = HashMap::new();
         for record in records {
             let group = match record {
                 Ok(group) => group,
@@ -1312,12 +1302,18 @@ impl<S: StorageProvider> Engine<S> {
             }
             if group.unrecoverable {
                 // mdk#971: a durable Unrecoverable halt must survive process
-                // restart, and the durable lifecycle marker is also an
-                // application-facing repair requirement — re-emit it on every
-                // session open because the original transition event belonged
-                // to the prior process. Terminal until a verified repair path
-                // (re-join welcome) clears the marker, so the group is NOT
-                // queued for lazy hydration.
+                // restart. Seed the halted epoch entry so every convergence /
+                // ingest gate observes it immediately, and queue the group
+                // for full hydration like any other seeded group: an
+                // unrecoverable group still needs its per-group hydration
+                // work (route indexing, interrupted probe/apply recovery,
+                // leave-request restore) — the pre-mdk#1161 open always ran
+                // it, and `hydrate_all_stored_groups` must stay
+                // behavior-preserving. `hydrate_one_stored_group` restores
+                // the halt and re-emits the application-facing
+                // `GroupUnrecoverable` event when it runs, so the event
+                // stays once-per-open on the eager path and arrives with the
+                // group's promotion on the deferred path.
                 self.epoch_manager
                     .restore_unrecoverable(group.id.clone(), group.epoch);
                 self.audit_group(
@@ -1331,10 +1327,8 @@ impl<S: StorageProvider> Engine<S> {
                         None,
                     ),
                 );
-                self.events_buf.push_back(GroupEvent::GroupUnrecoverable {
-                    group_id: group.id.clone(),
-                });
-                seedable_group_ids.insert(group.id);
+                self.unhydrated_groups.insert(group.id.clone());
+                seeded_group_epochs.insert(group.id, group.epoch);
                 continue;
             }
             // Provisional seed: the durable record's epoch mirror keeps
@@ -1357,26 +1351,38 @@ impl<S: StorageProvider> Engine<S> {
                 ),
             );
             self.unhydrated_groups.insert(group.id.clone());
-            seedable_group_ids.insert(group.id);
+            seeded_group_epochs.insert(group.id, group.epoch);
         }
 
         // Seed inbound routing from the durable route table so unhydrated
         // groups still resolve (mdk#740 semantics preserved: many-to-one,
-        // rotation overlap retained). Groups without a durable route —
-        // records predating migration 0043 or a provider without a route
-        // store — go to the backfill set: ingest re-derives their route from
-        // one MLS load on demand, and the background pipeline orders them
-        // first.
-        let mut routed_group_ids = HashSet::new();
-        for (transport_group_id, group_id) in self.storage.list_transport_group_routes()? {
-            if stored_group_ids.contains(&group_id) {
-                routed_group_ids.insert(group_id.clone());
-                self.transport_group_id_index
-                    .insert(transport_group_id, group_id);
+        // rotation overlap retained). A group's route set is trusted only if
+        // some row was stamped at the record's current epoch: every commit
+        // apply refreshes the current route's epoch stamp, so a lagging stamp
+        // means the last commit (which may have rotated the route) was not
+        // followed by a route write — a crash or write failure — and current
+        // traffic could miss the index. Untrusted and route-less groups —
+        // including records predating migration 0043 or providers without a
+        // route store — go to the backfill set: ingest re-derives their
+        // current route from one MLS load on demand, and the background
+        // pipeline orders them first. Stale rows still seed the index so
+        // overlap-window traffic keeps resolving.
+        let mut current_routed_group_ids = HashSet::new();
+        for route in self.storage.list_transport_group_routes()? {
+            if !stored_group_ids.contains(&route.group_id) {
+                continue;
             }
+            if seeded_group_epochs
+                .get(&route.group_id)
+                .is_some_and(|epoch| route.source_epoch >= *epoch)
+            {
+                current_routed_group_ids.insert(route.group_id.clone());
+            }
+            self.transport_group_id_index
+                .insert(route.transport_group_id, route.group_id);
         }
-        for group_id in seedable_group_ids {
-            if !routed_group_ids.contains(&group_id) {
+        for group_id in seeded_group_epochs.into_keys() {
+            if !current_routed_group_ids.contains(&group_id) {
                 self.route_backfill_pending.insert(group_id);
             }
         }
@@ -1448,6 +1454,40 @@ impl<S: StorageProvider> Engine<S> {
         Ok(())
     }
 
+    /// Full per-group hydration: load and validate one stored group's MLS and
+    /// Marmot state, run its crash recovery, and restore its live epoch entry.
+    ///
+    /// The application is expected to resolve publish success/failure
+    /// (`confirm_published` / `publish_failed`) before shutdown, but a *crash*
+    /// between transport publish and that resolution violates the
+    /// precondition: OpenMLS durably persists the staged commit
+    /// (`MlsGroupState::PendingCommit`) and `MlsGroup::load` restores it, while
+    /// the in-memory `PendingStateRef` that `confirm_published` /
+    /// `publish_failed` require is gone (the `EpochManager` starts empty on
+    /// every open). Left untouched, the group is stranded: every subsequent
+    /// commit-creating operation fails with a pending-commit error forever.
+    ///
+    /// So hydration detects a surviving pending commit and clears it,
+    /// treating an unresolved pending publish as publish-failed (the same
+    /// rewind `do_publish_failed` performs). The MLS group returns to its
+    /// pre-stage epoch, we re-derive the Marmot record from that cleared
+    /// state, and we surface a typed `PendingCommitRecovered` event so the
+    /// application can run a recovery / resync path — if relays accepted the
+    /// commit before the crash, this device is now behind and must catch up.
+    ///
+    /// **Member-removing commits are deliberately left untouched.** A surviving
+    /// pending commit is NOT a reliable crash signal on its own: a deferred
+    /// SelfRemove-only commit (the MIP-03 leave path) legitimately persists a
+    /// staged commit across process boundaries — a remaining member stages the
+    /// commit, projects the departing member out of the Marmot record
+    /// *forward*, and a later run publishes + confirms it. Rolling that
+    /// back re-derives the record from the pre-stage MLS state and so re-adds a
+    /// member who already left, forking convergence (the remaining members
+    /// advance past the leave while this device silently rewinds it). Clearing
+    /// an additive (invite) commit is safe — it only drops an invitee who never
+    /// actually joined — but clearing a Remove/SelfRemove is not. We therefore
+    /// scope crash-recovery to staged commits that remove no members, matching
+    /// the prior (pre-recovery) behaviour for removal-bearing commits.
     fn hydrate_one_stored_group(
         &mut self,
         group_id: &GroupId,
@@ -1511,7 +1551,8 @@ impl<S: StorageProvider> Engine<S> {
         if let Ok(transport_group_id) =
             crate::app_components::transport_group_id_of_group(&mls_group)
         {
-            self.index_transport_group_route(transport_group_id, group_id);
+            let current_epoch = EpochId(mls_group.epoch().as_u64());
+            self.index_transport_group_route(transport_group_id, group_id, current_epoch);
         }
         self.route_backfill_pending.remove(group_id);
         let wire_protocol_profile =

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -1254,7 +1254,23 @@ impl<S: StorageProvider> Engine<S> {
         &mut self,
         group_id: &GroupId,
     ) -> Result<EpochId, GroupHydrationQuarantineReason> {
-        let group = self
+        // A retained-anchor convergence probe durably rewinds the group while
+        // it explores historical candidates. Process termination cannot run
+        // the in-process rollback guard, so restore its pre-probe live snapshot
+        // before loading any MLS or Marmot state — including the group record
+        // read below, whose epoch seeds the epoch manager.
+        crate::openmls_projection::recover_interrupted_retained_anchor_probe(
+            &self.storage,
+            group_id,
+        )
+        .map_err(|_| GroupHydrationQuarantineReason::GroupRecordLoadFailed)?;
+        crate::openmls_projection::recover_interrupted_apply_snapshot(&self.storage, group_id)
+            .map_err(|_| GroupHydrationQuarantineReason::GroupRecordLoadFailed)?;
+
+        // The one group-record read for this hydration (mdk#1161): every later
+        // consumer (tombstone check, profile mirror check, pending-commit
+        // recovery, epoch seeding) shares this post-recovery record.
+        let mut group = self
             .storage
             .get_group(group_id)
             .map_err(|_| GroupHydrationQuarantineReason::GroupRecordLoadFailed)?;
@@ -1274,17 +1290,6 @@ impl<S: StorageProvider> Engine<S> {
                 .map_err(|_| GroupHydrationQuarantineReason::GroupRecordLoadFailed)?;
             return Ok(epoch);
         }
-        // A retained-anchor convergence probe durably rewinds the group while
-        // it explores historical candidates. Process termination cannot run
-        // the in-process rollback guard, so restore its pre-probe live snapshot
-        // before loading any MLS or Marmot state.
-        crate::openmls_projection::recover_interrupted_retained_anchor_probe(
-            &self.storage,
-            group_id,
-        )
-        .map_err(|_| GroupHydrationQuarantineReason::GroupRecordLoadFailed)?;
-        crate::openmls_projection::recover_interrupted_apply_snapshot(&self.storage, group_id)
-            .map_err(|_| GroupHydrationQuarantineReason::GroupRecordLoadFailed)?;
 
         let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
         let mut mls_group = {
@@ -1359,10 +1364,6 @@ impl<S: StorageProvider> Engine<S> {
             }
         }
 
-        let mut group = self
-            .storage
-            .get_group(group_id)
-            .map_err(|_| GroupHydrationQuarantineReason::GroupRecordLoadFailed)?;
         if group.protocol_profile != wire_protocol_profile {
             return Err(GroupHydrationQuarantineReason::MemberValidationFailed);
         }
@@ -1493,12 +1494,28 @@ impl<S: StorageProvider> Engine<S> {
                 });
         }
 
+        // The one full message scan for this hydration (mdk#1161): the
+        // leave-request probe, the convergence-input gate, the deferred-peel
+        // check, and the self-remove schedule restore below all classify
+        // subsets of the same rows, so they share this fetch instead of each
+        // re-reading the whole group message table.
+        let stored_message_records = self
+            .storage
+            .list_messages(group_id, EpochId(0))
+            .map_err(|_| GroupHydrationQuarantineReason::GroupRecordLoadFailed)?;
+
         let provider = crate::provider::EngineOpenMlsProvider::<S>::new(
             &self.crypto,
             self.storage.mls_storage(),
         );
         let leave_request = self
-            .leave_request_to_restore_on_hydrate(group_id, &mut mls_group, &group, &provider)
+            .leave_request_to_restore_on_hydrate(
+                group_id,
+                &mut mls_group,
+                &group,
+                &provider,
+                &stored_message_records,
+            )
             .map_err(|_| GroupHydrationQuarantineReason::GroupRecordLoadFailed)?;
 
         // Startup must recreate the in-memory scheduling edge for durable
@@ -1511,13 +1528,14 @@ impl<S: StorageProvider> Engine<S> {
             .map_err(|_| GroupHydrationQuarantineReason::GroupRecordLoadFailed)?
             .is_empty();
         let has_convergence_inputs = self
-            .has_pending_convergence_inputs(group_id)
+            .has_unresolved_convergence_inputs_in_records(
+                group_id,
+                &group,
+                &stored_message_records,
+            )
             .map_err(|_| GroupHydrationQuarantineReason::GroupRecordLoadFailed)?;
-        let has_deferred_peels = self
-            .storage
-            .list_messages(group_id, EpochId(0))
-            .map_err(|_| GroupHydrationQuarantineReason::GroupRecordLoadFailed)?
-            .into_iter()
+        let has_deferred_peels = stored_message_records
+            .iter()
             .any(|record| record.state == MessageState::PeelDeferred);
 
         // Do not expose any recovered pending state until every fallible
@@ -1594,10 +1612,11 @@ impl<S: StorageProvider> Engine<S> {
         }
 
         let restored_self_remove_work = self
-            .restore_self_remove_auto_commit_schedules_for_group(
+            .restore_self_remove_auto_commit_schedules_in_records(
                 group_id,
                 group.epoch,
                 self.convergence_now_ms(),
+                &stored_message_records,
             )
             .map_err(|_| GroupHydrationQuarantineReason::GroupRecordLoadFailed)?;
         if has_queued_intents
@@ -1746,6 +1765,7 @@ impl<S: StorageProvider> Engine<S> {
         mls_group: &mut openmls::group::MlsGroup,
         group: &Group,
         provider: &crate::provider::EngineOpenMlsProvider<'_, S>,
+        stored_message_records: &[cgka_traits::message::MessageRecord],
     ) -> Result<Option<LeaveRequest>, StorageError> {
         let self_is_still_member = group
             .members
@@ -1759,7 +1779,11 @@ impl<S: StorageProvider> Engine<S> {
         if let Some(mut request) = self.storage.leave_request(group_id)? {
             if request.last_proposed_epoch.is_none()
                 && self.sent_self_remove_leaving_gate_should_restore(
-                    group_id, mls_group, group, provider,
+                    group_id,
+                    mls_group,
+                    group,
+                    provider,
+                    stored_message_records,
                 )?
             {
                 request.last_proposed_epoch = Some(group.epoch);
@@ -1768,9 +1792,13 @@ impl<S: StorageProvider> Engine<S> {
             return Ok(Some(request));
         }
 
-        if self
-            .sent_self_remove_leaving_gate_should_restore(group_id, mls_group, group, provider)?
-        {
+        if self.sent_self_remove_leaving_gate_should_restore(
+            group_id,
+            mls_group,
+            group,
+            provider,
+            stored_message_records,
+        )? {
             let request = LeaveRequest {
                 group_id: group_id.clone(),
                 requested_at_ms: self.convergence_now_ms(),
@@ -1914,6 +1942,7 @@ impl<S: StorageProvider> Engine<S> {
         mls_group: &mut openmls::group::MlsGroup,
         group: &Group,
         provider: &crate::provider::EngineOpenMlsProvider<'_, S>,
+        stored_message_records: &[cgka_traits::message::MessageRecord],
     ) -> Result<bool, cgka_traits::storage::StorageError> {
         if !group
             .members
@@ -1923,7 +1952,7 @@ impl<S: StorageProvider> Engine<S> {
             return Ok(false);
         }
 
-        for record in self.storage.list_messages(group_id, EpochId(0))? {
+        for record in stored_message_records {
             if record.state != MessageState::Sent {
                 continue;
             }

--- a/crates/cgka-engine/src/epoch_manager.rs
+++ b/crates/cgka-engine/src/epoch_manager.rs
@@ -78,6 +78,24 @@ impl EpochManager {
         self.states.get(group_id)
     }
 
+    /// Drop a group's in-memory epoch entry: the retraction path for the
+    /// session-open cheap pass's provisional `Stable` seed (mdk#1161).
+    ///
+    /// Two callers only. `ensure_hydrated` retracts the seed immediately
+    /// before running full per-group hydration, so hydration derives the real
+    /// entry (`set_stable` / `restore_pending` / `restore_unrecoverable`)
+    /// from exactly the entry-absent conditions the open-time loop always
+    /// had — a projected-forward record mirror must not become the
+    /// `begin_pending` base. And `quarantine_stored_group_on_hydrate` clears
+    /// whatever entry remains when hydration fails, because a quarantined
+    /// group must have no epoch entry: `live_group_ids` filters on entry
+    /// presence, and every convergence/ingest gate treats "no state" as "not
+    /// live". Durable halt markers are unaffected:
+    /// `sync_unrecoverable_halt_from_storage` re-syncs them on demand.
+    pub(crate) fn clear_group_state(&mut self, group_id: &GroupId) {
+        self.states.remove(group_id);
+    }
+
     pub(crate) fn epoch(&self, group_id: &GroupId) -> Option<EpochId> {
         self.states.get(group_id).map(|s| s.epoch())
     }

--- a/crates/cgka-engine/src/group_lifecycle.rs
+++ b/crates/cgka-engine/src/group_lifecycle.rs
@@ -542,12 +542,15 @@ impl<S: StorageProvider> Engine<S> {
                 crate::app_components::transport_group_id_of_group(&mls_group)
             {
                 // Inlined `index_transport_group_route` (field-split borrows:
-                // `provider` above still holds `&self`).
+                // `provider` above still holds `&self`); creation needs no
+                // retention prune yet.
                 self.transport_group_id_index
                     .insert(transport_group_id.clone(), group_id.clone());
-                let _ = self
-                    .storage
-                    .put_transport_group_route(&transport_group_id, &group_id);
+                let _ = self.storage.put_transport_group_route(
+                    &transport_group_id,
+                    &group_id,
+                    EpochId(mls_group.epoch().as_u64()),
+                );
             }
         }
 
@@ -710,7 +713,7 @@ impl<S: StorageProvider> Engine<S> {
             if let Ok(transport_group_id) =
                 crate::app_components::transport_group_id_of_group(&mls_group)
             {
-                self.index_transport_group_route(transport_group_id, &group_id);
+                self.index_transport_group_route(transport_group_id, &group_id, canonical_epoch);
             }
             self.epoch_manager
                 .set_stable(group_id.clone(), canonical_epoch);
@@ -1198,7 +1201,8 @@ impl<S: StorageProvider> Engine<S> {
         if let Ok(transport_group_id) =
             crate::app_components::transport_group_id_of_group(&mls_group)
         {
-            self.index_transport_group_route(transport_group_id, &group_id);
+            let joined_epoch = EpochId(mls_group.epoch().as_u64());
+            self.index_transport_group_route(transport_group_id, &group_id, joined_epoch);
         }
 
         // 7. State machine: Stable at the post-welcome epoch.

--- a/crates/cgka-engine/src/group_lifecycle.rs
+++ b/crates/cgka-engine/src/group_lifecycle.rs
@@ -541,8 +541,13 @@ impl<S: StorageProvider> Engine<S> {
             if let Ok(transport_group_id) =
                 crate::app_components::transport_group_id_of_group(&mls_group)
             {
+                // Inlined `index_transport_group_route` (field-split borrows:
+                // `provider` above still holds `&self`).
                 self.transport_group_id_index
-                    .insert(transport_group_id, group_id.clone());
+                    .insert(transport_group_id.clone(), group_id.clone());
+                let _ = self
+                    .storage
+                    .put_transport_group_route(&transport_group_id, &group_id);
             }
         }
 
@@ -705,8 +710,7 @@ impl<S: StorageProvider> Engine<S> {
             if let Ok(transport_group_id) =
                 crate::app_components::transport_group_id_of_group(&mls_group)
             {
-                self.transport_group_id_index
-                    .insert(transport_group_id, group_id.clone());
+                self.index_transport_group_route(transport_group_id, &group_id);
             }
             self.epoch_manager
                 .set_stable(group_id.clone(), canonical_epoch);
@@ -1194,8 +1198,7 @@ impl<S: StorageProvider> Engine<S> {
         if let Ok(transport_group_id) =
             crate::app_components::transport_group_id_of_group(&mls_group)
         {
-            self.transport_group_id_index
-                .insert(transport_group_id, group_id.clone());
+            self.index_transport_group_route(transport_group_id, &group_id);
         }
 
         // 7. State machine: Stable at the post-welcome epoch.
@@ -1265,6 +1268,12 @@ impl<S: StorageProvider> Engine<S> {
                 });
         }
         self.seen_message_ids.insert(welcome_id);
+        // An authenticated welcome re-validated every leaf and wrote fresh
+        // group state, which supersedes any outstanding lazy hydration for
+        // this id (mdk#1161): the group is fully live now, and its route was
+        // indexed above.
+        self.unhydrated_groups.remove(&group_id);
+        self.route_backfill_pending.remove(&group_id);
         // An authenticated welcome re-validated every leaf and wrote fresh
         // group state — strictly stronger evidence of health than
         // `retry_hydrate_quarantined_group` re-reading stored state. Clear a

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -164,7 +164,7 @@ impl<S: StorageProvider> Engine<S> {
         msg: &TransportMessage,
         transport_group_id: Vec<u8>,
     ) -> Result<IngestOutcome, EngineError> {
-        let group_id = self.group_id_for_transport_group_id(&transport_group_id)?;
+        let group_id = self.resolve_or_backfill_group_id_for_transport(&transport_group_id)?;
 
         // Authenticated terminal evidence is permanent. Drop late traffic
         // before the missing-OpenMLS fallback can retain it as retryable
@@ -175,6 +175,12 @@ impl<S: StorageProvider> Engine<S> {
                 category: InputRejectionCategory::UnknownGroup,
             });
         }
+
+        // mdk#1161: an inbound message for a seeded-but-unhydrated group runs
+        // that group's full hydration first, so the peel below sees validated
+        // live state. A hydration failure quarantines the group and the
+        // quarantine gate below retains this input for post-repair replay.
+        let _ = self.ensure_hydrated(&group_id);
 
         // Quarantine gate (mdk#364): a group frozen by hydration
         // quarantine must not process any input — its OpenMLS state may load
@@ -2364,6 +2370,61 @@ impl<S: StorageProvider> Engine<S> {
         }
 
         Ok(direct)
+    }
+
+    /// [`Self::group_id_for_transport_group_id`] plus the pre-migration route
+    /// backfill (mdk#1161): while any stored group has no durable transport
+    /// route yet, an index miss cannot be trusted, so this loads each
+    /// backfill-pending group's MLS state once, persists + indexes its route,
+    /// and retries the match. Every probed group leaves the pending set
+    /// permanently — matched or not — so a kind-445 flood costs at most one
+    /// MLS load per stored group *ever*, preserving mdk#740's
+    /// attacker-paced-scan bound in amortized form. Once the set is empty
+    /// this is exactly the O(1) resolver.
+    fn resolve_or_backfill_group_id_for_transport(
+        &mut self,
+        transport_group_id: &[u8],
+    ) -> Result<GroupId, EngineError> {
+        let resolved = self.group_id_for_transport_group_id(transport_group_id)?;
+        if self.route_backfill_pending.is_empty()
+            || self
+                .transport_group_id_index
+                .contains_key(transport_group_id)
+            || self.storage.get_group(&resolved).is_ok()
+        {
+            return Ok(resolved);
+        }
+        let pending: Vec<GroupId> = self.route_backfill_pending.drain().collect();
+        let mut matched = None;
+        for group_id in pending {
+            let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
+            let mls_group = {
+                let provider = crate::provider::EngineOpenMlsProvider::<S>::new(
+                    &self.crypto,
+                    self.storage.mls_storage(),
+                );
+                match openmls::group::MlsGroup::load(
+                    <crate::provider::EngineOpenMlsProvider<'_, S> as openmls_traits::OpenMlsProvider>::storage(
+                        &provider,
+                    ),
+                    &mls_gid,
+                ) {
+                    Ok(Some(group)) => group,
+                    // Unreadable MLS state resolves nothing here; the group's
+                    // full hydration (or quarantine) owns that failure.
+                    _ => continue,
+                }
+            };
+            let Ok(route) = crate::app_components::transport_group_id_of_group(&mls_group) else {
+                continue;
+            };
+            let is_match = route == transport_group_id;
+            self.index_transport_group_route(route, &group_id);
+            if is_match && matched.is_none() {
+                matched = Some(group_id);
+            }
+        }
+        Ok(matched.unwrap_or(resolved))
     }
 
     async fn try_peel_group_message_from_available_snapshots(

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -2372,15 +2372,28 @@ impl<S: StorageProvider> Engine<S> {
         Ok(direct)
     }
 
-    /// [`Self::group_id_for_transport_group_id`] plus the pre-migration route
-    /// backfill (mdk#1161): while any stored group has no durable transport
-    /// route yet, an index miss cannot be trusted, so this loads each
-    /// backfill-pending group's MLS state once, persists + indexes its route,
-    /// and retries the match. Every probed group leaves the pending set
-    /// permanently — matched or not — so a kind-445 flood costs at most one
-    /// MLS load per stored group *ever*, preserving mdk#740's
-    /// attacker-paced-scan bound in amortized form. Once the set is empty
-    /// this is exactly the O(1) resolver.
+    /// Maximum backfill-pending groups probed (MLS-loaded) per unknown
+    /// inbound route. Small so one attacker-supplied route id never turns
+    /// into account-wide work; the background pipeline drains the rest.
+    const ROUTE_BACKFILL_PROBES_PER_MISS: usize = 4;
+
+    /// [`Self::group_id_for_transport_group_id`] plus the route backfill for
+    /// groups whose durable route set is missing or stale (mdk#1161): while
+    /// any such group remains, an index miss cannot be trusted, so this loads
+    /// pending groups' MLS state to persist + index their current route and
+    /// retries the match.
+    ///
+    /// Bounded per event: one unknown inbound route probes at most
+    /// [`ROUTE_BACKFILL_PROBES_PER_MISS`] pending groups — never the whole
+    /// account — so an attacker-supplied route id cannot force O(groups) MLS
+    /// loads in a single request (the amplification mdk#408 closed). The
+    /// remainder stays queued for later misses and for the app-layer
+    /// background hydration pipeline, which drains backfill-pending groups
+    /// first. A pending id leaves the set only on a successful route index or
+    /// the explicit terminal "group has no routing component" disposition; an
+    /// MLS load failure keeps the id pending because full hydration owns that
+    /// failure — every backfill-pending group is also in `unhydrated_groups`,
+    /// so `ensure_hydrated` will either index its route or quarantine it.
     fn resolve_or_backfill_group_id_for_transport(
         &mut self,
         transport_group_id: &[u8],
@@ -2394,9 +2407,14 @@ impl<S: StorageProvider> Engine<S> {
         {
             return Ok(resolved);
         }
-        let pending: Vec<GroupId> = self.route_backfill_pending.drain().collect();
+        let probes: Vec<GroupId> = self
+            .route_backfill_pending
+            .iter()
+            .take(Self::ROUTE_BACKFILL_PROBES_PER_MISS)
+            .cloned()
+            .collect();
         let mut matched = None;
-        for group_id in pending {
+        for group_id in probes {
             let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
             let mls_group = {
                 let provider = crate::provider::EngineOpenMlsProvider::<S>::new(
@@ -2410,18 +2428,27 @@ impl<S: StorageProvider> Engine<S> {
                     &mls_gid,
                 ) {
                     Ok(Some(group)) => group,
-                    // Unreadable MLS state resolves nothing here; the group's
-                    // full hydration (or quarantine) owns that failure.
+                    // Unreadable MLS state: keep the id pending — full
+                    // hydration owns the failure and will quarantine or
+                    // repair it; the per-miss budget bounds re-probes.
                     _ => continue,
                 }
             };
-            let Ok(route) = crate::app_components::transport_group_id_of_group(&mls_group) else {
-                continue;
-            };
-            let is_match = route == transport_group_id;
-            self.index_transport_group_route(route, &group_id);
-            if is_match && matched.is_none() {
-                matched = Some(group_id);
+            match crate::app_components::transport_group_id_of_group(&mls_group) {
+                Ok(route) => {
+                    let is_match = route == transport_group_id;
+                    let current_epoch = cgka_traits::types::EpochId(mls_group.epoch().as_u64());
+                    self.route_backfill_pending.remove(&group_id);
+                    self.index_transport_group_route(route, &group_id, current_epoch);
+                    if is_match && matched.is_none() {
+                        matched = Some(group_id);
+                    }
+                }
+                Err(_) => {
+                    // Terminal for routing: the group carries no routing
+                    // component, so there is no route to backfill.
+                    self.route_backfill_pending.remove(&group_id);
+                }
             }
         }
         Ok(matched.unwrap_or(resolved))

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -26,7 +26,7 @@ use cgka_traits::error::EngineError;
 use cgka_traits::ingest::{
     InboundResourceLimit, IngestOutcome, InputRejectionCategory, LocalIngestState,
 };
-use cgka_traits::message::{MessageState, StoredMessagePayload};
+use cgka_traits::message::{MessageRecord, MessageState, StoredMessagePayload};
 use cgka_traits::storage::{QueuedOutboundIntent, StorageError, StorageProvider};
 use cgka_traits::transport::{TransportEnvelope, TransportMessage};
 use cgka_traits::types::{EpochId, GroupId, MemberId, MessageId};
@@ -737,8 +737,27 @@ impl<S: StorageProvider> Engine<S> {
         source_epoch: EpochId,
         now_ms: u64,
     ) -> Result<bool, EngineError> {
+        let records = self.storage.list_messages(group_id, source_epoch)?;
+        self.restore_self_remove_auto_commit_schedules_in_records(
+            group_id,
+            source_epoch,
+            now_ms,
+            &records,
+        )
+    }
+
+    /// [`Self::restore_self_remove_auto_commit_schedules_for_group`] over an
+    /// already-fetched record list, so session-open hydration can share one
+    /// `list_messages` scan across every work-detection pass (mdk#1161).
+    pub(crate) fn restore_self_remove_auto_commit_schedules_in_records(
+        &mut self,
+        group_id: &GroupId,
+        source_epoch: EpochId,
+        now_ms: u64,
+        records: &[MessageRecord],
+    ) -> Result<bool, EngineError> {
         let mut restored = false;
-        for record in self.storage.list_messages(group_id, source_epoch)? {
+        for record in records {
             if record.epoch != source_epoch
                 || !matches!(
                     record.state,
@@ -838,49 +857,94 @@ impl<S: StorageProvider> Engine<S> {
         &self,
         group_id: &GroupId,
     ) -> Result<bool, EngineError> {
+        if self.has_unresolved_non_record_convergence_state(group_id)? {
+            return Ok(true);
+        }
+        let group = match self.storage.get_group(group_id) {
+            Ok(group) => group,
+            Err(StorageError::NotFound) => return Ok(false),
+            Err(e) => return Err(EngineError::Storage(e)),
+        };
+        let (anchor, ceiling) = self.convergence_gate_horizon(group_id, &group)?;
+        let records = self.storage.list_messages(group_id, EpochId(anchor))?;
+        Ok(self.any_gating_convergence_input(anchor, ceiling, &records))
+    }
+
+    /// [`Self::has_unresolved_convergence_inputs`] over an already-fetched
+    /// full record list, so session-open hydration can share one
+    /// `list_messages` scan across every work-detection pass (mdk#1161).
+    pub(crate) fn has_unresolved_convergence_inputs_in_records(
+        &self,
+        group_id: &GroupId,
+        group: &cgka_traits::group::Group,
+        records: &[MessageRecord],
+    ) -> Result<bool, EngineError> {
+        if self.has_unresolved_non_record_convergence_state(group_id)? {
+            return Ok(true);
+        }
+        let (anchor, ceiling) = self.convergence_gate_horizon(group_id, group)?;
+        Ok(self.any_gating_convergence_input(anchor, ceiling, records))
+    }
+
+    fn has_unresolved_non_record_convergence_state(
+        &self,
+        group_id: &GroupId,
+    ) -> Result<bool, EngineError> {
         if let Some(pass) = self.storage.convergence_pass(group_id)?
             && pass.is_active()
             && self.convergence_pass_gates_outbound(&pass)
         {
             return Ok(true);
         }
-        if self.disband_candidate_pending(group_id)? {
-            return Ok(true);
-        }
-        // The convergence horizon is bounded on BOTH sides (mdk#736). The past
-        // side (`anchor`) drops inputs older than the retained-anchor window.
-        // The future side (`ceiling`) is symmetric: a convergence input more
-        // than `max_rewind_commits` epochs ahead of the current tip cannot chain
-        // from the tip yet (the candidate-path BFS in `openmls_projection` only
-        // extends `source_epoch == tip_epoch`), so it is not *resolvable
-        // convergence work* and must not gate outbound sends. Without the
-        // ceiling, a single member could forge one far-future-epoch (e.g. 2^63)
-        // plaintext message whose buffered `Created` row is never materialized
-        // and never given a terminal disposition, permanently gating every send
-        // for the whole group. The row is left in storage (not dropped here), so
-        // it gates again correctly once the tip advances into `[anchor, ceiling]`.
-        let (anchor, ceiling) = match self.storage.get_group(group_id) {
-            Ok(group) => {
-                // Ungated: hydration calls this while the group is still
-                // quarantined to decide whether to schedule post-repair
-                // convergence. Live send/convergence paths already gate via
-                // `ensure_group_live` before reaching here.
-                let policy = self
-                    .convergence_policy_for_group_ungated(group_id)
-                    .map_err(|e| EngineError::Backend(format!("load convergence policy: {e}")))?;
-                let rewind = policy.convergence.max_rewind_commits;
-                (
-                    group.epoch.0.saturating_sub(rewind),
-                    group.epoch.0.saturating_add(rewind),
-                )
-            }
-            Err(StorageError::NotFound) => return Ok(false),
-            Err(e) => return Err(EngineError::Storage(e)),
-        };
-        let records = self.storage.list_messages(group_id, EpochId(anchor))?;
+        self.disband_candidate_pending(group_id)
+    }
+
+    /// The convergence horizon is bounded on BOTH sides (mdk#736). The past
+    /// side (`anchor`) drops inputs older than the retained-anchor window.
+    /// The future side (`ceiling`) is symmetric: a convergence input more
+    /// than `max_rewind_commits` epochs ahead of the current tip cannot chain
+    /// from the tip yet (the candidate-path BFS in `openmls_projection` only
+    /// extends `source_epoch == tip_epoch`), so it is not *resolvable
+    /// convergence work* and must not gate outbound sends. Without the
+    /// ceiling, a single member could forge one far-future-epoch (e.g. 2^63)
+    /// plaintext message whose buffered `Created` row is never materialized
+    /// and never given a terminal disposition, permanently gating every send
+    /// for the whole group. The row is left in storage (not dropped here), so
+    /// it gates again correctly once the tip advances into `[anchor, ceiling]`.
+    fn convergence_gate_horizon(
+        &self,
+        group_id: &GroupId,
+        group: &cgka_traits::group::Group,
+    ) -> Result<(u64, u64), EngineError> {
+        // Ungated: hydration calls this while the group is still
+        // quarantined to decide whether to schedule post-repair
+        // convergence. Live send/convergence paths already gate via
+        // `ensure_group_live` before reaching here.
+        let policy = self
+            .convergence_policy_for_group_ungated(group_id)
+            .map_err(|e| EngineError::Backend(format!("load convergence policy: {e}")))?;
+        let rewind = policy.convergence.max_rewind_commits;
+        Ok((
+            group.epoch.0.saturating_sub(rewind),
+            group.epoch.0.saturating_add(rewind),
+        ))
+    }
+
+    fn any_gating_convergence_input(
+        &self,
+        anchor: u64,
+        ceiling: u64,
+        records: &[MessageRecord],
+    ) -> bool {
         let mut skipped_non_resolvable: usize = 0;
         let mut classified = Vec::new();
         for record in records {
+            // Below the anchor: callers fetching via `list_messages(anchor)`
+            // never produce such rows; the shared-scan hydration path fetches
+            // from epoch 0 and filters here instead.
+            if record.epoch.0 < anchor {
+                continue;
+            }
             if !matches!(
                 record.state,
                 MessageState::Sent
@@ -934,7 +998,7 @@ impl<S: StorageProvider> Engine<S> {
             .into_iter()
             .any(|input| context.gates_outbound(input))
         {
-            return Ok(true);
+            return true;
         }
         // Reached only when nothing gates: surface any fail-open skips so an
         // insider spraying undecodable rows (which no longer wedges the gate but
@@ -948,7 +1012,7 @@ impl<S: StorageProvider> Engine<S> {
                 "skipped non-resolvable convergence rows (fail-open)"
             );
         }
-        Ok(false)
+        false
     }
 
     pub fn has_pending_convergence_inputs(&self, group_id: &GroupId) -> Result<bool, EngineError> {

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -821,9 +821,12 @@ impl<S: StorageProvider> Engine<S> {
         now_ms: u64,
     ) -> Result<bool, EngineError> {
         // Promote a seeded-but-unhydrated group before reading its stored
-        // inputs (mdk#1161); a hydration failure quarantines it and the
-        // converge call below reports the blocked run as before.
-        let _ = self.ensure_hydrated(group_id);
+        // inputs (mdk#1161). A failed promotion quarantines the group and
+        // MUST propagate — continuing would read convergence state for a
+        // group validation just rejected and could report it settled.
+        // Already-quarantined groups keep their pre-existing semantics
+        // (`ensure_hydrated` no-ops; converge reports the blocked run).
+        self.ensure_hydrated(group_id)?;
         for _ in 0..MAX_CONVERGENCE_REPROCESSING_PASSES {
             if self.has_unresolved_convergence_inputs(group_id)? {
                 let result = self

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -389,6 +389,10 @@ impl<S: StorageProvider> Engine<S> {
 
     fn validate_send_acceptance(&mut self, intent: &SendIntent) -> Result<GroupId, EngineError> {
         let group_id = send_intent_group_id(intent).clone();
+        // A send targeting a seeded-but-unhydrated group promotes it first
+        // (mdk#1161); a hydration failure quarantines it and falls through to
+        // the gate below as UnknownGroup.
+        let _ = self.ensure_hydrated(&group_id);
         // Quarantine gate: a group frozen by hydration quarantine must not
         // stage, queue, or publish anything — a confirm would set_stable and
         // silently un-quarantine it out of band (mdk#364).
@@ -473,6 +477,10 @@ impl<S: StorageProvider> Engine<S> {
         group_id: &GroupId,
         now_ms: u64,
     ) -> Result<Vec<SendResult>, EngineError> {
+        // Draining a seeded-but-unhydrated group promotes it first
+        // (mdk#1161); a hydration failure quarantines it and the gate below
+        // reports UnknownGroup.
+        let _ = self.ensure_hydrated(group_id);
         // Quarantined groups vanish from every live surface; convergence and
         // queued-intent drains must not touch their state (mdk#364).
         self.ensure_group_live(group_id)?;
@@ -1049,6 +1057,13 @@ impl<S: StorageProvider> Engine<S> {
         // the very state validation rejected (mdk#364). The rows replay
         // once repair clears the quarantine.
         if self.quarantined_reason(group_id).is_some() {
+            return Ok(0);
+        }
+        // A seeded-but-unhydrated group holds a provisional Stable entry, so
+        // the gate below would fall through and re-ingest retained rows
+        // against unvalidated state (mdk#1161). Skip; the sweep after
+        // `ensure_hydrated` promotes the group picks the rows up.
+        if self.unhydrated_groups.contains(group_id) {
             return Ok(0);
         }
         if let Some(state) = self.epoch_manager.state(group_id)

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -820,6 +820,10 @@ impl<S: StorageProvider> Engine<S> {
         group_id: &GroupId,
         now_ms: u64,
     ) -> Result<bool, EngineError> {
+        // Promote a seeded-but-unhydrated group before reading its stored
+        // inputs (mdk#1161); a hydration failure quarantines it and the
+        // converge call below reports the blocked run as before.
+        let _ = self.ensure_hydrated(group_id);
         for _ in 0..MAX_CONVERGENCE_REPROCESSING_PASSES {
             if self.has_unresolved_convergence_inputs(group_id)? {
                 let result = self
@@ -1307,6 +1311,13 @@ impl<S: StorageProvider> Engine<S> {
         group_id: &GroupId,
     ) -> Result<Option<u64>, EngineError> {
         if self.quarantined_reason(group_id).is_some() {
+            return Ok(None);
+        }
+        // A seeded-but-unhydrated group holds a provisional Stable entry, so
+        // the state gate below would fall through and persist deferred-peel
+        // lifecycle normalization against unvalidated state (mdk#1161). No
+        // deadline yet; the scheduler re-asks after hydration promotes it.
+        if self.unhydrated_groups.contains(group_id) {
             return Ok(None);
         }
         if let Some(state) = self.epoch_manager.state(group_id)

--- a/crates/cgka-engine/tests/AGENTS.md
+++ b/crates/cgka-engine/tests/AGENTS.md
@@ -78,8 +78,9 @@ backend on the same rail.
 
 - **File:** `two_phase_hydration.rs`
   - **Owns:** mdk#1161 two-phase hydration — cheap-pass seeding vs `GroupNotHydrated` gating, `ensure_hydrated`
-    promotion and quarantine parity, cheap-pass idempotency, durable transport-route seeding, and the one-shot
-    ingest route backfill for records predating the route table
+    promotion and quarantine parity, cheap-pass idempotency, durable transport-route seeding, the bounded ingest
+    route backfill (missing and stale-stamped route sets), eager full hydration of unrecoverable groups, and
+    retention-window route retirement across rotation and restart
 
 - **File:** `snapshot_privacy.rs`
   - **Owns:** Snapshot names do not expose plaintext group ids

--- a/crates/cgka-engine/tests/AGENTS.md
+++ b/crates/cgka-engine/tests/AGENTS.md
@@ -63,7 +63,7 @@ backend on the same rail.
   - **Owns:** Explicit publish-before-apply lifecycle for local group evolution
 
 - **File:** `pending_commit_recovery.rs`
-  - **Owns:** Crash-during-publish recovery at session open — `hydrate_stable_groups_from_storage` detects a surviving
+  - **Owns:** Crash-during-publish recovery at session open — `hydrate_all_stored_groups` detects a surviving
     `PendingCommit`, clears it, and surfaces `GroupEvent::PendingCommitRecovered` (mdk#150)
 
 - **File:** `auto_commit_atomicity.rs`
@@ -75,6 +75,11 @@ backend on the same rail.
 
 - **File:** `hydration_quarantine.rs`
   - **Owns:** Group hydration-quarantine path — `GroupHydrationQuarantineReason` classification on session open
+
+- **File:** `two_phase_hydration.rs`
+  - **Owns:** mdk#1161 two-phase hydration — cheap-pass seeding vs `GroupNotHydrated` gating, `ensure_hydrated`
+    promotion and quarantine parity, cheap-pass idempotency, durable transport-route seeding, and the one-shot
+    ingest route backfill for records predating the route table
 
 - **File:** `snapshot_privacy.rs`
   - **Owns:** Snapshot names do not expose plaintext group ids

--- a/crates/cgka-engine/tests/crash_recovery_sqlite.rs
+++ b/crates/cgka-engine/tests/crash_recovery_sqlite.rs
@@ -281,7 +281,7 @@ fn run_parent_case(point: &str, stranded_epoch: EpochId, snapshot_prefix: &str) 
 
     let mut reopened = build_client_with_storage(CAROL_SEED, storage.clone());
     reopened
-        .hydrate_stable_groups_from_storage()
+        .hydrate_all_stored_groups()
         .expect("hydrate killed database");
 
     assert_eq!(
@@ -422,7 +422,7 @@ fn run_transition_parent_case(point: &str) {
     );
     let mut reopened = build_client_with_storage(CAROL_SEED, storage.clone());
     reopened
-        .hydrate_stable_groups_from_storage()
+        .hydrate_all_stored_groups()
         .unwrap_or_else(|error| panic!("hydrate after {point}: {error}"));
     assert_eq!(
         storage

--- a/crates/cgka-engine/tests/deferred_peel_lifecycle.rs
+++ b/crates/cgka-engine/tests/deferred_peel_lifecycle.rs
@@ -570,7 +570,7 @@ async fn deferred_peel_residence_survives_restart_and_backward_clock() {
         carol_storage.clone(),
         clock.clone(),
     );
-    restarted.hydrate_stable_groups_from_storage().unwrap();
+    restarted.hydrate_all_stored_groups().unwrap();
     restarted.set_deferred_peel_residence_ms(1_000);
     assert_eq!(
         restarted.deferred_peel_cutoff_delay_ms(&group_id).unwrap(),
@@ -595,7 +595,7 @@ async fn deferred_peel_residence_survives_restart_and_backward_clock() {
         carol_storage.clone(),
         clock.clone(),
     );
-    backwards.hydrate_stable_groups_from_storage().unwrap();
+    backwards.hydrate_all_stored_groups().unwrap();
     backwards.set_deferred_peel_residence_ms(1_000);
     assert_eq!(
         backwards.deferred_peel_cutoff_delay_ms(&group_id).unwrap(),

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -3015,7 +3015,7 @@ async fn restart_preserves_admin_reservation() {
 
     let mut restarted = build_client_with_storage(b"carol", carol_storage.clone());
     restarted
-        .hydrate_stable_groups_from_storage()
+        .hydrate_all_stored_groups()
         .expect("session-open hydration succeeds");
     let preserved = carol_storage
         .convergence_pass(&group_id)
@@ -3068,7 +3068,7 @@ async fn restart_with_only_app_messages_opens_pass_without_delay() {
 
     let mut restarted = build_client_with_storage(b"carol", carol_storage.clone());
     restarted
-        .hydrate_stable_groups_from_storage()
+        .hydrate_all_stored_groups()
         .expect("session-open hydration succeeds");
 
     restarted
@@ -3879,7 +3879,7 @@ async fn unrecoverable_halt_survives_engine_restart_until_verified_repair() {
 
     let mut restarted = build_client_with_storage(b"carol", carol_storage.clone());
     restarted
-        .hydrate_stable_groups_from_storage()
+        .hydrate_all_stored_groups()
         .expect("session-open hydration succeeds");
     let hydration_events = restarted.drain_events();
     assert!(
@@ -4189,7 +4189,7 @@ async fn intent_retained_before_a_halt_is_delivered_after_a_verified_repair() {
     drop(carol);
     let mut repaired = build_client_with_storage(b"carol", carol_storage.clone());
     repaired
-        .hydrate_stable_groups_from_storage()
+        .hydrate_all_stored_groups()
         .expect("session-open hydration succeeds after repair");
     assert!(
         repaired
@@ -5577,7 +5577,7 @@ async fn conformance_progress_uses_the_schedulers_effective_policy_deadline() {
     clock.set_wall_ms(10_400);
     let mut restarted = build_client_with_storage_and_clock(b"carol", carol_storage.clone(), clock);
     restarted
-        .hydrate_stable_groups_from_storage()
+        .hydrate_all_stored_groups()
         .expect("restart hydrates the persisted group");
     restarted
         .set_convergence_policy(CanonicalizationPolicy {
@@ -5836,7 +5836,7 @@ async fn engine_ingest_retains_proposal_until_canonical_commit_consumes_it() {
 
     let mut restarted_alice = build_client_with_storage(b"alice", alice_storage.clone());
     restarted_alice
-        .hydrate_stable_groups_from_storage()
+        .hydrate_all_stored_groups()
         .expect("rebuild after proposal-consuming commit");
     assert_message_state(&alice_storage, &proposal, MessageState::Processed);
     assert!(
@@ -8024,7 +8024,7 @@ async fn restart_schedules_groups_with_durable_queued_intents() {
 
     let mut restarted = build_client_with_storage(b"alice-restart-queued", alice_storage);
     restarted
-        .hydrate_stable_groups_from_storage()
+        .hydrate_all_stored_groups()
         .expect("session-open hydration succeeds");
     let scheduled = restarted.drain_pending_convergence_groups();
     assert!(

--- a/crates/cgka-engine/tests/fork_detection.rs
+++ b/crates/cgka-engine/tests/fork_detection.rs
@@ -212,7 +212,7 @@ fn reopen_current_client(id: &[u8], storage: SqliteAccountStorage) -> Engine<Sql
         .peeler(Box::new(MockPeeler))
         .build()
         .unwrap();
-    engine.hydrate_stable_groups_from_storage().unwrap();
+    engine.hydrate_all_stored_groups().unwrap();
     engine
 }
 
@@ -225,7 +225,7 @@ fn reopen_legacy_client(id: &[u8], storage: SqliteAccountStorage) -> Engine<Sqli
         .peeler(Box::new(MockPeeler))
         .build()
         .unwrap();
-    engine.hydrate_stable_groups_from_storage().unwrap();
+    engine.hydrate_all_stored_groups().unwrap();
     engine
 }
 

--- a/crates/cgka-engine/tests/group_creation.rs
+++ b/crates/cgka-engine/tests/group_creation.rs
@@ -1112,7 +1112,7 @@ async fn current_group_persists_profile_and_rejects_legacy_key_packages() {
         .peeler(Box::new(MockPeeler::default()))
         .build()
         .unwrap();
-    reopened.hydrate_stable_groups_from_storage().unwrap();
+    reopened.hydrate_all_stored_groups().unwrap();
     let reopened_group = reopened.group_record(&group_id).unwrap();
     assert_eq!(reopened_group.protocol_profile, ProtocolProfile::Current);
     assert_eq!(reopened_group.epoch, cgka_traits::types::EpochId(1));
@@ -1373,7 +1373,7 @@ async fn solo_disband_is_durable_convergent_terminal_and_restart_safe() {
     drop(alice);
     let mut reopened =
         build_profile_client_on_storage(identity, storage.clone(), ProtocolProfile::Current);
-    reopened.hydrate_stable_groups_from_storage().unwrap();
+    reopened.hydrate_all_stored_groups().unwrap();
     assert!(matches!(
         reopened.epoch_state(&group_id),
         Some(cgka_traits::EpochState::Disbanded(_))
@@ -1397,7 +1397,7 @@ async fn solo_disband_is_durable_convergent_terminal_and_restart_safe() {
     );
     let mut tombstone_only =
         build_profile_client_on_storage(identity, storage, ProtocolProfile::Current);
-    tombstone_only.hydrate_stable_groups_from_storage().unwrap();
+    tombstone_only.hydrate_all_stored_groups().unwrap();
     assert!(matches!(
         tombstone_only.epoch_state(&group_id),
         Some(cgka_traits::EpochState::Disbanded(_))
@@ -1448,7 +1448,7 @@ async fn current_configured_engine_reopens_and_uses_a_legacy_group() {
         .peeler(Box::new(MockPeeler::default()))
         .build()
         .unwrap();
-    current.hydrate_stable_groups_from_storage().unwrap();
+    current.hydrate_all_stored_groups().unwrap();
     assert_eq!(
         current.group_record(&group_id).unwrap().protocol_profile,
         ProtocolProfile::Legacy

--- a/crates/cgka-engine/tests/hydration_quarantine.rs
+++ b/crates/cgka-engine/tests/hydration_quarantine.rs
@@ -217,7 +217,7 @@ async fn hydration_quarantines_bad_group_and_keeps_healthy_groups_available() {
         .expect("build reopened engine");
 
     reopened
-        .hydrate_stable_groups_from_storage()
+        .hydrate_all_stored_groups()
         .expect("hydration skips bad group instead of aborting account open");
 
     assert_eq!(reopened.epoch(&healthy_group).unwrap(), healthy_epoch);
@@ -276,7 +276,7 @@ async fn hydration_classifies_stored_wire_profile_mismatch_as_member_validation_
 
     let mut reopened = build_engine(storage);
     reopened
-        .hydrate_stable_groups_from_storage()
+        .hydrate_all_stored_groups()
         .expect("profile mismatch quarantines instead of aborting account open");
 
     assert_eq!(
@@ -309,7 +309,7 @@ async fn hydration_quarantines_first_bad_group_and_continues_to_later_healthy_gr
 
     let mut reopened = build_engine(storage.clone());
     reopened
-        .hydrate_stable_groups_from_storage()
+        .hydrate_all_stored_groups()
         .expect("hydration skips the first bad group and continues");
 
     assert_eq!(reopened.epoch(&healthy_group).unwrap(), healthy_epoch);
@@ -750,7 +750,7 @@ async fn welcome_delivery_accessors_hide_quarantined_groups() {
     storage.set_fail_get_group(true);
     let mut engine = build_current_flaky_engine(storage.clone(), b"alice-quarantined-welcome");
     engine
-        .hydrate_stable_groups_from_storage()
+        .hydrate_all_stored_groups()
         .expect("unreadable group is quarantined");
     assert_eq!(
         engine.quarantined_groups(),
@@ -814,7 +814,7 @@ async fn retry_recovers_a_transiently_quarantined_group() {
     storage.set_fail_get_group(true);
     let mut reopened = build_flaky_engine(storage.clone());
     reopened
-        .hydrate_stable_groups_from_storage()
+        .hydrate_all_stored_groups()
         .expect("hydration quarantines the unreadable group, does not abort");
 
     assert!(matches!(
@@ -865,7 +865,7 @@ async fn tombstone_read_failure_quarantines_instead_of_hydrating_live_state() {
     storage.set_fail_disband_tombstone(true);
     let mut reopened = build_flaky_engine(storage.clone());
     reopened
-        .hydrate_stable_groups_from_storage()
+        .hydrate_all_stored_groups()
         .expect("per-group tombstone failure is quarantined");
 
     assert_eq!(
@@ -933,7 +933,7 @@ async fn pending_fanout_is_not_exposed_until_hydration_fully_succeeds() {
     storage.set_fail_list_queued_outbound_intents(true);
     let mut reopened = build_flaky_engine(storage.clone());
     reopened
-        .hydrate_stable_groups_from_storage()
+        .hydrate_all_stored_groups()
         .expect("per-group failure is quarantined");
     assert!(matches!(
         reopened.quarantined_groups().as_slice(),
@@ -1017,7 +1017,7 @@ async fn retry_keeps_group_quarantined_when_still_unhealthy() {
     storage.set_fail_get_group(true);
     let mut reopened = build_flaky_engine(storage.clone());
     reopened
-        .hydrate_stable_groups_from_storage()
+        .hydrate_all_stored_groups()
         .expect("hydration quarantines the unreadable group");
     reopened.drain_events();
 
@@ -1137,7 +1137,7 @@ async fn quarantined_alice_with_live_bob() -> (
     storage.set_fail_get_group(true);
     let mut reopened = build_flaky_engine(storage.clone());
     reopened
-        .hydrate_stable_groups_from_storage()
+        .hydrate_all_stored_groups()
         .expect("hydration quarantines the unreadable group");
     assert_eq!(
         reopened.quarantined_groups(),
@@ -1395,7 +1395,7 @@ async fn rejoin_welcome_clears_quarantine() {
         .expect("build alice");
     insert_marmot_group_without_openmls_state(&alice_storage, &group_id, "corrupted-copy", 1);
     alice
-        .hydrate_stable_groups_from_storage()
+        .hydrate_all_stored_groups()
         .expect("hydration quarantines the corrupted copy");
     assert_eq!(
         alice.quarantined_groups(),
@@ -1476,7 +1476,7 @@ async fn rejoin_welcome_replays_and_retires_quarantine_retained_input() {
         .expect("build alice");
     insert_marmot_group_without_openmls_state(&alice_storage, &group_id, "corrupted-copy", 1);
     alice
-        .hydrate_stable_groups_from_storage()
+        .hydrate_all_stored_groups()
         .expect("hydration quarantines the corrupted copy");
     assert_eq!(alice.quarantined_groups().len(), 1);
     alice.drain_events();
@@ -1561,9 +1561,7 @@ async fn hydration_persists_validation_marker_and_unchanged_group_reopens() {
     );
 
     let mut first = build_engine(storage.clone());
-    first
-        .hydrate_stable_groups_from_storage()
-        .expect("first hydration");
+    first.hydrate_all_stored_groups().expect("first hydration");
     assert_eq!(first.epoch(&group).unwrap(), epoch);
 
     // First open validated the tree and persisted a marker.
@@ -1577,7 +1575,7 @@ async fn hydration_persists_validation_marker_and_unchanged_group_reopens() {
     // because the tree bytes are identical.
     let mut second = build_engine(storage.clone());
     second
-        .hydrate_stable_groups_from_storage()
+        .hydrate_all_stored_groups()
         .expect("second hydration of unchanged group");
     assert_eq!(second.epoch(&group).unwrap(), epoch);
     assert_eq!(
@@ -1624,7 +1622,7 @@ async fn hydration_recovers_interrupted_retained_anchor_probe() {
 
     let mut reopened = build_engine(storage.clone());
     reopened
-        .hydrate_stable_groups_from_storage()
+        .hydrate_all_stored_groups()
         .expect("hydrate recovers orphaned probe");
 
     assert_eq!(
@@ -1669,7 +1667,7 @@ async fn hydration_recovers_interrupted_convergence_apply() {
 
     let mut reopened = build_engine(storage.clone());
     reopened
-        .hydrate_stable_groups_from_storage()
+        .hydrate_all_stored_groups()
         .expect("hydrate recovers interrupted apply");
 
     assert_eq!(
@@ -1709,7 +1707,7 @@ async fn stale_validation_marker_forces_revalidation_and_refresh() {
 
     let mut reopened = build_engine(storage.clone());
     reopened
-        .hydrate_stable_groups_from_storage()
+        .hydrate_all_stored_groups()
         .expect("hydration revalidates and accepts the healthy group");
     assert_eq!(reopened.epoch(&group).unwrap(), epoch);
 

--- a/crates/cgka-engine/tests/ingest.rs
+++ b/crates/cgka-engine/tests/ingest.rs
@@ -1530,7 +1530,7 @@ async fn buffered_legacy_own_echo_retires_raw_retry_row() {
     // Rebuild to clear the hot-process sent-id cache as a real restart would.
     drop(alice);
     let mut alice = build_client_with_storage(storage.clone(), b"alice-legacy-own-echo");
-    alice.hydrate_stable_groups_from_storage().unwrap();
+    alice.hydrate_all_stored_groups().unwrap();
 
     // Buffer the echo before peeling while a local commit awaits publication.
     let staged = match alice
@@ -1642,7 +1642,7 @@ async fn rewrapped_own_openmls_message_after_restart_returns_own_echo() {
     assert_eq!(marker.state, MessageState::Sent);
 
     let mut alice = build_client_with_storage(reopened_store, b"alice-own-restart");
-    alice.hydrate_stable_groups_from_storage().unwrap();
+    alice.hydrate_all_stored_groups().unwrap();
     let rewrapped = TransportMessage {
         id: MessageId::new(b"fresh-own-echo-transport-id".to_vec()),
         timestamp: Timestamp(app_msg.timestamp.0 + 1),

--- a/crates/cgka-engine/tests/invite_leave.rs
+++ b/crates/cgka-engine/tests/invite_leave.rs
@@ -690,7 +690,7 @@ async fn strict_cutover_rejects_inbound_adds_to_legacy_groups_during_convergence
         .peeler(Box::new(MockPeeler))
         .build()
         .unwrap();
-    bob.hydrate_stable_groups_from_storage().unwrap();
+    bob.hydrate_all_stored_groups().unwrap();
     assert_eq!(
         bob.group_record(&group_id).unwrap().protocol_profile,
         ProtocolProfile::Legacy
@@ -804,7 +804,7 @@ async fn strict_cutover_add_replay_retires_raw_and_content_rows() {
         .peeler(Box::new(MockPeeler))
         .build()
         .unwrap();
-    bob.hydrate_stable_groups_from_storage().unwrap();
+    bob.hydrate_all_stored_groups().unwrap();
 
     let local_pending = match bob
         .send(SendIntent::UpdateGroupData {
@@ -2180,7 +2180,7 @@ async fn selfremove_local_selection_uses_lowest_complete_message_digest_after_re
     ));
     drop(alice);
     let mut alice = build_client_on_storage(b"alice", alice_storage.clone());
-    alice.hydrate_stable_groups_from_storage().unwrap();
+    alice.hydrate_all_stored_groups().unwrap();
     advance_selfremove_auto_commit(&mut alice, &group_id).await;
 
     let crypto = RustCrypto::default();
@@ -2567,7 +2567,7 @@ async fn selfremove_leaving_gate_survives_engine_rebuild() {
 
     drop(bob);
     let mut bob = build_client_on_storage(b"bob", bob_storage);
-    bob.hydrate_stable_groups_from_storage().unwrap();
+    bob.hydrate_all_stored_groups().unwrap();
     let blocked = bob
         .send(SendIntent::AppMessage {
             group_id: group_id.clone(),

--- a/crates/cgka-engine/tests/mip03_guards.rs
+++ b/crates/cgka-engine/tests/mip03_guards.rs
@@ -747,7 +747,7 @@ async fn inbound_by_reference_update_rejects_account_identity_spoofing() {
         .build()
         .unwrap();
     reopened
-        .hydrate_stable_groups_from_storage()
+        .hydrate_all_stored_groups()
         .expect("reopen after rejected proposal");
     assert!(reopened.drain_auto_publish().is_empty());
     assert_eq!(

--- a/crates/cgka-engine/tests/pending_commit_recovery.rs
+++ b/crates/cgka-engine/tests/pending_commit_recovery.rs
@@ -8,7 +8,7 @@
 //! stranded: every later commit-creating operation fails on the leftover
 //! pending commit forever.
 //!
-//! `hydrate_stable_groups_from_storage` (called by `AccountDeviceSession::open`)
+//! `hydrate_all_stored_groups` (the eager path behind `AccountDeviceSession::open`)
 //! must detect that surviving pending commit, clear it (treating it as
 //! publish-failed), re-derive the Marmot record, and surface a typed
 //! `GroupEvent::PendingCommitRecovered` so the app can resync.
@@ -246,7 +246,7 @@ async fn reopen_after_crash_during_publish_recovers_stranded_pending_commit() {
 
     let mut alice = build_client(reopened_store, b"alice-pcr");
     alice
-        .hydrate_stable_groups_from_storage()
+        .hydrate_all_stored_groups()
         .expect("hydrate must recover, not error");
 
     // The recovery event was surfaced so the app can resync.
@@ -403,7 +403,7 @@ async fn reopen_preserves_deferred_selfremove_auto_commit() {
 
     let mut alice = build_selfremove_client(reopened_store, b"alice-dsr");
     alice
-        .hydrate_stable_groups_from_storage()
+        .hydrate_all_stored_groups()
         .expect("hydrate must not error on a deferred selfremove");
 
     let events = alice.drain_events();

--- a/crates/cgka-engine/tests/publish_lifecycle.rs
+++ b/crates/cgka-engine/tests/publish_lifecycle.rs
@@ -419,7 +419,7 @@ async fn self_update_restart_republishes_the_identical_signed_event() {
     drop(alice);
 
     let mut restarted = build_engine_with_storage(b"alice", storage);
-    restarted.hydrate_stable_groups_from_storage().unwrap();
+    restarted.hydrate_all_stored_groups().unwrap();
     let recovered = restarted.drain_auto_publish();
     assert_eq!(recovered.len(), 1);
     assert_eq!(recovered[0].msg, original);

--- a/crates/cgka-engine/tests/two_phase_hydration.rs
+++ b/crates/cgka-engine/tests/two_phase_hydration.rs
@@ -647,3 +647,33 @@ async fn failed_promotion_in_convergence_buffer_persists_no_row() {
         "no convergence row may be persisted for the failed group"
     );
 }
+
+#[tokio::test]
+async fn failed_promotion_in_convergence_advance_propagates() {
+    let storage = SqliteAccountStorage::in_memory().expect("storage");
+    let broken_group = GroupId::new(b"missing-openmls-state".to_vec());
+    insert_marmot_group_without_openmls_state(&storage, &broken_group, 7);
+
+    let mut engine = build_engine(storage.clone());
+    engine
+        .hydrate_stable_groups_from_storage()
+        .expect("cheap pass");
+
+    // A fresh promotion failure must propagate instead of letting the
+    // advance loop read convergence state for the rejected group (and
+    // potentially report it settled).
+    let result = engine
+        .advance_convergence_inputs_until_settled(&broken_group, 0)
+        .await;
+    assert!(
+        matches!(result, Err(EngineError::UnknownGroup(ref id)) if id == &broken_group),
+        "failed promotion must propagate: {result:?}"
+    );
+    assert_eq!(
+        engine.quarantined_groups(),
+        vec![(
+            broken_group,
+            GroupHydrationQuarantineReason::OpenMlsGroupMissing
+        )]
+    );
+}

--- a/crates/cgka-engine/tests/two_phase_hydration.rs
+++ b/crates/cgka-engine/tests/two_phase_hydration.rs
@@ -15,7 +15,8 @@ use cgka_traits::app_components::{
 };
 use cgka_traits::capabilities::{Capability, CapabilityRequirement, Feature, RequirementLevel};
 use cgka_traits::engine::{
-    CgkaEngine, CreateGroupRequest, GroupEvent, GroupHydrationQuarantineReason, SendResult,
+    CgkaEngine, CreateGroupRequest, GroupEvent, GroupHydrationQuarantineReason, SendIntent,
+    SendResult,
 };
 use cgka_traits::error::{EngineError, PeelerError};
 use cgka_traits::group::Group;
@@ -334,7 +335,7 @@ async fn ingest_hydrates_seeded_group_resolved_through_durable_route() {
 
     // Group establishment persisted the transport route durably.
     assert_eq!(
-        storage.list_transport_group_routes().unwrap(),
+        route_pairs(&storage),
         vec![(ROUTE_BYTES.to_vec(), group_id.clone())]
     );
 
@@ -405,9 +406,196 @@ async fn ingest_backfills_route_for_record_predating_route_table() {
         "backfilled route must resolve and hydrate the group"
     );
     assert_eq!(
-        storage.list_transport_group_routes().unwrap(),
+        route_pairs(&storage),
         vec![(ROUTE_BYTES.to_vec(), group_id.clone())],
         "backfill must repopulate the durable route table"
     );
+    assert!(reopened.members(&group_id).is_ok());
+}
+
+/// (route bytes, group id) pairs, epoch stamps elided, sorted for comparison.
+fn route_pairs(storage: &SqliteAccountStorage) -> Vec<(Vec<u8>, GroupId)> {
+    let mut pairs: Vec<(Vec<u8>, GroupId)> = storage
+        .list_transport_group_routes()
+        .unwrap()
+        .into_iter()
+        .map(|route| (route.transport_group_id, route.group_id))
+        .collect();
+    pairs.sort_by(|a, b| a.0.cmp(&b.0));
+    pairs
+}
+
+async fn confirm_evolution(engine: &mut Engine<SqliteAccountStorage>, result: SendResult) {
+    match result {
+        SendResult::GroupEvolution { pending, .. } => {
+            engine.confirm_published(pending).await.expect("confirm");
+        }
+        other => panic!("expected group evolution, got {other:?}"),
+    }
+}
+
+async fn rotate_route(
+    engine: &mut Engine<SqliteAccountStorage>,
+    group_id: &GroupId,
+    new_route: [u8; 32],
+) {
+    let routing = NostrRoutingV1::new(new_route, vec!["wss://rotated.example".into()])
+        .expect("routing component");
+    let result = engine
+        .send(SendIntent::UpdateAppComponents {
+            group_id: group_id.clone(),
+            updates: vec![AppComponentData {
+                component_id: NOSTR_ROUTING_COMPONENT_ID,
+                data: encode_nostr_routing_v1(&routing).expect("encode routing"),
+            }],
+        })
+        .await
+        .expect("rotate routing");
+    confirm_evolution(engine, result).await;
+}
+
+async fn rename_group(engine: &mut Engine<SqliteAccountStorage>, group_id: &GroupId, name: &str) {
+    let result = engine
+        .send(SendIntent::UpdateGroupData {
+            group_id: group_id.clone(),
+            name: Some(name.into()),
+            description: None,
+        })
+        .await
+        .expect("rename group");
+    confirm_evolution(engine, result).await;
+}
+
+fn inbound(route: [u8; 32], id: &[u8]) -> TransportMessage {
+    TransportMessage {
+        id: MessageId::new(id.to_vec()),
+        payload: b"not real mls bytes".to_vec(),
+        timestamp: Timestamp(0),
+        causal_deps: vec![],
+        source: TransportSource("mock".into()),
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: route.to_vec(),
+        },
+    }
+}
+
+#[tokio::test]
+async fn hydrate_all_fully_hydrates_unrecoverable_groups() {
+    let storage = SqliteAccountStorage::in_memory().expect("storage");
+    let mut initial = build_routed_engine(storage.clone());
+    let group_id = create_confirmed_group(&mut initial, true).await;
+    drop(initial);
+
+    // Mark the durable halt and wipe the route rows: full hydration must
+    // still run for the halted group (pre-mdk#1161 open always did) and
+    // re-derive its route from MLS state.
+    let mut record = storage.get_group(&group_id).unwrap();
+    record.unrecoverable = true;
+    storage.put_group(&record).unwrap();
+    storage
+        .delete_transport_group_routes_for_group(&group_id)
+        .unwrap();
+
+    let mut reopened = build_routed_engine(storage.clone());
+    reopened.hydrate_all_stored_groups().expect("eager hydrate");
+
+    assert!(
+        reopened.unhydrated_group_ids().is_empty(),
+        "the eager path must finish unrecoverable groups too"
+    );
+    assert!(reopened.quarantined_groups().is_empty());
+    assert_eq!(
+        route_pairs(&storage),
+        vec![(ROUTE_BYTES.to_vec(), group_id.clone())],
+        "full hydration must re-index the halted group's transport route"
+    );
+    let events = reopened.drain_events();
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| matches!(
+                event,
+                GroupEvent::GroupUnrecoverable { group_id: id } if id == &group_id
+            ))
+            .count(),
+        1,
+        "the halt re-emits exactly once per open: {events:?}"
+    );
+}
+
+#[tokio::test]
+async fn stale_route_stamp_triggers_backfill_repair_after_restart() {
+    const ROTATED: [u8; 32] = [0x42; 32];
+    let storage = SqliteAccountStorage::in_memory().expect("storage");
+    let mut initial = build_routed_engine(storage.clone());
+    let group_id = create_confirmed_group(&mut initial, true).await;
+    rotate_route(&mut initial, &group_id, ROTATED).await;
+    drop(initial);
+
+    // Simulate a crash between the rotation commit apply and the post-commit
+    // route refresh: the current route's row is missing, and the surviving
+    // prior row's epoch stamp lags the record epoch.
+    storage.delete_transport_group_route(&ROTATED).unwrap();
+
+    let mut reopened = build_routed_engine(storage.clone());
+    reopened
+        .hydrate_stable_groups_from_storage()
+        .expect("cheap pass");
+
+    // The stale stamp must schedule backfill: a message on the CURRENT route
+    // resolves through the bounded probe, hydrates the group, and repairs
+    // the durable row. (Trusting any surviving row would send this message
+    // down the UnknownGroup path instead.)
+    let _ = reopened.ingest(inbound(ROTATED, b"post-rotation")).await;
+    assert!(
+        reopened.unhydrated_group_ids().is_empty(),
+        "current-route traffic must resolve and hydrate after the crash window"
+    );
+    assert!(reopened.members(&group_id).is_ok());
+    assert!(
+        route_pairs(&storage).contains(&(ROTATED.to_vec(), group_id.clone())),
+        "the backfill must repair the current route row"
+    );
+}
+
+#[tokio::test]
+async fn rotated_route_is_retired_once_retention_window_passes() {
+    const ROTATED: [u8; 32] = [0x42; 32];
+    let storage = SqliteAccountStorage::in_memory().expect("storage");
+    let mut engine = build_routed_engine(storage.clone());
+    let group_id = create_confirmed_group(&mut engine, true).await;
+    rotate_route(&mut engine, &group_id, ROTATED).await;
+
+    // Both routes coexist through the overlap window right after rotation.
+    assert_eq!(
+        route_pairs(&storage),
+        vec![
+            (ROUTE_BYTES.to_vec(), group_id.clone()),
+            (ROTATED.to_vec(), group_id.clone()),
+        ]
+    );
+
+    // Advance the tip past the retained-history window (pinned v1
+    // max_rewind_commits = 5); each commit apply refreshes the current
+    // route's stamp and retires rows the window moved past.
+    for step in 0..7 {
+        rename_group(&mut engine, &group_id, &format!("rename {step}")).await;
+    }
+    assert_eq!(
+        route_pairs(&storage),
+        vec![(ROTATED.to_vec(), group_id.clone())],
+        "the pre-rotation route must be retired once no retained epoch uses it"
+    );
+    drop(engine);
+
+    // Restart: the surviving current route seeds the index and is trusted
+    // (stamp matches the record epoch), so current traffic resolves without
+    // any backfill probing.
+    let mut reopened = build_routed_engine(storage.clone());
+    reopened
+        .hydrate_stable_groups_from_storage()
+        .expect("cheap pass");
+    let _ = reopened.ingest(inbound(ROTATED, b"post-retirement")).await;
+    assert!(reopened.unhydrated_group_ids().is_empty());
     assert!(reopened.members(&group_id).is_ok());
 }

--- a/crates/cgka-engine/tests/two_phase_hydration.rs
+++ b/crates/cgka-engine/tests/two_phase_hydration.rs
@@ -599,3 +599,51 @@ async fn rotated_route_is_retired_once_retention_window_passes() {
     assert!(reopened.unhydrated_group_ids().is_empty());
     assert!(reopened.members(&group_id).is_ok());
 }
+
+#[tokio::test]
+async fn failed_promotion_in_convergence_buffer_persists_no_row() {
+    let storage = SqliteAccountStorage::in_memory().expect("storage");
+    let broken_group = GroupId::new(b"missing-openmls-state".to_vec());
+    insert_marmot_group_without_openmls_state(&storage, &broken_group, 7);
+
+    let mut engine = build_engine(storage.clone());
+    engine
+        .hydrate_stable_groups_from_storage()
+        .expect("cheap pass");
+    assert_eq!(engine.unhydrated_group_ids(), vec![broken_group.clone()]);
+
+    // The buffering entry point promotes the seeded group first; the failed
+    // promotion quarantines it and MUST propagate — silently continuing
+    // would take the no-epoch-state admission branch and durably retain a
+    // convergence row for a group validation just rejected.
+    let result = engine.buffer_openmls_convergence_message(
+        &broken_group,
+        TransportMessage {
+            id: MessageId::new(b"buffered-into-broken".to_vec()),
+            payload: b"not real mls bytes".to_vec(),
+            timestamp: Timestamp(0),
+            causal_deps: vec![],
+            source: TransportSource("mock".into()),
+            envelope: TransportEnvelope::GroupMessage {
+                transport_group_id: broken_group.as_slice().to_vec(),
+            },
+        },
+    );
+    assert!(
+        result.is_err(),
+        "failed promotion must propagate: {result:?}"
+    );
+    assert_eq!(
+        engine.quarantined_groups(),
+        vec![(
+            broken_group.clone(),
+            GroupHydrationQuarantineReason::OpenMlsGroupMissing
+        )]
+    );
+    assert!(
+        cgka_traits::storage::MessageStorage::list_messages(&storage, &broken_group, EpochId(0))
+            .unwrap()
+            .is_empty(),
+        "no convergence row may be persisted for the failed group"
+    );
+}

--- a/crates/cgka-engine/tests/two_phase_hydration.rs
+++ b/crates/cgka-engine/tests/two_phase_hydration.rs
@@ -1,0 +1,413 @@
+//! Two-phase hydration (mdk#1161): the session-open cheap pass seeds every
+//! stored group without loading MLS state, gated surfaces fail closed with
+//! `GroupNotHydrated`, and full hydration runs per group — on demand from
+//! `&mut` entry points or explicitly via `ensure_hydrated` — with failure
+//! parity to open-time quarantine. Durable transport routes keep inbound
+//! routing working for seeded groups, with a one-shot backfill for records
+//! predating the route table.
+
+use async_trait::async_trait;
+use cgka_engine::feature_registry::FeatureRegistry;
+use cgka_engine::{Engine, EngineBuilder};
+use cgka_traits::app_components::{
+    AppComponentData, NOSTR_ROUTING_COMPONENT_ID, NostrRoutingV1, default_group_components,
+    encode_nostr_routing_v1,
+};
+use cgka_traits::capabilities::{Capability, CapabilityRequirement, Feature, RequirementLevel};
+use cgka_traits::engine::{
+    CgkaEngine, CreateGroupRequest, GroupEvent, GroupHydrationQuarantineReason, SendResult,
+};
+use cgka_traits::error::{EngineError, PeelerError};
+use cgka_traits::group::Group;
+use cgka_traits::group_context::GroupContextSnapshot;
+use cgka_traits::ingest::{PeeledContent, PeeledMessage};
+use cgka_traits::peeler::TransportPeeler;
+use cgka_traits::storage::GroupStorage;
+use cgka_traits::transport::{
+    EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
+};
+use cgka_traits::types::{EpochId, GroupId, MemberId, MessageId};
+use storage_sqlite::SqliteAccountStorage;
+
+mod support;
+use support::proof_signer;
+
+fn pad32(name: &[u8]) -> Vec<u8> {
+    use k256::schnorr::SigningKey;
+    use sha2::{Digest, Sha256};
+
+    let mut counter = 0u64;
+    loop {
+        let mut material = [0u8; 32];
+        let mut hasher = Sha256::new();
+        hasher.update(b"cgka-engine-test-identity-v1");
+        hasher.update(name);
+        hasher.update(counter.to_be_bytes());
+        material.copy_from_slice(&hasher.finalize());
+        if let Ok(sk) = SigningKey::from_bytes(&material) {
+            return sk.verifying_key().to_bytes().to_vec();
+        }
+        counter += 1;
+    }
+}
+
+struct MockPeeler;
+
+fn hash_id(bytes: &[u8]) -> MessageId {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let mut h = DefaultHasher::new();
+    bytes.hash(&mut h);
+    MessageId::new(h.finish().to_be_bytes().to_vec())
+}
+
+#[async_trait]
+impl TransportPeeler for MockPeeler {
+    async fn peel_group_message(
+        &self,
+        msg: &TransportMessage,
+        _ctx: &GroupContextSnapshot,
+    ) -> Result<PeeledMessage, PeelerError> {
+        Ok(PeeledMessage {
+            id: msg.id.clone(),
+            group_id: None,
+            sender: None,
+            content: PeeledContent::MlsMessage {
+                bytes: msg.payload.clone(),
+            },
+            origin: msg.clone(),
+        })
+    }
+
+    async fn peel_welcome(&self, msg: &TransportMessage) -> Result<PeeledMessage, PeelerError> {
+        Ok(PeeledMessage {
+            id: msg.id.clone(),
+            group_id: None,
+            sender: None,
+            content: PeeledContent::Welcome {
+                bytes: msg.payload.clone(),
+            },
+            origin: msg.clone(),
+        })
+    }
+
+    async fn wrap_group_message(
+        &self,
+        payload: &EncryptedPayload,
+        _ctx: &GroupContextSnapshot,
+    ) -> Result<TransportMessage, PeelerError> {
+        Ok(TransportMessage {
+            id: hash_id(&payload.ciphertext),
+            payload: payload.ciphertext.clone(),
+            timestamp: Timestamp(0),
+            causal_deps: vec![],
+            source: TransportSource("mock".into()),
+            envelope: TransportEnvelope::GroupMessage {
+                transport_group_id: vec![],
+            },
+        })
+    }
+
+    async fn wrap_welcome(
+        &self,
+        payload: &EncryptedPayload,
+        recipient: &MemberId,
+    ) -> Result<TransportMessage, PeelerError> {
+        Ok(TransportMessage {
+            id: hash_id(&payload.ciphertext),
+            payload: payload.ciphertext.clone(),
+            timestamp: Timestamp(0),
+            causal_deps: vec![],
+            source: TransportSource("mock".into()),
+            envelope: TransportEnvelope::Welcome {
+                recipient: recipient.clone(),
+            },
+        })
+    }
+}
+
+fn build_engine(storage: SqliteAccountStorage) -> Engine<SqliteAccountStorage> {
+    EngineBuilder::new(storage)
+        .legacy_compatibility_profile()
+        .identity(pad32(b"alice-two-phase"))
+        .account_identity_proof_signer(proof_signer(b"alice-two-phase"))
+        .peeler(Box::new(MockPeeler))
+        .build()
+        .expect("build engine")
+}
+
+const ROUTE_BYTES: [u8; 32] = [0x41; 32];
+
+/// Current-profile engine whose key packages advertise the routing component,
+/// for the transport-route tests (shape mirrors `update_group_data.rs`).
+fn build_routed_engine(storage: SqliteAccountStorage) -> Engine<SqliteAccountStorage> {
+    let mut registry = FeatureRegistry::new();
+    registry.register(
+        Feature("self-remove"),
+        CapabilityRequirement {
+            requires: Capability::Proposal(10),
+            level: RequirementLevel::Required,
+            description: "MIP-03",
+        },
+    );
+    let mut components: Vec<_> = default_group_components().into_iter().collect();
+    components.push(NOSTR_ROUTING_COMPONENT_ID);
+    EngineBuilder::new(storage)
+        .identity(pad32(b"alice-two-phase"))
+        .account_identity_proof_signer(proof_signer(b"alice-two-phase"))
+        .protocol_profile(cgka_traits::group::ProtocolProfile::Current)
+        .feature_registry(registry)
+        .supported_app_components(components)
+        .peeler(Box::new(MockPeeler))
+        .build()
+        .expect("build routed engine")
+}
+
+async fn create_confirmed_group(
+    engine: &mut Engine<SqliteAccountStorage>,
+    with_route: bool,
+) -> GroupId {
+    let app_components = if with_route {
+        let routing = NostrRoutingV1::new(ROUTE_BYTES, vec!["wss://relay.example".into()])
+            .expect("routing component");
+        vec![AppComponentData {
+            component_id: NOSTR_ROUTING_COMPONENT_ID,
+            data: encode_nostr_routing_v1(&routing).expect("encode routing"),
+        }]
+    } else {
+        Vec::new()
+    };
+    let (group_id, send_result) = engine
+        .create_group(CreateGroupRequest {
+            name: "two-phase".into(),
+            description: String::new(),
+            members: vec![],
+            required_features: vec![],
+            app_components,
+            initial_admins: vec![],
+        })
+        .await
+        .expect("create group");
+    match send_result {
+        SendResult::GroupCreated { pending, .. } => {
+            engine.confirm_published(pending).await.expect("confirm");
+        }
+        // Current-profile founding creation is already canonical locally.
+        SendResult::FoundingGroupCreated { .. } => {}
+        other => panic!("expected group-created send result, got {other:?}"),
+    }
+    group_id
+}
+
+fn insert_marmot_group_without_openmls_state(
+    storage: &SqliteAccountStorage,
+    group_id: &GroupId,
+    epoch: u64,
+) {
+    storage
+        .put_group(&Group {
+            id: group_id.clone(),
+            name: "broken".into(),
+            description: String::new(),
+            members: Vec::new(),
+            epoch: EpochId(epoch),
+            required_capabilities: Default::default(),
+            protocol_profile: cgka_traits::group::ProtocolProfile::Legacy,
+            removed: false,
+            unrecoverable: false,
+            disbanded: None,
+            join_epoch: EpochId(0),
+        })
+        .expect("insert marmot group record without openmls state");
+}
+
+#[tokio::test]
+async fn seeded_group_is_listed_but_gated_until_hydrated() {
+    let storage = SqliteAccountStorage::in_memory().expect("storage");
+    let mut initial = build_engine(storage.clone());
+    let group_id = create_confirmed_group(&mut initial, false).await;
+    let stored_epoch = storage.get_group(&group_id).unwrap().epoch;
+    drop(initial);
+
+    let mut reopened = build_engine(storage);
+    reopened
+        .hydrate_stable_groups_from_storage()
+        .expect("cheap pass");
+
+    // The projection keeps listing the group while hydration is outstanding.
+    assert_eq!(reopened.live_group_ids().unwrap(), vec![group_id.clone()]);
+    assert_eq!(reopened.unhydrated_group_ids(), vec![group_id.clone()]);
+
+    // Every gated accessor fails closed with the retryable variant — never a
+    // partial view, never UnknownGroup.
+    assert!(matches!(
+        reopened.members(&group_id),
+        Err(EngineError::GroupNotHydrated(id)) if id == group_id
+    ));
+    assert!(matches!(
+        reopened.epoch(&group_id),
+        Err(EngineError::GroupNotHydrated(id)) if id == group_id
+    ));
+
+    // Explicit promotion makes the group fully live.
+    reopened.ensure_hydrated(&group_id).expect("hydrate");
+    assert!(reopened.unhydrated_group_ids().is_empty());
+    assert_eq!(reopened.epoch(&group_id).unwrap(), stored_epoch);
+    assert!(reopened.members(&group_id).is_ok());
+}
+
+#[tokio::test]
+async fn ensure_hydrated_failure_quarantines_with_open_time_parity() {
+    let storage = SqliteAccountStorage::in_memory().expect("storage");
+    let broken_group = GroupId::new(b"missing-openmls-state".to_vec());
+    insert_marmot_group_without_openmls_state(&storage, &broken_group, 7);
+
+    let mut engine = build_engine(storage);
+    engine
+        .hydrate_stable_groups_from_storage()
+        .expect("cheap pass");
+    // The cheap pass cannot see the missing MLS state, so the group seeds.
+    assert_eq!(engine.live_group_ids().unwrap(), vec![broken_group.clone()]);
+
+    assert!(matches!(
+        engine.ensure_hydrated(&broken_group),
+        Err(EngineError::UnknownGroup(id)) if id == broken_group
+    ));
+
+    // Quarantine parity with an open-time failure: reason recorded, event
+    // emitted, and the group vanishes from every live surface including the
+    // group list (the provisional seed is retracted).
+    assert_eq!(
+        engine.quarantined_groups(),
+        vec![(
+            broken_group.clone(),
+            GroupHydrationQuarantineReason::OpenMlsGroupMissing
+        )]
+    );
+    assert!(engine.live_group_ids().unwrap().is_empty());
+    assert!(engine.unhydrated_group_ids().is_empty());
+    assert!(matches!(
+        engine.members(&broken_group),
+        Err(EngineError::UnknownGroup(_))
+    ));
+    let events = engine.drain_events();
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            GroupEvent::GroupHydrationQuarantined {
+                group_id,
+                reason: GroupHydrationQuarantineReason::OpenMlsGroupMissing,
+            } if group_id == &broken_group
+        )),
+        "quarantine event missing: {events:?}"
+    );
+}
+
+#[tokio::test]
+async fn cheap_pass_is_idempotent_and_never_demotes_a_live_group() {
+    let storage = SqliteAccountStorage::in_memory().expect("storage");
+    let mut initial = build_engine(storage.clone());
+    let group_id = create_confirmed_group(&mut initial, false).await;
+    drop(initial);
+
+    let mut reopened = build_engine(storage);
+    reopened.hydrate_all_stored_groups().expect("eager hydrate");
+    assert!(reopened.unhydrated_group_ids().is_empty());
+    assert!(reopened.members(&group_id).is_ok());
+
+    // A second cheap pass must not re-seed the already-live group back into
+    // the unhydrated set.
+    reopened
+        .hydrate_stable_groups_from_storage()
+        .expect("second cheap pass");
+    assert!(reopened.unhydrated_group_ids().is_empty());
+    assert!(reopened.members(&group_id).is_ok());
+}
+
+#[tokio::test]
+async fn ingest_hydrates_seeded_group_resolved_through_durable_route() {
+    let storage = SqliteAccountStorage::in_memory().expect("storage");
+    let mut initial = build_routed_engine(storage.clone());
+    let group_id = create_confirmed_group(&mut initial, true).await;
+    drop(initial);
+
+    // Group establishment persisted the transport route durably.
+    assert_eq!(
+        storage.list_transport_group_routes().unwrap(),
+        vec![(ROUTE_BYTES.to_vec(), group_id.clone())]
+    );
+
+    let mut reopened = build_routed_engine(storage);
+    reopened
+        .hydrate_stable_groups_from_storage()
+        .expect("cheap pass");
+    assert_eq!(reopened.unhydrated_group_ids(), vec![group_id.clone()]);
+
+    // An inbound message addressed to the transport route resolves through
+    // the durably seeded index and promotes the group before the peel.
+    let _ = reopened
+        .ingest(TransportMessage {
+            id: MessageId::new(b"inbound-two-phase".to_vec()),
+            payload: b"not real mls bytes".to_vec(),
+            timestamp: Timestamp(0),
+            causal_deps: vec![],
+            source: TransportSource("mock".into()),
+            envelope: TransportEnvelope::GroupMessage {
+                transport_group_id: ROUTE_BYTES.to_vec(),
+            },
+        })
+        .await;
+    assert!(
+        reopened.unhydrated_group_ids().is_empty(),
+        "ingest must hydrate the routed group on demand"
+    );
+    assert!(reopened.members(&group_id).is_ok());
+    assert!(reopened.quarantined_groups().is_empty());
+}
+
+#[tokio::test]
+async fn ingest_backfills_route_for_record_predating_route_table() {
+    let storage = SqliteAccountStorage::in_memory().expect("storage");
+    let mut initial = build_routed_engine(storage.clone());
+    let group_id = create_confirmed_group(&mut initial, true).await;
+    drop(initial);
+
+    // Simulate a store migrated from before the route table: the group
+    // exists but has no durable route row.
+    storage
+        .delete_transport_group_routes_for_group(&group_id)
+        .expect("drop route rows");
+    assert!(storage.list_transport_group_routes().unwrap().is_empty());
+
+    let mut reopened = build_routed_engine(storage.clone());
+    reopened
+        .hydrate_stable_groups_from_storage()
+        .expect("cheap pass");
+
+    // The routing miss triggers the one-shot backfill: the group's MLS state
+    // is loaded once, its route persisted and indexed, and the message then
+    // resolves and hydrates the group.
+    let _ = reopened
+        .ingest(TransportMessage {
+            id: MessageId::new(b"inbound-backfill".to_vec()),
+            payload: b"not real mls bytes".to_vec(),
+            timestamp: Timestamp(0),
+            causal_deps: vec![],
+            source: TransportSource("mock".into()),
+            envelope: TransportEnvelope::GroupMessage {
+                transport_group_id: ROUTE_BYTES.to_vec(),
+            },
+        })
+        .await;
+    assert!(
+        reopened.unhydrated_group_ids().is_empty(),
+        "backfilled route must resolve and hydrate the group"
+    );
+    assert_eq!(
+        storage.list_transport_group_routes().unwrap(),
+        vec![(ROUTE_BYTES.to_vec(), group_id.clone())],
+        "backfill must repopulate the durable route table"
+    );
+    assert!(reopened.members(&group_id).is_ok());
+}

--- a/crates/cgka-session/src/lib.rs
+++ b/crates/cgka-session/src/lib.rs
@@ -349,7 +349,10 @@ impl AccountDeviceSession {
         }
         let engine_build = build_started.elapsed();
         let hydration_started = std::time::Instant::now();
-        engine.hydrate_stable_groups_from_storage()?;
+        // Eager for now: the app-layer background hydration pipeline
+        // (mdk#1161 layer 3) switches this to the cheap seed pass once hosts
+        // drive per-group hydration after readiness.
+        engine.hydrate_all_stored_groups()?;
         let group_hydration = hydration_started.elapsed();
         engine
             .set_convergence_policy(config.convergence_policy)

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -18,6 +18,16 @@ versioning through the workspace version in the root `Cargo.toml`.
   chat-projection readiness from full account-command readiness across
   0/10/100/1000 stored groups.
 
+- Engine session open now uses two-phase hydration: a cheap seed pass reads
+  only durable group records (plus a new durable transport-route table) and
+  full per-group hydration — MLS load, validation, pending-commit recovery —
+  runs per group, on demand from send/ingest/convergence entry points or
+  eagerly via the compatibility path. Per-group hydration itself got cheaper:
+  one group-record read and one message scan replace the former three record
+  reads and four full message-table scans per group. Groups awaiting
+  hydration report a new retryable "not hydrated yet" state instead of
+  partial data.
+
 - `marmot-markdown` now recognizes bare `www.example.com/path` text as web
   autolinks. The AST preserves the displayed `www.` source while exposing an
   explicit `Www` autolink kind so renderers can synthesize `https://`

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -82,6 +82,8 @@ mod migration_0040_disband_requests;
 mod migration_0041_secure_delete_checkpoint_intents;
 #[path = "migrations/0042_group_state_checkpoints.rs"]
 mod migration_0042_group_state_checkpoints;
+#[path = "migrations/0043_transport_group_routes.rs"]
+mod migration_0043_transport_group_routes;
 
 use crate::SqliteResultExt;
 use cgka_traits::storage::{StorageError, StorageResult};
@@ -303,6 +305,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 42,
         name: "0042_group_state_checkpoints",
         apply: migration_0042_group_state_checkpoints::apply,
+    },
+    Migration {
+        version: 43,
+        name: "0043_transport_group_routes",
+        apply: migration_0043_transport_group_routes::apply,
     },
 ];
 

--- a/crates/storage-sqlite/src/migrations/0043_transport_group_routes.rs
+++ b/crates/storage-sqlite/src/migrations/0043_transport_group_routes.rs
@@ -5,22 +5,27 @@ use rusqlite::Transaction;
 /// Durable transport-route index (mdk#1161): opaque transport routing-id
 /// bytes -> MLS group id, so session open can seed inbound routing without
 /// loading each group's MLS state. Many-to-one per group: a routing rotation
-/// keeps the prior route for its overlap window (mdk#740). Deliberately not
-/// captured by group snapshots — routes are a regenerable projection of MLS
-/// state, and a rollback must not delete a still-valid route. Groups stored
-/// before this migration have no rows; the engine backfills their routes on
-/// first full hydration.
+/// keeps the prior route for its overlap window (mdk#740). `source_epoch`
+/// records the group epoch of the last write that observed the route as
+/// current: session open uses it to detect a stale route set (a crash
+/// between a commit apply and the route refresh), and the engine retires
+/// rows once the retained-history window moves past them (routing-v1 overlap
+/// rule). Deliberately not captured by group snapshots — routes are a
+/// regenerable projection of MLS state, and a rollback must not delete a
+/// still-valid route. Groups stored before this migration have no rows; the
+/// engine backfills their routes on first full hydration.
 pub(crate) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
     tx.execute_batch(
         r#"
 CREATE TABLE cgka_transport_group_routes (
     transport_group_id BLOB PRIMARY KEY,
     group_id BLOB NOT NULL,
+    source_epoch INTEGER NOT NULL,
     FOREIGN KEY (group_id) REFERENCES cgka_groups(id) ON DELETE CASCADE
 );
 
 CREATE INDEX idx_cgka_transport_group_routes_group
-    ON cgka_transport_group_routes(group_id);
+    ON cgka_transport_group_routes(group_id, source_epoch);
 "#,
     )
     .storage()

--- a/crates/storage-sqlite/src/migrations/0043_transport_group_routes.rs
+++ b/crates/storage-sqlite/src/migrations/0043_transport_group_routes.rs
@@ -1,0 +1,27 @@
+use crate::SqliteResultExt;
+use cgka_traits::storage::StorageResult;
+use rusqlite::Transaction;
+
+/// Durable transport-route index (mdk#1161): opaque transport routing-id
+/// bytes -> MLS group id, so session open can seed inbound routing without
+/// loading each group's MLS state. Many-to-one per group: a routing rotation
+/// keeps the prior route for its overlap window (mdk#740). Deliberately not
+/// captured by group snapshots — routes are a regenerable projection of MLS
+/// state, and a rollback must not delete a still-valid route. Groups stored
+/// before this migration have no rows; the engine backfills their routes on
+/// first full hydration.
+pub(crate) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
+    tx.execute_batch(
+        r#"
+CREATE TABLE cgka_transport_group_routes (
+    transport_group_id BLOB PRIMARY KEY,
+    group_id BLOB NOT NULL,
+    FOREIGN KEY (group_id) REFERENCES cgka_groups(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_cgka_transport_group_routes_group
+    ON cgka_transport_group_routes(group_id);
+"#,
+    )
+    .storage()
+}

--- a/crates/storage-sqlite/src/storage/groups.rs
+++ b/crates/storage-sqlite/src/storage/groups.rs
@@ -70,6 +70,35 @@ impl GroupStorage for SqliteAccountStorage {
             .collect::<Result<Vec<_>, _>>()
             .storage()
     }
+
+    fn list_group_records(&self) -> StorageResult<Vec<Group>> {
+        let conn = self.lock()?;
+        let mut stmt = conn
+            .prepare("SELECT record FROM cgka_groups ORDER BY id")
+            .storage()?;
+        let records = stmt
+            .query_map([], |row| row.get::<_, Vec<u8>>(0))
+            .storage()?
+            .collect::<Result<Vec<_>, _>>()
+            .storage()?;
+        records.iter().map(|record| deserialize(record)).collect()
+    }
+
+    fn put_transport_group_route(
+        &self,
+        transport_group_id: &[u8],
+        group_id: &GroupId,
+    ) -> StorageResult<()> {
+        super::transport_routes::put(self, transport_group_id, group_id)
+    }
+
+    fn list_transport_group_routes(&self) -> StorageResult<Vec<(Vec<u8>, GroupId)>> {
+        super::transport_routes::list(self)
+    }
+
+    fn delete_transport_group_routes_for_group(&self, group_id: &GroupId) -> StorageResult<()> {
+        super::transport_routes::delete_for_group(self, group_id)
+    }
 }
 
 #[cfg(test)]
@@ -86,6 +115,81 @@ mod tests {
     };
     use cgka_traits::types::EpochId;
     use openmls_traits::storage::StorageProvider as OpenMlsStorageProvider;
+
+    #[test]
+    fn list_group_records_returns_every_stored_record() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let first = sample_group(gid(1), 7, 3);
+        let second = sample_group(gid(2), 4, 2);
+        store.put_group(&first).unwrap();
+        store.put_group(&second).unwrap();
+        let records = store.list_group_records().unwrap();
+        assert_eq!(records.len(), 2);
+        assert!(records.contains(&first));
+        assert!(records.contains(&second));
+    }
+
+    #[test]
+    fn transport_group_routes_roundtrip_and_rotation_keeps_prior_route() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let group = sample_group(gid(1), 1, 1);
+        store.put_group(&group).unwrap();
+
+        // Rotation overlap (mdk#740): both the prior and the current route
+        // resolve to the group until the prior route is retired.
+        store
+            .put_transport_group_route(&[0xAA; 32], &group.id)
+            .unwrap();
+        store
+            .put_transport_group_route(&[0xBB; 32], &group.id)
+            .unwrap();
+        let mut routes = store.list_transport_group_routes().unwrap();
+        routes.sort_by(|a, b| a.0.cmp(&b.0));
+        assert_eq!(
+            routes,
+            vec![
+                (vec![0xAA; 32], group.id.clone()),
+                (vec![0xBB; 32], group.id.clone()),
+            ]
+        );
+
+        // Re-pointing an existing route replaces its target instead of
+        // erroring, matching the in-memory index's insert semantics.
+        let other = sample_group(gid(2), 1, 1);
+        store.put_group(&other).unwrap();
+        store
+            .put_transport_group_route(&[0xBB; 32], &other.id)
+            .unwrap();
+        let mut routes = store.list_transport_group_routes().unwrap();
+        routes.sort_by(|a, b| a.0.cmp(&b.0));
+        assert_eq!(
+            routes,
+            vec![
+                (vec![0xAA; 32], group.id.clone()),
+                (vec![0xBB; 32], other.id.clone()),
+            ]
+        );
+
+        store
+            .delete_transport_group_routes_for_group(&group.id)
+            .unwrap();
+        assert_eq!(
+            store.list_transport_group_routes().unwrap(),
+            vec![(vec![0xBB; 32], other.id.clone())]
+        );
+    }
+
+    #[test]
+    fn deleting_a_group_cascades_its_transport_routes() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let group = sample_group(gid(1), 1, 1);
+        store.put_group(&group).unwrap();
+        store
+            .put_transport_group_route(&[0xCC; 32], &group.id)
+            .unwrap();
+        store.delete_group(&group.id).unwrap();
+        assert!(store.list_transport_group_routes().unwrap().is_empty());
+    }
 
     #[test]
     fn group_roundtrip_preserves_every_field() {

--- a/crates/storage-sqlite/src/storage/groups.rs
+++ b/crates/storage-sqlite/src/storage/groups.rs
@@ -1,8 +1,8 @@
 use crate::openmls_storage::mls_group_key;
 use crate::{SqliteAccountStorage, SqliteResultExt, deserialize, epoch_to_i64, serialize};
 use cgka_traits::group::Group;
-use cgka_traits::storage::{GroupStorage, StorageError, StorageResult};
-use cgka_traits::types::GroupId;
+use cgka_traits::storage::{GroupStorage, StorageError, StorageResult, TransportGroupRoute};
+use cgka_traits::types::{EpochId, GroupId};
 use rusqlite::{OptionalExtension, params};
 
 impl GroupStorage for SqliteAccountStorage {
@@ -88,12 +88,25 @@ impl GroupStorage for SqliteAccountStorage {
         &self,
         transport_group_id: &[u8],
         group_id: &GroupId,
+        source_epoch: EpochId,
     ) -> StorageResult<()> {
-        super::transport_routes::put(self, transport_group_id, group_id)
+        super::transport_routes::put(self, transport_group_id, group_id, source_epoch)
     }
 
-    fn list_transport_group_routes(&self) -> StorageResult<Vec<(Vec<u8>, GroupId)>> {
+    fn list_transport_group_routes(&self) -> StorageResult<Vec<TransportGroupRoute>> {
         super::transport_routes::list(self)
+    }
+
+    fn delete_transport_group_route(&self, transport_group_id: &[u8]) -> StorageResult<()> {
+        super::transport_routes::delete_route(self, transport_group_id)
+    }
+
+    fn delete_transport_group_routes_below_epoch(
+        &self,
+        group_id: &GroupId,
+        cutoff: EpochId,
+    ) -> StorageResult<()> {
+        super::transport_routes::delete_below_epoch(self, group_id, cutoff)
     }
 
     fn delete_transport_group_routes_for_group(&self, group_id: &GroupId) -> StorageResult<()> {
@@ -111,7 +124,7 @@ mod tests {
     use cgka_traits::group::ProtocolProfile;
     use cgka_traits::storage::{
         CapabilityStorage, ConvergencePolicyStorage, GroupStorage, MessageStorage,
-        OutboundIntentStorage, StorageError, StorageProvider,
+        OutboundIntentStorage, StorageError, StorageProvider, TransportGroupRoute,
     };
     use cgka_traits::types::EpochId;
     use openmls_traits::storage::StorageProvider as OpenMlsStorageProvider;
@@ -129,6 +142,24 @@ mod tests {
         assert!(records.contains(&second));
     }
 
+    fn route(
+        transport_group_id: [u8; 32],
+        group_id: &cgka_traits::types::GroupId,
+        source_epoch: u64,
+    ) -> TransportGroupRoute {
+        TransportGroupRoute {
+            transport_group_id: transport_group_id.to_vec(),
+            group_id: group_id.clone(),
+            source_epoch: EpochId(source_epoch),
+        }
+    }
+
+    fn sorted_routes(store: &SqliteAccountStorage) -> Vec<TransportGroupRoute> {
+        let mut routes = store.list_transport_group_routes().unwrap();
+        routes.sort_by(|a, b| a.transport_group_id.cmp(&b.transport_group_id));
+        routes
+    }
+
     #[test]
     fn transport_group_routes_roundtrip_and_rotation_keeps_prior_route() {
         let store = SqliteAccountStorage::in_memory().unwrap();
@@ -138,44 +169,83 @@ mod tests {
         // Rotation overlap (mdk#740): both the prior and the current route
         // resolve to the group until the prior route is retired.
         store
-            .put_transport_group_route(&[0xAA; 32], &group.id)
+            .put_transport_group_route(&[0xAA; 32], &group.id, EpochId(3))
             .unwrap();
         store
-            .put_transport_group_route(&[0xBB; 32], &group.id)
+            .put_transport_group_route(&[0xBB; 32], &group.id, EpochId(4))
             .unwrap();
-        let mut routes = store.list_transport_group_routes().unwrap();
-        routes.sort_by(|a, b| a.0.cmp(&b.0));
         assert_eq!(
-            routes,
+            sorted_routes(&store),
             vec![
-                (vec![0xAA; 32], group.id.clone()),
-                (vec![0xBB; 32], group.id.clone()),
+                route([0xAA; 32], &group.id, 3),
+                route([0xBB; 32], &group.id, 4)
             ]
         );
 
-        // Re-pointing an existing route replaces its target instead of
-        // erroring, matching the in-memory index's insert semantics.
+        // Re-pointing an existing route replaces its target and refreshes its
+        // source epoch, matching the in-memory index's insert semantics.
         let other = sample_group(gid(2), 1, 1);
         store.put_group(&other).unwrap();
         store
-            .put_transport_group_route(&[0xBB; 32], &other.id)
+            .put_transport_group_route(&[0xBB; 32], &other.id, EpochId(9))
             .unwrap();
-        let mut routes = store.list_transport_group_routes().unwrap();
-        routes.sort_by(|a, b| a.0.cmp(&b.0));
         assert_eq!(
-            routes,
+            sorted_routes(&store),
             vec![
-                (vec![0xAA; 32], group.id.clone()),
-                (vec![0xBB; 32], other.id.clone()),
+                route([0xAA; 32], &group.id, 3),
+                route([0xBB; 32], &other.id, 9)
             ]
         );
 
         store
             .delete_transport_group_routes_for_group(&group.id)
             .unwrap();
+        assert_eq!(sorted_routes(&store), vec![route([0xBB; 32], &other.id, 9)]);
+    }
+
+    #[test]
+    fn transport_group_route_retirement_is_per_route_and_per_epoch_window() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let group = sample_group(gid(1), 1, 1);
+        store.put_group(&group).unwrap();
+        let bystander = sample_group(gid(2), 1, 1);
+        store.put_group(&bystander).unwrap();
+
+        store
+            .put_transport_group_route(&[0x01; 32], &group.id, EpochId(2))
+            .unwrap();
+        store
+            .put_transport_group_route(&[0x02; 32], &group.id, EpochId(7))
+            .unwrap();
+        store
+            .put_transport_group_route(&[0x03; 32], &group.id, EpochId(12))
+            .unwrap();
+        store
+            .put_transport_group_route(&[0x04; 32], &bystander.id, EpochId(1))
+            .unwrap();
+
+        // Bulk retirement below the retention cutoff touches only the named
+        // group; the bystander's old route survives.
+        store
+            .delete_transport_group_routes_below_epoch(&group.id, EpochId(7))
+            .unwrap();
         assert_eq!(
-            store.list_transport_group_routes().unwrap(),
-            vec![(vec![0xBB; 32], other.id.clone())]
+            sorted_routes(&store),
+            vec![
+                route([0x02; 32], &group.id, 7),
+                route([0x03; 32], &group.id, 12),
+                route([0x04; 32], &bystander.id, 1),
+            ]
+        );
+
+        // Single-route retirement.
+        store.delete_transport_group_route(&[0x02; 32]).unwrap();
+        assert_eq!(
+            sorted_routes(&store),
+            vec![
+                route([0x03; 32], &group.id, 12),
+                route([0x04; 32], &bystander.id, 1),
+            ]
         );
     }
 
@@ -185,7 +255,7 @@ mod tests {
         let group = sample_group(gid(1), 1, 1);
         store.put_group(&group).unwrap();
         store
-            .put_transport_group_route(&[0xCC; 32], &group.id)
+            .put_transport_group_route(&[0xCC; 32], &group.id, EpochId(1))
             .unwrap();
         store.delete_group(&group.id).unwrap();
         assert!(store.list_transport_group_routes().unwrap().is_empty());

--- a/crates/storage-sqlite/src/storage/mod.rs
+++ b/crates/storage-sqlite/src/storage/mod.rs
@@ -14,6 +14,7 @@ mod member_validation_cache;
 mod messages;
 mod outbound;
 pub(crate) mod snapshots;
+mod transport_routes;
 mod welcomes;
 
 #[cfg(test)]

--- a/crates/storage-sqlite/src/storage/transport_routes.rs
+++ b/crates/storage-sqlite/src/storage/transport_routes.rs
@@ -1,46 +1,98 @@
 //! Durable transport-route index rows (mdk#1161): opaque transport routing-id
-//! bytes -> MLS group id, seeded into the engine's in-memory routing index at
+//! bytes -> MLS group id plus the group epoch of the last write that observed
+//! the route as current. Seeded into the engine's in-memory routing index at
 //! session open so inbound routing does not require loading each group's MLS
-//! state. The `GroupStorage` impl in `groups.rs` delegates here.
+//! state; the epoch lets the seed detect a stale route set after a crash and
+//! lets the engine retire prior routes once the retained-history window moves
+//! past them. The `GroupStorage` impl in `groups.rs` delegates here.
 
-use crate::{SqliteAccountStorage, SqliteResultExt};
-use cgka_traits::storage::StorageResult;
-use cgka_traits::types::GroupId;
+use crate::{SqliteAccountStorage, SqliteResultExt, epoch_to_i64, i64_to_u64};
+use cgka_traits::storage::{StorageResult, TransportGroupRoute};
+use cgka_traits::types::{EpochId, GroupId};
 use rusqlite::params;
 
 pub(super) fn put(
     store: &SqliteAccountStorage,
     transport_group_id: &[u8],
     group_id: &GroupId,
+    source_epoch: EpochId,
 ) -> StorageResult<()> {
     store
         .lock()?
         .execute(
-            "INSERT INTO cgka_transport_group_routes (transport_group_id, group_id)
-             VALUES (?1, ?2)
-             ON CONFLICT(transport_group_id) DO UPDATE SET group_id = excluded.group_id",
-            params![transport_group_id, group_id.as_slice()],
+            "INSERT INTO cgka_transport_group_routes (transport_group_id, group_id, source_epoch)
+             VALUES (?1, ?2, ?3)
+             ON CONFLICT(transport_group_id) DO UPDATE SET
+                group_id = excluded.group_id,
+                source_epoch = excluded.source_epoch",
+            params![
+                transport_group_id,
+                group_id.as_slice(),
+                epoch_to_i64(source_epoch)?
+            ],
         )
         .storage()?;
     Ok(())
 }
 
-pub(super) fn list(store: &SqliteAccountStorage) -> StorageResult<Vec<(Vec<u8>, GroupId)>> {
+pub(super) fn list(store: &SqliteAccountStorage) -> StorageResult<Vec<TransportGroupRoute>> {
     let conn = store.lock()?;
     let mut statement = conn
-        .prepare("SELECT transport_group_id, group_id FROM cgka_transport_group_routes")
+        .prepare(
+            "SELECT transport_group_id, group_id, source_epoch
+             FROM cgka_transport_group_routes",
+        )
         .storage()?;
     let rows = statement
         .query_map([], |row| {
             Ok((
                 row.get::<_, Vec<u8>>(0)?,
                 GroupId::new(row.get::<_, Vec<u8>>(1)?),
+                row.get::<_, i64>(2)?,
             ))
         })
         .storage()?
         .collect::<Result<Vec<_>, _>>()
         .storage()?;
-    Ok(rows)
+    rows.into_iter()
+        .map(|(transport_group_id, group_id, epoch)| {
+            Ok(TransportGroupRoute {
+                transport_group_id,
+                group_id,
+                source_epoch: EpochId(i64_to_u64(epoch)?),
+            })
+        })
+        .collect()
+}
+
+pub(super) fn delete_route(
+    store: &SqliteAccountStorage,
+    transport_group_id: &[u8],
+) -> StorageResult<()> {
+    store
+        .lock()?
+        .execute(
+            "DELETE FROM cgka_transport_group_routes WHERE transport_group_id = ?1",
+            params![transport_group_id],
+        )
+        .storage()?;
+    Ok(())
+}
+
+pub(super) fn delete_below_epoch(
+    store: &SqliteAccountStorage,
+    group_id: &GroupId,
+    cutoff: EpochId,
+) -> StorageResult<()> {
+    store
+        .lock()?
+        .execute(
+            "DELETE FROM cgka_transport_group_routes
+             WHERE group_id = ?1 AND source_epoch < ?2",
+            params![group_id.as_slice(), epoch_to_i64(cutoff)?],
+        )
+        .storage()?;
+    Ok(())
 }
 
 pub(super) fn delete_for_group(

--- a/crates/storage-sqlite/src/storage/transport_routes.rs
+++ b/crates/storage-sqlite/src/storage/transport_routes.rs
@@ -1,0 +1,58 @@
+//! Durable transport-route index rows (mdk#1161): opaque transport routing-id
+//! bytes -> MLS group id, seeded into the engine's in-memory routing index at
+//! session open so inbound routing does not require loading each group's MLS
+//! state. The `GroupStorage` impl in `groups.rs` delegates here.
+
+use crate::{SqliteAccountStorage, SqliteResultExt};
+use cgka_traits::storage::StorageResult;
+use cgka_traits::types::GroupId;
+use rusqlite::params;
+
+pub(super) fn put(
+    store: &SqliteAccountStorage,
+    transport_group_id: &[u8],
+    group_id: &GroupId,
+) -> StorageResult<()> {
+    store
+        .lock()?
+        .execute(
+            "INSERT INTO cgka_transport_group_routes (transport_group_id, group_id)
+             VALUES (?1, ?2)
+             ON CONFLICT(transport_group_id) DO UPDATE SET group_id = excluded.group_id",
+            params![transport_group_id, group_id.as_slice()],
+        )
+        .storage()?;
+    Ok(())
+}
+
+pub(super) fn list(store: &SqliteAccountStorage) -> StorageResult<Vec<(Vec<u8>, GroupId)>> {
+    let conn = store.lock()?;
+    let mut statement = conn
+        .prepare("SELECT transport_group_id, group_id FROM cgka_transport_group_routes")
+        .storage()?;
+    let rows = statement
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, Vec<u8>>(0)?,
+                GroupId::new(row.get::<_, Vec<u8>>(1)?),
+            ))
+        })
+        .storage()?
+        .collect::<Result<Vec<_>, _>>()
+        .storage()?;
+    Ok(rows)
+}
+
+pub(super) fn delete_for_group(
+    store: &SqliteAccountStorage,
+    group_id: &GroupId,
+) -> StorageResult<()> {
+    store
+        .lock()?
+        .execute(
+            "DELETE FROM cgka_transport_group_routes WHERE group_id = ?1",
+            params![group_id.as_slice()],
+        )
+        .storage()?;
+    Ok(())
+}

--- a/crates/traits/src/error.rs
+++ b/crates/traits/src/error.rs
@@ -12,6 +12,15 @@ pub enum EngineError {
     #[error("unknown group")]
     UnknownGroup(GroupId),
 
+    /// The group was seeded by the session-open cheap pass but its full
+    /// per-group hydration (MLS load, validation, pending-commit recovery)
+    /// has not run yet (mdk#1161). Retryable: the caller can wait for the
+    /// background hydration pipeline or drive `ensure_hydrated` on a `&mut`
+    /// entry point. Distinct from [`Self::UnknownGroup`] so hosts can render
+    /// "still loading" instead of "no such group".
+    #[error("group not hydrated yet; retry after hydration")]
+    GroupNotHydrated(GroupId),
+
     #[error("unknown pending send reference")]
     UnknownPending,
 

--- a/crates/traits/src/storage.rs
+++ b/crates/traits/src/storage.rs
@@ -98,30 +98,66 @@ pub trait GroupStorage {
 
     /// Durable transport-route index: opaque transport routing-id bytes to
     /// MLS group id, many-to-one (a routing rotation retains the prior route
-    /// for its overlap window, mdk#740). Routes are a regenerable projection
-    /// of MLS state — the engine rebuilds a missing route from the loaded
-    /// group on demand — so the default implementations store nothing and
-    /// return nothing. Backends without an override are correct but pay a
-    /// per-group MLS load to re-derive routes on the first inbound lookup
-    /// after reopen. No transport *types* here: routes are bytes only
-    /// (`group.rs` invariants).
+    /// for its overlap window, mdk#740). Each row carries the group epoch of
+    /// the last write that observed the route as current, so the session-open
+    /// seed can detect a stale route set (a crash between a commit apply and
+    /// the route refresh) and the engine can retire prior routes once no
+    /// epoch using them remains inside the retained-history window
+    /// (routing-v1 overlap rule). Routes are a regenerable projection of MLS
+    /// state — the engine rebuilds a missing route from the loaded group on
+    /// demand — so the default implementations store nothing and return
+    /// nothing. Backends without an override are correct but pay a per-group
+    /// MLS load to re-derive routes on the first inbound lookup after
+    /// reopen. No transport *types* here: routes are bytes only (`group.rs`
+    /// invariants).
     fn put_transport_group_route(
         &self,
         transport_group_id: &[u8],
         group_id: &GroupId,
+        source_epoch: EpochId,
     ) -> StorageResult<()> {
-        let _ = (transport_group_id, group_id);
+        let _ = (transport_group_id, group_id, source_epoch);
         Ok(())
     }
 
-    fn list_transport_group_routes(&self) -> StorageResult<Vec<(Vec<u8>, GroupId)>> {
+    fn list_transport_group_routes(&self) -> StorageResult<Vec<TransportGroupRoute>> {
         Ok(Vec::new())
+    }
+
+    /// Retire one route (routing-v1: a prior address stops being accepted
+    /// once no epoch using it remains in either retained-history window).
+    fn delete_transport_group_route(&self, transport_group_id: &[u8]) -> StorageResult<()> {
+        let _ = transport_group_id;
+        Ok(())
+    }
+
+    /// Retire every route of `group_id` whose `source_epoch` is below
+    /// `cutoff` — the bulk form the engine uses when a route refresh advances
+    /// the retention horizon.
+    fn delete_transport_group_routes_below_epoch(
+        &self,
+        group_id: &GroupId,
+        cutoff: EpochId,
+    ) -> StorageResult<()> {
+        let _ = (group_id, cutoff);
+        Ok(())
     }
 
     fn delete_transport_group_routes_for_group(&self, group_id: &GroupId) -> StorageResult<()> {
         let _ = group_id;
         Ok(())
     }
+}
+
+/// One durable transport-route row; see
+/// [`GroupStorage::put_transport_group_route`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TransportGroupRoute {
+    /// Opaque transport routing-id bytes (no transport types).
+    pub transport_group_id: Vec<u8>,
+    pub group_id: GroupId,
+    /// Group epoch of the last write that observed this route as current.
+    pub source_epoch: EpochId,
 }
 
 // ── MessageStorage ──────────────────────────────────────────────────────────

--- a/crates/traits/src/storage.rs
+++ b/crates/traits/src/storage.rs
@@ -85,6 +85,43 @@ pub trait GroupStorage {
     fn get_group(&self, id: &GroupId) -> StorageResult<Group>;
     fn delete_group(&self, id: &GroupId) -> StorageResult<()>;
     fn list_groups(&self) -> StorageResult<Vec<GroupId>>;
+
+    /// Every stored group record in one pass. The engine's session-open seed
+    /// walks all records (mdk#1161); backends should override the default
+    /// `list_groups` + `get_group` loop with a single query.
+    fn list_group_records(&self) -> StorageResult<Vec<Group>> {
+        self.list_groups()?
+            .iter()
+            .map(|id| self.get_group(id))
+            .collect()
+    }
+
+    /// Durable transport-route index: opaque transport routing-id bytes to
+    /// MLS group id, many-to-one (a routing rotation retains the prior route
+    /// for its overlap window, mdk#740). Routes are a regenerable projection
+    /// of MLS state — the engine rebuilds a missing route from the loaded
+    /// group on demand — so the default implementations store nothing and
+    /// return nothing. Backends without an override are correct but pay a
+    /// per-group MLS load to re-derive routes on the first inbound lookup
+    /// after reopen. No transport *types* here: routes are bytes only
+    /// (`group.rs` invariants).
+    fn put_transport_group_route(
+        &self,
+        transport_group_id: &[u8],
+        group_id: &GroupId,
+    ) -> StorageResult<()> {
+        let _ = (transport_group_id, group_id);
+        Ok(())
+    }
+
+    fn list_transport_group_routes(&self) -> StorageResult<Vec<(Vec<u8>, GroupId)>> {
+        Ok(Vec::new())
+    }
+
+    fn delete_transport_group_routes_for_group(&self, group_id: &GroupId) -> StorageResult<()> {
+        let _ = group_id;
+        Ok(())
+    }
 }
 
 // ── MessageStorage ──────────────────────────────────────────────────────────

--- a/crates/traits/tests/error_display.rs
+++ b/crates/traits/tests/error_display.rs
@@ -11,6 +11,7 @@ fn engine_error_display_does_not_expose_group_or_member_ids() {
     let member_hex = hex::encode(member_id.as_slice());
     let errors = [
         EngineError::UnknownGroup(group_id.clone()).to_string(),
+        EngineError::GroupNotHydrated(group_id.clone()).to_string(),
         EngineError::NotAMember {
             group_id: group_id.clone(),
         }


### PR DESCRIPTION
Part 2 of 3 for #1161 (engine layer), stacked on #1306.

- **Storage surface**: `GroupStorage` gains `list_group_records` and a durable transport-route index (opaque bytes → MLS group id, many-to-one preserving the #740 rotation-overlap semantics) with default impls so non-sqlite providers stay correct. Sqlite stores routes in a new `cgka_transport_group_routes` table (migration 0043), cascade-deleted with the group and deliberately outside group-snapshot scope so a rollback cannot delete a still-valid route.
- **Per-group hydration cheap wins**: `hydrate_one_stored_group` now runs interrupted probe/apply recovery first and reads the group record once (previously up to three times), and fetches the group's message rows once, shared by the leave-request probe, the convergence-input gate, the deferred-peel check, and the self-remove schedule restore (previously four separate full-table scans). The #625 marker deliberately keeps hashing the exported tree bytes — the stored OpenMLS `tree_hash` is not recomputed from the stored leaves, so it cannot detect stored-tree tampering.
- **Two-phase core**: `hydrate_stable_groups_from_storage` becomes a cheap seed pass (durable records only — no MLS load, snapshot list, or message scan) that seeds a provisional epoch entry so `live_group_ids` and the app projection keep listing every group, restores disband/unrecoverable terminal state, and seeds inbound routing from the durable route table. Seeded groups fail closed through the existing `ensure_group_live` chokepoint with a new retryable `EngineError::GroupNotHydrated`; send, ingest, and convergence entry points promote them via `ensure_hydrated`, whose failure quarantines with exact open-time parity (including retracting the provisional epoch entry — a quarantined group never holds one). Groups without a durable route row backfill via at most one MLS load ever, keeping #740's attacker-paced-scan bound in amortized form. The former all-groups loop survives as `hydrate_all_stored_groups`, which `AccountDeviceSession::open` keeps calling until part 3 lands — so this PR is behavior-preserving for every consumer.

New `tests/two_phase_hydration.rs` covers seeding vs gating, `ensure_hydrated` promotion and quarantine parity, cheap-pass idempotency, durable-route round-trips across reopen, and the one-shot ingest backfill. Existing hydration/crash-recovery/pending-commit suites adapt to the eager compatibility path and pass unchanged in behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added faster session startup by loading group records first and completing group hydration on demand.
  * Added a retryable “group not hydrated” state for groups still loading.
  * Improved transport-route persistence, recovery, backfill, and cleanup across restarts.
  * Preserved compatibility with full hydration when needed.

* **Bug Fixes**
  * Improved recovery of interrupted, quarantined, and unrecoverable groups.
  * Prevented unavailable group state from exposing outbound messages or processing operations prematurely.

* **Tests**
  * Expanded coverage for hydration, restart recovery, route repair, quarantine, and convergence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->