### PR TITLE
feat: expose lightweight group roster projection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,9 @@ The canonical protocol specification lives in
 - Keep multi-step state changes torn-write-free: validate before mutating, compensate every applied step on the error
   path, record intent before external side effects, and never confirm work that reached no one. See
   `docs/marmot-architecture/overview/multi-step-state-changes.md`.
+- Treat workspace and conformance-fixture version bumps as manual release operations. Never change the root workspace
+  version, workspace package versions in `Cargo.lock`, or vector `conformance_version` values during feature, fix,
+  binding, or review-feedback work unless the user explicitly requests that version bump.
 - Title GitHub Releases with the version first so release lists group by cohort: whole-workspace `v<version> - MDK`,
   WN Agent `v<version> - wn-agent`, and MarmotKit `v<version> - MarmotKit`.
 - Prefer `just release-all <version>` for a full MDK/WN Agent/MarmotKit cohort release, or

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -52,9 +52,10 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 - MarmotKit exposes `groupRoster`, a single lightweight membership projection
   with enriched roster rows, MLS epoch, caller self-membership or eviction
-  state, lifecycle state, and a roster revision derived from epoch for cheap
-  membership-screen change detection. Existing `groupDetails`, `groupMlsState`,
-  and `groupMembers` remain available for compatibility.
+  state, lifecycle state, and a monotonic revision covering MLS epoch plus
+  caller membership for cheap membership-screen change detection. Existing
+  `groupDetails`, `groupMlsState`, and `groupMembers` remain available for
+  compatibility.
   
 - MarmotKit exposes `downloadProfileImage` for dial-safe fetching of untrusted
   kind:0 profile `picture` URLs (HTTPS-only, proxy-disabled pinned public

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -49,6 +49,12 @@ versioning through the workspace version in the root `Cargo.toml`.
   typed `RuntimeBusy` contention so foreground apps can retry and notification
   extensions can return bounded fallback content instead of creating a second
   stateful writer.
+
+- MarmotKit exposes `groupRoster`, a single lightweight membership projection
+  with enriched roster rows, MLS epoch, caller self-membership or eviction
+  state, lifecycle state, and a roster revision derived from epoch for cheap
+  membership-screen change detection. Existing `groupDetails`, `groupMlsState`,
+  and `groupMembers` remain available for compatibility.
   
 - MarmotKit exposes `downloadProfileImage` for dial-safe fetching of untrusted
   kind:0 profile `picture` URLs (HTTPS-only, proxy-disabled pinned public

--- a/crates/marmot-app/src/app_telemetry.rs
+++ b/crates/marmot-app/src/app_telemetry.rs
@@ -43,6 +43,7 @@ pub(crate) enum AppPerformanceOperation {
     GroupPromoteAdmin,
     GroupDetailsRead,
     GroupMlsStateRead,
+    GroupRosterRead,
     MediaUpload,
     MediaDownload,
     HostSplashReady,
@@ -122,6 +123,8 @@ pub struct AppPerformanceSnapshot {
     pub group_details_read: AppPerformanceOperationSnapshot,
     #[serde(default)]
     pub group_mls_state_read: AppPerformanceOperationSnapshot,
+    #[serde(default)]
+    pub group_roster_read: AppPerformanceOperationSnapshot,
     pub media_upload: AppPerformanceOperationSnapshot,
     pub media_download: AppPerformanceOperationSnapshot,
     #[serde(default)]
@@ -162,6 +165,7 @@ struct AppPerformanceTelemetryInner {
     group_promote_admin: AppPerformanceOperationTelemetry,
     group_details_read: AppPerformanceOperationTelemetry,
     group_mls_state_read: AppPerformanceOperationTelemetry,
+    group_roster_read: AppPerformanceOperationTelemetry,
     media_upload: AppPerformanceOperationTelemetry,
     media_download: AppPerformanceOperationTelemetry,
     host_splash_ready: AppPerformanceOperationTelemetry,
@@ -332,6 +336,9 @@ impl AppPerformanceTelemetry {
             AppPerformanceOperation::GroupMlsStateRead => {
                 inner.group_mls_state_read.record(duration, success);
             }
+            AppPerformanceOperation::GroupRosterRead => {
+                inner.group_roster_read.record(duration, success);
+            }
             AppPerformanceOperation::MediaUpload => inner.media_upload.record(duration, success),
             AppPerformanceOperation::MediaDownload => {
                 inner.media_download.record(duration, success);
@@ -399,6 +406,7 @@ impl AppPerformanceTelemetry {
             group_promote_admin: inner.group_promote_admin.snapshot(),
             group_details_read: inner.group_details_read.snapshot(),
             group_mls_state_read: inner.group_mls_state_read.snapshot(),
+            group_roster_read: inner.group_roster_read.snapshot(),
             media_upload: inner.media_upload.snapshot(),
             media_download: inner.media_download.snapshot(),
             host_splash_ready: inner.host_splash_ready.snapshot(),

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -777,13 +777,14 @@ impl AppClient {
         group_id: &GroupId,
     ) -> Result<crate::groups::AppGroupRosterSession, AppError> {
         let group_id_hex = hex::encode(group_id.as_slice());
-        let group_record = self
+        let mut group_record = self
             .state
             .groups
             .iter()
             .find(|group| group.group_id_hex == group_id_hex)
             .cloned()
             .ok_or_else(|| AppError::UnknownGroup(group_id_hex))?;
+        self.overlay_storage_self_membership(&mut group_record)?;
         let profiles = self.app.profiles_by_id()?;
         let members = self.members_with_profiles_unchecked(group_id, &profiles)?;
         let mls_state = self.group_mls_state_unchecked(group_id)?;
@@ -792,6 +793,19 @@ impl AppClient {
             members,
             mls_state,
         })
+    }
+
+    fn overlay_storage_self_membership(
+        &self,
+        group_record: &mut AppGroupRecord,
+    ) -> Result<(), AppError> {
+        if let Some(membership) = self
+            .app
+            .stored_group_self_membership(&self.state.label, &group_record.group_id_hex)?
+        {
+            group_record.self_membership = membership;
+        }
+        Ok(())
     }
 
     fn group_mls_state_unchecked(&self, group_id: &GroupId) -> Result<AppGroupMlsState, AppError> {
@@ -908,6 +922,7 @@ impl AppClient {
             );
         }
         let profiles = profiles?;
+        let stored_self_memberships = self.app.account_group_self_memberships(&self.state.label)?;
         let mut groups = HashMap::new();
         let mut members = HashMap::new();
         let mut mls_state = HashMap::new();
@@ -918,7 +933,11 @@ impl AppClient {
                 continue;
             };
             let group_id = GroupId::new(bytes);
-            groups.insert(group_id.clone(), group.clone());
+            let mut group_record = group.clone();
+            if let Some(membership) = stored_self_memberships.get(&group.group_id_hex) {
+                group_record.self_membership = *membership;
+            }
+            groups.insert(group_id.clone(), group_record);
             if let Ok(records) = self.members_with_profiles_unchecked(&group_id, &profiles) {
                 members.insert(group_id.clone(), records);
             }

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -141,7 +141,7 @@ fn recover_post_canonical_result<T: Default>(
 }
 
 /// A point-in-time copy of the live session's read-only group projections
-/// (`members`, `group_mls_state`, `quarantined_groups`).
+/// (`groups`, `members`, `group_mls_state`, `quarantined_groups`).
 ///
 /// The account worker captures this from the live session and uses it to answer
 /// read commands while a relay catch-up runs in the background. The catch-up
@@ -157,6 +157,7 @@ fn recover_post_canonical_result<T: Default>(
 /// the same shape the live path returns for a group the session does not hold.
 #[derive(Default)]
 pub(crate) struct GroupReadSnapshot {
+    groups: HashMap<GroupId, AppGroupRecord>,
     members: HashMap<GroupId, Vec<AppGroupMemberRecord>>,
     mls_state: HashMap<GroupId, AppGroupMlsState>,
     quarantined: Vec<AppQuarantinedGroup>,
@@ -178,6 +179,21 @@ impl GroupReadSnapshot {
             .get(group_id)
             .cloned()
             .ok_or_else(|| AppError::UnknownGroup(hex::encode(group_id.as_slice())))
+    }
+
+    pub(crate) fn group_roster(
+        &self,
+        group_id: &GroupId,
+    ) -> Result<crate::groups::AppGroupRosterSession, AppError> {
+        Ok(crate::groups::AppGroupRosterSession {
+            group_record: self
+                .groups
+                .get(group_id)
+                .cloned()
+                .ok_or_else(|| AppError::UnknownGroup(hex::encode(group_id.as_slice())))?,
+            members: self.members(group_id)?,
+            mls_state: self.group_mls_state(group_id)?,
+        })
     }
 
     pub(crate) fn quarantined_groups(&self) -> Vec<AppQuarantinedGroup> {
@@ -756,6 +772,28 @@ impl AppClient {
         self.group_mls_state_unchecked(group_id)
     }
 
+    pub(crate) fn group_roster_session(
+        &self,
+        group_id: &GroupId,
+    ) -> Result<crate::groups::AppGroupRosterSession, AppError> {
+        let group_id_hex = hex::encode(group_id.as_slice());
+        let group_record = self
+            .state
+            .groups
+            .iter()
+            .find(|group| group.group_id_hex == group_id_hex)
+            .cloned()
+            .ok_or_else(|| AppError::UnknownGroup(group_id_hex))?;
+        let profiles = self.app.profiles_by_id()?;
+        let members = self.members_with_profiles_unchecked(group_id, &profiles)?;
+        let mls_state = self.group_mls_state_unchecked(group_id)?;
+        Ok(crate::groups::AppGroupRosterSession {
+            group_record,
+            members,
+            mls_state,
+        })
+    }
+
     fn group_mls_state_unchecked(&self, group_id: &GroupId) -> Result<AppGroupMlsState, AppError> {
         let group = self.runtime.group_record(group_id)?;
         let lifecycle_state = self
@@ -870,6 +908,7 @@ impl AppClient {
             );
         }
         let profiles = profiles?;
+        let mut groups = HashMap::new();
         let mut members = HashMap::new();
         let mut mls_state = HashMap::new();
         let mut skipped_malformed_group_records = 0usize;
@@ -879,6 +918,7 @@ impl AppClient {
                 continue;
             };
             let group_id = GroupId::new(bytes);
+            groups.insert(group_id.clone(), group.clone());
             if let Ok(records) = self.members_with_profiles_unchecked(&group_id, &profiles) {
                 members.insert(group_id.clone(), records);
             }
@@ -895,6 +935,7 @@ impl AppClient {
             );
         }
         Ok(GroupReadSnapshot {
+            groups,
             members,
             mls_state,
             quarantined: self.quarantined_groups(),

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -942,6 +942,14 @@ impl AppClient {
         &self,
         telemetry: Option<&crate::app_telemetry::AppPerformanceTelemetry>,
     ) -> Result<GroupReadSnapshot, AppError> {
+        if cfg!(feature = "test-policy-overrides")
+            && self.app.config.dev_force_group_read_snapshot_failure
+        {
+            return Err(cgka_traits::StorageError::Backend(
+                "injected group-read snapshot failure".to_owned(),
+            )
+            .into());
+        }
         // Load account profiles once and reuse across every group: the rest of
         // the capture is in-memory engine reads, so the snapshot adds a single
         // storage read to the worker readiness path regardless of group count.

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -147,14 +147,15 @@ fn recover_post_canonical_result<T: Default>(
 /// read commands while a relay catch-up runs in the background. The catch-up
 /// future holds `&mut AppClient`, so concurrent reads cannot touch the live
 /// session and are served from this snapshot instead.
-/// Membership/epoch only change on a committed group operation, which the
+/// MLS membership/epoch only change on a committed group operation, which the
 /// catch-up surfaces via `GroupStateUpdated` so subscribers re-read once it
-/// lands; the snapshot is therefore a brief, self-healing stand-in, only used
-/// until the catch-up completes (after which reads go live again).
+/// lands. Storage-owned self-membership is refreshed separately when a roster
+/// is served, so an observed departure during catch-up is not hidden by this
+/// snapshot. The snapshot is only used until catch-up completes.
 ///
-/// Groups whose live read errored at capture time (e.g. quarantined / not yet
-/// live) are simply absent; a read for an absent group returns `UnknownGroup`,
-/// the same shape the live path returns for a group the session does not hold.
+/// Capture is atomic: if any known group's member or MLS projection cannot be
+/// read, the whole snapshot fails and the worker defers reads to live state
+/// after catch-up instead of misreporting a degraded known group as unknown.
 #[derive(Default)]
 pub(crate) struct GroupReadSnapshot {
     groups: HashMap<GroupId, AppGroupRecord>,
@@ -808,6 +809,38 @@ impl AppClient {
         Ok(())
     }
 
+    /// Reconcile a storage row still carrying the preserving `Member` default
+    /// against one hydrated engine roster. Used by on-demand startup reads so
+    /// they cannot expose a legacy migration default before the full hydration
+    /// pipeline finishes its once-only backfill.
+    pub(crate) fn reconcile_group_self_membership(
+        &self,
+        group_id: &GroupId,
+    ) -> Result<(), AppError> {
+        let group_id_hex = hex::encode(group_id.as_slice());
+        if !matches!(
+            self.app
+                .stored_group_self_membership(&self.state.label, &group_id_hex)?,
+            Some(SelfMembership::Member)
+        ) {
+            return Ok(());
+        }
+        let local_account_id_hex = self
+            .app
+            .account_home()
+            .account(&self.state.label)?
+            .account_id_hex;
+        let members = self.runtime.members(group_id)?;
+        if local_account_removed_from_roster(&members, &local_account_id_hex) {
+            self.app.set_group_self_membership(
+                &self.state.label,
+                &group_id_hex,
+                SelfMembership::Removed,
+            )?;
+        }
+        Ok(())
+    }
+
     fn group_mls_state_unchecked(&self, group_id: &GroupId) -> Result<AppGroupMlsState, AppError> {
         let group = self.runtime.group_record(group_id)?;
         let lifecycle_state = self
@@ -880,10 +913,10 @@ impl AppClient {
     /// projections from the live (hydrated) session.
     ///
     /// Used by the account worker to answer read commands during relay catch-up
-    /// without blocking on it; see [`GroupReadSnapshot`]. Reads
-    /// that error for a given group (quarantined / not yet live) are omitted —
-    /// the snapshot accessor reports those as `UnknownGroup`, matching the live
-    /// path for a group the session does not hold.
+    /// without blocking on it; see [`GroupReadSnapshot`]. If a known group's
+    /// member or MLS projection fails, snapshot capture
+    /// fails atomically. The worker then defers reads until it can answer them
+    /// from live state and preserve the underlying error classification.
     ///
     /// Returns the storage error if the one shared profile load fails, rather
     /// than masking it as empty profiles (which would make every member read
@@ -937,13 +970,11 @@ impl AppClient {
             if let Some(membership) = stored_self_memberships.get(&group.group_id_hex) {
                 group_record.self_membership = *membership;
             }
+            let records = self.members_with_profiles_unchecked(&group_id, &profiles)?;
+            let state = self.group_mls_state_unchecked(&group_id)?;
             groups.insert(group_id.clone(), group_record);
-            if let Ok(records) = self.members_with_profiles_unchecked(&group_id, &profiles) {
-                members.insert(group_id.clone(), records);
-            }
-            if let Ok(state) = self.group_mls_state_unchecked(&group_id) {
-                mls_state.insert(group_id, state);
-            }
+            members.insert(group_id.clone(), records);
+            mls_state.insert(group_id, state);
         }
         if skipped_malformed_group_records > 0 {
             tracing::warn!(

--- a/crates/marmot-app/src/config.rs
+++ b/crates/marmot-app/src/config.rs
@@ -93,6 +93,10 @@ pub struct MarmotAppConfig {
     /// chat projection and per-group read behavior, without changing startup
     /// timing in normal builds. Commands are still served during the delay.
     pub dev_startup_hydration_batch_delay_ms: Option<u64>,
+    /// Dev/test-only override that forces group-read snapshot capture to fail.
+    /// Honored only with `test-policy-overrides`; this exercises the account
+    /// worker's degraded catch-up path without corrupting a real database.
+    pub dev_force_group_read_snapshot_failure: bool,
     /// Accounts to search outward from when the searcher's own web of trust is
     /// empty, as pubkey hex.
     ///
@@ -145,6 +149,7 @@ impl Default for MarmotAppConfig {
             dev_settlement_quiescence_ms: None,
             dev_scheduled_convergence_delay_ms: None,
             dev_startup_hydration_batch_delay_ms: None,
+            dev_force_group_read_snapshot_failure: false,
             directory_search_fallback_seeds: Vec::new(),
         }
     }
@@ -229,6 +234,13 @@ impl MarmotAppConfig {
     /// (mdk#1161). Normal builds ignore this field.
     pub fn with_dev_startup_hydration_batch_delay_ms(mut self, ms: u64) -> Self {
         self.dev_startup_hydration_batch_delay_ms = Some(ms);
+        self
+    }
+
+    /// Force group-read snapshot capture to fail in test-policy builds.
+    /// Normal builds ignore this field.
+    pub fn with_dev_force_group_read_snapshot_failure(mut self, enabled: bool) -> Self {
+        self.dev_force_group_read_snapshot_failure = enabled;
         self
     }
 }

--- a/crates/marmot-app/src/groups.rs
+++ b/crates/marmot-app/src/groups.rs
@@ -223,9 +223,9 @@ pub struct AppGroupRoster {
     pub group_id_hex: String,
     pub members: Vec<AppGroupRosterMember>,
     pub epoch: u64,
-    /// Mirrors [`Self::epoch`] from the authoritative MLS projection. Non-roster
-    /// MLS commits may bump this revision; directory-only display-name changes
-    /// do not.
+    /// Monotonic change token for MLS roster state plus caller membership.
+    /// Non-roster MLS commits may bump this revision; directory-only
+    /// display-name changes do not.
     pub roster_revision: u64,
     pub self_membership: SelfMembership,
     pub member_count: usize,
@@ -260,11 +260,16 @@ pub(crate) fn app_group_roster_from_session(
         })
         .collect();
     let epoch = mls_state.epoch;
+    let membership_revision = match group_record.self_membership {
+        SelfMembership::Member => 0,
+        SelfMembership::Left => 1,
+        SelfMembership::Removed => 2,
+    };
     AppGroupRoster {
         group_id_hex: group_record.group_id_hex,
         members,
         epoch,
-        roster_revision: epoch,
+        roster_revision: epoch.saturating_mul(3).saturating_add(membership_revision),
         self_membership: group_record.self_membership,
         member_count: mls_state.member_count,
         lifecycle_state: mls_state.lifecycle_state,
@@ -2585,7 +2590,7 @@ mod group_roster_api_tests {
             HashMap::from([(self_id.to_owned(), "Alice".to_owned())]),
         );
         assert_eq!(roster.epoch, 7);
-        assert_eq!(roster.roster_revision, 7);
+        assert_eq!(roster.roster_revision, 23);
         assert_eq!(roster.self_membership, SelfMembership::Removed);
         assert_eq!(roster.member_count, 1);
         assert_eq!(roster.lifecycle_state, AppGroupLifecycleState::Stable);

--- a/crates/marmot-app/src/groups.rs
+++ b/crates/marmot-app/src/groups.rs
@@ -198,6 +198,79 @@ pub struct AppGroupMlsState {
     pub disband_request: Option<AppDisbandRequest>,
 }
 
+/// Session-consistent group record, members, and MLS state captured in one live read.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct AppGroupRosterSession {
+    pub group_record: AppGroupRecord,
+    pub members: Vec<AppGroupMemberRecord>,
+    pub mls_state: AppGroupMlsState,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AppGroupRosterMember {
+    pub member_id_hex: String,
+    pub account: Option<String>,
+    pub local: bool,
+    pub is_admin: bool,
+    pub is_self: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+}
+
+/// Lightweight membership projection for roster screens and change detection.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AppGroupRoster {
+    pub group_id_hex: String,
+    pub members: Vec<AppGroupRosterMember>,
+    pub epoch: u64,
+    /// Mirrors [`Self::epoch`] from the authoritative MLS projection. Non-roster
+    /// MLS commits may bump this revision; directory-only display-name changes
+    /// do not.
+    pub roster_revision: u64,
+    pub self_membership: SelfMembership,
+    pub member_count: usize,
+    pub lifecycle_state: AppGroupLifecycleState,
+}
+
+pub(crate) fn app_group_roster_from_session(
+    session: AppGroupRosterSession,
+    my_account_id_hex: &str,
+    display_names: std::collections::HashMap<String, String>,
+) -> AppGroupRoster {
+    use std::collections::HashSet;
+
+    let AppGroupRosterSession {
+        group_record,
+        members,
+        mls_state,
+    } = session;
+    let admin_ids: HashSet<String> = group_record.admin_policy.admins.iter().cloned().collect();
+    let members = members
+        .into_iter()
+        .map(|member| {
+            let member_id_hex = member.member_id_hex.clone();
+            AppGroupRosterMember {
+                member_id_hex,
+                account: member.account,
+                local: member.local,
+                is_admin: admin_ids.contains(&member.member_id_hex),
+                is_self: member.member_id_hex == my_account_id_hex,
+                display_name: display_names.get(&member.member_id_hex).cloned(),
+            }
+        })
+        .collect();
+    let epoch = mls_state.epoch;
+    AppGroupRoster {
+        group_id_hex: group_record.group_id_hex,
+        members,
+        epoch,
+        roster_revision: epoch,
+        self_membership: group_record.self_membership,
+        member_count: mls_state.member_count,
+        lifecycle_state: mls_state.lifecycle_state,
+    }
+}
+
 #[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AppGroupLifecycleState {
@@ -2447,5 +2520,78 @@ mod fail_if_publish_failed_tests {
             AppError::Publish(msg) => assert_eq!(msg, "reason-a; reason-b"),
             other => panic!("expected AppError::Publish, got {other:?}"),
         }
+    }
+}
+
+#[cfg(test)]
+mod group_roster_api_tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    use cgka_traits::NostrRoutingV1;
+
+    fn test_record() -> AppGroupRecord {
+        let routing = AppGroupNostrRoutingComponent::new(NostrRoutingV1 {
+            nostr_group_id: [0u8; 32],
+            relays: vec!["wss://relay.example.com".to_owned()],
+        })
+        .expect("routing component");
+        AppGroupRecord::new(
+            hex::encode([1u8; 16]),
+            routing,
+            "group".to_owned(),
+            String::new(),
+            AppGroupImageInput::default(),
+            AppGroupAdminPolicyComponent::new(Vec::new()),
+            AppGroupMessageRetentionComponent::disabled(),
+        )
+    }
+
+    #[test]
+    fn app_group_roster_carries_self_membership_and_epoch_revision() {
+        let mut record = test_record();
+        record.self_membership = SelfMembership::Removed;
+        let self_id = "aa4fc8665f5696e33db7e1a572e3b0f5b3d615837b0f362dcb1c8068b098c7b4";
+        let self_id_bytes = hex::decode(self_id)
+            .expect("self id hex")
+            .try_into()
+            .expect("32-byte self id");
+        record.admin_policy = AppGroupAdminPolicyComponent::new(vec![self_id_bytes]);
+        let members = vec![AppGroupMemberRecord {
+            member_id_hex: self_id.to_owned(),
+            account: Some("alice".to_owned()),
+            local: true,
+        }];
+        let mls_state = AppGroupMlsState {
+            group_id_hex: record.group_id_hex.clone(),
+            protocol_profile: AppProtocolProfile::Current,
+            lifecycle_state: AppGroupLifecycleState::Stable,
+            epoch: 7,
+            member_count: 1,
+            unrecoverable: false,
+            required_app_components: Vec::new(),
+            disbanding_enabled: false,
+            disbanding: false,
+            disbanding_blockers: Vec::new(),
+            disband_request: None,
+        };
+        let roster = app_group_roster_from_session(
+            AppGroupRosterSession {
+                group_record: record,
+                members,
+                mls_state,
+            },
+            self_id,
+            HashMap::from([(self_id.to_owned(), "Alice".to_owned())]),
+        );
+        assert_eq!(roster.epoch, 7);
+        assert_eq!(roster.roster_revision, 7);
+        assert_eq!(roster.self_membership, SelfMembership::Removed);
+        assert_eq!(roster.member_count, 1);
+        assert_eq!(roster.lifecycle_state, AppGroupLifecycleState::Stable);
+        assert_eq!(roster.members.len(), 1);
+        assert!(roster.members[0].is_admin);
+        assert!(roster.members[0].is_self);
+        assert_eq!(roster.members[0].display_name.as_deref(), Some("Alice"));
     }
 }

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -154,8 +154,9 @@ pub use groups::{
     AppGroupHydrationQuarantineReason, AppGroupImageComponent, AppGroupLifecycleState,
     AppGroupMemberRecord, AppGroupMessageRetentionComponent, AppGroupMlsState,
     AppGroupNostrRoutingComponent, AppGroupOpaqueComponent, AppGroupProfileComponent,
-    AppGroupRecord, AppGroupSystemEvent, AppInitialGroupImage, AppPriorNostrRoute,
-    AppProtocolProfile, AppQuarantinedGroup, group_system_event_from_message,
+    AppGroupRecord, AppGroupRoster, AppGroupRosterMember, AppGroupSystemEvent,
+    AppInitialGroupImage, AppPriorNostrRoute, AppProtocolProfile, AppQuarantinedGroup,
+    group_system_event_from_message,
 };
 pub use ids::{
     account_id_hex_from_ref, nprofile_for_account_id, npub_for_account_id, validate_relay_urls,

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -2571,6 +2571,30 @@ impl MarmotApp {
         Ok(())
     }
 
+    /// Storage-owned `account_groups.self_membership` for roster and chat-list
+    /// reads. In-memory `AppClient.state.groups` may lag after a local leave or
+    /// observed self-eviction because those paths write storage directly.
+    pub(crate) fn stored_group_self_membership(
+        &self,
+        label: &str,
+        group_id_hex: &str,
+    ) -> Result<Option<SelfMembership>, AppError> {
+        self.ensure_account_state(label)?;
+        Ok(self
+            .account_storage(label)?
+            .group_self_membership(group_id_hex)?)
+    }
+
+    pub(crate) fn account_group_self_memberships(
+        &self,
+        label: &str,
+    ) -> Result<std::collections::HashMap<String, SelfMembership>, AppError> {
+        self.ensure_account_state(label)?;
+        Ok(self
+            .account_storage(label)?
+            .account_group_self_memberships()?)
+    }
+
     /// `group_id_hex` of every `account_groups` row still carrying the migration
     /// default `self_membership = 'member'`. The one-time open/upgrade backfill
     /// uses this to derive membership for legacy rows from current engine state.

--- a/crates/marmot-app/src/relay_telemetry_export.rs
+++ b/crates/marmot-app/src/relay_telemetry_export.rs
@@ -312,6 +312,14 @@ pub mod metric_names {
     pub const APP_GROUP_MLS_STATE_READ_SUCCESSES: &str = "app_group_mls_state_read_successes";
     /// Failed group MLS state reads.
     pub const APP_GROUP_MLS_STATE_READ_FAILURES: &str = "app_group_mls_state_read_failures";
+    /// Group roster read duration histogram.
+    pub const APP_GROUP_ROSTER_READ_DURATION: &str = "app_group_roster_read_duration_ms";
+    /// Group roster read attempts.
+    pub const APP_GROUP_ROSTER_READ_ATTEMPTS: &str = "app_group_roster_read_attempts";
+    /// Successful group roster reads.
+    pub const APP_GROUP_ROSTER_READ_SUCCESSES: &str = "app_group_roster_read_successes";
+    /// Failed group roster reads.
+    pub const APP_GROUP_ROSTER_READ_FAILURES: &str = "app_group_roster_read_failures";
     /// Media upload duration histogram.
     pub const APP_MEDIA_UPLOAD_DURATION: &str = "app_media_upload_duration_ms";
     /// Media upload attempts.
@@ -802,6 +810,14 @@ fn append_app_performance_points(
         metric_names::APP_GROUP_MLS_STATE_READ_ATTEMPTS,
         metric_names::APP_GROUP_MLS_STATE_READ_SUCCESSES,
         metric_names::APP_GROUP_MLS_STATE_READ_FAILURES,
+    );
+    append_app_operation_points(
+        points,
+        &app_performance.group_roster_read,
+        metric_names::APP_GROUP_ROSTER_READ_DURATION,
+        metric_names::APP_GROUP_ROSTER_READ_ATTEMPTS,
+        metric_names::APP_GROUP_ROSTER_READ_SUCCESSES,
+        metric_names::APP_GROUP_ROSTER_READ_FAILURES,
     );
     append_app_operation_points(
         points,

--- a/crates/marmot-app/src/relay_telemetry_export/tests.rs
+++ b/crates/marmot-app/src/relay_telemetry_export/tests.rs
@@ -230,6 +230,12 @@ fn build_export_batch_appends_unlabeled_app_performance_metrics() {
             failures: 0,
             duration_ms: hist(1),
         },
+        group_roster_read: AppPerformanceOperationSnapshot {
+            attempts: 1,
+            successes: 1,
+            failures: 0,
+            duration_ms: hist(1),
+        },
         host_splash_ready: AppPerformanceOperationSnapshot {
             attempts: 1,
             successes: 1,
@@ -298,6 +304,10 @@ fn build_export_batch_appends_unlabeled_app_performance_metrics() {
     assert!(batch.points.iter().any(|point| {
         point.name == metric_names::APP_GROUP_DETAILS_READ_ATTEMPTS
             && point.value == ExportMetricValue::Counter(2)
+    }));
+    assert!(batch.points.iter().any(|point| {
+        point.name == metric_names::APP_GROUP_ROSTER_READ_ATTEMPTS
+            && point.value == ExportMetricValue::Counter(1)
     }));
 
     let duration = batch

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -111,6 +111,10 @@ pub(crate) enum AccountWorkerCommand {
         group_id: GroupId,
         respond: oneshot::Sender<Result<AppGroupMlsState, AppError>>,
     },
+    GroupRoster {
+        group_id: GroupId,
+        respond: oneshot::Sender<Result<crate::groups::AppGroupRosterSession, AppError>>,
+    },
     EnableGroupDisbanding {
         group_id: GroupId,
         respond: oneshot::Sender<Result<SendSummary, AppError>>,
@@ -454,13 +458,15 @@ async fn run_app_runtime_account_worker(
     // The session's cheap open pass has seeded every stored group. Signal
     // command-readiness *now*: the hydration pipeline right below enters its
     // command-serving loop immediately, so "ready" genuinely means "serving
-    // commands" — group reads issued from this point hydrate exactly the
-    // group they name and answer live, and everything else joins the startup
+    // commands" — group reads (`Members` / `GroupMlsState` / `GroupRoster` /
+    // `QuarantinedGroups`) issued from this point hydrate exactly the group
+    // they name and answer live, and everything else joins the startup
     // deferral. `AccountOpen` (recorded by `reconcile` as the ready-wait)
     // measures the seeded open; the mdk#1161 stage telemetry attributes it
     // (`AccountSessionOpen` / `AccountGroupHydration` for the open the
     // worker just awaited, with the pipeline and snapshot capture measured
     // separately below).
+
     {
         let open_timings = client.runtime.session().open_timings();
         let telemetry = shared.app_performance_telemetry();
@@ -583,6 +589,16 @@ async fn run_app_runtime_account_worker(
                                 }
                                 None => deferred.push(DeferredStartupCommand::Command(Box::new(
                                     AccountWorkerCommand::GroupMlsState { group_id, respond },
+                                ))),
+                            }
+                        }
+                        Some(AccountWorkerCommand::GroupRoster { group_id, respond }) => {
+                            match &read_snapshot {
+                                Some(snapshot) => {
+                                    let _ = respond.send(snapshot.group_roster(&group_id));
+                                }
+                                None => deferred.push(DeferredStartupCommand::Command(Box::new(
+                                    AccountWorkerCommand::GroupRoster { group_id, respond },
                                 ))),
                             }
                         }
@@ -1434,7 +1450,7 @@ async fn drain_deferred_hydration(client: &mut AppClient) -> Result<(), AppError
 }
 
 /// Serve one command that arrived while the startup hydration pipeline was
-/// running. The three local reads answer live — hydrating exactly the group
+/// running. Group-local reads answer live — hydrating exactly the group
 /// they name first, so a read "waits for that group only". The quarantine
 /// list answers the incrementally-growing set; later additions reach
 /// subscribers through their `GroupHydrationQuarantined` events. Everything
@@ -1458,6 +1474,13 @@ async fn handle_startup_hydration_command(
                 .session_mut()
                 .ensure_group_hydrated(&group_id);
             let _ = respond.send(client.group_mls_state(&group_id));
+        }
+        AccountWorkerCommand::GroupRoster { group_id, respond } => {
+            let _ = client
+                .runtime
+                .session_mut()
+                .ensure_group_hydrated(&group_id);
+            let _ = respond.send(client.group_roster(&group_id));
         }
         AccountWorkerCommand::QuarantinedGroups { respond } => {
             let _ = respond.send(Ok(client.quarantined_groups()));
@@ -1619,6 +1642,10 @@ async fn handle_account_worker_command(
                 .session_mut()
                 .ensure_group_hydrated(&group_id);
             let result = client.group_mls_state(&group_id);
+            let _ = respond.send(result);
+        }
+        AccountWorkerCommand::GroupRoster { group_id, respond } => {
+            let result = client.group_roster_session(&group_id);
             let _ = respond.send(result);
         }
         AccountWorkerCommand::EnableGroupDisbanding { group_id, respond } => {

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -1480,7 +1480,7 @@ async fn handle_startup_hydration_command(
                 .runtime
                 .session_mut()
                 .ensure_group_hydrated(&group_id);
-            let _ = respond.send(client.group_roster(&group_id));
+            let _ = respond.send(client.group_roster_session(&group_id));
         }
         AccountWorkerCommand::QuarantinedGroups { respond } => {
             let _ = respond.send(Ok(client.quarantined_groups()));

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -595,7 +595,20 @@ async fn run_app_runtime_account_worker(
                         Some(AccountWorkerCommand::GroupRoster { group_id, respond }) => {
                             match &read_snapshot {
                                 Some(snapshot) => {
-                                    let _ = respond.send(snapshot.group_roster(&group_id));
+                                    let result = snapshot.group_roster(&group_id).and_then(
+                                        |mut session| {
+                                            if let Some(membership) = app
+                                                .stored_group_self_membership(
+                                                    &account_label,
+                                                    &session.group_record.group_id_hex,
+                                                )?
+                                            {
+                                                session.group_record.self_membership = membership;
+                                            }
+                                            Ok(session)
+                                        },
+                                    );
+                                    let _ = respond.send(result);
                                 }
                                 None => deferred.push(DeferredStartupCommand::Command(Box::new(
                                     AccountWorkerCommand::GroupRoster { group_id, respond },
@@ -1476,11 +1489,7 @@ async fn handle_startup_hydration_command(
             let _ = respond.send(client.group_mls_state(&group_id));
         }
         AccountWorkerCommand::GroupRoster { group_id, respond } => {
-            let _ = client
-                .runtime
-                .session_mut()
-                .ensure_group_hydrated(&group_id);
-            let _ = respond.send(client.group_roster_session(&group_id));
+            let _ = respond.send(group_roster_after_hydration(client, &group_id));
         }
         AccountWorkerCommand::QuarantinedGroups { respond } => {
             let _ = respond.send(Ok(client.quarantined_groups()));
@@ -1645,7 +1654,7 @@ async fn handle_account_worker_command(
             let _ = respond.send(result);
         }
         AccountWorkerCommand::GroupRoster { group_id, respond } => {
-            let result = client.group_roster_session(&group_id);
+            let result = group_roster_after_hydration(client, &group_id);
             let _ = respond.send(result);
         }
         AccountWorkerCommand::EnableGroupDisbanding { group_id, respond } => {
@@ -2314,6 +2323,18 @@ async fn handle_account_worker_command(
     // every command path covered; the summary is empty for commands that
     // applied nothing.
     publish_client_pending_applied_summary(client, events, account_id_hex, account_label);
+}
+
+pub(super) fn group_roster_after_hydration(
+    client: &mut AppClient,
+    group_id: &GroupId,
+) -> Result<crate::groups::AppGroupRosterSession, AppError> {
+    client
+        .runtime
+        .session_mut()
+        .ensure_group_hydrated(group_id)?;
+    client.reconcile_group_self_membership(group_id)?;
+    client.group_roster_session(group_id)
 }
 
 #[derive(Debug, Clone)]

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -1188,17 +1188,20 @@ async fn handle_account_worker_catch_up(
     context: AccountWorkerCatchUpContext<'_>,
 ) {
     let read_snapshot = match client.group_read_snapshot() {
-        Ok(snapshot) => snapshot,
+        Ok(snapshot) => Some(snapshot),
         Err(err) => {
             let message = account_error_message("runtime catch-up snapshot failed", &err);
             publish_app_runtime_account_error(
                 context.events,
                 context.account_id_hex,
                 context.account_label,
-                message.clone(),
+                message,
             );
-            let _ = respond.send(Err(message));
-            return;
+            // Snapshot availability controls whether reads can run concurrently
+            // with sync; it must not prevent the explicit catch-up itself from
+            // retrieving updates that may advance or repair degraded state.
+            // Defer reads to live state until sync releases `&mut client`.
+            None
         }
     };
     let mut catch_up_responders = vec![respond];
@@ -1225,25 +1228,40 @@ async fn handle_account_worker_catch_up(
             let Some(command) = command else {
                 continue;
             };
+            let snapshot_reads_available = read_snapshot.is_some() && deferred.is_empty();
             match command {
-                AccountWorkerCommand::Members { group_id, respond } if deferred.is_empty() => {
-                    let _ = respond.send(read_snapshot.members(&group_id));
+                AccountWorkerCommand::Members { group_id, respond } if snapshot_reads_available => {
+                    let snapshot = read_snapshot
+                        .as_ref()
+                        .expect("snapshot availability checked above");
+                    let _ = respond.send(snapshot.members(&group_id));
                 }
                 AccountWorkerCommand::GroupMlsState { group_id, respond }
-                    if deferred.is_empty() =>
+                    if snapshot_reads_available =>
                 {
-                    let _ = respond.send(read_snapshot.group_mls_state(&group_id));
+                    let snapshot = read_snapshot
+                        .as_ref()
+                        .expect("snapshot availability checked above");
+                    let _ = respond.send(snapshot.group_mls_state(&group_id));
                 }
-                AccountWorkerCommand::GroupRoster { group_id, respond } if deferred.is_empty() => {
+                AccountWorkerCommand::GroupRoster { group_id, respond }
+                    if snapshot_reads_available =>
+                {
+                    let snapshot = read_snapshot
+                        .as_ref()
+                        .expect("snapshot availability checked above");
                     let _ = respond.send(group_roster_from_snapshot(
                         context.app,
                         context.account_label,
-                        &read_snapshot,
+                        snapshot,
                         &group_id,
                     ));
                 }
-                AccountWorkerCommand::QuarantinedGroups { respond } if deferred.is_empty() => {
-                    let _ = respond.send(Ok(read_snapshot.quarantined_groups()));
+                AccountWorkerCommand::QuarantinedGroups { respond } if snapshot_reads_available => {
+                    let snapshot = read_snapshot
+                        .as_ref()
+                        .expect("snapshot availability checked above");
+                    let _ = respond.send(Ok(snapshot.quarantined_groups()));
                 }
                 AccountWorkerCommand::CatchUp { respond } if deferred.is_empty() => {
                     catch_up_responders.push(respond);

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -595,18 +595,11 @@ async fn run_app_runtime_account_worker(
                         Some(AccountWorkerCommand::GroupRoster { group_id, respond }) => {
                             match &read_snapshot {
                                 Some(snapshot) => {
-                                    let result = snapshot.group_roster(&group_id).and_then(
-                                        |mut session| {
-                                            if let Some(membership) = app
-                                                .stored_group_self_membership(
-                                                    &account_label,
-                                                    &session.group_record.group_id_hex,
-                                                )?
-                                            {
-                                                session.group_record.self_membership = membership;
-                                            }
-                                            Ok(session)
-                                        },
+                                    let result = group_roster_from_snapshot(
+                                        &app,
+                                        &account_label,
+                                        snapshot,
+                                        &group_id,
                                     );
                                     let _ = respond.send(result);
                                 }
@@ -865,6 +858,7 @@ async fn run_app_runtime_account_worker(
                                         &mut commands,
                                         &mut pending,
                                         AccountWorkerCatchUpContext {
+                                            app: &app,
                                             events: &events,
                                             account_id_hex: &account_id_hex,
                                             account_label: &account_label,
@@ -1179,6 +1173,7 @@ async fn run_app_runtime_account_worker(
 /// Additional catch-up requests received before such a command coalesce onto
 /// the in-flight sync.
 struct AccountWorkerCatchUpContext<'a> {
+    app: &'a MarmotApp,
     events: &'a broadcast::Sender<MarmotAppEvent>,
     account_id_hex: &'a str,
     account_label: &'a str,
@@ -1238,6 +1233,14 @@ async fn handle_account_worker_catch_up(
                     if deferred.is_empty() =>
                 {
                     let _ = respond.send(read_snapshot.group_mls_state(&group_id));
+                }
+                AccountWorkerCommand::GroupRoster { group_id, respond } if deferred.is_empty() => {
+                    let _ = respond.send(group_roster_from_snapshot(
+                        context.app,
+                        context.account_label,
+                        &read_snapshot,
+                        &group_id,
+                    ));
                 }
                 AccountWorkerCommand::QuarantinedGroups { respond } if deferred.is_empty() => {
                     let _ = respond.send(Ok(read_snapshot.quarantined_groups()));
@@ -2335,6 +2338,21 @@ pub(super) fn group_roster_after_hydration(
         .ensure_group_hydrated(group_id)?;
     client.reconcile_group_self_membership(group_id)?;
     client.group_roster_session(group_id)
+}
+
+fn group_roster_from_snapshot(
+    app: &MarmotApp,
+    account_label: &str,
+    snapshot: &crate::client::GroupReadSnapshot,
+    group_id: &GroupId,
+) -> Result<crate::groups::AppGroupRosterSession, AppError> {
+    let mut session = snapshot.group_roster(group_id)?;
+    if let Some(membership) =
+        app.stored_group_self_membership(account_label, &session.group_record.group_id_hex)?
+    {
+        session.group_record.self_membership = membership;
+    }
+    Ok(session)
 }
 
 #[derive(Debug, Clone)]

--- a/crates/marmot-app/src/runtime/commands.rs
+++ b/crates/marmot-app/src/runtime/commands.rs
@@ -19,11 +19,12 @@ use crate::app_telemetry::AppPerformanceOperation;
 use crate::messages::AppMessageIntent;
 use crate::{
     AgentOperationEventRequest, AgentTextStreamFinishRequest, AppBlobEndpoint, AppDisbandRequest,
-    AppError, AppGroupMemberRecord, AppGroupMlsState, AppGroupRecord, AppQuarantinedGroup,
-    GroupInviteDeclineResult, GroupPushDebugInfo, MaintenanceRunSummary, MediaAttachmentReference,
-    MediaDownloadResult, MediaUploadRequest, MediaUploadResult, NotificationSettings,
-    PendingWelcomeDelivery, PushPlatform, PushRegistration, PushRegistrationShareOutcome,
-    PushRegistrationSyncResult, RetentionSweepReport, SecureDeleteExpiredResult, SendSummary,
+    AppError, AppGroupMemberRecord, AppGroupMlsState, AppGroupRecord, AppGroupRoster,
+    AppQuarantinedGroup, GroupInviteDeclineResult, GroupPushDebugInfo, MaintenanceRunSummary,
+    MediaAttachmentReference, MediaDownloadResult, MediaUploadRequest, MediaUploadResult,
+    NotificationSettings, PendingWelcomeDelivery, PushPlatform, PushRegistration,
+    PushRegistrationShareOutcome, PushRegistrationSyncResult, RetentionSweepReport,
+    SecureDeleteExpiredResult, SendSummary,
 };
 
 impl AccountManager {
@@ -182,6 +183,40 @@ impl AccountManager {
             result.is_ok(),
         );
         result
+    }
+
+    pub async fn group_roster(
+        &self,
+        account_ref: &str,
+        group_id: &GroupId,
+    ) -> Result<AppGroupRoster, AppError> {
+        let account = self.resolve(account_ref)?;
+        let command = self.worker_commands(account_ref).await?;
+        let (respond, response) = oneshot::channel();
+        command
+            .send(AccountWorkerCommand::GroupRoster {
+                group_id: group_id.clone(),
+                respond,
+            })
+            .await
+            .map_err(|_| AppError::TransportClosed)?;
+        let session = account_worker_response(response).await?;
+        let member_ids = session
+            .members
+            .iter()
+            .map(|member| member.member_id_hex.clone())
+            .collect::<Vec<_>>();
+        // Display names are optional directory enrichment; preserve the
+        // authoritative roster if that cache is unavailable.
+        let display_names = self
+            .app
+            .display_names_for_account_ids(&member_ids)
+            .unwrap_or_default();
+        Ok(crate::groups::app_group_roster_from_session(
+            session,
+            &account.account_id_hex,
+            display_names,
+        ))
     }
 
     pub async fn enable_group_disbanding(

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -34,14 +34,14 @@ use crate::{
     APP_RUNTIME_RELAY_REBUILD_LOOKBACK, AccountKeyPackageRecord, AccountRelayListBootstrap,
     AccountRelayListStatus, AccountUnread, AgentOperationEventRequest,
     AgentTextStreamFinishRequest, AppBlobEndpoint, AppDisbandRequest, AppError,
-    AppGroupMemberRecord, AppGroupMlsState, AppGroupRecord, AppMessageQuery, AppMessageRecord,
-    AppProjectionUpdate, AppQuarantinedGroup, AuditLogDeleteOutcome, AuditLogFile,
-    AuditLogSettings, AuditLogTrackerConfig, AuditLogTrackerUpdateResult, AuditLogUploadResult,
-    BackgroundNotificationCollection, ChatListRow, ChatNotificationSettings, ChatPinState,
-    GroupInviteDeclineResult, GroupPushDebugInfo, KeyPackageDeletionTarget, MAX_SEEN_EVENT_IDS,
-    MarmotApp, MarmotRelayPlane, MarmotServiceEndpoints, MediaAttachmentReference,
-    MediaDownloadResult, MediaUploadRequest, MediaUploadResult, MessageDraft,
-    MessageDraftAttachment, MessageDraftSummary, NotificationCollectionStatus,
+    AppGroupMemberRecord, AppGroupMlsState, AppGroupRecord, AppGroupRoster, AppMessageQuery,
+    AppMessageRecord, AppProjectionUpdate, AppQuarantinedGroup, AuditLogDeleteOutcome,
+    AuditLogFile, AuditLogSettings, AuditLogTrackerConfig, AuditLogTrackerUpdateResult,
+    AuditLogUploadResult, BackgroundNotificationCollection, ChatListRow, ChatNotificationSettings,
+    ChatPinState, GroupInviteDeclineResult, GroupPushDebugInfo, KeyPackageDeletionTarget,
+    MAX_SEEN_EVENT_IDS, MarmotApp, MarmotRelayPlane, MarmotServiceEndpoints,
+    MediaAttachmentReference, MediaDownloadResult, MediaUploadRequest, MediaUploadResult,
+    MessageDraft, MessageDraftAttachment, MessageDraftSummary, NotificationCollectionStatus,
     NotificationSettings, NotificationUpdate, NotificationWakeSource, PendingWelcomeDelivery,
     PushPlatform, PushRegistration, PushRegistrationShareOutcome, PushRegistrationSyncResult,
     ReceivedMessage, RelayTelemetryExportConfig, RelayTelemetryRuntimeConfig,
@@ -1197,6 +1197,21 @@ impl MarmotAppRuntime {
         group_id: &GroupId,
     ) -> Result<AppGroupMlsState, AppError> {
         self.accounts.group_mls_state(account_ref, group_id).await
+    }
+
+    pub async fn group_roster(
+        &self,
+        account_ref: &str,
+        group_id: &GroupId,
+    ) -> Result<AppGroupRoster, AppError> {
+        let started_at = Instant::now();
+        let result = self.accounts.group_roster(account_ref, group_id).await;
+        self.shared.app_performance_telemetry().record(
+            AppPerformanceOperation::GroupRosterRead,
+            started_at.elapsed(),
+            result.is_ok(),
+        );
+        result
     }
 
     pub async fn enable_group_disbanding(

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -636,16 +636,20 @@ async fn invite_members_detaches_post_mutation_catch_up_body() {
         .expect("invite task should not panic")
         .expect("invite should succeed");
 
-    let (members, mls_state) = tokio::time::timeout(std::time::Duration::from_millis(250), async {
-        let members = runtime.group_members("alice", &group_id).await?;
-        let mls_state = runtime.group_mls_state("alice", &group_id).await?;
-        Ok::<_, AppError>((members, mls_state))
-    })
-    .await
-    .expect("same-account post-invite projection reads must not queue behind catch-up")
-    .expect("same-account post-invite projection reads should succeed");
+    let (members, mls_state, roster) =
+        tokio::time::timeout(std::time::Duration::from_millis(250), async {
+            let members = runtime.group_members("alice", &group_id).await?;
+            let mls_state = runtime.group_mls_state("alice", &group_id).await?;
+            let roster = runtime.group_roster("alice", &group_id).await?;
+            Ok::<_, AppError>((members, mls_state, roster))
+        })
+        .await
+        .expect("same-account post-invite projection reads must not queue behind catch-up")
+        .expect("same-account post-invite projection reads should succeed");
     assert_eq!(members.len(), 2);
     assert_eq!(mls_state.member_count, 2);
+    assert_eq!(roster.members.len(), 2);
+    assert_eq!(roster.epoch, mls_state.epoch);
 
     let before_release = runtime
         .shared_services()

--- a/crates/marmot-app/tests/catch_up_snapshot_failure.rs
+++ b/crates/marmot-app/tests/catch_up_snapshot_failure.rs
@@ -1,0 +1,54 @@
+//! Regression for explicit catch-up when the concurrent-read snapshot cannot
+//! be captured. Snapshot failure must defer reads, not suppress synchronization.
+#![cfg(feature = "test-policy-overrides")]
+
+use std::time::{Duration, Instant};
+
+use marmot_account::AccountHome;
+use marmot_app::{MarmotApp, MarmotAppConfig, MarmotAppRuntime};
+use nostr_relay_builder::MockRelay;
+
+#[tokio::test]
+async fn explicit_catch_up_syncs_when_group_read_snapshot_fails() {
+    let relay = MockRelay::run().await.unwrap();
+    let relay_url = relay.url().await.to_string();
+    let dir = tempfile::tempdir().unwrap();
+    AccountHome::open(dir.path())
+        .create_account("snapshot-failure")
+        .unwrap();
+
+    let config = MarmotAppConfig::default()
+        .with_allow_loopback_relay_endpoints(true)
+        .with_dev_force_group_read_snapshot_failure(true);
+    let app = MarmotApp::with_relay_and_config(dir.path(), relay_url, config);
+    let runtime = MarmotAppRuntime::new(app);
+    runtime.start().await.unwrap();
+
+    let telemetry = runtime.shared_services().app_performance_telemetry();
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while telemetry.snapshot().account_sync.attempts == 0 {
+        assert!(
+            Instant::now() < deadline,
+            "startup catch-up did not complete before the deadline"
+        );
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    let sync_attempts_before = telemetry.snapshot().account_sync.attempts;
+
+    runtime
+        .catch_up_accounts()
+        .await
+        .expect("snapshot failure must not suppress explicit synchronization");
+
+    let after = telemetry.snapshot();
+    assert!(
+        after.account_sync.attempts > sync_attempts_before,
+        "explicit catch-up must run a new sync after snapshot capture fails"
+    );
+    assert_eq!(
+        after.account_sync.successes, after.account_sync.attempts,
+        "the injected snapshot failure must not turn a successful sync into a catch-up failure"
+    );
+
+    runtime.shutdown().await;
+}

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -2303,9 +2303,30 @@ async fn app_runtime_serves_member_reads_before_initial_catch_up_completes() {
         "restart must become command-ready before the initial catch-up completes",
     );
 
-    // And the read is answered with correct membership while (or right after)
-    // the catch-up runs — served from the post-hydration snapshot during the
-    // window, from the live session afterwards. Either way it must not block.
+    // The combined roster read is answered with a session-consistent group
+    // record, member list, and MLS state while (or right after) catch-up runs.
+    // During the catch-up window it comes from the post-hydration snapshot;
+    // afterwards it comes from the live session. Either way it must not block.
+    let roster = timeout(
+        Duration::from_secs(2),
+        runtime.group_roster(&bob_id, &group_id),
+    )
+    .await
+    .expect("roster read must not block on the initial catch-up")
+    .unwrap();
+    assert_eq!(roster.epoch, roster.roster_revision);
+    assert_eq!(roster.self_membership, SelfMembership::Member);
+    let roster_member_ids = roster
+        .members
+        .into_iter()
+        .map(|member| member.member_id_hex)
+        .collect::<std::collections::HashSet<_>>();
+    assert!(
+        roster_member_ids.contains(&alice_id) && roster_member_ids.contains(&bob_id),
+        "snapshot/live roster read must report the full roster",
+    );
+
+    // The existing member-only read remains command-ready as well.
     let members = timeout(
         Duration::from_secs(2),
         runtime.group_members(&bob_id, &group_id),

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -2314,7 +2314,7 @@ async fn app_runtime_serves_member_reads_before_initial_catch_up_completes() {
     .await
     .expect("roster read must not block on the initial catch-up")
     .unwrap();
-    assert_eq!(roster.epoch, roster.roster_revision);
+    assert_eq!(roster.roster_revision, roster.epoch.saturating_mul(3));
     assert_eq!(roster.self_membership, SelfMembership::Member);
     let roster_member_ids = roster
         .members
@@ -2398,6 +2398,12 @@ async fn group_roster_reports_left_after_local_leave_without_worker_restart() {
     })
     .await;
 
+    let revision_before_leave = runtime
+        .group_roster(&bob_id, &group_id)
+        .await
+        .unwrap()
+        .roster_revision;
+
     runtime.leave_group(&bob_id, &group_id).await.unwrap();
 
     let roster = runtime.group_roster(&bob_id, &group_id).await.unwrap();
@@ -2405,6 +2411,10 @@ async fn group_roster_reports_left_after_local_leave_without_worker_restart() {
         roster.self_membership,
         SelfMembership::Left,
         "groupRoster must read storage-owned self_membership without restarting the worker"
+    );
+    assert_ne!(
+        roster.roster_revision, revision_before_leave,
+        "caller membership changes must invalidate the roster revision"
     );
 
     runtime.shutdown().await;
@@ -2448,6 +2458,12 @@ async fn group_roster_reports_removed_after_admin_eviction_without_worker_restar
     })
     .await;
 
+    let revision_before_eviction = runtime
+        .group_roster(&bob_id, &group_id)
+        .await
+        .unwrap()
+        .roster_revision;
+
     runtime
         .remove_members(&alice_id, &group_id, std::slice::from_ref(&bob_id))
         .await
@@ -2476,6 +2492,10 @@ async fn group_roster_reports_removed_after_admin_eviction_without_worker_restar
         roster.self_membership,
         SelfMembership::Removed,
         "groupRoster must read storage-owned self_membership without restarting the worker"
+    );
+    assert_ne!(
+        roster.roster_revision, revision_before_eviction,
+        "observed eviction must invalidate the roster revision"
     );
 
     runtime.shutdown().await;

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -2361,6 +2361,127 @@ async fn app_runtime_serves_member_reads_before_initial_catch_up_completes() {
 }
 
 #[tokio::test]
+async fn group_roster_reports_left_after_local_leave_without_worker_restart() {
+    let dir = tempfile::tempdir().unwrap();
+    let (_relay, app, url) = mock_app(&dir).await;
+    let runtime = MarmotAppRuntime::new(app.clone());
+    let setup = AccountSetupRequest {
+        default_relays: vec![endpoint(&url)],
+        bootstrap_relays: vec![endpoint(&url)],
+        publish_initial_key_package: true,
+        ..AccountSetupRequest::default()
+    };
+    let alice = runtime
+        .create_identity(setup.relay_options_only())
+        .await
+        .unwrap();
+    let bob = runtime.create_identity(setup).await.unwrap();
+    let alice_id = alice.account.account_id_hex.clone();
+    let bob_id = bob.account.account_id_hex.clone();
+    let mut events = runtime.subscribe();
+
+    let group_id = runtime
+        .create_group(
+            &alice_id,
+            "roster leave",
+            std::slice::from_ref(&bob_id),
+            None,
+        )
+        .await
+        .unwrap();
+    wait_for_event(&mut events, |event| {
+        matches!(
+            event,
+            MarmotAppEvent::GroupJoined { account_id_hex, group_id: joined, .. }
+                if account_id_hex == &bob_id && joined == &group_id
+        )
+    })
+    .await;
+
+    runtime.leave_group(&bob_id, &group_id).await.unwrap();
+
+    let roster = runtime.group_roster(&bob_id, &group_id).await.unwrap();
+    assert_eq!(
+        roster.self_membership,
+        SelfMembership::Left,
+        "groupRoster must read storage-owned self_membership without restarting the worker"
+    );
+
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn group_roster_reports_removed_after_admin_eviction_without_worker_restart() {
+    let dir = tempfile::tempdir().unwrap();
+    let (_relay, app, url) = mock_app(&dir).await;
+    let runtime = MarmotAppRuntime::new(app.clone());
+    let setup = AccountSetupRequest {
+        default_relays: vec![endpoint(&url)],
+        bootstrap_relays: vec![endpoint(&url)],
+        publish_initial_key_package: true,
+        ..AccountSetupRequest::default()
+    };
+    let alice = runtime
+        .create_identity(setup.relay_options_only())
+        .await
+        .unwrap();
+    let bob = runtime.create_identity(setup).await.unwrap();
+    let alice_id = alice.account.account_id_hex.clone();
+    let bob_id = bob.account.account_id_hex.clone();
+    let mut events = runtime.subscribe();
+
+    let group_id = runtime
+        .create_group(
+            &alice_id,
+            "roster eviction",
+            std::slice::from_ref(&bob_id),
+            None,
+        )
+        .await
+        .unwrap();
+    wait_for_event(&mut events, |event| {
+        matches!(
+            event,
+            MarmotAppEvent::GroupJoined { account_id_hex, group_id: joined, .. }
+                if account_id_hex == &bob_id && joined == &group_id
+        )
+    })
+    .await;
+
+    runtime
+        .remove_members(&alice_id, &group_id, std::slice::from_ref(&bob_id))
+        .await
+        .unwrap();
+    wait_for_event(&mut events, |event| {
+        matches!(
+            event,
+            MarmotAppEvent::GroupEvent(group_event)
+                if group_event.account_id_hex == bob_id
+                    && matches!(
+                        &group_event.event,
+                        cgka_traits::engine::GroupEvent::GroupStateChanged {
+                            group_id: changed_group,
+                            change:
+                                cgka_traits::engine::GroupStateChange::MemberRemoved { member },
+                            ..
+                        } if changed_group == &group_id
+                            && hex::encode(member.as_slice()) == bob_id
+                    )
+        )
+    })
+    .await;
+
+    let roster = runtime.group_roster(&bob_id, &group_id).await.unwrap();
+    assert_eq!(
+        roster.self_membership,
+        SelfMembership::Removed,
+        "groupRoster must read storage-owned self_membership without restarting the worker"
+    );
+
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
 async fn app_runtime_schedules_audit_tracker_update_after_managed_send() {
     let dir = tempfile::tempdir().unwrap();
     let (_relay, app, url) = mock_app(&dir).await;

--- a/crates/marmot-app/tests/startup_hydration.rs
+++ b/crates/marmot-app/tests/startup_hydration.rs
@@ -14,7 +14,7 @@ use std::time::{Duration, Instant};
 
 use cgka_traits::types::GroupId;
 use marmot_account::AccountHome;
-use marmot_app::{MarmotApp, MarmotAppConfig, MarmotAppRuntime};
+use marmot_app::{MarmotApp, MarmotAppConfig, MarmotAppRuntime, SelfMembership};
 use nostr_relay_builder::MockRelay;
 
 const BENCH_ACCOUNT: &str = "held";
@@ -212,6 +212,16 @@ async fn held_hydration_body() {
         read_started.elapsed() < Duration::from_millis(BATCH_HOLD_MS / 2),
         "group read must not wait out the pipeline hold"
     );
+    let roster = tokio::time::timeout(
+        Duration::from_millis(BATCH_HOLD_MS / 2),
+        runtime.group_roster(BENCH_ACCOUNT, probed),
+    )
+    .await
+    .expect("roster read during the hold must wait for its group only")
+    .unwrap();
+    assert_eq!(roster.self_membership, SelfMembership::Member);
+    assert_eq!(roster.roster_revision, roster.epoch.saturating_mul(3));
+    assert_eq!(roster.members.len(), members.len());
 
     // The pipeline itself is still held: only the session-open stage sample
     // exists (the pipeline records its own AccountGroupHydration sample when

--- a/crates/marmot-uniffi/AGENTS.md
+++ b/crates/marmot-uniffi/AGENTS.md
@@ -19,8 +19,10 @@ UniFFI bindings for the Marmot app runtime. Read `README.md` first for build scr
 - Host-supplied `group_id_hex` values are variable-length MLS `GroupId` bytes, not Nostr `nostr_group_id` route handles.
   Accept non-empty opaque MLS group ids, including the 16-byte ids OpenMLS generates for MDK today, and do not validate
   them with the 32-byte route-id/pubkey/message-id rule.
-- Keep binding changes in lockstep with `marmot-app` public API changes; bump the workspace version when UniFFI records,
-  enums, object methods, or error variants change.
+- Keep binding changes in lockstep with `marmot-app` public API changes, but do not bump the workspace version as part
+  of feature, fix, binding, or review-feedback work. Workspace versions are bumped only as an explicit, user-directed
+  release operation; UniFFI records, enums, object methods, and error variants may change while the current workspace
+  version remains unchanged.
 
 ## Verification
 

--- a/crates/marmot-uniffi/src/commands/group.rs
+++ b/crates/marmot-uniffi/src/commands/group.rs
@@ -13,9 +13,10 @@ use crate::conversions::{
     AppBlobEndpointFfi, AppGroupMemberRecordFfi, AppGroupMlsStateFfi, AppGroupRecordFfi,
     AppQuarantinedGroupFfi, DisbandRequestFfi, GroupDetailsFfi, GroupInviteDeclineResultFfi,
     GroupMaintenanceStatusFfi, GroupManagementStateFfi, GroupMemberActionStateFfi,
-    GroupMutationResultFfi, KeyPackageMaintenanceStatusFfi, MaintenanceRunSummaryFfi, MemberRefFfi,
-    PeriodicMaintenancePolicyFfi, SendSummaryFfi, group_details_ffi, group_id_from_hex,
-    group_management_state_ffi, normalize_member_ref_ffi,
+    GroupMutationResultFfi, GroupRosterFfi, KeyPackageMaintenanceStatusFfi,
+    MaintenanceRunSummaryFfi, MemberRefFfi, PeriodicMaintenancePolicyFfi, SendSummaryFfi,
+    group_details_ffi, group_id_from_hex, group_management_state_ffi, group_roster_ffi,
+    normalize_member_ref_ffi,
 };
 use crate::errors::MarmotKitError;
 
@@ -331,6 +332,17 @@ impl Marmot {
         let group_id = group_id_from_hex(&group_id_hex)?;
         let group_id_hex = hex::encode(group_id.as_slice());
         group_details_for(self, &account_ref, &group_id, &group_id_hex).await
+    }
+
+    /// Lightweight membership roster projection for membership screens.
+    pub async fn group_roster(
+        &self,
+        account_ref: String,
+        group_id_hex: String,
+    ) -> Result<GroupRosterFfi, MarmotKitError> {
+        let group_id = group_id_from_hex(&group_id_hex)?;
+        let roster = self.runtime.group_roster(&account_ref, &group_id).await?;
+        group_roster_ffi(roster)
     }
 
     /// Current caller permissions plus per-member action availability.

--- a/crates/marmot-uniffi/src/conversions/group.rs
+++ b/crates/marmot-uniffi/src/conversions/group.rs
@@ -6,8 +6,8 @@ use marmot_app::{
     AppBlobEndpoint, AppDisbandFailureReason, AppDisbandRequest, AppGroupAdminPolicyComponent,
     AppGroupEncryptedMediaComponent, AppGroupHydrationQuarantineReason, AppGroupLifecycleState,
     AppGroupMemberRecord, AppGroupMlsState, AppGroupNostrRoutingComponent,
-    AppGroupProfileComponent, AppGroupRecord, AppProtocolProfile, AppQuarantinedGroup,
-    GroupInviteDeclineResult, account_id_hex_from_ref, npub_for_account_id,
+    AppGroupProfileComponent, AppGroupRecord, AppGroupRoster, AppProtocolProfile,
+    AppQuarantinedGroup, GroupInviteDeclineResult, account_id_hex_from_ref, npub_for_account_id,
 };
 
 use super::account::SendSummaryFfi;
@@ -376,6 +376,52 @@ pub(crate) fn group_details_ffi(
     })
 }
 
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct GroupRosterFfi {
+    pub group_id_hex: String,
+    pub members: Vec<GroupMemberDetailsFfi>,
+    pub epoch: u64,
+    /// Mirrors [`Self::epoch`] for cheap membership-screen change detection.
+    /// Non-roster MLS commits may bump this revision; directory-only display-name
+    /// changes do not.
+    pub roster_revision: u64,
+    pub self_membership: SelfMembershipFfi,
+    pub member_count: u32,
+    pub lifecycle_state: GroupLifecycleStateFfi,
+}
+
+pub(crate) fn group_roster_ffi(roster: AppGroupRoster) -> Result<GroupRosterFfi, MarmotKitError> {
+    let members = roster
+        .members
+        .into_iter()
+        .map(|member| {
+            let npub = npub_for_account_id(&member.member_id_hex).map_err(|err| {
+                MarmotKitError::InvalidIdentity {
+                    details: err.to_string(),
+                }
+            })?;
+            Ok(GroupMemberDetailsFfi {
+                member_id_hex: member.member_id_hex,
+                account: member.account,
+                local: member.local,
+                is_admin: member.is_admin,
+                is_self: member.is_self,
+                npub,
+                display_name: member.display_name,
+            })
+        })
+        .collect::<Result<Vec<_>, MarmotKitError>>()?;
+    Ok(GroupRosterFfi {
+        group_id_hex: roster.group_id_hex,
+        members,
+        epoch: roster.epoch,
+        roster_revision: roster.roster_revision,
+        self_membership: roster.self_membership.into(),
+        member_count: super::saturating_u32(roster.member_count),
+        lifecycle_state: roster.lifecycle_state.into(),
+    })
+}
+
 pub(crate) fn group_management_state_ffi(
     my_account_id_hex: &str,
     details: &GroupDetailsFfi,
@@ -654,5 +700,40 @@ mod profile_presence_tests {
             profile_ffi_fields(profile(true)),
             (true, String::new(), String::new())
         );
+    }
+}
+
+#[cfg(test)]
+mod group_roster_tests {
+    use super::*;
+    use marmot_app::{
+        AppGroupLifecycleState, AppGroupRoster, AppGroupRosterMember, SelfMembership,
+    };
+
+    #[test]
+    fn group_roster_ffi_preserves_self_membership_and_revision() {
+        let self_id = "aa4fc8665f5696e33db7e1a572e3b0f5b3d615837b0f362dcb1c8068b098c7b4";
+        let roster = AppGroupRoster {
+            group_id_hex: "01".repeat(16),
+            members: vec![AppGroupRosterMember {
+                member_id_hex: self_id.to_owned(),
+                account: Some("alice".to_owned()),
+                local: true,
+                is_admin: true,
+                is_self: true,
+                display_name: Some("Alice".to_owned()),
+            }],
+            epoch: 12,
+            roster_revision: 12,
+            self_membership: SelfMembership::Removed,
+            member_count: 1,
+            lifecycle_state: AppGroupLifecycleState::Stable,
+        };
+        let ffi = group_roster_ffi(roster).expect("ffi roster");
+        assert_eq!(ffi.epoch, 12);
+        assert_eq!(ffi.roster_revision, 12);
+        assert!(matches!(ffi.self_membership, SelfMembershipFfi::Removed));
+        assert_eq!(ffi.members.len(), 1);
+        assert_eq!(ffi.members[0].display_name.as_deref(), Some("Alice"));
     }
 }

--- a/crates/marmot-uniffi/src/conversions/group.rs
+++ b/crates/marmot-uniffi/src/conversions/group.rs
@@ -381,9 +381,9 @@ pub struct GroupRosterFfi {
     pub group_id_hex: String,
     pub members: Vec<GroupMemberDetailsFfi>,
     pub epoch: u64,
-    /// Mirrors [`Self::epoch`] for cheap membership-screen change detection.
-    /// Non-roster MLS commits may bump this revision; directory-only display-name
-    /// changes do not.
+    /// Monotonic change token for MLS roster state plus caller membership.
+    /// Non-roster MLS commits may bump this revision; directory-only
+    /// display-name changes do not.
     pub roster_revision: u64,
     pub self_membership: SelfMembershipFfi,
     pub member_count: u32,

--- a/crates/storage-sqlite/src/account_projection.rs
+++ b/crates/storage-sqlite/src/account_projection.rs
@@ -965,6 +965,47 @@ impl SqliteAccountStorage {
         Ok(ids)
     }
 
+    /// Authoritative `account_groups.self_membership` for one group row.
+    pub fn group_self_membership(
+        &self,
+        group_id_hex: &str,
+    ) -> StorageResult<Option<SelfMembership>> {
+        let conn = self.lock()?;
+        let value = conn
+            .query_row(
+                "SELECT self_membership FROM account_groups WHERE group_id_hex = ?1",
+                params![group_id_hex],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .storage()?;
+        Ok(value.map(|stored| SelfMembership::from_storage(&stored)))
+    }
+
+    /// Authoritative `account_groups.self_membership` for every group row.
+    pub fn account_group_self_memberships(
+        &self,
+    ) -> StorageResult<std::collections::HashMap<String, SelfMembership>> {
+        let conn = self.lock()?;
+        let mut statement = conn
+            .prepare("SELECT group_id_hex, self_membership FROM account_groups")
+            .storage()?;
+        let rows = statement
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    SelfMembership::from_storage(&row.get::<_, String>(1)?),
+                ))
+            })
+            .storage()?;
+        let mut memberships = std::collections::HashMap::new();
+        for row in rows {
+            let (group_id_hex, membership) = row.storage()?;
+            memberships.insert(group_id_hex, membership);
+        }
+        Ok(memberships)
+    }
+
     pub fn app_messages(
         &self,
         query: StoredAppMessageQuery,


### PR DESCRIPTION
Fixes #1297

## Summary

- Adds `groupRoster`, a single MarmotKit/UniFFI membership projection with enriched member identities, MLS epoch, roster revision, caller self-membership or eviction state, and lifecycle state.
- Routes roster reads through the serialized account worker. Initial and steady-state catch-up serve a session-consistent snapshot without blocking projection reads; steady state otherwise reads the live session.
- Sources self-membership from the storage-owned projection and reconciles it against the authoritative MLS roster, so local leave and observed eviction are visible without restarting the worker.
- Keeps `groupDetails`, `groupMlsState`, and `groupMembers` unchanged and adds dedicated performance and OTLP latency metrics.
- Keeps the workspace and conformance fixtures at `0.9.10`. Workspace version bumps are manual release operations, not part of feature or review-feedback work.
- Updates repository agent guidance to make that manual-only version policy explicit.

## Verification

- `just fast-ci`
- `cargo test -p cgka-conformance-simulator canonical_vector_fixtures_match_generated_traces --locked`
- `cargo test -p marmot-app --lib --locked -- --test-threads=1` — 588 passed
- `cargo test -p marmot-app group_roster --locked`
- `cargo test -p marmot-app --test startup_hydration chat_list_is_readable_and_group_reads_wait_per_group_while_hydration_is_held --features test-policy-overrides --locked`
- `cargo test -p storage-sqlite --locked` — 324 passed
- `cargo test -p marmot-uniffi --locked` — 100 unit, 2 media fixture, and 28 smoke tests passed
- Takeover review of the rebased final diff — no remaining actionable findings

## Sensitive paths

Touches app group-state/runtime read projection and UniFFI binding code. No cryptographic algorithms, MLS state mutation, key material, trust anchors, or authentication flows changed. The group-state core touch should still be treated as sensitive at the merge gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a lightweight group roster API with member identities, display names, admin and self status, membership state, member count, lifecycle state, epoch, and revision.
  - Exposed group roster access through runtime and FFI interfaces.
  - Roster results are available before initial synchronization completes when startup data is available.
  - Added accurate reporting for members who leave or are administratively removed.

- **Monitoring**
  - Added performance tracking and exported metrics for group roster reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->