### PR TITLE
Make generated scenarios selectable across adapters

### DIFF
--- a/crates/cgka-conformance-simulator/README.md
+++ b/crates/cgka-conformance-simulator/README.md
@@ -466,8 +466,9 @@ semantic expectations, so a crash or panic cannot erase the exact executable inp
 `--generated-input FILE`. Add `--adapter engine|retained-relay|app-runtime` to deliberately run the embedded canonical
 Scenario IR through a different in-process adapter; capability preflight still rejects unsupported operations before
 action zero. Reports retain the producer's family/version/seed/case/subject provenance plus separate SHA-256 digests for
-the selected envelope bytes and the canonical Scenario IR inside it. The post-run report and promotable vector candidate
-remain separate owner-only artifacts.
+the selected envelope bytes and the selected canonical Scenario IR inside it. An adapter override adds the executing
+adapter to report and failure-capsule filenames so A/B runs cannot overwrite one another. Override runs do not mint a
+promotable vector candidate; only the generator-recorded subject may supply that adapter-neutral fixture.
 
 The process adapter accepts the same saved input in place of a raw Scenario IR file:
 
@@ -478,9 +479,11 @@ cargo run -p cgka-conformance-simulator --bin cgka-conformance-process -- \
   target/chat-journey-process-report.json
 ```
 
-Its report preserves the same provenance, canonical digest, and semantic expectations. Container and VM manifests use
-the same envelope through `convergence-campaign-runner`; the distributed runner resolves and privately materializes the
-canonical IR before launching nodes or an external VM driver.
+Its report preserves the same provenance and carries semantic expectations for downstream oracle tooling; the process
+executor does not evaluate those expectations itself. It separately records the digest of the Scenario IR it compiled.
+Container and VM manifests use the same envelope through `convergence-campaign-runner`. Containers resolve it in memory
+and may apply deterministic manifest-declared host-crash lowering; VM runs privately materialize the selected canonical
+IR before launching the external driver.
 
 ## Report artifacts
 
@@ -506,10 +509,11 @@ canonical IR before launching nodes or an external VM driver.
 case index, and an optional `minimized_case` field. Failing generated cases run a conservative greedy minimizer that
 removes removable delivery/app steps only when the semantic failure identity (classification, action type, and failure
 kind) still reproduces. The complete fingerprint, including the state digest, remains in the capsule for diagnosis.
-Generated report runs also write
-a sibling `*-fixture.v1.json` candidate. Cases with semantic expectations keep those expectations; cases without them
-use the observed trace as an exact expected trace in the candidate. When a failing generated case has a minimized
-reproducer, the fixture candidate uses that minimized scenario.
+Generated report runs on the generator-recorded subject also write a sibling `*-fixture.v1.json` candidate. Adapter
+override runs deliberately do not, because their observed trace is an A/B result rather than an adapter-neutral source
+of truth. Cases with semantic expectations keep those expectations; cases without them use the observed trace as an
+exact expected trace in the candidate. When a failing generated case has a minimized reproducer, the fixture candidate
+uses that minimized scenario.
 
 To run the current generated family and write JSON reports:
 

--- a/crates/cgka-conformance-simulator/README.md
+++ b/crates/cgka-conformance-simulator/README.md
@@ -463,7 +463,24 @@ the conformance contract clearer.
 For every generated family, the report runner writes a versioned `*-generated-input.json` artifact with owner-only
 permissions before executing its case. It preserves the full generated case, including its selected subject adapter and
 semantic expectations, so a crash or panic cannot erase the exact executable input. Replay one directly with
-`--generated-input FILE`. The post-run report and promotable vector candidate remain separate owner-only artifacts.
+`--generated-input FILE`. Add `--adapter engine|retained-relay|app-runtime` to deliberately run the embedded canonical
+Scenario IR through a different in-process adapter; capability preflight still rejects unsupported operations before
+action zero. Reports retain the producer's family/version/seed/case/subject provenance plus separate SHA-256 digests for
+the selected envelope bytes and the canonical Scenario IR inside it. The post-run report and promotable vector candidate
+remain separate owner-only artifacts.
+
+The process adapter accepts the same saved input in place of a raw Scenario IR file:
+
+```sh
+cargo run -p cgka-conformance-simulator --bin cgka-conformance-process -- \
+  target/cgka-conformance-simulator-reports/chat-journey-v1-seed-42-case-0-generated-input.json \
+  target/debug/cgka-conformance-node \
+  target/chat-journey-process-report.json
+```
+
+Its report preserves the same provenance, canonical digest, and semantic expectations. Container and VM manifests use
+the same envelope through `convergence-campaign-runner`; the distributed runner resolves and privately materializes the
+canonical IR before launching nodes or an external VM driver.
 
 ## Report artifacts
 

--- a/crates/cgka-conformance-simulator/src/bin/cgka-conformance-process.rs
+++ b/crates/cgka-conformance-simulator/src/bin/cgka-conformance-process.rs
@@ -1,7 +1,9 @@
 use std::path::PathBuf;
 use std::process::ExitCode;
 
-use cgka_conformance_simulator::{ScenarioSpec, process_orchestrator::ProcessOrchestrator};
+use cgka_conformance_simulator::{
+    process_orchestrator::ProcessOrchestrator, resolve_scenario_input_bytes,
+};
 
 #[tokio::main]
 async fn main() -> ExitCode {
@@ -25,7 +27,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     if args.next().is_some() {
         return Err("unexpected extra arguments".into());
     }
-    let scenario: ScenarioSpec = serde_json::from_slice(&std::fs::read(scenario_path)?)?;
+    let input = resolve_scenario_input_bytes(&std::fs::read(scenario_path)?)?;
     let artifact_name = format!(
         "{}.artifacts",
         out.file_stem()
@@ -37,7 +39,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         .unwrap_or_else(|| std::path::Path::new("."))
         .join(artifact_name);
     let mut orchestrator =
-        ProcessOrchestrator::launch(node_bin, &scenario, artifact_directory).await?;
+        ProcessOrchestrator::launch_resolved(node_bin, &input, artifact_directory).await?;
     let report_result = orchestrator.run().await.and_then(|report| {
         orchestrator.write_report_private(&report, &out)?;
         Ok(report)

--- a/crates/cgka-conformance-simulator/src/family.rs
+++ b/crates/cgka-conformance-simulator/src/family.rs
@@ -83,9 +83,17 @@ impl GeneratedSubjectKind {
     pub fn parse(value: &str) -> Result<Self, String> {
         match value {
             "engine" => Ok(Self::Engine),
-            "retained-relay" | "retained_relay" => Ok(Self::RetainedRelay),
-            "app-runtime" | "app_runtime" => Ok(Self::AppRuntime),
+            "retained-relay" => Ok(Self::RetainedRelay),
+            "app-runtime" => Ok(Self::AppRuntime),
             other => Err(format!("unsupported generated-case adapter {other}")),
+        }
+    }
+
+    pub(crate) fn artifact_label(self) -> &'static str {
+        match self {
+            Self::Engine => "engine",
+            Self::RetainedRelay => "retained-relay",
+            Self::AppRuntime => "app-runtime",
         }
     }
 }

--- a/crates/cgka-conformance-simulator/src/family.rs
+++ b/crates/cgka-conformance-simulator/src/family.rs
@@ -5,11 +5,11 @@
 
 use crate::scenario::subject_setup_error;
 use crate::{
-    GeneratedScenarioMetadata, HarnessStorageMode, RetainedRelaySubject, ScenarioFailureCaptureV1,
-    ScenarioMessageSelectorV2, ScenarioOutboundSelection, ScenarioReport, ScenarioRunError,
-    ScenarioSpec, ScenarioStep, ScenarioTrace, ScenarioTransportClass, SubjectFailureCategory,
-    SubjectOutboundOutcome, TraceExpectation, VectorFixture, fingerprint_report_failure,
-    run_scenario_report_with_outcomes_and_capture,
+    AppRuntimeHarness, GeneratedScenarioMetadata, HarnessStorageMode, RetainedRelaySubject,
+    ScenarioFailureCaptureV1, ScenarioMessageSelectorV2, ScenarioOutboundSelection, ScenarioReport,
+    ScenarioRunError, ScenarioSpec, ScenarioStep, ScenarioTrace, ScenarioTransportClass,
+    SubjectFailureCategory, SubjectOutboundOutcome, TraceExpectation, VectorFixture,
+    fingerprint_report_failure, run_scenario_report_with_outcomes_and_capture,
     run_scenario_report_with_outcomes_and_storage_mode, run_scenario_report_with_subject,
     stable_action_id,
 };
@@ -72,11 +72,21 @@ pub enum GeneratedSubjectKind {
     #[default]
     Engine,
     RetainedRelay,
+    AppRuntime,
 }
 
 impl GeneratedSubjectKind {
     fn is_engine(&self) -> bool {
         *self == Self::Engine
+    }
+
+    pub fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "engine" => Ok(Self::Engine),
+            "retained-relay" | "retained_relay" => Ok(Self::RetainedRelay),
+            "app-runtime" | "app_runtime" => Ok(Self::AppRuntime),
+            other => Err(format!("unsupported generated-case adapter {other}")),
+        }
     }
 }
 
@@ -279,7 +289,14 @@ pub async fn run_generated_case_report_with_storage_mode(
         storage_mode,
     )
     .await?;
-    add_generated_metadata(case, expected_trace.as_ref(), &mut report, storage_mode).await;
+    add_generated_metadata(
+        case,
+        case.subject,
+        expected_trace.as_ref(),
+        &mut report,
+        storage_mode,
+    )
+    .await;
     Ok(report)
 }
 
@@ -291,7 +308,24 @@ pub async fn run_generated_case_report_with_capture(
     storage_mode: HarnessStorageMode,
     capture_sensitive_replay: bool,
 ) -> Result<(ScenarioReport, crate::ScenarioFailureCaptureV1), ScenarioRunError> {
-    let (mut report, failure_capture) = match case.subject {
+    run_generated_case_report_with_capture_on_subject(
+        case,
+        case.subject,
+        expected_trace,
+        storage_mode,
+        capture_sensitive_replay,
+    )
+    .await
+}
+
+pub async fn run_generated_case_report_with_capture_on_subject(
+    case: &GeneratedScenarioCase,
+    execution_subject: GeneratedSubjectKind,
+    expected_trace: Option<ScenarioTrace>,
+    storage_mode: HarnessStorageMode,
+    capture_sensitive_replay: bool,
+) -> Result<(ScenarioReport, crate::ScenarioFailureCaptureV1), ScenarioRunError> {
+    let (mut report, failure_capture) = match execution_subject {
         GeneratedSubjectKind::Engine => {
             run_scenario_report_with_outcomes_and_capture(
                 &case.scenario,
@@ -334,19 +368,63 @@ pub async fn run_generated_case_report_with_capture(
                 },
             )
         }
+        GeneratedSubjectKind::AppRuntime => {
+            if capture_sensitive_replay {
+                return Err(ScenarioRunError {
+                    step_index: None,
+                    kind: "sensitive_replay_capture_unsupported".into(),
+                    category: SubjectFailureCategory::Environment,
+                    message: "app-runtime generated cases cannot capture an engine checkpoint"
+                        .into(),
+                });
+            }
+            let mut subject = AppRuntimeHarness::new(&case.scenario.clients)
+                .await
+                .map_err(subject_setup_error)?;
+            let result = run_scenario_report_with_subject(
+                &case.scenario,
+                expected_trace.clone(),
+                case.expected_outcomes.clone(),
+                &mut subject,
+            )
+            .await;
+            subject.shutdown().await;
+            (
+                result?,
+                ScenarioFailureCaptureV1 {
+                    transport: Default::default(),
+                    byte_replay: None,
+                },
+            )
+        }
     };
-    add_generated_metadata(case, expected_trace.as_ref(), &mut report, storage_mode).await;
+    add_generated_metadata(
+        case,
+        execution_subject,
+        expected_trace.as_ref(),
+        &mut report,
+        storage_mode,
+    )
+    .await;
     Ok((report, failure_capture))
 }
 
 async fn add_generated_metadata(
     case: &GeneratedScenarioCase,
+    execution_subject: GeneratedSubjectKind,
     expected_trace: Option<&ScenarioTrace>,
     report: &mut ScenarioReport,
     storage_mode: HarnessStorageMode,
 ) {
     let minimized_case = if fingerprint_report_failure(report).is_ok() {
-        minimize_failing_case(case, expected_trace, report, storage_mode).await
+        minimize_failing_case(
+            case,
+            execution_subject,
+            expected_trace,
+            report,
+            storage_mode,
+        )
+        .await
     } else {
         None
     };
@@ -361,6 +439,7 @@ async fn add_generated_metadata(
 
 async fn minimize_failing_case(
     case: &GeneratedScenarioCase,
+    execution_subject: GeneratedSubjectKind,
     expected_trace: Option<&ScenarioTrace>,
     failing_report: &ScenarioReport,
     storage_mode: HarnessStorageMode,
@@ -379,7 +458,7 @@ async fn minimize_failing_case(
                 expected_outcomes,
                 &target_identity,
                 storage_mode,
-                case.subject,
+                execution_subject,
             )
             .await
         }
@@ -576,6 +655,20 @@ async fn run_generated_scenario(
                 &mut retained,
             )
             .await
+        }
+        GeneratedSubjectKind::AppRuntime => {
+            let mut app = AppRuntimeHarness::new(&scenario.clients)
+                .await
+                .map_err(subject_setup_error)?;
+            let result = run_scenario_report_with_subject(
+                scenario,
+                expected_trace,
+                expected_outcomes,
+                &mut app,
+            )
+            .await;
+            app.shutdown().await;
+            result
         }
     }
 }

--- a/crates/cgka-conformance-simulator/src/lib.rs
+++ b/crates/cgka-conformance-simulator/src/lib.rs
@@ -48,6 +48,7 @@ pub mod scenario;
 mod scenario_assertions;
 mod scenario_authoring;
 mod scenario_faults;
+mod scenario_input;
 mod scenario_input_ledger;
 mod scenario_ir;
 mod stateful_generator;
@@ -95,7 +96,8 @@ pub use family::{
     generate_adversarial_reliability_sustained_regression, generate_convergence_chaos_family,
     generate_convergence_e2e_delivery_family, generate_send_leave_family,
     run_generated_case_report, run_generated_case_report_with_capture,
-    run_generated_case_report_with_storage_mode, semantic_reduction_units,
+    run_generated_case_report_with_capture_on_subject, run_generated_case_report_with_storage_mode,
+    semantic_reduction_units,
 };
 pub use oracle::{
     BehaviorEvidenceSummary, CoverageMatrixEntry, OracleBehavior, OracleCoverageWarning,
@@ -146,6 +148,11 @@ pub use scenario_authoring::{
 pub use scenario_faults::{
     ScenarioMessageSelectorV2, ScenarioStorageFaultKind, ScenarioStorageFaultV2,
     ScenarioTransportClass,
+};
+pub use scenario_input::{
+    GeneratedScenarioProvenanceV1, ResolvedScenarioInputV1,
+    SCENARIO_INPUT_PROVENANCE_SCHEMA_VERSION, ScenarioInputError, ScenarioInputFormatV1,
+    ScenarioInputProvenanceV1, canonical_scenario_ir_sha256, resolve_scenario_input_bytes,
 };
 pub use scenario_input_ledger::{
     ScenarioInputDisposition, ScenarioInputKind, ScenarioInputLedgerEntry,

--- a/crates/cgka-conformance-simulator/src/process_orchestrator.rs
+++ b/crates/cgka-conformance-simulator/src/process_orchestrator.rs
@@ -21,7 +21,7 @@ use crate::{
     CompiledScenarioV2, ResolvedScenarioInputV1, ScenarioActionScheduleV2,
     ScenarioInputProvenanceV1, ScenarioRelaySyncModeV2, ScenarioSpec, ScenarioStep,
     SubjectCapability, SubjectDescriptor, SubjectFailureCategory, TraceExpectation,
-    compile_scenario, preflight_compiled_scenario,
+    canonical_scenario_ir_sha256, compile_scenario, preflight_compiled_scenario,
 };
 
 pub const PROCESS_SCENARIO_REPORT_SCHEMA_VERSION: &str = "1";
@@ -109,8 +109,14 @@ fn render_node_arg(
 pub struct ProcessScenarioReportV1 {
     pub schema_version: String,
     pub scenario_name: String,
+    /// Identity of the selected source input, before any adapter-owned lowering.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub input_provenance: Option<ScenarioInputProvenanceV1>,
+    /// Digest of the canonical Scenario IR this process executor compiled.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub executed_scenario_ir_sha256: Option<String>,
+    /// Carried as source provenance for downstream oracle tooling. The process
+    /// executor does not evaluate these semantic expectations itself.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub expected_outcomes: Vec<TraceExpectation>,
     pub canonical_schedule: Vec<ScenarioActionScheduleV2>,
@@ -182,6 +188,7 @@ pub struct ProcessOrchestrator {
     groups: BTreeMap<String, String>,
     lifecycle: Vec<ProcessLifecycleEventV1>,
     input_provenance: Option<ScenarioInputProvenanceV1>,
+    executed_scenario_ir_sha256: String,
     expected_outcomes: Vec<TraceExpectation>,
 }
 
@@ -232,6 +239,8 @@ impl ProcessOrchestrator {
         scenario: &ScenarioSpec,
         artifact_directory: impl AsRef<Path>,
     ) -> Result<Self, ProcessOrchestratorError> {
+        let executed_scenario_ir_sha256 = canonical_scenario_ir_sha256(scenario)
+            .map_err(|error| ProcessOrchestratorError::new("scenario_digest", error.to_string()))?;
         let compiled = compile_scenario(scenario).map_err(|error| {
             ProcessOrchestratorError::new("scenario_compile", error.to_string())
         })?;
@@ -319,6 +328,7 @@ impl ProcessOrchestrator {
             groups: BTreeMap::new(),
             lifecycle: Vec::new(),
             input_provenance: None,
+            executed_scenario_ir_sha256,
             expected_outcomes: Vec::new(),
         };
         for client in &clients {
@@ -389,6 +399,7 @@ impl ProcessOrchestrator {
             schema_version: PROCESS_SCENARIO_REPORT_SCHEMA_VERSION.into(),
             scenario_name: compiled.name.clone(),
             input_provenance: self.input_provenance.clone(),
+            executed_scenario_ir_sha256: Some(self.executed_scenario_ir_sha256.clone()),
             expected_outcomes: self.expected_outcomes.clone(),
             canonical_schedule: schedule,
             actions: Vec::new(),
@@ -1449,6 +1460,7 @@ mod tests {
             schema_version: PROCESS_SCENARIO_REPORT_SCHEMA_VERSION.into(),
             scenario_name: "round-trip".into(),
             input_provenance: None,
+            executed_scenario_ir_sha256: None,
             expected_outcomes: Vec::new(),
             canonical_schedule: Vec::new(),
             actions: Vec::new(),

--- a/crates/cgka-conformance-simulator/src/process_orchestrator.rs
+++ b/crates/cgka-conformance-simulator/src/process_orchestrator.rs
@@ -18,9 +18,10 @@ use crate::node_protocol::{
     NodeFailureCapsuleV1, NodeObservationV1, NodeRequestV1, NodeResponseBodyV1, NodeResponseV1,
 };
 use crate::{
-    CompiledScenarioV2, ScenarioActionScheduleV2, ScenarioRelaySyncModeV2, ScenarioSpec,
-    ScenarioStep, SubjectCapability, SubjectDescriptor, SubjectFailureCategory, compile_scenario,
-    preflight_compiled_scenario,
+    CompiledScenarioV2, ResolvedScenarioInputV1, ScenarioActionScheduleV2,
+    ScenarioInputProvenanceV1, ScenarioRelaySyncModeV2, ScenarioSpec, ScenarioStep,
+    SubjectCapability, SubjectDescriptor, SubjectFailureCategory, TraceExpectation,
+    compile_scenario, preflight_compiled_scenario,
 };
 
 pub const PROCESS_SCENARIO_REPORT_SCHEMA_VERSION: &str = "1";
@@ -108,6 +109,10 @@ fn render_node_arg(
 pub struct ProcessScenarioReportV1 {
     pub schema_version: String,
     pub scenario_name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_provenance: Option<ScenarioInputProvenanceV1>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub expected_outcomes: Vec<TraceExpectation>,
     pub canonical_schedule: Vec<ScenarioActionScheduleV2>,
     pub actions: Vec<ProcessActionResultV1>,
     pub observations: Vec<NodeObservationV1>,
@@ -176,6 +181,8 @@ pub struct ProcessOrchestrator {
     process_relays: BTreeMap<String, Vec<String>>,
     groups: BTreeMap<String, String>,
     lifecycle: Vec<ProcessLifecycleEventV1>,
+    input_provenance: Option<ScenarioInputProvenanceV1>,
+    expected_outcomes: Vec<TraceExpectation>,
 }
 
 struct NodeProcess {
@@ -201,6 +208,18 @@ impl ProcessOrchestrator {
             artifact_directory,
         )
         .await
+    }
+
+    pub async fn launch_resolved(
+        node_executable: impl AsRef<Path>,
+        input: &ResolvedScenarioInputV1,
+        artifact_directory: impl AsRef<Path>,
+    ) -> Result<Self, ProcessOrchestratorError> {
+        let mut orchestrator =
+            Self::launch(node_executable, &input.scenario, artifact_directory).await?;
+        orchestrator.input_provenance = Some(input.provenance.clone());
+        orchestrator.expected_outcomes = input.expected_outcomes.clone();
+        Ok(orchestrator)
     }
 
     /// Launch participant nodes through a caller-supplied argv template and,
@@ -299,6 +318,8 @@ impl ProcessOrchestrator {
             process_relays,
             groups: BTreeMap::new(),
             lifecycle: Vec::new(),
+            input_provenance: None,
+            expected_outcomes: Vec::new(),
         };
         for client in &clients {
             orchestrator.launch_participant(client, "launch").await?;
@@ -308,6 +329,24 @@ impl ProcessOrchestrator {
             .barrier_all("launch", "all_nodes_initialized")
             .await
             .map_err(process_action_error)?;
+        Ok(orchestrator)
+    }
+
+    pub async fn launch_resolved_with(
+        node_launch: ProcessNodeLaunchV1,
+        external_relay_urls: Option<BTreeMap<String, String>>,
+        input: &ResolvedScenarioInputV1,
+        artifact_directory: impl AsRef<Path>,
+    ) -> Result<Self, ProcessOrchestratorError> {
+        let mut orchestrator = Self::launch_with(
+            node_launch,
+            external_relay_urls,
+            &input.scenario,
+            artifact_directory,
+        )
+        .await?;
+        orchestrator.input_provenance = Some(input.provenance.clone());
+        orchestrator.expected_outcomes = input.expected_outcomes.clone();
         Ok(orchestrator)
     }
 
@@ -349,6 +388,8 @@ impl ProcessOrchestrator {
         let mut report = ProcessScenarioReportV1 {
             schema_version: PROCESS_SCENARIO_REPORT_SCHEMA_VERSION.into(),
             scenario_name: compiled.name.clone(),
+            input_provenance: self.input_provenance.clone(),
+            expected_outcomes: self.expected_outcomes.clone(),
             canonical_schedule: schedule,
             actions: Vec::new(),
             observations: Vec::new(),
@@ -1407,6 +1448,8 @@ mod tests {
         let report = ProcessScenarioReportV1 {
             schema_version: PROCESS_SCENARIO_REPORT_SCHEMA_VERSION.into(),
             scenario_name: "round-trip".into(),
+            input_provenance: None,
+            expected_outcomes: Vec::new(),
             canonical_schedule: Vec::new(),
             actions: Vec::new(),
             observations: Vec::new(),

--- a/crates/cgka-conformance-simulator/src/report.rs
+++ b/crates/cgka-conformance-simulator/src/report.rs
@@ -1,6 +1,7 @@
 use std::error::Error;
 use std::path::{Path, PathBuf};
 
+use crate::scenario_input::generated_scenario_input_provenance;
 use crate::{
     CoverageMatrixEntry, FailureCapsuleSensitivity, FailureCapsuleV1, GeneratedScenarioCase,
     GeneratedScenarioInputV1, HarnessStorageMode, ScenarioInputProvenanceV1, ScenarioReport,
@@ -271,7 +272,7 @@ async fn run_generated_family_reports(
         let source = case.family_name.clone();
         let input = GeneratedScenarioInputV1::new(case.clone());
         let input_bytes = serde_json::to_vec_pretty(&input)?;
-        let provenance = resolve_scenario_input_bytes(&input_bytes)?.provenance;
+        let provenance = generated_scenario_input_provenance(&input_bytes, &case)?;
         fs_private::write_private(&input_output, &input_bytes)?;
         summaries.push(
             run_generated_case_artifacts(
@@ -308,11 +309,12 @@ async fn run_generated_input_reports(
     for path in paths {
         let input_bytes = std::fs::read(path)?;
         let resolved = resolve_scenario_input_bytes(&input_bytes)?;
-        let input: GeneratedScenarioInputV1 = serde_json::from_slice(&input_bytes)?;
-        input.validate()?;
+        let case = resolved
+            .generated_case
+            .ok_or("--generated-input requires a GeneratedScenarioInputV1 envelope")?;
         summaries.push(
             run_generated_case_artifacts(
-                &input.case,
+                &case,
                 GeneratedCaseArtifactSource {
                     adapter,
                     provenance: resolved.provenance,
@@ -343,48 +345,33 @@ async fn run_generated_case_artifacts(
     storage_mode: HarnessStorageMode,
     capture_sensitive_replay: bool,
 ) -> Result<ScenarioReportSummary, Box<dyn Error>> {
+    let execution_subject = source.adapter.unwrap_or(case.subject);
+    let adapter_overridden = execution_subject != case.subject;
     let (mut report, failure_capture) = crate::run_generated_case_report_with_capture_on_subject(
         case,
-        source.adapter.unwrap_or(case.subject),
+        execution_subject,
         None,
         storage_mode,
         capture_sensitive_replay,
     )
     .await?;
     report.metadata.input_provenance = Some(source.provenance);
-    let output = out.join(format!(
-        "{}-seed-{}-case-{}.json",
-        case.family_name.replace('/', "-"),
-        case.seed,
-        case.case_index
-    ));
+    let artifact_stem = generated_artifact_stem(case, execution_subject);
+    let output = out.join(format!("{artifact_stem}.json"));
     fs_private::write_private(&output, &serde_json::to_vec_pretty(&report)?)?;
-    let fixture_output = out.join(format!(
-        "{}-seed-{}-case-{}-fixture.v1.json",
-        case.family_name.replace('/', "-"),
-        case.seed,
-        case.case_index
-    ));
-    let fixture = generated_fixture_candidate(case, &report);
-    fs_private::write_private(&fixture_output, &serde_json::to_vec_pretty(&fixture)?)?;
+    if !adapter_overridden {
+        let fixture_output = out.join(format!("{artifact_stem}-fixture.v1.json"));
+        let fixture = generated_fixture_candidate(case, &report);
+        fs_private::write_private(&fixture_output, &serde_json::to_vec_pretty(&fixture)?)?;
+    }
     let coverage = coverage_matrix_entry(source.label.clone(), &report);
     let failures = scenario_report_failures(&report, strict_oracle);
     let failure_count = failures.len();
     let failure_capsules = if failures.is_empty() {
         WrittenFailureCapsules::default()
     } else {
-        let portable_path = out.join(format!(
-            "{}-seed-{}-case-{}-failure-capsule.v1.json",
-            case.family_name.replace('/', "-"),
-            case.seed,
-            case.case_index
-        ));
-        let replay_path = out.join(format!(
-            "{}-seed-{}-case-{}-sensitive-replay-capsule.v1.json",
-            case.family_name.replace('/', "-"),
-            case.seed,
-            case.case_index
-        ));
+        let portable_path = out.join(format!("{artifact_stem}-failure-capsule.v1.json"));
+        let replay_path = out.join(format!("{artifact_stem}-sensitive-replay-capsule.v1.json"));
         write_report_failure_capsules(
             &report,
             failure_capture_for(&failures, failure_capture),
@@ -403,6 +390,23 @@ async fn run_generated_case_artifacts(
         failures,
         coverage,
     })
+}
+
+fn generated_artifact_stem(
+    case: &GeneratedScenarioCase,
+    execution_subject: crate::GeneratedSubjectKind,
+) -> String {
+    let base = format!(
+        "{}-seed-{}-case-{}",
+        case.family_name.replace('/', "-"),
+        case.seed,
+        case.case_index
+    );
+    if execution_subject == case.subject {
+        base
+    } else {
+        format!("{base}-{}", execution_subject.artifact_label())
+    }
 }
 
 fn generated_fixture_candidate(

--- a/crates/cgka-conformance-simulator/src/report.rs
+++ b/crates/cgka-conformance-simulator/src/report.rs
@@ -3,12 +3,11 @@ use std::path::{Path, PathBuf};
 
 use crate::{
     CoverageMatrixEntry, FailureCapsuleSensitivity, FailureCapsuleV1, GeneratedScenarioCase,
-    GeneratedScenarioInputV1, HarnessStorageMode, ScenarioReport, VectorFixture,
-    coverage_matrix_entry, generate_adversarial_reliability_family,
+    GeneratedScenarioInputV1, HarnessStorageMode, ScenarioInputProvenanceV1, ScenarioReport,
+    VectorFixture, coverage_matrix_entry, generate_adversarial_reliability_family,
     generate_convergence_chaos_family, generate_convergence_e2e_delivery_family,
     generate_send_leave_family, generate_stateful_chat_journey_family,
-    run_generated_case_report_with_capture, run_vector_fixture_report_with_capture,
-    write_failure_capsule,
+    resolve_scenario_input_bytes, run_vector_fixture_report_with_capture, write_failure_capsule,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -33,6 +32,9 @@ pub enum ReportInput {
     },
     GeneratedInputs {
         paths: Vec<PathBuf>,
+        /// Override the producer-recorded subject while preserving it in the
+        /// saved input as provenance.
+        adapter: Option<crate::GeneratedSubjectKind>,
     },
 }
 
@@ -215,9 +217,10 @@ pub async fn run_report(args: &ReportArgs) -> Result<ReportRunSummary, Box<dyn E
             )
             .await?
         }
-        ReportInput::GeneratedInputs { paths } => {
+        ReportInput::GeneratedInputs { paths, adapter } => {
             run_generated_input_reports(
                 paths,
+                *adapter,
                 &args.out,
                 args.strict_oracle,
                 args.storage_mode,
@@ -267,11 +270,17 @@ async fn run_generated_family_reports(
         ));
         let source = case.family_name.clone();
         let input = GeneratedScenarioInputV1::new(case.clone());
-        fs_private::write_private(&input_output, &serde_json::to_vec_pretty(&input)?)?;
+        let input_bytes = serde_json::to_vec_pretty(&input)?;
+        let provenance = resolve_scenario_input_bytes(&input_bytes)?.provenance;
+        fs_private::write_private(&input_output, &input_bytes)?;
         summaries.push(
             run_generated_case_artifacts(
                 &case,
-                source,
+                GeneratedCaseArtifactSource {
+                    adapter: None,
+                    provenance,
+                    label: source,
+                },
                 out,
                 strict_oracle,
                 storage_mode,
@@ -286,6 +295,7 @@ async fn run_generated_family_reports(
 
 async fn run_generated_input_reports(
     paths: &[PathBuf],
+    adapter: Option<crate::GeneratedSubjectKind>,
     out: &Path,
     strict_oracle: bool,
     storage_mode: HarnessStorageMode,
@@ -296,13 +306,18 @@ async fn run_generated_input_reports(
     }
     let mut summaries = Vec::with_capacity(paths.len());
     for path in paths {
-        let input: GeneratedScenarioInputV1 =
-            serde_json::from_str(&std::fs::read_to_string(path)?)?;
+        let input_bytes = std::fs::read(path)?;
+        let resolved = resolve_scenario_input_bytes(&input_bytes)?;
+        let input: GeneratedScenarioInputV1 = serde_json::from_slice(&input_bytes)?;
         input.validate()?;
         summaries.push(
             run_generated_case_artifacts(
                 &input.case,
-                path.display().to_string(),
+                GeneratedCaseArtifactSource {
+                    adapter,
+                    provenance: resolved.provenance,
+                    label: path.display().to_string(),
+                },
                 out,
                 strict_oracle,
                 storage_mode,
@@ -314,17 +329,29 @@ async fn run_generated_input_reports(
     Ok(summaries)
 }
 
+struct GeneratedCaseArtifactSource {
+    adapter: Option<crate::GeneratedSubjectKind>,
+    provenance: ScenarioInputProvenanceV1,
+    label: String,
+}
+
 async fn run_generated_case_artifacts(
     case: &GeneratedScenarioCase,
-    source: String,
+    source: GeneratedCaseArtifactSource,
     out: &Path,
     strict_oracle: bool,
     storage_mode: HarnessStorageMode,
     capture_sensitive_replay: bool,
 ) -> Result<ScenarioReportSummary, Box<dyn Error>> {
-    let (report, failure_capture) =
-        run_generated_case_report_with_capture(case, None, storage_mode, capture_sensitive_replay)
-            .await?;
+    let (mut report, failure_capture) = crate::run_generated_case_report_with_capture_on_subject(
+        case,
+        source.adapter.unwrap_or(case.subject),
+        None,
+        storage_mode,
+        capture_sensitive_replay,
+    )
+    .await?;
+    report.metadata.input_provenance = Some(source.provenance);
     let output = out.join(format!(
         "{}-seed-{}-case-{}.json",
         case.family_name.replace('/', "-"),
@@ -340,7 +367,7 @@ async fn run_generated_case_artifacts(
     ));
     let fixture = generated_fixture_candidate(case, &report);
     fs_private::write_private(&fixture_output, &serde_json::to_vec_pretty(&fixture)?)?;
-    let coverage = coverage_matrix_entry(source.clone(), &report);
+    let coverage = coverage_matrix_entry(source.label.clone(), &report);
     let failures = scenario_report_failures(&report, strict_oracle);
     let failure_count = failures.len();
     let failure_capsules = if failures.is_empty() {
@@ -367,7 +394,7 @@ async fn run_generated_case_artifacts(
     };
     Ok(ScenarioReportSummary {
         scenario_name: report.metadata.scenario_name.clone(),
-        source,
+        source: source.label,
         output,
         failure_capsule: failure_capsules.portable,
         replay_capsule: failure_capsules.replay,
@@ -579,6 +606,7 @@ pub fn parse_report_command(
     let mut cases = 1usize;
     let mut vectors = Vec::new();
     let mut generated_inputs = Vec::new();
+    let mut generated_input_adapter = None;
     let mut out = PathBuf::from("target/cgka-conformance-simulator-reports");
     let mut strict_oracle = true;
     let mut storage_mode = None;
@@ -613,6 +641,13 @@ pub fn parse_report_command(
                 scenario_input_selected = true;
                 generated_inputs.push(PathBuf::from(next_value(&mut args, "--generated-input")?));
             }
+            "--adapter" => {
+                scenario_input_selected = true;
+                generated_input_adapter = Some(crate::GeneratedSubjectKind::parse(&next_value(
+                    &mut args,
+                    "--adapter",
+                )?)?);
+            }
             "--replay-capsule" => {
                 replay_capsule = Some(PathBuf::from(next_value(&mut args, "--replay-capsule")?));
             }
@@ -646,10 +681,14 @@ pub fn parse_report_command(
                 .into(),
         );
     }
+    if generated_input_adapter.is_some() && generated_inputs.is_empty() {
+        return Err("--adapter requires at least one --generated-input".into());
+    }
 
     let input = if !generated_inputs.is_empty() {
         ReportInput::GeneratedInputs {
             paths: generated_inputs,
+            adapter: generated_input_adapter,
         }
     } else if vectors.is_empty() {
         ReportInput::GeneratedFamily {
@@ -679,7 +718,7 @@ fn next_value(
 }
 
 pub fn report_usage() -> &'static str {
-    "Usage: cgka-conformance-simulator-report [--replay-capsule FILE | --generated-input FILE ... | --vectors FILE_OR_DIR ... | --family send-leave/v1|convergence-e2e-delivery/v1|convergence-chaos/v1|adversarial-reliability/v1|chat-journey/v1 --seed N --cases N] [--out DIR] [--storage memory|file] [--strict-oracle|--allow-weak-oracle] [--capture-sensitive-replay]"
+    "Usage: cgka-conformance-simulator-report [--replay-capsule FILE | --generated-input FILE ... [--adapter engine|retained-relay|app-runtime] | --vectors FILE_OR_DIR ... | --family send-leave/v1|convergence-e2e-delivery/v1|convergence-chaos/v1|adversarial-reliability/v1|chat-journey/v1 --seed N --cases N] [--out DIR] [--storage memory|file] [--strict-oracle|--allow-weak-oracle] [--capture-sensitive-replay]"
 }
 
 #[cfg(test)]
@@ -700,6 +739,7 @@ mod tests {
                 subject: None,
                 generated: None,
                 fixture: None,
+                input_provenance: None,
             },
             scenario: ScenarioSpec {
                 name: "oracle-summary-test".into(),

--- a/crates/cgka-conformance-simulator/src/scenario.rs
+++ b/crates/cgka-conformance-simulator/src/scenario.rs
@@ -405,6 +405,8 @@ pub struct ScenarioReportMetadata {
     pub subject: Option<SubjectDescriptor>,
     pub generated: Option<GeneratedScenarioMetadata>,
     pub fixture: Option<VectorFixtureMetadata>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_provenance: Option<crate::ScenarioInputProvenanceV1>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -1380,6 +1382,7 @@ async fn run_scenario_report_inner(
             subject: Some(descriptor),
             generated: None,
             fixture,
+            input_provenance: None,
         },
         scenario: spec.clone(),
         resolved_topology: compiled.topology.clone(),

--- a/crates/cgka-conformance-simulator/src/scenario_input.rs
+++ b/crates/cgka-conformance-simulator/src/scenario_input.rs
@@ -1,0 +1,202 @@
+//! Shared resolution of canonical Scenario IR and saved generated inputs.
+//!
+//! Wider adapters consume this boundary so a saved generated case keeps one
+//! scenario meaning. The source-byte digest identifies the selected artifact;
+//! the canonical-IR digest identifies the exact [`ScenarioSpec`] every adapter
+//! must execute after resolving the envelope.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::{GeneratedScenarioInputV1, GeneratedSubjectKind, ScenarioSpec, TraceExpectation};
+
+pub const SCENARIO_INPUT_PROVENANCE_SCHEMA_VERSION: &str = "1";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ScenarioInputFormatV1 {
+    CanonicalScenarioIr,
+    GeneratedScenarioInputV1,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GeneratedScenarioProvenanceV1 {
+    pub family_name: String,
+    pub generator_version: String,
+    pub seed: u64,
+    pub case_index: u64,
+    pub recorded_subject: GeneratedSubjectKind,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScenarioInputProvenanceV1 {
+    pub schema_version: String,
+    pub format: ScenarioInputFormatV1,
+    /// SHA-256 of the selected file bytes, including an envelope when present.
+    pub source_sha256: String,
+    /// SHA-256 of the deterministic compact JSON encoding of the embedded IR.
+    pub canonical_ir_sha256: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub generated: Option<GeneratedScenarioProvenanceV1>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ResolvedScenarioInputV1 {
+    pub scenario: ScenarioSpec,
+    pub expected_outcomes: Vec<TraceExpectation>,
+    pub provenance: ScenarioInputProvenanceV1,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ScenarioInputError {
+    pub code: &'static str,
+    pub message: String,
+}
+
+impl ScenarioInputError {
+    fn new(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for ScenarioInputError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}: {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for ScenarioInputError {}
+
+pub fn resolve_scenario_input_bytes(
+    bytes: &[u8],
+) -> Result<ResolvedScenarioInputV1, ScenarioInputError> {
+    let value: serde_json::Value = serde_json::from_slice(bytes)
+        .map_err(|error| ScenarioInputError::new("scenario_input_parse", error.to_string()))?;
+    let source_sha256 = hex::encode(Sha256::digest(bytes));
+
+    if value.get("schema_version").is_some() && value.get("case").is_some() {
+        let input: GeneratedScenarioInputV1 = serde_json::from_value(value).map_err(|error| {
+            ScenarioInputError::new("generated_scenario_input_parse", error.to_string())
+        })?;
+        input.validate().map_err(|message| {
+            ScenarioInputError::new("generated_scenario_input_version", message)
+        })?;
+        let case = input.case;
+        let canonical_ir_sha256 = canonical_scenario_ir_sha256(&case.scenario)?;
+        return Ok(ResolvedScenarioInputV1 {
+            scenario: case.scenario,
+            expected_outcomes: case.expected_outcomes,
+            provenance: ScenarioInputProvenanceV1 {
+                schema_version: SCENARIO_INPUT_PROVENANCE_SCHEMA_VERSION.into(),
+                format: ScenarioInputFormatV1::GeneratedScenarioInputV1,
+                source_sha256,
+                canonical_ir_sha256,
+                generated: Some(GeneratedScenarioProvenanceV1 {
+                    family_name: case.family_name,
+                    generator_version: case.generator_version,
+                    seed: case.seed,
+                    case_index: case.case_index,
+                    recorded_subject: case.subject,
+                }),
+            },
+        });
+    }
+
+    let scenario: ScenarioSpec = serde_json::from_value(value).map_err(|error| {
+        ScenarioInputError::new("canonical_scenario_ir_parse", error.to_string())
+    })?;
+    let canonical_ir_sha256 = canonical_scenario_ir_sha256(&scenario)?;
+    Ok(ResolvedScenarioInputV1 {
+        scenario,
+        expected_outcomes: Vec::new(),
+        provenance: ScenarioInputProvenanceV1 {
+            schema_version: SCENARIO_INPUT_PROVENANCE_SCHEMA_VERSION.into(),
+            format: ScenarioInputFormatV1::CanonicalScenarioIr,
+            source_sha256,
+            canonical_ir_sha256,
+            generated: None,
+        },
+    })
+}
+
+pub fn canonical_scenario_ir_sha256(scenario: &ScenarioSpec) -> Result<String, ScenarioInputError> {
+    let bytes = serde_json::to_vec(scenario).map_err(|error| {
+        ScenarioInputError::new("canonical_scenario_ir_encode", error.to_string())
+    })?;
+    Ok(hex::encode(Sha256::digest(bytes)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{GeneratedScenarioCase, ScenarioStep};
+
+    fn scenario() -> ScenarioSpec {
+        ScenarioSpec {
+            name: "selectable-input".into(),
+            spec_version: "2".into(),
+            clients: vec!["alice".into()],
+            topology: Default::default(),
+            steps: vec![ScenarioStep::DeliverAll],
+        }
+    }
+
+    #[test]
+    fn raw_and_generated_inputs_resolve_to_the_same_canonical_ir_digest() {
+        let scenario = scenario();
+        let raw = serde_json::to_vec(&scenario).unwrap();
+        let generated = serde_json::to_vec(&GeneratedScenarioInputV1::new(GeneratedScenarioCase {
+            family_name: "selectable/v1".into(),
+            generator_version: "3".into(),
+            seed: 42,
+            case_index: 7,
+            subject: GeneratedSubjectKind::RetainedRelay,
+            scenario: scenario.clone(),
+            expected_outcomes: Vec::new(),
+        }))
+        .unwrap();
+
+        let raw = resolve_scenario_input_bytes(&raw).unwrap();
+        let generated = resolve_scenario_input_bytes(&generated).unwrap();
+        assert_eq!(raw.scenario, scenario);
+        assert_eq!(generated.scenario, scenario);
+        assert_eq!(
+            raw.provenance.canonical_ir_sha256,
+            generated.provenance.canonical_ir_sha256
+        );
+        assert_ne!(
+            raw.provenance.source_sha256,
+            generated.provenance.source_sha256
+        );
+        assert_eq!(
+            generated.provenance.generated.unwrap().recorded_subject,
+            GeneratedSubjectKind::RetainedRelay
+        );
+    }
+
+    #[test]
+    fn a_generated_envelope_with_an_unknown_version_does_not_fall_back_to_raw_ir() {
+        let bytes = serde_json::to_vec(&GeneratedScenarioInputV1 {
+            schema_version: "99".into(),
+            case: GeneratedScenarioCase {
+                family_name: "selectable/v1".into(),
+                generator_version: "3".into(),
+                seed: 42,
+                case_index: 7,
+                subject: GeneratedSubjectKind::Engine,
+                scenario: scenario(),
+                expected_outcomes: Vec::new(),
+            },
+        })
+        .unwrap();
+        assert_eq!(
+            resolve_scenario_input_bytes(&bytes).unwrap_err().code,
+            "generated_scenario_input_version"
+        );
+    }
+}

--- a/crates/cgka-conformance-simulator/src/scenario_input.rs
+++ b/crates/cgka-conformance-simulator/src/scenario_input.rs
@@ -2,15 +2,19 @@
 //!
 //! Wider adapters consume this boundary so a saved generated case keeps one
 //! scenario meaning. The source-byte digest identifies the selected artifact;
-//! the canonical-IR digest identifies the exact [`ScenarioSpec`] every adapter
-//! must execute after resolving the envelope.
+//! the canonical-IR digest identifies the selected [`ScenarioSpec`] inside it.
+//! An adapter that deterministically lowers that selected history must record a
+//! separate digest for the history it actually executes.
 
 use std::fmt;
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use crate::{GeneratedScenarioInputV1, GeneratedSubjectKind, ScenarioSpec, TraceExpectation};
+use crate::{
+    GeneratedScenarioCase, GeneratedScenarioInputV1, GeneratedSubjectKind, ScenarioSpec,
+    TraceExpectation,
+};
 
 pub const SCENARIO_INPUT_PROVENANCE_SCHEMA_VERSION: &str = "1";
 
@@ -47,6 +51,9 @@ pub struct ResolvedScenarioInputV1 {
     pub scenario: ScenarioSpec,
     pub expected_outcomes: Vec<TraceExpectation>,
     pub provenance: ScenarioInputProvenanceV1,
+    /// The parsed source envelope, when one was selected. Wider adapters use
+    /// `scenario`; report tooling retains the case without parsing twice.
+    pub generated_case: Option<GeneratedScenarioCase>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -77,7 +84,6 @@ pub fn resolve_scenario_input_bytes(
 ) -> Result<ResolvedScenarioInputV1, ScenarioInputError> {
     let value: serde_json::Value = serde_json::from_slice(bytes)
         .map_err(|error| ScenarioInputError::new("scenario_input_parse", error.to_string()))?;
-    let source_sha256 = hex::encode(Sha256::digest(bytes));
 
     if value.get("schema_version").is_some() && value.get("case").is_some() {
         let input: GeneratedScenarioInputV1 = serde_json::from_value(value).map_err(|error| {
@@ -87,23 +93,12 @@ pub fn resolve_scenario_input_bytes(
             ScenarioInputError::new("generated_scenario_input_version", message)
         })?;
         let case = input.case;
-        let canonical_ir_sha256 = canonical_scenario_ir_sha256(&case.scenario)?;
+        let provenance = generated_scenario_input_provenance(bytes, &case)?;
         return Ok(ResolvedScenarioInputV1 {
-            scenario: case.scenario,
-            expected_outcomes: case.expected_outcomes,
-            provenance: ScenarioInputProvenanceV1 {
-                schema_version: SCENARIO_INPUT_PROVENANCE_SCHEMA_VERSION.into(),
-                format: ScenarioInputFormatV1::GeneratedScenarioInputV1,
-                source_sha256,
-                canonical_ir_sha256,
-                generated: Some(GeneratedScenarioProvenanceV1 {
-                    family_name: case.family_name,
-                    generator_version: case.generator_version,
-                    seed: case.seed,
-                    case_index: case.case_index,
-                    recorded_subject: case.subject,
-                }),
-            },
+            scenario: case.scenario.clone(),
+            expected_outcomes: case.expected_outcomes.clone(),
+            provenance,
+            generated_case: Some(case),
         });
     }
 
@@ -117,10 +112,30 @@ pub fn resolve_scenario_input_bytes(
         provenance: ScenarioInputProvenanceV1 {
             schema_version: SCENARIO_INPUT_PROVENANCE_SCHEMA_VERSION.into(),
             format: ScenarioInputFormatV1::CanonicalScenarioIr,
-            source_sha256,
+            source_sha256: hex::encode(Sha256::digest(bytes)),
             canonical_ir_sha256,
             generated: None,
         },
+        generated_case: None,
+    })
+}
+
+pub(crate) fn generated_scenario_input_provenance(
+    source_bytes: &[u8],
+    case: &GeneratedScenarioCase,
+) -> Result<ScenarioInputProvenanceV1, ScenarioInputError> {
+    Ok(ScenarioInputProvenanceV1 {
+        schema_version: SCENARIO_INPUT_PROVENANCE_SCHEMA_VERSION.into(),
+        format: ScenarioInputFormatV1::GeneratedScenarioInputV1,
+        source_sha256: hex::encode(Sha256::digest(source_bytes)),
+        canonical_ir_sha256: canonical_scenario_ir_sha256(&case.scenario)?,
+        generated: Some(GeneratedScenarioProvenanceV1 {
+            family_name: case.family_name.clone(),
+            generator_version: case.generator_version.clone(),
+            seed: case.seed,
+            case_index: case.case_index,
+            recorded_subject: case.subject,
+        }),
     })
 }
 
@@ -165,6 +180,8 @@ mod tests {
         let generated = resolve_scenario_input_bytes(&generated).unwrap();
         assert_eq!(raw.scenario, scenario);
         assert_eq!(generated.scenario, scenario);
+        assert!(raw.generated_case.is_none());
+        assert_eq!(generated.generated_case.as_ref().unwrap().seed, 42);
         assert_eq!(
             raw.provenance.canonical_ir_sha256,
             generated.provenance.canonical_ir_sha256

--- a/crates/cgka-conformance-simulator/tests/app_runtime_adapter.rs
+++ b/crates/cgka-conformance-simulator/tests/app_runtime_adapter.rs
@@ -4,8 +4,9 @@ use std::collections::BTreeSet;
 use std::time::Duration;
 
 use cgka_conformance_simulator::{
-    AppRuntimeHarness, ConvergenceSubject, ScenarioSpec, ScenarioStep,
-    run_scenario_report_with_subject,
+    AppRuntimeHarness, ConvergenceSubject, GeneratedScenarioCase, GeneratedSubjectKind,
+    HarnessStorageMode, ScenarioSpec, ScenarioStep, TraceExpectation,
+    run_generated_case_report_with_capture_on_subject, run_scenario_report_with_subject,
 };
 
 fn in_group(group: &str, action: ScenarioStep) -> ScenarioStep {
@@ -111,6 +112,38 @@ async fn app_runtime_subject_uses_distinct_private_encrypted_roots_and_public_pr
         );
     }
     subject.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn app_runtime_adapter_is_selectable_for_a_saved_generated_case() {
+    let case = GeneratedScenarioCase {
+        family_name: "selectable-app-runtime/v1".into(),
+        generator_version: "2".into(),
+        seed: 23,
+        case_index: 5,
+        subject: GeneratedSubjectKind::Engine,
+        scenario: two_client_scenario(),
+        expected_outcomes: vec![TraceExpectation::ClientsConverged {
+            clients: vec!["alice".into(), "bob".into()],
+            epoch: Some(1),
+            member_count: Some(2),
+        }],
+    };
+
+    let (report, _) = run_generated_case_report_with_capture_on_subject(
+        &case,
+        GeneratedSubjectKind::AppRuntime,
+        None,
+        HarnessStorageMode::InMemorySqlite,
+        false,
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        report.metadata.subject.as_ref().unwrap().adapter,
+        "marmot_app_runtime"
+    );
+    assert!(report.expectation_failures.is_empty(), "{report:#?}");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/crates/cgka-conformance-simulator/tests/process_orchestrator.rs
+++ b/crates/cgka-conformance-simulator/tests/process_orchestrator.rs
@@ -4,9 +4,10 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use cgka_conformance_simulator::process_orchestrator::{ProcessNodeLaunchV1, ProcessOrchestrator};
 use cgka_conformance_simulator::{
-    AppRuntimeHarness, ScenarioAccountV2, ScenarioDeviceV2, ScenarioProcessV2, ScenarioRelayV2,
-    ScenarioSpec, ScenarioStep, ScenarioTopologyV2, compile_scenario, run_scenario_report,
-    run_scenario_report_with_subject,
+    AppRuntimeHarness, GeneratedScenarioCase, GeneratedScenarioInputV1, GeneratedSubjectKind,
+    ScenarioAccountV2, ScenarioDeviceV2, ScenarioProcessV2, ScenarioRelayV2, ScenarioSpec,
+    ScenarioStep, ScenarioTopologyV2, TraceExpectation, compile_scenario,
+    resolve_scenario_input_bytes, run_scenario_report, run_scenario_report_with_subject,
 };
 
 fn in_group(group: &str, action: ScenarioStep) -> ScenarioStep {
@@ -297,6 +298,47 @@ async fn engine_app_runtime_and_process_adapters_reach_equivalent_public_state()
 
     process.shutdown().await;
     app.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn process_adapter_executes_the_ir_embedded_in_a_saved_generated_input() {
+    let spec = cross_adapter_scenario();
+    let input = GeneratedScenarioInputV1::new(GeneratedScenarioCase {
+        family_name: "selectable-process/v1".into(),
+        generator_version: "4".into(),
+        seed: 17,
+        case_index: 2,
+        subject: GeneratedSubjectKind::Engine,
+        scenario: spec.clone(),
+        expected_outcomes: vec![TraceExpectation::GroupProfile {
+            client: "alice".into(),
+            name: "equivalent result".into(),
+            description: "equivalent description".into(),
+        }],
+    });
+    let resolved = resolve_scenario_input_bytes(&serde_json::to_vec(&input).unwrap()).unwrap();
+    let artifacts = tempfile::tempdir().unwrap();
+    let mut process = ProcessOrchestrator::launch_resolved(
+        env!("CARGO_BIN_EXE_cgka-conformance-node"),
+        &resolved,
+        artifacts.path(),
+    )
+    .await
+    .unwrap();
+
+    let report = process.run().await.unwrap();
+    assert!(report.completed, "{report:#?}");
+    assert_eq!(report.expected_outcomes, input.case.expected_outcomes);
+    let provenance = report.input_provenance.unwrap();
+    assert_eq!(
+        provenance.canonical_ir_sha256,
+        resolved.provenance.canonical_ir_sha256
+    );
+    assert_eq!(
+        provenance.generated.unwrap().family_name,
+        "selectable-process/v1"
+    );
+    process.shutdown().await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/crates/cgka-conformance-simulator/tests/process_orchestrator.rs
+++ b/crates/cgka-conformance-simulator/tests/process_orchestrator.rs
@@ -329,6 +329,10 @@ async fn process_adapter_executes_the_ir_embedded_in_a_saved_generated_input() {
     let report = process.run().await.unwrap();
     assert!(report.completed, "{report:#?}");
     assert_eq!(report.expected_outcomes, input.case.expected_outcomes);
+    assert_eq!(
+        report.executed_scenario_ir_sha256.as_deref(),
+        Some(resolved.provenance.canonical_ir_sha256.as_str())
+    );
     let provenance = report.input_provenance.unwrap();
     assert_eq!(
         provenance.canonical_ir_sha256,

--- a/crates/cgka-conformance-simulator/tests/report_runner.rs
+++ b/crates/cgka-conformance-simulator/tests/report_runner.rs
@@ -2,9 +2,10 @@ use std::fs;
 use std::path::PathBuf;
 
 use cgka_conformance_simulator::{
-    FailureCapsuleSensitivity, HarnessStorageMode, OracleBehavior, ReportArgs, ReportCommand,
-    ReportInput, ScenarioStimulus, parse_report_command, promote_failure_capsule_to_vector,
-    property_test_coverage_entries, read_failure_capsule, replay_engine_bytes, run_report,
+    FailureCapsuleSensitivity, GeneratedSubjectKind, HarnessStorageMode, OracleBehavior,
+    ReportArgs, ReportCommand, ReportInput, ScenarioStimulus, parse_report_command,
+    promote_failure_capsule_to_vector, property_test_coverage_entries, read_failure_capsule,
+    replay_engine_bytes, run_report,
 };
 
 #[test]
@@ -107,6 +108,8 @@ fn parse_generated_input_report_args() {
         "target/case-1-generated-input.json".into(),
         "--generated-input".into(),
         "target/case-3-generated-input.json".into(),
+        "--adapter".into(),
+        "app-runtime".into(),
         "--out".into(),
         "target/generated-input-reports".into(),
     ])
@@ -120,6 +123,7 @@ fn parse_generated_input_report_args() {
                     PathBuf::from("target/case-1-generated-input.json"),
                     PathBuf::from("target/case-3-generated-input.json"),
                 ],
+                adapter: Some(GeneratedSubjectKind::AppRuntime),
             },
             out: PathBuf::from("target/generated-input-reports"),
             strict_oracle: true,

--- a/crates/cgka-conformance-simulator/tests/report_runner.rs
+++ b/crates/cgka-conformance-simulator/tests/report_runner.rs
@@ -2,8 +2,9 @@ use std::fs;
 use std::path::PathBuf;
 
 use cgka_conformance_simulator::{
-    FailureCapsuleSensitivity, GeneratedSubjectKind, HarnessStorageMode, OracleBehavior,
-    ReportArgs, ReportCommand, ReportInput, ScenarioStimulus, parse_report_command,
+    FailureCapsuleSensitivity, GeneratedScenarioCase, GeneratedScenarioInputV1,
+    GeneratedSubjectKind, HarnessStorageMode, OracleBehavior, ReportArgs, ReportCommand,
+    ReportInput, ScenarioSpec, ScenarioStep, ScenarioStimulus, parse_report_command,
     promote_failure_capsule_to_vector, property_test_coverage_entries, read_failure_capsule,
     replay_engine_bytes, run_report,
 };
@@ -151,6 +152,71 @@ fn parse_generated_input_rejects_other_scenario_sources() {
         .expect_err("generated input must be the only scenario source");
         assert!(error.to_string().contains("--generated-input"));
     }
+}
+
+#[test]
+fn parse_adapter_accepts_only_the_documented_hyphenated_names() {
+    for adapter in ["retained_relay", "app_runtime"] {
+        let error = parse_report_command([
+            "--generated-input".into(),
+            "target/case-generated-input.json".into(),
+            "--adapter".into(),
+            adapter.into(),
+        ])
+        .expect_err("undocumented adapter alias must fail");
+        assert!(
+            error
+                .to_string()
+                .contains("unsupported generated-case adapter")
+        );
+    }
+}
+
+#[tokio::test]
+async fn adapter_override_uses_distinct_artifacts_without_minting_a_fixture() {
+    let root = tempfile::tempdir().unwrap();
+    let input_path = root.path().join("case.json");
+    let out = root.path().join("reports");
+    let input = GeneratedScenarioInputV1::new(GeneratedScenarioCase {
+        family_name: "selectable-report/v1".into(),
+        generator_version: "1".into(),
+        seed: 5,
+        case_index: 2,
+        subject: GeneratedSubjectKind::Engine,
+        scenario: ScenarioSpec {
+            name: "selectable-report/v1/case-2".into(),
+            spec_version: "2".into(),
+            clients: vec!["alice".into()],
+            topology: Default::default(),
+            steps: vec![ScenarioStep::DeliverAll],
+        },
+        expected_outcomes: Vec::new(),
+    });
+    fs_private::write_private(&input_path, &serde_json::to_vec_pretty(&input).unwrap()).unwrap();
+
+    for adapter in [None, Some(GeneratedSubjectKind::AppRuntime)] {
+        run_report(&ReportArgs {
+            input: ReportInput::GeneratedInputs {
+                paths: vec![input_path.clone()],
+                adapter,
+            },
+            out: out.clone(),
+            strict_oracle: false,
+            storage_mode: HarnessStorageMode::InMemorySqlite,
+            capture_sensitive_replay: false,
+        })
+        .await
+        .unwrap();
+    }
+
+    let base = "selectable-report-v1-seed-5-case-2";
+    assert!(out.join(format!("{base}.json")).exists());
+    assert!(out.join(format!("{base}-fixture.v1.json")).exists());
+    assert!(out.join(format!("{base}-app-runtime.json")).exists());
+    assert!(
+        !out.join(format!("{base}-app-runtime-fixture.v1.json"))
+            .exists()
+    );
 }
 
 #[test]

--- a/crates/cgka-conformance-simulator/tests/stateful_generator.rs
+++ b/crates/cgka-conformance-simulator/tests/stateful_generator.rs
@@ -137,6 +137,7 @@ async fn report_runner_executes_and_preserves_both_journey_profiles() {
     let replay = run_report(&ReportArgs {
         input: ReportInput::GeneratedInputs {
             paths: vec![retained_input.expect("retained input was saved")],
+            adapter: None,
         },
         out: replay_output.path().to_path_buf(),
         strict_oracle: true,

--- a/crates/convergence-campaign-runner/README.md
+++ b/crates/convergence-campaign-runner/README.md
@@ -14,6 +14,13 @@ manifest selects either:
   filesystem, or stronger host-isolation behavior that containers cannot
   represent faithfully.
 
+The selected scenario path may contain raw canonical Scenario IR or a
+`GeneratedScenarioInputV1` saved by the simulator report runner. Generated
+inputs pin both their exact envelope digest and their resolved canonical-IR
+digest. The runner writes the resolved IR privately as `canonical-scenario.json`;
+container nodes and external VM drivers therefore execute the same scenario
+without needing to understand the generator envelope.
+
 Commands are always built as argv arrays. Manifests do not contain shell
 fragments, credentials, key material, plaintext application payloads, or
 public relay endpoints. Campaign artifacts are written with owner-only modes.

--- a/crates/convergence-campaign-runner/README.md
+++ b/crates/convergence-campaign-runner/README.md
@@ -17,9 +17,11 @@ manifest selects either:
 The selected scenario path may contain raw canonical Scenario IR or a
 `GeneratedScenarioInputV1` saved by the simulator report runner. Generated
 inputs pin both their exact envelope digest and their resolved canonical-IR
-digest. The runner writes the resolved IR privately as `canonical-scenario.json`;
-container nodes and external VM drivers therefore execute the same scenario
-without needing to understand the generator envelope.
+digest. Container runs resolve the selected IR in memory and record the digest
+of the post-lowering IR they execute; manifest-declared host crashes add
+deterministic process lifecycle steps. VM runs write the selected IR privately
+as `canonical-scenario.json`, so external drivers do not need to understand the
+generator envelope.
 
 Commands are always built as argv arrays. Manifests do not contain shell
 fragments, credentials, key material, plaintext application payloads, or

--- a/crates/convergence-campaign-runner/src/main.rs
+++ b/crates/convergence-campaign-runner/src/main.rs
@@ -226,17 +226,16 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
             scenario,
             build_id,
         } => {
-            use sha2::Digest;
-
             let node_capsule: cgka_conformance_simulator::node_protocol::NodeFailureCapsuleV1 =
                 serde_json::from_slice(&std::fs::read(&capsule)?)?;
             let scenario_bytes = std::fs::read(scenario)?;
-            let scenario = serde_json::from_slice(&scenario_bytes)?;
+            let scenario =
+                cgka_conformance_simulator::resolve_scenario_input_bytes(&scenario_bytes)?;
             let observation = convergence_campaign_runner::observation_from_node_capsule(
                 &node_capsule,
                 capsule,
-                scenario,
-                &hex::encode(sha2::Sha256::digest(&scenario_bytes)),
+                scenario.scenario,
+                &scenario.provenance.canonical_ir_sha256,
                 BTreeMap::from([("indexed_build".into(), build_id)]),
             );
             let fingerprint = observation.fingerprint.clone();

--- a/crates/convergence-campaign-runner/src/main.rs
+++ b/crates/convergence-campaign-runner/src/main.rs
@@ -231,11 +231,12 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
             let scenario_bytes = std::fs::read(scenario)?;
             let scenario =
                 cgka_conformance_simulator::resolve_scenario_input_bytes(&scenario_bytes)?;
+            let scenario_digest = node_capsule_scenario_digest(&scenario).to_owned();
             let observation = convergence_campaign_runner::observation_from_node_capsule(
                 &node_capsule,
                 capsule,
                 scenario.scenario,
-                &scenario.provenance.canonical_ir_sha256,
+                &scenario_digest,
                 BTreeMap::from([("indexed_build".into(), build_id)]),
             );
             let fingerprint = observation.fingerprint.clone();
@@ -281,4 +282,38 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
     Ok(())
+}
+
+fn node_capsule_scenario_digest(
+    input: &cgka_conformance_simulator::ResolvedScenarioInputV1,
+) -> &str {
+    &input.provenance.source_sha256
+}
+
+#[cfg(test)]
+mod tests {
+    use cgka_conformance_simulator::{ScenarioSpec, ScenarioStep, resolve_scenario_input_bytes};
+    use sha2::Digest;
+
+    use super::node_capsule_scenario_digest;
+
+    #[test]
+    fn node_capsule_index_preserves_pretty_printed_raw_ir_fingerprint_identity() {
+        let scenario = ScenarioSpec {
+            name: "pretty-raw-index".into(),
+            spec_version: "2".into(),
+            clients: vec!["alice".into()],
+            topology: Default::default(),
+            steps: vec![ScenarioStep::DeliverAll],
+        };
+        let bytes = serde_json::to_vec_pretty(&scenario).unwrap();
+        let input = resolve_scenario_input_bytes(&bytes).unwrap();
+        let source_sha256 = hex::encode(sha2::Sha256::digest(&bytes));
+
+        assert_eq!(node_capsule_scenario_digest(&input), source_sha256);
+        assert_ne!(
+            node_capsule_scenario_digest(&input),
+            input.provenance.canonical_ir_sha256
+        );
+    }
 }

--- a/crates/convergence-campaign-runner/src/manifest.rs
+++ b/crates/convergence-campaign-runner/src/manifest.rs
@@ -23,8 +23,14 @@ pub struct DistributedCampaignManifestV1 {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ScenarioArtifactV1 {
     pub path: PathBuf,
-    /// SHA-256 of the exact scenario bytes, accepted in either hex case.
+    /// SHA-256 of the exact selected source bytes, accepted in either hex case.
+    /// The source may be raw canonical Scenario IR or a generated-input envelope.
     pub sha256: String,
+    /// SHA-256 of the resolved canonical Scenario IR. Required for generated
+    /// inputs so distributed evidence remains tied to the executable history,
+    /// not only to its surrounding envelope.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub canonical_ir_sha256: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -220,6 +226,19 @@ impl DistributedCampaignManifestV1 {
             return Err(RunnerError::validation(
                 "scenario_digest",
                 "scenario sha256 must be 64 hexadecimal characters",
+            ));
+        }
+        if self
+            .scenario
+            .canonical_ir_sha256
+            .as_ref()
+            .is_some_and(|digest| {
+                digest.len() != 64 || !digest.bytes().all(|byte| byte.is_ascii_hexdigit())
+            })
+        {
+            return Err(RunnerError::validation(
+                "canonical_scenario_ir_digest",
+                "canonical scenario IR sha256 must be 64 hexadecimal characters",
             ));
         }
         let mut participants = BTreeSet::new();

--- a/crates/convergence-campaign-runner/src/plan.rs
+++ b/crates/convergence-campaign-runner/src/plan.rs
@@ -92,7 +92,8 @@ pub fn build_execution_plan(
         DistributedBackendV1::VirtualMachine(vm) => {
             let normalized_manifest = manifest.output_dir.join("normalized-manifest.json");
             let normalized_manifest = utf8_path(&normalized_manifest, "normalized_manifest")?;
-            let scenario = utf8_path(&manifest.scenario.path, "scenario")?;
+            let scenario_path = manifest.output_dir.join("canonical-scenario.json");
+            let scenario = utf8_path(&scenario_path, "scenario")?;
             let output_dir = utf8_path(&manifest.output_dir, "output_dir")?;
             let driver = utf8_path(&vm.driver, "vm_driver")?;
             let render_args = |args: &[String]| {

--- a/crates/convergence-campaign-runner/src/runner.rs
+++ b/crates/convergence-campaign-runner/src/runner.rs
@@ -7,7 +7,10 @@ use cgka_conformance_simulator::process_orchestrator::{
     ProcessBarrierHook, ProcessOrchestrator, ProcessOrchestratorError, ProcessScenarioReportV1,
     process_participant_token,
 };
-use cgka_conformance_simulator::{ScenarioSpec, compile_scenario};
+use cgka_conformance_simulator::{
+    ResolvedScenarioInputV1, ScenarioInputFormatV1, ScenarioSpec, compile_scenario,
+    resolve_scenario_input_bytes,
+};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tokio::process::Command;
@@ -78,24 +81,41 @@ pub async fn run_manifest(
     manifest: &DistributedCampaignManifestV1,
 ) -> Result<DistributedRunReceiptV1, RunnerError> {
     let scenario_bytes = verify_manifest_inputs(manifest)?;
-    let plan = build_execution_plan(manifest)?;
-    let scenario = validate_scenario_bytes(manifest, &scenario_bytes)?;
-    fs_private::create_dir_all_private(&manifest.output_dir)
+    let scenario_input = validate_scenario_bytes(manifest, &scenario_bytes)?;
+    let mut normalized_manifest = manifest.clone();
+    normalized_manifest.scenario.canonical_ir_sha256 =
+        Some(scenario_input.provenance.canonical_ir_sha256.clone());
+    let plan = build_execution_plan(&normalized_manifest)?;
+    fs_private::create_dir_all_private(&normalized_manifest.output_dir)
         .map_err(|error| RunnerError::environment("output_directory", error))?;
     fs_private::write_private(
-        &manifest.output_dir.join("normalized-manifest.json"),
-        &serde_json::to_vec_pretty(manifest)
+        &normalized_manifest
+            .output_dir
+            .join("canonical-scenario.json"),
+        &serde_json::to_vec(&scenario_input.scenario)
+            .map_err(|error| RunnerError::environment("scenario_serialize", error))?,
+    )
+    .map_err(|error| RunnerError::environment("scenario_write", error))?;
+    fs_private::write_private(
+        &normalized_manifest
+            .output_dir
+            .join("normalized-manifest.json"),
+        &serde_json::to_vec_pretty(&normalized_manifest)
             .map_err(|error| RunnerError::environment("manifest_serialize", error))?,
     )
     .map_err(|error| RunnerError::environment("manifest_write", error))?;
-    let result = match &manifest.backend {
-        DistributedBackendV1::Container(_) => run_container(manifest, &plan, &scenario).await,
-        DistributedBackendV1::VirtualMachine(_) => run_vm(manifest, &plan).await,
+    let result = match &normalized_manifest.backend {
+        DistributedBackendV1::Container(_) => {
+            run_container(&normalized_manifest, &plan, &scenario_input).await
+        }
+        DistributedBackendV1::VirtualMachine(_) => run_vm(&normalized_manifest, &plan).await,
     };
     match result {
         Ok(receipt) => Ok(receipt),
         Err(error) => {
-            let corpus_error = record_distributed_failure(manifest, &error, &scenario).err();
+            let corpus_error =
+                record_distributed_failure(&normalized_manifest, &error, &scenario_input.scenario)
+                    .err();
             Err(with_secondary_corpus_error(error, corpus_error.as_ref()))
         }
     }
@@ -119,11 +139,32 @@ fn with_secondary_corpus_error(
 pub fn validate_scenario_bytes(
     manifest: &DistributedCampaignManifestV1,
     scenario_bytes: &[u8],
-) -> Result<ScenarioSpec, RunnerError> {
-    let scenario: ScenarioSpec = serde_json::from_slice(scenario_bytes)
-        .map_err(|error| RunnerError::environment("scenario_parse", error))?;
-    validate_scenario_binding(manifest, &scenario)?;
-    Ok(scenario)
+) -> Result<ResolvedScenarioInputV1, RunnerError> {
+    let input = resolve_scenario_input_bytes(scenario_bytes)
+        .map_err(|error| RunnerError::environment(error.code, error))?;
+    if input.provenance.format == ScenarioInputFormatV1::GeneratedScenarioInputV1
+        && manifest.scenario.canonical_ir_sha256.is_none()
+    {
+        return Err(RunnerError::validation(
+            "canonical_scenario_ir_digest_required",
+            "generated scenario inputs require canonical_ir_sha256 in the distributed manifest",
+        ));
+    }
+    if manifest
+        .scenario
+        .canonical_ir_sha256
+        .as_ref()
+        .is_some_and(|expected| {
+            !expected.eq_ignore_ascii_case(&input.provenance.canonical_ir_sha256)
+        })
+    {
+        return Err(RunnerError::validation(
+            "canonical_scenario_ir_digest_mismatch",
+            "resolved canonical Scenario IR does not match the distributed manifest digest",
+        ));
+    }
+    validate_scenario_binding(manifest, &input.scenario)?;
+    Ok(input)
 }
 
 fn validate_scenario_binding(
@@ -241,7 +282,7 @@ fn fault_peer_key(peer: &crate::FaultPeerV1) -> String {
 async fn run_container(
     manifest: &DistributedCampaignManifestV1,
     plan: &DistributedExecutionPlanV1,
-    scenario: &ScenarioSpec,
+    input: &ResolvedScenarioInputV1,
 ) -> Result<DistributedRunReceiptV1, RunnerError> {
     let resource_lease = ContainerResourceLease::acquire()?;
     let resource_token = resource_lease.token.as_str();
@@ -285,8 +326,7 @@ async fn run_container(
         }
     }
 
-    let result =
-        run_container_scenario(manifest, plan, scenario, resource_token, &mut receipts).await;
+    let result = run_container_scenario(manifest, plan, input, resource_token, &mut receipts).await;
     let run_token = match &result {
         Ok(result) => Some(result.run_token.as_str()),
         Err(failure) => failure.run_token.as_deref(),
@@ -353,7 +393,7 @@ struct ContainerScenarioFailure {
 async fn run_container_scenario(
     manifest: &DistributedCampaignManifestV1,
     plan: &DistributedExecutionPlanV1,
-    scenario: &ScenarioSpec,
+    input: &ResolvedScenarioInputV1,
     resource_token: &str,
     receipts: &mut Vec<CommandReceiptV1>,
 ) -> Result<ContainerScenarioResult, ContainerScenarioFailure> {
@@ -363,7 +403,7 @@ async fn run_container_scenario(
             run_token: None,
         }
     })?;
-    let scenario = lower_container_host_faults(manifest, scenario).map_err(|error| {
+    let scenario = lower_container_host_faults(manifest, &input.scenario).map_err(|error| {
         ContainerScenarioFailure {
             error,
             run_token: None,
@@ -387,10 +427,15 @@ async fn run_container_scenario(
         .into_iter()
         .map(|label| (label, format!("ws://{NODE_RELAY_PROXY_LISTEN}")))
         .collect::<BTreeMap<_, _>>();
-    let mut orchestrator = ProcessOrchestrator::launch_with(
+    let resolved = ResolvedScenarioInputV1 {
+        scenario,
+        expected_outcomes: input.expected_outcomes.clone(),
+        provenance: input.provenance.clone(),
+    };
+    let mut orchestrator = ProcessOrchestrator::launch_resolved_with(
         node_launch,
         Some(relay_urls),
-        &scenario,
+        &resolved,
         &manifest.output_dir,
     )
     .await
@@ -840,6 +885,7 @@ mod tests {
             scenario: ScenarioArtifactV1 {
                 path: root.join("scenario.json"),
                 sha256: "00".repeat(32),
+                canonical_ir_sha256: None,
             },
             participants: ["alice", "bob"]
                 .into_iter()
@@ -1189,6 +1235,8 @@ mod tests {
             topology: cgka_conformance_simulator::ScenarioTopologyV2::default(),
             steps: Vec::new(),
         };
+        let scenario =
+            resolve_scenario_input_bytes(&serde_json::to_vec(&scenario).unwrap()).unwrap();
         let error = run_container(&manifest, &plan, &scenario)
             .await
             .unwrap_err();

--- a/crates/convergence-campaign-runner/src/runner.rs
+++ b/crates/convergence-campaign-runner/src/runner.rs
@@ -88,14 +88,19 @@ pub async fn run_manifest(
     let plan = build_execution_plan(&normalized_manifest)?;
     fs_private::create_dir_all_private(&normalized_manifest.output_dir)
         .map_err(|error| RunnerError::environment("output_directory", error))?;
-    fs_private::write_private(
-        &normalized_manifest
-            .output_dir
-            .join("canonical-scenario.json"),
-        &serde_json::to_vec(&scenario_input.scenario)
-            .map_err(|error| RunnerError::environment("scenario_serialize", error))?,
-    )
-    .map_err(|error| RunnerError::environment("scenario_write", error))?;
+    if matches!(
+        &normalized_manifest.backend,
+        DistributedBackendV1::VirtualMachine(_)
+    ) {
+        fs_private::write_private(
+            &normalized_manifest
+                .output_dir
+                .join("canonical-scenario.json"),
+            &serde_json::to_vec(&scenario_input.scenario)
+                .map_err(|error| RunnerError::environment("scenario_serialize", error))?,
+        )
+        .map_err(|error| RunnerError::environment("scenario_write", error))?;
+    }
     fs_private::write_private(
         &normalized_manifest
             .output_dir
@@ -431,6 +436,7 @@ async fn run_container_scenario(
         scenario,
         expected_outcomes: input.expected_outcomes.clone(),
         provenance: input.provenance.clone(),
+        generated_case: input.generated_case.clone(),
     };
     let mut orchestrator = ProcessOrchestrator::launch_resolved_with(
         node_launch,
@@ -1297,6 +1303,11 @@ mod tests {
             }],
         };
         let lowered = lower_container_host_faults(&manifest, &scenario).unwrap();
+        assert_ne!(
+            cgka_conformance_simulator::canonical_scenario_ir_sha256(&scenario).unwrap(),
+            cgka_conformance_simulator::canonical_scenario_ir_sha256(&lowered).unwrap(),
+            "selected and executed digests must distinguish host-crash lowering"
+        );
         assert!(matches!(
             &lowered.steps[1],
             cgka_conformance_simulator::ScenarioStep::CrashProcess { process }

--- a/crates/convergence-campaign-runner/tests/container_runtime.rs
+++ b/crates/convergence-campaign-runner/tests/container_runtime.rs
@@ -109,6 +109,7 @@ async fn real_container_nodes_survive_network_shaping_and_reach_exact_state() {
         scenario: ScenarioArtifactV1 {
             path: scenario_path,
             sha256: hex::encode(sha2::Sha256::digest(&scenario_bytes)),
+            canonical_ir_sha256: None,
         },
         participants: ["alice", "bob"]
             .into_iter()

--- a/crates/convergence-campaign-runner/tests/distributed_runner.rs
+++ b/crates/convergence-campaign-runner/tests/distributed_runner.rs
@@ -1,10 +1,15 @@
 use std::collections::BTreeSet;
 
+use cgka_conformance_simulator::{
+    GeneratedScenarioCase, GeneratedScenarioInputV1, GeneratedSubjectKind, ScenarioInputFormatV1,
+    ScenarioSpec, ScenarioStep,
+};
 use convergence_campaign_runner::{
     ContainerBackendV1, DistributedBackendV1, DistributedCampaignManifestV1, DistributedFaultV1,
     DistributedParticipantV1, FaultPeerV1, OciRuntimeV1, ScenarioArtifactV1, ScheduledFaultV1,
     VirtualMachineBackendV1, VirtualMachineCapabilityV1, build_execution_plan,
-    container_node_launch, load_manifest, verify_manifest_inputs,
+    container_node_launch, load_manifest, run_manifest, validate_scenario_bytes,
+    verify_manifest_inputs,
 };
 use sha2::Digest;
 
@@ -20,6 +25,7 @@ fn container_manifest() -> (tempfile::TempDir, DistributedCampaignManifestV1) {
         scenario: ScenarioArtifactV1 {
             path: scenario,
             sha256,
+            canonical_ir_sha256: None,
         },
         participants: vec![
             DistributedParticipantV1 {
@@ -318,6 +324,118 @@ fn scenario_digest_accepts_uppercase_hex() {
 }
 
 #[test]
+fn distributed_manifest_selects_a_generated_input_and_pins_its_canonical_ir() {
+    let (_root, mut manifest) = container_manifest();
+    manifest.faults.clear();
+    let scenario = ScenarioSpec {
+        name: "saved-distributed-input".into(),
+        spec_version: "2".into(),
+        clients: vec!["alice".into(), "bob".into()],
+        topology: Default::default(),
+        steps: Vec::new(),
+    };
+    let input = GeneratedScenarioInputV1::new(GeneratedScenarioCase {
+        family_name: "saved-distributed/v1".into(),
+        generator_version: "7".into(),
+        seed: 41,
+        case_index: 9,
+        subject: GeneratedSubjectKind::Engine,
+        scenario: scenario.clone(),
+        expected_outcomes: Vec::new(),
+    });
+    let bytes = serde_json::to_vec_pretty(&input).unwrap();
+    fs_private::write_private(&manifest.scenario.path, &bytes).unwrap();
+    manifest.scenario.sha256 = hex::encode(sha2::Sha256::digest(&bytes));
+    let resolved = cgka_conformance_simulator::resolve_scenario_input_bytes(&bytes).unwrap();
+    manifest.scenario.canonical_ir_sha256 = Some(resolved.provenance.canonical_ir_sha256.clone());
+
+    let selected = validate_scenario_bytes(&manifest, &bytes).unwrap();
+    assert_eq!(selected.scenario, scenario);
+    assert_eq!(
+        selected.provenance.format,
+        ScenarioInputFormatV1::GeneratedScenarioInputV1
+    );
+    assert_eq!(
+        selected.provenance.generated.unwrap().family_name,
+        "saved-distributed/v1"
+    );
+
+    manifest.scenario.canonical_ir_sha256 = None;
+    assert_eq!(
+        validate_scenario_bytes(&manifest, &bytes).unwrap_err().code,
+        "canonical_scenario_ir_digest_required"
+    );
+    manifest.scenario.canonical_ir_sha256 = Some("ff".repeat(32));
+    assert_eq!(
+        validate_scenario_bytes(&manifest, &bytes).unwrap_err().code,
+        "canonical_scenario_ir_digest_mismatch"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn vm_run_materializes_the_selected_generated_input_as_canonical_ir() {
+    let (_root, mut manifest) = container_manifest();
+    let scenario = ScenarioSpec {
+        name: "saved-vm-input".into(),
+        spec_version: "2".into(),
+        clients: vec!["alice".into(), "bob".into()],
+        topology: Default::default(),
+        steps: vec![ScenarioStep::Barrier {
+            name: "slow-disk".into(),
+        }],
+    };
+    let input = GeneratedScenarioInputV1::new(GeneratedScenarioCase {
+        family_name: "saved-vm/v1".into(),
+        generator_version: "3".into(),
+        seed: 91,
+        case_index: 4,
+        subject: GeneratedSubjectKind::Engine,
+        scenario: scenario.clone(),
+        expected_outcomes: Vec::new(),
+    });
+    let bytes = serde_json::to_vec_pretty(&input).unwrap();
+    fs_private::write_private(&manifest.scenario.path, &bytes).unwrap();
+    let resolved = cgka_conformance_simulator::resolve_scenario_input_bytes(&bytes).unwrap();
+    manifest.scenario.sha256 = hex::encode(sha2::Sha256::digest(&bytes));
+    manifest.scenario.canonical_ir_sha256 = Some(resolved.provenance.canonical_ir_sha256.clone());
+    for participant in &mut manifest.participants {
+        participant.container_image = None;
+    }
+    manifest.faults = vec![ScheduledFaultV1 {
+        at_barrier: "slow-disk".into(),
+        action: DistributedFaultV1::SlowBlockDevice {
+            participant: "alice".into(),
+            latency_ms: 10,
+        },
+    }];
+    manifest.backend = DistributedBackendV1::VirtualMachine(VirtualMachineBackendV1 {
+        driver_contract_version: "1".into(),
+        driver: "test".into(),
+        driver_args: vec!["-f".into(), "{scenario}".into()],
+        cleanup_args: vec!["-f".into(), "{manifest}".into()],
+        timeout_seconds: 5,
+        cleanup_timeout_seconds: 5,
+        capabilities: BTreeSet::from([VirtualMachineCapabilityV1::BlockDeviceLatency]),
+    });
+
+    let receipt = run_manifest(&manifest).await.unwrap();
+    assert!(receipt.completed, "{receipt:#?}");
+    let canonical_path = manifest.output_dir.join("canonical-scenario.json");
+    let materialized: ScenarioSpec =
+        serde_json::from_slice(&std::fs::read(canonical_path).unwrap()).unwrap();
+    assert_eq!(materialized, scenario);
+    let normalized: DistributedCampaignManifestV1 = serde_json::from_slice(
+        &std::fs::read(manifest.output_dir.join("normalized-manifest.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        normalized.scenario.canonical_ir_sha256,
+        Some(resolved.provenance.canonical_ir_sha256)
+    );
+}
+
+#[test]
 fn uppercase_yaml_extension_uses_the_yaml_parser() {
     let (root, manifest) = container_manifest();
     let path = root.path().join("campaign.YAML");
@@ -481,7 +599,7 @@ fn vm_plan_rejects_non_utf8_argv_paths() {
         cleanup_timeout_seconds: 300,
         capabilities: BTreeSet::from([VirtualMachineCapabilityV1::BlockDeviceLatency]),
     });
-    manifest.scenario.path = std::path::PathBuf::from(std::ffi::OsString::from_vec(vec![0xff]));
+    manifest.output_dir = std::path::PathBuf::from(std::ffi::OsString::from_vec(vec![0xff]));
     let error = build_execution_plan(&manifest).unwrap_err();
     assert_eq!(error.code, "non_utf8_path");
 }
@@ -594,6 +712,14 @@ fn slow_block_devices_require_a_capable_vm_backend() {
     let plan = build_execution_plan(&manifest).unwrap();
     assert_eq!(plan.backend, "virtual_machine");
     assert!(plan.vm_driver.as_ref().unwrap().args.contains(&"2".into()));
+    assert!(
+        plan.vm_driver
+            .as_ref()
+            .unwrap()
+            .args
+            .iter()
+            .any(|argument| { argument.ends_with("canonical-scenario.json") })
+    );
     assert_eq!(plan.cleanup.len(), 1);
     assert_eq!(plan.cleanup[0].purpose, "cleanup_external_vm_campaign");
     assert!(

--- a/crates/convergence-campaign-runner/tests/failure_corpus.rs
+++ b/crates/convergence-campaign-runner/tests/failure_corpus.rs
@@ -173,6 +173,7 @@ fn distributed_product_failures_are_saved_with_a_process_reduction_candidate() {
         scenario: ScenarioArtifactV1 {
             path: scenario_path,
             sha256: hex::encode(sha2::Sha256::digest(&bytes)),
+            canonical_ir_sha256: None,
         },
         participants: ["alice", "bob"]
             .into_iter()

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -1093,15 +1093,16 @@ restricted to synthetic shareable capsules with portable expectations.
 - [x] Persist an owner-only, versioned generated-case input before action zero, including the selected subject adapter
   and semantic expectations, so a crash cannot erase or change the reproducer.
 - [ ] Expose these saved journeys as first-class selectable app-runtime, process, container, and VM campaign inputs.
-  Every wider adapter must execute the canonical Scenario IR embedded in the saved generated-input envelope, preserve
-  its generator/profile provenance and semantic expectations, and record the exact IR digest in distributed manifests;
-  this remains the next cross-layer usability slice rather than being hidden inside the generator.
+  Every wider adapter must select the canonical Scenario IR embedded in the saved generated-input envelope, preserve
+  its generator/profile provenance and semantic expectations, and record the selected IR digest in distributed
+  manifests. An adapter that deterministically lowers the selected history must also record the executed IR digest;
+  this remains a cross-layer usability slice rather than being hidden inside the generator.
 
-Selection plumbing now resolves raw Scenario IR and saved generated inputs through one parser, records source and
-canonical-IR digests, preserves generator provenance and expectations in app/process/container reports, and hands VM
-drivers a privately materialized canonical file. This item remains open until representative stateful journeys pass the
-capability and oracle contracts of every listed adapter; an adapter merely rejecting an engine-only observation during
-preflight is useful evidence, not completion.
+Selection plumbing now resolves raw Scenario IR and saved generated inputs through one parser, records source,
+selected-IR, and (after adapter lowering) executed-IR digests, preserves generator provenance and expectations in
+app/process/container reports, and hands VM drivers a privately materialized canonical file. This item remains open
+until representative stateful journeys pass the capability and oracle contracts of every listed adapter; an adapter
+merely rejecting an engine-only observation during preflight is useful evidence, not completion.
 
 ### 6.6 Shared legality model and workload profiles (planned follow-up)
 

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -1097,6 +1097,12 @@ restricted to synthetic shareable capsules with portable expectations.
   its generator/profile provenance and semantic expectations, and record the exact IR digest in distributed manifests;
   this remains the next cross-layer usability slice rather than being hidden inside the generator.
 
+Selection plumbing now resolves raw Scenario IR and saved generated inputs through one parser, records source and
+canonical-IR digests, preserves generator provenance and expectations in app/process/container reports, and hands VM
+drivers a privately materialized canonical file. This item remains open until representative stateful journeys pass the
+capability and oracle contracts of every listed adapter; an adapter merely rejecting an engine-only observation during
+preflight is useful evidence, not completion.
+
 ### 6.6 Shared legality model and workload profiles (planned follow-up)
 
 The current generated families are useful coverage slices, but they should not mature into independent mini-simulators

--- a/docs/marmot-architecture/distributed-convergence-campaigns.md
+++ b/docs/marmot-architecture/distributed-convergence-campaigns.md
@@ -1,7 +1,7 @@
 ---
 title: "Distributed Convergence Campaigns"
 created: 2026-08-04
-updated: 2026-08-06
+updated: 2026-08-07
 tags: [marmot, convergence, testing, containers, virtual-machines]
 ---
 
@@ -9,7 +9,10 @@ tags: [marmot, convergence, testing, containers, virtual-machines]
 
 The `convergence-campaign-runner` crate extends the canonical conformance scenario boundary across operating-system
 processes and isolated hosts. It does not define a second scenario language or convergence oracle. A campaign pins the
-exact Scenario IR bytes by SHA-256, assigns each scenario participant to a build, and selects an execution backend.
+exact selected input bytes by SHA-256, assigns each scenario participant to a build, and selects an execution backend.
+The input may be raw canonical Scenario IR or a saved generated-input envelope. Generated inputs additionally pin the
+digest of the canonical IR inside the envelope, so changing generator provenance or expectations cannot obscure which
+executable history reached the adapter.
 The child nodes continue to report through the same versioned process protocol and exact-state oracle used by the
 process adapter.
 
@@ -39,6 +42,11 @@ unless the campaign requests behavior that the container backend cannot faithful
 latency. Driver capability declarations make the reason for escalation reviewable. Provisioning belongs in the
 dedicated multi-VM harness rather than this repository.
 
+Before either backend starts, the runner resolves the selected input through the simulator-owned parser and writes the
+compact canonical IR privately to `canonical-scenario.json` in the campaign output directory. Container orchestration
+uses that resolved value directly. The VM `{scenario}` placeholder names the materialized canonical file, so external
+drivers never need a second generated-envelope parser and cannot accidentally execute envelope metadata as Scenario IR.
+
 VM driver lifecycle contract v1 contains two argv-only invocations on the same driver: the campaign action and an
 idempotent cancellation/cleanup action. The runner executes cleanup after success, failure, or campaign timeout under
 its own nonzero timeout, records its receipt, and fails closed if cleanup does not complete. The external driver owns
@@ -51,7 +59,8 @@ normalized manifest so the driver targets the exact versioned ownership record r
 Every manifest contains:
 
 - a stable campaign id and schema version;
-- the canonical scenario path and digest;
+- the selected scenario/envelope path and exact source digest;
+- the resolved canonical Scenario IR digest when a generated envelope is selected;
 - the complete participant/build/image assignment;
 - the backend and its declared capabilities;
 - faults attached to named Scenario IR barriers; and
@@ -59,8 +68,9 @@ Every manifest contains:
 
 `validate` checks the manifest, participant-to-scenario binding, digest, fault parameters, and backend suitability.
 It also rejects a heal without a matching active partition and a duplicate partition that has not first been healed.
-`plan` emits the exact normalized command plan without running it. `run` first writes the normalized manifest with
-owner-only permissions, then writes the process report and distributed run receipt. Container cleanup is attempted on
+`plan` emits the exact normalized command plan without running it. `run` first writes the resolved
+`canonical-scenario.json` and normalized manifest with owner-only permissions, then writes the process report and
+distributed run receipt. The normalized manifest always records the resolved canonical digest. Container cleanup is attempted on
 both success and failure and cleanup failures remain visible in the receipt.
 
 External container faults run immediately before the named barrier. Host crash faults are different: the runner lowers

--- a/docs/marmot-architecture/distributed-convergence-campaigns.md
+++ b/docs/marmot-architecture/distributed-convergence-campaigns.md
@@ -42,10 +42,12 @@ unless the campaign requests behavior that the container backend cannot faithful
 latency. Driver capability declarations make the reason for escalation reviewable. Provisioning belongs in the
 dedicated multi-VM harness rather than this repository.
 
-Before either backend starts, the runner resolves the selected input through the simulator-owned parser and writes the
-compact canonical IR privately to `canonical-scenario.json` in the campaign output directory. Container orchestration
-uses that resolved value directly. The VM `{scenario}` placeholder names the materialized canonical file, so external
-drivers never need a second generated-envelope parser and cannot accidentally execute envelope metadata as Scenario IR.
+Before either backend starts, the runner resolves the selected input through the simulator-owned parser. Container
+orchestration consumes that value in memory; manifest-declared host crashes deterministically lower into process crash
+and restart steps, and the process report records a distinct digest for the post-lowering IR it compiles. VM runs write
+the selected canonical IR privately to `canonical-scenario.json`. The VM `{scenario}` placeholder names that file, so
+external drivers never need a second generated-envelope parser and cannot accidentally execute envelope metadata as
+Scenario IR.
 
 VM driver lifecycle contract v1 contains two argv-only invocations on the same driver: the campaign action and an
 idempotent cancellation/cleanup action. The runner executes cleanup after success, failure, or campaign timeout under
@@ -68,10 +70,10 @@ Every manifest contains:
 
 `validate` checks the manifest, participant-to-scenario binding, digest, fault parameters, and backend suitability.
 It also rejects a heal without a matching active partition and a duplicate partition that has not first been healed.
-`plan` emits the exact normalized command plan without running it. `run` first writes the resolved
-`canonical-scenario.json` and normalized manifest with owner-only permissions, then writes the process report and
-distributed run receipt. The normalized manifest always records the resolved canonical digest. Container cleanup is attempted on
-both success and failure and cleanup failures remain visible in the receipt.
+`plan` emits the exact normalized command plan without running it. `run` first writes the normalized manifest with
+owner-only permissions; VM runs also write the selected `canonical-scenario.json`. It then writes the process report and
+distributed run receipt. The normalized manifest always records the selected canonical digest. Container cleanup is
+attempted on both success and failure and cleanup failures remain visible in the receipt.
 
 External container faults run immediately before the named barrier. Host crash faults are different: the runner lowers
 them into scenario-owned process crash and restart actions immediately after the named barrier, so evidence describes


### PR DESCRIPTION
## What changed

- add a shared resolver for raw canonical Scenario IR and saved `GeneratedScenarioInputV1` envelopes
- preserve the generated family, generator version, seed, case index, recorded subject, semantic expectations, source digest, and selected canonical-IR digest
- allow the report runner to replay a saved generated case through the engine, retained-relay, or app-runtime adapter
- give adapter overrides distinct report/capsule filenames and prevent override runs from silently minting adapter-dependent fixture candidates
- let the process orchestrator CLI consume the same saved generated input directly
- carry selected-input provenance into process/container reports and separately record the digest of the IR the process executor actually compiled
- let container campaigns resolve the selected scenario in memory, with deterministic manifest-declared lowering for host-crash campaigns
- privately materialize `canonical-scenario.json` only for VM drivers, so external drivers do not need a second generated-envelope parser
- preserve the existing raw-file digest identity used by indexed node-capsule fingerprints
- update the convergence tracking plan and adapter documentation

## Why

The stateful generator already produces deterministic, replayable journeys, but those saved journeys were tied to the simulator subject recorded by the generator. Process, container, and VM runners expected bare Scenario IR, which made it easy for adapter-specific launch paths to lose generator provenance, expectations, or execute a differently identified scenario.

This change establishes one selection boundary. Every adapter resolves the same saved source input and records its selected canonical Scenario IR. If an adapter deterministically lowers that history—currently container host-crash campaigns—the process report records a distinct executed-IR digest.

## Impact and scope

This is simulator and campaign-runner infrastructure only. It does not change production convergence-engine behavior or production Marmot app behavior.

Capability preflight remains authoritative. Selecting an adapter does not silently lower or skip unsupported operations. Some current stateful journeys still contain engine-only exact-state or observation steps and will be rejected by app/process capability contracts; the tracking-plan item remains open until representative journeys satisfy every adapter's capability and oracle contracts.

Process reports carry semantic expectations as provenance for downstream oracle tooling; the process executor does not yet evaluate those expectations itself.

## Validation

- `just fast-ci`
- `cargo test -p cgka-conformance-simulator --lib` — 133 passed
- adapter A/B artifact isolation and no override fixture minting
- saved generated input through the real app-runtime harness
- saved generated input through real child-process nodes
- `cargo test -p convergence-campaign-runner`
- raw Scenario IR node-capsule fingerprint continuity
- selected-vs-executed digest distinction for host-crash lowering
- generated-input VM materialization and normalized-manifest regression
- `cargo fmt --all -- --check`
- `git diff --check`

The real OCI container test remains intentionally ignored because it requires a prebuilt campaign image and Docker/Podman daemon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replay saved generated scenarios with preserved source, canonical scenario, adapter, and expectation metadata.
  * Execute generated scenarios through alternate adapters, including app-runtime and process execution.
  * Materialize canonical scenario files for VM-based runs.
  * Record source and canonical scenario digests in reports and campaign manifests.
  * Support selecting execution subjects and prevent adapter overrides from creating fixture candidates.

* **Bug Fixes**
  * Reject unsupported generated-input versions and invalid canonical digest values.
  * Ensure equivalent scenario formatting produces consistent canonical digests.

* **Documentation**
  * Updated simulator and campaign documentation with scenario-input, provenance, digest, and VM execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->