### PR TITLE
perf(app): reduce create-group latency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1920,6 +1920,7 @@ checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -3211,6 +3212,7 @@ dependencies = [
  "cgka-session",
  "cgka-traits",
  "fs-private",
+ "futures",
  "hex",
  "keyring-core",
  "libc",
@@ -3241,6 +3243,7 @@ dependencies = [
  "cgka-traits",
  "chacha20poly1305",
  "fs-private",
+ "futures",
  "hex",
  "hkdf 0.12.4",
  "image",

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -51,6 +51,12 @@ versioning through the workspace version in the root `Cargo.toml`.
   
 ### Fixed
 
+- Group creation now performs member KeyPackage lookup and founding Welcome
+  publication with bounded concurrency, includes the initial description in the
+  founding MLS state, and returns once the founder projection is locally usable.
+  Repairable subscription refresh and broad catch-up continue in the background,
+  while privacy-safe stage histograms expose the remaining latency budget.
+
 - Account setup interruptions now have stable JSON recovery codes and repair
   hints instead of falling through to the generic `command_failed` bucket.
 

--- a/crates/marmot-account/Cargo.toml
+++ b/crates/marmot-account/Cargo.toml
@@ -10,6 +10,7 @@ async-trait.workspace = true
 cgka-session.workspace = true
 cgka-traits.workspace = true
 fs-private.workspace = true
+futures.workspace = true
 hex.workspace = true
 keyring-core.workspace = true
 libc.workspace = true

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -29,6 +29,8 @@ use cgka_traits::{
     TransportEndpoint, TransportEndpointFailure, TransportEndpointReceipt, TransportGroupSync,
     TransportPublishReport, TransportPublishRequest, TransportPublishTarget,
 };
+use futures::StreamExt;
+use futures::stream::FuturesUnordered;
 use marmot_forensics::{
     AuditEventContext, AuditEventKind, AuditTransportWire, MessageArtifactKind, PublishRelayFailure,
 };
@@ -45,6 +47,7 @@ use crate::time::{
 };
 
 const TRACE_TARGET: &str = "marmot_account::runtime";
+const FOUNDING_WELCOME_PUBLISH_CONCURRENCY: usize = 8;
 const KEY_PACKAGE_MAX_FUTURE_SKEW_SECS: u64 = 5 * 60;
 const KEY_PACKAGE_REFRESH_MIN_LEAD_SECS: u64 = 14 * 24 * 60 * 60;
 const KEY_PACKAGE_REFRESH_MAX_LEAD_SECS: u64 = 21 * 24 * 60 * 60;
@@ -54,6 +57,27 @@ const MAINTENANCE_QUIET_SECS: u64 = 60;
 const PERIODIC_MIN_SECS: u64 = 24 * 24 * 60 * 60;
 const PERIODIC_MAX_SECS: u64 = 36 * 24 * 60 * 60;
 const TRANSPORT_FANOUT_RETENTION_SECS: u64 = 24 * 60 * 60;
+
+/// Run independent async work with fixed fan-out while returning results in
+/// input order. Completion order therefore cannot reorder reports or select a
+/// different caller-visible error.
+#[cfg(test)]
+async fn collect_bounded_ordered<I, F, T, E>(work: I, limit: usize) -> Result<Vec<T>, E>
+where
+    I: IntoIterator<Item = F>,
+    I::IntoIter: Send,
+    F: std::future::Future<Output = Result<T, E>> + Send,
+    T: Send,
+    E: Send,
+{
+    let mut results = futures::stream::iter(work.into_iter().enumerate())
+        .map(|(index, future)| async move { (index, future.await) })
+        .buffer_unordered(limit.max(1))
+        .collect::<Vec<_>>()
+        .await;
+    results.sort_unstable_by_key(|(index, _)| *index);
+    results.into_iter().map(|(_, result)| result).collect()
+}
 
 fn saturating_u32(value: usize) -> u32 {
     u32::try_from(value).unwrap_or(u32::MAX)
@@ -65,6 +89,36 @@ struct PublishStatus {
     accepted_by_any_endpoint: bool,
     possible_ambiguous_exposure: bool,
     retry_deferred: bool,
+}
+
+enum PreparedLegacyPublish {
+    Complete(PublishStatus),
+    Network(Box<PreparedLegacyPublishAttempt>),
+}
+
+enum LegacyPublishCompletion {
+    Complete(PublishStatus),
+    Network(
+        Box<PreparedLegacyPublishAttempt>,
+        Result<TransportPublishReport, TransportAdapterError>,
+    ),
+}
+
+struct PreparedLegacyPublishAttempt {
+    message_id: cgka_traits::MessageId,
+    msg_id_hex: String,
+    wire: AuditTransportWire,
+    artifact_kind: Option<MessageArtifactKind>,
+    publish_context: AuditEventContext,
+    fanout: DurableTransportFanout,
+    retry_endpoints: Vec<TransportEndpoint>,
+    accepted_before: usize,
+    required_acks: usize,
+    target_kind: String,
+    relay_urls: Vec<String>,
+    target_group_id: Option<GroupId>,
+    defers_remaining_fanout_until_confirmation: bool,
+    request: TransportPublishRequest,
 }
 
 pub struct AccountDeviceRuntime<A, R = StaticTransportRouting, K = NoopKeyPackagePublisher> {
@@ -2197,31 +2251,71 @@ where
         &mut self,
         welcomes: Vec<TransportMessage>,
         output: &mut AccountDeviceEffects,
-        queue: &mut VecDeque<PublishWork>,
+        _queue: &mut VecDeque<PublishWork>,
         context: Option<AuditEventContext>,
     ) -> AccountResult<()> {
         let group_id = output.events.iter().find_map(|event| match event {
             GroupEvent::GroupCreated { group_id } => Some(group_id.clone()),
             _ => None,
         });
-        for welcome in welcomes {
+        let mut metadata = Vec::with_capacity(welcomes.len());
+        let mut completions = Vec::with_capacity(welcomes.len());
+        completions.resize_with(welcomes.len(), || None);
+        let mut pending = VecDeque::new();
+        for (index, welcome) in welcomes.into_iter().enumerate() {
             let recipient = welcome_recipient(&welcome);
             let welcome_id = welcome.id.clone();
-            let failures_before = output.failures.len();
-            let status = self
-                .publish_one(welcome, None, output, queue, context.clone())
-                .await?;
+            let mut effects = AccountDeviceEffects::default();
+            match self.prepare_legacy_publish(welcome, &mut effects, context.clone(), false)? {
+                PreparedLegacyPublish::Complete(status) => {
+                    completions[index] = Some(LegacyPublishCompletion::Complete(status));
+                }
+                PreparedLegacyPublish::Network(attempt) => pending.push_back((index, attempt)),
+            }
+            metadata.push((recipient, welcome_id, effects));
+        }
+
+        let adapter = &self.adapter;
+        let publish = |index, attempt: Box<PreparedLegacyPublishAttempt>| async move {
+            let result = adapter.publish(attempt.request.clone()).await;
+            (index, attempt, result)
+        };
+        let mut in_flight = FuturesUnordered::new();
+        while in_flight.len() < FOUNDING_WELCOME_PUBLISH_CONCURRENCY {
+            let Some((index, attempt)) = pending.pop_front() else {
+                break;
+            };
+            in_flight.push(publish(index, attempt));
+        }
+        while let Some((index, attempt, result)) = in_flight.next().await {
+            completions[index] = Some(LegacyPublishCompletion::Network(attempt, result));
+            if let Some((next_index, next_attempt)) = pending.pop_front() {
+                in_flight.push(publish(next_index, next_attempt));
+            }
+        }
+
+        for ((recipient, welcome_id, mut effects), completion) in
+            metadata.into_iter().zip(completions)
+        {
+            let status = match completion.expect("every Welcome publish completed") {
+                LegacyPublishCompletion::Complete(status) => status,
+                LegacyPublishCompletion::Network(attempt, result) => {
+                    self.finish_prepared_legacy_publish(*attempt, result, &mut effects)
+                        .await?
+                }
+            };
             if status.met_required_acks {
                 self.mark_welcome_delivered_best_effort(&welcome_id);
             } else if let Some(recipient) = recipient {
-                output.welcome_failures.push(self.welcome_delivery_failure(
+                effects.welcome_failures.push(self.welcome_delivery_failure(
                     welcome_id,
                     recipient,
                     group_id.clone(),
-                    output,
-                    failures_before,
+                    &effects,
+                    0,
                 ));
             }
+            output.extend(effects);
         }
         Ok(())
     }
@@ -2718,6 +2812,23 @@ where
         context: Option<AuditEventContext>,
         retry_immediately: bool,
     ) -> AccountResult<PublishStatus> {
+        match self.prepare_legacy_publish(message, output, context, retry_immediately)? {
+            PreparedLegacyPublish::Complete(status) => Ok(status),
+            PreparedLegacyPublish::Network(attempt) => {
+                let result = self.adapter.publish(attempt.request.clone()).await;
+                self.finish_prepared_legacy_publish(*attempt, result, output)
+                    .await
+            }
+        }
+    }
+
+    fn prepare_legacy_publish(
+        &self,
+        message: TransportMessage,
+        output: &mut AccountDeviceEffects,
+        context: Option<AuditEventContext>,
+        retry_immediately: bool,
+    ) -> AccountResult<PreparedLegacyPublish> {
         let message_id = message.id.clone();
         let msg_id_hex = hex::encode(message_id.as_slice());
         // Capture the outbound wire envelope before `message` is moved into the
@@ -2769,7 +2880,7 @@ where
                         message_id,
                         reason: e.to_string(),
                     });
-                    return Ok(PublishStatus::default());
+                    return Ok(PreparedLegacyPublish::Complete(PublishStatus::default()));
                 }
             }
         };
@@ -2793,7 +2904,7 @@ where
                 transport: Some(wire.clone()),
             },
         );
-        let mut fanout = if let Some(fanout) = existing_fanout {
+        let fanout = if let Some(fanout) = existing_fanout {
             fanout
         } else {
             DurableTransportFanout {
@@ -2870,12 +2981,12 @@ where
                             | TransportFanoutAttemptState::AttemptedFailed
                     )
                 });
-            return Ok(PublishStatus {
+            return Ok(PreparedLegacyPublish::Complete(PublishStatus {
                 met_required_acks: accepted_before >= required_acks.max(1),
                 accepted_by_any_endpoint: accepted_before > 0,
                 possible_ambiguous_exposure: fanout.possible_exposure,
                 retry_deferred,
-            });
+            }));
         }
         let attempt_target = publish_target_with_endpoints(&target, retry_endpoints.clone());
         let attempt_required_acks = required_acks
@@ -2884,18 +2995,56 @@ where
             .max(1)
             .min(retry_endpoints.len());
 
-        let report = match self
-            .adapter
-            .publish(TransportPublishRequest {
-                account_id: self.session.self_id(),
-                message: message.clone(),
-                target: attempt_target,
-                required_acks: attempt_required_acks,
-            })
-            .await
-        {
+        Ok(PreparedLegacyPublish::Network(Box::new(
+            PreparedLegacyPublishAttempt {
+                message_id,
+                msg_id_hex,
+                wire,
+                artifact_kind,
+                publish_context,
+                fanout,
+                retry_endpoints,
+                accepted_before,
+                required_acks,
+                target_kind,
+                relay_urls,
+                target_group_id,
+                defers_remaining_fanout_until_confirmation,
+                request: TransportPublishRequest {
+                    account_id: self.session.self_id(),
+                    message,
+                    target: attempt_target,
+                    required_acks: attempt_required_acks,
+                },
+            },
+        )))
+    }
+
+    async fn finish_prepared_legacy_publish(
+        &self,
+        attempt: PreparedLegacyPublishAttempt,
+        result: Result<TransportPublishReport, TransportAdapterError>,
+        output: &mut AccountDeviceEffects,
+    ) -> AccountResult<PublishStatus> {
+        let PreparedLegacyPublishAttempt {
+            message_id,
+            msg_id_hex,
+            wire,
+            artifact_kind,
+            publish_context,
+            mut fanout,
+            retry_endpoints,
+            accepted_before,
+            required_acks,
+            target_kind,
+            relay_urls,
+            target_group_id,
+            defers_remaining_fanout_until_confirmation,
+            request: _,
+        } = attempt;
+        let report = match result {
             Ok(report) => report,
-            Err(e) => {
+            Err(error) => {
                 fanout.possible_exposure = true;
                 for target in &mut fanout.targets {
                     if retry_endpoints.contains(&target.endpoint)
@@ -2919,14 +3068,14 @@ where
                         relay_url: None,
                         relay_urls,
                         required_acks: Some(required_acks as u64),
-                        reason: e.to_string(),
+                        reason: error.to_string(),
                         detail: None,
                         transport: Some(wire),
                     },
                 );
                 output.failures.push(PublishFailure {
                     message_id,
-                    reason: e.to_string(),
+                    reason: error.to_string(),
                 });
                 return Ok(PublishStatus {
                     met_required_acks: accepted_before >= required_acks.max(1),
@@ -3419,5 +3568,55 @@ mod tests {
         });
 
         assert_eq!(combined.published_app_messages, vec![first, second]);
+    }
+
+    #[tokio::test]
+    async fn founding_welcome_work_is_bounded_concurrent_and_ordered() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use tokio::sync::Semaphore;
+        use tokio::time::{Duration, timeout};
+
+        for item_count in [1, 5, 20] {
+            let active = Arc::new(AtomicUsize::new(0));
+            let max_active = Arc::new(AtomicUsize::new(0));
+            let release = Arc::new(Semaphore::new(0));
+            let work_active = active.clone();
+            let work_max_active = max_active.clone();
+            let work_release = release.clone();
+            let work = (0..item_count).map(move |index| {
+                let active = work_active.clone();
+                let max_active = work_max_active.clone();
+                let release = work_release.clone();
+                async move {
+                    let now_active = active.fetch_add(1, Ordering::SeqCst) + 1;
+                    max_active.fetch_max(now_active, Ordering::SeqCst);
+                    let permit = release.acquire().await.unwrap();
+                    permit.forget();
+                    active.fetch_sub(1, Ordering::SeqCst);
+                    Ok::<_, &'static str>(index)
+                }
+            });
+
+            let expected_parallelism = item_count.min(FOUNDING_WELCOME_PUBLISH_CONCURRENCY);
+            let task = tokio::spawn(collect_bounded_ordered(
+                work,
+                FOUNDING_WELCOME_PUBLISH_CONCURRENCY,
+            ));
+            timeout(Duration::from_secs(1), async {
+                while max_active.load(Ordering::SeqCst) < expected_parallelism {
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .expect("bounded collector should start the available parallel work");
+            assert_eq!(max_active.load(Ordering::SeqCst), expected_parallelism);
+            release.add_permits(item_count);
+
+            assert_eq!(
+                task.await.unwrap().unwrap(),
+                (0..item_count).collect::<Vec<_>>()
+            );
+        }
     }
 }

--- a/crates/marmot-account/tests/runtime.rs
+++ b/crates/marmot-account/tests/runtime.rs
@@ -1,5 +1,5 @@
 use std::collections::VecDeque;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -341,9 +341,32 @@ struct RecordingAdapterInner {
     publish_errors: Mutex<VecDeque<bool>>,
     reported_message_ids: Mutex<VecDeque<MessageId>>,
     timeout_pattern: Mutex<VecDeque<bool>>,
+    welcome_gate: Mutex<Option<Arc<WelcomePublishGate>>>,
+}
+
+struct WelcomePublishGate {
+    active: AtomicUsize,
+    max_active: AtomicUsize,
+    release: tokio::sync::Semaphore,
+}
+
+impl Default for WelcomePublishGate {
+    fn default() -> Self {
+        Self {
+            active: AtomicUsize::new(0),
+            max_active: AtomicUsize::new(0),
+            release: tokio::sync::Semaphore::new(0),
+        }
+    }
 }
 
 impl RecordingAdapter {
+    fn gate_welcome_publishes(&self) -> Arc<WelcomePublishGate> {
+        let gate = Arc::new(WelcomePublishGate::default());
+        *self.inner.welcome_gate.lock().unwrap() = Some(gate.clone());
+        gate
+    }
+
     fn accept_only_next(&self, accepted_count: usize) {
         self.accept_next(accepted_count);
     }
@@ -411,6 +434,19 @@ impl TransportAdapter for RecordingAdapter {
         request: TransportPublishRequest,
     ) -> Result<TransportPublishReport, TransportAdapterError> {
         self.inner.publishes.lock().unwrap().push(request.clone());
+        let welcome_gate = if matches!(&request.message.envelope, TransportEnvelope::Welcome { .. })
+        {
+            self.inner.welcome_gate.lock().unwrap().clone()
+        } else {
+            None
+        };
+        if let Some(gate) = welcome_gate {
+            let active = gate.active.fetch_add(1, Ordering::SeqCst) + 1;
+            gate.max_active.fetch_max(active, Ordering::SeqCst);
+            let permit = gate.release.acquire().await.unwrap();
+            permit.forget();
+            gate.active.fetch_sub(1, Ordering::SeqCst);
+        }
         let timed_out = self
             .inner
             .timeout_pattern
@@ -2636,6 +2672,74 @@ async fn create_group_stops_welcome_publish_after_unexposed_failure() {
     assert_eq!(runtime.session().epoch(&group_id).unwrap().0, 0);
     assert_eq!(runtime.session().members(&group_id).unwrap().len(), 1);
     assert_eq!(adapter.publishes().len(), 1);
+}
+
+#[tokio::test]
+async fn current_founding_welcomes_publish_with_bounded_concurrency() {
+    for recipient_count in [1usize, 5, 20] {
+        let dir = tempfile::tempdir().unwrap();
+        let key = SqlCipherKey::new(format!("bounded Welcome key {recipient_count}")).unwrap();
+        let mut members = Vec::with_capacity(recipient_count);
+        let mut policy = StaticTransportRouting::new(vec![TransportEndpoint(
+            "wss://alice-inbox.example".into(),
+        )]);
+        for index in 0..recipient_count {
+            let identity = format!("recipient-{recipient_count}-{index}");
+            let mut recipient = current_session(
+                dir.path().join(format!("recipient-{index}.sqlite")),
+                &key,
+                identity.as_bytes(),
+            );
+            members.push(recipient.fresh_key_package().await.unwrap());
+            policy = policy.with_inbox_route(
+                recipient.self_id(),
+                vec![TransportEndpoint(format!(
+                    "wss://recipient-{index}.example"
+                ))],
+            );
+        }
+        let adapter = RecordingAdapter::default();
+        let gate = adapter.gate_welcome_publishes();
+        let session = current_session(
+            dir.path().join("alice.sqlite"),
+            &key,
+            format!("alice-{recipient_count}").as_bytes(),
+        );
+        let mut runtime = AccountDeviceRuntime::new(
+            session,
+            adapter.clone(),
+            policy,
+            RecordingKeyPackages::default(),
+        );
+        let create = tokio::spawn(async move {
+            runtime
+                .create_group(CreateGroupRequest {
+                    name: format!("bounded {recipient_count}"),
+                    description: String::new(),
+                    members,
+                    required_features: Vec::new(),
+                    app_components: Vec::new(),
+                    initial_admins: Vec::new(),
+                })
+                .await
+        });
+
+        let expected_parallelism = recipient_count.min(8);
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while gate.max_active.load(Ordering::SeqCst) < expected_parallelism {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("Welcome publishes should fill the bounded worker set");
+        assert_eq!(gate.max_active.load(Ordering::SeqCst), expected_parallelism);
+        gate.release.add_permits(recipient_count);
+
+        let (_, effects) = create.await.unwrap().unwrap();
+        assert_eq!(effects.reports.len(), recipient_count);
+        assert_eq!(adapter.publishes().len(), recipient_count);
+        assert!(gate.max_active.load(Ordering::SeqCst) <= 8);
+    }
 }
 
 #[tokio::test]

--- a/crates/marmot-app/Cargo.toml
+++ b/crates/marmot-app/Cargo.toml
@@ -24,6 +24,7 @@ cgka-session.workspace = true
 cgka-traits.workspace = true
 chacha20poly1305.workspace = true
 fs-private.workspace = true
+futures.workspace = true
 hex.workspace = true
 hkdf.workspace = true
 image.workspace = true

--- a/crates/marmot-app/src/app_telemetry.rs
+++ b/crates/marmot-app/src/app_telemetry.rs
@@ -32,6 +32,15 @@ pub(crate) enum AppPerformanceOperation {
     AccountSync,
     AccountSetupAdvisoryStep,
     OutboundMessageSend,
+    GroupCreateQueueWait,
+    GroupCreateKeyPackageLookup,
+    GroupCreateImageUpload,
+    GroupCreateMlsPreparePersist,
+    GroupCreateWelcomePublish,
+    GroupCreateLocalProjectionSave,
+    GroupCreateSubscriptionRefresh,
+    GroupCreatePostMutationCatchUp,
+    GroupCreateTotalCallerLatency,
     GroupInviteMembers,
     GroupInviteKeyPackageLookup,
     GroupInviteRoutingRefresh,
@@ -101,6 +110,24 @@ pub struct AppPerformanceSnapshot {
     pub account_setup_advisory_step: AppPerformanceOperationSnapshot,
     pub outbound_message_send: AppPerformanceOperationSnapshot,
     #[serde(default)]
+    pub group_create_queue_wait: AppPerformanceOperationSnapshot,
+    #[serde(default)]
+    pub group_create_key_package_lookup: AppPerformanceOperationSnapshot,
+    #[serde(default)]
+    pub group_create_image_upload: AppPerformanceOperationSnapshot,
+    #[serde(default)]
+    pub group_create_mls_prepare_persist: AppPerformanceOperationSnapshot,
+    #[serde(default)]
+    pub group_create_welcome_publish: AppPerformanceOperationSnapshot,
+    #[serde(default)]
+    pub group_create_local_projection_save: AppPerformanceOperationSnapshot,
+    #[serde(default)]
+    pub group_create_subscription_refresh: AppPerformanceOperationSnapshot,
+    #[serde(default)]
+    pub group_create_post_mutation_catch_up: AppPerformanceOperationSnapshot,
+    #[serde(default)]
+    pub group_create_total_caller_latency: AppPerformanceOperationSnapshot,
+    #[serde(default)]
     pub group_invite_members: AppPerformanceOperationSnapshot,
     #[serde(default)]
     pub group_invite_key_package_lookup: AppPerformanceOperationSnapshot,
@@ -151,6 +178,15 @@ struct AppPerformanceTelemetryInner {
     account_sync: AppPerformanceOperationTelemetry,
     account_setup_advisory_step: AppPerformanceOperationTelemetry,
     outbound_message_send: AppPerformanceOperationTelemetry,
+    group_create_queue_wait: AppPerformanceOperationTelemetry,
+    group_create_key_package_lookup: AppPerformanceOperationTelemetry,
+    group_create_image_upload: AppPerformanceOperationTelemetry,
+    group_create_mls_prepare_persist: AppPerformanceOperationTelemetry,
+    group_create_welcome_publish: AppPerformanceOperationTelemetry,
+    group_create_local_projection_save: AppPerformanceOperationTelemetry,
+    group_create_subscription_refresh: AppPerformanceOperationTelemetry,
+    group_create_post_mutation_catch_up: AppPerformanceOperationTelemetry,
+    group_create_total_caller_latency: AppPerformanceOperationTelemetry,
     group_invite_members: AppPerformanceOperationTelemetry,
     group_invite_key_package_lookup: AppPerformanceOperationTelemetry,
     group_invite_routing_refresh: AppPerformanceOperationTelemetry,
@@ -293,6 +329,45 @@ impl AppPerformanceTelemetry {
             AppPerformanceOperation::OutboundMessageSend => {
                 inner.outbound_message_send.record(duration, success);
             }
+            AppPerformanceOperation::GroupCreateQueueWait => {
+                inner.group_create_queue_wait.record(duration, success);
+            }
+            AppPerformanceOperation::GroupCreateKeyPackageLookup => {
+                inner
+                    .group_create_key_package_lookup
+                    .record(duration, success);
+            }
+            AppPerformanceOperation::GroupCreateImageUpload => {
+                inner.group_create_image_upload.record(duration, success);
+            }
+            AppPerformanceOperation::GroupCreateMlsPreparePersist => {
+                inner
+                    .group_create_mls_prepare_persist
+                    .record(duration, success);
+            }
+            AppPerformanceOperation::GroupCreateWelcomePublish => {
+                inner.group_create_welcome_publish.record(duration, success);
+            }
+            AppPerformanceOperation::GroupCreateLocalProjectionSave => {
+                inner
+                    .group_create_local_projection_save
+                    .record(duration, success);
+            }
+            AppPerformanceOperation::GroupCreateSubscriptionRefresh => {
+                inner
+                    .group_create_subscription_refresh
+                    .record(duration, success);
+            }
+            AppPerformanceOperation::GroupCreatePostMutationCatchUp => {
+                inner
+                    .group_create_post_mutation_catch_up
+                    .record(duration, success);
+            }
+            AppPerformanceOperation::GroupCreateTotalCallerLatency => {
+                inner
+                    .group_create_total_caller_latency
+                    .record(duration, success);
+            }
             AppPerformanceOperation::GroupInviteMembers => {
                 inner.group_invite_members.record(duration, success);
             }
@@ -386,6 +461,17 @@ impl AppPerformanceTelemetry {
             account_sync: inner.account_sync.snapshot(),
             account_setup_advisory_step: inner.account_setup_advisory_step.snapshot(),
             outbound_message_send: inner.outbound_message_send.snapshot(),
+            group_create_queue_wait: inner.group_create_queue_wait.snapshot(),
+            group_create_key_package_lookup: inner.group_create_key_package_lookup.snapshot(),
+            group_create_image_upload: inner.group_create_image_upload.snapshot(),
+            group_create_mls_prepare_persist: inner.group_create_mls_prepare_persist.snapshot(),
+            group_create_welcome_publish: inner.group_create_welcome_publish.snapshot(),
+            group_create_local_projection_save: inner.group_create_local_projection_save.snapshot(),
+            group_create_subscription_refresh: inner.group_create_subscription_refresh.snapshot(),
+            group_create_post_mutation_catch_up: inner
+                .group_create_post_mutation_catch_up
+                .snapshot(),
+            group_create_total_caller_latency: inner.group_create_total_caller_latency.snapshot(),
             group_invite_members: inner.group_invite_members.snapshot(),
             group_invite_key_package_lookup: inner.group_invite_key_package_lookup.snapshot(),
             group_invite_routing_refresh: inner.group_invite_routing_refresh.snapshot(),
@@ -537,6 +623,42 @@ mod tests {
         assert_eq!(snapshot.account_profile_load.duration_ms.sum_ms, 15);
         assert_eq!(snapshot.account_group_read_snapshot.successes, 1);
         assert_eq!(snapshot.account_group_read_snapshot.duration_ms.sum_ms, 40);
+    }
+
+    #[test]
+    fn records_each_group_create_stage() {
+        let telemetry = AppPerformanceTelemetry::default();
+        let operations = [
+            AppPerformanceOperation::GroupCreateQueueWait,
+            AppPerformanceOperation::GroupCreateKeyPackageLookup,
+            AppPerformanceOperation::GroupCreateImageUpload,
+            AppPerformanceOperation::GroupCreateMlsPreparePersist,
+            AppPerformanceOperation::GroupCreateWelcomePublish,
+            AppPerformanceOperation::GroupCreateLocalProjectionSave,
+            AppPerformanceOperation::GroupCreateSubscriptionRefresh,
+            AppPerformanceOperation::GroupCreatePostMutationCatchUp,
+            AppPerformanceOperation::GroupCreateTotalCallerLatency,
+        ];
+        for (index, operation) in operations.into_iter().enumerate() {
+            telemetry.record(operation, Duration::from_millis(index as u64 + 1), true);
+        }
+
+        let snapshot = telemetry.snapshot();
+        for stage in [
+            snapshot.group_create_queue_wait,
+            snapshot.group_create_key_package_lookup,
+            snapshot.group_create_image_upload,
+            snapshot.group_create_mls_prepare_persist,
+            snapshot.group_create_welcome_publish,
+            snapshot.group_create_local_projection_save,
+            snapshot.group_create_subscription_refresh,
+            snapshot.group_create_post_mutation_catch_up,
+            snapshot.group_create_total_caller_latency,
+        ] {
+            assert_eq!(stage.attempts, 1);
+            assert_eq!(stage.successes, 1);
+            assert_eq!(stage.duration_ms.sample_count(), 1);
+        }
     }
 
     #[test]

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -22,6 +22,7 @@ use cgka_traits::engine::{CreateGroupRequest, KeyPackage, SendIntent};
 use cgka_traits::group::ProtocolProfile;
 use cgka_traits::transport::TransportEnvelope;
 use cgka_traits::{GroupId, SecretBytes};
+use futures::StreamExt;
 use marmot_forensics::AuditEventContext;
 
 use crate::app_telemetry::AppPerformanceOperation;
@@ -63,6 +64,25 @@ use push::notification_trigger_for_intent;
 pub(crate) use sync::ConvergenceScheduleState;
 #[cfg(test)]
 pub(crate) use sync::is_own_relay_echo;
+
+const CREATE_GROUP_LOOKUP_CONCURRENCY: usize = 8;
+
+/// Run independent async work with fixed fan-out while returning results in
+/// input order. All started work finishes before deterministic error selection,
+/// so completion timing cannot change which member error the caller observes.
+async fn collect_bounded_ordered<I, F, T, E>(work: I, limit: usize) -> Result<Vec<T>, E>
+where
+    I: IntoIterator<Item = F>,
+    F: std::future::Future<Output = Result<T, E>>,
+{
+    let mut results = futures::stream::iter(work.into_iter().enumerate())
+        .map(|(index, future)| async move { (index, future.await) })
+        .buffer_unordered(limit.max(1))
+        .collect::<Vec<_>>()
+        .await;
+    results.sort_unstable_by_key(|(index, _)| *index);
+    results.into_iter().map(|(_, result)| result).collect()
+}
 
 pub struct AppClient {
     pub(crate) app: MarmotApp,
@@ -555,11 +575,75 @@ impl AppClient {
         member_refs: &[&str],
         initial_image: Option<AppInitialGroupImage>,
     ) -> Result<GroupId, AppError> {
-        validate_group_profile(name, "")?;
-        let mut members = Vec::with_capacity(member_refs.len());
-        for member in member_refs {
-            members.push(self.app.member_key_package(member).await?);
+        let group_id = self
+            .create_group_with_initial_profile_and_optional_telemetry(
+                name,
+                "",
+                member_refs,
+                initial_image,
+                None,
+            )
+            .await?;
+        // Direct `AppClient` callers do not have the managed account worker to
+        // refresh subscriptions after its response. Preserve that API's
+        // historical readiness guarantee; the managed runtime uses the
+        // telemetry-aware entry point below and performs this step after
+        // replying so it stays off the user-visible latency boundary.
+        if let Err(error) = self.sync_runtime_groups().await {
+            tracing::warn!(
+                target: "marmot_app::client",
+                method = "create_group",
+                error_kind = error.privacy_safe_kind(),
+                "confirmed group creation could not refresh subscriptions immediately"
+            );
         }
+        Ok(group_id)
+    }
+
+    pub(crate) async fn create_group_with_initial_profile_and_telemetry(
+        &mut self,
+        name: &str,
+        description: &str,
+        member_refs: &[&str],
+        initial_image: Option<AppInitialGroupImage>,
+        telemetry: &AppPerformanceTelemetry,
+    ) -> Result<GroupId, AppError> {
+        self.create_group_with_initial_profile_and_optional_telemetry(
+            name,
+            description,
+            member_refs,
+            initial_image,
+            Some(telemetry),
+        )
+        .await
+    }
+
+    async fn create_group_with_initial_profile_and_optional_telemetry(
+        &mut self,
+        name: &str,
+        description: &str,
+        member_refs: &[&str],
+        initial_image: Option<AppInitialGroupImage>,
+        telemetry: Option<&AppPerformanceTelemetry>,
+    ) -> Result<GroupId, AppError> {
+        validate_group_profile(name, description)?;
+        let key_package_started_at = Instant::now();
+        let lookups = member_refs
+            .iter()
+            .map(|member| {
+                let app = self.app.clone();
+                let member = (*member).to_owned();
+                async move { app.member_key_package(&member).await }
+            })
+            .collect::<Vec<_>>();
+        let key_packages = collect_bounded_ordered(lookups, CREATE_GROUP_LOOKUP_CONCURRENCY).await;
+        record_app_performance(
+            telemetry,
+            AppPerformanceOperation::GroupCreateKeyPackageLookup,
+            key_package_started_at.elapsed(),
+            key_packages.is_ok(),
+        );
+        let members = key_packages?;
         self.refresh_routing()?;
         let nostr_routing = self.app.new_nostr_routing()?;
         let nostr_routing_bytes =
@@ -577,32 +661,47 @@ impl AppClient {
         let encrypted_media_component_id = encrypted_media.component_id;
         app_components.push(encrypted_media);
         let constructable = self.runtime.constructable_capabilities(&members)?;
-        let mut optional_app_components = Vec::new();
-        if let Some(image) = initial_image {
-            match preferred_initial_group_image_component(
-                &constructable,
-                image.source_url.is_some(),
-            ) {
-                Some(GROUP_BLOSSOM_IMAGE_COMPONENT_ID) => {
-                    let upload =
-                        upload_group_image(&image.plaintext, &image.media_type, None).await?;
-                    let input = AppGroupImageInput::from(upload);
-                    optional_app_components.push(AppComponentData {
-                        component_id: GROUP_BLOSSOM_IMAGE_COMPONENT_ID,
-                        data: hex::decode(AppGroupImageComponent::new(input).data_hex)?,
-                    });
-                }
-                Some(GROUP_AVATAR_URL_COMPONENT_ID) => {
-                    if let Some(url) = image.source_url {
-                        optional_app_components.push(
-                            AppGroupAvatarUrlComponent::new(url, image.dim, image.thumbhash)?
-                                .to_app_component_data()?,
-                        );
+        let has_initial_image = initial_image.is_some();
+        let image_started_at = Instant::now();
+        let optional_app_components = async {
+            let mut optional_app_components = Vec::new();
+            if let Some(image) = initial_image {
+                match preferred_initial_group_image_component(
+                    &constructable,
+                    image.source_url.is_some(),
+                ) {
+                    Some(GROUP_BLOSSOM_IMAGE_COMPONENT_ID) => {
+                        let upload =
+                            upload_group_image(&image.plaintext, &image.media_type, None).await?;
+                        let input = AppGroupImageInput::from(upload);
+                        optional_app_components.push(AppComponentData {
+                            component_id: GROUP_BLOSSOM_IMAGE_COMPONENT_ID,
+                            data: hex::decode(AppGroupImageComponent::new(input).data_hex)?,
+                        });
                     }
+                    Some(GROUP_AVATAR_URL_COMPONENT_ID) => {
+                        if let Some(url) = image.source_url {
+                            optional_app_components.push(
+                                AppGroupAvatarUrlComponent::new(url, image.dim, image.thumbhash)?
+                                    .to_app_component_data()?,
+                            );
+                        }
+                    }
+                    _ => {}
                 }
-                _ => {}
             }
+            Ok::<_, AppError>(optional_app_components)
         }
+        .await;
+        if has_initial_image {
+            record_app_performance(
+                telemetry,
+                AppPerformanceOperation::GroupCreateImageUpload,
+                image_started_at.elapsed(),
+                optional_app_components.is_ok(),
+            );
+        }
+        let optional_app_components = optional_app_components?;
         let mut touched_components = vec![
             NOSTR_ROUTING_COMPONENT_ID,
             AGENT_TEXT_STREAM_QUIC_COMPONENT_ID,
@@ -613,11 +712,13 @@ impl AppClient {
                 .iter()
                 .map(|component| component.component_id),
         );
-        let changed_fields = if optional_app_components.is_empty() {
-            vec!["name", "members"]
-        } else {
-            vec!["name", "members", "image"]
-        };
+        let mut changed_fields = vec!["name", "members"];
+        if !description.is_empty() {
+            changed_fields.push("description");
+        }
+        if !optional_app_components.is_empty() {
+            changed_fields.push("image");
+        }
         let audit_context = Self::local_human_action_context(
             "create_group",
             changed_fields,
@@ -625,12 +726,13 @@ impl AppClient {
             Some(member_refs.len() as u64),
         );
 
+        let mls_started_at = Instant::now();
         let prepared = self
             .runtime
             .prepare_create_group_with_optional_app_components_and_audit_context(
                 CreateGroupRequest {
                     name: name.to_owned(),
-                    description: String::new(),
+                    description: description.to_owned(),
                     members,
                     required_features: Vec::new(),
                     app_components,
@@ -639,7 +741,14 @@ impl AppClient {
                 optional_app_components,
                 audit_context.clone(),
             )
-            .await?;
+            .await;
+        record_app_performance(
+            telemetry,
+            AppPerformanceOperation::GroupCreateMlsPreparePersist,
+            mls_started_at.elapsed(),
+            prepared.is_ok(),
+        );
+        let prepared = prepared?;
         let group_id = prepared.group_id;
         // Current-profile founding creation is already canonical before
         // transport delivery. Persist every exact Welcome obligation before
@@ -649,16 +758,23 @@ impl AppClient {
             "record_founding_welcome_delivery_intents",
             self.record_founding_welcome_delivery_intents(&group_id, &prepared.effects),
         );
-        let effects = recover_post_canonical_result(
-            "publish_prepared_founding_group",
-            self.runtime
-                .publish_prepared_session_effects_with_audit_context(
-                    prepared.effects,
-                    audit_context.clone(),
-                )
-                .await
-                .map_err(AppError::from),
+        let welcome_publish_started_at = Instant::now();
+        let publish_result = self
+            .runtime
+            .publish_prepared_session_effects_with_audit_context(
+                prepared.effects,
+                audit_context.clone(),
+            )
+            .await
+            .map_err(AppError::from);
+        record_app_performance(
+            telemetry,
+            AppPerformanceOperation::GroupCreateWelcomePublish,
+            welcome_publish_started_at.elapsed(),
+            publish_result.is_ok(),
         );
+        let effects =
+            recover_post_canonical_result("publish_prepared_founding_group", publish_result);
         recover_post_canonical_result(
             "clear_delivered_founding_welcome_intents",
             self.clear_delivered_founding_welcome_intents(&founding_welcome_intents, &effects),
@@ -677,17 +793,20 @@ impl AppClient {
         // state persistence, and subscription refresh are downstream repairable
         // work; none can roll the group back, so none may turn this operation
         // into a false failure that invites the caller to create a duplicate.
-        match self.add_group(&group_id) {
-            Ok(()) => {
-                if let Err(error) = self.app.save_state(&self.state) {
+        let local_projection_started_at = Instant::now();
+        let local_projection_saved = match self.add_group(&group_id) {
+            Ok(()) => match self.app.save_state(&self.state) {
+                Ok(()) => true,
+                Err(error) => {
                     tracing::warn!(
                         target: "marmot_app::client",
                         method = "create_group",
                         error_kind = error.privacy_safe_kind(),
                         "confirmed group creation outpaced projection persistence; account open will reconcile it"
                     );
+                    false
                 }
-            }
+            },
             Err(error) => {
                 tracing::warn!(
                     target: "marmot_app::client",
@@ -695,17 +814,16 @@ impl AppClient {
                     error_kind = error.privacy_safe_kind(),
                     "confirmed group creation could not be projected immediately; account open will reconcile it"
                 );
+                false
             }
-        }
-        if let Err(error) = self.sync_runtime_groups().await {
-            tracing::warn!(
-                target: "marmot_app::client",
-                method = "create_group",
-                error_kind = error.privacy_safe_kind(),
-                "confirmed group creation could not refresh subscriptions immediately"
-            );
-        }
+        };
         self.queue_own_group_system_projection_updates(&effects);
+        record_app_performance(
+            telemetry,
+            AppPerformanceOperation::GroupCreateLocalProjectionSave,
+            local_projection_started_at.elapsed(),
+            local_projection_saved,
+        );
         Ok(group_id)
     }
 
@@ -3117,7 +3235,10 @@ fn local_account_removed_from_roster(
 
 #[cfg(test)]
 mod post_canonical_create_tests {
-    use super::{preferred_initial_group_image_component, recover_post_canonical_result};
+    use super::{
+        CREATE_GROUP_LOOKUP_CONCURRENCY, collect_bounded_ordered,
+        preferred_initial_group_image_component, recover_post_canonical_result,
+    };
     use crate::AppError;
     use cgka_traits::app_components::{
         GROUP_AVATAR_URL_COMPONENT_ID, GROUP_BLOSSOM_IMAGE_COMPONENT_ID,
@@ -3162,6 +3283,78 @@ mod post_canonical_create_tests {
 
         let successful: u8 = recover_post_canonical_result("test_post_canonical_success", Ok(7));
         assert_eq!(successful, 7);
+    }
+
+    #[tokio::test]
+    async fn bounded_create_group_lookups_scale_for_cached_and_delayed_sources() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use tokio::sync::Semaphore;
+        use tokio::time::{Duration, timeout};
+
+        for item_count in [1, 5, 20] {
+            let cached = collect_bounded_ordered(
+                (0..item_count).map(|index| std::future::ready(Ok::<_, &'static str>(index))),
+                CREATE_GROUP_LOOKUP_CONCURRENCY,
+            )
+            .await
+            .unwrap();
+            assert_eq!(cached, (0..item_count).collect::<Vec<_>>());
+
+            let active = Arc::new(AtomicUsize::new(0));
+            let max_active = Arc::new(AtomicUsize::new(0));
+            let release = Arc::new(Semaphore::new(0));
+            let work_active = active.clone();
+            let work_max_active = max_active.clone();
+            let work_release = release.clone();
+            let work = (0..item_count).map(move |index| {
+                let active = work_active.clone();
+                let max_active = work_max_active.clone();
+                let release = work_release.clone();
+                async move {
+                    let now_active = active.fetch_add(1, Ordering::SeqCst) + 1;
+                    max_active.fetch_max(now_active, Ordering::SeqCst);
+                    let permit = release.acquire().await.unwrap();
+                    permit.forget();
+                    active.fetch_sub(1, Ordering::SeqCst);
+                    Ok::<_, &'static str>(index)
+                }
+            });
+
+            let expected_parallelism = item_count.min(CREATE_GROUP_LOOKUP_CONCURRENCY);
+            let task = tokio::spawn(collect_bounded_ordered(
+                work,
+                CREATE_GROUP_LOOKUP_CONCURRENCY,
+            ));
+            timeout(Duration::from_secs(1), async {
+                while max_active.load(Ordering::SeqCst) < expected_parallelism {
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .expect("bounded collector should start the available parallel work");
+            assert_eq!(max_active.load(Ordering::SeqCst), expected_parallelism);
+            release.add_permits(item_count);
+
+            assert_eq!(
+                task.await.unwrap().unwrap(),
+                (0..item_count).collect::<Vec<_>>()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn bounded_create_group_work_reports_errors_in_input_order() {
+        use tokio::time::{Duration, sleep};
+
+        let work = (0..2).map(|index| async move {
+            if index == 0 {
+                sleep(Duration::from_millis(10)).await;
+            }
+            Err::<usize, _>(if index == 0 { "first" } else { "second" })
+        });
+
+        assert_eq!(collect_bounded_ordered(work, 2).await, Err("first"));
     }
 }
 

--- a/crates/marmot-app/src/relay_telemetry_export.rs
+++ b/crates/marmot-app/src/relay_telemetry_export.rs
@@ -196,6 +196,84 @@ pub mod metric_names {
     pub const APP_OUTBOUND_MESSAGE_SEND_SUCCESSES: &str = "app_outbound_message_send_successes";
     /// Failed one-sided outbound message sends.
     pub const APP_OUTBOUND_MESSAGE_SEND_FAILURES: &str = "app_outbound_message_send_failures";
+    /// Group-create queue wait metrics.
+    pub const APP_GROUP_CREATE_QUEUE_WAIT_DURATION: &str =
+        "app_group_create_queue_wait_duration_ms";
+    pub const APP_GROUP_CREATE_QUEUE_WAIT_ATTEMPTS: &str = "app_group_create_queue_wait_attempts";
+    pub const APP_GROUP_CREATE_QUEUE_WAIT_SUCCESSES: &str = "app_group_create_queue_wait_successes";
+    pub const APP_GROUP_CREATE_QUEUE_WAIT_FAILURES: &str = "app_group_create_queue_wait_failures";
+    /// Group-create KeyPackage lookup metrics.
+    pub const APP_GROUP_CREATE_KEY_PACKAGE_LOOKUP_DURATION: &str =
+        "app_group_create_key_package_lookup_duration_ms";
+    pub const APP_GROUP_CREATE_KEY_PACKAGE_LOOKUP_ATTEMPTS: &str =
+        "app_group_create_key_package_lookup_attempts";
+    pub const APP_GROUP_CREATE_KEY_PACKAGE_LOOKUP_SUCCESSES: &str =
+        "app_group_create_key_package_lookup_successes";
+    pub const APP_GROUP_CREATE_KEY_PACKAGE_LOOKUP_FAILURES: &str =
+        "app_group_create_key_package_lookup_failures";
+    /// Group-create image upload metrics.
+    pub const APP_GROUP_CREATE_IMAGE_UPLOAD_DURATION: &str =
+        "app_group_create_image_upload_duration_ms";
+    pub const APP_GROUP_CREATE_IMAGE_UPLOAD_ATTEMPTS: &str =
+        "app_group_create_image_upload_attempts";
+    pub const APP_GROUP_CREATE_IMAGE_UPLOAD_SUCCESSES: &str =
+        "app_group_create_image_upload_successes";
+    pub const APP_GROUP_CREATE_IMAGE_UPLOAD_FAILURES: &str =
+        "app_group_create_image_upload_failures";
+    /// Group-create MLS prepare/persist metrics.
+    pub const APP_GROUP_CREATE_MLS_PREPARE_PERSIST_DURATION: &str =
+        "app_group_create_mls_prepare_persist_duration_ms";
+    pub const APP_GROUP_CREATE_MLS_PREPARE_PERSIST_ATTEMPTS: &str =
+        "app_group_create_mls_prepare_persist_attempts";
+    pub const APP_GROUP_CREATE_MLS_PREPARE_PERSIST_SUCCESSES: &str =
+        "app_group_create_mls_prepare_persist_successes";
+    pub const APP_GROUP_CREATE_MLS_PREPARE_PERSIST_FAILURES: &str =
+        "app_group_create_mls_prepare_persist_failures";
+    /// Group-create Welcome publish metrics.
+    pub const APP_GROUP_CREATE_WELCOME_PUBLISH_DURATION: &str =
+        "app_group_create_welcome_publish_duration_ms";
+    pub const APP_GROUP_CREATE_WELCOME_PUBLISH_ATTEMPTS: &str =
+        "app_group_create_welcome_publish_attempts";
+    pub const APP_GROUP_CREATE_WELCOME_PUBLISH_SUCCESSES: &str =
+        "app_group_create_welcome_publish_successes";
+    pub const APP_GROUP_CREATE_WELCOME_PUBLISH_FAILURES: &str =
+        "app_group_create_welcome_publish_failures";
+    /// Group-create local projection save metrics.
+    pub const APP_GROUP_CREATE_LOCAL_PROJECTION_SAVE_DURATION: &str =
+        "app_group_create_local_projection_save_duration_ms";
+    pub const APP_GROUP_CREATE_LOCAL_PROJECTION_SAVE_ATTEMPTS: &str =
+        "app_group_create_local_projection_save_attempts";
+    pub const APP_GROUP_CREATE_LOCAL_PROJECTION_SAVE_SUCCESSES: &str =
+        "app_group_create_local_projection_save_successes";
+    pub const APP_GROUP_CREATE_LOCAL_PROJECTION_SAVE_FAILURES: &str =
+        "app_group_create_local_projection_save_failures";
+    /// Group-create subscription refresh metrics.
+    pub const APP_GROUP_CREATE_SUBSCRIPTION_REFRESH_DURATION: &str =
+        "app_group_create_subscription_refresh_duration_ms";
+    pub const APP_GROUP_CREATE_SUBSCRIPTION_REFRESH_ATTEMPTS: &str =
+        "app_group_create_subscription_refresh_attempts";
+    pub const APP_GROUP_CREATE_SUBSCRIPTION_REFRESH_SUCCESSES: &str =
+        "app_group_create_subscription_refresh_successes";
+    pub const APP_GROUP_CREATE_SUBSCRIPTION_REFRESH_FAILURES: &str =
+        "app_group_create_subscription_refresh_failures";
+    /// Group-create post-mutation catch-up metrics.
+    pub const APP_GROUP_CREATE_POST_MUTATION_CATCH_UP_DURATION: &str =
+        "app_group_create_post_mutation_catch_up_duration_ms";
+    pub const APP_GROUP_CREATE_POST_MUTATION_CATCH_UP_ATTEMPTS: &str =
+        "app_group_create_post_mutation_catch_up_attempts";
+    pub const APP_GROUP_CREATE_POST_MUTATION_CATCH_UP_SUCCESSES: &str =
+        "app_group_create_post_mutation_catch_up_successes";
+    pub const APP_GROUP_CREATE_POST_MUTATION_CATCH_UP_FAILURES: &str =
+        "app_group_create_post_mutation_catch_up_failures";
+    /// End-to-end group-create caller latency metrics.
+    pub const APP_GROUP_CREATE_TOTAL_CALLER_LATENCY_DURATION: &str =
+        "app_group_create_total_caller_latency_duration_ms";
+    pub const APP_GROUP_CREATE_TOTAL_CALLER_LATENCY_ATTEMPTS: &str =
+        "app_group_create_total_caller_latency_attempts";
+    pub const APP_GROUP_CREATE_TOTAL_CALLER_LATENCY_SUCCESSES: &str =
+        "app_group_create_total_caller_latency_successes";
+    pub const APP_GROUP_CREATE_TOTAL_CALLER_LATENCY_FAILURES: &str =
+        "app_group_create_total_caller_latency_failures";
     /// Group invite-member runtime duration histogram.
     pub const APP_GROUP_INVITE_MEMBERS_DURATION: &str = "app_group_invite_members_duration_ms";
     /// Group invite-member attempts.
@@ -714,6 +792,78 @@ fn append_app_performance_points(
         metric_names::APP_OUTBOUND_MESSAGE_SEND_ATTEMPTS,
         metric_names::APP_OUTBOUND_MESSAGE_SEND_SUCCESSES,
         metric_names::APP_OUTBOUND_MESSAGE_SEND_FAILURES,
+    );
+    append_app_operation_points(
+        points,
+        &app_performance.group_create_queue_wait,
+        metric_names::APP_GROUP_CREATE_QUEUE_WAIT_DURATION,
+        metric_names::APP_GROUP_CREATE_QUEUE_WAIT_ATTEMPTS,
+        metric_names::APP_GROUP_CREATE_QUEUE_WAIT_SUCCESSES,
+        metric_names::APP_GROUP_CREATE_QUEUE_WAIT_FAILURES,
+    );
+    append_app_operation_points(
+        points,
+        &app_performance.group_create_key_package_lookup,
+        metric_names::APP_GROUP_CREATE_KEY_PACKAGE_LOOKUP_DURATION,
+        metric_names::APP_GROUP_CREATE_KEY_PACKAGE_LOOKUP_ATTEMPTS,
+        metric_names::APP_GROUP_CREATE_KEY_PACKAGE_LOOKUP_SUCCESSES,
+        metric_names::APP_GROUP_CREATE_KEY_PACKAGE_LOOKUP_FAILURES,
+    );
+    append_app_operation_points(
+        points,
+        &app_performance.group_create_image_upload,
+        metric_names::APP_GROUP_CREATE_IMAGE_UPLOAD_DURATION,
+        metric_names::APP_GROUP_CREATE_IMAGE_UPLOAD_ATTEMPTS,
+        metric_names::APP_GROUP_CREATE_IMAGE_UPLOAD_SUCCESSES,
+        metric_names::APP_GROUP_CREATE_IMAGE_UPLOAD_FAILURES,
+    );
+    append_app_operation_points(
+        points,
+        &app_performance.group_create_mls_prepare_persist,
+        metric_names::APP_GROUP_CREATE_MLS_PREPARE_PERSIST_DURATION,
+        metric_names::APP_GROUP_CREATE_MLS_PREPARE_PERSIST_ATTEMPTS,
+        metric_names::APP_GROUP_CREATE_MLS_PREPARE_PERSIST_SUCCESSES,
+        metric_names::APP_GROUP_CREATE_MLS_PREPARE_PERSIST_FAILURES,
+    );
+    append_app_operation_points(
+        points,
+        &app_performance.group_create_welcome_publish,
+        metric_names::APP_GROUP_CREATE_WELCOME_PUBLISH_DURATION,
+        metric_names::APP_GROUP_CREATE_WELCOME_PUBLISH_ATTEMPTS,
+        metric_names::APP_GROUP_CREATE_WELCOME_PUBLISH_SUCCESSES,
+        metric_names::APP_GROUP_CREATE_WELCOME_PUBLISH_FAILURES,
+    );
+    append_app_operation_points(
+        points,
+        &app_performance.group_create_local_projection_save,
+        metric_names::APP_GROUP_CREATE_LOCAL_PROJECTION_SAVE_DURATION,
+        metric_names::APP_GROUP_CREATE_LOCAL_PROJECTION_SAVE_ATTEMPTS,
+        metric_names::APP_GROUP_CREATE_LOCAL_PROJECTION_SAVE_SUCCESSES,
+        metric_names::APP_GROUP_CREATE_LOCAL_PROJECTION_SAVE_FAILURES,
+    );
+    append_app_operation_points(
+        points,
+        &app_performance.group_create_subscription_refresh,
+        metric_names::APP_GROUP_CREATE_SUBSCRIPTION_REFRESH_DURATION,
+        metric_names::APP_GROUP_CREATE_SUBSCRIPTION_REFRESH_ATTEMPTS,
+        metric_names::APP_GROUP_CREATE_SUBSCRIPTION_REFRESH_SUCCESSES,
+        metric_names::APP_GROUP_CREATE_SUBSCRIPTION_REFRESH_FAILURES,
+    );
+    append_app_operation_points(
+        points,
+        &app_performance.group_create_post_mutation_catch_up,
+        metric_names::APP_GROUP_CREATE_POST_MUTATION_CATCH_UP_DURATION,
+        metric_names::APP_GROUP_CREATE_POST_MUTATION_CATCH_UP_ATTEMPTS,
+        metric_names::APP_GROUP_CREATE_POST_MUTATION_CATCH_UP_SUCCESSES,
+        metric_names::APP_GROUP_CREATE_POST_MUTATION_CATCH_UP_FAILURES,
+    );
+    append_app_operation_points(
+        points,
+        &app_performance.group_create_total_caller_latency,
+        metric_names::APP_GROUP_CREATE_TOTAL_CALLER_LATENCY_DURATION,
+        metric_names::APP_GROUP_CREATE_TOTAL_CALLER_LATENCY_ATTEMPTS,
+        metric_names::APP_GROUP_CREATE_TOTAL_CALLER_LATENCY_SUCCESSES,
+        metric_names::APP_GROUP_CREATE_TOTAL_CALLER_LATENCY_FAILURES,
     );
     append_app_operation_points(
         points,

--- a/crates/marmot-app/src/relay_telemetry_export/tests.rs
+++ b/crates/marmot-app/src/relay_telemetry_export/tests.rs
@@ -299,6 +299,22 @@ fn build_export_batch_appends_unlabeled_app_performance_metrics() {
         point.name == metric_names::APP_GROUP_DETAILS_READ_ATTEMPTS
             && point.value == ExportMetricValue::Counter(2)
     }));
+    for metric_name in [
+        metric_names::APP_GROUP_CREATE_QUEUE_WAIT_DURATION,
+        metric_names::APP_GROUP_CREATE_KEY_PACKAGE_LOOKUP_DURATION,
+        metric_names::APP_GROUP_CREATE_IMAGE_UPLOAD_DURATION,
+        metric_names::APP_GROUP_CREATE_MLS_PREPARE_PERSIST_DURATION,
+        metric_names::APP_GROUP_CREATE_WELCOME_PUBLISH_DURATION,
+        metric_names::APP_GROUP_CREATE_LOCAL_PROJECTION_SAVE_DURATION,
+        metric_names::APP_GROUP_CREATE_SUBSCRIPTION_REFRESH_DURATION,
+        metric_names::APP_GROUP_CREATE_POST_MUTATION_CATCH_UP_DURATION,
+        metric_names::APP_GROUP_CREATE_TOTAL_CALLER_LATENCY_DURATION,
+    ] {
+        assert!(
+            batch.points.iter().any(|point| point.name == metric_name),
+            "missing create-group telemetry export {metric_name}",
+        );
+    }
 
     let duration = batch
         .points

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -97,6 +97,7 @@ pub(crate) enum AccountWorkerCommand {
         respond: oneshot::Sender<Result<(), String>>,
     },
     CreateGroup {
+        queued_at: Instant,
         name: String,
         members: Vec<String>,
         description: Option<String>,
@@ -1122,25 +1123,29 @@ async fn handle_account_worker_command(
             let _ = respond.send(result);
         }
         AccountWorkerCommand::CreateGroup {
+            queued_at,
             name,
             members,
             description,
             initial_image,
             respond,
         } => {
-            let result = async {
-                let member_refs = members.iter().map(String::as_str).collect::<Vec<_>>();
-                let group_id = client
-                    .create_group_with_initial_image(&name, &member_refs, initial_image)
-                    .await?;
-                if description.is_some() {
-                    client
-                        .update_group_profile(&group_id, None, description.as_deref())
-                        .await?;
-                }
-                Ok(group_id)
-            }
-            .await;
+            let telemetry = shared.app_performance_telemetry();
+            telemetry.record(
+                AppPerformanceOperation::GroupCreateQueueWait,
+                queued_at.elapsed(),
+                true,
+            );
+            let member_refs = members.iter().map(String::as_str).collect::<Vec<_>>();
+            let result = client
+                .create_group_with_initial_profile_and_telemetry(
+                    &name,
+                    description.as_deref().unwrap_or_default(),
+                    &member_refs,
+                    initial_image,
+                    &telemetry,
+                )
+                .await;
             if let Ok(group_id) = &result {
                 publish_app_runtime_group_state_updated(
                     events,
@@ -1150,9 +1155,24 @@ async fn handle_account_worker_command(
                 );
             }
             publish_pending_welcome_delivery_events(events, account_id_hex, account_label, client);
-            let retry_after_response = result.is_ok();
+            let created = result.is_ok();
             let _ = respond.send(result);
-            if retry_after_response {
+            if created {
+                let subscription_started_at = Instant::now();
+                let subscription_refresh = client.sync_runtime_groups().await;
+                telemetry.record(
+                    AppPerformanceOperation::GroupCreateSubscriptionRefresh,
+                    subscription_started_at.elapsed(),
+                    subscription_refresh.is_ok(),
+                );
+                if let Err(error) = subscription_refresh {
+                    tracing::warn!(
+                        target: "marmot_app::runtime",
+                        method = "create_group_subscription_refresh",
+                        error_kind = error.privacy_safe_kind(),
+                        "confirmed group creation could not refresh subscriptions immediately"
+                    );
+                }
                 client
                     .retry_pending_push_registration_shares_best_effort()
                     .await;

--- a/crates/marmot-app/src/runtime/commands.rs
+++ b/crates/marmot-app/src/runtime/commands.rs
@@ -42,6 +42,27 @@ impl AccountManager {
         }
     }
 
+    fn schedule_create_group_post_mutation_catch_up(&self) {
+        let manager = self.clone();
+        tokio::spawn(async move {
+            let started_at = Instant::now();
+            let result = manager.catch_up_accounts().await;
+            manager.shared.app_performance_telemetry().record(
+                AppPerformanceOperation::GroupCreatePostMutationCatchUp,
+                started_at.elapsed(),
+                result.is_ok(),
+            );
+            if let Err(error) = result {
+                tracing::warn!(
+                    target: "marmot_app::runtime",
+                    method = "create_group_post_mutation_catch_up",
+                    error_kind = error.privacy_safe_kind(),
+                    "committed group creation outpaced post-mutation catch-up; state will refresh on the next cycle"
+                );
+            }
+        });
+    }
+
     /// Force one complete relay-history query for a local account and project
     /// every returned event through the ordinary runtime path.
     pub async fn repair_full_history(&self, account_ref: &str) -> Result<(), AppError> {
@@ -79,20 +100,31 @@ impl AccountManager {
         description: Option<String>,
         initial_image: Option<crate::AppInitialGroupImage>,
     ) -> Result<GroupId, AppError> {
-        let command = self.worker_commands(account_ref).await?;
-        let (respond, response) = oneshot::channel();
-        command
-            .send(AccountWorkerCommand::CreateGroup {
-                name: name.to_owned(),
-                members: members.to_vec(),
-                description,
-                initial_image,
-                respond,
-            })
-            .await
-            .map_err(|_| AppError::TransportClosed)?;
-        let group_id = account_worker_response(response).await?;
-        self.catch_up_after_committed_mutation("create_group").await;
+        let started_at = Instant::now();
+        let result = async {
+            let command = self.worker_commands(account_ref).await?;
+            let (respond, response) = oneshot::channel();
+            command
+                .send(AccountWorkerCommand::CreateGroup {
+                    queued_at: Instant::now(),
+                    name: name.to_owned(),
+                    members: members.to_vec(),
+                    description,
+                    initial_image,
+                    respond,
+                })
+                .await
+                .map_err(|_| AppError::TransportClosed)?;
+            account_worker_response(response).await
+        }
+        .await;
+        self.shared.app_performance_telemetry().record(
+            AppPerformanceOperation::GroupCreateTotalCallerLatency,
+            started_at.elapsed(),
+            result.is_ok(),
+        );
+        let group_id = result?;
+        self.schedule_create_group_post_mutation_catch_up();
         self.schedule_audit_log_tracker_update("create_group");
         Ok(group_id)
     }

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -1939,15 +1939,58 @@ async fn app_runtime_executes_group_and_message_intents_on_managed_accounts() {
     let bob_id = bob.account.account_id_hex.clone();
     let mut events = runtime.subscribe();
 
+    runtime.catch_up_accounts().await.unwrap();
+    let account_sync_attempts = || {
+        runtime
+            .shared_services()
+            .app_performance_telemetry()
+            .snapshot()
+            .account_sync
+            .attempts
+    };
+    let sync_attempts_before_create = account_sync_attempts();
+
     let group_id = runtime
         .create_group(
             &alice.account.account_id_hex,
             "runtime intents",
             std::slice::from_ref(&bob.account.account_id_hex),
-            None,
+            Some("initial description".to_owned()),
         )
         .await
         .unwrap();
+    assert_eq!(
+        account_sync_attempts(),
+        sync_attempts_before_create,
+        "create_group must return before the repairable account-wide catch-up completes",
+    );
+    let alice_group = app
+        .groups(&alice.account.label)
+        .unwrap()
+        .into_iter()
+        .find(|group| group.group_id_hex == hex::encode(group_id.as_slice()))
+        .expect("founder projection is queryable when create returns");
+    assert_eq!(alice_group.profile.description, "initial description");
+    assert_eq!(
+        runtime
+            .group_mls_state(&alice.account.account_id_hex, &group_id)
+            .await
+            .unwrap()
+            .epoch,
+        1,
+        "one invited member should require only the founding epoch transition"
+    );
+    let catch_up_deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if account_sync_attempts() > sync_attempts_before_create {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < catch_up_deadline,
+            "post-create catch-up must still complete in the background",
+        );
+        sleep(Duration::from_millis(25)).await;
+    }
     wait_for_event(&mut events, |event| {
         matches!(
             event,
@@ -1956,6 +1999,13 @@ async fn app_runtime_executes_group_and_message_intents_on_managed_accounts() {
         )
     })
     .await;
+    let bob_group = app
+        .groups(&bob.account.label)
+        .unwrap()
+        .into_iter()
+        .find(|group| group.group_id_hex == hex::encode(group_id.as_slice()))
+        .expect("joiner projected the founding Welcome");
+    assert_eq!(bob_group.profile.description, "initial description");
 
     runtime
         .send_message(


### PR DESCRIPTION
## Summary

- resolve independent member KeyPackages with bounded concurrency (maximum 8), while preserving input order and deterministic error selection
- persist every exact founding Welcome obligation before network publication, then publish Welcomes with bounded concurrency (maximum 8); failed recipients remain available through the existing pending-Welcome event/query and exact-byte retry path
- include the requested description in founding MLS state instead of publishing a second profile commit
- return the managed create call after canonical state and local projection are ready, before repairable subscription refresh, broad account catch-up, push-share retry, and audit-upload scheduling
- add privacy-safe create-group histograms for queue wait, KeyPackage lookup, optional image upload, MLS prepare/persist, Welcome publication, local projection save, subscription refresh, post-mutation catch-up, and total caller latency
- document the behavior in the compatibility-cohort `Unreleased` changelog

## Safety and lifecycle

- preserves the current-profile epoch-0/epoch-1 founding lifecycle and existing publish-before-apply behavior for legacy pending creation
- records all exact signed Welcome bytes and endpoint snapshots before the first external publish
- processes publish results in member-input order even when network completion order differs
- treats insufficient Welcome delivery as a durable per-recipient obligation rather than rolling back or creating another group
- keeps local projection persistence on the awaited path; only repairable subscription/catch-up work moves after the response
- makes no field-latency claim; the new stage telemetry provides the aggregate evidence required for field measurement

## Verification

- `just fast-ci`
- `cargo test -p marmot-account --locked` (96 passed)
- `cargo test -p marmot-app --test relay_runtime --features test-policy-overrides --locked -- --test-threads=1` (92 passed)
- focused 1/5/20-member cached/delayed KeyPackage scaling tests
- focused 1/5/20-recipient bounded Welcome publication test
- restart-before-publication and all-deliveries-fail exact-retry regressions
- founder/joiner initial-description, immediate projection, and deferred-catch-up regression
- create-group telemetry record/export regressions

Fixes #1162
