### PR TITLE
feat(hermes): send multi-image responses as one Marmot album

### DIFF
--- a/crates/agent-connector/src/connection.rs
+++ b/crates/agent-connector/src/connection.rs
@@ -453,9 +453,16 @@ impl AgentConnector {
                 group_id_hex,
                 attachments,
                 caption,
+                idempotency_key,
             } => {
-                self.send_media_response(&account_id_hex, &group_id_hex, attachments, caption)
-                    .await
+                self.send_media_response(
+                    &account_id_hex,
+                    &group_id_hex,
+                    attachments,
+                    caption,
+                    idempotency_key,
+                )
+                .await
             }
             AgentControlRequest::DownloadMedia {
                 account_id_hex,

--- a/crates/agent-connector/src/error.rs
+++ b/crates/agent-connector/src/error.rs
@@ -34,6 +34,8 @@ pub enum ConnectorError {
     SendInProgress,
     #[error("outbound media path denied: {0}")]
     MediaPathDenied(&'static str),
+    #[error("outbound media exceeds connector limits: {0}")]
+    MediaLimitsExceeded(&'static str),
     #[error("stream id is already reserved")]
     StreamIdInUse,
     #[error("stream capability denied")]
@@ -61,6 +63,7 @@ impl ConnectorError {
             Self::OperationTimedOut(_) => "operation_timed_out",
             Self::SendInProgress => "send_in_progress",
             Self::MediaPathDenied(_) => "media_path_denied",
+            Self::MediaLimitsExceeded(_) => "media_limits_exceeded",
             Self::StreamIdInUse => "stream_id_in_use",
             Self::StreamCapabilityDenied => "stream_capability_denied",
             Self::InvalidStreamBeginRequestId => "invalid_stream_begin_request_id",
@@ -82,6 +85,7 @@ impl ConnectorError {
                 "matching send is still in progress; retry with the same idempotency key"
             }
             Self::MediaPathDenied(_) => "media path is not allowed",
+            Self::MediaLimitsExceeded(_) => "outbound media exceeds connector limits",
             Self::StreamIdInUse => "stream id is already in use",
             Self::StreamCapabilityDenied => "stream capability is not authorized",
             Self::InvalidStreamBeginRequestId => "stream begin request id is invalid",

--- a/crates/agent-connector/src/lib.rs
+++ b/crates/agent-connector/src/lib.rs
@@ -92,6 +92,13 @@ pub(crate) const STREAM_SESSION_SWEEP_INTERVAL: Duration = Duration::from_secs(3
 pub(crate) const MEDIA_TEMP_MAX_AGE: Duration = Duration::from_secs(3600);
 /// How often the background sweeper scans for stale inbound media temp dirs.
 pub(crate) const MEDIA_TEMP_SWEEP_INTERVAL: Duration = Duration::from_secs(60);
+/// Maximum attachments accepted by one connector `send_media` request.
+pub(crate) const MAX_MEDIA_UPLOAD_ATTACHMENTS: usize = 10;
+/// Largest plaintext whose 16-byte AEAD tag still fits the 64 MiB encrypted
+/// Blossom blob limit enforced by `marmot-app`.
+pub(crate) const MAX_MEDIA_UPLOAD_ATTACHMENT_BYTES: u64 = 64 * 1024 * 1024 - 16;
+/// Maximum aggregate plaintext buffered by one connector `send_media` request.
+pub(crate) const MAX_MEDIA_UPLOAD_BATCH_BYTES: u64 = 128 * 1024 * 1024;
 /// Capacity of the per-subscription delivered-inbound-id cursor used to dedup storage-backed
 /// replay after broadcast lag. Comfortably larger than the runtime broadcast channel depth
 /// (1024) so every message that could be re-queried after a single overflow is still tracked.

--- a/crates/agent-connector/src/media_roots.rs
+++ b/crates/agent-connector/src/media_roots.rs
@@ -57,14 +57,32 @@ impl MediaAllowedRoots {
         })
     }
 
-    pub(crate) async fn read_regular_file(&self, path: PathBuf) -> Result<Vec<u8>, ConnectorError> {
-        let roots = self.clone();
-        tokio::task::spawn_blocking(move || roots.read_regular_file_blocking(&path))
+    #[cfg(test)]
+    async fn read_regular_file(&self, path: PathBuf) -> Result<Vec<u8>, ConnectorError> {
+        self.read_regular_file_limited(path, u64::MAX, "attachment_bytes")
             .await
-            .map_err(|_| ConnectorError::MediaPathDenied("media file read task failed"))?
     }
 
-    fn read_regular_file_blocking(&self, path: &Path) -> Result<Vec<u8>, ConnectorError> {
+    pub(crate) async fn read_regular_file_limited(
+        &self,
+        path: PathBuf,
+        max_bytes: u64,
+        limit_reason: &'static str,
+    ) -> Result<Vec<u8>, ConnectorError> {
+        let roots = self.clone();
+        tokio::task::spawn_blocking(move || {
+            roots.read_regular_file_blocking(&path, max_bytes, limit_reason)
+        })
+        .await
+        .map_err(|_| ConnectorError::MediaPathDenied("media file read task failed"))?
+    }
+
+    fn read_regular_file_blocking(
+        &self,
+        path: &Path,
+        max_bytes: u64,
+        limit_reason: &'static str,
+    ) -> Result<Vec<u8>, ConnectorError> {
         if self.roots.is_empty() || !path.is_absolute() {
             return Err(ConnectorError::MediaPathDenied(
                 "media path is outside configured roots",
@@ -81,12 +99,19 @@ impl MediaAllowedRoots {
             if relative.as_os_str().is_empty() {
                 continue;
             }
-            let Ok(mut file) = open_regular_beneath(&root.directory, relative) else {
+            let Ok(file) = open_regular_beneath(&root.directory, relative) else {
                 continue;
             };
+            if file.metadata()?.len() > max_bytes {
+                return Err(ConnectorError::MediaLimitsExceeded(limit_reason));
+            }
             let mut plaintext = Vec::new();
-            file.read_to_end(&mut plaintext)
+            file.take(max_bytes.saturating_add(1))
+                .read_to_end(&mut plaintext)
                 .map_err(|_| ConnectorError::MediaPathDenied("media file could not be read"))?;
+            if plaintext.len() as u64 > max_bytes {
+                return Err(ConnectorError::MediaLimitsExceeded(limit_reason));
+            }
             return Ok(plaintext);
         }
         Err(ConnectorError::MediaPathDenied(

--- a/crates/agent-connector/src/messaging.rs
+++ b/crates/agent-connector/src/messaging.rs
@@ -19,6 +19,8 @@ use crate::validation::normalize_hex;
 
 /// Current schema version for persisted `send_final` request fingerprints.
 pub(crate) const SEND_FINAL_FINGERPRINT_VERSION: u8 = 1;
+/// Current schema version for persisted `send_media` request fingerprints.
+pub(crate) const SEND_MEDIA_FINGERPRINT_VERSION: u8 = 1;
 
 /// Server-derived fingerprint of a `send_final` request: a versioned SHA-256 digest
 /// over the destination (account + group), message text, and optional reply target.
@@ -40,6 +42,41 @@ pub(crate) fn send_final_fingerprint(
         reply_to_message_id_hex,
     ]);
     let bytes = serde_json::to_vec(&preimage).expect("send_final fingerprint preimage cannot fail");
+    hex::encode(Sha256::digest(bytes))
+}
+
+/// Server-derived fingerprint of a media send. Local paths are deliberately
+/// excluded; retries may stage the same bytes under a different private path.
+/// Attachment order, safe metadata, caption, destination, and plaintext bytes
+/// are all bound so one key cannot return ids for a different album.
+pub(crate) fn send_media_fingerprint(
+    account_id_hex: &str,
+    group_id_hex: &str,
+    caption: Option<&str>,
+    attachments: &[MediaUploadAttachmentRequest],
+) -> String {
+    use sha2::{Digest, Sha256};
+
+    let attachments = attachments
+        .iter()
+        .map(|attachment| {
+            serde_json::json!([
+                attachment.file_name,
+                attachment.media_type,
+                hex::encode(Sha256::digest(&attachment.plaintext)),
+                attachment.dim,
+                attachment.thumbhash,
+            ])
+        })
+        .collect::<Vec<_>>();
+    let preimage = serde_json::json!([
+        SEND_MEDIA_FINGERPRINT_VERSION,
+        account_id_hex,
+        group_id_hex,
+        caption,
+        attachments,
+    ]);
+    let bytes = serde_json::to_vec(&preimage).expect("send_media fingerprint preimage cannot fail");
     hex::encode(Sha256::digest(bytes))
 }
 
@@ -417,6 +454,7 @@ impl AgentConnector {
         group_id_hex: &str,
         attachments: Vec<AgentControlMediaUpload>,
         caption: Option<String>,
+        idempotency_key: Option<String>,
     ) -> Result<AgentControlResponse, ConnectorError> {
         let account = self.local_account_for_account_id(account_id_hex)?;
         let group_id_hex = normalize_hex(group_id_hex)?;
@@ -435,6 +473,28 @@ impl AgentConnector {
                 thumbhash: attachment.thumbhash,
             });
         }
+        let fingerprint = send_media_fingerprint(
+            account_id_hex,
+            &group_id_hex,
+            caption.as_deref(),
+            &upload_attachments,
+        );
+        let idempotency = if let Some(key) = idempotency_key {
+            match self.idempotency.acquire(&key, &fingerprint).await? {
+                SendIdempotencyAcquisition::Completed((
+                    message_ids_hex,
+                    maintenance_disposition,
+                )) => {
+                    return Ok(AgentControlResponse::FinalSent {
+                        message_ids_hex,
+                        maintenance_disposition,
+                    });
+                }
+                SendIdempotencyAcquisition::Leader(reservation) => Some((key, reservation)),
+            }
+        } else {
+            None
+        };
         let result = self
             .runtime
             .upload_media(
@@ -448,15 +508,26 @@ impl AgentConnector {
                 },
             )
             .await?;
-        let sent = result.sent;
+        let Some(sent) = result.sent else {
+            return Ok(AgentControlResponse::FinalSent {
+                message_ids_hex: Vec::new(),
+                maintenance_disposition: AgentControlSendMaintenanceDisposition::default(),
+            });
+        };
+        let message_ids_hex = sent.message_ids;
+        let maintenance_disposition = agent_maintenance_disposition(sent.maintenance_disposition);
+        if let Some((key, reservation)) = idempotency {
+            self.idempotency.record_with_disposition(
+                key,
+                fingerprint,
+                message_ids_hex.clone(),
+                maintenance_disposition,
+            );
+            reservation.complete(message_ids_hex.clone(), maintenance_disposition);
+        }
         Ok(AgentControlResponse::FinalSent {
-            message_ids_hex: sent
-                .as_ref()
-                .map(|sent| sent.message_ids.clone())
-                .unwrap_or_default(),
-            maintenance_disposition: sent
-                .map(|sent| agent_maintenance_disposition(sent.maintenance_disposition))
-                .unwrap_or_default(),
+            message_ids_hex,
+            maintenance_disposition,
         })
     }
 

--- a/crates/agent-connector/src/messaging.rs
+++ b/crates/agent-connector/src/messaging.rs
@@ -11,16 +11,64 @@ use marmot_app::{
     MediaUploadAttachmentRequest, MediaUploadRequest,
 };
 
-use crate::AgentConnector;
 use crate::error::ConnectorError;
 use crate::maintenance::agent_maintenance_disposition;
+use crate::media_roots::MediaAllowedRoots;
 use crate::stream_session::SendIdempotencyAcquisition;
 use crate::validation::normalize_hex;
+use crate::{
+    AgentConnector, MAX_MEDIA_UPLOAD_ATTACHMENT_BYTES, MAX_MEDIA_UPLOAD_ATTACHMENTS,
+    MAX_MEDIA_UPLOAD_BATCH_BYTES,
+};
 
 /// Current schema version for persisted `send_final` request fingerprints.
 pub(crate) const SEND_FINAL_FINGERPRINT_VERSION: u8 = 1;
 /// Current schema version for persisted `send_media` request fingerprints.
 pub(crate) const SEND_MEDIA_FINGERPRINT_VERSION: u8 = 1;
+
+#[derive(Clone, Copy)]
+pub(crate) struct MediaUploadLimits {
+    pub(crate) max_attachments: usize,
+    pub(crate) max_attachment_bytes: u64,
+    pub(crate) max_batch_bytes: u64,
+}
+
+pub(crate) async fn read_media_upload_attachments_with_limits(
+    media_allowed_roots: &MediaAllowedRoots,
+    attachments: Vec<AgentControlMediaUpload>,
+    limits: MediaUploadLimits,
+) -> Result<Vec<MediaUploadAttachmentRequest>, ConnectorError> {
+    if attachments.len() > limits.max_attachments {
+        return Err(ConnectorError::MediaLimitsExceeded("attachment_count"));
+    }
+
+    let mut upload_attachments = Vec::with_capacity(attachments.len());
+    let mut total_bytes = 0_u64;
+    for attachment in attachments {
+        let remaining_batch_bytes = limits.max_batch_bytes.saturating_sub(total_bytes);
+        let max_read_bytes = limits.max_attachment_bytes.min(remaining_batch_bytes);
+        let limit_reason = if remaining_batch_bytes < limits.max_attachment_bytes {
+            "aggregate_bytes"
+        } else {
+            "attachment_bytes"
+        };
+        let plaintext = media_allowed_roots
+            .read_regular_file_limited(attachment.path.into(), max_read_bytes, limit_reason)
+            .await?;
+        if plaintext.is_empty() {
+            return Err(ConnectorError::MediaLimitsExceeded("empty_attachment"));
+        }
+        total_bytes += plaintext.len() as u64;
+        upload_attachments.push(MediaUploadAttachmentRequest {
+            file_name: attachment.file_name,
+            media_type: attachment.media_type,
+            plaintext,
+            dim: attachment.dim,
+            thumbhash: attachment.thumbhash,
+        });
+    }
+    Ok(upload_attachments)
+}
 
 /// Server-derived fingerprint of a `send_final` request: a versioned SHA-256 digest
 /// over the destination (account + group), message text, and optional reply target.
@@ -459,20 +507,16 @@ impl AgentConnector {
         let account = self.local_account_for_account_id(account_id_hex)?;
         let group_id_hex = normalize_hex(group_id_hex)?;
         let group_id = GroupId::new(hex::decode(&group_id_hex)?);
-        let mut upload_attachments = Vec::with_capacity(attachments.len());
-        for attachment in attachments {
-            let plaintext = self
-                .media_allowed_roots
-                .read_regular_file(attachment.path.into())
-                .await?;
-            upload_attachments.push(MediaUploadAttachmentRequest {
-                file_name: attachment.file_name,
-                media_type: attachment.media_type,
-                plaintext,
-                dim: attachment.dim,
-                thumbhash: attachment.thumbhash,
-            });
-        }
+        let upload_attachments = read_media_upload_attachments_with_limits(
+            &self.media_allowed_roots,
+            attachments,
+            MediaUploadLimits {
+                max_attachments: MAX_MEDIA_UPLOAD_ATTACHMENTS,
+                max_attachment_bytes: MAX_MEDIA_UPLOAD_ATTACHMENT_BYTES,
+                max_batch_bytes: MAX_MEDIA_UPLOAD_BATCH_BYTES,
+            },
+        )
+        .await?;
         let idempotency = if let Some(key) = idempotency_key {
             let fingerprint = send_media_fingerprint(
                 account_id_hex,

--- a/crates/agent-connector/src/messaging.rs
+++ b/crates/agent-connector/src/messaging.rs
@@ -473,13 +473,13 @@ impl AgentConnector {
                 thumbhash: attachment.thumbhash,
             });
         }
-        let fingerprint = send_media_fingerprint(
-            account_id_hex,
-            &group_id_hex,
-            caption.as_deref(),
-            &upload_attachments,
-        );
         let idempotency = if let Some(key) = idempotency_key {
+            let fingerprint = send_media_fingerprint(
+                account_id_hex,
+                &group_id_hex,
+                caption.as_deref(),
+                &upload_attachments,
+            );
             match self.idempotency.acquire(&key, &fingerprint).await? {
                 SendIdempotencyAcquisition::Completed((
                     message_ids_hex,
@@ -490,7 +490,9 @@ impl AgentConnector {
                         maintenance_disposition,
                     });
                 }
-                SendIdempotencyAcquisition::Leader(reservation) => Some((key, reservation)),
+                SendIdempotencyAcquisition::Leader(reservation) => {
+                    Some((key, fingerprint, reservation))
+                }
             }
         } else {
             None
@@ -516,7 +518,7 @@ impl AgentConnector {
         };
         let message_ids_hex = sent.message_ids;
         let maintenance_disposition = agent_maintenance_disposition(sent.maintenance_disposition);
-        if let Some((key, reservation)) = idempotency {
+        if let Some((key, fingerprint, reservation)) = idempotency {
             self.idempotency.record_with_disposition(
                 key,
                 fingerprint,

--- a/crates/agent-connector/src/tests.rs
+++ b/crates/agent-connector/src/tests.rs
@@ -4835,6 +4835,68 @@ fn send_media_fingerprint_is_content_bound() {
 }
 
 #[tokio::test]
+async fn media_upload_reader_enforces_connector_count_and_byte_limits() {
+    use crate::media_roots::MediaAllowedRoots;
+    use crate::messaging::{MediaUploadLimits, read_media_upload_attachments_with_limits};
+    use agent_control::AgentControlMediaUpload;
+
+    let root = tempfile::tempdir().unwrap();
+    let first = root.path().join("first.bin");
+    let second = root.path().join("second.bin");
+    let third = root.path().join("third.bin");
+    let oversize = root.path().join("oversize.bin");
+    std::fs::write(&first, b"1234").unwrap();
+    std::fs::write(&second, b"12").unwrap();
+    std::fs::write(&third, b"123").unwrap();
+    std::fs::write(&oversize, b"12345").unwrap();
+    let roots = MediaAllowedRoots::prepare(&[root.path().to_owned()]).unwrap();
+    let limits = MediaUploadLimits {
+        max_attachments: 2,
+        max_attachment_bytes: 4,
+        max_batch_bytes: 6,
+    };
+    let attachment = |path: &std::path::Path| AgentControlMediaUpload {
+        path: path.to_string_lossy().into_owned(),
+        media_type: "application/octet-stream".to_owned(),
+        file_name: path.file_name().unwrap().to_string_lossy().into_owned(),
+        dim: None,
+        thumbhash: None,
+    };
+
+    let accepted = read_media_upload_attachments_with_limits(
+        &roots,
+        vec![attachment(&first), attachment(&second)],
+        limits,
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        accepted
+            .iter()
+            .map(|item| item.plaintext.as_slice())
+            .collect::<Vec<_>>(),
+        vec![b"1234".as_slice(), b"12".as_slice()]
+    );
+
+    for (attachments, reason) in [
+        (
+            vec![attachment(&first), attachment(&second), attachment(&third)],
+            "attachment_count",
+        ),
+        (vec![attachment(&oversize)], "attachment_bytes"),
+        (
+            vec![attachment(&first), attachment(&third)],
+            "aggregate_bytes",
+        ),
+    ] {
+        assert!(matches!(
+            read_media_upload_attachments_with_limits(&roots, attachments, limits).await,
+            Err(crate::ConnectorError::MediaLimitsExceeded(actual)) if actual == reason
+        ));
+    }
+}
+
+#[tokio::test]
 async fn media_temp_sweeper_removes_directories_older_than_cutoff() {
     use std::time::{Duration, SystemTime};
 

--- a/crates/agent-connector/src/tests.rs
+++ b/crates/agent-connector/src/tests.rs
@@ -4781,6 +4781,38 @@ fn send_final_fingerprint_includes_reply_to_target() {
     );
 }
 
+#[test]
+fn send_media_fingerprint_is_content_bound() {
+    use crate::messaging::send_media_fingerprint;
+    use marmot_app::MediaUploadAttachmentRequest;
+
+    let attachment = |plaintext: &[u8]| MediaUploadAttachmentRequest {
+        file_name: "a.png".to_owned(),
+        media_type: "image/png".to_owned(),
+        plaintext: plaintext.to_vec(),
+        dim: None,
+        thumbhash: None,
+    };
+    let first = send_media_fingerprint("aa", "bb", Some("caption"), &[attachment(b"same bytes")]);
+    assert_eq!(
+        first,
+        send_media_fingerprint("aa", "bb", Some("caption"), &[attachment(b"same bytes")],)
+    );
+    assert_ne!(
+        first,
+        send_media_fingerprint(
+            "aa",
+            "bb",
+            Some("caption"),
+            &[attachment(b"different bytes")],
+        )
+    );
+    assert_ne!(
+        first,
+        send_media_fingerprint("aa", "bb", None, &[attachment(b"same bytes")])
+    );
+}
+
 #[tokio::test]
 async fn media_temp_sweeper_removes_directories_older_than_cutoff() {
     use std::time::{Duration, SystemTime};

--- a/crates/agent-connector/src/tests.rs
+++ b/crates/agent-connector/src/tests.rs
@@ -4811,6 +4811,27 @@ fn send_media_fingerprint_is_content_bound() {
         first,
         send_media_fingerprint("aa", "bb", None, &[attachment(b"same bytes")])
     );
+    let ordered = send_media_fingerprint(
+        "aa",
+        "bb",
+        Some("caption"),
+        &[attachment(b"one"), attachment(b"two")],
+    );
+    assert_ne!(
+        ordered,
+        send_media_fingerprint(
+            "aa",
+            "bb",
+            Some("caption"),
+            &[attachment(b"two"), attachment(b"one")],
+        ),
+        "attachment order must change the fingerprint"
+    );
+    assert_ne!(
+        first,
+        send_media_fingerprint("aa", "cc", Some("caption"), &[attachment(b"same bytes")]),
+        "destination group must change the fingerprint"
+    );
 }
 
 #[tokio::test]

--- a/crates/agent-control/src/lib.rs
+++ b/crates/agent-control/src/lib.rs
@@ -270,6 +270,10 @@ pub enum AgentControlRequest {
         group_id_hex: String,
         attachments: Vec<AgentControlMediaUpload>,
         caption: Option<String>,
+        /// Optional client-supplied dedup key. Matching retries return the
+        /// original durable message ids without re-uploading or re-publishing.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        idempotency_key: Option<String>,
     },
     /// Fetch + decrypt an inbound media reference and write the plaintext to a
     /// temp file on the connector host. The content key stays in the connector;
@@ -824,7 +828,7 @@ mod tests {
     use tokio::io::BufReader;
 
     use crate::{
-        AgentControlEnvelope, AgentControlError, AgentControlEvent,
+        AgentControlEnvelope, AgentControlError, AgentControlEvent, AgentControlMediaUpload,
         AgentControlProfileLookupStatus, AgentControlRequest, AgentControlResponse,
         AgentControlSendMaintenanceDisposition, AgentControlTimelineCursor,
         MAX_AGENT_CONTROL_FRAME_BYTES, decode_envelope, encode_frame, read_envelope, read_frame,
@@ -955,6 +959,38 @@ mod tests {
         };
         let value = serde_json::to_value(&with).unwrap();
         assert_eq!(value["idempotency_key"], "key-1");
+        let round_tripped: AgentControlRequest = serde_json::from_value(value).unwrap();
+        assert_eq!(round_tripped, with);
+    }
+
+    #[test]
+    fn send_media_idempotency_key_is_omitted_when_absent_and_present_when_set() {
+        let upload = || AgentControlMediaUpload {
+            path: "/tmp/a.png".to_owned(),
+            media_type: "image/png".to_owned(),
+            file_name: "a.png".to_owned(),
+            dim: None,
+            thumbhash: None,
+        };
+        let without = AgentControlRequest::SendMedia {
+            account_id_hex: "aa".repeat(32),
+            group_id_hex: "cc".repeat(32),
+            attachments: vec![upload()],
+            caption: Some("look".to_owned()),
+            idempotency_key: None,
+        };
+        let value = serde_json::to_value(&without).unwrap();
+        assert!(value.get("idempotency_key").is_none());
+
+        let with = AgentControlRequest::SendMedia {
+            account_id_hex: "aa".repeat(32),
+            group_id_hex: "cc".repeat(32),
+            attachments: vec![upload()],
+            caption: Some("look".to_owned()),
+            idempotency_key: Some("media-key-1".to_owned()),
+        };
+        let value = serde_json::to_value(&with).unwrap();
+        assert_eq!(value["idempotency_key"], "media-key-1");
         let round_tripped: AgentControlRequest = serde_json::from_value(value).unwrap();
         assert_eq!(round_tripped, with);
     }
@@ -1453,6 +1489,7 @@ mod tests {
                         thumbhash: None,
                     }],
                     caption: Some("look".to_owned()),
+                    idempotency_key: None,
                 },
                 "send_media",
             ),

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -13,10 +13,11 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 - Hermes Marmot delivery now batches up to 10 ordered local images into one
   encrypted-media application message instead of sending one message per image.
-  The adapter preflights every path and the bounded per-file/aggregate byte
-  limits before staging, applies the album caption once, reports every durable
-  message id and attachment outcome, and retries timed-out sends with connector-
-  persisted idempotency so a retry cannot duplicate the album.
+  The adapter pins approved source files before bounded staging, while the
+  connector independently enforces the attachment-count and byte limits. Album
+  sends apply the caption once, report every durable message id and attachment
+  outcome, wait for terminal upload completion, and retry transport failures
+  with connector-persisted idempotency so a retry cannot duplicate the album.
 
 - Account-open startup is now stage-attributed in app telemetry: engine
   session open, stored-group hydration, the shared startup profile load, and

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -11,6 +11,13 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ### Added
 
+- Hermes Marmot delivery now batches up to 10 ordered local images into one
+  encrypted-media application message instead of sending one message per image.
+  The adapter preflights every path and the bounded per-file/aggregate byte
+  limits before staging, applies the album caption once, reports every durable
+  message id and attachment outcome, and retries timed-out sends with connector-
+  persisted idempotency so a retry cannot duplicate the album.
+
 - Account-open startup is now stage-attributed in app telemetry: engine
   session open, stored-group hydration, the shared startup profile load, and
   the group-read-snapshot capture each get fixed-bucket duration metrics.

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -16,8 +16,10 @@ versioning through the workspace version in the root `Cargo.toml`.
   The adapter pins approved source files before bounded staging, while the
   connector independently enforces the attachment-count and byte limits. Album
   sends apply the caption once, report every durable message id and attachment
-  outcome, wait for terminal upload completion, and retry transport failures
-  with connector-persisted idempotency so a retry cannot duplicate the album.
+  outcome, wait up to 15 minutes for terminal upload completion, and return a
+  retryable timeout while cleaning staged files if the connector never finishes.
+  Transport retries reuse connector-persisted idempotency so they cannot
+  duplicate the album.
 
 - Account-open startup is now stage-attributed in app telemetry: engine
   session open, stored-group hydration, the shared startup profile load, and

--- a/integrations/hermes/marmot/README.md
+++ b/integrations/hermes/marmot/README.md
@@ -441,6 +441,17 @@ then stages a private copy under `MARMOT_OUTBOUND_MEDIA_DIR` (defaults to
 the connector responds. `wn-agent` must independently allow that exact staging
 directory with `--media-allowed-root`; without one, path sends fail closed.
 
+Hermes multi-image responses are sent as one ordered Marmot media message, not
+as one message per image. The adapter accepts at most 10 attachments, caps each
+plaintext to the encrypted-blob limit (64 MiB minus authentication overhead),
+and caps the full batch at 128 MiB. It validates every source before staging or
+uploading any of them, applies the first non-empty caption once, and removes all
+staged copies on success, error, timeout, or cancellation. Retryable control-
+plane failures reuse one idempotency key; `wn-agent` binds that key to the
+destination, caption, ordered attachment metadata, and plaintext hashes before
+uploading, then returns the original durable message ids on a matching retry.
+Reply-targeted media sends remain unsupported and fail before upload.
+
 ## Behavior
 
 - Inbound Marmot messages become Hermes `MessageEvent`s with `chat_id` set to

--- a/integrations/hermes/marmot/adapter.py
+++ b/integrations/hermes/marmot/adapter.py
@@ -2357,22 +2357,30 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
                     last_exc = exc
                     if attempt < len(SEND_MEDIA_RETRY_BACKOFF_S) and is_retryable(exc):
                         logger.debug(
-                            "Marmot send_media failed; retrying (attempt %d): %s",
+                            "Marmot send_media failed; retrying (attempt %d, %s)",
                             attempt + 1,
-                            exc,
+                            type(exc).__name__,
                         )
                         await asyncio.sleep(SEND_MEDIA_RETRY_BACKOFF_S[attempt])
                         continue
-                    logger.debug("Marmot send_media failed: %s", exc)
-                    return SendResult(success=False, error=str(exc), retryable=is_retryable(exc))
+                    logger.debug("Marmot send_media failed (%s)", type(exc).__name__)
+                    return SendResult(
+                        success=False,
+                        error="Marmot media send failed",
+                        retryable=is_retryable(exc),
+                    )
             return SendResult(
                 success=False,
-                error=str(last_exc) if last_exc else "Marmot media send failed",
+                error="Marmot media send failed",
                 retryable=is_retryable(last_exc) if last_exc else False,
             )
         except Exception as exc:
-            logger.debug("Marmot outbound media staging failed: %s", exc)
-            return SendResult(success=False, error=str(exc), retryable=is_retryable(exc))
+            logger.debug("Marmot outbound media staging failed (%s)", type(exc).__name__)
+            return SendResult(
+                success=False,
+                error="Marmot outbound media staging failed",
+                retryable=is_retryable(exc),
+            )
         finally:
             for staged_path in staged_paths:
                 staged_path.unlink(missing_ok=True)
@@ -3561,10 +3569,11 @@ async def _standalone_send(
                     "file_name": path.name,
                 }
             )
+        caption = str(message or "")
         result = await adapter._send_media_batch(
             str(chat_id),
             attachments,
-            caption=str(message or ""),
+            caption=caption if caption.strip() else None,
         )
         if not result.success:
             return {"error": result.error or "Marmot media send failed"}

--- a/integrations/hermes/marmot/adapter.py
+++ b/integrations/hermes/marmot/adapter.py
@@ -54,6 +54,10 @@ TOOL_EVENT_PREFIX = "\x1fMARMOT_TOOL_EVENT:"
 # the connector instead of double-posting. Mirrors OpenClaw dispatch ([100, 300]ms).
 SEND_FINAL_RETRY_BACKOFF_S = (0.1, 0.3)
 SEND_MEDIA_RETRY_BACKOFF_S = (0.1, 0.3)
+# Ten sequential uploads may each consume the connector's 60-second media
+# operation budget. Leave headroom for publication while bounding staged-file
+# and descriptor retention if the connector never reaches a terminal result.
+SEND_MEDIA_COMPLETION_TIMEOUT_S = 15 * 60.0
 STREAM_BEGIN_RETRY_BACKOFF_S = (0.1, 0.3)
 STREAM_FINALIZE_RETRY_BACKOFF_S = (0.1, 0.3)
 # Hermes albums and the native Telegram/Discord/Slack batch APIs share a
@@ -1296,6 +1300,7 @@ class MarmotAgentControlClient:
         *,
         caption: Optional[str] = None,
         idempotency_key: Optional[str] = None,
+        response_timeout: Optional[float] = None,
     ) -> Dict[str, Any]:
         payload: Dict[str, Any] = {
             "type": "send_media",
@@ -1309,10 +1314,15 @@ class MarmotAgentControlClient:
             payload["idempotency_key"] = key
         # Media upload duration is bounded by connector attachment/byte limits
         # and per-endpoint HTTP deadlines, not by the generic 30-second control
-        # timeout. Keep the response wait attached to the one durable operation
-        # instead of reporting a timeout while it can still publish. Socket
+        # timeout. Keep the response wait attached to the one durable operation,
+        # but retain a finite ceiling for a connector that never answers. Socket
         # writes remain timed; transport failures retry with the same key.
-        return await self.request(payload, response_timeout=None)
+        completion_timeout = (
+            SEND_MEDIA_COMPLETION_TIMEOUT_S
+            if response_timeout is None
+            else max(0.0, float(response_timeout))
+        )
+        return await self.request(payload, response_timeout=completion_timeout)
 
     async def download_media(
         self,
@@ -2421,14 +2431,26 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
             idempotency_key = uuid.uuid4().hex
             retry_attempt = 0
             in_progress_attempt = 0
+            completion_deadline = time.monotonic() + SEND_MEDIA_COMPLETION_TIMEOUT_S
             while True:
+                remaining = completion_deadline - time.monotonic()
+                if remaining <= 0:
+                    return SendResult(
+                        success=False,
+                        error="Marmot media send timed out",
+                        retryable=True,
+                    )
                 try:
-                    response = await self.client.send_media(
-                        account_id,
-                        normalized_chat_id,
-                        wire_attachments,
-                        caption=caption,
-                        idempotency_key=idempotency_key,
+                    response = await asyncio.wait_for(
+                        self.client.send_media(
+                            account_id,
+                            normalized_chat_id,
+                            wire_attachments,
+                            caption=caption,
+                            idempotency_key=idempotency_key,
+                            response_timeout=remaining,
+                        ),
+                        timeout=remaining,
                     )
                     message_ids = tuple(response.get("message_ids_hex") or ())
                     if response.get("type") != "final_sent" or not message_ids:
@@ -2457,6 +2479,12 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
                         raw_response=audit_response,
                         continuation_message_ids=message_ids[:-1],
                     )
+                except asyncio.TimeoutError:
+                    return SendResult(
+                        success=False,
+                        error="Marmot media send timed out",
+                        retryable=True,
+                    )
                 except Exception as exc:
                     if isinstance(exc, AgentControlError) and exc.code == "send_in_progress":
                         logger.debug(
@@ -2467,7 +2495,12 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
                             in_progress_attempt,
                             len(SEND_MEDIA_RETRY_BACKOFF_S) - 1,
                         )
-                        await asyncio.sleep(SEND_MEDIA_RETRY_BACKOFF_S[backoff_index])
+                        await asyncio.sleep(
+                            min(
+                                SEND_MEDIA_RETRY_BACKOFF_S[backoff_index],
+                                max(0.0, completion_deadline - time.monotonic()),
+                            )
+                        )
                         in_progress_attempt += 1
                         continue
                     if retry_attempt < len(SEND_MEDIA_RETRY_BACKOFF_S) and is_retryable(exc):
@@ -2476,7 +2509,12 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
                             retry_attempt + 1,
                             type(exc).__name__,
                         )
-                        await asyncio.sleep(SEND_MEDIA_RETRY_BACKOFF_S[retry_attempt])
+                        await asyncio.sleep(
+                            min(
+                                SEND_MEDIA_RETRY_BACKOFF_S[retry_attempt],
+                                max(0.0, completion_deadline - time.monotonic()),
+                            )
+                        )
                         retry_attempt += 1
                         continue
                     logger.debug("Marmot send_media failed (%s)", type(exc).__name__)

--- a/integrations/hermes/marmot/adapter.py
+++ b/integrations/hermes/marmot/adapter.py
@@ -746,49 +746,121 @@ def resolve_welcomer_allowlist(extra: Dict[str, Any]) -> list[str]:
     return _split_config_list(configured) if configured else []
 
 
-def path_is_under_root(path: Path, root: Path) -> bool:
+def open_directory_without_symlinks(path: Path) -> int:
+    directory_flags = (
+        os.O_RDONLY
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_CLOEXEC", 0)
+    )
+    directory_fd = os.open("/", directory_flags)
     try:
-        path.resolve().relative_to(root.resolve())
-        return True
-    except ValueError:
-        return False
+        for component in path.parts[1:]:
+            child_fd = os.open(component, directory_flags, dir_fd=directory_fd)
+            os.close(directory_fd)
+            directory_fd = child_fd
+        return directory_fd
+    except Exception:
+        os.close(directory_fd)
+        raise
 
 
-def assert_local_media_allowed(path: Path, allowed_roots: list[Path]) -> None:
-    resolved = path.expanduser().resolve()
+def pin_allowed_media_roots(allowed_roots: list[Path]) -> list[tuple[Path, int]]:
+    pinned: list[tuple[Path, int]] = []
+    try:
+        for root in allowed_roots:
+            resolved = root.expanduser().resolve()
+            try:
+                directory_fd = open_directory_without_symlinks(resolved)
+            except FileNotFoundError:
+                continue
+            if not stat.S_ISDIR(os.fstat(directory_fd).st_mode):
+                os.close(directory_fd)
+                raise AgentControlError("Marmot media root is not a readable directory")
+            pinned.append((resolved, directory_fd))
+        return pinned
+    except Exception:
+        for _, directory_fd in pinned:
+            os.close(directory_fd)
+        raise
+
+
+def open_outbound_media_source(
+    source: Path,
+    pinned_roots: list[tuple[Path, int]],
+) -> tuple[Path, int, os.stat_result]:
+    """Open one approved source and pin the inode used by later staging."""
+    resolved = source.expanduser().resolve()
     if not resolved.is_file():
         raise AgentControlError("Marmot media path is not a readable file")
-    if not allowed_roots:
+    approved_root = next(
+        ((root, directory_fd) for root, directory_fd in pinned_roots if resolved.is_relative_to(root)),
+        None,
+    )
+    if approved_root is None:
         raise AgentControlError("Marmot media path is outside allowed local roots")
-    if any(path_is_under_root(resolved, root) for root in allowed_roots):
-        return
-    raise AgentControlError("Marmot media path is outside allowed local roots")
+    allowed_root, root_fd = approved_root
+    relative = resolved.relative_to(allowed_root)
+    directory_flags = (
+        os.O_RDONLY
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_CLOEXEC", 0)
+    )
+    source_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+    directory_fd = os.dup(root_fd)
+    try:
+        for component in relative.parts[:-1]:
+            child_fd = os.open(component, directory_flags, dir_fd=directory_fd)
+            os.close(directory_fd)
+            directory_fd = child_fd
+        source_fd = os.open(relative.name, source_flags, dir_fd=directory_fd)
+    finally:
+        os.close(directory_fd)
+    try:
+        opened = os.fstat(source_fd)
+        if not stat.S_ISREG(opened.st_mode):
+            raise AgentControlError("Marmot media path is not a readable file")
+        return resolved, source_fd, opened
+    except Exception:
+        os.close(source_fd)
+        raise
 
 
-def stage_outbound_media_file(source: Path, staging_root: Path, *, file_name: str) -> Path:
+def stage_outbound_media_file(
+    source: Path,
+    staging_root: Path,
+    *,
+    file_name: str,
+    source_fd: int,
+    max_bytes: Optional[int] = None,
+    limit_error: str = "Marmot media file exceeds the encrypted blob size limit",
+) -> Path:
     staging_root.mkdir(mode=0o700, parents=True, exist_ok=True)
     safe_name = Path(str(file_name or source.name or "attachment")).name or "attachment"
     destination = staging_root / f"{uuid.uuid4().hex}-{safe_name}"
-    source_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
     destination_flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
-    source_fd = os.open(source, source_flags)
+    if not stat.S_ISREG(os.fstat(source_fd).st_mode):
+        raise AgentControlError("Marmot media path is not a readable file")
+    destination_fd = os.open(destination, destination_flags, 0o640)
     try:
-        if not stat.S_ISREG(os.fstat(source_fd).st_mode):
-            raise AgentControlError("Marmot media path is not a readable file")
-        destination_fd = os.open(destination, destination_flags, 0o640)
-        try:
-            os.fchmod(destination_fd, 0o640)
-            with os.fdopen(os.dup(source_fd), "rb") as source_file, os.fdopen(
-                os.dup(destination_fd), "wb"
-            ) as destination_file:
-                shutil.copyfileobj(source_file, destination_file)
-        except Exception:
-            destination.unlink(missing_ok=True)
-            raise
-        finally:
-            os.close(destination_fd)
+        os.fchmod(destination_fd, 0o640)
+        with os.fdopen(os.dup(source_fd), "rb") as source_file, os.fdopen(
+            os.dup(destination_fd), "wb"
+        ) as destination_file:
+            copied = 0
+            while chunk := source_file.read(1024 * 1024):
+                copied += len(chunk)
+                if max_bytes is not None and copied > max_bytes:
+                    raise AgentControlError(limit_error)
+                destination_file.write(chunk)
+            if copied == 0:
+                raise AgentControlError("Marmot media path is empty")
+    except Exception:
+        destination.unlink(missing_ok=True)
+        raise
     finally:
-        os.close(source_fd)
+        os.close(destination_fd)
     return destination
 
 
@@ -1065,13 +1137,17 @@ class MarmotAgentControlClient:
         *,
         request_id: Optional[str] = None,
         timeout: Optional[float] = None,
+        response_timeout: Any = _DEFAULT_READ_TIMEOUT,
     ) -> Dict[str, Any]:
         request_id = request_id or uuid.uuid4().hex
         effective_timeout = self.request_timeout if timeout is None else float(timeout)
+        effective_response_timeout = (
+            effective_timeout if response_timeout is _DEFAULT_READ_TIMEOUT else response_timeout
+        )
         reader, writer = await asyncio.open_unix_connection(self.socket_path)
         try:
             await self._write_envelope(writer, payload, request_id=request_id, timeout=effective_timeout)
-            response = await self._read_envelope(reader, timeout=effective_timeout)
+            response = await self._read_envelope(reader, timeout=effective_response_timeout)
             self._validate_response_id(response, request_id)
             self._raise_if_error(response)
             return response
@@ -1231,7 +1307,12 @@ class MarmotAgentControlClient:
         key = str(idempotency_key or "").strip()
         if key:
             payload["idempotency_key"] = key
-        return await self.request(payload)
+        # Media upload duration is bounded by connector attachment/byte limits
+        # and per-endpoint HTTP deadlines, not by the generic 30-second control
+        # timeout. Keep the response wait attached to the one durable operation
+        # instead of reporting a timeout while it can still publish. Socket
+        # writes remain timed; transport failures retry with the same key.
+        return await self.request(payload, response_timeout=None)
 
     async def download_media(
         self,
@@ -1566,9 +1647,11 @@ class MarmotAgentControlClient:
     @staticmethod
     def _raise_if_error(envelope: Dict[str, Any]) -> None:
         if envelope.get("type") == "error":
+            code = str(envelope.get("code") or "agent_control_error")
             raise AgentControlError(
                 str(envelope.get("message") or "agent control error"),
-                code=str(envelope.get("code") or "agent_control_error"),
+                code=code,
+                retryable=code == "send_in_progress",
             )
 
 
@@ -2271,40 +2354,60 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
             )
 
         validated: list[Dict[str, Any]] = []
-        total_bytes = 0
-        try:
-            for item in requested:
-                local_path = Path(str(item["path"])).expanduser()
-                assert_local_media_allowed(local_path, self._allowed_media_roots)
-                resolved = local_path.resolve()
-                size_bytes = resolved.stat().st_size
-                if size_bytes <= 0:
-                    raise AgentControlError("Marmot media path is empty")
-                if size_bytes > MAX_OUTBOUND_MEDIA_FILE_BYTES:
-                    raise AgentControlError("Marmot media file exceeds the encrypted blob size limit")
-                total_bytes += size_bytes
-                if total_bytes > MAX_OUTBOUND_MEDIA_BATCH_BYTES:
-                    raise AgentControlError("Marmot media batch exceeds the total size limit")
-                validated.append(
-                    {
-                        "source_path": resolved,
-                        "media_type": str(item.get("media_type") or "application/octet-stream"),
-                        "file_name": str(item.get("file_name") or local_path.name or "attachment"),
-                    }
-                )
-        except (AgentControlError, KeyError, OSError) as exc:
-            return SendResult(success=False, error=str(exc), retryable=False)
-
         staged_paths: list[Path] = []
+        pinned_roots: list[tuple[Path, int]] = []
         try:
+            total_preflight_bytes = 0
+            try:
+                pinned_roots = pin_allowed_media_roots(self._allowed_media_roots)
+                for item in requested:
+                    local_path = Path(str(item["path"])).expanduser()
+                    resolved, source_fd, opened = open_outbound_media_source(
+                        local_path,
+                        pinned_roots,
+                    )
+                    validated.append(
+                        {
+                            "source_path": resolved,
+                            "source_fd": source_fd,
+                            "media_type": str(item.get("media_type") or "application/octet-stream"),
+                            "file_name": str(item.get("file_name") or local_path.name or "attachment"),
+                        }
+                    )
+                    size_bytes = opened.st_size
+                    if size_bytes <= 0:
+                        raise AgentControlError("Marmot media path is empty")
+                    if size_bytes > MAX_OUTBOUND_MEDIA_FILE_BYTES:
+                        raise AgentControlError("Marmot media file exceeds the encrypted blob size limit")
+                    total_preflight_bytes += size_bytes
+                    if total_preflight_bytes > MAX_OUTBOUND_MEDIA_BATCH_BYTES:
+                        raise AgentControlError("Marmot media batch exceeds the total size limit")
+            except AgentControlError as exc:
+                return SendResult(success=False, error=str(exc), retryable=False)
+            except (KeyError, OSError) as exc:
+                logger.debug("Marmot media preflight failed (%s)", type(exc).__name__)
+                return SendResult(success=False, error="Marmot media preflight failed", retryable=False)
+
             wire_attachments: list[Dict[str, Any]] = []
+            total_staged_bytes = 0
             for item in validated:
+                remaining_batch_bytes = MAX_OUTBOUND_MEDIA_BATCH_BYTES - total_staged_bytes
+                max_copy_bytes = min(MAX_OUTBOUND_MEDIA_FILE_BYTES, remaining_batch_bytes)
+                limit_error = (
+                    "Marmot media batch exceeds the total size limit"
+                    if remaining_batch_bytes < MAX_OUTBOUND_MEDIA_FILE_BYTES
+                    else "Marmot media file exceeds the encrypted blob size limit"
+                )
                 staged_path = stage_outbound_media_file(
                     item["source_path"],
                     self._outbound_media_dir,
                     file_name=item["file_name"],
+                    source_fd=item["source_fd"],
+                    max_bytes=max_copy_bytes,
+                    limit_error=limit_error,
                 )
                 staged_paths.append(staged_path)
+                total_staged_bytes += staged_path.stat().st_size
                 wire_attachments.append(
                     {
                         "path": str(staged_path),
@@ -2316,8 +2419,9 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
             account_id = await self._ensure_account_id()
             normalized_chat_id = _normalize_hex(chat_id, "chat_id")
             idempotency_key = uuid.uuid4().hex
-            last_exc: BaseException | None = None
-            for attempt in range(len(SEND_MEDIA_RETRY_BACKOFF_S) + 1):
+            retry_attempt = 0
+            in_progress_attempt = 0
+            while True:
                 try:
                     response = await self.client.send_media(
                         account_id,
@@ -2354,14 +2458,26 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
                         continuation_message_ids=message_ids[:-1],
                     )
                 except Exception as exc:
-                    last_exc = exc
-                    if attempt < len(SEND_MEDIA_RETRY_BACKOFF_S) and is_retryable(exc):
+                    if isinstance(exc, AgentControlError) and exc.code == "send_in_progress":
                         logger.debug(
-                            "Marmot send_media failed; retrying (attempt %d, %s)",
-                            attempt + 1,
+                            "Marmot send_media remains in progress; retrying (%s)",
                             type(exc).__name__,
                         )
-                        await asyncio.sleep(SEND_MEDIA_RETRY_BACKOFF_S[attempt])
+                        backoff_index = min(
+                            in_progress_attempt,
+                            len(SEND_MEDIA_RETRY_BACKOFF_S) - 1,
+                        )
+                        await asyncio.sleep(SEND_MEDIA_RETRY_BACKOFF_S[backoff_index])
+                        in_progress_attempt += 1
+                        continue
+                    if retry_attempt < len(SEND_MEDIA_RETRY_BACKOFF_S) and is_retryable(exc):
+                        logger.debug(
+                            "Marmot send_media failed; retrying (attempt %d, %s)",
+                            retry_attempt + 1,
+                            type(exc).__name__,
+                        )
+                        await asyncio.sleep(SEND_MEDIA_RETRY_BACKOFF_S[retry_attempt])
+                        retry_attempt += 1
                         continue
                     logger.debug("Marmot send_media failed (%s)", type(exc).__name__)
                     return SendResult(
@@ -2369,11 +2485,8 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
                         error="Marmot media send failed",
                         retryable=is_retryable(exc),
                     )
-            return SendResult(
-                success=False,
-                error="Marmot media send failed",
-                retryable=is_retryable(last_exc) if last_exc else False,
-            )
+        except AgentControlError as exc:
+            return SendResult(success=False, error=str(exc), retryable=False)
         except Exception as exc:
             logger.debug("Marmot outbound media staging failed (%s)", type(exc).__name__)
             return SendResult(
@@ -2382,6 +2495,10 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
                 retryable=is_retryable(exc),
             )
         finally:
+            for item in validated:
+                os.close(item["source_fd"])
+            for _, directory_fd in pinned_roots:
+                os.close(directory_fd)
             for staged_path in staged_paths:
                 staged_path.unlink(missing_ok=True)
 

--- a/integrations/hermes/marmot/adapter.py
+++ b/integrations/hermes/marmot/adapter.py
@@ -53,8 +53,18 @@ TOOL_EVENT_PREFIX = "\x1fMARMOT_TOOL_EVENT:"
 # is reused across these attempts so a retry after a post-write timeout dedups at
 # the connector instead of double-posting. Mirrors OpenClaw dispatch ([100, 300]ms).
 SEND_FINAL_RETRY_BACKOFF_S = (0.1, 0.3)
+SEND_MEDIA_RETRY_BACKOFF_S = (0.1, 0.3)
 STREAM_BEGIN_RETRY_BACKOFF_S = (0.1, 0.3)
 STREAM_FINALIZE_RETRY_BACKOFF_S = (0.1, 0.3)
+# Hermes albums and the native Telegram/Discord/Slack batch APIs share a
+# ten-item ceiling. Keeping one Marmot album within that bound also limits the
+# encrypted blobs an all-or-error upload can orphan before publication fails.
+MAX_OUTBOUND_MEDIA_ATTACHMENTS = 10
+# Marmot receivers cap encrypted Blossom blobs at 64 MiB. ChaCha20-Poly1305 adds
+# a 16-byte tag, so cap plaintext below that wire limit. The aggregate cap keeps
+# the connector's pre-upload in-memory batch bounded as well.
+MAX_OUTBOUND_MEDIA_FILE_BYTES = 64 * 1024 * 1024 - 16
+MAX_OUTBOUND_MEDIA_BATCH_BYTES = 128 * 1024 * 1024
 DEFAULT_STREAMING_CURSOR = "\u2589"
 _DEFAULT_READ_TIMEOUT = object()
 MAX_TOOL_PROGRESS_MESSAGES = 512
@@ -1209,16 +1219,19 @@ class MarmotAgentControlClient:
         attachments: Iterable[Dict[str, Any]],
         *,
         caption: Optional[str] = None,
+        idempotency_key: Optional[str] = None,
     ) -> Dict[str, Any]:
-        return await self.request(
-            {
-                "type": "send_media",
-                "account_id_hex": _normalize_hex(account_id_hex, "account_id_hex"),
-                "group_id_hex": _normalize_hex(group_id_hex, "group_id_hex"),
-                "attachments": list(attachments),
-                "caption": str(caption) if caption is not None else None,
-            }
-        )
+        payload: Dict[str, Any] = {
+            "type": "send_media",
+            "account_id_hex": _normalize_hex(account_id_hex, "account_id_hex"),
+            "group_id_hex": _normalize_hex(group_id_hex, "group_id_hex"),
+            "attachments": list(attachments),
+            "caption": str(caption) if caption is not None else None,
+        }
+        key = str(idempotency_key or "").strip()
+        if key:
+            payload["idempotency_key"] = key
+        return await self.request(payload)
 
     async def download_media(
         self,
@@ -2234,6 +2247,136 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
             retryable=is_retryable(last_exc) if last_exc else False,
         )
 
+    async def _send_media_batch(
+        self,
+        chat_id: str,
+        attachments: Iterable[Dict[str, Any]],
+        *,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+    ) -> SendResult:
+        if reply_to:
+            return SendResult(
+                success=False,
+                error="Marmot media sends do not support reply threading yet",
+            )
+
+        requested = list(attachments)
+        if not requested:
+            return SendResult(success=False, error="Marmot media send requires at least one attachment")
+        if len(requested) > MAX_OUTBOUND_MEDIA_ATTACHMENTS:
+            return SendResult(
+                success=False,
+                error=f"Marmot media send supports at most {MAX_OUTBOUND_MEDIA_ATTACHMENTS} attachments",
+            )
+
+        validated: list[Dict[str, Any]] = []
+        total_bytes = 0
+        try:
+            for item in requested:
+                local_path = Path(str(item["path"])).expanduser()
+                assert_local_media_allowed(local_path, self._allowed_media_roots)
+                resolved = local_path.resolve()
+                size_bytes = resolved.stat().st_size
+                if size_bytes <= 0:
+                    raise AgentControlError("Marmot media path is empty")
+                if size_bytes > MAX_OUTBOUND_MEDIA_FILE_BYTES:
+                    raise AgentControlError("Marmot media file exceeds the encrypted blob size limit")
+                total_bytes += size_bytes
+                if total_bytes > MAX_OUTBOUND_MEDIA_BATCH_BYTES:
+                    raise AgentControlError("Marmot media batch exceeds the total size limit")
+                validated.append(
+                    {
+                        "source_path": resolved,
+                        "media_type": str(item.get("media_type") or "application/octet-stream"),
+                        "file_name": str(item.get("file_name") or local_path.name or "attachment"),
+                    }
+                )
+        except (AgentControlError, KeyError, OSError) as exc:
+            return SendResult(success=False, error=str(exc), retryable=False)
+
+        staged_paths: list[Path] = []
+        try:
+            wire_attachments: list[Dict[str, Any]] = []
+            for item in validated:
+                staged_path = stage_outbound_media_file(
+                    item["source_path"],
+                    self._outbound_media_dir,
+                    file_name=item["file_name"],
+                )
+                staged_paths.append(staged_path)
+                wire_attachments.append(
+                    {
+                        "path": str(staged_path),
+                        "media_type": item["media_type"],
+                        "file_name": item["file_name"],
+                    }
+                )
+
+            account_id = await self._ensure_account_id()
+            normalized_chat_id = _normalize_hex(chat_id, "chat_id")
+            idempotency_key = uuid.uuid4().hex
+            last_exc: BaseException | None = None
+            for attempt in range(len(SEND_MEDIA_RETRY_BACKOFF_S) + 1):
+                try:
+                    response = await self.client.send_media(
+                        account_id,
+                        normalized_chat_id,
+                        wire_attachments,
+                        caption=caption,
+                        idempotency_key=idempotency_key,
+                    )
+                    message_ids = tuple(response.get("message_ids_hex") or ())
+                    if response.get("type") != "final_sent" or not message_ids:
+                        raise AgentControlError(
+                            "Marmot media send returned no message ids",
+                            code="unexpected_media_send_response",
+                            retryable=True,
+                        )
+                    self._sent_targets.record_all(
+                        message_ids,
+                        account_id_hex=account_id,
+                        group_id_hex=normalized_chat_id,
+                    )
+                    audit_response = dict(response)
+                    audit_response["attachment_outcomes"] = [
+                        {
+                            "file_name": item["file_name"],
+                            "media_type": item["media_type"],
+                            "status": "sent",
+                        }
+                        for item in validated
+                    ]
+                    return SendResult(
+                        success=True,
+                        message_id=message_ids[-1],
+                        raw_response=audit_response,
+                        continuation_message_ids=message_ids[:-1],
+                    )
+                except Exception as exc:
+                    last_exc = exc
+                    if attempt < len(SEND_MEDIA_RETRY_BACKOFF_S) and is_retryable(exc):
+                        logger.debug(
+                            "Marmot send_media failed; retrying (attempt %d): %s",
+                            attempt + 1,
+                            exc,
+                        )
+                        await asyncio.sleep(SEND_MEDIA_RETRY_BACKOFF_S[attempt])
+                        continue
+                    logger.debug("Marmot send_media failed: %s", exc)
+                    return SendResult(success=False, error=str(exc), retryable=is_retryable(exc))
+            return SendResult(
+                success=False,
+                error=str(last_exc) if last_exc else "Marmot media send failed",
+                retryable=is_retryable(last_exc) if last_exc else False,
+            )
+        except Exception as exc:
+            logger.debug("Marmot outbound media staging failed: %s", exc)
+            return SendResult(success=False, error=str(exc), retryable=is_retryable(exc))
+        finally:
+            for staged_path in staged_paths:
+                staged_path.unlink(missing_ok=True)
+
     async def _send_media_upload(
         self,
         chat_id: str,
@@ -2244,63 +2387,73 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
     ) -> SendResult:
-        if reply_to:
-            return SendResult(
-                success=False,
-                error="Marmot media sends do not support reply threading yet",
+        return await self._send_media_batch(
+            chat_id,
+            [
+                {
+                    "path": path,
+                    "media_type": media_type,
+                    "file_name": file_name,
+                }
+            ],
+            caption=caption,
+            reply_to=reply_to,
+        )
+
+    async def send_multiple_images(
+        self,
+        chat_id: str,
+        images: list[tuple[str, str]],
+        metadata: Optional[Dict[str, Any]] = None,
+        human_delay: float = 0.0,
+    ) -> None:
+        if not images:
+            return
+
+        from urllib.parse import unquote, urlsplit
+
+        attachments = []
+        captions = []
+        for image_url, alt_text in images:
+            parsed = urlsplit(str(image_url))
+            if parsed.scheme != "file" or parsed.netloc not in {"", "localhost"}:
+                raise AgentControlError("Marmot multi-image sends require local file URLs")
+            local_path = Path(unquote(parsed.path)).expanduser()
+            attachments.append(
+                {
+                    "path": str(local_path),
+                    "media_type": mimetypes.guess_type(local_path.name)[0] or "image/jpeg",
+                    "file_name": local_path.name,
+                }
             )
+            if str(alt_text or "").strip():
+                captions.append(str(alt_text))
 
-        local_path = Path(str(path)).expanduser()
-        try:
-            assert_local_media_allowed(local_path, self._allowed_media_roots)
-        except AgentControlError as exc:
-            return SendResult(success=False, error=str(exc))
-
-        try:
-            staged_path = stage_outbound_media_file(
-                local_path.resolve(),
-                self._outbound_media_dir,
-                file_name=file_name,
-            )
-        except Exception as exc:
-            logger.debug("Marmot outbound media staging failed: %s", exc)
-            return SendResult(success=False, error=str(exc), retryable=False)
-
-        account_id = await self._ensure_account_id()
-        chat_id = _normalize_hex(chat_id, "chat_id")
-        try:
-            try:
-                response = await self.client.send_media(
-                    account_id,
-                    chat_id,
-                    [
-                        {
-                            "path": str(staged_path),
-                            "media_type": str(media_type or "application/octet-stream"),
-                            "file_name": str(file_name or local_path.name or "attachment"),
-                        }
-                    ],
-                    caption=caption,
+        metadata = metadata or {}
+        reply_to = next(
+            (
+                str(metadata[key])
+                for key in (
+                    "reply_to_message_id_hex",
+                    "reply_to_message_id",
+                    "reply_to",
+                    "parent_message_id_hex",
                 )
-            except Exception as exc:
-                logger.debug("Marmot send_media failed: %s", exc)
-                return SendResult(success=False, error=str(exc), retryable=is_retryable(exc))
-        finally:
-            staged_path.unlink(missing_ok=True)
-
-        message_ids = tuple(response.get("message_ids_hex") or ())
-        message_id = message_ids[-1] if message_ids else None
-        self._sent_targets.record_all(
-            message_ids,
-            account_id_hex=account_id,
-            group_id_hex=chat_id,
+                if metadata.get(key)
+            ),
+            None,
         )
-        return SendResult(
-            success=True,
-            message_id=message_id,
-            raw_response=response,
-            continuation_message_ids=message_ids[:-1],
+        result = await self._send_media_batch(
+            chat_id,
+            attachments,
+            caption=captions[0] if captions else None,
+            reply_to=reply_to,
         )
+        if not result.success:
+            raise AgentControlError(
+                result.error or "Marmot media send failed",
+                retryable=result.retryable,
+            )
 
     async def send_image_file(
         self,
@@ -3398,22 +3551,33 @@ async def _standalone_send(
 ):
     adapter = MarmotPlatformAdapter(pconfig)
     if media_files:
-        results = []
-        caption = str(message or "")
-        for index, media_path in enumerate(media_files):
+        attachments = []
+        for media_path in media_files:
             path = Path(str(media_path)).expanduser()
-            media_type = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
-            result = await adapter._send_media_upload(
-                str(chat_id),
-                path=str(path),
-                media_type=media_type,
-                file_name=path.name,
-                caption=caption if index == 0 else None,
+            attachments.append(
+                {
+                    "path": str(path),
+                    "media_type": mimetypes.guess_type(path.name)[0] or "application/octet-stream",
+                    "file_name": path.name,
+                }
             )
-            if not result.success:
-                return {"error": result.error or "Marmot media send failed"}
-            results.append(result.message_id)
-        return {"success": True, "message_id": results[-1] if results else None}
+        result = await adapter._send_media_batch(
+            str(chat_id),
+            attachments,
+            caption=str(message or ""),
+        )
+        if not result.success:
+            return {"error": result.error or "Marmot media send failed"}
+        message_ids = [*result.continuation_message_ids]
+        if result.message_id:
+            message_ids.append(result.message_id)
+        raw_response = result.raw_response if isinstance(result.raw_response, dict) else {}
+        return {
+            "success": True,
+            "message_id": result.message_id,
+            "message_ids": message_ids,
+            "attachment_outcomes": list(raw_response.get("attachment_outcomes") or ()),
+        }
     result = await adapter.send(str(chat_id), str(message or ""))
     if result.success:
         return {"success": True, "message_id": result.message_id}

--- a/integrations/hermes/marmot/tests/test_adapter.py
+++ b/integrations/hermes/marmot/tests/test_adapter.py
@@ -295,6 +295,52 @@ class AgentControlClientTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("idempotency_key", requests[1])
         self.assertNotIn("idempotency_key", requests[2])
 
+    async def test_send_media_waits_for_terminal_response_beyond_generic_timeout(self):
+        publishes = 0
+
+        async def handler(reader, writer):
+            nonlocal publishes
+            request = await read_json_line(reader)
+            self.assertEqual(request["type"], "send_media")
+            await asyncio.sleep(0.05)
+            publishes += 1
+            await write_json_line(
+                writer,
+                {
+                    "marmot_agent_control": "marmot.agent-control.v2",
+                    "id": request["id"],
+                    "type": "final_sent",
+                    "message_ids_hex": ["44" * 32],
+                },
+            )
+            writer.close()
+
+        await self.start_server(handler)
+        client = self.adapter.MarmotAgentControlClient(self.socket_path, request_timeout=0.01)
+
+        response = await client.send_media(
+            "11" * 32,
+            "22" * 32,
+            [{"path": "/tmp/a.png", "media_type": "image/png", "file_name": "a.png"}],
+            idempotency_key="media-key-1",
+        )
+
+        self.assertEqual(response["message_ids_hex"], ["44" * 32])
+        self.assertEqual(publishes, 1)
+
+    def test_send_in_progress_error_remains_retryable(self):
+        with self.assertRaises(self.adapter.AgentControlError) as raised:
+            self.adapter.MarmotAgentControlClient._raise_if_error(
+                {
+                    "type": "error",
+                    "code": "send_in_progress",
+                    "message": "matching send is still in progress",
+                }
+            )
+
+        self.assertEqual(raised.exception.code, "send_in_progress")
+        self.assertTrue(raised.exception.retryable)
+
     async def test_timeline_reads_write_exact_message_and_cursor_requests(self):
         requests = []
 
@@ -4023,7 +4069,14 @@ class ParityBehaviorTests(unittest.IsolatedAsyncioTestCase):
         seen = []
 
         class TimeoutRecordingClient(self.adapter_module.MarmotAgentControlClient):
-            async def request(self, payload, *, request_id=None, timeout=None):
+            async def request(
+                self,
+                payload,
+                *,
+                request_id=None,
+                timeout=None,
+                response_timeout=self.adapter_module._DEFAULT_READ_TIMEOUT,
+            ):
                 seen.append((payload.get("type"), timeout))
                 return {"type": "ack", "message_ids_hex": ["77" * 32], "stream_id_hex": "55" * 32, "start_message_id_hex": "66" * 32, "quic_candidates": []}
 
@@ -4417,6 +4470,33 @@ class MediaSupportTests(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(fake_client.calls, 0)
             self.assertEqual(list(adapter._outbound_media_dir.iterdir()), [])
 
+    async def test_multiple_images_preflight_oserror_redacts_local_path(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            image = root / "private.png"
+            image.write_bytes(b"private")
+            adapter = self.adapter_module.MarmotPlatformAdapter(
+                self.config_cls(
+                    extra={
+                        "account_id_hex": "11" * 32,
+                        "media_local_roots": [str(root)],
+                    }
+                ),
+                client=unittest.mock.AsyncMock(),
+            )
+            private_error = OSError(f"stat failed for {image}")
+
+            with (
+                unittest.mock.patch.object(self.adapter_module.Path, "stat", side_effect=private_error),
+                unittest.mock.patch.object(self.adapter_module.logger, "debug") as debug_log,
+                self.assertRaises(self.adapter_module.AgentControlError) as raised,
+            ):
+                await adapter.send_multiple_images("22" * 32, [(image.as_uri(), "caption")])
+
+            self.assertEqual(str(raised.exception), "Marmot media preflight failed")
+            self.assertNotIn(str(image), str(raised.exception))
+            self.assertNotIn(str(image), repr(debug_log.call_args_list))
+
     async def test_multiple_images_preserves_duplicate_paths(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
@@ -4508,6 +4588,115 @@ class MediaSupportTests(unittest.IsolatedAsyncioTestCase):
                         )
 
             self.assertEqual(len(fake_client.calls), 1)
+
+    async def test_multiple_images_pins_open_source_across_ancestor_symlink_replacement(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            allowed = base / "allowed"
+            album = allowed / "album"
+            album.mkdir(parents=True)
+            image = album / "image.png"
+            image.write_bytes(b"approved")
+            outside = base / "outside"
+            outside.mkdir()
+            (outside / "image.png").write_bytes(b"private")
+
+            class FakeClient:
+                staged_bytes = []
+
+                async def send_media(self, account, group, attachments, **kwargs):
+                    self.staged_bytes = [Path(item["path"]).read_bytes() for item in attachments]
+                    return {"type": "final_sent", "message_ids_hex": ["99" * 32]}
+
+            fake_client = FakeClient()
+            adapter = self.adapter_module.MarmotPlatformAdapter(
+                self.config_cls(
+                    extra={
+                        "account_id_hex": "11" * 32,
+                        "media_local_roots": [str(allowed)],
+                    }
+                ),
+                client=fake_client,
+            )
+            real_stage = self.adapter_module.stage_outbound_media_file
+            replaced = False
+
+            def replace_parent_then_stage(source, staging_root, **kwargs):
+                nonlocal replaced
+                if not replaced:
+                    replaced = True
+                    album.rename(allowed / "album-original")
+                    album.symlink_to(outside, target_is_directory=True)
+                return real_stage(source, staging_root, **kwargs)
+
+            with unittest.mock.patch.object(
+                self.adapter_module,
+                "stage_outbound_media_file",
+                side_effect=replace_parent_then_stage,
+            ):
+                await adapter.send_multiple_images("22" * 32, [(image.as_uri(), "caption")])
+
+            self.assertEqual(fake_client.staged_bytes, [b"approved"])
+
+    async def test_pinned_media_root_rejects_root_path_replaced_by_outside_symlink(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            allowed = base / "allowed"
+            allowed.mkdir()
+            image = allowed / "image.png"
+            image.write_bytes(b"approved")
+            outside = base / "outside"
+            outside.mkdir()
+            (outside / "image.png").write_bytes(b"private")
+            pinned_roots = self.adapter_module.pin_allowed_media_roots([allowed])
+            allowed.rename(base / "allowed-original")
+            allowed.symlink_to(outside, target_is_directory=True)
+
+            try:
+                with self.assertRaisesRegex(
+                    self.adapter_module.AgentControlError,
+                    "outside allowed local roots",
+                ):
+                    self.adapter_module.open_outbound_media_source(image, pinned_roots)
+            finally:
+                for _, directory_fd in pinned_roots:
+                    self.adapter_module.os.close(directory_fd)
+
+    async def test_multiple_images_enforces_limit_against_bytes_copied_after_growth(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            image = root / "growing.png"
+            image.write_bytes(b"1234")
+            client = unittest.mock.AsyncMock()
+            adapter = self.adapter_module.MarmotPlatformAdapter(
+                self.config_cls(
+                    extra={
+                        "account_id_hex": "11" * 32,
+                        "media_local_roots": [str(root)],
+                    }
+                ),
+                client=client,
+            )
+            real_stage = self.adapter_module.stage_outbound_media_file
+
+            def grow_then_stage(source, staging_root, **kwargs):
+                source.write_bytes(b"12345")
+                return real_stage(source, staging_root, **kwargs)
+
+            with (
+                unittest.mock.patch.object(self.adapter_module, "MAX_OUTBOUND_MEDIA_FILE_BYTES", 4),
+                unittest.mock.patch.object(self.adapter_module, "MAX_OUTBOUND_MEDIA_BATCH_BYTES", 8),
+                unittest.mock.patch.object(
+                    self.adapter_module,
+                    "stage_outbound_media_file",
+                    side_effect=grow_then_stage,
+                ),
+                self.assertRaisesRegex(self.adapter_module.AgentControlError, "blob size limit"),
+            ):
+                await adapter.send_multiple_images("22" * 32, [(image.as_uri(), "caption")])
+
+            client.send_media.assert_not_awaited()
+            self.assertEqual(list(adapter._outbound_media_dir.iterdir()), [])
 
     async def test_multiple_images_partial_upload_failure_is_all_error_and_cleans_staging(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -4633,6 +4822,51 @@ class MediaSupportTests(unittest.IsolatedAsyncioTestCase):
 
             self.assertEqual(len(fake_client.calls), 2)
             self.assertEqual(fake_client.calls[0], fake_client.calls[1])
+            self.assertEqual(list(adapter._outbound_media_dir.iterdir()), [])
+
+    async def test_multiple_images_waits_past_retry_budget_for_in_progress_send(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            image = root / "image.png"
+            image.write_bytes(b"image")
+
+            class FakeClient:
+                def __init__(self):
+                    self.idempotency_keys = []
+
+                async def send_media(self, account, group, attachments, **kwargs):
+                    self.idempotency_keys.append(kwargs["idempotency_key"])
+                    if len(self.idempotency_keys) <= 4:
+                        raise self_error(
+                            "send remains in progress",
+                            code="send_in_progress",
+                            retryable=True,
+                        )
+                    return {"type": "final_sent", "message_ids_hex": ["99" * 32]}
+
+            self_error = self.adapter_module.AgentControlError
+            fake_client = FakeClient()
+            adapter = self.adapter_module.MarmotPlatformAdapter(
+                self.config_cls(
+                    extra={
+                        "account_id_hex": "11" * 32,
+                        "media_local_roots": [str(root)],
+                    }
+                ),
+                client=fake_client,
+            )
+            with unittest.mock.patch.object(
+                self.adapter_module,
+                "SEND_MEDIA_RETRY_BACKOFF_S",
+                (0.0,),
+            ):
+                await adapter.send_multiple_images(
+                    "22" * 32,
+                    [(image.as_uri(), "caption")],
+                )
+
+            self.assertEqual(len(fake_client.idempotency_keys), 5)
+            self.assertEqual(len(set(fake_client.idempotency_keys)), 1)
             self.assertEqual(list(adapter._outbound_media_dir.iterdir()), [])
 
     async def test_multiple_images_cancellation_cleans_staged_files(self):

--- a/integrations/hermes/marmot/tests/test_adapter.py
+++ b/integrations/hermes/marmot/tests/test_adapter.py
@@ -4526,7 +4526,10 @@ class MediaSupportTests(unittest.IsolatedAsyncioTestCase):
                     self.calls += 1
                     self.staged_paths = [Path(item["path"]) for item in attachments]
                     self.asserted_bytes = [path.read_bytes() for path in self.staged_paths]
-                    raise self_error("second upload failed", retryable=False)
+                    raise self_error(
+                        f"second upload failed at {self.staged_paths[1]}",
+                        retryable=False,
+                    )
 
             self_error = self.adapter_module.AgentControlError
             fake_client = FakeClient()
@@ -4539,15 +4542,49 @@ class MediaSupportTests(unittest.IsolatedAsyncioTestCase):
                 ),
                 client=fake_client,
             )
-            with self.assertRaisesRegex(self.adapter_module.AgentControlError, "second upload failed"):
-                await adapter.send_multiple_images(
-                    "22" * 32,
-                    [(first.as_uri(), "caption"), (second.as_uri(), "")],
-                )
+            with self.assertLogs(self.adapter_module.logger, level="DEBUG") as logs:
+                with self.assertRaises(self.adapter_module.AgentControlError) as raised:
+                    await adapter.send_multiple_images(
+                        "22" * 32,
+                        [(first.as_uri(), "caption"), (second.as_uri(), "")],
+                    )
 
+            self.assertEqual(str(raised.exception), "Marmot media send failed")
+            self.assertNotIn(str(adapter._outbound_media_dir), str(raised.exception))
+            self.assertNotIn(str(adapter._outbound_media_dir), "\n".join(logs.output))
             self.assertEqual(fake_client.calls, 1)
             self.assertEqual(fake_client.asserted_bytes, [b"one", b"two"])
             self.assertTrue(all(not path.exists() for path in fake_client.staged_paths))
+
+    async def test_outbound_media_staging_failure_redacts_local_path(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            image = root / "private.png"
+            image.write_bytes(b"private")
+            adapter = self.adapter_module.MarmotPlatformAdapter(
+                self.config_cls(
+                    extra={
+                        "account_id_hex": "11" * 32,
+                        "media_local_roots": [str(root)],
+                    }
+                ),
+                client=object(),
+            )
+            staged_path = adapter._outbound_media_dir / "private-staged.png"
+
+            with (
+                unittest.mock.patch.object(
+                    self.adapter_module,
+                    "stage_outbound_media_file",
+                    side_effect=OSError(f"could not stage {staged_path}"),
+                ),
+                self.assertLogs(self.adapter_module.logger, level="DEBUG") as logs,
+            ):
+                result = await adapter.send_image_file("22" * 32, str(image))
+
+            self.assertFalse(result.success)
+            self.assertEqual(result.error, "Marmot outbound media staging failed")
+            self.assertNotIn(str(staged_path), "\n".join(logs.output))
 
     async def test_multiple_images_retry_reuses_staged_paths_and_idempotency_key(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -4681,17 +4718,25 @@ class MediaSupportTests(unittest.IsolatedAsyncioTestCase):
             response = await self.adapter_module._standalone_send(
                 object(),
                 "22" * 32,
-                "one caption",
+                " one caption ",
                 media_files=["first.png", "second.jpg"],
             )
+            blank_response = await self.adapter_module._standalone_send(
+                object(),
+                "22" * 32,
+                "   ",
+                media_files=["first.png"],
+            )
 
-        self.assertEqual(len(fake_adapter.batches), 1)
+        self.assertEqual(len(fake_adapter.batches), 2)
         batch = fake_adapter.batches[0]
         self.assertEqual(batch[0], "22" * 32)
         self.assertEqual([item["file_name"] for item in batch[1]], ["first.png", "second.jpg"])
-        self.assertEqual(batch[2], "one caption")
+        self.assertEqual(batch[2], " one caption ")
         self.assertEqual(response["message_ids"], ["88" * 32, "99" * 32])
         self.assertEqual(len(response["attachment_outcomes"]), 2)
+        self.assertIsNone(fake_adapter.batches[1][2])
+        self.assertTrue(blank_response["success"])
 
     async def test_outbound_media_outside_allowlist_is_rejected(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/integrations/hermes/marmot/tests/test_adapter.py
+++ b/integrations/hermes/marmot/tests/test_adapter.py
@@ -265,6 +265,36 @@ class AgentControlClientTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("idempotency_key", requests[1])
         self.assertNotIn("idempotency_key", requests[2])
 
+    async def test_send_media_includes_idempotency_key_only_when_supplied(self):
+        requests = []
+
+        async def handler(reader, writer):
+            request = await read_json_line(reader)
+            requests.append(request)
+            await write_json_line(
+                writer,
+                {
+                    "marmot_agent_control": "marmot.agent-control.v2",
+                    "id": request["id"],
+                    "type": "final_sent",
+                    "message_ids_hex": ["44" * 32],
+                    "maintenance_disposition": "not_required",
+                },
+            )
+            writer.close()
+
+        await self.start_server(handler)
+        client = self.adapter.MarmotAgentControlClient(self.socket_path)
+        attachment = [{"path": "/tmp/a.png", "media_type": "image/png", "file_name": "a.png"}]
+
+        await client.send_media("11" * 32, "22" * 32, attachment, idempotency_key="media-key-1")
+        await client.send_media("11" * 32, "22" * 32, attachment, idempotency_key="  ")
+        await client.send_media("11" * 32, "22" * 32, attachment)
+
+        self.assertEqual(requests[0]["idempotency_key"], "media-key-1")
+        self.assertNotIn("idempotency_key", requests[1])
+        self.assertNotIn("idempotency_key", requests[2])
+
     async def test_timeline_reads_write_exact_message_and_cursor_requests(self):
         requests = []
 
@@ -4199,19 +4229,26 @@ class MediaSupportTests(unittest.IsolatedAsyncioTestCase):
         self.adapter_module = load_adapter_module()
         self.config_cls = sys.modules["gateway.config"].PlatformConfig
 
-    async def test_inbound_media_download_populates_message_event(self):
+    async def test_inbound_media_download_populates_ordered_message_event(self):
         with tempfile.TemporaryDirectory() as tmpdir:
-            source = Path(tmpdir) / "inbound.png"
-            source.write_bytes(b"png")
+            first_source = Path(tmpdir) / "inbound.png"
+            second_source = Path(tmpdir) / "inbound.jpg"
+            first_source.write_bytes(b"png")
+            second_source.write_bytes(b"jpg")
+            sources = {
+                "inbound.png": (first_source, "image/png"),
+                "inbound.jpg": (second_source, "image/jpeg"),
+            }
 
             class FakeClient:
                 async def download_media(self, account_id_hex, group_id_hex, media):
+                    source, media_type = sources[media["file_name"]]
                     return {
                         "type": "media_downloaded",
                         "path": str(source),
-                        "media_type": "image/png",
-                        "file_name": "inbound.png",
-                        "size_bytes": 12,
+                        "media_type": media_type,
+                        "file_name": media["file_name"],
+                        "size_bytes": source.stat().st_size,
                     }
 
             adapter = self.adapter_module.MarmotPlatformAdapter(
@@ -4220,23 +4257,36 @@ class MediaSupportTests(unittest.IsolatedAsyncioTestCase):
             )
             adapter.handle_message = unittest.mock.AsyncMock()
 
+            base_media = {
+                "ciphertext_sha256": "aa",
+                "plaintext_sha256": "bb",
+                "nonce_hex": "cc",
+                "version": "1",
+                "source_epoch": 1,
+                "locators": [],
+            }
             event = {
                 "type": "inbound_message",
                 "account_id_hex": "11" * 32,
                 "group_id_hex": "22" * 32,
                 "message_id_hex": "33" * 32,
                 "sender_account_id_hex": "44" * 32,
-                "text": "photo",
+                "text": "photo album",
                 "mentions_self": True,
-                "media": [{"file_name": "inbound.png", "media_type": "image/png", "ciphertext_sha256": "aa", "plaintext_sha256": "bb", "nonce_hex": "cc", "version": "1", "source_epoch": 1, "locators": []}],
+                "media": [
+                    {**base_media, "file_name": "inbound.png", "media_type": "image/png"},
+                    {**base_media, "file_name": "inbound.jpg", "media_type": "image/jpeg"},
+                ],
             }
             await adapter._dispatch_inbound_message(event)
 
             dispatched = adapter.handle_message.await_args.args[0]
             staged_root = str(Path(tmpdir) / "dev" / "inbound-media")
-            self.assertTrue(dispatched.media_urls[0].startswith(staged_root))
-            self.assertEqual(dispatched.media_types, ["image/png"])
-            self.assertFalse(source.exists())
+            self.assertEqual(len(dispatched.media_urls), 2)
+            self.assertTrue(all(url.startswith(staged_root) for url in dispatched.media_urls))
+            self.assertEqual(dispatched.media_types, ["image/png", "image/jpeg"])
+            self.assertFalse(first_source.exists())
+            self.assertFalse(second_source.exists())
 
     async def test_outbound_send_image_file_routes_to_send_media(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -4249,9 +4299,19 @@ class MediaSupportTests(unittest.IsolatedAsyncioTestCase):
                 def __init__(self):
                     self.media_sends = []
 
-                async def send_media(self, account_id_hex, group_id_hex, attachments, *, caption=None, reply_to_message_id_hex=None):
+                async def send_media(
+                    self,
+                    account_id_hex,
+                    group_id_hex,
+                    attachments,
+                    *,
+                    caption=None,
+                    idempotency_key=None,
+                ):
                     self.assert_staged = Path(attachments[0]["path"]).read_bytes()
-                    self.media_sends.append((account_id_hex, group_id_hex, attachments, caption))
+                    self.media_sends.append(
+                        (account_id_hex, group_id_hex, attachments, caption, idempotency_key)
+                    )
                     return {"type": "final_sent", "message_ids_hex": ["99" * 32]}
 
             fake_client = FakeClient()
@@ -4270,6 +4330,368 @@ class MediaSupportTests(unittest.IsolatedAsyncioTestCase):
             self.assertFalse(staged_path.exists())
             self.assertTrue(image_path.exists())
             self.assertEqual(fake_client.media_sends[0][3], "look")
+
+    async def test_outbound_send_multiple_images_routes_one_ordered_batch_to_send_media(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            media_dir = Path(tmpdir) / "dev" / "inbound-media"
+            media_dir.mkdir(parents=True)
+            first_path = media_dir / "first.png"
+            second_path = media_dir / "second.jpg"
+            first_path.write_bytes(b"first")
+            second_path.write_bytes(b"second")
+
+            class FakeClient:
+                def __init__(self):
+                    self.media_sends = []
+                    self.staged_bytes = []
+
+                async def send_media(
+                    self,
+                    account_id_hex,
+                    group_id_hex,
+                    attachments,
+                    *,
+                    caption=None,
+                    idempotency_key=None,
+                ):
+                    self.staged_bytes = [Path(item["path"]).read_bytes() for item in attachments]
+                    self.media_sends.append(
+                        (account_id_hex, group_id_hex, attachments, caption, idempotency_key)
+                    )
+                    return {"type": "final_sent", "message_ids_hex": ["99" * 32]}
+
+            fake_client = FakeClient()
+            adapter = self.adapter_module.MarmotPlatformAdapter(
+                self.config_cls(extra={"account_id_hex": "11" * 32, "home": tmpdir}),
+                client=fake_client,
+            )
+            result = await adapter.send_multiple_images(
+                "22" * 32,
+                [(f"file://{first_path}", "album caption"), (f"file://{second_path}", "")],
+            )
+
+            self.assertIsNone(result)
+            self.assertEqual(len(fake_client.media_sends), 1)
+            sent = fake_client.media_sends[0]
+            self.assertEqual(fake_client.staged_bytes, [b"first", b"second"])
+            self.assertEqual(
+                [(item["file_name"], item["media_type"]) for item in sent[2]],
+                [("first.png", "image/png"), ("second.jpg", "image/jpeg")],
+            )
+            self.assertEqual(sent[3], "album caption")
+            self.assertTrue(sent[4])
+            self.assertTrue(all(not Path(item["path"]).exists() for item in sent[2]))
+            self.assertTrue(first_path.exists())
+            self.assertTrue(second_path.exists())
+
+    async def test_multiple_images_preflight_rejects_mixed_valid_and_invalid_paths(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            valid = root / "valid.png"
+            valid.write_bytes(b"valid")
+
+            class FakeClient:
+                def __init__(self):
+                    self.calls = 0
+
+                async def send_media(self, *args, **kwargs):
+                    self.calls += 1
+                    return {"type": "final_sent", "message_ids_hex": ["99" * 32]}
+
+            fake_client = FakeClient()
+            adapter = self.adapter_module.MarmotPlatformAdapter(
+                self.config_cls(
+                    extra={
+                        "account_id_hex": "11" * 32,
+                        "media_local_roots": [str(root)],
+                    }
+                ),
+                client=fake_client,
+            )
+            with self.assertRaisesRegex(self.adapter_module.AgentControlError, "not a readable file"):
+                await adapter.send_multiple_images(
+                    "22" * 32,
+                    [(valid.as_uri(), "caption"), ((root / "missing.png").as_uri(), "")],
+                )
+
+            self.assertEqual(fake_client.calls, 0)
+            self.assertEqual(list(adapter._outbound_media_dir.iterdir()), [])
+
+    async def test_multiple_images_preserves_duplicate_paths(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            image = root / "same.png"
+            image.write_bytes(b"same")
+
+            class FakeClient:
+                def __init__(self):
+                    self.attachments = []
+
+                async def send_media(self, account, group, attachments, **kwargs):
+                    self.attachments = attachments
+                    self.asserted_bytes = [Path(item["path"]).read_bytes() for item in attachments]
+                    return {"type": "final_sent", "message_ids_hex": ["99" * 32]}
+
+            fake_client = FakeClient()
+            adapter = self.adapter_module.MarmotPlatformAdapter(
+                self.config_cls(
+                    extra={
+                        "account_id_hex": "11" * 32,
+                        "media_local_roots": [str(root)],
+                    }
+                ),
+                client=fake_client,
+            )
+            await adapter.send_multiple_images(
+                "22" * 32,
+                [(image.as_uri(), "caption"), (image.as_uri(), "")],
+            )
+
+            self.assertEqual([item["file_name"] for item in fake_client.attachments], ["same.png", "same.png"])
+            self.assertEqual(fake_client.asserted_bytes, [b"same", b"same"])
+            self.assertNotEqual(fake_client.attachments[0]["path"], fake_client.attachments[1]["path"])
+
+    async def test_multiple_images_count_and_byte_boundaries(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            paths = []
+            for index in range(4):
+                path = root / f"{index}.png"
+                path.write_bytes(b"1234")
+                paths.append(path)
+
+            class FakeClient:
+                def __init__(self):
+                    self.calls = []
+
+                async def send_media(self, account, group, attachments, **kwargs):
+                    self.calls.append(attachments)
+                    return {"type": "final_sent", "message_ids_hex": ["99" * 32]}
+
+            fake_client = FakeClient()
+            adapter = self.adapter_module.MarmotPlatformAdapter(
+                self.config_cls(
+                    extra={
+                        "account_id_hex": "11" * 32,
+                        "media_local_roots": [str(root)],
+                    }
+                ),
+                client=fake_client,
+            )
+            with (
+                unittest.mock.patch.object(self.adapter_module, "MAX_OUTBOUND_MEDIA_ATTACHMENTS", 3),
+                unittest.mock.patch.object(self.adapter_module, "MAX_OUTBOUND_MEDIA_FILE_BYTES", 4),
+                unittest.mock.patch.object(self.adapter_module, "MAX_OUTBOUND_MEDIA_BATCH_BYTES", 12),
+            ):
+                await adapter.send_multiple_images(
+                    "22" * 32,
+                    [(path.as_uri(), "") for path in paths[:3]],
+                )
+                with self.assertRaisesRegex(self.adapter_module.AgentControlError, "at most 3"):
+                    await adapter.send_multiple_images(
+                        "22" * 32,
+                        [(path.as_uri(), "") for path in paths],
+                    )
+                oversize = root / "oversize.png"
+                oversize.write_bytes(b"12345")
+                with self.assertRaisesRegex(self.adapter_module.AgentControlError, "blob size limit"):
+                    await adapter.send_multiple_images("22" * 32, [(oversize.as_uri(), "")])
+                with unittest.mock.patch.object(
+                    self.adapter_module,
+                    "MAX_OUTBOUND_MEDIA_BATCH_BYTES",
+                    7,
+                ):
+                    with self.assertRaisesRegex(self.adapter_module.AgentControlError, "total size limit"):
+                        await adapter.send_multiple_images(
+                            "22" * 32,
+                            [(path.as_uri(), "") for path in paths[:2]],
+                        )
+
+            self.assertEqual(len(fake_client.calls), 1)
+
+    async def test_multiple_images_partial_upload_failure_is_all_error_and_cleans_staging(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            first = root / "first.png"
+            second = root / "second.jpg"
+            first.write_bytes(b"one")
+            second.write_bytes(b"two")
+
+            class FakeClient:
+                def __init__(self):
+                    self.calls = 0
+                    self.staged_paths = []
+
+                async def send_media(self, account, group, attachments, **kwargs):
+                    self.calls += 1
+                    self.staged_paths = [Path(item["path"]) for item in attachments]
+                    self.asserted_bytes = [path.read_bytes() for path in self.staged_paths]
+                    raise self_error("second upload failed", retryable=False)
+
+            self_error = self.adapter_module.AgentControlError
+            fake_client = FakeClient()
+            adapter = self.adapter_module.MarmotPlatformAdapter(
+                self.config_cls(
+                    extra={
+                        "account_id_hex": "11" * 32,
+                        "media_local_roots": [str(root)],
+                    }
+                ),
+                client=fake_client,
+            )
+            with self.assertRaisesRegex(self.adapter_module.AgentControlError, "second upload failed"):
+                await adapter.send_multiple_images(
+                    "22" * 32,
+                    [(first.as_uri(), "caption"), (second.as_uri(), "")],
+                )
+
+            self.assertEqual(fake_client.calls, 1)
+            self.assertEqual(fake_client.asserted_bytes, [b"one", b"two"])
+            self.assertTrue(all(not path.exists() for path in fake_client.staged_paths))
+
+    async def test_multiple_images_retry_reuses_staged_paths_and_idempotency_key(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            first = root / "first.png"
+            second = root / "second.png"
+            first.write_bytes(b"one")
+            second.write_bytes(b"two")
+
+            class FakeClient:
+                def __init__(self):
+                    self.calls = []
+
+                async def send_media(self, account, group, attachments, **kwargs):
+                    self.calls.append(
+                        ([item["path"] for item in attachments], kwargs["idempotency_key"])
+                    )
+                    if len(self.calls) == 1:
+                        raise self_error(
+                            "timed out",
+                            code="request_timed_out",
+                            retryable=True,
+                        )
+                    return {"type": "final_sent", "message_ids_hex": ["99" * 32]}
+
+            self_error = self.adapter_module.AgentControlError
+            fake_client = FakeClient()
+            adapter = self.adapter_module.MarmotPlatformAdapter(
+                self.config_cls(
+                    extra={
+                        "account_id_hex": "11" * 32,
+                        "media_local_roots": [str(root)],
+                    }
+                ),
+                client=fake_client,
+            )
+            with unittest.mock.patch.object(
+                self.adapter_module,
+                "SEND_MEDIA_RETRY_BACKOFF_S",
+                (0.0,),
+            ):
+                await adapter.send_multiple_images(
+                    "22" * 32,
+                    [(first.as_uri(), "caption"), (second.as_uri(), "")],
+                )
+
+            self.assertEqual(len(fake_client.calls), 2)
+            self.assertEqual(fake_client.calls[0], fake_client.calls[1])
+            self.assertEqual(list(adapter._outbound_media_dir.iterdir()), [])
+
+    async def test_multiple_images_cancellation_cleans_staged_files(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            image = root / "cancel.png"
+            image.write_bytes(b"cancel")
+            entered = asyncio.Event()
+            release = asyncio.Event()
+
+            class FakeClient:
+                async def send_media(self, account, group, attachments, **kwargs):
+                    entered.set()
+                    await release.wait()
+                    return {"type": "final_sent", "message_ids_hex": ["99" * 32]}
+
+            adapter = self.adapter_module.MarmotPlatformAdapter(
+                self.config_cls(
+                    extra={
+                        "account_id_hex": "11" * 32,
+                        "media_local_roots": [str(root)],
+                    }
+                ),
+                client=FakeClient(),
+            )
+            task = asyncio.create_task(
+                adapter.send_multiple_images("22" * 32, [(image.as_uri(), "caption")])
+            )
+            await asyncio.wait_for(entered.wait(), timeout=1.0)
+            task.cancel()
+            with self.assertRaises(asyncio.CancelledError):
+                await task
+
+            self.assertEqual(list(adapter._outbound_media_dir.iterdir()), [])
+
+    async def test_multiple_images_reply_metadata_remains_blocked(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            image = root / "reply.png"
+            image.write_bytes(b"reply")
+            adapter = self.adapter_module.MarmotPlatformAdapter(
+                self.config_cls(
+                    extra={
+                        "account_id_hex": "11" * 32,
+                        "media_local_roots": [str(root)],
+                    }
+                ),
+                client=object(),
+            )
+            with self.assertRaisesRegex(self.adapter_module.AgentControlError, "reply threading"):
+                await adapter.send_multiple_images(
+                    "22" * 32,
+                    [(image.as_uri(), "caption")],
+                    metadata={"reply_to_message_id_hex": "33" * 32},
+                )
+
+    async def test_standalone_media_files_use_one_batch_send(self):
+        class FakeAdapter:
+            def __init__(self):
+                self.batches = []
+
+            async def _send_media_batch(self, chat_id, attachments, *, caption=None, reply_to=None):
+                self.batches.append((chat_id, attachments, caption, reply_to))
+                return self_module.SendResult(
+                    success=True,
+                    message_id="99" * 32,
+                    continuation_message_ids=("88" * 32,),
+                    raw_response={
+                        "attachment_outcomes": [
+                            {"file_name": item["file_name"], "status": "sent"}
+                            for item in attachments
+                        ]
+                    },
+                )
+
+        self_module = self.adapter_module
+        fake_adapter = FakeAdapter()
+        with unittest.mock.patch.object(
+            self.adapter_module,
+            "MarmotPlatformAdapter",
+            return_value=fake_adapter,
+        ):
+            response = await self.adapter_module._standalone_send(
+                object(),
+                "22" * 32,
+                "one caption",
+                media_files=["first.png", "second.jpg"],
+            )
+
+        self.assertEqual(len(fake_adapter.batches), 1)
+        batch = fake_adapter.batches[0]
+        self.assertEqual(batch[0], "22" * 32)
+        self.assertEqual([item["file_name"] for item in batch[1]], ["first.png", "second.jpg"])
+        self.assertEqual(batch[2], "one caption")
+        self.assertEqual(response["message_ids"], ["88" * 32, "99" * 32])
+        self.assertEqual(len(response["attachment_outcomes"]), 2)
 
     async def test_outbound_media_outside_allowlist_is_rejected(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/integrations/hermes/marmot/tests/test_adapter.py
+++ b/integrations/hermes/marmot/tests/test_adapter.py
@@ -328,6 +328,33 @@ class AgentControlClientTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response["message_ids_hex"], ["44" * 32])
         self.assertEqual(publishes, 1)
 
+    async def test_send_media_times_out_when_connector_never_responds(self):
+        async def handler(reader, writer):
+            request = await read_json_line(reader)
+            self.assertEqual(request["type"], "send_media")
+            await reader.read()
+            writer.close()
+
+        await self.start_server(handler)
+        client = self.adapter.MarmotAgentControlClient(self.socket_path)
+        attachment = [{"path": "/tmp/a.png", "media_type": "image/png", "file_name": "a.png"}]
+
+        with unittest.mock.patch.object(
+            self.adapter,
+            "SEND_MEDIA_COMPLETION_TIMEOUT_S",
+            0.01,
+        ):
+            with self.assertRaises(self.adapter.AgentControlError) as raised:
+                await client.send_media(
+                    "11" * 32,
+                    "22" * 32,
+                    attachment,
+                    idempotency_key="media-key-1",
+                )
+
+        self.assertEqual(raised.exception.code, "timeout")
+        self.assertTrue(raised.exception.retryable)
+
     def test_send_in_progress_error_remains_retryable(self):
         with self.assertRaises(self.adapter.AgentControlError) as raised:
             self.adapter.MarmotAgentControlClient._raise_if_error(
@@ -4360,6 +4387,7 @@ class MediaSupportTests(unittest.IsolatedAsyncioTestCase):
                     *,
                     caption=None,
                     idempotency_key=None,
+                    response_timeout=None,
                 ):
                     self.assert_staged = Path(attachments[0]["path"]).read_bytes()
                     self.media_sends.append(
@@ -4406,6 +4434,7 @@ class MediaSupportTests(unittest.IsolatedAsyncioTestCase):
                     *,
                     caption=None,
                     idempotency_key=None,
+                    response_timeout=None,
                 ):
                     self.staged_bytes = [Path(item["path"]).read_bytes() for item in attachments]
                     self.media_sends.append(
@@ -4866,6 +4895,59 @@ class MediaSupportTests(unittest.IsolatedAsyncioTestCase):
                 )
 
             self.assertEqual(len(fake_client.idempotency_keys), 5)
+            self.assertEqual(len(set(fake_client.idempotency_keys)), 1)
+            self.assertEqual(list(adapter._outbound_media_dir.iterdir()), [])
+
+    async def test_multiple_images_times_out_when_send_stays_in_progress(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            image = root / "image.png"
+            image.write_bytes(b"image")
+
+            class FakeClient:
+                def __init__(self):
+                    self.idempotency_keys = []
+
+                async def send_media(self, account, group, attachments, **kwargs):
+                    self.idempotency_keys.append(kwargs["idempotency_key"])
+                    raise self_error(
+                        "send remains in progress",
+                        code="send_in_progress",
+                        retryable=True,
+                    )
+
+            self_error = self.adapter_module.AgentControlError
+            fake_client = FakeClient()
+            adapter = self.adapter_module.MarmotPlatformAdapter(
+                self.config_cls(
+                    extra={
+                        "account_id_hex": "11" * 32,
+                        "media_local_roots": [str(root)],
+                    }
+                ),
+                client=fake_client,
+            )
+            with (
+                unittest.mock.patch.object(
+                    self.adapter_module,
+                    "SEND_MEDIA_COMPLETION_TIMEOUT_S",
+                    0.02,
+                ),
+                unittest.mock.patch.object(
+                    self.adapter_module,
+                    "SEND_MEDIA_RETRY_BACKOFF_S",
+                    (0.005,),
+                ),
+            ):
+                result = await adapter._send_media_batch(
+                    "22" * 32,
+                    [{"path": str(image), "media_type": "image/png", "file_name": image.name}],
+                )
+
+            self.assertFalse(result.success)
+            self.assertEqual(result.error, "Marmot media send timed out")
+            self.assertTrue(result.retryable)
+            self.assertGreater(len(fake_client.idempotency_keys), 1)
             self.assertEqual(len(set(fake_client.idempotency_keys)), 1)
             self.assertEqual(list(adapter._outbound_media_dir.iterdir()), [])
 


### PR DESCRIPTION
## Summary

- override Hermes `send_multiple_images(...)` so ordered local images are preflighted, privately staged, and sent in one Marmot `SendMedia` request
- bound albums to 10 attachments, the encrypted-blob per-file limit, and a 128 MiB aggregate; clean all staged files on success, failure, timeout, or cancellation
- add persisted `SendMedia` idempotency keyed to destination, caption, ordered metadata, and plaintext hashes so timeout retries return the original durable message ids
- return safe attachment outcomes without local paths or content keys; keep reply-targeted albums fail-closed until #859

## Verification

- `python3 -m unittest discover -s integrations/hermes/marmot/tests -q` (179 passed)
- `just hermes-dev-script-test`
- `cargo test -p agent-control` (17 passed)
- `cargo test -p agent-connector` (135 unit + 1 integration passed)
- `RUSTFLAGS='-D warnings' cargo check --workspace --all-targets --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`

## Baseline note

The pre-existing `marmot-app` E2E test `encrypted_media_upload_sends_ciphertext_and_download_decrypts_plaintext` fails twice at unchanged `origin/master` (`9396adb6`) with `missing encrypted media secret for epoch 2`. This branch does not modify `marmot-app`, MLS, session, storage, or transport code. The adapter's ordered two-image inbound/outbound projection tests pass.

Fixes #1320


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Send up to 10 images as one ordered, encrypted media message.
  - Supports captions, per-attachment results, and durable message ID reporting.
  - Automatically retries timed-out media sends without creating duplicates.
- **Bug Fixes**
  - Added validation for file size, total batch size, attachment count, and unsupported reply-targeted media.
  - Improved protection against unsafe file paths and cleanup after failed or cancelled uploads.
- **Documentation**
  - Documented media batching limits, validation, retry behavior, captions, and cleanup guarantees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->