### PR TITLE
fix(openclaw): import plugin-sdk symbols that survive the beta re-cut

### DIFF
--- a/integrations/openclaw/marmot/AGENTS.md
+++ b/integrations/openclaw/marmot/AGENTS.md
@@ -41,6 +41,14 @@ The OpenClaw counterpart of `integrations/hermes/marmot`. Read `README.md` first
   `openclaw/plugin-sdk/*` subpath exports against the new version's types, and
   re-verify the deliberate test-only `dist/plugins/loader.js` import used by the
   connector E2E (the pinned SDK exposes no supported plugin-loader subpath).
+- Keep `test/plugin-sdk-surface.test.ts` in sync when adding or removing a
+  runtime (non-type) `openclaw/plugin-sdk/*` import. A named import the host SDK
+  no longer exports is an ESM link error that fails the *whole* plugin load, not
+  just the feature using it, so the channel disappears from OpenClaw entirely.
+  Prefer subpaths that carry the symbol on both the `latest` and `beta` release
+  channels; the SDK's barrels get re-cut between them (2026.7.2-beta moved
+  `getDefaultLocalRoots` out of `plugin-sdk/media-runtime` and dropped
+  `assertLocalMediaAllowed` from the public surface altogether).
 - The inbound→agent and live-preview-pipeline seams use OpenClaw gateway runtime
   internals and are validated by the deterministic connector E2E plus the docker
   phone test, not the unit tests alone.

--- a/integrations/openclaw/marmot/src/dispatch.ts
+++ b/integrations/openclaw/marmot/src/dispatch.ts
@@ -14,10 +14,7 @@ import {
   runChannelInboundEvent,
   type InboundMediaFacts,
 } from "openclaw/plugin-sdk/channel-inbound";
-import {
-  deliverInboundReplyWithMessageSendContext,
-  type DurableInboundReplyDeliveryResult,
-} from "openclaw/plugin-sdk/channel-outbound";
+import { deliverInboundReplyWithMessageSendContext } from "openclaw/plugin-sdk/channel-outbound";
 import { saveMediaBuffer } from "openclaw/plugin-sdk/media-store";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-payload";
 
@@ -101,6 +98,16 @@ export interface MarmotDispatchDeps {
   /** Override OpenClaw durable delivery in focused tests. */
   deliverInboundReply?: typeof deliverInboundReplyWithMessageSendContext;
 }
+
+/**
+ * Derived from the delivery function rather than imported by name: the
+ * `DurableInboundReplyDeliveryResult` alias is not re-exported from
+ * `plugin-sdk/channel-outbound` on the beta channel, but the function's return
+ * type is identical on both.
+ */
+type DurableInboundReplyDeliveryResult = Awaited<
+  ReturnType<typeof deliverInboundReplyWithMessageSendContext>
+>;
 
 function assertDurableReplyHandled(result: DurableInboundReplyDeliveryResult): void {
   if (result.status === "handled_visible" || result.status === "handled_no_send") {

--- a/integrations/openclaw/marmot/src/outbound.ts
+++ b/integrations/openclaw/marmot/src/outbound.ts
@@ -8,7 +8,7 @@
 // contract tests.
 
 import { randomUUID } from "node:crypto";
-import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, extname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -20,10 +20,12 @@ import {
   type MessageReceipt,
   type MessageReceiptPart,
 } from "openclaw/plugin-sdk/channel-outbound";
-import {
-  assertLocalMediaAllowed,
-  getDefaultLocalRoots,
-} from "openclaw/plugin-sdk/media-runtime";
+// `readLocalFileFromRoots` (allowlist check + hardened read) and the local media
+// access types are imported from the subpaths that export them on both the
+// `latest` and `beta` OpenClaw channels. The `plugin-sdk/media-runtime` barrel
+// dropped `assertLocalMediaAllowed`/`getDefaultLocalRoots` in 2026.7.2-beta.
+import { readLocalFileFromRoots } from "openclaw/plugin-sdk/infra-runtime";
+import { getDefaultLocalRoots, LocalMediaAccessError } from "openclaw/plugin-sdk/web-media";
 
 import type { AgentControlMediaUpload, MarmotAgentControlClient } from "./client.js";
 
@@ -193,8 +195,8 @@ function resolveAllowedMediaRoots(ctx: ChannelMessageSendMediaContext): readonly
  * Resolve `ctx.mediaUrl` to a local `AgentControlMediaUpload` the connector can
  * read by path. Handles two cases the ctx can express with the real SDK types:
  *
- * 1. A local filesystem path or `file://` URL — validated against the send's
- *    allowlisted media roots (`assertLocalMediaAllowed`), then copied to the
+ * 1. A local filesystem path or `file://` URL — read only through the send's
+ *    allowlisted media roots (`readLocalFileFromRoots`), then copied to the
  *    connector-shared staging root. Without the source guard
  *    an agent-influenced `mediaUrl` (e.g. `~/.ssh/id_rsa`) would let a prompt-
  *    injected agent exfiltrate any connector-host file into a group. This
@@ -207,8 +209,8 @@ function resolveAllowedMediaRoots(ctx: ChannelMessageSendMediaContext): readonly
  * the connector reads a path it cannot be given in that case (see Seam 2 note).
  *
  * Throws `LocalMediaAccessError` (from the SDK) when a local path escapes the
- * allowlist; the caller surfaces that as a failed send rather than reading the
- * file.
+ * allowlist; the caller surfaces that as a failed send. The file is never read
+ * in that case — the allowlist check and the read are the same operation.
  */
 async function resolveOutboundMediaUpload(
   ctx: ChannelMessageSendMediaContext,
@@ -217,12 +219,23 @@ async function resolveOutboundMediaUpload(
   const { mediaUrl } = ctx;
   if (isLocalMediaUrl(mediaUrl)) {
     const localPath = mediaUrl.startsWith("file://") ? fileURLToPath(mediaUrl) : mediaUrl;
-    // Defense against exfiltration via a tool/prompt-influenced path: the
-    // Keep OpenClaw's source policy as the first layer; wn-agent independently
-    // confines the staged path it ultimately reads. Throws on violation.
-    await assertLocalMediaAllowed(localPath, resolveAllowedMediaRoots(ctx));
+    // Defense against exfiltration via a tool/prompt-influenced path: the read
+    // itself is confined to the allowlisted roots, so a path outside them is
+    // never opened. Keep OpenClaw's source policy as the first layer; wn-agent
+    // independently confines the staged path it ultimately reads.
+    const read = await readLocalFileFromRoots({
+      filePath: localPath,
+      roots: resolveAllowedMediaRoots(ctx),
+      label: "outbound media roots",
+    });
+    if (!read) {
+      throw new LocalMediaAccessError(
+        "path-not-allowed",
+        "marmot: outbound media path is outside the allowed local media roots",
+      );
+    }
     const fileName = basename(localPath) || "attachment";
-    const path = await writeTempMedia(fileName, await readFile(localPath));
+    const path = await writeTempMedia(fileName, read.buffer);
     return {
       upload: { path, media_type: mimeFromExtension(fileName), file_name: fileName },
       cleanup: () => rm(path, { force: true }),

--- a/integrations/openclaw/marmot/src/outbound.ts
+++ b/integrations/openclaw/marmot/src/outbound.ts
@@ -208,9 +208,11 @@ function resolveAllowedMediaRoots(ctx: ChannelMessageSendMediaContext): readonly
  * Returns `null` when the ctx provides only a remote URL and no buffer accessor;
  * the connector reads a path it cannot be given in that case (see Seam 2 note).
  *
- * Throws `LocalMediaAccessError` (from the SDK) when a local path escapes the
- * allowlist; the caller surfaces that as a failed send. The file is never read
- * in that case — the allowlist check and the read are the same operation.
+ * Throws `LocalMediaAccessError` (from the SDK) when a local path cannot be read
+ * from the allowlisted roots; the caller surfaces that as a failed send. A path
+ * outside the roots is never opened — the allowlist check and the read are the
+ * same operation — but the error does not distinguish that from an in-root read
+ * failure, so treat it as "refused", not specifically "escaped the allowlist".
  */
 async function resolveOutboundMediaUpload(
   ctx: ChannelMessageSendMediaContext,
@@ -228,10 +230,15 @@ async function resolveOutboundMediaUpload(
       roots: resolveAllowedMediaRoots(ctx),
       label: "outbound media roots",
     });
+    // `readLocalFileFromRoots` collapses every failure to `null`: an allowlist
+    // miss, but also a missing file, an IO error, or a symlink/hardlink policy
+    // rejection *under* an allowed root. Fail closed on all of them, but do not
+    // claim which one it was — a missing in-root attachment should not read as
+    // an exfiltration attempt in the logs.
     if (!read) {
       throw new LocalMediaAccessError(
         "path-not-allowed",
-        "marmot: outbound media path is outside the allowed local media roots",
+        "marmot: outbound media is not readable from the allowed local media roots",
       );
     }
     const fileName = basename(localPath) || "attachment";

--- a/integrations/openclaw/marmot/test/outbound.test.ts
+++ b/integrations/openclaw/marmot/test/outbound.test.ts
@@ -347,6 +347,36 @@ describe("createMarmotMessageAdapter", () => {
     }
   });
 
+  it("fails closed when an in-root media path does not exist", async () => {
+    // `readLocalFileFromRoots` returns null for an allowlist miss *and* for a
+    // read failure under an allowed root. Both must fail the send rather than
+    // reaching wn-agent, and the message must not claim the path escaped the
+    // allowlist when it did not.
+    const tmpRoot = await mkdtemp(join(tmpdir(), "marmot-outbound-test-"));
+    try {
+      const calls = emptyClientCalls();
+      const adapter = createMarmotMessageAdapter({
+        resolveTarget: () => ({ client: stubClient(calls), marmotAccountIdHex: HEX32("aa") }),
+        outboundMediaDir: join(tmpRoot, "staging"),
+      });
+      const ctx = {
+        cfg: {},
+        to: HEX32("cc"),
+        text: "missing",
+        mediaUrl: join(tmpRoot, "absent.png"),
+        mediaLocalRoots: [tmpRoot],
+      } as unknown as ChannelMessageSendMediaContext;
+
+      await expect(adapter.send!.media!(ctx)).rejects.toMatchObject({
+        name: "LocalMediaAccessError",
+      });
+      await expect(adapter.send!.media!(ctx)).rejects.toThrow(/not readable/);
+      expect(calls.sendMedia).toHaveLength(0);
+    } finally {
+      await rm(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
   it("honors ctx.mediaAccess.localRoots when mediaLocalRoots is absent", async () => {
     const tmpRoot = await mkdtemp(join(tmpdir(), "marmot-outbound-test-"));
     try {

--- a/integrations/openclaw/marmot/test/plugin-sdk-surface.test.ts
+++ b/integrations/openclaw/marmot/test/plugin-sdk-surface.test.ts
@@ -1,0 +1,46 @@
+// Canary for the `openclaw/plugin-sdk/*` subpath exports this plugin links
+// against at runtime.
+//
+// A named import that the installed SDK no longer exports is an ESM link error,
+// so the whole plugin fails to initialize and OpenClaw loses the Marmot channel
+// entirely — not just the feature that used the symbol. That is exactly what
+// happened when 2026.7.2-beta re-cut `plugin-sdk/media-runtime` and dropped
+// `assertLocalMediaAllowed` / `getDefaultLocalRoots` from it.
+//
+// Failing here on an SDK pin bump is much cheaper than failing at gateway
+// startup on a user's machine. Each entry below must name a subpath and the
+// runtime *values* (not types — those are erased) that our `src/` imports from
+// it; type-only regressions are caught by `pnpm typecheck`.
+
+import { describe, expect, it } from "vitest";
+
+const RUNTIME_IMPORTS: ReadonlyArray<readonly [string, readonly string[]]> = [
+  ["openclaw/plugin-sdk/channel-config-schema", ["buildJsonChannelConfigSchema"]],
+  ["openclaw/plugin-sdk/channel-core", ["defineChannelPluginEntry", "defineSetupPluginEntry"]],
+  ["openclaw/plugin-sdk/channel-inbound", ["buildChannelInboundEventContext", "runChannelInboundEvent"]],
+  ["openclaw/plugin-sdk/channel-inbound-debounce", ["createInboundDebouncer"]],
+  ["openclaw/plugin-sdk/channel-lifecycle", ["createAccountStatusSink", "runPassiveAccountLifecycle"]],
+  [
+    "openclaw/plugin-sdk/channel-outbound",
+    ["defineChannelMessageAdapter", "deliverInboundReplyWithMessageSendContext"],
+  ],
+  ["openclaw/plugin-sdk/core", ["createChatChannelPlugin", "jsonResult"]],
+  ["openclaw/plugin-sdk/infra-runtime", ["readLocalFileFromRoots"]],
+  ["openclaw/plugin-sdk/keyed-async-queue", ["KeyedAsyncQueue"]],
+  ["openclaw/plugin-sdk/media-store", ["saveMediaBuffer"]],
+  [
+    "openclaw/plugin-sdk/status-helpers",
+    ["buildBaseChannelStatusSummary", "collectStatusIssuesFromLastError"],
+  ],
+  ["openclaw/plugin-sdk/web-media", ["LocalMediaAccessError", "getDefaultLocalRoots"]],
+];
+
+describe("OpenClaw plugin-sdk runtime surface", () => {
+  for (const [subpath, symbols] of RUNTIME_IMPORTS) {
+    it(`${subpath} exports the symbols the plugin imports`, async () => {
+      const mod = (await import(subpath)) as Record<string, unknown>;
+      const missing = symbols.filter((symbol) => mod[symbol] === undefined);
+      expect(missing).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
## Problem

The Marmot plugin fails to load entirely on `openclaw@2026.7.2-beta.7` (the `beta` channel):

```
[plugins] marmot failed to load from ~/.openclaw/extensions/marmot/dist/index.js:
SyntaxError: The requested module 'openclaw/plugin-sdk/media-runtime'
does not provide an export named 'assertLocalMediaAllowed'
[plugins] 1 plugin(s) failed to initialize (load: marmot).
```

The beta re-cut the `plugin-sdk/media-runtime` barrel. Diffing the published `latest` (`2026.7.1-2`) and `beta` tarballs:

| Symbol | `latest` | `beta` |
| --- | --- | --- |
| `getDefaultLocalRoots` | `plugin-sdk/media-runtime` | moved to `plugin-sdk/web-media` |
| `assertLocalMediaAllowed` | `plugin-sdk/media-runtime` | **dropped from the public plugin-sdk surface** (still exists internally in `dist/local-media-access-*.js`) |

A named import the host SDK no longer exports is an ESM link error, so the **whole plugin** fails to initialize and the Marmot channel disappears from OpenClaw — not just the media send path that used the symbol.

## Fix

Import from subpaths that carry the symbols on **both** channels, verified against both published tarballs:

- `getDefaultLocalRoots` + `LocalMediaAccessError` from `plugin-sdk/web-media`.
- `readLocalFileFromRoots` from `plugin-sdk/infra-runtime`, replacing the `assertLocalMediaAllowed` + `readFile` pair.

`infra-runtime` was chosen over the more obvious `plugin-sdk/file-access-runtime` deliberately: beta ships that entry with **no `.d.ts`**, so importing from it would break `pnpm typecheck` the moment the pin moves. `infra-runtime` carries both the symbol and its types on `latest` and `beta`.

Folding the guard and the read into one call is also a small hardening win. The old shape was check-then-read — `assertLocalMediaAllowed(path)` then `readFile(path)`, two separate resolutions of the same path. `readLocalFileFromRoots` makes the allowlist check and the open a single operation against a scoped root handle with symlink/hardlink policy applied, closing the TOCTOU window between guard and open. It returns `null` rather than throwing, so the caller raises `LocalMediaAccessError` to preserve the existing failed-send behavior; the tests asserting on that error name pass unchanged.

Also drops the `DurableInboundReplyDeliveryResult` type import, which beta no longer re-exports from `plugin-sdk/channel-outbound`. Deriving it from the delivery function's return type is identical on both channels and cannot drift again. Type-only, so it did not contribute to the load failure — but it would have broken `pnpm typecheck` on a pin bump.

## Regression guard

`test/plugin-sdk-surface.test.ts` asserts every runtime-valued `plugin-sdk/*` import the plugin makes still resolves. The list was extracted mechanically from `src/` rather than by hand. Run against the beta build it reports `['assertLocalMediaAllowed', 'getDefaultLocalRoots']` missing, so it would have caught this before shipping.

This is a canary, not a cure — it only tests whatever version is installed, and the pin is still `latest`. The real fix for the class of bug is a non-blocking CI job that typechecks against `openclaw@beta`; filed as follow-up rather than bundled here.

## Verification

- `just fast-ci` — pass
- `just openclaw-dev-test` (typecheck + 217 tests) — pass
- `just openclaw-dev-script-test` — pass
- CI's `openclaw-plugin` job reproduced locally (`pnpm install --frozen-lockfile` → `typecheck` → `test` → `build`) — pass
- Installed the real `openclaw@2026.7.2-beta.7` in a scratch project and confirmed all four moved symbols resolve at runtime
- Re-ran the full import audit against both tarballs — zero unresolved imports on `latest` **and** `beta`

`just openclaw-dev-e2e-connector` **fails locally**, with `wn-agent: startup failed code=io_error io_kind=PermissionDenied` on its `/tmp/omce-*` control socket. I stashed every change and re-ran it on a clean tree: identical failure. It is a sandbox limitation upstream of anything TypeScript — the plugin never connects — not a regression from this change. It does mean the media send path is covered here by unit tests rather than end-to-end.

Two caveats on the beta verification: this machine runs Node 24.5.0 and beta requires ≥24.15.0, so beta was installed with `--ignore-scripts` (skips a version-warning preinstall script only; module resolution is unaffected), and the plugin was not exercised end-to-end under beta.

## Not fixed here

A separate `Session "agent:main:main" changed while starting work. Retry.` was reported on the same beta instance. That is `CronSessionLifecycleClaimError` from OpenClaw core's `src/cron/isolated-agent/run-session-state.ts` — an optimistic-concurrency guard on the cron path, reachable only from `server-cron`. Unrelated to this change and not addressed by it.

Note this fix is source-only: an affected instance needs a rebuild, reinstall, and Gateway restart before the load error clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of outbound local media, including clearer access-denied errors and safer validation within configured locations.
  * Improved compatibility across supported OpenClaw SDK versions.
* **Reliability**
  * Added checks to detect missing SDK capabilities earlier, helping prevent integration startup or runtime failures.
  * Durable inbound reply delivery behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->