### PR TITLE
Add an explicit storage close so hosts can suspend without a lock kill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,8 @@ The canonical protocol specification lives in
   account ids, group ids, message ids, relay URLs, pubkeys, payloads, ciphertext, plaintext, or key material. See
   `docs/marmot-architecture/overview/observability.md`.
 - Create local files, sockets, and databases restrictive-by-construction via `crates/fs-private` (or equivalent
-  posture with an on-disk mode test); see `docs/marmot-architecture/overview/local-artifact-safety.md`.
+  posture with an on-disk mode test), and release their file locks explicitly before a host suspends
+  (`MarmotAppRuntime::shutdown_and_close`); see `docs/marmot-architecture/overview/local-artifact-safety.md`.
 - Route every outbound connection through the host-safety dial discipline: validate each resolved address with
   `cgka_traits::app_components::reject_non_public_ip`, pin the validated address, choose TLS trust from config (never a
   resolved IP), apply a connect timeout, and gate loopback behind an explicit dev flag. See

--- a/crates/marmot-app/AGENTS.md
+++ b/crates/marmot-app/AGENTS.md
@@ -71,6 +71,11 @@ App runtime bridge for the first real Marmot app surfaces.
   `src/runtime/agent_stream_watch.rs`, before any connect; both follow the one dial discipline in
   `docs/marmot-architecture/overview/dial-safety.md` (validate + pin, trust from config, loopback only under an explicit
   dev flag). Do not add an outbound relay/broker path that bypasses them.
+- Keep `MarmotAppRuntime::shutdown_and_close` the one sequenced teardown for hosts whose process can be suspended: it
+  drains workers, then closes every SQLite database and releases the root runtime lease. `shutdown` alone does not
+  release file locks. Closing is terminal — do not add a path that transparently reopens a database afterwards, and
+  put shutdown checks at engine-step boundaries (never inside a step, where a snapshot guard may be live). See
+  `docs/marmot-architecture/overview/local-artifact-safety.md`.
 - Keep local test relay code in tests; production app runtime should talk to Nostr relay URLs through the adapter.
 - Do not print or log account ids, group ids, relay URLs, message ids, pubkeys, payloads, ciphertext, plaintext, or key
   material.

--- a/crates/marmot-app/src/directory/cache.rs
+++ b/crates/marmot-app/src/directory/cache.rs
@@ -1,14 +1,16 @@
 use std::fs;
 use std::path::PathBuf;
+use std::sync::Arc;
 #[cfg(test)]
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
-use storage_sqlite::{SqlCipherHardening, SqlCipherKey, open_hardened_sqlcipher};
+use storage_sqlite::{
+    CloseableConnection, ConnectionGuard, SqlCipherHardening, SqlCipherKey, open_hardened_sqlcipher,
+};
 
 use crate::{AccountRelayListStatus, AppError, UserDirectoryRecord, UserProfileMetadata};
 
@@ -24,9 +26,12 @@ use crate::{AccountRelayListStatus, AppError, UserDirectoryRecord, UserProfileMe
 /// profile; the alternative risks hiding accounts that do.
 pub(crate) const SEARCH_GRAPH_PROFILE_TTL_SECONDS: i64 = 24 * 60 * 60;
 
-#[derive(Clone)]
+/// Message carried by every storage error this cache raises after a close.
+const CLOSED_DETAIL: &str = "directory cache is closed";
+
+#[derive(Clone, Debug)]
 pub(crate) struct DirectoryCache {
-    conn: Arc<Mutex<Connection>>,
+    conn: Arc<CloseableConnection>,
     #[cfg(test)]
     put_count: Arc<AtomicUsize>,
 }
@@ -65,7 +70,7 @@ impl DirectoryCache {
     fn from_connection(conn: Connection) -> Result<Self, AppError> {
         initialize_schema(&conn)?;
         let cache = Self {
-            conn: Arc::new(Mutex::new(conn)),
+            conn: Arc::new(CloseableConnection::new(conn, CLOSED_DETAIL)),
             #[cfg(test)]
             put_count: Arc::new(AtomicUsize::new(0)),
         };
@@ -83,17 +88,22 @@ impl DirectoryCache {
         self.put_count.store(0, Ordering::SeqCst);
     }
 
-    fn lock(&self) -> MutexGuard<'_, Connection> {
-        self.conn
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    /// Close this cache's database, releasing its file handle and any locks.
+    /// Terminal and idempotent: later reads and writes fail with a closed
+    /// storage error and nothing reopens.
+    pub(crate) fn close(&self) -> Result<(), AppError> {
+        Ok(self.conn.close()?)
+    }
+
+    fn lock(&self) -> Result<ConnectionGuard<'_>, AppError> {
+        Ok(self.conn.lock()?)
     }
 
     pub(crate) fn entry(
         &self,
         account_id_hex: &str,
     ) -> Result<Option<UserDirectoryRecord>, AppError> {
-        let conn = self.lock();
+        let conn = self.lock()?;
         let Some(row) = Self::directory_user_row(&conn, account_id_hex)? else {
             return Ok(None);
         };
@@ -101,7 +111,7 @@ impl DirectoryCache {
     }
 
     pub(crate) fn entries(&self) -> Result<Vec<UserDirectoryRecord>, AppError> {
-        let conn = self.lock();
+        let conn = self.lock()?;
         let mut statement = conn.prepare(
             "SELECT account_id_hex, npub, local_account_json, profile_json,
                     relay_lists_json, key_package_json
@@ -145,7 +155,7 @@ impl DirectoryCache {
     ) -> Result<(), AppError> {
         #[cfg(test)]
         self.put_count.fetch_add(1, Ordering::SeqCst);
-        let mut conn = self.lock();
+        let mut conn = self.lock()?;
         let tx = conn.transaction()?;
         Self::put_with_reason_locked(&tx, entry, reason)?;
         tx.commit()?;
@@ -250,7 +260,7 @@ impl DirectoryCache {
         account_id_hex: &str,
         now: i64,
     ) -> Result<Option<UserDirectoryRecord>, AppError> {
-        let conn = self.lock();
+        let conn = self.lock()?;
         let Some(row) = conn
             .query_row(
                 "SELECT account_id_hex, npub, profile_json, follows_known, metadata_expires_at
@@ -329,7 +339,7 @@ impl DirectoryCache {
         &self,
         account_id_hex: &str,
     ) -> Result<Option<Vec<String>>, AppError> {
-        let conn = self.lock();
+        let conn = self.lock()?;
         let known = conn
             .query_row(
                 "SELECT follows_known FROM directory_search_graph_users WHERE account_id_hex = ?1",
@@ -355,7 +365,7 @@ impl DirectoryCache {
         record: &DirectorySearchGraphRecord,
         now: i64,
     ) -> Result<(), AppError> {
-        let mut conn = self.lock();
+        let mut conn = self.lock()?;
         let tx = conn.transaction()?;
         Self::put_search_graph_record_locked(&tx, record, now)?;
         tx.commit()?;
@@ -376,7 +386,7 @@ impl DirectoryCache {
         follows: &[String],
     ) -> Result<(), AppError> {
         let now = unix_now_seconds() as i64;
-        let mut conn = self.lock();
+        let mut conn = self.lock()?;
         let tx = conn.transaction()?;
         tx.execute(
             "INSERT INTO directory_search_graph_users (
@@ -590,7 +600,7 @@ impl DirectoryCache {
     }
 
     fn migrate_legacy_json_records(&self) -> Result<(), AppError> {
-        let mut conn = self.lock();
+        let mut conn = self.lock()?;
         if !Self::table_exists_locked(&conn, "user_directory_records")? {
             return Ok(());
         }
@@ -615,7 +625,7 @@ impl DirectoryCache {
 
     #[cfg(test)]
     fn table_exists(&self, table: &str) -> Result<bool, AppError> {
-        let conn = self.lock();
+        let conn = self.lock()?;
         Self::table_exists_locked(&conn, table)
     }
 
@@ -864,7 +874,7 @@ mod tests {
             .put(&directory_record(alice.clone(), vec![bob.clone()]))
             .unwrap();
 
-        let conn = cache.lock();
+        let conn = cache.lock().unwrap();
         let user_count: i64 = conn
             .query_row(
                 "SELECT count(*) FROM directory_users WHERE account_id_hex = ?1",
@@ -1076,7 +1086,7 @@ mod tests {
 
         let cache = DirectoryCache::open(path, &key).unwrap();
         let entry = cache.entry(&alice).unwrap().unwrap();
-        let conn = cache.lock();
+        let conn = cache.lock().unwrap();
         let user_count: i64 = conn
             .query_row("SELECT count(*) FROM directory_users", [], |row| row.get(0))
             .unwrap();

--- a/crates/marmot-app/src/directory/methods.rs
+++ b/crates/marmot-app/src/directory/methods.rs
@@ -1066,6 +1066,7 @@ impl MarmotApp {
         &self,
         account: &AccountSummary,
     ) -> Result<DirectoryCache, AppError> {
+        self.ensure_storage_open("directory cache")?;
         self.clean_future_dated_directory_caches_for_all_accounts_once()?;
         if let Some(cache) = self
             .directory_caches
@@ -1107,6 +1108,13 @@ impl MarmotApp {
             .directory_caches
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
+        // See `MarmotApp::account_storage`: a close that latched mid-open must
+        // not leave this cache published and holding its database open.
+        if let Err(error) = self.ensure_storage_open("directory cache") {
+            drop(caches);
+            let _ = cache.close();
+            return Err(error);
+        }
         Ok(caches
             .entry(account.label.clone())
             .or_insert_with(|| cache.clone())

--- a/crates/marmot-app/src/directory/methods.rs
+++ b/crates/marmot-app/src/directory/methods.rs
@@ -1077,6 +1077,7 @@ impl MarmotApp {
         {
             return Ok(cache);
         }
+        let _lifecycle = self.begin_storage_open("directory cache")?;
         let _span = tracing::debug_span!(
             target: "marmot_app::directory",
             "directory_cache_handle_open",
@@ -1104,17 +1105,12 @@ impl MarmotApp {
         #[cfg(test)]
         self.directory_cache_open_count
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        // Publishing under `_lifecycle` is what keeps this cache reachable by a
+        // later `close_storage`; see `MarmotApp::begin_storage_open`.
         let mut caches = self
             .directory_caches
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        // See `MarmotApp::account_storage`: a close that latched mid-open must
-        // not leave this cache published and holding its database open.
-        if let Err(error) = self.ensure_storage_open("directory cache") {
-            drop(caches);
-            let _ = cache.close();
-            return Err(error);
-        }
         Ok(caches
             .entry(account.label.clone())
             .or_insert_with(|| cache.clone())

--- a/crates/marmot-app/src/error.rs
+++ b/crates/marmot-app/src/error.rs
@@ -290,6 +290,7 @@ fn storage_error_kind(error: &StorageError) -> &'static str {
         StorageError::AlreadyExists => "storage_already_exists",
         StorageError::SnapshotMissing(_) => "storage_snapshot_missing",
         StorageError::Busy(_) => "storage_busy",
+        StorageError::Closed(_) => "storage_closed",
         StorageError::Backend(_) => "storage_backend",
         StorageError::Serialization(_) => "storage_serialization",
     }

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -445,6 +445,11 @@ pub struct MarmotApp {
     /// a late call cannot silently reopen a database — and re-lock a container
     /// the host has just been told is lock-free.
     storage_closed: Arc<AtomicBool>,
+    /// Admission control that makes the close *atomic* rather than merely
+    /// latched: database opens hold the read side across create-and-publish,
+    /// [`Self::close_storage`] holds the write side across its whole teardown.
+    /// See [`Self::begin_storage_open`].
+    storage_lifecycle: Arc<RwLock<()>>,
     relay_urls: Vec<String>,
     account_home: AccountHome,
     relay_plane: MarmotRelayPlane,
@@ -1159,6 +1164,7 @@ impl MarmotApp {
             root,
             root_runtime_lease: Arc::new(Mutex::new(None)),
             storage_closed: Arc::new(AtomicBool::new(false)),
+            storage_lifecycle: Arc::new(RwLock::new(())),
             relay_urls,
             relay_plane,
             config,
@@ -1220,6 +1226,7 @@ impl MarmotApp {
             root: root.as_ref().to_path_buf(),
             root_runtime_lease: Arc::new(Mutex::new(None)),
             storage_closed: Arc::new(AtomicBool::new(false)),
+            storage_lifecycle: Arc::new(RwLock::new(())),
             relay_urls,
             account_home,
             relay_plane,
@@ -4133,6 +4140,19 @@ impl MarmotApp {
     /// error is returned once all of them have been closed.
     pub fn close_storage(&self) -> Result<(), AppError> {
         let started_at = Instant::now();
+        // Exclusive for the whole teardown. The `storage_closed` flag alone
+        // would not make this atomic: two concurrent closes could interleave so
+        // that one released the root lease and returned while the other was
+        // still closing connections, and an open already in flight could finish
+        // creating its connection after this method returned. Either way the
+        // host would be told the container is lock-free while a lock still
+        // existed. Holding the writer means every opener has either published
+        // (so the drain below closes it) or has not yet checked the flag (so it
+        // will refuse).
+        let _lifecycle = self
+            .storage_lifecycle
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         self.storage_closed.store(true, Ordering::Release);
         let mut first_error = None;
         let mut closed = 0usize;
@@ -4215,6 +4235,30 @@ impl MarmotApp {
         Ok(())
     }
 
+    /// Admission for a database *open*, held from the closed check through
+    /// publication into the handle cache.
+    ///
+    /// Opens are readers, so they still run concurrently with each other;
+    /// [`Self::close_storage`] is the writer. That is what makes the close's
+    /// promise true: an open holding this guard either publishes before the
+    /// close can start draining, or has not yet checked the flag and will
+    /// refuse. No connection can be created after the close returns.
+    ///
+    /// Cache *hits* deliberately skip this — a handle already in the cache is
+    /// one the close will drain and shut, so returning a clone of it cannot
+    /// leak a lock, and the hot read path stays uncontended.
+    fn begin_storage_open(
+        &self,
+        database: &'static str,
+    ) -> Result<RwLockReadGuard<'_, ()>, AppError> {
+        let guard = self
+            .storage_lifecycle
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        self.ensure_storage_open(database)?;
+        Ok(guard)
+    }
+
     fn account_storage(&self, label: &str) -> Result<SqliteAccountStorage, AppError> {
         self.ensure_storage_open("account storage")?;
         if let Some(storage) = self
@@ -4226,6 +4270,7 @@ impl MarmotApp {
         {
             return Ok(storage);
         }
+        let _lifecycle = self.begin_storage_open("account storage")?;
         let _span = tracing::debug_span!(
             target: "marmot_app::storage",
             "account_storage_open",
@@ -4246,21 +4291,12 @@ impl MarmotApp {
             )?
         };
         let storage = SqliteAccountStorage::open_encrypted(&path, &key)?;
+        // Publishing under `_lifecycle` is what keeps this connection reachable
+        // by a later `close_storage`; see `begin_storage_open`.
         let mut storages = self
             .account_storages
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        // A close that latched while this open was in flight has already
-        // drained the map, so publishing here would strand an open connection
-        // — and its file locks — past `close_storage`. Close it instead. The
-        // ordering holds both ways: `close_storage` sets the flag before it
-        // takes this same lock, so either we observe the flag or the drain
-        // observes our entry.
-        if let Err(error) = self.ensure_storage_open("account storage") {
-            drop(storages);
-            let _ = storage.close();
-            return Err(error);
-        }
         Ok(storages
             .entry(label.to_owned())
             .or_insert_with(|| storage.clone())
@@ -4604,6 +4640,7 @@ impl MarmotApp {
         {
             return Ok(storage);
         }
+        let _lifecycle = self.begin_storage_open("shared storage")?;
         let _span = tracing::debug_span!(
             target: "marmot_app::storage",
             "shared_storage_open",
@@ -4615,13 +4652,6 @@ impl MarmotApp {
             .shared_storage
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        // See `account_storage`: a close that latched mid-open must not leave
-        // this connection published and holding the shared database's locks.
-        if let Err(error) = self.ensure_storage_open("shared storage") {
-            drop(shared);
-            let _ = storage.close();
-            return Err(error);
-        }
         Ok(shared.get_or_insert_with(|| storage.clone()).clone())
     }
 

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -430,6 +430,9 @@ type AppRuntime = AccountDeviceRuntime<
     AppKeyPackagePublisher,
 >;
 
+#[cfg(test)]
+type LegacyProjectionOpenHook = Arc<dyn Fn() + Send + Sync>;
+
 #[derive(Clone)]
 pub struct MarmotApp {
     root: PathBuf,
@@ -461,6 +464,8 @@ pub struct MarmotApp {
     legacy_directory_cache_checked: Arc<Mutex<bool>>,
     #[cfg(test)]
     directory_cache_open_count: Arc<std::sync::atomic::AtomicUsize>,
+    #[cfg(test)]
+    legacy_projection_open_hook: Arc<Mutex<Option<LegacyProjectionOpenHook>>>,
     #[cfg(test)]
     test_relay_client: Option<Arc<dyn NostrRelayClient>>,
     shared_storage: Arc<Mutex<Option<SqliteSharedStorage>>>,
@@ -1176,6 +1181,8 @@ impl MarmotApp {
             #[cfg(test)]
             directory_cache_open_count: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             #[cfg(test)]
+            legacy_projection_open_hook: Arc::new(Mutex::new(None)),
+            #[cfg(test)]
             test_relay_client: None,
             shared_storage: Arc::new(Mutex::new(None)),
             account_state_ready: Arc::new(Mutex::new(HashSet::new())),
@@ -1238,6 +1245,8 @@ impl MarmotApp {
             legacy_directory_cache_checked: Arc::new(Mutex::new(false)),
             #[cfg(test)]
             directory_cache_open_count: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            #[cfg(test)]
+            legacy_projection_open_hook: Arc::new(Mutex::new(None)),
             #[cfg(test)]
             test_relay_client: None,
             shared_storage: Arc::new(Mutex::new(None)),
@@ -1467,7 +1476,7 @@ impl MarmotApp {
             transport: self.transport_label().to_owned(),
             group_count: state.groups.len(),
             message_count,
-            projections: self.projection_status(label),
+            projections: self.projection_status(label)?,
             groups: state.groups,
             seen_events: state.seen_events.len(),
             relay_lists: self.account_relay_list_status_for_account_id(&account.account_id_hex)?,
@@ -4499,6 +4508,14 @@ impl MarmotApp {
             return Ok(());
         }
 
+        // The cached account-storage lookup above releases its open guard before
+        // returning. Take a new lifecycle admission across the raw legacy
+        // connection and the complete import so `close_storage` cannot latch,
+        // release the root lease, and then have this path reopen a database in
+        // the supposedly lock-free root.
+        let _lifecycle = self.begin_storage_open("legacy account projection")?;
+        #[cfg(test)]
+        self.run_legacy_projection_open_hook_for_test();
         let legacy = self.legacy_account_projection(label)?;
         let state = legacy.load_state(label)?;
         storage.save_account_projection_state(
@@ -4538,6 +4555,26 @@ impl MarmotApp {
         Ok(())
     }
 
+    #[cfg(test)]
+    fn set_legacy_projection_open_hook_for_test(&self, hook: LegacyProjectionOpenHook) {
+        *self
+            .legacy_projection_open_hook
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(hook);
+    }
+
+    #[cfg(test)]
+    fn run_legacy_projection_open_hook_for_test(&self) {
+        let hook = self
+            .legacy_projection_open_hook
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
+        if let Some(hook) = hook {
+            hook();
+        }
+    }
+
     fn legacy_account_projection(
         &self,
         label: &str,
@@ -4563,10 +4600,15 @@ impl MarmotApp {
         LegacyAccountProjectionDb::open(path, &key)
     }
 
-    fn projection_status(&self, label: &str) -> AppProjectionStatus {
+    fn projection_status(&self, label: &str) -> Result<AppProjectionStatus, AppError> {
+        // These probes use short-lived raw SQLite connections rather than the
+        // cached handles. Admit the complete probe through the same lifecycle
+        // gate so a status call already in flight cannot reopen either database
+        // after terminal close has returned.
+        let _lifecycle = self.begin_storage_open("projection status")?;
         let account_path = self.account_storage_path(label);
         let shared_path = self.shared_storage_path();
-        AppProjectionStatus {
+        Ok(AppProjectionStatus {
             account: AppDatabaseStatus {
                 path: account_path.display().to_string(),
                 exists: account_path.exists(),
@@ -4577,7 +4619,7 @@ impl MarmotApp {
                 exists: shared_path.exists(),
                 encrypted: sqlite_file_requires_key(&shared_path),
             },
-        }
+        })
     }
 
     fn relay_endpoints(&self) -> Vec<TransportEndpoint> {

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -7,8 +7,9 @@
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 use cgka_engine::{
@@ -432,10 +433,18 @@ type AppRuntime = AccountDeviceRuntime<
 #[derive(Clone)]
 pub struct MarmotApp {
     root: PathBuf,
-    /// Present for exclusive-root entry points. Every clone shares this lease
+    /// Present for exclusive-root entry points. Every clone shares this cell,
     /// so the root remains exclusively owned until all database-capable app and
-    /// runtime handles have been released.
-    _root_runtime_lease: Option<Arc<MarmotRootRuntimeLease>>,
+    /// runtime handles have been released — or until [`Self::close_storage`]
+    /// takes the lease out, which is the only way to release it early. The
+    /// lease is an advisory lock on a file *inside the Marmot root*, so on iOS
+    /// it counts against the same App Group suspension rule as the databases
+    /// (see [`Self::close_storage`]).
+    root_runtime_lease: Arc<Mutex<Option<MarmotRootRuntimeLease>>>,
+    /// Latched by [`Self::close_storage`]. Every database accessor checks it so
+    /// a late call cannot silently reopen a database — and re-lock a container
+    /// the host has just been told is lock-free.
+    storage_closed: Arc<AtomicBool>,
     relay_urls: Vec<String>,
     account_home: AccountHome,
     relay_plane: MarmotRelayPlane,
@@ -1148,7 +1157,8 @@ impl MarmotApp {
         Self {
             account_home: AccountHome::open(&root),
             root,
-            _root_runtime_lease: None,
+            root_runtime_lease: Arc::new(Mutex::new(None)),
+            storage_closed: Arc::new(AtomicBool::new(false)),
             relay_urls,
             relay_plane,
             config,
@@ -1208,7 +1218,8 @@ impl MarmotApp {
         );
         Self {
             root: root.as_ref().to_path_buf(),
-            _root_runtime_lease: None,
+            root_runtime_lease: Arc::new(Mutex::new(None)),
+            storage_closed: Arc::new(AtomicBool::new(false)),
             relay_urls,
             account_home,
             relay_plane,
@@ -1245,10 +1256,12 @@ impl MarmotApp {
         config: MarmotAppConfig,
     ) -> Result<Self, AppError> {
         let root = root.as_ref().to_path_buf();
-        let lease = Arc::new(MarmotRootRuntimeLease::try_acquire(&root)?);
-        let mut app =
+        let lease = MarmotRootRuntimeLease::try_acquire(&root)?;
+        let app =
             Self::with_relays_and_account_home_and_config(&root, relay_urls, account_home, config);
-        app._root_runtime_lease = Some(lease);
+        *app.root_runtime_lease
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(lease);
         Ok(app)
     }
 
@@ -4088,7 +4101,122 @@ impl MarmotApp {
         self.account_dir(label).join(SESSION_DB_FILE)
     }
 
+    /// Close every SQLite database this app has open and release the root
+    /// runtime lease, so nothing this process owns holds a file lock inside the
+    /// Marmot root.
+    ///
+    /// Callers must quiesce first — this closes databases out from under any
+    /// work still running (see [`SqliteAccountStorage::close`] for what that
+    /// does to in-flight transactions). [`MarmotAppRuntime::shutdown_and_close`]
+    /// is the sequenced entry point host apps should use; it drains the account
+    /// workers before calling this.
+    ///
+    /// **Terminal.** [`Self::storage_is_closed`] latches, and every database
+    /// accessor then fails with
+    /// [`StorageError::Closed`][cgka_traits::storage::StorageError::Closed]
+    /// rather than reopening;
+    /// otherwise a stray background read would re-lock the container a host has
+    /// just been told is lock-free. Construct a new [`MarmotApp`] to use the
+    /// root again. Idempotent.
+    ///
+    /// This exists for hosts that share the Marmot root across processes
+    /// through a container the OS polices. On iOS the root lives in an App
+    /// Group container shared with the Notification Service Extension, and a
+    /// process suspended while holding *any* lock there is killed with
+    /// `0xdead10cc` — which a WAL connection does for its whole lifetime, and
+    /// the root lease does by design. Dropping handles cannot fix that: the
+    /// databases sit behind `Arc`s reachable from the engine, the OpenMLS
+    /// adapter, and app projections, so the host can neither observe nor await
+    /// the last clone going away.
+    ///
+    /// Every database is attempted even if an earlier one fails; the first
+    /// error is returned once all of them have been closed.
+    pub fn close_storage(&self) -> Result<(), AppError> {
+        let started_at = Instant::now();
+        self.storage_closed.store(true, Ordering::Release);
+        let mut first_error = None;
+        let mut closed = 0usize;
+
+        let account_storages = self
+            .account_storages
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .drain()
+            .map(|(_, storage)| storage)
+            .collect::<Vec<_>>();
+        let directory_caches = self
+            .directory_caches
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .drain()
+            .map(|(_, cache)| cache)
+            .collect::<Vec<_>>();
+        let shared_storage = self
+            .shared_storage
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
+
+        for storage in account_storages {
+            closed += 1;
+            if let Err(error) = storage.close() {
+                first_error.get_or_insert(AppError::from(error));
+            }
+        }
+        for cache in directory_caches {
+            closed += 1;
+            if let Err(error) = cache.close() {
+                first_error.get_or_insert(error);
+            }
+        }
+        if let Some(storage) = shared_storage {
+            closed += 1;
+            if let Err(error) = storage.close() {
+                first_error.get_or_insert(AppError::from(error));
+            }
+        }
+
+        // Last: the lease guards the databases, so it outlives them.
+        drop(
+            self.root_runtime_lease
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .take(),
+        );
+
+        tracing::debug!(
+            target: "marmot_app::storage",
+            method = "close_storage",
+            databases_closed = closed,
+            elapsed_ms = started_at.elapsed().as_millis() as u64,
+            failed = first_error.is_some(),
+            "app storage closed",
+        );
+        match first_error {
+            Some(error) => Err(error),
+            None => Ok(()),
+        }
+    }
+
+    /// Whether [`Self::close_storage`] has run. Databases are unreachable from
+    /// this handle once it returns true.
+    #[must_use]
+    pub fn storage_is_closed(&self) -> bool {
+        self.storage_closed.load(Ordering::Acquire)
+    }
+
+    /// Fail rather than reopen a database after [`Self::close_storage`].
+    fn ensure_storage_open(&self, database: &'static str) -> Result<(), AppError> {
+        if self.storage_is_closed() {
+            return Err(AppError::from(cgka_traits::StorageError::Closed(format!(
+                "{database} unavailable: app storage is closed"
+            ))));
+        }
+        Ok(())
+    }
+
     fn account_storage(&self, label: &str) -> Result<SqliteAccountStorage, AppError> {
+        self.ensure_storage_open("account storage")?;
         if let Some(storage) = self
             .account_storages
             .lock()
@@ -4122,6 +4250,17 @@ impl MarmotApp {
             .account_storages
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
+        // A close that latched while this open was in flight has already
+        // drained the map, so publishing here would strand an open connection
+        // — and its file locks — past `close_storage`. Close it instead. The
+        // ordering holds both ways: `close_storage` sets the flag before it
+        // takes this same lock, so either we observe the flag or the drain
+        // observes our entry.
+        if let Err(error) = self.ensure_storage_open("account storage") {
+            drop(storages);
+            let _ = storage.close();
+            return Err(error);
+        }
         Ok(storages
             .entry(label.to_owned())
             .or_insert_with(|| storage.clone())
@@ -4455,6 +4594,7 @@ impl MarmotApp {
     }
 
     pub(crate) fn shared_storage(&self) -> Result<SqliteSharedStorage, AppError> {
+        self.ensure_storage_open("shared storage")?;
         if let Some(storage) = self
             .shared_storage
             .lock()
@@ -4475,6 +4615,13 @@ impl MarmotApp {
             .shared_storage
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
+        // See `account_storage`: a close that latched mid-open must not leave
+        // this connection published and holding the shared database's locks.
+        if let Err(error) = self.ensure_storage_open("shared storage") {
+            drop(shared);
+            let _ = storage.close();
+            return Err(error);
+        }
         Ok(shared.get_or_insert_with(|| storage.clone()).clone())
     }
 

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -680,7 +680,29 @@ async fn run_app_runtime_account_worker(
                 let groups = scheduled_convergence.take_ready();
                 match client.sync_runtime_groups().await {
                     Ok(()) => {
+                        let mut remaining = groups.len();
                         for group_id in groups {
+                            // Each group's convergence pass is a long blocking
+                            // stretch of synchronous engine + SQLite work with
+                            // no await inside it, so `JoinHandle::abort` cannot
+                            // land there: without this check the shutdown budget
+                            // is spent running the whole batch to completion.
+                            // The group boundary is the only cut point where no
+                            // snapshot guard is live, so it is also the only one
+                            // that cannot leave a group half-rolled-back.
+                            // Undispatched groups need no hand-off — their
+                            // convergence inputs are durable, so the next
+                            // runtime rediscovers them at catch-up.
+                            if lifecycle.is_stopping() {
+                                tracing::debug!(
+                                    target: "marmot_app::runtime",
+                                    method = "scheduled_convergence",
+                                    skipped_groups = remaining,
+                                    "shutdown requested; leaving remaining convergence passes for the next runtime",
+                                );
+                                break;
+                            }
+                            remaining -= 1;
                             match client.advance_convergence_after_runtime_sync(&group_id).await {
                                 Ok(summary) => {
                                     publish_app_runtime_summary(&events, &account_id_hex, &account_label, &summary);
@@ -946,6 +968,13 @@ async fn run_app_runtime_account_worker(
                 }
             }
             _ = maintenance_tick.tick() => {
+                // Periodic maintenance is never urgent, and its catch-up leg is
+                // capped at 15s — three times the whole shutdown budget. Skip
+                // the tick outright once shutdown is requested rather than
+                // starting work the drain would then have to wait out.
+                if lifecycle.is_stopping() {
+                    continue 'worker;
+                }
                 if client.key_package_maintenance_requires_catch_up() {
                     match timeout(Duration::from_secs(15), client.sync()).await {
                         Ok(Ok(summary)) => {

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -3324,7 +3324,8 @@ impl MarmotAppRuntime {
     /// whatever SQLite statement is executing.
     pub async fn shutdown_and_close(&self) -> Result<(), AppError> {
         self.shutdown().await;
-        self.accounts.app.close_storage()
+        let app = self.accounts.app.clone();
+        blocking_app_task(move || app.close_storage()).await
     }
 
     /// Whether this runtime's storage has been closed by

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -3292,6 +3292,47 @@ impl MarmotAppRuntime {
             "runtime shutdown completed",
         );
     }
+
+    /// [`Self::shutdown`], then close every SQLite database and release the
+    /// root runtime lease — so when this returns, nothing this process owns
+    /// holds a file lock inside the Marmot root.
+    ///
+    /// This is the operation a host needs before its process can be suspended.
+    /// [`Self::shutdown`] alone is not enough: it stops workers but takes
+    /// `&self`, so it cannot drop anything, and the databases live behind
+    /// `Arc`s shared by the engine, the OpenMLS adapter, and app projections.
+    /// A WAL connection holds a lock on its `-shm` sidecar for its entire
+    /// lifetime, so "the workers stopped" and "the store is unlocked" are
+    /// different facts, and only the second one keeps an iOS app alive across
+    /// suspension (`0xdead10cc`, raised for holding a lock in a shared App
+    /// Group container).
+    ///
+    /// Ordering is the point of this method: workers drain first, so the
+    /// databases close under quiesced state rather than out from under live
+    /// engine work.
+    ///
+    /// **Terminal.** This runtime and the [`MarmotApp`] it came from are done:
+    /// every later database access fails with
+    /// [`StorageError::Closed`][cgka_traits::storage::StorageError::Closed]
+    /// rather than reopening, because reopening would re-lock the container the
+    /// host has just been told is clear. Build a fresh `MarmotApp` and runtime
+    /// to use the root again — which is what a foregrounding app does anyway.
+    ///
+    /// Safe to call twice, and safe to call with or without a preceding
+    /// [`Self::shutdown`]. Worker drain is bounded by
+    /// `APP_RUNTIME_ACCOUNT_SHUTDOWN_WAIT`; the close itself waits only for
+    /// whatever SQLite statement is executing.
+    pub async fn shutdown_and_close(&self) -> Result<(), AppError> {
+        self.shutdown().await;
+        self.accounts.app.close_storage()
+    }
+
+    /// Whether this runtime's storage has been closed by
+    /// [`Self::shutdown_and_close`].
+    #[must_use]
+    pub fn storage_is_closed(&self) -> bool {
+        self.accounts.app.storage_is_closed()
+    }
 }
 
 impl AccountManager {

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -5342,3 +5342,134 @@ async fn an_escalation_recorded_during_a_received_delivery_rides_that_seam() {
         "the receive seam must publish the escalation recorded during its ingest"
     );
 }
+
+/// Every SQLite database this app can open, plus the root runtime lease, must
+/// be released by one `close_storage` call — that is the whole contract iOS
+/// depends on before it suspends the process (`0xdead10cc` is raised for *any*
+/// lock held in the shared App Group container, not just the session database).
+#[test]
+fn close_storage_releases_every_database_and_the_root_lease() {
+    let directory = tempfile::tempdir().unwrap();
+    let root = directory.path();
+    let account = AccountHome::open(root).create_account("closing").unwrap();
+    let app = MarmotApp::try_with_relays_and_account_home_and_config(
+        root,
+        Vec::new(),
+        AccountHome::open(root),
+        MarmotAppConfig::default(),
+    )
+    .unwrap();
+
+    // Open, and dirty, all three database families so each has live WAL state.
+    app.account_storage(&account.label)
+        .unwrap()
+        .app_message_count()
+        .unwrap();
+    app.shared_storage()
+        .unwrap()
+        .set_relay_telemetry_settings(&StoredRelayTelemetrySettings {
+            export_enabled: true,
+            export_interval_seconds: 30,
+        })
+        .unwrap();
+    app.directory_cache_for_account(&account).unwrap();
+
+    let session_db = app.account_storage_path(&account.label);
+    let shared_db = app.shared_storage_path();
+    let sidecars = |db: &std::path::Path| {
+        [
+            PathBuf::from(format!("{}-wal", db.display())),
+            PathBuf::from(format!("{}-shm", db.display())),
+        ]
+    };
+    assert!(
+        sidecars(&shared_db).iter().all(|p| p.exists()),
+        "the shared database should hold WAL sidecars while open",
+    );
+    // The lease is held for as long as the app is alive.
+    assert!(matches!(
+        MarmotRootRuntimeLease::try_acquire(root),
+        Err(AppError::RuntimeBusy)
+    ));
+
+    app.close_storage().expect("close_storage should succeed");
+
+    assert!(app.storage_is_closed());
+    for db in [&session_db, &shared_db] {
+        for sidecar in sidecars(db) {
+            assert!(
+                !sidecar.exists(),
+                "{} must be gone once the last connection closes",
+                sidecar.display(),
+            );
+        }
+    }
+    // The lease is an advisory lock on a file in the same container, so it has
+    // to go too; a second acquirer proves it did.
+    drop(MarmotRootRuntimeLease::try_acquire(root).expect("root lease must be released"));
+
+    // Nothing reopens: a late read must report the close instead of re-locking
+    // the container the host was just told is clear.
+    for error in [
+        app.account_storage(&account.label).err(),
+        app.shared_storage().err(),
+        app.directory_cache_for_account(&account).err(),
+    ]
+    .into_iter()
+    .map(|error| error.expect("a closed app must not hand out a database"))
+    {
+        assert!(
+            matches!(&error, AppError::Storage(err) if err.is_closed()),
+            "expected a closed-storage error, got {error:?}",
+        );
+    }
+}
+
+#[test]
+fn close_storage_is_idempotent() {
+    let directory = tempfile::tempdir().unwrap();
+    let account = AccountHome::open(directory.path())
+        .create_account("closing-twice")
+        .unwrap();
+    let app = MarmotApp::with_relays_and_account_home(
+        directory.path(),
+        Vec::new(),
+        AccountHome::open(directory.path()),
+    );
+    app.account_storage(&account.label).unwrap();
+
+    app.close_storage().expect("first close should succeed");
+    app.close_storage().expect("second close should be a no-op");
+    // Closing a never-opened app is fine too.
+    let untouched = MarmotApp::with_relays_and_account_home(
+        directory.path(),
+        Vec::new(),
+        AccountHome::open(directory.path()),
+    );
+    untouched
+        .close_storage()
+        .expect("closing an app that opened nothing should succeed");
+}
+
+/// `shutdown_and_close` must work as the host's single call, with or without a
+/// preceding `shutdown`, and must stay safe when repeated.
+#[tokio::test]
+async fn runtime_shutdown_and_close_is_idempotent_with_or_without_prior_shutdown() {
+    let directory = tempfile::tempdir().unwrap();
+    let app = MarmotApp::with_relays_and_account_home(
+        directory.path(),
+        Vec::new(),
+        AccountHome::open(directory.path()),
+    );
+    let runtime = app.runtime();
+    assert!(!runtime.storage_is_closed());
+
+    // No preceding `shutdown`: the method performs its own.
+    runtime.shutdown_and_close().await.unwrap();
+    assert!(runtime.storage_is_closed());
+
+    // Repeat, and repeat after an explicit `shutdown`, without panicking.
+    runtime.shutdown_and_close().await.unwrap();
+    runtime.shutdown().await;
+    runtime.shutdown_and_close().await.unwrap();
+}

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -5360,19 +5360,20 @@ fn close_storage_releases_every_database_and_the_root_lease() {
     )
     .unwrap();
 
-    // Open, and dirty, all three database families so each has live WAL state.
-    app.account_storage(&account.label)
-        .unwrap()
-        .app_message_count()
-        .unwrap();
-    app.shared_storage()
-        .unwrap()
+    // Open, and dirty, all three database families. Keep the handles: they are
+    // the only way to prove the *connections* were closed rather than merely
+    // dropped from the app's caches.
+    let session_storage = app.account_storage(&account.label).unwrap();
+    session_storage.app_message_count().unwrap();
+    let shared_storage = app.shared_storage().unwrap();
+    shared_storage
         .set_relay_telemetry_settings(&StoredRelayTelemetrySettings {
             export_enabled: true,
             export_interval_seconds: 30,
         })
         .unwrap();
-    app.directory_cache_for_account(&account).unwrap();
+    let directory_cache = app.directory_cache_for_account(&account).unwrap();
+    directory_cache.entries().unwrap();
 
     let session_db = app.account_storage_path(&account.label);
     let shared_db = app.shared_storage_path();
@@ -5404,6 +5405,21 @@ fn close_storage_releases_every_database_and_the_root_lease() {
             );
         }
     }
+    // The directory cache is opened in rollback-journal mode, so it has no WAL
+    // sidecars to check. Its connection still has to be closed, and the handle
+    // taken before the close is what proves it: a cache that was merely evicted
+    // from the app's map would keep answering.
+    assert!(
+        matches!(
+            directory_cache.entries(),
+            Err(AppError::Storage(err)) if err.is_closed()
+        ),
+        "the directory cache connection must be closed, not just uncached",
+    );
+    // Same for the two WAL databases, via the handles rather than the caches.
+    assert!(session_storage.is_closed());
+    assert!(shared_storage.is_closed());
+
     // The lease is an advisory lock on a file in the same container, so it has
     // to go too; a second acquirer proves it did.
     drop(MarmotRootRuntimeLease::try_acquire(root).expect("root lease must be released"));
@@ -5422,6 +5438,100 @@ fn close_storage_releases_every_database_and_the_root_lease() {
             matches!(&error, AppError::Storage(err) if err.is_closed()),
             "expected a closed-storage error, got {error:?}",
         );
+    }
+}
+
+/// `close_storage` must not return — or release the root lease — while a
+/// database open is still in flight. Otherwise a host that awaited it, or
+/// another process that saw the lease free, would proceed while a freshly
+/// created SQLite connection still held locks in the container.
+///
+/// The read side of `storage_lifecycle` is exactly what an in-flight open
+/// holds, so taking it here stands in for one deterministically.
+#[test]
+fn close_storage_waits_for_an_open_that_is_already_in_flight() {
+    let directory = tempfile::tempdir().unwrap();
+    let root = directory.path();
+    AccountHome::open(root).create_account("racing").unwrap();
+    let app = MarmotApp::try_with_relays_and_account_home_and_config(
+        root,
+        Vec::new(),
+        AccountHome::open(root),
+        MarmotAppConfig::default(),
+    )
+    .unwrap();
+
+    let in_flight_open = app
+        .storage_lifecycle
+        .read()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    let closing_app = app.clone();
+    let (closed_tx, closed_rx) = std::sync::mpsc::channel();
+    let closer = std::thread::spawn(move || {
+        let result = closing_app.close_storage();
+        let _ = closed_tx.send(());
+        result
+    });
+
+    // While the open is in flight the close must make no observable progress:
+    // it has not returned, and the root lease is still held.
+    assert!(
+        closed_rx
+            .recv_timeout(std::time::Duration::from_millis(250))
+            .is_err(),
+        "close_storage must not return while an open is in flight",
+    );
+    assert!(
+        matches!(
+            MarmotRootRuntimeLease::try_acquire(root),
+            Err(AppError::RuntimeBusy)
+        ),
+        "the root lease must not be released while an open is in flight",
+    );
+
+    drop(in_flight_open);
+    closer
+        .join()
+        .unwrap()
+        .expect("close_storage should succeed once the open finishes");
+    drop(MarmotRootRuntimeLease::try_acquire(root).expect("root lease must be released"));
+}
+
+/// Concurrent `close_storage` callers must serialize: no caller may return
+/// while another is still closing connections, or the host gets a lock-free
+/// answer that is not yet true.
+#[test]
+fn concurrent_close_storage_callers_serialize() {
+    let directory = tempfile::tempdir().unwrap();
+    let root = directory.path();
+    let account = AccountHome::open(root).create_account("closing").unwrap();
+    let app = MarmotApp::try_with_relays_and_account_home_and_config(
+        root,
+        Vec::new(),
+        AccountHome::open(root),
+        MarmotAppConfig::default(),
+    )
+    .unwrap();
+    let session_storage = app.account_storage(&account.label).unwrap();
+    app.shared_storage().unwrap();
+    app.directory_cache_for_account(&account).unwrap();
+
+    let closers = (0..4)
+        .map(|_| {
+            let app = app.clone();
+            std::thread::spawn(move || app.close_storage())
+        })
+        .collect::<Vec<_>>();
+    for closer in closers {
+        // Every caller returns only after the teardown is complete, so every
+        // caller's return is a truthful "nothing is locked any more".
+        closer
+            .join()
+            .unwrap()
+            .expect("close_storage should succeed");
+        assert!(session_storage.is_closed());
+        drop(MarmotRootRuntimeLease::try_acquire(root).expect("root lease must be released"));
     }
 }
 

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -5430,6 +5430,7 @@ fn close_storage_releases_every_database_and_the_root_lease() {
         app.account_storage(&account.label).err(),
         app.shared_storage().err(),
         app.directory_cache_for_account(&account).err(),
+        app.projection_status(&account.label).err(),
     ]
     .into_iter()
     .map(|error| error.expect("a closed app must not hand out a database"))
@@ -5495,6 +5496,77 @@ fn close_storage_waits_for_an_open_that_is_already_in_flight() {
         .join()
         .unwrap()
         .expect("close_storage should succeed once the open finishes");
+    drop(MarmotRootRuntimeLease::try_acquire(root).expect("root lease must be released"));
+}
+
+/// Legacy account projection import opens a short-lived raw SQLite connection
+/// after the cached account storage has already been returned. That entire
+/// window must count as an in-flight storage open; otherwise terminal close can
+/// return and release the root lease immediately before the migration reopens
+/// the legacy database in the shared container.
+#[test]
+fn close_storage_waits_for_legacy_projection_import() {
+    let directory = tempfile::tempdir().unwrap();
+    let root = directory.path();
+    let home = AccountHome::open(root);
+    home.create_account("legacy-racing").unwrap();
+    let app = MarmotApp::try_with_relays_and_account_home_and_config(
+        root,
+        Vec::new(),
+        AccountHome::open(root),
+        MarmotAppConfig::default(),
+    )
+    .unwrap();
+
+    let keys = app
+        .account_home()
+        .load_signing_keys("legacy-racing")
+        .unwrap();
+    let legacy_path = app.legacy_account_projection_path("legacy-racing");
+    let legacy_key = app
+        .sqlcipher_key(
+            "legacy-racing",
+            &keys,
+            &legacy_path,
+            SqlcipherDatabaseKind::AccountProjection,
+        )
+        .unwrap();
+    drop(LegacyAccountProjectionDb::open(legacy_path, &legacy_key).unwrap());
+
+    let entered = std::sync::Arc::new(std::sync::Barrier::new(2));
+    let release = std::sync::Arc::new(std::sync::Barrier::new(2));
+    let hook_entered = std::sync::Arc::clone(&entered);
+    let hook_release = std::sync::Arc::clone(&release);
+    app.set_legacy_projection_open_hook_for_test(std::sync::Arc::new(move || {
+        hook_entered.wait();
+        hook_release.wait();
+    }));
+
+    let migrating_app = app.clone();
+    let migration = std::thread::spawn(move || migrating_app.ensure_account_state("legacy-racing"));
+    entered.wait();
+
+    let closing_app = app.clone();
+    let (closed_tx, closed_rx) = std::sync::mpsc::channel();
+    let closer = std::thread::spawn(move || {
+        let result = closing_app.close_storage();
+        closed_tx.send(()).unwrap();
+        result
+    });
+    assert!(
+        closed_rx
+            .recv_timeout(std::time::Duration::from_millis(250))
+            .is_err(),
+        "terminal close must wait for the legacy database import window",
+    );
+    assert!(matches!(
+        MarmotRootRuntimeLease::try_acquire(root),
+        Err(AppError::RuntimeBusy)
+    ));
+
+    release.wait();
+    migration.join().unwrap().unwrap();
+    closer.join().unwrap().unwrap();
     drop(MarmotRootRuntimeLease::try_acquire(root).expect("root lease must be released"));
 }
 

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -5468,12 +5468,20 @@ fn close_storage_waits_for_an_open_that_is_already_in_flight() {
         .unwrap_or_else(|poisoned| poisoned.into_inner());
 
     let closing_app = app.clone();
+    let (started_tx, started_rx) = std::sync::mpsc::channel();
     let (closed_tx, closed_rx) = std::sync::mpsc::channel();
     let closer = std::thread::spawn(move || {
+        // Signal from inside the thread, immediately before the call. Without
+        // this the timeout assertion below would also pass if the thread had
+        // simply not been scheduled yet, which proves nothing about blocking.
+        let _ = started_tx.send(());
         let result = closing_app.close_storage();
         let _ = closed_tx.send(());
         result
     });
+    started_rx
+        .recv()
+        .expect("the closing thread should reach close_storage");
 
     // While the open is in flight the close must make no observable progress:
     // it has not returned, and the root lease is still held.
@@ -5547,12 +5555,21 @@ fn close_storage_waits_for_legacy_projection_import() {
     entered.wait();
 
     let closing_app = app.clone();
+    let (started_tx, started_rx) = std::sync::mpsc::channel();
     let (closed_tx, closed_rx) = std::sync::mpsc::channel();
     let closer = std::thread::spawn(move || {
+        // Signal from inside the thread, immediately before the call. Without
+        // this the timeout assertion below would also pass if the thread had
+        // simply not been scheduled yet, which proves nothing about the import
+        // window holding the close off.
+        started_tx.send(()).unwrap();
         let result = closing_app.close_storage();
         closed_tx.send(()).unwrap();
         result
     });
+    started_rx
+        .recv()
+        .expect("the closing thread should reach close_storage");
     assert!(
         closed_rx
             .recv_timeout(std::time::Duration::from_millis(250))

--- a/crates/marmot-uniffi/src/errors.rs
+++ b/crates/marmot-uniffi/src/errors.rs
@@ -112,6 +112,17 @@ pub enum MarmotKitError {
     /// surfacing it as a fatal "Send failed".
     #[error("storage busy: {details}")]
     StorageBusy { details: String },
+    /// The store has been closed by [`Marmot::shutdown_and_close`][crate::Marmot::shutdown_and_close]
+    /// and this call reached a database that is no longer open.
+    ///
+    /// Typed, and deliberately not [`MarmotKitError::Runtime`], because it is
+    /// an *expected* outcome rather than a fault: a host closing its store
+    /// before suspension races whatever work was still in flight, and that work
+    /// must be reportable as "we shut down" instead of as a storage failure the
+    /// user gets told about. Never retryable — the handle is spent; construct a
+    /// new `Marmot` when the app resumes.
+    #[error("storage closed: {details}")]
+    StorageClosed { details: String },
     /// The account exists but its raw private key could not be located in the
     /// keystore — e.g. a public-only / watch-only account, or a secret that was
     /// never loaded. Distinct, typed variant (#543) so a key-backup surface can
@@ -259,6 +270,12 @@ impl From<AppError> for MarmotKitError {
             AppError::Storage(ref storage_err) if storage_err.is_transient() => Self::StorageBusy {
                 details: storage_err.to_string(),
             },
+            // A store closed for suspension is an orderly end state, not a
+            // fault. Give it its own variant so hosts can drop the result
+            // silently instead of surfacing an error while backgrounding.
+            AppError::Storage(ref storage_err) if storage_err.is_closed() => Self::StorageClosed {
+                details: storage_err.to_string(),
+            },
             AppError::ExternalSignerUnavailable(account) => {
                 Self::ExternalSignerUnavailable { account }
             }
@@ -320,6 +337,11 @@ impl MarmotKitError {
             // untyped `Runtime` bucket. `StorageError::is_transient()` is the
             // single source of truth for which storage errors are transient.
             EngineError::Storage(storage_err) if storage_err.is_transient() => Self::StorageBusy {
+                details: storage_err.to_string(),
+            },
+            // Engine work racing a close for suspension: an orderly end state,
+            // reported as such rather than as a runtime fault.
+            EngineError::Storage(storage_err) if storage_err.is_closed() => Self::StorageClosed {
                 details: storage_err.to_string(),
             },
             other => Self::Runtime {

--- a/crates/marmot-uniffi/src/lib.rs
+++ b/crates/marmot-uniffi/src/lib.rs
@@ -210,8 +210,51 @@ impl Marmot {
     /// Tear the runtime down. Drops all subscriptions; long-lived
     /// [`EventsSubscription`] / [`ChatsSubscription`] / etc. instances on the
     /// host side will see their `next()` return `None` shortly after.
+    ///
+    /// This stops work but does **not** release the store's file locks — the
+    /// SQLite connections stay open. Hosts whose process can be suspended
+    /// should call [`Marmot::shutdown_and_close`] instead.
     pub async fn shutdown(&self) {
         self.runtime.shutdown().await;
+    }
+
+    /// [`Marmot::shutdown`], then close every SQLite database and release the
+    /// Marmot root's runtime lease.
+    ///
+    /// Await this before letting the process be suspended. When it returns,
+    /// nothing this process owns holds a file lock inside the Marmot root —
+    /// which is the fact iOS actually checks: a process suspended while holding
+    /// a lock in a shared App Group container is killed with `0xdead10cc`, and
+    /// a WAL connection holds one on its `-shm` sidecar for its entire
+    /// lifetime. [`Marmot::shutdown`] cannot deliver that on its own; it stops
+    /// workers, but the databases are shared behind `Arc`s that no host can
+    /// observe or await going away.
+    ///
+    /// **Terminal: this handle is finished.** Every subsequent call that
+    /// touches storage fails with [`MarmotKitError::StorageClosed`] rather than
+    /// reopening the databases, because reopening would re-lock the container
+    /// this method just cleared. Construct a new `Marmot` on resume — which is
+    /// what a foregrounding app does anyway.
+    ///
+    /// Safe to call twice, and safe to call with or without a preceding
+    /// [`Marmot::shutdown`]. Bounded: worker drain has a fixed budget and the
+    /// close itself waits only for the SQLite statement currently executing.
+    /// An error means at least one database reported a problem while closing;
+    /// every database is still attempted and left closed, so a failure is not
+    /// a reason to retry or to keep the process alive.
+    // Object-method and error-variant addition: binding regeneration and the
+    // workspace version bump ride the release per this crate's lockstep
+    // invariant — do not bump versions here.
+    pub async fn shutdown_and_close(&self) -> Result<(), MarmotKitError> {
+        self.runtime.shutdown_and_close().await?;
+        Ok(())
+    }
+
+    /// True once [`Marmot::shutdown_and_close`] has closed the store. A host
+    /// can check this to confirm it is safe to be suspended, or to notice it is
+    /// holding a spent handle and needs a fresh one.
+    pub fn storage_is_closed(&self) -> bool {
+        self.runtime.storage_is_closed()
     }
 
     /// True once shutdown has started. Host apps can use this to avoid

--- a/crates/storage-sqlite/AGENTS.md
+++ b/crates/storage-sqlite/AGENTS.md
@@ -30,6 +30,9 @@ not "fix" it into the per-account database.
 - Accept raw SQLCipher keys only. Key derivation and recovery live above this crate.
 - Apply privacy/durability defaults unless callers opt out with `SqliteStorageOptions`.
 - Keep invalidated message records. Applications decide whether to show them.
+- Build every long-lived connection on `CloseableConnection` so a host can release the database's file locks at a known
+  instant. Closing is terminal: surviving clones return `StorageError::Closed`, and nothing reopens implicitly. See
+  `docs/marmot-architecture/overview/local-artifact-safety.md`.
 - Retained-anchor policy is engine/group policy. SQLite stores snapshots and policy bytes; the engine decides when to
   prune.
 - Migration file names use padded numeric prefixes, for example `0001_initial_schema.rs`.

--- a/crates/storage-sqlite/src/connection.rs
+++ b/crates/storage-sqlite/src/connection.rs
@@ -5,7 +5,9 @@ use cgka_traits::storage::{
 };
 use cgka_traits::types::Backend;
 use std::fmt;
+use std::ops::{Deref, DerefMut};
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Condvar, Mutex, MutexGuard};
 use std::thread::ThreadId;
 use std::time::Duration;
@@ -82,13 +84,175 @@ fn busy_backoff(attempt: u32) -> Duration {
     scaled.min(BUSY_BACKOFF_CAP)
 }
 
+/// Message carried by every [`StorageError::Closed`] this module raises.
+const CLOSED_DETAIL: &str = "sqlite account storage is closed";
+
+/// Coarse, privacy-safe label for a `rusqlite::Error`, for `tracing` fields.
+/// The full error text can carry SQL, so only the classification is logged.
+fn sqlite_error_kind(error: &rusqlite::Error) -> &'static str {
+    match error.sqlite_error_code() {
+        Some(rusqlite::ErrorCode::DatabaseBusy) => "busy",
+        Some(rusqlite::ErrorCode::DatabaseLocked) => "locked",
+        Some(_) => "sqlite",
+        None => "rusqlite",
+    }
+}
+
+/// Borrowed access to the live `rusqlite::Connection` behind a
+/// [`CloseableConnection`].
+///
+/// The connection lives in an `Option` so a close can take it out and close it
+/// for real while other handles are still alive. Every path that hands out a
+/// guard has already checked, *while holding the same mutex the guard holds*,
+/// that the slot is occupied, so the deref is infallible for the guard's
+/// lifetime.
+pub struct ConnectionGuard<'a> {
+    guard: MutexGuard<'a, Option<rusqlite::Connection>>,
+}
+
+impl Deref for ConnectionGuard<'_> {
+    type Target = rusqlite::Connection;
+
+    fn deref(&self) -> &Self::Target {
+        self.guard
+            .as_ref()
+            .expect("connection guard outlived its checked slot")
+    }
+}
+
+impl DerefMut for ConnectionGuard<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.guard
+            .as_mut()
+            .expect("connection guard outlived its checked slot")
+    }
+}
+
+/// A `rusqlite::Connection` that can be closed on demand, even while other
+/// handles to it survive.
+///
+/// Dropping handles is not a usable close for a shared connection: it lives
+/// behind an `Arc` reachable from the engine, the OpenMLS adapter, and app
+/// projections at once, so a host has no way to observe or await the last clone
+/// going away. And in WAL mode an open connection holds a persistent lock on
+/// its `-shm` sidecar for its whole lifetime — on iOS a process suspended while
+/// holding a lock in a shared App Group container is killed with `0xdead10cc`.
+/// Hosts therefore need an operation that ends the connection at a known
+/// instant and can be awaited.
+///
+/// This type is that operation. It is the shared building block for every
+/// closeable SQLite handle in the workspace, including databases opened outside
+/// the [`SqliteAccountStorage`] aggregate (the app's shared cache and directory
+/// caches), so the checkpoint-then-close ordering and the closed-state contract
+/// live in one place.
+#[derive(Debug)]
+pub struct CloseableConnection {
+    slot: Mutex<Option<rusqlite::Connection>>,
+    /// Mirrors "the slot is empty" so [`Self::is_closed`] can answer without
+    /// taking the connection mutex — a caller asking whether the database is
+    /// closed must not have to queue behind whatever statement is running on
+    /// it.
+    closed: AtomicBool,
+    /// Detail carried by the [`StorageError::Closed`] this connection raises,
+    /// naming which database is closed.
+    closed_detail: &'static str,
+}
+
+impl CloseableConnection {
+    /// Take ownership of `connection`. `closed_detail` names this database in
+    /// the [`StorageError::Closed`] raised after a close.
+    #[must_use]
+    pub fn new(connection: rusqlite::Connection, closed_detail: &'static str) -> Self {
+        Self {
+            slot: Mutex::new(Some(connection)),
+            closed: AtomicBool::new(false),
+            closed_detail,
+        }
+    }
+
+    /// Borrow the connection, or fail with [`StorageError::Closed`] if it has
+    /// been closed.
+    pub fn lock(&self) -> StorageResult<ConnectionGuard<'_>> {
+        let guard = self
+            .slot
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if guard.is_none() {
+            return Err(StorageError::Closed(self.closed_detail.to_string()));
+        }
+        Ok(ConnectionGuard { guard })
+    }
+
+    /// Whether [`Self::close`] has already taken the connection. Nonblocking.
+    #[must_use]
+    pub fn is_closed(&self) -> bool {
+        self.closed.load(Ordering::Acquire)
+    }
+
+    /// Checkpoint the WAL and close the connection, releasing every file lock
+    /// it holds on the database and its `-wal`/`-shm` sidecars.
+    ///
+    /// Idempotent: a second call finds an empty slot and returns `Ok(())`.
+    /// Blocking only for as long as the statement currently executing on
+    /// another thread; SQLite rolls back any transaction still open on that
+    /// connection as part of closing, so a half-applied transaction is not a
+    /// reachable outcome.
+    ///
+    /// A failed checkpoint is logged and does not block the close: leaving a
+    /// larger `-wal` behind costs the next open a replay, whereas leaving the
+    /// connection open costs the host its process.
+    pub fn close(&self) -> StorageResult<()> {
+        let mut slot = self
+            .slot
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        // Publish under the mutex, alongside the take, so `is_closed` can never
+        // report open for a slot that is already empty.
+        self.closed.store(true, Ordering::Release);
+        let Some(connection) = slot.take() else {
+            return Ok(());
+        };
+
+        // TRUNCATE folds the WAL back into the main database and resets the
+        // file to zero length, so the next open starts from a clean sidecar
+        // rather than replaying this session's log. It is a no-op error on
+        // rollback-journal databases, which is why the failure is not fatal.
+        if let Err(error) = connection.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);") {
+            tracing::debug!(
+                target: "storage_sqlite::connection",
+                method = "close",
+                error_kind = sqlite_error_kind(&error),
+                "wal checkpoint before close failed; closing anyway",
+            );
+        }
+
+        match connection.close() {
+            Ok(()) => Ok(()),
+            Err((connection, error)) => {
+                // `close` handing the connection back means SQLite still had
+                // work attached to it. Drop it regardless: rusqlite's `Drop`
+                // uses `sqlite3_close_v2`, which detaches the handle and frees
+                // it once that work finishes, so the file locks still go away.
+                drop(connection);
+                Err(StorageError::Backend(format!(
+                    "closing sqlite connection: {error}"
+                )))
+            }
+        }
+    }
+}
+
 #[derive(Clone)]
 pub(crate) struct SharedConnection {
     inner: Arc<SharedConnectionInner>,
 }
 
 struct SharedConnectionInner {
-    connection: Mutex<rusqlite::Connection>,
+    connection: CloseableConnection,
+    /// Set before the connection is taken so threads parked on
+    /// [`SharedConnectionInner::transaction_released`] wake up and bail out
+    /// rather than waiting for a transaction owner that will never run again.
+    closed: AtomicBool,
     transaction_owner: Mutex<Option<ThreadId>>,
     transaction_unusable: Mutex<Option<String>>,
     transaction_released: Condvar,
@@ -104,7 +268,8 @@ impl SharedConnection {
     fn new(connection: rusqlite::Connection) -> Self {
         Self {
             inner: Arc::new(SharedConnectionInner {
-                connection: Mutex::new(connection),
+                connection: CloseableConnection::new(connection, CLOSED_DETAIL),
+                closed: AtomicBool::new(false),
                 transaction_owner: Mutex::new(None),
                 transaction_unusable: Mutex::new(None),
                 transaction_released: Condvar::new(),
@@ -112,21 +277,17 @@ impl SharedConnection {
         }
     }
 
-    pub(crate) fn lock(&self) -> StorageResult<MutexGuard<'_, rusqlite::Connection>> {
+    pub(crate) fn lock(&self) -> StorageResult<ConnectionGuard<'_>> {
         let current = std::thread::current().id();
         loop {
             self.wait_for_transaction_slot(current)?;
-            let connection = self
-                .inner
-                .connection
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let connection = self.inner.connection.lock()?;
             let owner = self
                 .inner
                 .transaction_owner
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
-            if let Some(err) = self.transaction_unusable_error() {
+            if let Some(err) = self.unusable_error() {
                 return Err(err);
             }
             if !owner.as_ref().is_some_and(|owner| owner != &current) {
@@ -136,6 +297,55 @@ impl SharedConnection {
             drop(owner);
             drop(connection);
         }
+    }
+
+    /// Whether [`Self::close`] has run (or is running) on this connection.
+    pub(crate) fn is_closed(&self) -> bool {
+        self.inner.closed.load(Ordering::Acquire)
+    }
+
+    /// Checkpoint the WAL and close the underlying `rusqlite::Connection`,
+    /// releasing every database file lock it holds.
+    ///
+    /// This is the only way to guarantee the `-wal`/`-shm` sidecars are
+    /// unlocked: in WAL mode an open connection holds a persistent shared lock
+    /// on `-shm` for its entire lifetime, and dropping one `SharedConnection`
+    /// clone does nothing while other clones survive somewhere in the process.
+    /// Hosts that must be lock-free at a known instant — notably iOS apps
+    /// facing the `0xdead10cc` suspension kill for holding a lock in a shared
+    /// App Group container — call this and await it.
+    ///
+    /// Behavior:
+    /// - Idempotent. The second and later calls see an empty slot and return
+    ///   `Ok(())`.
+    /// - Terminal. Surviving clones (including the OpenMLS adapter's) fail with
+    ///   [`StorageError::Closed`]; nothing reopens. Callers construct a fresh
+    ///   [`SqliteAccountStorage`] to use the database again.
+    /// - Safe under concurrent work. Acquiring the connection mutex waits out
+    ///   whatever statement is executing; an open transaction owned by another
+    ///   thread is rolled back by SQLite as part of closing, and that thread's
+    ///   next call fails with [`StorageError::Closed`]. Partial application is
+    ///   therefore impossible — a transaction either committed before the close
+    ///   or was discarded whole.
+    ///
+    /// A failed checkpoint is logged and does not prevent the close: leaving a
+    /// larger `-wal` behind costs the next open a replay, whereas leaving the
+    /// connection open costs the host its process.
+    pub(crate) fn close(&self) -> StorageResult<()> {
+        // Publish "closed" before taking the connection so anyone parked in
+        // `wait_for_transaction_slot` wakes to an error rather than a deadlock.
+        self.inner.closed.store(true, Ordering::Release);
+        self.wake_transaction_waiters();
+        self.inner.connection.close()
+    }
+
+    fn wake_transaction_waiters(&self) {
+        let _owner = self
+            .inner
+            .transaction_owner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        self.inner.transaction_released.notify_all();
     }
 
     pub(crate) fn is_current_thread_transaction_owner(&self) -> bool {
@@ -160,7 +370,7 @@ impl SharedConnection {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         while owner.as_ref().is_some_and(|owner| owner != &current) {
-            if let Some(err) = self.transaction_unusable_error() {
+            if let Some(err) = self.unusable_error() {
                 return Err(E::from(err));
             }
             owner = self
@@ -169,7 +379,7 @@ impl SharedConnection {
                 .wait(owner)
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
         }
-        if let Some(err) = self.transaction_unusable_error() {
+        if let Some(err) = self.unusable_error() {
             return Err(E::from(err));
         }
 
@@ -236,7 +446,7 @@ impl SharedConnection {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         loop {
-            if let Some(err) = self.transaction_unusable_error() {
+            if let Some(err) = self.unusable_error() {
                 return Err(err);
             }
             if !owner.as_ref().is_some_and(|owner| owner != &current) {
@@ -258,14 +468,20 @@ impl SharedConnection {
     /// bounded policy so a transient boundary failure cannot strand a usable
     /// connection. Ownership is cleared only by the caller after a boundary
     /// succeeds; an exhausted rollback instead marks the connection unusable.
+    ///
+    /// A boundary that lands after [`Self::close`] took the connection is not
+    /// a fault: closing rolls the open transaction back inside SQLite. So a
+    /// `ROLLBACK` against a closed connection reports success — the rollback it
+    /// asked for has already happened — while a `COMMIT` reports
+    /// [`StorageError::Closed`], because that work was discarded. Reporting the
+    /// rollback as a failure instead would latch the connection "unusable" and
+    /// turn an orderly host suspension into a corruption-shaped error.
     fn execute_transaction_boundary_with_retry(&self, sql: &str) -> StorageResult<()> {
         retry_transaction_boundary(sql, || {
-            let conn = self
-                .inner
-                .connection
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-            conn.execute_batch(sql)
+            let Ok(conn) = self.inner.connection.lock() else {
+                return Err(BoundaryOutcome::Closed);
+            };
+            conn.execute_batch(sql).map_err(BoundaryOutcome::Sqlite)
         })
     }
 
@@ -280,14 +496,22 @@ impl SharedConnection {
     /// fault (issue #484).
     fn begin_immediate_with_retry(&self) -> StorageResult<()> {
         retry_on_busy(|| {
-            let conn = self
-                .inner
+            self.inner
                 .connection
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-            conn.execute_batch("BEGIN IMMEDIATE")
+                .lock()?
+                .execute_batch("BEGIN IMMEDIATE")
                 .map_err(crate::codec::map_sqlite_error)
         })
+    }
+
+    /// The reason this connection can no longer serve work, if any. Closing
+    /// takes precedence over a latched transaction fault: once the host has
+    /// closed the store, "closed" is the accurate and more actionable answer.
+    fn unusable_error(&self) -> Option<StorageError> {
+        if self.is_closed() {
+            return Some(StorageError::Closed(CLOSED_DETAIL.to_string()));
+        }
+        self.transaction_unusable_error()
     }
 
     fn transaction_unusable_error(&self) -> Option<StorageError> {
@@ -333,21 +557,59 @@ impl SharedConnection {
     }
 }
 
+/// Why a transaction-boundary statement did not execute.
+enum BoundaryOutcome {
+    /// SQLite ran the statement and rejected it.
+    Sqlite(rusqlite::Error),
+    /// The connection was closed before the statement could run.
+    Closed,
+}
+
 fn retry_transaction_boundary<F>(sql: &str, mut execute: F) -> StorageResult<()>
 where
-    F: FnMut() -> rusqlite::Result<()>,
+    F: FnMut() -> Result<(), BoundaryOutcome>,
 {
     retry_on_busy(|| {
-        execute().map_err(|error| match crate::codec::map_sqlite_error(error) {
-            StorageError::Busy(detail) => {
-                StorageError::Busy(format!("sqlite transaction {sql}: {detail}"))
+        execute().map_err(|outcome| match outcome {
+            // Closing the connection rolled the transaction back inside
+            // SQLite, so the rollback this boundary wanted is already done.
+            // A commit, by contrast, genuinely did not happen.
+            BoundaryOutcome::Closed if sql == "ROLLBACK" => {
+                BoundaryClosedOrError::RolledBackByClose
             }
-            StorageError::Backend(detail) => {
-                StorageError::Backend(format!("sqlite transaction {sql}: {detail}"))
+            BoundaryOutcome::Closed => BoundaryClosedOrError::Error(StorageError::Closed(format!(
+                "sqlite transaction {sql}: {CLOSED_DETAIL}"
+            ))),
+            BoundaryOutcome::Sqlite(error) => {
+                BoundaryClosedOrError::Error(match crate::codec::map_sqlite_error(error) {
+                    StorageError::Busy(detail) => {
+                        StorageError::Busy(format!("sqlite transaction {sql}: {detail}"))
+                    }
+                    StorageError::Backend(detail) => {
+                        StorageError::Backend(format!("sqlite transaction {sql}: {detail}"))
+                    }
+                    other => StorageError::Backend(format!("sqlite transaction {sql}: {other}")),
+                })
             }
-            other => StorageError::Backend(format!("sqlite transaction {sql}: {other}")),
         })
     })
+    .or_else(|outcome| match outcome {
+        BoundaryClosedOrError::RolledBackByClose => Ok(()),
+        BoundaryClosedOrError::Error(error) => Err(error),
+    })
+}
+
+/// [`retry_transaction_boundary`]'s internal error, distinguishing the
+/// "already rolled back by close" success-in-disguise from a real failure.
+enum BoundaryClosedOrError {
+    RolledBackByClose,
+    Error(StorageError),
+}
+
+impl TransientError for BoundaryClosedOrError {
+    fn is_busy(&self) -> bool {
+        matches!(self, Self::Error(error) if error.is_busy())
+    }
 }
 
 pub struct SqlCipherKey(Zeroizing<String>);
@@ -513,8 +775,41 @@ impl SqliteAccountStorage {
         })
     }
 
-    pub(crate) fn lock(&self) -> StorageResult<std::sync::MutexGuard<'_, rusqlite::Connection>> {
+    pub(crate) fn lock(&self) -> StorageResult<ConnectionGuard<'_>> {
         self.connection.lock()
+    }
+
+    /// Checkpoint the WAL and close this account database, releasing every
+    /// file lock it holds on the main database and its `-wal`/`-shm` sidecars.
+    ///
+    /// **Closing is terminal.** Every clone of this handle — including the
+    /// OpenMLS adapter reached through
+    /// [`StorageProvider::mls_storage`][cgka_traits::storage::StorageProvider::mls_storage]
+    /// and any clone held elsewhere in the process — fails with
+    /// [`StorageError::Closed`] from here on. Nothing reopens implicitly; to
+    /// use the database again, construct a new [`SqliteAccountStorage`].
+    ///
+    /// Callers should quiesce their own work first. Closing is nonetheless
+    /// safe under concurrent use: it waits out the statement currently
+    /// executing, and SQLite rolls back any transaction still open on another
+    /// thread as part of closing, so a partially applied transaction is not a
+    /// reachable outcome. Idempotent — later calls return `Ok(())`.
+    ///
+    /// This exists because dropping handles is not a usable close: the
+    /// connection lives behind an `Arc` shared by the engine, the OpenMLS
+    /// adapter, and app projections, so a host has no way to observe or await
+    /// the last clone going away. Hosts that must be provably lock-free at a
+    /// known instant need this — on iOS, a WAL connection left open across app
+    /// suspension holds a lock in the shared App Group container and the
+    /// process is killed with `0xdead10cc`.
+    pub fn close(&self) -> StorageResult<()> {
+        self.connection.close()
+    }
+
+    /// Whether [`Self::close`] has run on this database.
+    #[must_use]
+    pub fn is_closed(&self) -> bool {
+        self.connection.is_closed()
     }
 }
 
@@ -892,11 +1187,7 @@ mod tests {
     fn connection_lock_rechecks_transaction_owner_after_acquiring_connection() {
         let store = SqliteAccountStorage::in_memory().unwrap();
         let shared = store.connection.clone();
-        let connection_guard = shared
-            .inner
-            .connection
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let connection_guard = shared.inner.connection.lock().unwrap();
         let (lock_returned_tx, lock_returned_rx) = mpsc::channel();
         let worker_connection = shared.clone();
         let worker = std::thread::spawn(move || {
@@ -1139,8 +1430,12 @@ mod tests {
         retry_transaction_boundary("ROLLBACK", || {
             calls += 1;
             match calls {
-                1 => Err(sqlite_failure(rusqlite::ffi::SQLITE_BUSY)),
-                2 => Err(sqlite_failure(rusqlite::ffi::SQLITE_LOCKED)),
+                1 => Err(BoundaryOutcome::Sqlite(sqlite_failure(
+                    rusqlite::ffi::SQLITE_BUSY,
+                ))),
+                2 => Err(BoundaryOutcome::Sqlite(sqlite_failure(
+                    rusqlite::ffi::SQLITE_LOCKED,
+                ))),
                 _ => Ok(()),
             }
         })
@@ -1150,7 +1445,9 @@ mod tests {
         let mut persistent_calls = 0;
         let result = retry_transaction_boundary("ROLLBACK", || {
             persistent_calls += 1;
-            Err(sqlite_failure(rusqlite::ffi::SQLITE_LOCKED))
+            Err(BoundaryOutcome::Sqlite(sqlite_failure(
+                rusqlite::ffi::SQLITE_LOCKED,
+            )))
         });
         assert!(
             matches!(result, Err(StorageError::Busy(_))),
@@ -1209,6 +1506,235 @@ mod tests {
             assert!(sidecar.exists(), "expected {suffix} sidecar to exist");
             assert_eq!(mode(&sidecar), 0o600, "sidecar {suffix} should be 0600");
         }
+    }
+
+    /// The load-bearing assertion for the iOS `0xdead10cc` fix: after `close`,
+    /// the WAL sidecars are gone and a *fresh* connection can take an exclusive
+    /// lock on the database. SQLite only unlinks `-wal`/`-shm` when the last
+    /// connection to a database closes, and `locking_mode = EXCLUSIVE` only
+    /// takes hold if nothing else holds a lock — together these are the same
+    /// property iOS checks when it decides whether to kill a suspended process.
+    #[test]
+    fn close_releases_wal_locks_and_sidecars() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("marmot.sqlite");
+        let key = SqlCipherKey::new("close releases locks key").unwrap();
+        let store = SqliteAccountStorage::open_encrypted(&path, &key).unwrap();
+        store
+            .lock()
+            .unwrap()
+            .execute_batch(
+                "CREATE TABLE close_probe (id INTEGER); INSERT INTO close_probe VALUES (1);",
+            )
+            .unwrap();
+
+        let wal = std::path::PathBuf::from(format!("{}-wal", path.display()));
+        let shm = std::path::PathBuf::from(format!("{}-shm", path.display()));
+        assert!(
+            wal.exists() && shm.exists(),
+            "WAL sidecars should exist while open"
+        );
+
+        // A clone the host cannot reach — exactly the situation that makes
+        // dropping handles useless — must not keep the database locked.
+        let surviving_clone = store.clone();
+        store.close().expect("close should succeed");
+
+        assert!(
+            !wal.exists(),
+            "-wal must be gone once the last connection closes"
+        );
+        assert!(
+            !shm.exists(),
+            "-shm must be gone once the last connection closes"
+        );
+
+        let reopened = rusqlite::Connection::open(&path).unwrap();
+        apply_sqlcipher_key(&reopened, &key).unwrap();
+        reopened
+            .pragma_update(None, "locking_mode", "EXCLUSIVE")
+            .unwrap();
+        reopened
+            .execute_batch("INSERT INTO close_probe VALUES (2);")
+            .expect("an exclusive writer must be able to take the database");
+        let rows: i64 = reopened
+            .query_row("SELECT count(*) FROM close_probe", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(
+            rows, 2,
+            "the pre-close write must have been durably committed"
+        );
+
+        // The surviving clone is inert, not dangerous.
+        assert!(surviving_clone.is_closed());
+        assert!(matches!(
+            surviving_clone.lock().err(),
+            Some(StorageError::Closed(_))
+        ));
+    }
+
+    #[test]
+    fn close_is_idempotent_and_leaves_every_handle_reporting_closed() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        assert!(!store.is_closed());
+
+        store.close().expect("first close should succeed");
+        store.close().expect("second close should be a no-op");
+        assert!(store.is_closed());
+
+        assert!(matches!(store.lock().err(), Some(StorageError::Closed(_))));
+        // The OpenMLS adapter shares the same connection and must report the
+        // same terminal state rather than panicking on a missing connection.
+        assert!(matches!(
+            store.openmls.stored_key_package_bundles().err(),
+            Some(StorageError::Closed(_))
+        ));
+        // And a real storage operation, not just the raw lock.
+        assert!(matches!(
+            cgka_traits::storage::GroupStorage::list_groups(&store).err(),
+            Some(StorageError::Closed(_))
+        ));
+    }
+
+    /// A transaction that is open when the store closes must report the close,
+    /// not latch the connection "unusable" with a rollback-failed message. The
+    /// rollback it wanted did happen — SQLite performs it as part of closing.
+    #[test]
+    fn transaction_open_at_close_reports_closed_without_latching_unusable() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let closed_during_callback = store.connection.clone();
+
+        let result: Result<(), StorageError> = store.connection.with_transaction(|| {
+            closed_during_callback.close().unwrap();
+            Ok(())
+        });
+
+        assert!(
+            matches!(result, Err(StorageError::Closed(_))),
+            "COMMIT against a closed connection must report Closed, got {result:?}",
+        );
+        assert!(
+            store.connection.transaction_unusable_error().is_none(),
+            "closing must not latch the transaction-unusable flag",
+        );
+
+        // An error path through the same window rolls back and still reports
+        // the close rather than a doubled rollback failure.
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let closed_during_callback = store.connection.clone();
+        let result: Result<(), StorageError> = store.connection.with_transaction(|| {
+            closed_during_callback.close().unwrap();
+            Err(StorageError::Backend("callback failed".into()))
+        });
+        assert!(
+            matches!(result, Err(StorageError::Backend(detail)) if detail == "callback failed"),
+            "the callback's own error must survive the closed rollback",
+        );
+        assert!(store.connection.transaction_unusable_error().is_none());
+    }
+
+    /// Closing while another thread is parked waiting for the transaction slot
+    /// must wake it with an error rather than leave it blocked forever.
+    #[test]
+    fn close_wakes_threads_waiting_for_the_transaction_slot() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let shared = store.connection.clone();
+        let (entered_tx, entered_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel::<()>();
+
+        let holder_connection = shared.clone();
+        let holder = std::thread::spawn(move || {
+            holder_connection.with_transaction(|| {
+                entered_tx.send(()).unwrap();
+                release_rx.recv().unwrap();
+                Ok::<_, StorageError>(())
+            })
+        });
+        entered_rx.recv().unwrap();
+
+        let waiter_connection = shared.clone();
+        let waiter = std::thread::spawn(move || waiter_connection.lock().map(|_| ()));
+
+        // Give the waiter time to park on the condvar, then close under it.
+        std::thread::sleep(Duration::from_millis(100));
+        shared.close().unwrap();
+        release_tx.send(()).unwrap();
+
+        assert!(
+            matches!(waiter.join().unwrap(), Err(StorageError::Closed(_))),
+            "a parked waiter must be woken with Closed",
+        );
+        let _ = holder.join().unwrap();
+    }
+
+    /// Closing under a live writer is the case that matters most: a host
+    /// suspending in a hurry will not always have quiesced cleanly. The close
+    /// must be prompt, and every transaction must be all-or-nothing across the
+    /// cut — a half-applied multi-table write would be worse than the crash
+    /// this whole change exists to avoid.
+    #[test]
+    fn close_under_a_live_writer_is_prompt_and_leaves_no_torn_transaction() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("marmot.sqlite");
+        let key = SqlCipherKey::new("torn write probe key").unwrap();
+        let store = SqliteAccountStorage::open_encrypted(&path, &key).unwrap();
+        store
+            .lock()
+            .unwrap()
+            .execute_batch(
+                "CREATE TABLE torn_left (id INTEGER); CREATE TABLE torn_right (id INTEGER);",
+            )
+            .unwrap();
+
+        let writer_store = store.clone();
+        let writer = std::thread::spawn(move || {
+            for id in 0..10_000i64 {
+                // Both inserts land, or neither does. Nothing else is allowed.
+                let result: Result<(), StorageError> =
+                    writer_store.connection.with_transaction(|| {
+                        let conn = writer_store.lock()?;
+                        conn.execute("INSERT INTO torn_left VALUES (?1)", [id])
+                            .storage()?;
+                        conn.execute("INSERT INTO torn_right VALUES (?1)", [id])
+                            .storage()?;
+                        Ok(())
+                    });
+                if let Err(error) = result {
+                    // The only acceptable way to stop is the close itself.
+                    assert!(
+                        error.is_closed(),
+                        "writer should only ever fail with Closed, got {error:?}",
+                    );
+                    return;
+                }
+            }
+        });
+
+        // Let the writer get going, then close out from under it.
+        std::thread::sleep(Duration::from_millis(50));
+        let started_at = std::time::Instant::now();
+        store.close().unwrap();
+        let close_elapsed = started_at.elapsed();
+        writer.join().unwrap();
+
+        assert!(
+            close_elapsed < Duration::from_secs(1),
+            "close should wait only for the executing statement, took {close_elapsed:?}",
+        );
+
+        let reopened = rusqlite::Connection::open(&path).unwrap();
+        apply_sqlcipher_key(&reopened, &key).unwrap();
+        let left: i64 = reopened
+            .query_row("SELECT count(*) FROM torn_left", [], |row| row.get(0))
+            .unwrap();
+        let right: i64 = reopened
+            .query_row("SELECT count(*) FROM torn_right", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(
+            left, right,
+            "a transaction interrupted by close must be rolled back whole",
+        );
+        assert!(left > 0, "the writer should have committed something first");
     }
 
     #[test]

--- a/crates/storage-sqlite/src/connection.rs
+++ b/crates/storage-sqlite/src/connection.rs
@@ -148,10 +148,10 @@ impl DerefMut for ConnectionGuard<'_> {
 #[derive(Debug)]
 pub struct CloseableConnection {
     slot: Mutex<Option<rusqlite::Connection>>,
-    /// Mirrors "the slot is empty" so [`Self::is_closed`] can answer without
-    /// taking the connection mutex — a caller asking whether the database is
-    /// closed must not have to queue behind whatever statement is running on
-    /// it.
+    /// Published before [`Self::close`] waits for the connection mutex. New
+    /// operations must stop being admitted as soon as closing begins; otherwise
+    /// racing callers could repeatedly acquire `slot` ahead of the closer and
+    /// extend the host's suspension-critical teardown indefinitely.
     closed: AtomicBool,
     /// Detail carried by the [`StorageError::Closed`] this connection raises,
     /// naming which database is closed.
@@ -171,19 +171,25 @@ impl CloseableConnection {
     }
 
     /// Borrow the connection, or fail with [`StorageError::Closed`] if it has
-    /// been closed.
+    /// been closed or is currently closing.
     pub fn lock(&self) -> StorageResult<ConnectionGuard<'_>> {
+        if self.is_closed() {
+            return Err(StorageError::Closed(self.closed_detail.to_string()));
+        }
         let guard = self
             .slot
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if guard.is_none() {
+        // `close` may have published after the optimistic check but before this
+        // mutex acquisition. Recheck under the mutex so a caller that queued
+        // behind the closer cannot start fresh work during teardown.
+        if self.is_closed() || guard.is_none() {
             return Err(StorageError::Closed(self.closed_detail.to_string()));
         }
         Ok(ConnectionGuard { guard })
     }
 
-    /// Whether [`Self::close`] has already taken the connection. Nonblocking.
+    /// Whether [`Self::close`] has started. Nonblocking.
     #[must_use]
     pub fn is_closed(&self) -> bool {
         self.closed.load(Ordering::Acquire)
@@ -202,13 +208,15 @@ impl CloseableConnection {
     /// larger `-wal` behind costs the next open a replay, whereas leaving the
     /// connection open costs the host its process.
     pub fn close(&self) -> StorageResult<()> {
+        // Close admission before waiting for the currently executing operation.
+        // Do not return early when this was already set: concurrent close
+        // callers still have to serialize on `slot` so every return truthfully
+        // means the connection has been taken and closed.
+        self.closed.store(true, Ordering::Release);
         let mut slot = self
             .slot
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        // Publish under the mutex, alongside the take, so `is_closed` can never
-        // report open for a slot that is already empty.
-        self.closed.store(true, Ordering::Release);
         let Some(connection) = slot.take() else {
             return Ok(());
         };
@@ -1594,6 +1602,57 @@ mod tests {
             cgka_traits::storage::GroupStorage::list_groups(&store).err(),
             Some(StorageError::Closed(_))
         ));
+    }
+
+    /// Once closing starts, later callers must fail without queueing for the
+    /// connection mutex. Otherwise a stream of racing operations can repeatedly
+    /// get ahead of the closer and defeat the host's suspension deadline.
+    #[test]
+    fn close_rejects_new_admissions_while_waiting_for_the_active_operation() {
+        let connection = Arc::new(CloseableConnection::new(
+            rusqlite::Connection::open_in_memory().unwrap(),
+            "admission test connection is closed",
+        ));
+        let active_operation = connection.lock().unwrap();
+
+        let closing_connection = Arc::clone(&connection);
+        let (closed_tx, closed_rx) = mpsc::channel();
+        let closer = std::thread::spawn(move || {
+            let result = closing_connection.close();
+            closed_tx.send(()).unwrap();
+            result
+        });
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(1);
+        while !connection.is_closed() && std::time::Instant::now() < deadline {
+            std::thread::yield_now();
+        }
+        assert!(
+            connection.is_closed(),
+            "the closer must publish terminal admission before waiting for slot",
+        );
+
+        let waiting_connection = Arc::clone(&connection);
+        let (admission_tx, admission_rx) = mpsc::channel();
+        let waiter = std::thread::spawn(move || {
+            admission_tx
+                .send(waiting_connection.lock().map(|_| ()))
+                .unwrap();
+        });
+        assert!(matches!(
+            admission_rx
+                .recv_timeout(Duration::from_millis(250))
+                .expect("new admission must be rejected without waiting for slot"),
+            Err(StorageError::Closed(_)),
+        ));
+        assert!(
+            closed_rx.recv_timeout(Duration::from_millis(50)).is_err(),
+            "close must still wait for the operation that was active before it began",
+        );
+
+        drop(active_operation);
+        closer.join().unwrap().unwrap();
+        waiter.join().unwrap();
     }
 
     /// A transaction that is open when the store closes must report the close,

--- a/crates/storage-sqlite/src/lib.rs
+++ b/crates/storage-sqlite/src/lib.rs
@@ -34,8 +34,8 @@ pub use chat_list::{
 #[allow(deprecated)]
 pub use connection::SqliteStorage;
 pub use connection::{
-    SqlCipherHardening, SqlCipherKey, SqliteAccountStorage, SqliteJournalMode,
-    SqliteStorageOptions, SqliteSynchronous, open_hardened_sqlcipher,
+    CloseableConnection, ConnectionGuard, SqlCipherHardening, SqlCipherKey, SqliteAccountStorage,
+    SqliteJournalMode, SqliteStorageOptions, SqliteSynchronous, open_hardened_sqlcipher,
 };
 pub use message_drafts::{
     StoredMessageDraft, StoredMessageDraftAttachment, StoredMessageDraftAttachmentSummary,

--- a/crates/storage-sqlite/src/openmls_storage.rs
+++ b/crates/storage-sqlite/src/openmls_storage.rs
@@ -24,9 +24,7 @@ impl SqliteOpenMlsStorage {
         Ok(serde_json::to_vec(group_id)?)
     }
 
-    fn lock(
-        &self,
-    ) -> Result<std::sync::MutexGuard<'_, rusqlite::Connection>, SqliteOpenMlsStorageError> {
+    fn lock(&self) -> Result<crate::connection::ConnectionGuard<'_>, SqliteOpenMlsStorageError> {
         self.connection
             .lock()
             .map_err(|e| SqliteOpenMlsStorageError::Lock(e.to_string()))

--- a/crates/storage-sqlite/src/openmls_storage.rs
+++ b/crates/storage-sqlite/src/openmls_storage.rs
@@ -24,10 +24,16 @@ impl SqliteOpenMlsStorage {
         Ok(serde_json::to_vec(group_id)?)
     }
 
+    /// Borrow the shared connection, preserving the [`StorageError`] variant.
+    ///
+    /// Flattening it to a stringly-typed lock error would erase the
+    /// distinction the variants exist for — most importantly
+    /// [`StorageError::Closed`], which every OpenMLS value-store path can now
+    /// see when a host closes the store to release its file locks before
+    /// suspension. That has to stay reportable as orderly shutdown rather than
+    /// as an opaque lock fault.
     fn lock(&self) -> Result<crate::connection::ConnectionGuard<'_>, SqliteOpenMlsStorageError> {
-        self.connection
-            .lock()
-            .map_err(|e| SqliteOpenMlsStorageError::Lock(e.to_string()))
+        Ok(self.connection.lock()?)
     }
 
     pub(crate) fn stored_key_package_bundles(&self) -> StorageResult<Vec<StoredKeyPackageBundle>> {
@@ -94,8 +100,6 @@ pub enum SqliteOpenMlsStorageError {
     Serialization(#[from] serde_json::Error),
     #[error("queued proposal reference was present without a queued proposal")]
     MissingQueuedProposal,
-    #[error("connection lock poisoned: {0}")]
-    Lock(String),
 }
 
 impl crate::connection::TransientError for SqliteOpenMlsStorageError {

--- a/crates/storage-sqlite/src/shared.rs
+++ b/crates/storage-sqlite/src/shared.rs
@@ -1,7 +1,8 @@
 use std::path::Path;
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::Arc;
 use std::time::Duration;
 
+use crate::connection::{CloseableConnection, ConnectionGuard};
 use crate::{
     SqliteResultExt, bool_i64, connection::retry_on_busy, optional_u64_to_i64, u64_to_i64,
     unix_now_ms, usize_to_i64,
@@ -20,9 +21,16 @@ const SHARED_BUSY_TIMEOUT_MS: u64 = 5_000;
 /// realistic result set; a warn fires if it is ever hit.
 const PUBLIC_DIRECTORY_USERS_MAX: usize = 10_000;
 
+/// Message carried by every [`StorageError::Closed`] this module raises.
+const CLOSED_DETAIL: &str = "sqlite shared storage is closed";
+
 #[derive(Clone, Debug)]
 pub struct SqliteSharedStorage {
-    conn: Arc<Mutex<rusqlite::Connection>>,
+    /// Closeable because this database is opened in WAL mode: an open
+    /// connection holds a persistent lock on its `-shm` sidecar, so a host that
+    /// must be lock-free at suspension needs an explicit close, not a dropped
+    /// clone.
+    conn: Arc<CloseableConnection>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -75,6 +83,21 @@ impl SqliteSharedStorage {
 
     pub fn in_memory() -> StorageResult<Self> {
         Self::from_connection(rusqlite::Connection::open_in_memory().storage()?)
+    }
+
+    /// Checkpoint the WAL and close this shared database, releasing its file
+    /// locks. Terminal and idempotent, with the same contract as
+    /// [`SqliteAccountStorage::close`][crate::SqliteAccountStorage::close]:
+    /// surviving clones fail with [`StorageError::Closed`] and nothing
+    /// reopens.
+    pub fn close(&self) -> StorageResult<()> {
+        self.conn.close()
+    }
+
+    /// Whether [`Self::close`] has run on this database.
+    #[must_use]
+    pub fn is_closed(&self) -> bool {
+        self.conn.is_closed()
     }
 
     fn from_connection(conn: rusqlite::Connection) -> StorageResult<Self> {
@@ -132,7 +155,7 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
         Self::clear_legacy_relay_telemetry_endpoint(&conn)?;
         Self::ensure_audit_log_data_mode_column(&conn)?;
         Ok(Self {
-            conn: Arc::new(Mutex::new(conn)),
+            conn: Arc::new(CloseableConnection::new(conn, CLOSED_DETAIL)),
         })
     }
 
@@ -171,7 +194,7 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
         record: &PublicDirectoryUserRecord,
     ) -> StorageResult<()> {
         retry_on_busy(|| {
-            let mut conn = self.lock();
+            let mut conn = self.lock()?;
             let tx = conn
                 .transaction_with_behavior(TransactionBehavior::Immediate)
                 .storage()?;
@@ -230,7 +253,7 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
         &self,
         account_id_hex: &str,
     ) -> StorageResult<Option<PublicDirectoryUserRecord>> {
-        let mut conn = self.lock();
+        let mut conn = self.lock()?;
         let tx = conn.transaction().storage()?;
         let Some(mut record) = tx
             .query_row(
@@ -294,7 +317,7 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
         // loads the whole cache. Ordering preserved (users by account_id_hex;
         // each user's follows by position then follow id).
         let cap = i64::try_from(max).unwrap_or(i64::MAX);
-        let mut conn = self.lock();
+        let mut conn = self.lock()?;
         let tx = conn.transaction().storage()?;
         let mut follows_by_account: std::collections::HashMap<String, Vec<String>> =
             std::collections::HashMap::new();
@@ -373,7 +396,7 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
 
     pub fn relay_telemetry_settings(&self) -> StorageResult<StoredRelayTelemetrySettings> {
         self.ensure_relay_telemetry_settings()?;
-        self.lock()
+        self.lock()?
             .query_row(
                 "SELECT export_enabled, export_interval_seconds
                  FROM relay_telemetry_settings
@@ -395,7 +418,7 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
         settings: &StoredRelayTelemetrySettings,
     ) -> StorageResult<()> {
         retry_on_busy(|| {
-            self.lock()
+            self.lock()?
                 .execute(
                     "INSERT INTO relay_telemetry_settings (
                     id, export_enabled, export_interval_seconds, updated_at_ms
@@ -417,7 +440,7 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
     }
 
     pub fn telemetry_install_id(&self) -> StorageResult<Option<String>> {
-        self.lock()
+        self.lock()?
             .query_row(
                 "SELECT install_id
                  FROM telemetry_install
@@ -431,7 +454,7 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
 
     pub fn set_telemetry_install_id(&self, install_id: &str) -> StorageResult<()> {
         retry_on_busy(|| {
-            self.lock()
+            self.lock()?
                 .execute(
                     "INSERT INTO telemetry_install (id, install_id, updated_at_ms)
                  VALUES (1, ?1, ?2)
@@ -447,7 +470,7 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
 
     pub fn audit_log_settings(&self) -> StorageResult<StoredAuditLogSettings> {
         self.ensure_audit_log_settings()?;
-        self.lock()
+        self.lock()?
             .query_row(
                 "SELECT enabled, data_mode
                  FROM audit_log_settings
@@ -465,7 +488,7 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
 
     pub fn set_audit_log_settings(&self, settings: &StoredAuditLogSettings) -> StorageResult<()> {
         retry_on_busy(|| {
-            self.lock()
+            self.lock()?
                 .execute(
                     "INSERT INTO audit_log_settings (
                     id, enabled, data_mode, updated_at_ms
@@ -488,7 +511,7 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
 
     #[cfg(test)]
     fn table_columns(&self, table: &str) -> Vec<String> {
-        let conn = self.lock();
+        let conn = self.lock().unwrap();
         let mut stmt = conn
             .prepare(&format!("PRAGMA table_info({table})"))
             .unwrap();
@@ -498,15 +521,13 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
             .unwrap()
     }
 
-    fn lock(&self) -> MutexGuard<'_, rusqlite::Connection> {
-        self.conn
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    fn lock(&self) -> StorageResult<ConnectionGuard<'_>> {
+        self.conn.lock()
     }
 
     fn ensure_relay_telemetry_settings(&self) -> StorageResult<()> {
         retry_on_busy(|| {
-            self.lock()
+            self.lock()?
                 .execute(
                     "INSERT INTO relay_telemetry_settings (
                     id, export_enabled, export_interval_seconds, updated_at_ms
@@ -542,7 +563,7 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
 
     fn ensure_audit_log_settings(&self) -> StorageResult<()> {
         retry_on_busy(|| {
-            self.lock()
+            self.lock()?
                 .execute(
                     "INSERT INTO audit_log_settings (
                     id, enabled, updated_at_ms
@@ -609,7 +630,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("shared.sqlite");
         let storage = SqliteSharedStorage::open(&path).unwrap();
-        let conn = storage.lock();
+        let conn = storage.lock().unwrap();
 
         let journal_mode: String = conn
             .query_row("PRAGMA journal_mode", [], |row| row.get(0))

--- a/crates/traits/src/storage.rs
+++ b/crates/traits/src/storage.rs
@@ -47,6 +47,18 @@ pub enum StorageError {
     /// it as a transient (not fatal) error.
     #[error("backend busy: {0}")]
     Busy(String),
+    /// The backend has been closed and will not serve further operations.
+    ///
+    /// Distinct from [`StorageError::Backend`] because it is an *expected*
+    /// terminal state, not a fault: a host that closes its store to release
+    /// database file locks before process suspension (see
+    /// `docs/marmot-architecture/overview/local-artifact-safety.md`) will race
+    /// a small amount of in-flight work, and that work must be reportable as
+    /// "we shut down" rather than as storage corruption. Never retryable —
+    /// a closed backend is terminal for the handle, and callers reopen a fresh
+    /// one instead.
+    #[error("backend closed: {0}")]
+    Closed(String),
     #[error("backend failure: {0}")]
     Backend(String),
     #[error("serialization failure: {0}")]
@@ -61,6 +73,16 @@ impl StorageError {
     #[must_use]
     pub fn is_transient(&self) -> bool {
         matches!(self, StorageError::Busy(_))
+    }
+
+    /// Whether this error means the backend has been deliberately closed.
+    ///
+    /// Callers use this to classify a failure as orderly shutdown rather than
+    /// a storage fault — for example to downgrade log severity or to suppress
+    /// a user-visible error while an app is being suspended.
+    #[must_use]
+    pub fn is_closed(&self) -> bool {
+        matches!(self, StorageError::Closed(_))
     }
 }
 

--- a/docs/marmot-architecture/AGENTS.md
+++ b/docs/marmot-architecture/AGENTS.md
@@ -34,7 +34,7 @@ Agent map for the Marmot architecture docs.
 
 - **Path:** `overview/local-artifact-safety.md`
   - **Role:** Restrictive-by-construction creation policy for local files, sockets, and databases; the
-    `crates/fs-private` helper contract.
+    `crates/fs-private` helper contract; the close-before-suspension rules for WAL connections and the root lease.
 
 - **Path:** `overview/dial-safety.md`
   - **Role:** One host-safety discipline for every outbound connection (validate resolved addresses, pin, trust from

--- a/docs/marmot-architecture/index.md
+++ b/docs/marmot-architecture/index.md
@@ -86,7 +86,8 @@ Written to be readable in 5 minutes each, shareable as a package.
 
 - **Doc:** [`overview/local-artifact-safety.md`](./overview/local-artifact-safety.md)
   - **What it covers:** Restrictive-by-construction creation of local files, sockets, and databases: the
-    `fs-private` helpers, the one octal-mode parser, and the DB sidecar/PRAGMA-at-open rules.
+    `fs-private` helpers, the one octal-mode parser, the DB sidecar/PRAGMA-at-open rules, and the close-before-host-
+    suspension rules that release WAL and root-lease file locks.
 
 - **Doc:** [`overview/multi-step-state-changes.md`](./overview/multi-step-state-changes.md)
   - **What it covers:** The no-torn-writes convention for multi-step operations: validate-before-mutate, full

--- a/docs/marmot-architecture/overview/local-artifact-safety.md
+++ b/docs/marmot-architecture/overview/local-artifact-safety.md
@@ -1,7 +1,7 @@
 ---
 title: "Local Artifact Safety"
 created: 2026-07-02
-updated: 2026-07-02
+updated: 2026-08-08
 tags: [marmot, overview, security, filesystem, permissions]
 status: overview
 ---
@@ -43,6 +43,38 @@ restrictive-by-construction posture with an on-disk mode test) instead of re-der
 `crates/marmot-account/src/io.rs` (`write_file_atomically` with `FileMode::Private`) is a compliant-equivalent
 implementation that predates the shared crate.
 
+## Releasing artifacts before host suspension
+
+Creation posture is not the only thing a shared container polices. On iOS the Marmot root lives in an App Group
+container shared with the Notification Service Extension, and a process suspended while holding **any** file lock
+there is killed with `RUNNINGBOARD 0xdead10cc`. Two artifacts hold such a lock by design:
+
+- every SQLite connection in WAL mode, which holds a shared lock on its `-shm` sidecar for its entire lifetime, and
+- the root runtime lease (`.marmot-runtime.lock`), an advisory lock held for as long as any app/runtime handle lives.
+
+So a host needs an operation that ends those at a known instant and can be awaited. Dropping handles is not that
+operation: the databases live behind `Arc`s reachable from the engine, the OpenMLS adapter, and app projections at
+once, so no host can observe or await the last clone going away, and `shutdown()` takes `&self` and therefore cannot
+drop anything.
+
+**The rules:**
+
+- **Close, don't drop.** Every long-lived SQLite handle is built on `storage_sqlite::CloseableConnection`, which takes
+  the connection out of its slot, checkpoints (`PRAGMA wal_checkpoint(TRUNCATE)`), and closes it. Surviving clones then
+  fail with `StorageError::Closed` rather than panicking or keeping the file locked.
+- **Closing is terminal, and nothing reopens.** `MarmotApp::close_storage` latches, and every database accessor
+  refuses afterwards. A late background read that transparently reopened would re-lock the container the host was just
+  told is clear — the exact failure the close exists to prevent. Hosts construct a fresh runtime on resume.
+- **Drain, then close.** `MarmotAppRuntime::shutdown_and_close` is the sequenced entry point: workers stop first, so
+  databases close under quiesced state. Closing under live work stays *safe* — SQLite rolls back any open transaction
+  as part of closing, so a write is all-or-nothing across the cut — but it is not the intended path.
+- **Bail out at engine-step boundaries, not inside them.** Shutdown checks belong between whole engine operations
+  (`RuntimeLifecycle::is_stopping()` in the account worker's per-group loops), where no snapshot guard is live.
+  Interrupting *inside* a step can leave a `SnapshotRollbackGuard`'s window half-applied, which is worse than the kill.
+
+`StorageError::Closed` is deliberately its own variant, and non-transient: work racing a close must be reportable as
+"we shut down" rather than as a storage fault the user is shown.
+
 ## Deliberate exception
 
 The application root directory's mode is left as-is when it already exists: retroactively chmod-ing the root of
@@ -50,7 +82,8 @@ existing installs is a behavior change outside this policy's scope. File-level 0
 
 ## Scope
 
-This policy covers *creation-time* posture (permissions, creation ordering, mode parsing, PRAGMA-at-open). Handling
+This policy covers *creation-time* posture (permissions, creation ordering, mode parsing, PRAGMA-at-open) and the
+*release* posture above (closing connections and locks before host suspension). Handling
 of secret contents in memory, logs, and FFI is tracked separately under the sensitive-material discipline; tracing
 rules live in [`observability.md`](./observability.md).
 


### PR DESCRIPTION
## Why

The White Noise iOS app is being SIGKILL'd in the background with `RUNNINGBOARD 0xdead10cc` — suspended while holding a file lock in the shared App Group container. Five identical TestFlight reports (build 2026.8.6 (23), iOS 18.7.8 and 26.5.2, three devices), in two signatures.

Nothing in this workspace could release those locks:

- `MarmotAppRuntime::shutdown()` / `AccountManager::shutdown()` take `&self`, so they stop workers but cannot drop anything.
- `SharedConnection` is a `Clone` wrapper over an `Arc`, handed out freely to the engine, the OpenMLS adapter, and app projections. It had no `close()` and no `Drop`. The connection went away only when the last clone anywhere in the process did — which the host can neither observe nor await.
- In WAL mode an open connection holds a persistent lock on its `-shm` sidecar for its entire lifetime.

So "the workers stopped" and "the store is unlocked" were different facts, and only the second one keeps the process alive. Three of the five reports had **no Rust threads at all** and were still killed.

The other two were an account worker frozen mid-write inside `rollback_snapshot` / snapshot capture. The 5s worker timeout wasn't a real bound there: `tokio::task::abort()` is cooperative, and a per-group convergence pass is a long *synchronous* engine + SQLite stretch with no await for it to land at.

## What changed

**Storage can be closed** — `storage-sqlite/src/connection.rs`

New public `CloseableConnection` holds the connection in a `Mutex<Option<Connection>>`. `close()` checkpoints (`PRAGMA wal_checkpoint(TRUNCATE)`), takes the connection out, and closes it for real. Surviving clones get the new `StorageError::Closed` rather than panicking or keeping the file locked. `SqliteAccountStorage`, `SqliteSharedStorage`, and the app's directory caches all build on it, so the checkpoint-then-close ordering lives in one place.

The transaction machinery is closed-aware. A `ROLLBACK` against a closed connection reports **success** — closing performed it inside SQLite — while a `COMMIT` reports `Closed`. Latching the connection "unusable" on that rollback would turn an orderly host suspension into a corruption-shaped error. Threads parked on the transaction condvar are woken so they bail out instead of blocking on an owner that will never run again.

**`MarmotAppRuntime::shutdown_and_close()`** — drains workers, then closes every account database, the shared database, and every directory cache. Terminal by design: `MarmotApp` latches a closed flag and every accessor refuses afterwards, because a stray background read that transparently reopened would re-lock the container the host was just told is clear. Idempotent, and safe with or without a preceding `shutdown()`.

**Shutdown-aware engine dispatch** — `runtime/account_worker.rs`

The scheduled-convergence `for group_id in groups` loop now checks `lifecycle.is_stopping()` between groups. That boundary is the only cut point where no `SnapshotRollbackGuard` is live, so it is also the only one that cannot leave a group half-rolled-back — a partially applied snapshot capture or rollback would be strictly worse than the crash this fixes. Undispatched groups need no hand-off; their convergence inputs are durable and the next runtime rediscovers them at catch-up. The maintenance tick (capped at 15s, 3× the whole shutdown budget) is skipped outright when stopping.

## One finding beyond the reported diagnosis

The root runtime lease (`.marmot-runtime.lock`) is an advisory `flock` on a file **inside the Marmot root** — the same App Group container — and was documented as held until the last app/runtime handle drops, even after `shutdown()`. That is a second, independent `0xdead10cc` trigger and would have left the no-threads signature partly unfixed. `close_storage` now takes and drops it; the field moved from `Option<Arc<Lease>>` to `Arc<Mutex<Option<Lease>>>` so the shared-across-clones semantics are preserved while an explicit close can still release it early.

## FFI surface for the iOS handoff

```rust
pub async fn shutdown_and_close(&self) -> Result<(), MarmotKitError>  // Swift: shutdownAndClose()
pub fn storage_is_closed(&self) -> bool                               // Swift: storageIsClosed()
```

Plus a typed `MarmotKitError::StorageClosed { details }` — non-retryable, so work racing the close reads as "we shut down" rather than a storage fault the user gets told about.

The iOS app picks these up via `./scripts/sync-bindings.sh` and wires `shutdownAndClose()` into `RuntimeLifecycle.prepareForBackgroundSuspension()`. Per this crate's lockstep invariant, **versions are not bumped here** — binding regeneration and the version bump ride the release.

## Tests

- `close_releases_wal_locks_and_sidecars` — `-wal`/`-shm` unlinked, and a *fresh* connection takes `locking_mode = EXCLUSIVE` and writes. That exclusive open is the real proxy for what iOS checks.
- `close_under_a_live_writer_is_prompt_and_leaves_no_torn_transaction` — 10k two-table transactions on a worker thread, closed mid-flight; asserts the close returns in under 1s and both tables match on reopen.
- `transaction_open_at_close_reports_closed_without_latching_unusable`, `close_wakes_threads_waiting_for_the_transaction_slot`, idempotency, and surviving-clone / OpenMLS-adapter handles reporting `Closed`.
- App level: all three database families' sidecars released, the root lease re-acquirable by a second owner, accessors refusing afterwards, and `shutdown_and_close` idempotent with and without a prior `shutdown`.

**Not covered by a test:** the runtime-level deferral in the convergence loop. Exercising it needs a live account with a multi-group batch and a shutdown landing mid-batch, which only the relay harness can set up. The equivalent guarantee is tested at the storage layer instead. Flagging it rather than implying coverage.

## Verification

`just fast-ci` clean. `storage-sqlite` 329 passed, `marmot-app --lib` 568, `relay_runtime` 92 (CI invocation: `--features test-policy-overrides -- --test-threads=1`), plus `marmot-account`, `cgka-session`, `cgka-traits`, and `marmot-uniffi`.

## Notes for review

- `StorageError` gains a `Closed(String)` variant. It is deliberately its own variant and non-transient — `is_transient()` stays false, and a new `is_closed()` lets callers classify orderly shutdown apart from a storage fault. Compiler-checked at every match site.
- WAL is unchanged. The app and the Notification Service Extension both open this store and WAL is what makes that workable; the fix is to close the store, not to weaken it.
- `docs/marmot-architecture/overview/local-artifact-safety.md` gains a "Releasing artifacts before host suspension" section, and the crate `AGENTS.md` files carry the matching invariants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a complete shutdown-and-close operation that stops services, closes local storage, and releases file locks.
  - Added storage status checks to confirm when closure is complete.
  - Added a distinct “Storage Closed” error for operations attempted after closure.

- **Reliability**
  - Improved handling of temporary SQLite contention with bounded retries.
  - Prevented new work from starting during shutdown.
  - Closure is terminal, safe to repeat, and prevents storage from reopening.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->