### PR TITLE
fix(app): close invite catch-up lifecycle races

### DIFF
--- a/crates/marmot-app/src/runtime/commands.rs
+++ b/crates/marmot-app/src/runtime/commands.rs
@@ -13,7 +13,7 @@ use tokio::sync::oneshot;
 
 use super::{
     AccountManager, AccountWorkerCommand, account_worker_response, group_contributes_co_members,
-    publish_app_runtime_group_state_updated,
+    publish_app_runtime_group_state_updated, wait_for_runtime_shutdown,
 };
 use crate::app_telemetry::AppPerformanceOperation;
 use crate::messages::AppMessageIntent;
@@ -29,9 +29,21 @@ use crate::{
 impl AccountManager {
     fn spawn_invite_catch_up(&self) {
         let post_mutation = self.clone();
-        tokio::spawn(async move {
+        let mut stopping = self.shared.lifecycle().subscribe_shutdown();
+        let mut tasks = self
+            .invite_catch_up_tasks
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        tasks.handles.retain(|task| !task.is_finished());
+        if !tasks.accepting {
+            return;
+        }
+        let handle = tokio::spawn(async move {
             let catch_up_started_at = Instant::now();
-            let catch_up = post_mutation.catch_up_accounts().await;
+            let catch_up = tokio::select! {
+                _ = wait_for_runtime_shutdown(&mut stopping) => return,
+                catch_up = post_mutation.catch_up_accounts() => catch_up,
+            };
             post_mutation.shared.app_performance_telemetry().record(
                 AppPerformanceOperation::GroupInvitePostMutationCatchUp,
                 catch_up_started_at.elapsed(),
@@ -46,6 +58,7 @@ impl AccountManager {
                 );
             }
         });
+        tasks.handles.push(handle);
     }
 
     /// Refresh other account workers after an irreversible mutation without

--- a/crates/marmot-app/src/runtime/commands.rs
+++ b/crates/marmot-app/src/runtime/commands.rs
@@ -13,7 +13,7 @@ use tokio::sync::oneshot;
 
 use super::{
     AccountManager, AccountWorkerCommand, account_worker_response, group_contributes_co_members,
-    publish_app_runtime_group_state_updated, wait_for_runtime_shutdown,
+    publish_app_runtime_group_state_updated,
 };
 use crate::app_telemetry::AppPerformanceOperation;
 use crate::messages::AppMessageIntent;
@@ -27,9 +27,7 @@ use crate::{
 };
 
 impl AccountManager {
-    fn spawn_invite_catch_up(&self) {
-        let post_mutation = self.clone();
-        let mut stopping = self.shared.lifecycle().subscribe_shutdown();
+    pub(super) fn spawn_invite_catch_up(&self) {
         let mut tasks = self
             .invite_catch_up_tasks
             .lock()
@@ -38,12 +36,13 @@ impl AccountManager {
         if !tasks.accepting {
             return;
         }
+        let post_mutation = self.clone();
         let handle = tokio::spawn(async move {
             let catch_up_started_at = Instant::now();
-            let catch_up = tokio::select! {
-                _ = wait_for_runtime_shutdown(&mut stopping) => return,
-                catch_up = post_mutation.catch_up_accounts() => catch_up,
-            };
+            // Once started, catch-up must run to a normal result. Cancelling
+            // reconcile mid-await could abandon stale workers that it already
+            // removed from the manager map but has not finished reaping.
+            let catch_up = post_mutation.catch_up_accounts().await;
             post_mutation.shared.app_performance_telemetry().record(
                 AppPerformanceOperation::GroupInvitePostMutationCatchUp,
                 catch_up_started_at.elapsed(),

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -122,6 +122,12 @@ pub struct AccountManager {
     shared: RuntimeSharedServices,
     workers: Arc<Mutex<HashMap<String, ManagedAccountWorker>>>,
     tearing_down: Arc<StdMutex<HashSet<String>>>,
+    invite_catch_up_tasks: Arc<StdMutex<InviteCatchUpTasks>>,
+}
+
+struct InviteCatchUpTasks {
+    accepting: bool,
+    handles: Vec<JoinHandle<()>>,
 }
 
 #[derive(Clone)]
@@ -3306,6 +3312,10 @@ impl AccountManager {
             shared,
             workers: Arc::new(Mutex::new(HashMap::new())),
             tearing_down: Arc::new(StdMutex::new(HashSet::new())),
+            invite_catch_up_tasks: Arc::new(StdMutex::new(InviteCatchUpTasks {
+                accepting: true,
+                handles: Vec::new(),
+            })),
         }
     }
 
@@ -4634,6 +4644,14 @@ impl AccountManager {
 
     pub async fn shutdown(&self) {
         self.shared.lifecycle().begin_shutdown();
+        let invite_catch_up_tasks = {
+            let mut tasks = self
+                .invite_catch_up_tasks
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            tasks.accepting = false;
+            std::mem::take(&mut tasks.handles)
+        };
         let workers = {
             let mut workers = self.workers.lock().await;
             workers
@@ -4645,6 +4663,11 @@ impl AccountManager {
         for worker in workers {
             shutdowns.spawn(async move {
                 worker.shutdown().await;
+            });
+        }
+        for task in invite_catch_up_tasks {
+            shutdowns.spawn(async move {
+                let _ = task.await;
             });
         }
         while shutdowns.join_next().await.is_some() {}

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -4652,6 +4652,13 @@ impl AccountManager {
             tasks.accepting = false;
             std::mem::take(&mut tasks.handles)
         };
+        // A catch-up may already have passed reconcile's lifecycle check and
+        // still be replacing a stale worker. Reap every tracked catch-up
+        // before the final worker-map drain so no replacement can escape
+        // shutdown.
+        for task in invite_catch_up_tasks {
+            let _ = task.await;
+        }
         let workers = {
             let mut workers = self.workers.lock().await;
             workers
@@ -4663,11 +4670,6 @@ impl AccountManager {
         for worker in workers {
             shutdowns.spawn(async move {
                 worker.shutdown().await;
-            });
-        }
-        for task in invite_catch_up_tasks {
-            shutdowns.spawn(async move {
-                let _ = task.await;
             });
         }
         while shutdowns.join_next().await.is_some() {}

--- a/crates/marmot-app/src/runtime/tests.rs
+++ b/crates/marmot-app/src/runtime/tests.rs
@@ -1479,6 +1479,29 @@ async fn account_manager_shutdown_drains_worker_inserted_by_in_flight_catch_up()
     assert!(manager.workers.lock().await.is_empty());
 }
 
+#[test]
+fn invite_catch_up_is_not_spawned_after_shutdown_stops_accepting_tasks() {
+    let dir = tempfile::tempdir().unwrap();
+    let runtime = MarmotAppRuntime::new(MarmotApp::with_relay(dir.path(), "wss://relay.example"));
+    let manager = runtime.accounts.clone();
+    manager
+        .invite_catch_up_tasks
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .accepting = false;
+
+    manager.spawn_invite_catch_up();
+
+    assert!(
+        manager
+            .invite_catch_up_tasks
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .handles
+            .is_empty()
+    );
+}
+
 // Sender-controlled broker candidates must clear the shared dial-safety gate
 // at resolve time: literal-IP authorities resolve without DNS, so these cover
 // the canonical non-public classes end to end (issue #331).

--- a/crates/marmot-app/src/runtime/tests.rs
+++ b/crates/marmot-app/src/runtime/tests.rs
@@ -1413,6 +1413,72 @@ async fn lifecycle_waits_for_account_opens_to_drain() {
     assert!(waiter.await.expect("drain waiter should complete"));
 }
 
+#[tokio::test]
+async fn account_manager_shutdown_drains_worker_inserted_by_in_flight_catch_up() {
+    let dir = tempfile::tempdir().unwrap();
+    let runtime = MarmotAppRuntime::new(MarmotApp::with_relay(dir.path(), "wss://relay.example"));
+    let manager = runtime.accounts.clone();
+    let release_insertion = Arc::new(Notify::new());
+    let release_for_catch_up = release_insertion.clone();
+    let (catch_up_waiting_tx, catch_up_waiting_rx) = oneshot::channel();
+    let workers = manager.workers.clone();
+    let (worker_exited_tx, worker_exited_rx) = oneshot::channel();
+
+    let catch_up = tokio::spawn(async move {
+        let insertion_released = release_for_catch_up.notified();
+        tokio::pin!(insertion_released);
+        insertion_released.as_mut().enable();
+        let _ = catch_up_waiting_tx.send(());
+        insertion_released.await;
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let (commands, _command_rx) = mpsc::channel(1);
+        let handle = tokio::spawn(async move {
+            let _ = shutdown_rx.await;
+            let _ = worker_exited_tx.send(());
+        });
+        workers.lock().await.insert(
+            "replacement".to_owned(),
+            ManagedAccountWorker {
+                handle,
+                commands,
+                shutdown: shutdown_tx,
+            },
+        );
+    });
+    manager
+        .invite_catch_up_tasks
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .handles
+        .push(catch_up);
+    catch_up_waiting_rx
+        .await
+        .expect("catch-up should register its release waiter");
+
+    let shutdown_manager = manager.clone();
+    let shutdown = tokio::spawn(async move {
+        shutdown_manager.shutdown().await;
+    });
+    loop {
+        let accepting = manager
+            .invite_catch_up_tasks
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .accepting;
+        if !accepting {
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+    release_insertion.notify_waiters();
+
+    shutdown.await.expect("manager shutdown should complete");
+    worker_exited_rx
+        .await
+        .expect("replacement worker should be shut down");
+    assert!(manager.workers.lock().await.is_empty());
+}
+
 // Sender-controlled broker candidates must clear the shared dial-safety gate
 // at resolve time: literal-IP authorities resolve without DNS, so these cover
 // the canonical non-public classes end to end (issue #331).

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -208,9 +208,12 @@ impl WritePolicy for BlockNextGroupMessages {
                     })
                     .is_ok();
             if should_block {
+                let released = self.release.notified();
+                tokio::pin!(released);
+                released.as_mut().enable();
                 self.blocked.fetch_add(1, Ordering::SeqCst);
                 self.entered.notify_one();
-                self.release.notified().await;
+                released.await;
             }
             PolicyResult::Accept
         })


### PR DESCRIPTION
## What was broken

Two late automated review findings landed on #1309 after its final CI run had started:

- invite-triggered catch-up tasks dropped their `JoinHandle`, so runtime shutdown did not coordinate their completion;
- the reciprocal-invite relay test published its blocked counter before registering the `Notify` waiter, leaving a small missed-wakeup race.

## Root cause and impact

The detached catch-up was lifecycle-aware only indirectly through worker shutdown. A runtime could therefore finish its own shutdown path while a catch-up task still held cloned runtime services. Separately, `notify_waiters()` stores no permit, so a fast test release could occur between the counter increment and waiter registration and hang the test.

## Changes

- register invite catch-up handles before returning from the mutation path;
- stop accepting new catch-up tasks once shutdown begins, cancel in-flight catch-ups from the shared lifecycle signal, and await their handles alongside account workers;
- register the relay-test release waiter before publishing the blocked counter;
- keep one catch-up per successful invite instead of coalescing, preserving the reciprocal/mixed-result delivery guarantee from #1309.

## Validation

- `just fast-ci`
- `cargo test -p marmot-app --test relay_runtime overlapping_reciprocal_invites_deliver_both_incoming_welcomes --locked -- --exact`
- `cargo test -p marmot-app --test relay_runtime successful_invite_delivers_while_overlapping_invite_fails --locked -- --exact`
- `cargo test -p marmot-app --lib tests::invite_members_keeps_same_account_projection_reads_off_detached_catch_up --locked -- --exact`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved invite synchronization during shutdown to prevent missed updates and ensure in-progress tasks finish cleanly.
  * Prevented new invite catch-up operations from starting once shutdown begins.
  * Fixed event notification handling to reliably preserve notifications that occur before a waiting task is ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->