### PR TITLE
feat: provide bounded local membership reads

### DIFF
--- a/crates/cgka-conformance-simulator/src/app_runtime.rs
+++ b/crates/cgka-conformance-simulator/src/app_runtime.rs
@@ -1054,6 +1054,7 @@ fn app_error(error: AppError) -> SubjectError {
         AppError::Json(_)
         | AppError::Hex(_)
         | AppError::InvalidChatPin(_)
+        | AppError::InvalidGroupMembershipPage(_)
         | AppError::InvalidMessageDraft(_)
         | AppError::InvalidPublicKey
         | AppError::UnexpectedPrivateKey

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -56,6 +56,13 @@ versioning through the workspace version in the root `Cargo.toml`.
   caller membership for cheap membership-screen change detection. Existing
   `groupDetails`, `groupMlsState`, and `groupMembers` remain available for
   compatibility.
+
+- MarmotKit exposes `groupMemberIdsPage`, a bounded identifier-only companion
+  read for chat-list consumers. A host can fetch membership for up to 100
+  groups in one account-worker command instead of issuing one `groupMembers`
+  or `groupRoster` command per chat. The page preserves input order, performs
+  no profile enrichment, and fails as a whole when any requested group is
+  unknown or quarantined.
   
 - MarmotKit exposes `downloadProfileImage` for dial-safe fetching of untrusted
   kind:0 profile `picture` URLs (HTTPS-only, proxy-disabled pinned public

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -62,7 +62,8 @@ versioning through the workspace version in the root `Cargo.toml`.
   groups in one account-worker command instead of issuing one `groupMembers`
   or `groupRoster` command per chat. The page preserves input order, performs
   no profile enrichment, and fails as a whole when any requested group is
-  unknown or quarantined.
+  unknown or quarantined
+  ([#1342](https://github.com/marmot-protocol/mdk/pull/1342)).
   
 - MarmotKit exposes `downloadProfileImage` for dial-safe fetching of untrusted
   kind:0 profile `picture` URLs (HTTPS-only, proxy-disabled pinned public

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -175,6 +175,25 @@ impl GroupReadSnapshot {
             .ok_or_else(|| AppError::UnknownGroup(hex::encode(group_id.as_slice())))
     }
 
+    pub(crate) fn member_ids_page(
+        &self,
+        group_ids: &[GroupId],
+    ) -> Result<Vec<crate::AppGroupMemberIds>, AppError> {
+        group_ids
+            .iter()
+            .map(|group_id| {
+                let members = self.members(group_id)?;
+                Ok(crate::AppGroupMemberIds {
+                    group_id_hex: hex::encode(group_id.as_slice()),
+                    member_ids_hex: members
+                        .into_iter()
+                        .map(|member| member.member_id_hex)
+                        .collect(),
+                })
+            })
+            .collect()
+    }
+
     pub(crate) fn group_mls_state(&self, group_id: &GroupId) -> Result<AppGroupMlsState, AppError> {
         self.mls_state
             .get(group_id)
@@ -729,6 +748,28 @@ impl AppClient {
     pub fn members(&self, group_id: &GroupId) -> Result<Vec<AppGroupMemberRecord>, AppError> {
         let profiles = self.app.profiles_by_id()?;
         self.members_with_profiles(group_id, &profiles)
+    }
+
+    pub(crate) fn member_ids_page(
+        &self,
+        group_ids: &[GroupId],
+    ) -> Result<Vec<crate::AppGroupMemberIds>, AppError> {
+        group_ids
+            .iter()
+            .map(|group_id| {
+                self.ensure_group(group_id)?;
+                let member_ids_hex = self
+                    .runtime
+                    .members(group_id)?
+                    .into_iter()
+                    .map(|member| hex::encode(member.id.as_slice()))
+                    .collect();
+                Ok(crate::AppGroupMemberIds {
+                    group_id_hex: hex::encode(group_id.as_slice()),
+                    member_ids_hex,
+                })
+            })
+            .collect()
     }
 
     /// Build a group's member records against a caller-provided account-profile

--- a/crates/marmot-app/src/client/projection.rs
+++ b/crates/marmot-app/src/client/projection.rs
@@ -551,6 +551,9 @@ fn read_marker_error_code(error: &AppError) -> &'static str {
         AppError::Hex(_) => "read_marker_failed:hex",
         AppError::MissingKeyPackage(_) => "read_marker_failed:missing_key_package",
         AppError::UnknownGroup(_) => "read_marker_failed:unknown_group",
+        AppError::InvalidGroupMembershipPage(_) => {
+            "read_marker_failed:invalid_group_membership_page"
+        }
         AppError::InvalidChatPin(_) => "read_marker_failed:invalid_chat_pin",
         AppError::GroupDisbanding(_) => "read_marker_failed:group_disbanding",
         AppError::InvalidMessageDraft(_) => "read_marker_failed:invalid_message_draft",

--- a/crates/marmot-app/src/error.rs
+++ b/crates/marmot-app/src/error.rs
@@ -27,6 +27,8 @@ pub enum AppError {
     MissingKeyPackage(String),
     #[error("unknown local group")]
     UnknownGroup(String),
+    #[error("invalid group membership page: {0}")]
+    InvalidGroupMembershipPage(String),
     #[error("invalid chat pin: {0}")]
     InvalidChatPin(String),
     #[error("group is disbanding or disbanded; outbound work is blocked")]
@@ -182,6 +184,7 @@ impl AppError {
             Self::Hex(_) => "hex",
             Self::MissingKeyPackage(_) => "missing_key_package",
             Self::UnknownGroup(_) => "unknown_group",
+            Self::InvalidGroupMembershipPage(_) => "invalid_group_membership_page",
             Self::InvalidChatPin(_) => "invalid_chat_pin",
             Self::GroupDisbanding(_) => "group_disbanding",
             Self::InvalidMessageDraft(_) => "invalid_message_draft",

--- a/crates/marmot-app/src/groups.rs
+++ b/crates/marmot-app/src/groups.rs
@@ -39,6 +39,13 @@ use crate::{AccountState, AppError, ReceivedMessage, SelfMembership, SendSummary
 /// protocol's retained-epoch windows.
 const MAX_PRIOR_NOSTR_ROUTES: usize = 32;
 
+/// Maximum number of group rosters returned by one local membership read.
+///
+/// Host chat-list consumers should page larger accounts rather than issuing
+/// one worker command per group. Keeping the page bounded also prevents an
+/// untrusted host input from monopolizing the per-account worker.
+pub const MAX_GROUP_MEMBER_IDS_PAGE_SIZE: usize = 100;
+
 /// Initial group-image input for encrypted-Blossom-first creation.
 ///
 /// The host owns discovery and download. MDK receives the decoded image bytes,
@@ -175,6 +182,16 @@ pub struct AppGroupMemberRecord {
     pub member_id_hex: String,
     pub account: Option<String>,
     pub local: bool,
+}
+
+/// Lightweight local roster projection for one group.
+///
+/// This deliberately contains identifiers only: profile/display-name
+/// enrichment remains on the group-detail path.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AppGroupMemberIds {
+    pub group_id_hex: String,
+    pub member_ids_hex: Vec<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -152,11 +152,11 @@ pub use groups::{
     AppAgentTextStreamComponent, AppBlobEndpoint, AppDisbandFailureReason, AppDisbandRequest,
     AppGroupAdminPolicyComponent, AppGroupAvatarUrlComponent, AppGroupEncryptedMediaComponent,
     AppGroupHydrationQuarantineReason, AppGroupImageComponent, AppGroupLifecycleState,
-    AppGroupMemberRecord, AppGroupMessageRetentionComponent, AppGroupMlsState,
+    AppGroupMemberIds, AppGroupMemberRecord, AppGroupMessageRetentionComponent, AppGroupMlsState,
     AppGroupNostrRoutingComponent, AppGroupOpaqueComponent, AppGroupProfileComponent,
     AppGroupRecord, AppGroupRoster, AppGroupRosterMember, AppGroupSystemEvent,
     AppInitialGroupImage, AppPriorNostrRoute, AppProtocolProfile, AppQuarantinedGroup,
-    group_system_event_from_message,
+    MAX_GROUP_MEMBER_IDS_PAGE_SIZE, group_system_event_from_message,
 };
 pub use ids::{
     account_id_hex_from_ref, nprofile_for_account_id, npub_for_account_id, validate_relay_urls,

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -107,6 +107,10 @@ pub(crate) enum AccountWorkerCommand {
         group_id: GroupId,
         respond: oneshot::Sender<Result<Vec<AppGroupMemberRecord>, AppError>>,
     },
+    MemberIdsPage {
+        group_ids: Vec<GroupId>,
+        respond: oneshot::Sender<Result<Vec<crate::AppGroupMemberIds>, AppError>>,
+    },
     GroupMlsState {
         group_id: GroupId,
         respond: oneshot::Sender<Result<AppGroupMlsState, AppError>>,
@@ -458,10 +462,10 @@ async fn run_app_runtime_account_worker(
     // The session's cheap open pass has seeded every stored group. Signal
     // command-readiness *now*: the hydration pipeline right below enters its
     // command-serving loop immediately, so "ready" genuinely means "serving
-    // commands" — group reads (`Members` / `GroupMlsState` / `GroupRoster` /
-    // `QuarantinedGroups`) issued from this point hydrate exactly the group
-    // they name and answer live, and everything else joins the startup
-    // deferral. `AccountOpen` (recorded by `reconcile` as the ready-wait)
+    // commands" — group reads (`Members` / `MemberIdsPage` / `GroupMlsState` /
+    // `GroupRoster` / `QuarantinedGroups`) issued from this point hydrate the
+    // group(s) they name and answer live. Everything else
+    // joins the startup deferral. `AccountOpen` (recorded by `reconcile` as the ready-wait)
     // measures the seeded open; the mdk#1161 stage telemetry attributes it
     // (`AccountSessionOpen` / `AccountGroupHydration` for the open the
     // worker just awaited, with the pipeline and snapshot capture measured
@@ -579,6 +583,16 @@ async fn run_app_runtime_account_worker(
                                 // state after catch-up instead of guessing.
                                 None => deferred.push(DeferredStartupCommand::Command(Box::new(
                                     AccountWorkerCommand::Members { group_id, respond },
+                                ))),
+                            }
+                        }
+                        Some(AccountWorkerCommand::MemberIdsPage { group_ids, respond }) => {
+                            match &read_snapshot {
+                                Some(snapshot) => {
+                                    let _ = respond.send(snapshot.member_ids_page(&group_ids));
+                                }
+                                None => deferred.push(DeferredStartupCommand::Command(Box::new(
+                                    AccountWorkerCommand::MemberIdsPage { group_ids, respond },
                                 ))),
                             }
                         }
@@ -1236,6 +1250,14 @@ async fn handle_account_worker_catch_up(
                         .expect("snapshot availability checked above");
                     let _ = respond.send(snapshot.members(&group_id));
                 }
+                AccountWorkerCommand::MemberIdsPage { group_ids, respond }
+                    if snapshot_reads_available =>
+                {
+                    let snapshot = read_snapshot
+                        .as_ref()
+                        .expect("snapshot availability checked above");
+                    let _ = respond.send(snapshot.member_ids_page(&group_ids));
+                }
                 AccountWorkerCommand::GroupMlsState { group_id, respond }
                     if snapshot_reads_available =>
                 {
@@ -1502,6 +1524,9 @@ async fn handle_startup_hydration_command(
                 .ensure_group_hydrated(&group_id);
             let _ = respond.send(client.members(&group_id));
         }
+        AccountWorkerCommand::MemberIdsPage { group_ids, respond } => {
+            let _ = respond.send(member_ids_page_after_hydration(client, &group_ids));
+        }
         AccountWorkerCommand::GroupMlsState { group_id, respond } => {
             let _ = client
                 .runtime
@@ -1527,7 +1552,8 @@ async fn handle_startup_hydration_command(
 /// Extracted so the worker can drive commands from two places: the steady-state
 /// command loop, and the deferred-command replay that runs after catch-up
 /// completes (commands that arrived while catch-up held `&mut client`). Read
-/// commands (`Members` / `GroupMlsState` / `QuarantinedGroups`) are also
+/// commands (`Members` / `MemberIdsPage` / `GroupMlsState` /
+/// `QuarantinedGroups`) are also
 /// intercepted inline during catch-up and answered from a `GroupReadSnapshot`;
 /// here they read the live session.
 async fn handle_account_worker_command(
@@ -1663,6 +1689,11 @@ async fn handle_account_worker_command(
                 .ensure_group_hydrated(&group_id);
             let result = client.members(&group_id);
             let _ = respond.send(result);
+        }
+        AccountWorkerCommand::MemberIdsPage { group_ids, respond } => {
+            // The page is one worker command, but each requested group keeps
+            // the same on-demand promotion and quarantine gate as `Members`.
+            let _ = respond.send(member_ids_page_after_hydration(client, &group_ids));
         }
         AccountWorkerCommand::GroupMlsState { group_id, respond } => {
             // See the Members arm: on-demand promotion for pipeline-abort
@@ -2356,6 +2387,23 @@ pub(super) fn group_roster_after_hydration(
         .ensure_group_hydrated(group_id)?;
     client.reconcile_group_self_membership(group_id)?;
     client.group_roster_session(group_id)
+}
+
+fn member_ids_page_after_hydration(
+    client: &mut AppClient,
+    group_ids: &[GroupId],
+) -> Result<Vec<crate::AppGroupMemberIds>, AppError> {
+    // Match every existing worker-routed group read: a seeded group promotes
+    // on demand, while a failed promotion enters quarantine and is exposed as
+    // UnknownGroup. Build the response only after all requested rosters pass
+    // that gate so callers never receive a partial page.
+    for group_id in group_ids {
+        let _live = client
+            .runtime
+            .session_mut()
+            .ensure_group_hydrated(group_id)?;
+    }
+    client.member_ids_page(group_ids)
 }
 
 fn group_roster_from_snapshot(

--- a/crates/marmot-app/src/runtime/commands.rs
+++ b/crates/marmot-app/src/runtime/commands.rs
@@ -170,6 +170,34 @@ impl AccountManager {
         account_worker_response(response).await
     }
 
+    /// Read identifier-only rosters for a bounded page of groups in one
+    /// account-worker round trip.
+    ///
+    /// The response preserves input order and fails as a whole if any group is
+    /// unknown or hydration-quarantined; it never returns a partial page.
+    pub async fn group_member_ids_page(
+        &self,
+        account_ref: &str,
+        group_ids: &[GroupId],
+    ) -> Result<Vec<crate::AppGroupMemberIds>, AppError> {
+        if group_ids.len() > crate::MAX_GROUP_MEMBER_IDS_PAGE_SIZE {
+            return Err(AppError::InvalidGroupMembershipPage(format!(
+                "at most {} groups are allowed",
+                crate::MAX_GROUP_MEMBER_IDS_PAGE_SIZE
+            )));
+        }
+        let command = self.worker_commands(account_ref).await?;
+        let (respond, response) = oneshot::channel();
+        command
+            .send(AccountWorkerCommand::MemberIdsPage {
+                group_ids: group_ids.to_vec(),
+                respond,
+            })
+            .await
+            .map_err(|_| AppError::TransportClosed)?;
+        account_worker_response(response).await
+    }
+
     pub async fn group_mls_state(
         &self,
         account_ref: &str,

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -1197,6 +1197,18 @@ impl MarmotAppRuntime {
         self.accounts.group_members(account_ref, group_id).await
     }
 
+    /// Identifier-only membership for a bounded page of groups, served in one
+    /// per-account worker command without profile enrichment.
+    pub async fn group_member_ids_page(
+        &self,
+        account_ref: &str,
+        group_ids: &[GroupId],
+    ) -> Result<Vec<crate::AppGroupMemberIds>, AppError> {
+        self.accounts
+            .group_member_ids_page(account_ref, group_ids)
+            .await
+    }
+
     pub async fn group_mls_state(
         &self,
         account_ref: &str,

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -2306,6 +2306,24 @@ async fn app_runtime_serves_member_reads_before_initial_catch_up_completes() {
         "restart must become command-ready before the initial catch-up completes",
     );
 
+    // The bounded chat-list companion read uses the same snapshot during the
+    // detached catch-up, so batching does not reintroduce a readiness wait.
+    let member_ids_page = timeout(
+        Duration::from_secs(2),
+        runtime.group_member_ids_page(&bob_id, std::slice::from_ref(&group_id)),
+    )
+    .await
+    .expect("member-id page must not block on the initial catch-up")
+    .unwrap();
+    assert_eq!(member_ids_page.len(), 1);
+    assert!(member_ids_page[0].member_ids_hex.contains(&alice_id));
+    assert!(member_ids_page[0].member_ids_hex.contains(&bob_id));
+    assert_eq!(
+        account_sync_attempts(),
+        before_restart,
+        "member-id page must complete before the initial catch-up finishes",
+    );
+
     // The combined roster read is answered with a session-consistent group
     // record, member list, and MLS state while (or right after) catch-up runs.
     // During the catch-up window it comes from the post-hydration snapshot;
@@ -2328,19 +2346,6 @@ async fn app_runtime_serves_member_reads_before_initial_catch_up_completes() {
         roster_member_ids.contains(&alice_id) && roster_member_ids.contains(&bob_id),
         "snapshot/live roster read must report the full roster",
     );
-
-    // The bounded chat-list companion read uses the same snapshot during the
-    // detached catch-up, so batching does not reintroduce a readiness wait.
-    let member_ids_page = timeout(
-        Duration::from_secs(2),
-        runtime.group_member_ids_page(&bob_id, std::slice::from_ref(&group_id)),
-    )
-    .await
-    .expect("member-id page must not block on the initial catch-up")
-    .unwrap();
-    assert_eq!(member_ids_page.len(), 1);
-    assert!(member_ids_page[0].member_ids_hex.contains(&alice_id));
-    assert!(member_ids_page[0].member_ids_hex.contains(&bob_id));
 
     // The existing member-only read remains command-ready as well.
     let members = timeout(

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -2329,6 +2329,19 @@ async fn app_runtime_serves_member_reads_before_initial_catch_up_completes() {
         "snapshot/live roster read must report the full roster",
     );
 
+    // The bounded chat-list companion read uses the same snapshot during the
+    // detached catch-up, so batching does not reintroduce a readiness wait.
+    let member_ids_page = timeout(
+        Duration::from_secs(2),
+        runtime.group_member_ids_page(&bob_id, std::slice::from_ref(&group_id)),
+    )
+    .await
+    .expect("member-id page must not block on the initial catch-up")
+    .unwrap();
+    assert_eq!(member_ids_page.len(), 1);
+    assert!(member_ids_page[0].member_ids_hex.contains(&alice_id));
+    assert!(member_ids_page[0].member_ids_hex.contains(&bob_id));
+
     // The existing member-only read remains command-ready as well.
     let members = timeout(
         Duration::from_secs(2),

--- a/crates/marmot-app/tests/startup_hydration.rs
+++ b/crates/marmot-app/tests/startup_hydration.rs
@@ -14,7 +14,10 @@ use std::time::{Duration, Instant};
 
 use cgka_traits::types::GroupId;
 use marmot_account::AccountHome;
-use marmot_app::{MarmotApp, MarmotAppConfig, MarmotAppRuntime, SelfMembership};
+use marmot_app::{
+    AppError, MAX_GROUP_MEMBER_IDS_PAGE_SIZE, MarmotApp, MarmotAppConfig, MarmotAppRuntime,
+    SelfMembership,
+};
 use nostr_relay_builder::MockRelay;
 
 const BENCH_ACCOUNT: &str = "held";
@@ -192,6 +195,50 @@ async fn held_hydration_body() {
         GROUP_COUNT,
         "persisted chat list must hold every group while hydration is held"
     );
+
+    // The identifier-only roster page is the bounded companion read for that
+    // chat projection (mdk#1314). One worker command promotes only the named
+    // groups from durable state and returns every roster without waiting for
+    // the held background pipeline or doing profile enrichment.
+    let page_started = Instant::now();
+    let member_ids_page = tokio::time::timeout(
+        Duration::from_millis(BATCH_HOLD_MS / 2),
+        runtime.group_member_ids_page(BENCH_ACCOUNT, &group_ids),
+    )
+    .await
+    .expect("bounded membership read must not wait out the hydration hold")
+    .unwrap();
+    assert_eq!(member_ids_page.len(), GROUP_COUNT);
+    for (row, group_id) in member_ids_page.iter().zip(&group_ids) {
+        assert_eq!(row.group_id_hex, hex::encode(group_id.as_slice()));
+        assert_eq!(row.member_ids_hex.len(), 2);
+        assert!(row.member_ids_hex.contains(&donor_id));
+    }
+    assert!(
+        page_started.elapsed() < Duration::from_millis(BATCH_HOLD_MS / 2),
+        "bounded membership read must not wait out the pipeline hold"
+    );
+
+    // A page is all-or-error: an unknown (including quarantine-hidden) group
+    // cannot produce a partial response containing the preceding safe row.
+    let unknown = GroupId::new(vec![0xff; 16]);
+    assert!(matches!(
+        runtime
+            .group_member_ids_page(BENCH_ACCOUNT, &[group_ids[0].clone(), unknown])
+            .await,
+        Err(AppError::UnknownGroup(_))
+            | Err(AppError::Session(cgka_session::SessionError::Engine(
+                cgka_traits::error::EngineError::UnknownGroup(_)
+            )))
+    ));
+
+    let oversized = vec![group_ids[0].clone(); MAX_GROUP_MEMBER_IDS_PAGE_SIZE + 1];
+    assert!(matches!(
+        runtime
+            .group_member_ids_page(BENCH_ACCOUNT, &oversized)
+            .await,
+        Err(AppError::InvalidGroupMembershipPage(_))
+    ));
 
     // A group read issued during the hold hydrates exactly the group it
     // names and answers from live state — it must not wait out the hold.

--- a/crates/marmot-uniffi/src/commands/group.rs
+++ b/crates/marmot-uniffi/src/commands/group.rs
@@ -10,13 +10,13 @@ use cgka_traits::GroupId;
 
 use crate::Marmot;
 use crate::conversions::{
-    AppBlobEndpointFfi, AppGroupMemberRecordFfi, AppGroupMlsStateFfi, AppGroupRecordFfi,
-    AppQuarantinedGroupFfi, DisbandRequestFfi, GroupDetailsFfi, GroupInviteDeclineResultFfi,
-    GroupMaintenanceStatusFfi, GroupManagementStateFfi, GroupMemberActionStateFfi,
-    GroupMutationResultFfi, GroupRosterFfi, KeyPackageMaintenanceStatusFfi,
-    MaintenanceRunSummaryFfi, MemberRefFfi, PeriodicMaintenancePolicyFfi, SendSummaryFfi,
-    group_details_ffi, group_id_from_hex, group_management_state_ffi, group_roster_ffi,
-    normalize_member_ref_ffi,
+    AppBlobEndpointFfi, AppGroupMemberIdsFfi, AppGroupMemberRecordFfi, AppGroupMlsStateFfi,
+    AppGroupRecordFfi, AppQuarantinedGroupFfi, DisbandRequestFfi, GroupDetailsFfi,
+    GroupInviteDeclineResultFfi, GroupMaintenanceStatusFfi, GroupManagementStateFfi,
+    GroupMemberActionStateFfi, GroupMutationResultFfi, GroupRosterFfi,
+    KeyPackageMaintenanceStatusFfi, MaintenanceRunSummaryFfi, MemberRefFfi,
+    PeriodicMaintenancePolicyFfi, SendSummaryFfi, group_details_ffi, group_id_from_hex,
+    group_management_state_ffi, group_roster_ffi, normalize_member_ref_ffi,
 };
 use crate::errors::MarmotKitError;
 
@@ -321,6 +321,34 @@ impl Marmot {
         let group_id = group_id_from_hex(&group_id_hex)?;
         let members = self.runtime.group_members(&account_ref, &group_id).await?;
         Ok(members.into_iter().map(Into::into).collect())
+    }
+
+    /// Identifier-only rosters for a bounded page of groups.
+    ///
+    /// This is the chat-projection companion read: it is one worker command,
+    /// performs no profile enrichment, and fails the whole page if any group
+    /// is unknown or quarantined.
+    pub async fn group_member_ids_page(
+        &self,
+        account_ref: String,
+        group_ids_hex: Vec<String>,
+    ) -> Result<Vec<AppGroupMemberIdsFfi>, MarmotKitError> {
+        if group_ids_hex.len() > marmot_app::MAX_GROUP_MEMBER_IDS_PAGE_SIZE {
+            return Err(MarmotKitError::InvalidGroupMembershipPage {
+                max_groups: marmot_app::MAX_GROUP_MEMBER_IDS_PAGE_SIZE as u64,
+            });
+        }
+        let group_ids = group_ids_hex
+            .iter()
+            .map(|group_id_hex| group_id_from_hex(group_id_hex))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(self
+            .runtime
+            .group_member_ids_page(&account_ref, &group_ids)
+            .await?
+            .into_iter()
+            .map(Into::into)
+            .collect())
     }
 
     /// Group plus enriched member rows for detail screens.

--- a/crates/marmot-uniffi/src/conversions/group.rs
+++ b/crates/marmot-uniffi/src/conversions/group.rs
@@ -5,7 +5,7 @@ use std::collections::{HashMap, HashSet};
 use marmot_app::{
     AppBlobEndpoint, AppDisbandFailureReason, AppDisbandRequest, AppGroupAdminPolicyComponent,
     AppGroupEncryptedMediaComponent, AppGroupHydrationQuarantineReason, AppGroupLifecycleState,
-    AppGroupMemberRecord, AppGroupMlsState, AppGroupNostrRoutingComponent,
+    AppGroupMemberIds, AppGroupMemberRecord, AppGroupMlsState, AppGroupNostrRoutingComponent,
     AppGroupProfileComponent, AppGroupRecord, AppGroupRoster, AppProtocolProfile,
     AppQuarantinedGroup, GroupInviteDeclineResult, account_id_hex_from_ref, npub_for_account_id,
 };
@@ -204,6 +204,21 @@ pub struct AppGroupMemberRecordFfi {
     pub member_id_hex: String,
     pub account: Option<String>,
     pub local: bool,
+}
+
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct AppGroupMemberIdsFfi {
+    pub group_id_hex: String,
+    pub member_ids_hex: Vec<String>,
+}
+
+impl From<AppGroupMemberIds> for AppGroupMemberIdsFfi {
+    fn from(value: AppGroupMemberIds) -> Self {
+        Self {
+            group_id_hex: value.group_id_hex,
+            member_ids_hex: value.member_ids_hex,
+        }
+    }
 }
 
 impl From<AppGroupMemberRecord> for AppGroupMemberRecordFfi {
@@ -735,5 +750,15 @@ mod group_roster_tests {
         assert!(matches!(ffi.self_membership, SelfMembershipFfi::Removed));
         assert_eq!(ffi.members.len(), 1);
         assert_eq!(ffi.members[0].display_name.as_deref(), Some("Alice"));
+    }
+
+    #[test]
+    fn member_ids_page_row_preserves_group_and_member_identifiers() {
+        let ffi = AppGroupMemberIdsFfi::from(AppGroupMemberIds {
+            group_id_hex: "01".repeat(16),
+            member_ids_hex: vec!["02".repeat(32), "03".repeat(32)],
+        });
+        assert_eq!(ffi.group_id_hex, "01".repeat(16));
+        assert_eq!(ffi.member_ids_hex, vec!["02".repeat(32), "03".repeat(32)]);
     }
 }

--- a/crates/marmot-uniffi/src/errors.rs
+++ b/crates/marmot-uniffi/src/errors.rs
@@ -10,6 +10,8 @@ pub enum MarmotKitError {
     UnknownAccount { account_ref: String },
     #[error("unknown group: {group_id_hex}")]
     UnknownGroup { group_id_hex: String },
+    #[error("group membership page exceeds the maximum of {max_groups} groups")]
+    InvalidGroupMembershipPage { max_groups: u64 },
     /// The group exists but its full hydration has not completed yet
     /// (mdk#1161). Retryable: the runtime's background pipeline promotes the
     /// group shortly after account readiness, and worker-routed reads wait
@@ -236,6 +238,9 @@ impl From<AppError> for MarmotKitError {
                 details: err.to_string(),
             },
             AppError::UnknownGroup(group_id_hex) => Self::UnknownGroup { group_id_hex },
+            AppError::InvalidGroupMembershipPage(_) => Self::InvalidGroupMembershipPage {
+                max_groups: marmot_app::MAX_GROUP_MEMBER_IDS_PAGE_SIZE as u64,
+            },
             AppError::InvalidChatPin(details) => Self::InvalidChatPin { details },
             AppError::GroupDisbanding(group_id_hex) => Self::GroupDisbanding { group_id_hex },
             AppError::InvalidMessageDraft(details) => Self::InvalidMessageDraft { details },
@@ -369,6 +374,16 @@ mod tests {
     use cgka_traits::storage::StorageError;
     use marmot_account::{AccountError, AccountHomeError};
     use marmot_app::AppError;
+
+    #[test]
+    fn oversized_membership_page_crosses_ffi_as_typed_variant() {
+        let ffi: MarmotKitError =
+            AppError::InvalidGroupMembershipPage("too many groups".into()).into();
+        assert!(matches!(
+            ffi,
+            MarmotKitError::InvalidGroupMembershipPage { max_groups: 100 }
+        ));
+    }
 
     // #484: a transient SQLITE_BUSY surfaced from a send must cross the UniFFI
     // boundary as the typed `StorageBusy` variant — never the untyped `Runtime`

--- a/crates/marmot-uniffi/src/lib.rs
+++ b/crates/marmot-uniffi/src/lib.rs
@@ -44,7 +44,7 @@ uniffi::setup_scaffolding!();
 
 pub use commands::{InitialGroupImageFfi, parse_media_imeta_tag};
 pub use conversions::{
-    AppBlobEndpointFfi, AppGroupEncryptedMediaComponentFfi, AuditDataModeFfi,
+    AppBlobEndpointFfi, AppGroupEncryptedMediaComponentFfi, AppGroupMemberIdsFfi, AuditDataModeFfi,
     AuditLogDeleteResultFfi, AuditLogFileFfi, AuditLogSettingsFfi, AuditLogTrackerConfigFfi,
     AuditLogTrackerUpdateResultFfi, AuditLogUploadResultFfi, AuditLogUploadSourceFfi,
     BackgroundNotificationCollectionFfi, ChatConversationKindFfi, ChatListAttachmentKindFfi,


### PR DESCRIPTION
## What changed

Adds a bounded `groupMemberIdsPage` read for the chat projection. Callers can request identifier-only membership for up to 100 groups in one account-worker command, with matching Rust and UniFFI DTOs plus generated Swift and Kotlin surfaces.

The response preserves input order and performs no profile enrichment. It fails as a whole when any requested group is unknown or hydration-quarantined, so callers never receive a partial unsafe page.

## Why

The existing per-group roster API added by #1312 is appropriate for detail screens, but using it to decorate a chat list requires one serialized worker and FFI round trip per group. During startup hydration that produces avoidable latency and can tie projection rendering to background work.

This companion read batches the identifiers needed by the chat projection while retaining the same on-demand hydration and quarantine gates as existing member reads.

## Impact

Apps can populate membership-derived chat-list state for many groups in a few local calls without waiting for the background hydration pipeline. Detail screens can continue using the enriched roster API from #1312.

## Validation

- `just fast-ci`
- held startup-hydration regression covering six groups, page bounds, and all-or-error behavior
- blocked initial catch-up regression covering snapshot and live roster identifiers
- full `marmot-uniffi` test suite: 132 tests passed
- Swift binding regeneration
- Kotlin binding regeneration and Android builds for arm64-v8a, armeabi-v7a, x86, and x86_64

## Dependency

#1312 is merged. This branch is rebased directly onto current `master` and uses its lightweight roster projection.

Closes #1314

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bounded membership lookup for up to 100 groups per request.
  * Returns group and member identifiers without profile details, preserving requested group order.
  * Exposed the lookup through runtime and FFI interfaces.
  * Requests fail as a whole for oversized, invalid, unknown, or unavailable groups.

* **Bug Fixes**
  * Membership lookup failures now receive consistent protocol and FFI error handling.

* **Documentation**
  * Documented the new membership lookup command and its 100-group limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->