### PR TITLE
test(app): cover reconnect hydration ordering

### DIFF
--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -49,6 +49,11 @@ versioning through the workspace version in the root `Cargo.toml`.
   MarmotKit surfaces a new retryable `GroupHydrationPending` error, distinct
   from `UnknownGroup`, for the remaining direct-read window.
 
+- Regression coverage (mdk#1337): after a receive-error transport reconnect,
+  the managed account worker eagerly drains every deferred stored group (more
+  than one hydration batch) before resuming steady-state commands, so groups
+  are not left gated until a later read or send promotes them individually.
+
 - `marmot-markdown` now recognizes bare `www.example.com/path` text as web
   autolinks. The AST preserves the displayed `www.` source while exposing an
   explicit `Www` autolink kind so renderers can synthesize `https://`

--- a/crates/marmot-app/src/relay_plane/mod.rs
+++ b/crates/marmot-app/src/relay_plane/mod.rs
@@ -732,6 +732,16 @@ impl MarmotRelayPlane {
             .handle_relay_event(relay_event)
             .await
     }
+
+    /// Drive the managed account worker through its receive-error reconnect path
+    /// by closing inbound delivery, matching relay-notification recovery.
+    #[cfg(test)]
+    pub(crate) fn simulate_notification_recovery_for_test(&self, skipped_notifications: u64) {
+        recover_relay_notification_forwarder(
+            &self.inner.transport,
+            RelayNotificationConsumerExit::Lagged(skipped_notifications),
+        );
+    }
 }
 
 impl RelayPlaneHealth {

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -1354,6 +1354,9 @@ async fn handle_account_worker_catch_up(
 /// its own group's hydration.
 const STARTUP_HYDRATION_BATCH_SIZE: usize = 4;
 
+#[cfg(test)]
+pub(crate) const STARTUP_HYDRATION_BATCH_SIZE_FOR_TEST: usize = STARTUP_HYDRATION_BATCH_SIZE;
+
 /// Commands served between hydration batches. Bounded so sustained
 /// account-worker traffic cannot starve the pipeline: without a budget, an
 /// unbounded drain-until-empty could defer hydration (and the mutation

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -360,6 +360,12 @@ pub(crate) enum AccountWorkerCommand {
         reason: String,
         respond: oneshot::Sender<Result<(), AppError>>,
     },
+    /// Count seeded groups the session has not fully hydrated yet, without
+    /// promoting them on demand (mdk#1337 regression probe).
+    #[cfg(test)]
+    UnhydratedGroupCount {
+        respond: oneshot::Sender<usize>,
+    },
 }
 
 impl AccountWorkerCommand {
@@ -1545,6 +1551,11 @@ async fn handle_startup_hydration_command(
         AccountWorkerCommand::QuarantinedGroups { respond } => {
             let _ = respond.send(Ok(client.quarantined_groups()));
         }
+        #[cfg(test)]
+        AccountWorkerCommand::UnhydratedGroupCount { respond } => {
+            let count = client.runtime.session().unhydrated_group_ids().len();
+            let _ = respond.send(count);
+        }
         AccountWorkerCommand::CatchUp { respond } => {
             deferred.push(DeferredStartupCommand::CatchUp(respond));
         }
@@ -1572,6 +1583,11 @@ async fn handle_account_worker_command(
     match command {
         AccountWorkerCommand::NetworkStartupSettled { respond } => {
             let _ = respond.send(());
+        }
+        #[cfg(test)]
+        AccountWorkerCommand::UnhydratedGroupCount { respond } => {
+            let count = client.runtime.session().unhydrated_group_ids().len();
+            let _ = respond.send(count);
         }
         AccountWorkerCommand::CatchUp { respond } => {
             let sync_started_at = Instant::now();

--- a/crates/marmot-app/src/runtime/commands.rs
+++ b/crates/marmot-app/src/runtime/commands.rs
@@ -28,6 +28,26 @@ use crate::{
 };
 
 impl AccountManager {
+    #[cfg(test)]
+    pub(super) async fn unhydrated_group_count_for_test(
+        &self,
+        account_ref: &str,
+    ) -> Result<usize, AppError> {
+        let commands = self.worker_commands(account_ref).await?;
+        let (respond, response) = oneshot::channel();
+        commands
+            .send(AccountWorkerCommand::UnhydratedGroupCount { respond })
+            .await
+            .map_err(|_| AppError::TransportClosed)?;
+        match tokio::time::timeout(super::APP_RUNTIME_ACCOUNT_READY_WAIT, response).await {
+            Ok(Ok(count)) => Ok(count),
+            Ok(Err(_)) => Err(AppError::TransportClosed),
+            Err(_) => Err(AppError::BlockingTask(
+                "account worker unhydrated-group probe timed out".into(),
+            )),
+        }
+    }
+
     pub(super) fn spawn_invite_catch_up(&self) {
         let mut tasks = self
             .invite_catch_up_tasks

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -1232,6 +1232,18 @@ impl MarmotAppRuntime {
             .await
     }
 
+    /// Count groups the worker session has seeded but not fully hydrated,
+    /// without issuing a read that would promote them (mdk#1337).
+    #[cfg(test)]
+    pub(crate) async fn unhydrated_group_count_for_test(
+        &self,
+        account_ref: &str,
+    ) -> Result<usize, AppError> {
+        self.accounts
+            .unhydrated_group_count_for_test(account_ref)
+            .await
+    }
+
     pub async fn group_mls_state(
         &self,
         account_ref: &str,

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -80,7 +80,9 @@ pub(crate) use audit_tracker::{AuditLogTrackerUploader, post_audit_log_tracker_u
 // (a child of this module) via `super::*`. Test-only, so gate them out of the
 // production build to avoid unused-import noise.
 #[cfg(test)]
-pub(crate) use account_worker::AccountWorkerReconnectBackoff;
+pub(crate) use account_worker::{
+    AccountWorkerReconnectBackoff, STARTUP_HYDRATION_BATCH_SIZE_FOR_TEST,
+};
 #[cfg(test)]
 pub(crate) use agent_stream_watch::{
     broker_trust_for_candidate, latest_agent_stream_start, parse_quic_candidate,

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -39,6 +39,7 @@ use crate::messages::{AppMessageIntent, build_inner_event};
 struct ScriptedPushRelayClient {
     publish_results: std::sync::Mutex<std::collections::VecDeque<bool>>,
     published_events: std::sync::Mutex<Vec<NostrTransportEvent>>,
+    subscriptions: std::sync::Mutex<Vec<NostrSubscription>>,
     block_next_subscribe: std::sync::atomic::AtomicBool,
     fail_blocked_subscribe: std::sync::atomic::AtomicBool,
     fail_next_subscribe: std::sync::atomic::AtomicBool,
@@ -135,6 +136,21 @@ impl ScriptedPushRelayClient {
     fn release_publish(&self) {
         self.publish_release.notify_waiters();
     }
+
+    fn inbox_subscription_count(&self, expected_account_id: &MemberId) -> usize {
+        self.subscriptions
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|subscription| {
+                matches!(
+                    subscription,
+                    NostrSubscription::AccountInbox { account_id, .. }
+                        if account_id == expected_account_id
+                )
+            })
+            .count()
+    }
 }
 
 #[async_trait]
@@ -176,6 +192,7 @@ impl NostrRelayClient for ScriptedPushRelayClient {
                 ));
             }
         }
+        self.subscriptions.lock().unwrap().push(subscription);
         Ok(())
     }
 
@@ -4248,6 +4265,118 @@ fn account_worker_reconnect_backoff_doubles_caps_and_resets() {
         backoff.next_delay_with_jitter(Duration::ZERO),
         Duration::from_secs(2)
     );
+}
+
+#[test]
+fn reconnect_drains_deferred_hydration_before_steady_state_serves_groups() {
+    run_composed_app_runtime_test(
+        "reconnect-deferred-hydration",
+        reconnect_drains_deferred_hydration_before_steady_state_serves_groups_body,
+    );
+}
+
+async fn reconnect_drains_deferred_hydration_before_steady_state_serves_groups_body() {
+    const ACCOUNT: &str = "bench";
+    const GROUP_COUNT: usize = 6;
+
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let dir = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(dir.path());
+    home.create_account("donor").unwrap();
+    home.create_account(ACCOUNT).unwrap();
+    let donor_id = home.account("donor").unwrap().account_id_hex;
+    let account_id =
+        MemberId::new(hex::decode(home.account(ACCOUNT).unwrap().account_id_hex).unwrap());
+    let mut group_ids = Vec::new();
+    {
+        let app_fixture = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+            .with_test_relay_client(relay.clone());
+        let mut donor = app_fixture.client("donor").await.unwrap();
+        donor.publish_key_package().await.unwrap();
+        let mut client = app_fixture.client(ACCOUNT).await.unwrap();
+        for group in 0..GROUP_COUNT {
+            group_ids.push(
+                client
+                    .create_group(&format!("reconnect group {group}"), &[donor_id.as_str()])
+                    .await
+                    .unwrap(),
+            );
+        }
+    }
+    const {
+        assert!(
+            GROUP_COUNT > 4,
+            "fixture must span more than one startup hydration batch"
+        );
+    }
+
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+        .with_test_relay_client(relay.clone());
+    let runtime = MarmotAppRuntime::new(app);
+    runtime.start().await.unwrap();
+
+    tokio::time::timeout(std::time::Duration::from_secs(30), async {
+        loop {
+            if relay.inbox_subscription_count(&account_id) >= 1
+                && matches!(
+                    runtime.unhydrated_group_count_for_test(ACCOUNT).await,
+                    Ok(0)
+                )
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("initial startup should finish hydration and transport activation");
+
+    let subscriptions_before_recovery = relay.inbox_subscription_count(&account_id);
+    runtime
+        .shared_services()
+        .relay_plane()
+        .simulate_notification_recovery_for_test(3);
+
+    tokio::time::timeout(std::time::Duration::from_secs(30), async {
+        loop {
+            if relay.inbox_subscription_count(&account_id) <= subscriptions_before_recovery {
+                tokio::task::yield_now().await;
+                continue;
+            }
+            match runtime.unhydrated_group_count_for_test(ACCOUNT).await {
+                Ok(0) => break,
+                Ok(_) | Err(AppError::TransportClosed) => tokio::task::yield_now().await,
+                Err(err) => panic!("unexpected worker error during reconnect: {err:?}"),
+            }
+        }
+    })
+    .await
+    .expect("notification recovery should reconnect and drain deferred hydration");
+
+    assert_eq!(
+        runtime
+            .unhydrated_group_count_for_test(ACCOUNT)
+            .await
+            .unwrap(),
+        0,
+        "reconnect must drain deferred hydration before steady-state group reads"
+    );
+
+    for group_id in &group_ids {
+        let members = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            runtime.group_members(ACCOUNT, group_id),
+        )
+        .await
+        .expect("group read should succeed once reconnect is steady")
+        .unwrap();
+        assert!(
+            !members.is_empty(),
+            "every stored group must be readable once reconnect settles"
+        );
+    }
+
+    runtime.shutdown().await;
 }
 
 #[test]

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -4277,7 +4277,7 @@ fn reconnect_drains_deferred_hydration_before_steady_state_serves_groups() {
 
 async fn reconnect_drains_deferred_hydration_before_steady_state_serves_groups_body() {
     const ACCOUNT: &str = "bench";
-    const GROUP_COUNT: usize = 6;
+    const GROUP_COUNT: usize = crate::runtime::STARTUP_HYDRATION_BATCH_SIZE_FOR_TEST + 1;
 
     let relay = Arc::new(ScriptedPushRelayClient::default());
     let dir = tempfile::tempdir().unwrap();
@@ -4303,13 +4303,6 @@ async fn reconnect_drains_deferred_hydration_before_steady_state_serves_groups_b
             );
         }
     }
-    const {
-        assert!(
-            GROUP_COUNT > 4,
-            "fixture must span more than one startup hydration batch"
-        );
-    }
-
     let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
         .with_test_relay_client(relay.clone());
     let runtime = MarmotAppRuntime::new(app);


### PR DESCRIPTION
Fixes #1337

## Summary
- Adds a deterministic account-worker reconnect test with more than one deferred hydration batch.
- Forces relay notification recovery, proves the affected account re-subscribed, and verifies deferred groups are fully hydrated before steady-state commands and reads resume.
- Keeps all new relay/reconnect probes behind `cfg(test)`; production behavior is unchanged.
- Adds `Unreleased` changelog coverage. No version, fixture cohort, or conformance changes.

## Verification
- RED proof: temporarily bypassing `drain_deferred_hydration` made the regression test time out after reconnect.
- `cargo test -p marmot-app --lib --locked reconnect_drains_deferred_hydration_before_steady_state_serves_groups -- --nocapture`
- `just fast-ci`
- `cargo test -p marmot-app --lib --locked` — 596 passed
- `cargo test -p marmot-app --test relay_runtime --features test-policy-overrides --locked -- --test-threads=1` — 94 passed during pre-final-base validation

## Sensitive paths
- `crates/marmot-app/src/runtime/account_worker.rs` (test-only group hydration introspection)
- `crates/marmot-app/src/runtime/commands.rs` (test-only worker RPC)

No production crypto, MLS, key-handling, trust-anchor, or authentication behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account recovery after notification or receive errors.
  * Deferred groups are now fully restored before normal command processing resumes.
  * Ensured all groups remain available and readable after reconnection.

* **Tests**
  * Added integration coverage for reconnect recovery and multi-batch group hydration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->