### PR TITLE
Harden simulator oracle and replay fidelity

### DIFF
--- a/crates/cgka-conformance-simulator/README.md
+++ b/crates/cgka-conformance-simulator/README.md
@@ -516,8 +516,10 @@ kind) still reproduces. The complete fingerprint, including the state digest, re
 Generated report runs on the generator-recorded subject also write a sibling `*-fixture.v1.json` candidate. Adapter
 override runs deliberately do not, because their observed trace is an A/B result rather than an adapter-neutral source
 of truth. Cases with semantic expectations keep those expectations; cases without them use the observed trace as an
-exact expected trace in the candidate. When a failing generated case has a minimized reproducer, the fixture candidate
-uses that minimized scenario.
+exact expected trace in the candidate. Fixture candidates always preserve the original executed scenario. A failing
+report may additionally carry a smaller semantic reproducer in `metadata.generated.minimized_case`, but that reducer
+permits the terminal state digest to change and is therefore diagnostic evidence rather than a faithful fixture for the
+original observation.
 
 To run the current generated family and write JSON reports:
 

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -627,7 +627,8 @@ These tests keep the simulator machinery honest.
   commit/Welcome publication so a failed rollback cannot partially mutate transport state.
 - `failing_generated_case_records_a_minimized_reproducer` checks that semantic failure identity lets a failing
   generated case remove an entire irrelevant application-message storm even though action indices and the full state
-  digest change.
+  digest change. The minimized case remains diagnostic metadata; fixture candidates retain the original executed
+  scenario so they cannot silently reproduce a different terminal state under the same broad failure kind.
 - `failed_campaign_capsule_contains_a_replayable_tick_witness` checks that a real report campaign exports a sensitive
   recipient checkpoint plus exact mailbox bytes and that both the replay API and report CLI reproduce its fingerprint.
 - `tests/generated_policy_cases.rs` checks that Tamarin-derived branch selector cases match the Rust selector across

--- a/crates/cgka-conformance-simulator/src/failure_capsule.rs
+++ b/crates/cgka-conformance-simulator/src/failure_capsule.rs
@@ -402,6 +402,12 @@ pub fn read_failure_capsule(path: &Path) -> Result<FailureCapsuleV1, FailureCaps
 
 /// Convert a reviewed synthetic failure into a portable regression-vector
 /// candidate. Sensitive incident capsules are intentionally ineligible.
+///
+/// A minimized reproducer is eligible here only as a human-reviewed,
+/// semantic-identity-preserving reduction. Promotion does not attest that it
+/// preserves the capsule's full fingerprint or terminal state digest; callers
+/// must rerun the candidate against its portable expectation before accepting
+/// it into the vector corpus.
 pub fn promote_failure_capsule_to_vector(
     capsule: &FailureCapsuleV1,
     conformance_version: impl Into<String>,

--- a/crates/cgka-conformance-simulator/src/oracle.rs
+++ b/crates/cgka-conformance-simulator/src/oracle.rs
@@ -799,7 +799,14 @@ fn recommended_behaviors(stimulus: ScenarioStimulus) -> Vec<OracleBehavior> {
             OracleBehavior::ReplayDeduplication,
         ],
         ScenarioStimulus::PublishLifecycle => vec![OracleBehavior::PublishLifecycleChecked],
-        ScenarioStimulus::VirtualTimeAdvance => vec![OracleBehavior::QuiescenceState],
+        // Advancing the controlled clock must be paired with evidence that the
+        // resulting timed work was observed. A fixed-point quiescence result is
+        // the strongest form, while a final exact no-pending observation is the
+        // appropriate equivalent for explicitly stepped scenarios.
+        ScenarioStimulus::VirtualTimeAdvance => vec![
+            OracleBehavior::QuiescenceState,
+            OracleBehavior::NoPendingWorkObserved,
+        ],
     }
 }
 
@@ -942,5 +949,35 @@ mod tests {
 
         assert!(behaviors.contains(&OracleBehavior::BidirectionalDecryptabilityObserved));
         assert!(behaviors.contains(&OracleBehavior::DeliveredPayload));
+    }
+
+    #[test]
+    fn virtual_time_accepts_fixed_point_or_exact_no_pending_evidence() {
+        assert!(
+            weak_oracle_warnings(
+                &[ScenarioStimulus::VirtualTimeAdvance],
+                &[OracleBehavior::QuiescenceState],
+            )
+            .is_empty()
+        );
+        assert!(
+            weak_oracle_warnings(
+                &[ScenarioStimulus::VirtualTimeAdvance],
+                &[OracleBehavior::NoPendingWorkObserved],
+            )
+            .is_empty()
+        );
+        assert_eq!(
+            weak_oracle_warnings(&[ScenarioStimulus::VirtualTimeAdvance], &[])
+                .first()
+                .map(|warning| warning.expected_any_of.as_slice()),
+            Some(
+                [
+                    OracleBehavior::QuiescenceState,
+                    OracleBehavior::NoPendingWorkObserved,
+                ]
+                .as_slice()
+            )
+        );
     }
 }

--- a/crates/cgka-conformance-simulator/src/oracle.rs
+++ b/crates/cgka-conformance-simulator/src/oracle.rs
@@ -801,8 +801,10 @@ fn recommended_behaviors(stimulus: ScenarioStimulus) -> Vec<OracleBehavior> {
         ScenarioStimulus::PublishLifecycle => vec![OracleBehavior::PublishLifecycleChecked],
         // Advancing the controlled clock must be paired with evidence that the
         // resulting timed work was observed. A fixed-point quiescence result is
-        // the strongest form, while a final exact no-pending observation is the
-        // appropriate equivalent for explicitly stepped scenarios.
+        // the strongest form; an exact no-pending observation is the appropriate
+        // equivalent for explicitly stepped scenarios. Coverage is set-based and
+        // does not prove that the no-pending expectation follows the advance;
+        // generated families rely on `add_strict_reliability_oracle` appending it.
         ScenarioStimulus::VirtualTimeAdvance => vec![
             OracleBehavior::QuiescenceState,
             OracleBehavior::NoPendingWorkObserved,

--- a/crates/cgka-conformance-simulator/src/report.rs
+++ b/crates/cgka-conformance-simulator/src/report.rs
@@ -418,17 +418,12 @@ fn generated_fixture_candidate(
         .is_empty()
         .then(|| report.observed_trace.clone())
         .flatten();
-    let mut fixture = case.to_vector_fixture(env!("CARGO_PKG_VERSION"), expected_trace);
-    if let Some(minimized) = report
-        .metadata
-        .generated
-        .as_ref()
-        .and_then(|generated| generated.minimized_case.as_ref())
-    {
-        fixture.scenario_name = minimized.name.clone();
-        fixture.scenario = minimized.clone();
-    }
-    fixture
+    // The semantic minimizer preserves the failure class/action/kind while it
+    // deliberately permits the terminal state digest to change. Keep that
+    // smaller case as diagnostic metadata, but never present it as the fixture
+    // for the original observation. A fixture candidate must retain the exact
+    // scenario whose report and expectations it accompanies.
+    case.to_vector_fixture(env!("CARGO_PKG_VERSION"), expected_trace)
 }
 
 async fn run_vector_fixture_reports(
@@ -729,8 +724,9 @@ pub fn report_usage() -> &'static str {
 mod tests {
     use super::*;
     use crate::{
-        BehaviorEvidenceSummary, OracleBehavior, OracleCoverageWarning, ScenarioOracleReport,
-        ScenarioReportMetadata, ScenarioSpec, ScenarioStimulus,
+        BehaviorEvidenceSummary, GeneratedScenarioMetadata, GeneratedSubjectKind, OracleBehavior,
+        OracleCoverageWarning, ScenarioOracleReport, ScenarioReportMetadata, ScenarioSpec,
+        ScenarioStep, ScenarioStimulus,
     };
 
     fn report_with_oracle(oracle: ScenarioOracleReport) -> ScenarioReport {
@@ -850,5 +846,57 @@ mod tests {
                 .as_deref()
                 .is_some_and(|resource| resource.contains("replay budget exceeded"))
         );
+    }
+
+    #[test]
+    fn fixture_candidates_keep_original_scenario_when_a_semantic_reducer_exists() {
+        let original = ScenarioSpec {
+            name: "fixture-original".into(),
+            spec_version: "2".into(),
+            clients: vec!["alice".into()],
+            topology: Default::default(),
+            steps: vec![
+                ScenarioStep::DeliverAll,
+                ScenarioStep::Tick {
+                    clients: vec!["alice".into()],
+                },
+            ],
+        };
+        let minimized = ScenarioSpec {
+            name: "fixture-original".into(),
+            spec_version: "2".into(),
+            clients: vec!["alice".into()],
+            topology: Default::default(),
+            steps: vec![ScenarioStep::DeliverAll],
+        };
+        let case = GeneratedScenarioCase {
+            family_name: "fixture-fidelity/v1".into(),
+            generator_version: "1".into(),
+            seed: 7,
+            case_index: 0,
+            subject: GeneratedSubjectKind::Engine,
+            scenario: original.clone(),
+            expected_outcomes: Vec::new(),
+        };
+        let mut report = report_with_oracle(ScenarioOracleReport {
+            stimuli: Vec::new(),
+            oracle_behaviors: Vec::new(),
+            observed_behaviors: Vec::new(),
+            missing_observed_behaviors: Vec::new(),
+            evidence: BehaviorEvidenceSummary::default(),
+            weak_oracle_warnings: Vec::new(),
+        });
+        report.metadata.generated = Some(GeneratedScenarioMetadata {
+            family_name: case.family_name.clone(),
+            generator_version: case.generator_version.clone(),
+            seed: case.seed,
+            case_index: case.case_index,
+            minimized_case: Some(minimized.clone()),
+        });
+
+        let fixture = generated_fixture_candidate(&case, &report);
+
+        assert_eq!(fixture.scenario, original);
+        assert_ne!(fixture.scenario, minimized);
     }
 }

--- a/crates/convergence-campaign-runner/src/failure_corpus.rs
+++ b/crates/convergence-campaign-runner/src/failure_corpus.rs
@@ -563,6 +563,9 @@ pub fn observation_from_capsule(
         }
         _ => FailureClassificationV1::ProductDefect,
     };
+    // Corpus indexing deliberately prefers the reducer's semantic-identity
+    // candidate. This is diagnostic/reduction provenance, not an assertion
+    // that the candidate preserves the capsule's full state fingerprint.
     let scenario = capsule
         .minimized_reproducer
         .clone()

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -1094,7 +1094,9 @@ copying raw error text.
 The reducer now treats paired transport, partition, lifecycle, and storage actions as dependency units before removing
 independent noise. Non-layer-specific failures receive a canonical Scenario IR candidate for the next smaller adapter;
 the semantic identity must reproduce there before concluding that the larger layer is uninvolved. Promotion remains
-restricted to synthetic shareable capsules with portable expectations.
+restricted to synthetic shareable capsules with portable expectations. Semantic minimization may change the terminal
+state digest, so generated fixture candidates retain the original executed scenario; the smaller case is labeled only
+as diagnostic report metadata unless a separate replay contract proves stronger fidelity.
 
 ### 6.5 Stateful canonical journeys
 
@@ -1321,6 +1323,7 @@ incorrect result.
 | 2026-08-07 | Planned shared legality model and workload profiles | Recorded the follow-up architecture: one canonical product-action legality model, separately typed composable faults, thin workload profiles, explicit size controls, and corpus-level operation/interaction coverage rather than independent family semantics or overloaded case counts | Section 6.6; planned verification and migration gates |
 | 2026-08-09 | Sender-ratchet reorder policy restoration | Restored the historical 100-message out-of-order tolerance and 1,000-message maximum forward distance for new/joined groups, normalized persisted groups during hydration before new traffic, and pinned the seed-2001 rollback-flood regressions that exposed OpenMLS's inherited five-message default; already-pruned secrets remain unrecoverable | `wire_format`; encrypted-SQLite hydration migration/restart; convergence-chaos cases 2 and 13 |
 | 2026-08-09 | 6.1 decision-route inventory, abstract model, and claim lifecycle | Registered every current production decision route with specific source markers, adopted rule, evidence owner, mutation sentinel, campaign owner, and explicit partial/gap limitations; modeled route choice and restart as a bounded abstract witness without treating it as production route-equivalence proof; added a pairwise-loser terminalization mutant and stable assurance claims whose recurring falsifications reopen cleanly and require explicit reviewed resolution | `route_assurance`; `pairwise_losing_branch_terminalization`; [`CONVERGENCE_ROUTE_MATRIX.md`](../../crates/cgka-conformance-simulator/CONVERGENCE_ROUTE_MATRIX.md); focused source-drift, abstract lifecycle, mutation, matrix, serialization, and claim-lifecycle tests |
+| 2026-08-09 | Campaign follow-up: strict clock oracle and fixture fidelity | Accepted exact no-pending evidence as temporal closure after an explicit virtual-time advance, while retaining fixed-point quiescence as the stronger option; kept semantic minimizers diagnostic and made fixture candidates preserve the original executed scenario so broad failure identity cannot silently replace a five-of-six delivery failure with a zero-delivery case | Oracle coverage unit tests; fixture-candidate fidelity unit test; strict seed-2001 convergence-chaos replay |
 
 ## Capability Naming Cleanup
 

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -538,8 +538,10 @@ snapshots intentionally do not rewind pass scheduling; only this replay envelope
 checkpoint contains key material, and the writer creates directories/files with owner-only modes. The report CLI
 accepts `--replay-capsule FILE` and verifies the captured engine fingerprint. `promote_failure_capsule_to_vector` accepts only
 `synthetic_shareable` capsules, preserves the intended exact or semantic expectation rather than the buggy observed
-trace, and uses the fingerprint-preserving minimized scenario when present. It refuses capsules without a portable
-expectation.
+trace, and may use a semantic-identity-preserving minimized scenario only through this explicit reviewed-promotion
+path. That is not a full-fingerprint or terminal-state-digest attestation: the reviewer must rerun the promoted
+candidate and validate that its portable expectation still expresses the intended regression. Automatic generated
+fixture candidates do not take this exception. Promotion refuses capsules without a portable expectation.
 
 ### Milestone 1 Exit Gate
 
@@ -1095,8 +1097,10 @@ The reducer now treats paired transport, partition, lifecycle, and storage actio
 independent noise. Non-layer-specific failures receive a canonical Scenario IR candidate for the next smaller adapter;
 the semantic identity must reproduce there before concluding that the larger layer is uninvolved. Promotion remains
 restricted to synthetic shareable capsules with portable expectations. Semantic minimization may change the terminal
-state digest, so generated fixture candidates retain the original executed scenario; the smaller case is labeled only
-as diagnostic report metadata unless a separate replay contract proves stronger fidelity.
+state digest, so automatic generated fixture candidates retain the original executed scenario. Two intentional corpus
+consumers use the smaller case under a narrower contract: corpus indexing records it as a semantic-identity reduction
+candidate, and explicit human-reviewed vector promotion may select it only after rerunning and validating the portable
+expectation. Neither path labels the reduced case as full-fingerprint-equivalent to the original execution.
 
 ### 6.5 Stateful canonical journeys
 


### PR DESCRIPTION
## What changed

- Treat either a fixed-point quiescence observation or an exact no-pending-work observation as valid coverage after an explicit virtual-time advance.
- Keep semantic minimizers as diagnostic report metadata instead of substituting them into generated fixture candidates.
- Document the distinction in the simulator guide, scenario registry, and convergence tracking plan.

## Why

Fresh convergence-chaos campaigns exposed two simulator trust issues:

1. Seed 2001 case 4 satisfied its state and no-pending expectations but failed strict mode because virtual-time coverage accepted only the quiescence driver.
2. Older minimized fixture candidates for cases 2 and 13 retained the original expectations while replacing the 29-step executed scenarios with 19-step semantic reductions. Those candidates reproduced zero deliveries rather than the original five-of-six delivery failure.

The reducer intentionally preserves only failure class, action type, and kind, so it remains useful for diagnosis. A fixture candidate now keeps the original executed scenario and therefore cannot imply stronger replay fidelity than the reducer provides.

## Impact

This changes simulator/reporting behavior only. It does not modify the convergence engine, app runtime, storage, wire format, or production policy constants.

## Validation

- cargo test -p cgka-conformance-simulator oracle::tests --locked
- cargo test -p cgka-conformance-simulator report::tests --locked
- cargo test -p cgka-conformance-simulator --test report_runner --locked
- cargo test -p cgka-conformance-simulator --test canonical_scenarios failing_generated_case_records_a_minimized_reproducer --locked
- strict file-backed replay of convergence-chaos seed 2001 case 4: 1 passed, 0 failed
- just fast-ci


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Generated failure fixtures now preserve the original executed scenario, preventing inaccurate or incomplete reproductions.
  * Minimized reproducers remain available as diagnostic metadata rather than replacing fixture scenarios.
  * Virtual-time checks now recognize either confirmed quiescence or explicit confirmation that no work remains.
  * Improved warnings identify both types of missing temporal-closure evidence.

* **Documentation**
  * Clarified fixture fidelity, diagnostic reproducers, and accepted virtual-time completion evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->