### PR TITLE
chore(release): prepare 0.9.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agent-connector"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "agent-control",
  "agent-stream-compose",
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "agent-control"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "serde",
  "serde_json",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "agent-stream-compose"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "cgka-traits",
  "hex",
@@ -852,7 +852,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cgka-conformance-simulator"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-engine"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-session"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-traits"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "async-trait",
  "hex",
@@ -1150,7 +1150,7 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "convergence-campaign-runner"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "async-trait",
  "cgka-conformance-simulator",
@@ -1900,7 +1900,7 @@ dependencies = [
 
 [[package]]
 name = "fs-private"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "libc",
  "tempfile",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "incident-replay"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "cgka-conformance-simulator",
  "fs-private",
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-account"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
@@ -3235,7 +3235,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-app"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -3279,7 +3279,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-forensics"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "fs-private",
  "serde",
@@ -3289,7 +3289,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-markdown"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "serde",
  "serde_json",
@@ -3297,7 +3297,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-terminal-harness"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "agent-control",
  "async-trait",
@@ -3312,7 +3312,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-uniffi"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "cgka-engine",
  "cgka-traits",
@@ -5497,7 +5497,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-sqlite"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "cgka-traits",
  "fs-private",
@@ -6103,7 +6103,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-adapter"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-peeler"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -6139,7 +6139,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-broker"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "cgka-traits",
  "clap",
@@ -6158,7 +6158,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-stream"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "cgka-traits",
  "chacha20poly1305",
@@ -7225,7 +7225,7 @@ dependencies = [
 
 [[package]]
 name = "wn-cli"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "agent-stream-compose",
  "cgka-session",
@@ -7259,7 +7259,7 @@ dependencies = [
 
 [[package]]
 name = "wn-opencode"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "async-trait",
  "clap",
@@ -7274,7 +7274,7 @@ dependencies = [
 
 [[package]]
 name = "wn-pi"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "async-trait",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "0.9.10"
+version = "0.9.11"
 license = "MIT"
 publish = false
 

--- a/crates/cgka-conformance-simulator/vectors/admin-handover.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/admin-handover.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "admin-handover/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.11",
   "seed": null,
   "scenario": {
     "name": "admin-handover/v1",

--- a/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "admin-policy-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.11",
   "seed": null,
   "scenario": {
     "name": "admin-policy-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "concurrent-invite-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.11",
   "seed": null,
   "scenario": {
     "name": "concurrent-invite-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-committer-selected/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.11",
   "seed": null,
   "scenario": {
     "name": "convergence-committer-selected/v1",

--- a/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-witness-selected/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.11",
   "seed": null,
   "scenario": {
     "name": "convergence-witness-selected/v1",

--- a/crates/cgka-conformance-simulator/vectors/conversation.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/conversation.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "conversation/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.11",
   "seed": null,
   "scenario": {
     "name": "conversation/v1",

--- a/crates/cgka-conformance-simulator/vectors/cross-route-own-commit-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/cross-route-own-commit-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "cross-route-own-commit-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.11",
   "seed": null,
   "scenario": {
     "name": "cross-route-own-commit-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/current-profile-required-set.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/current-profile-required-set.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "current-profile-required-set/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.11",
   "seed": null,
   "application_profile": {
     "name": "current",

--- a/crates/cgka-conformance-simulator/vectors/deferred-tick-catchup.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/deferred-tick-catchup.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "deferred-tick-catchup/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.11",
   "seed": null,
   "scenario": {
     "name": "deferred-tick-catchup/v1",

--- a/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "delayed-past-epoch-app-message/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.11",
   "seed": null,
   "scenario": {
     "name": "delayed-past-epoch-app-message/v1",

--- a/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "drop-queued/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.11",
   "seed": null,
   "scenario": {
     "name": "drop-queued/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.11",
   "seed": null,
   "scenario": {
     "name": "group-data-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.11",
   "seed": null,
   "scenario": {
     "name": "group-data-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-profile-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-profile-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-profile-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.11",
   "seed": null,
   "scenario": {
     "name": "group-profile-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.11",
   "seed": null,
   "scenario": {
     "name": "convergence-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "fork-recovery-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.11",
   "seed": null,
   "scenario": {
     "name": "fork-recovery-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "membership-fork-recovery-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.11",
   "seed": null,
   "scenario": {
     "name": "membership-fork-recovery-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incremental-growth.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incremental-growth.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "incremental-growth/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.11",
   "seed": null,
   "scenario": {
     "name": "incremental-growth/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-member/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.11",
   "seed": null,
   "scenario": {
     "name": "invite-member/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.11",
   "seed": null,
   "scenario": {
     "name": "invite-publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/latecomer-forward-secrecy.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/latecomer-forward-secrecy.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "latecomer-forward-secrecy/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.11",
   "seed": null,
   "scenario": {
     "name": "latecomer-forward-secrecy/v1",

--- a/crates/cgka-conformance-simulator/vectors/leaver-removal-secrecy.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/leaver-removal-secrecy.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "leaver-removal-secrecy/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.11",
   "seed": null,
   "scenario": {
     "name": "leaver-removal-secrecy/v1",

--- a/crates/cgka-conformance-simulator/vectors/multigroup-isolation.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/multigroup-isolation.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "multigroup-isolation/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.11",
   "seed": null,
   "scenario": {
     "name": "multigroup-isolation/v1",

--- a/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "partition-clear-leave/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.11",
   "seed": null,
   "scenario": {
     "name": "partition-clear-leave/v1",

--- a/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.11",
   "seed": null,
   "scenario": {
     "name": "publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "queue-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.11",
   "seed": null,
   "scenario": {
     "name": "queue-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "restart-delivery-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.11",
   "seed": null,
   "scenario": {
     "name": "restart-delivery-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "three-client-message-exchange/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.11",
   "seed": null,
   "scenario": {
     "name": "three-client-message-exchange/v1",

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -9,6 +9,8 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ## [Unreleased]
 
+## [0.9.11] - 2026-08-09
+
 ### Added
 
 - Hermes Marmot delivery now batches up to 10 ordered local images into one
@@ -20,6 +22,12 @@ versioning through the workspace version in the root `Cargo.toml`.
   retryable timeout while cleaning staged files if the connector never finishes.
   Transport retries reuse connector-persisted idempotency so they cannot
   duplicate the album.
+
+- WN Agent releases now include the `wn-pi` terminal-harness connector and
+  installer for Linux and macOS. Pi runs in isolated JSON-mode sessions with
+  bounded working-directory access, persisted conversation state, streamed
+  assistant output, and the same hardened shared connector runtime now used by
+  `wn-opencode`.
 
 - Account-open startup is now stage-attributed in app telemetry: engine
   session open, stored-group hydration, the shared startup profile load, and
@@ -49,10 +57,15 @@ versioning through the workspace version in the root `Cargo.toml`.
   MarmotKit surfaces a new retryable `GroupHydrationPending` error, distinct
   from `UnknownGroup`, for the remaining direct-read window.
 
-- Regression coverage (mdk#1337): after a receive-error transport reconnect,
-  the managed account worker eagerly drains every deferred stored group (more
-  than one hydration batch) before resuming steady-state commands, so groups
-  are not left gated until a later read or send promotes them individually.
+- After a receive-error transport reconnect, the managed account worker eagerly
+  drains every deferred stored group (including more than one hydration batch)
+  before resuming steady-state commands, so groups are not left gated until a
+  later read or send promotes them individually.
+
+- Repeated epoch-gap backfill stalls now emit a one-time typed escalation event
+  and durable forensic record with aggregate attempt and epoch information.
+  Successful progress resets the escalation state so a later independent stall
+  can be diagnosed separately.
 
 - `marmot-markdown` now recognizes bare `www.example.com/path` text as web
   autolinks. The AST preserves the displayed `www.` source while exposing an
@@ -95,6 +108,16 @@ versioning through the workspace version in the root `Cargo.toml`.
   the user the message was not accepted and offer to resend once the group is
   sending again. Nothing already queued is discarded; a slot frees only once its
   message is accepted by a relay.
+
+- Freshly created local identities now publish an explicit empty Nostr contact
+  list, giving the first follow update a safe relay-visible baseline without
+  weakening anti-clobber handling for imported identities with a missing list.
+
+- The conformance suite now includes a permanent four-participant cross-route
+  recovery vector covering simultaneous privileged commits, pairwise and
+  observer-side resolution, branch-depth reversal, encrypted-SQLite restart,
+  exact canonical agreement, durable input dispositions, and all twelve
+  directed application-decryptability probes.
   
 ### Fixed
 
@@ -122,8 +145,31 @@ versioning through the workspace version in the root `Cargo.toml`.
   work remains visible in the existing invite-stage telemetry
   ([#1309](https://github.com/marmot-protocol/mdk/pull/1309)).
 
-- Account setup interruptions now have stable JSON recovery codes and repair
-  hints instead of falling through to the generic `command_failed` bucket.
+- Account imports now journal setup progress and resume the exact persisted
+  KeyPackage publication after relay failure, cancellation, or restart instead
+  of minting a new stable slot. Ambiguous pre-journal state returns the typed,
+  consent-gated `AccountSetupRecoveryRequired` flow; setup interruptions also
+  have stable JSON recovery codes and repair hints instead of falling through
+  to the generic `command_failed` bucket.
+
+- Published NIP-65 and inbox lists containing retired relays no longer prevent
+  account activation or remote KeyPackage lookup. The original lists remain
+  cached and visible for settings UI, while unsafe endpoints are filtered only
+  from runtime routes and configured directory relays provide operational
+  fallback without rewriting or republishing the account's list.
+
+- MarmotKit root preparation now works in physical iOS App Group and Android
+  application sandboxes while retaining descriptor-relative creation and
+  symlink rejection for app-controlled paths. New iOS account secrets use the
+  device-only after-first-unlock Keychain policy, and legacy entries migrate
+  crash-safely after the next unlocked access so notification extensions and
+  background refresh can operate while the device is locked.
+
+- Hermes and OpenClaw now bound automatically attached timeline context to the
+  newest eight records and 16 KiB, dropping oldest or individually oversized
+  records first. The Hermes one-line installer no longer lets an interactive
+  child consume the remainder of `curl | bash`, and its guided sender allowlist
+  is collected in one explicit step.
 
 - Account projection storage types now redact encrypted group-image decryption
   and Blossom upload keys from `Debug` output, including nested group
@@ -177,6 +223,34 @@ versioning through the workspace version in the root `Cargo.toml`.
   interrupted resolution can no longer drop it without a trace.
   ([#1285](https://github.com/marmot-protocol/mdk/pull/1285))
 
+- Locally authored messages now retain authenticated send-time branch
+  provenance through stored convergence and restart, preventing an accepted
+  own message from being misclassified as undecryptable merely because OpenMLS
+  cannot decrypt a sender's own private-message ciphertext during replay.
+
+- Inbound MLS commits now apply the epoch, roster, and capability projections
+  atomically with the OpenMLS merge. SQLite transaction boundaries retry
+  transient contention without rerunning application closures, pruning scales
+  without unbounded bind lists and preserves draft-owning groups, and secure
+  deletion retains a durable WAL-truncation intent until physical erasure can
+  complete.
+
+- Opaque transport objects that remain unpeelable now have a restart-safe,
+  bounded 30-day local residence. Expiry releases local resources without a
+  terminal protocol verdict and preserves exact-ID redelivery eligibility if
+  missing history later arrives.
+
+- Stored convergence passes whose durable base no longer matches the live tip
+  are discarded and reopened at the current epoch instead of halting the group
+  as unrecoverable. Eligible non-selected branches and missing-parent inputs
+  remain explicitly deferred for reconsideration rather than being
+  terminally invalidated.
+
+- The full-cohort release coordinator now fetches only immutable MDK,
+  WN Agent, and MarmotKit version tags, so an older local copy of the
+  intentionally moving `wn-agent-latest` installer alias no longer blocks a
+  release preflight with a tag-clobber error.
+
 - `MarmotApp` now permits only one live in-memory engine session per account
   across direct clients and managed workers. Concurrent opens return the typed
   `AccountSessionBusy` error, and worker reconnect drops the failed session
@@ -206,6 +280,18 @@ versioning through the workspace version in the root `Cargo.toml`.
   success and error paths.
 
 ### Changed
+
+- Generated simulator failure fixtures now preserve the complete executed
+  scenario instead of substituting a diagnostic semantic reduction that may
+  reproduce only the failure class. Strict virtual-time coverage also accepts
+  either fixed-point quiescence or an exact no-pending-work observation after
+  an explicit time advance.
+
+- UniFFI was upgraded from 0.28.3 to 0.29.4. Generated Swift keeps the existing
+  Marmot-facing declarations while gaining the generator's current
+  `Sendable`/`Error` conformances; the dependency refresh also removes the
+  audited `bincode`, `paste`, and `proc-macro-error2` paths and incorporates the
+  `nostr` fix for RUSTSEC-2026-0219.
 
 - The bundled SQLCipher stack now uses rusqlite 0.40.1/libsqlite3-sys 0.38.1,
   providing SQLCipher 4.14.0 and SQLite 3.51.3 with SQLite's WAL-reset
@@ -1258,7 +1344,8 @@ Initial release of the `dm` command-line app, the `dmd` background daemon, and t
 - Local installation docs for `cargo install --path crates/cli --locked --bins`.
 - Homebrew release checklist and namespaced tap packaging path for `marmot-protocol/tap/darkmatter`.
 
-[Unreleased]: https://github.com/marmot-protocol/mdk/compare/v0.9.10...HEAD
+[Unreleased]: https://github.com/marmot-protocol/mdk/compare/v0.9.11...HEAD
+[0.9.11]: https://github.com/marmot-protocol/mdk/compare/v0.9.10...v0.9.11
 [0.9.10]: https://github.com/marmot-protocol/mdk/compare/v0.9.9...v0.9.10
 [0.9.9]: https://github.com/marmot-protocol/mdk/compare/v0.9.8...v0.9.9
 [0.9.8]: https://github.com/marmot-protocol/mdk/compare/v0.9.7...v0.9.8

--- a/scripts/cut-full-release.sh
+++ b/scripts/cut-full-release.sh
@@ -119,7 +119,14 @@ if [ -n "$(git status --porcelain)" ]; then
     fi
 fi
 
-run git fetch origin master --tags
+# Fetch only the immutable release-track tags used below. The
+# `wn-agent-latest` installer alias intentionally moves after publication, and
+# a blanket `--tags` fetch rejects that normal movement as a clobber when a
+# caller has an older local copy.
+run git fetch --no-tags origin master \
+    'refs/tags/v*:refs/tags/v*' \
+    'refs/tags/wn-agent-v*:refs/tags/wn-agent-v*' \
+    'refs/tags/marmotkit-v*:refs/tags/marmotkit-v*'
 
 head_sha="$(git rev-parse HEAD)"
 origin_master_sha="$(git rev-parse origin/master)"


### PR DESCRIPTION
## Why

MDK 0.9.10 was released on 2026-07-29. Since then the workspace has accumulated compatible app/runtime fixes, additive MarmotKit APIs, convergence and storage hardening, and WN Agent integration changes including the Pi terminal harness. This prepares those changes as the 0.9.11 compatibility cohort without creating any tags or GitHub Releases yet.

The release branch is rebased onto current `origin/master` at `25cec98f`, including #1344 and #1345.

## What changed

- bump the root workspace version and all 24 inherited workspace package entries in `Cargo.lock` from 0.9.10 to 0.9.11
- bump all 28 checked-in simulator fixture `conformance_version` values to 0.9.11
- finalize the curated changelog as 0.9.11 and reconcile missing WN Agent/Pi, iOS/Android, relay-routing, storage, binding, convergence, simulator-fidelity, and cross-route assurance notes
- update changelog compare links for the new cohort
- make the full release coordinator fetch only the immutable MDK, WN Agent, and MarmotKit version-tag families

The release coordinator change fixes a concrete preflight failure: `wn-agent-latest` intentionally moves after publication, so a blanket `git fetch --tags` rejects a stale local copy as a clobber before the release can start. The coordinator does not use that alias when selecting previous versions or creating the three cohort tags.

## Validation

- `just fast-ci` after rebase
- `cargo test -p marmot-uniffi` (102 unit, 2 media fixture, and 28 smoke tests passed)
- `cargo test -p cgka-conformance-simulator --test canonical_scenarios canonical_vector_fixtures_match_generated_traces --locked`
- `cargo test -p cgka-conformance-simulator --test route_assurance --locked`
- `cargo test -p cgka-conformance-simulator --test vector_artifacts --locked`
- `cargo test -p cgka-conformance-simulator --test report_runner --locked` (23 passed)
- previous failed CI case `retained_media_rehydrates_a_retired_current_epoch_before_the_group_advances` passed six consecutive exact local runs after rebase
- `just release-all-dry-run 0.9.11`
- `cargo metadata --locked --format-version 1 --no-deps`
- `bash -n scripts/cut-full-release.sh`
- exact immutable-tag fetch reproduced successfully while an older local `wn-agent-latest` tag remained present
- `git diff --check`

## After merge

Once the merge commit is on `origin/master` and the full GitHub matrix is green, stage all three release tracks for manual review with:

```sh
just release-all-draft 0.9.11
```

That will create `v0.9.11`, `wn-agent-v0.9.11`, and `marmotkit-v0.9.11` on the same `origin/master` commit and leave all three GitHub Releases as drafts. Use `just release-all 0.9.11` instead only when immediate publication is intended.