### PR TITLE
fix: drop unsupported ObserveExact from container smoke scenario

### DIFF
--- a/crates/convergence-campaign-runner/tests/container_runtime.rs
+++ b/crates/convergence-campaign-runner/tests/container_runtime.rs
@@ -89,7 +89,10 @@ fn smoke_scenario() -> ScenarioSpec {
             ScenarioStep::Tick {
                 clients: clients.clone(),
             },
-            in_group(ScenarioStep::ObserveExact { clients }),
+            // The marmot_app_process adapter deliberately omits
+            // ExactConformanceObservation; a plain Observe records the
+            // per-node projections this smoke campaign asserts on.
+            in_group(ScenarioStep::Observe { clients }),
         ],
     }
 }

--- a/crates/convergence-campaign-runner/tests/container_runtime.rs
+++ b/crates/convergence-campaign-runner/tests/container_runtime.rs
@@ -3,8 +3,8 @@
 
 use cgka_conformance_simulator::process_orchestrator::ProcessScenarioReportV1;
 use cgka_conformance_simulator::{
-    ScenarioAccountV2, ScenarioDeviceV2, ScenarioProcessV2, ScenarioRelayV2, ScenarioSpec,
-    ScenarioStep, ScenarioTopologyV2,
+    QuiescencePolicy, ScenarioAccountV2, ScenarioDeviceV2, ScenarioProcessV2, ScenarioRelayV2,
+    ScenarioSpec, ScenarioStep, ScenarioTopologyV2,
 };
 use convergence_campaign_runner::{
     ContainerBackendV1, DistributedBackendV1, DistributedCampaignManifestV1, DistributedFaultV1,
@@ -90,9 +90,12 @@ fn smoke_scenario() -> ScenarioSpec {
                 clients: clients.clone(),
             },
             // The marmot_app_process adapter deliberately omits
-            // ExactConformanceObservation; a plain Observe records the
-            // per-node projections this smoke campaign asserts on.
-            in_group(ScenarioStep::Observe { clients }),
+            // ExactConformanceObservation. AwaitQuiescence is its supported
+            // exactness gate: it fails unless every node reports one shared
+            // state_commitment_sha256 and an observably quiescent projection.
+            ScenarioStep::AwaitQuiescence {
+                policy: QuiescencePolicy::default(),
+            },
         ],
     }
 }


### PR DESCRIPTION
## Summary
- The container smoke campaign scenario ended with `ObserveExact`, which requires the `exact_conformance_observation` capability that the `marmot_app_process` adapter deliberately does not declare (the node protocol has no exact-observation command; the orchestrator handled `ObserveExact` identically to a plain `Observe`).
- Whole-schedule capability preflight therefore rejected the scenario at launch (`process_capability_preflight` → `container_node_launch`), so the nightly real-container campaign has failed on every run since the test was introduced in #1270.
- The test is `#[ignore]`d in PR lanes and only runs in the nightly / weekly `convergence-hardening` lane via `--run-ignored ignored-only`, which is why the regression reached master unnoticed. Downgrading the step to `Observe` matches the adapter's declared capabilities and what the smoke campaign actually asserts.

Refs #1336

## Test plan
- [x] `cargo check -p convergence-campaign-runner --tests --locked`
- [x] `cargo test -p convergence-campaign-runner --locked`
- [ ] Tonight's Simulator Nightly runs the real-container campaign green (requires Docker + the campaign image, so not runnable locally here)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the smoke scenario to record observed state projections for each node.
  * Adjusted validation to accommodate container environments that do not provide exact conformance observations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->