### PR TITLE
Close the strict-oracle coverage gaps in generated scenario families

### DIFF
--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -499,10 +499,17 @@ regression, covers a new semantic edge, or is the smallest readable example of a
 
 ### `convergence-e2e-delivery/v1`
 
-- Generator: `generate_convergence_e2e_delivery_family`
-- Setup: the real-peeler invite-fork scenario runs with generated delivery mutations.
+- Generator: `generate_convergence_e2e_delivery_family` (generator version `2`).
+- Setup: the real-peeler invite-fork scenario runs with generated delivery mutations, then a settle tail delivers and
+  ticks the founders, accepts outstanding outbound work, runs an active bidirectional decryptability probe, and
+  observes the founders exactly.
 - Pressure: duplicate, delay, release, and reorder before observer clients tick.
-- Expected: observers converge on one selected branch and emit only the selected branch payload.
+- Expected: the mid-schedule observation stays branch-dependent, and so does the selected branch itself — app-witness
+  scoring can hand the win to either committer depending on the delivery schedule, and the losing branch's commits
+  deliberately remain reconsiderable deferred candidates on non-committing clients. The generated expectations
+  therefore pin the schedule-invariant claims: every scripted accepted acknowledgement confirms, the founders converge
+  and are exactly equivalent, and post-selection application traffic decrypts in every founder direction. Final
+  epoch/member-count and a whole-roster no-pending-work claim are deliberately not asserted.
 
 ### `admin-churn/v1`
 
@@ -644,7 +651,7 @@ regression, covers a new semantic edge, or is the smallest readable example of a
 
 ### Adversarial Reliability Catalog
 
-`adversarial-reliability/v1` rotates through twelve deterministic workload shapes: retained-history offline floods;
+`adversarial-reliability/v1` (generator version `3`) rotates through twelve deterministic workload shapes: retained-history offline floods;
 sustained app/proposal/commit traffic; self-update versus admin progress; a named unrecoverable losing-branch invite;
 unequal relay reconciliation; restart boundaries plus the engine's real SIGKILL durable-phase matrix; multi-group noisy
 neighbors; replay-budget exhaustion; shared-account multi-device witnesses; full-engine app-witness A/B selection;

--- a/crates/cgka-conformance-simulator/src/family.rs
+++ b/crates/cgka-conformance-simulator/src/family.rs
@@ -143,14 +143,17 @@ pub fn generate_convergence_e2e_delivery_family(
     let mut out = Vec::with_capacity(cases);
     for case_index in 0..cases {
         let mut rng = StdRng::seed_from_u64(seed ^ 0xC0A7_C0A7 ^ ((case_index as u64) << 32));
+        let (scenario, mut expected_outcomes) =
+            convergence_e2e_delivery_case(&mut rng, case_index as u64);
+        push_labelled_confirmation_expectations(&scenario, &mut expected_outcomes);
         out.push(GeneratedScenarioCase {
             family_name: "convergence-e2e-delivery/v1".into(),
-            generator_version: "1".into(),
+            generator_version: "2".into(),
             seed,
             case_index: case_index as u64,
             subject: GeneratedSubjectKind::Engine,
-            scenario: convergence_e2e_delivery_case(&mut rng, case_index as u64),
-            expected_outcomes: vec![],
+            scenario,
+            expected_outcomes,
         });
     }
     out
@@ -235,10 +238,11 @@ pub fn generate_adversarial_reliability_case(seed: u64, case_index: u64) -> Gene
     let mut rng = StdRng::seed_from_u64(seed ^ 0x4d33_4144_5645_5253 ^ case_index.rotate_left(17));
     let (family_name, subject, mut scenario, mut expected_outcomes) =
         adversarial_reliability_case(&mut rng, case_index);
+    push_labelled_confirmation_expectations(&scenario, &mut expected_outcomes);
     add_strict_reliability_oracle(&mut scenario, &mut expected_outcomes);
     GeneratedScenarioCase {
         family_name,
-        generator_version: "2".into(),
+        generator_version: "3".into(),
         seed,
         case_index,
         subject,
@@ -255,10 +259,11 @@ pub fn generate_adversarial_reliability_sustained_regression(seed: u64) -> Gener
     let (family_name, subject, mut scenario, mut expected_outcomes) =
         adversarial_reliability_sustained_mixed_traffic_with_rounds(&mut rng, case_index, 1);
     scenario.name = "adversarial-reliability/sustained-mixed-traffic/regression".into();
+    push_labelled_confirmation_expectations(&scenario, &mut expected_outcomes);
     add_strict_reliability_oracle(&mut scenario, &mut expected_outcomes);
     GeneratedScenarioCase {
         family_name,
-        generator_version: "2-regression".into(),
+        generator_version: "3-regression".into(),
         seed,
         case_index,
         subject,
@@ -301,10 +306,11 @@ fn adversarial_reliability_regression_case(
     let mut rng = StdRng::seed_from_u64(seed ^ 0x4d33_4144_5645_5253 ^ case_index.rotate_left(17));
     let (family_name, subject, mut scenario, mut expected_outcomes) = build(&mut rng, case_index);
     scenario.name = format!("{family_name}/regression");
+    push_labelled_confirmation_expectations(&scenario, &mut expected_outcomes);
     add_strict_reliability_oracle(&mut scenario, &mut expected_outcomes);
     GeneratedScenarioCase {
         family_name,
-        generator_version: "2-regression".into(),
+        generator_version: "3-regression".into(),
         seed,
         case_index,
         subject,
@@ -1983,7 +1989,9 @@ fn adversarial_reliability_offline_retained_flood_with_rounds(
             client: "bob".into(),
         },
     ];
+    let mut bob_payloads = Vec::with_capacity(rounds + 1);
     for round in 0..rounds {
+        bob_payloads.push(format!("offline-flood-{case_index}-{round}"));
         steps.push(ScenarioStep::SendAppMessage {
             sender: "alice".into(),
             payload: format!("offline-flood-{case_index}-{round}"),
@@ -2027,7 +2035,15 @@ fn adversarial_reliability_offline_retained_flood_with_rounds(
         },
         tick(["bob"]),
     ]);
-    let expected = vec![clients_converged(["alice", "bob", "carol"], None, Some(3))];
+    bob_payloads.push(format!("membership-window-{case_index}"));
+    // Bob's full-history catch-up transcript is the arm's delivery claim: every
+    // flood payload plus the membership-window payload, in publication order,
+    // at the deterministic post-remove epoch.
+    let final_epoch = 3 + u64::try_from(rounds).expect("rounds fit u64");
+    let expected = vec![
+        clients_converged(["alice", "bob", "carol"], None, Some(3)),
+        client_state("bob", final_epoch, 3, bob_payloads),
+    ];
     (
         "adversarial-reliability/offline-retained-history-flood/v1".into(),
         GeneratedSubjectKind::RetainedRelay,
@@ -2078,11 +2094,15 @@ fn adversarial_reliability_sustained_mixed_traffic_with_rounds(
         clients.clone(),
         labels(["bob", "carol", "david"]),
     );
+    let mut carol_payloads = Vec::with_capacity(rounds * 3);
     for round in 0..rounds {
         let mut senders = labels(["alice", "bob", "carol", "david"]);
         let sender_count = senders.len();
         senders.rotate_left(rng.gen_range(0..sender_count));
         for sender in &senders {
+            if sender != "carol" {
+                carol_payloads.push(format!("mixed-{case_index}-{round}-{sender}"));
+            }
             steps.push(ScenarioStep::SendAppMessage {
                 sender: sender.clone(),
                 payload: format!("mixed-{case_index}-{round}-{sender}"),
@@ -2112,6 +2132,10 @@ fn adversarial_reliability_sustained_mixed_traffic_with_rounds(
         ScenarioStep::DeliverAll,
         tick(["bob", "carol", "david"]),
     ]);
+    // Carol never commits, so her transcript is the arm's delivery claim:
+    // every other sender's payload in send order, at the deterministic
+    // post-leave epoch.
+    let final_epoch = 2 + u64::try_from(rounds).expect("rounds fit u64");
     (
         "adversarial-reliability/sustained-mixed-traffic/v1".into(),
         GeneratedSubjectKind::Engine,
@@ -2122,7 +2146,10 @@ fn adversarial_reliability_sustained_mixed_traffic_with_rounds(
             topology: Default::default(),
             steps,
         },
-        vec![clients_converged(["alice", "bob", "carol"], None, Some(3))],
+        vec![
+            clients_converged(["alice", "bob", "carol"], None, Some(3)),
+            client_state("carol", final_epoch, 3, carol_payloads),
+        ],
     )
 }
 
@@ -2473,7 +2500,13 @@ fn adversarial_reliability_multi_group_noisy_neighbor(
             topology: Default::default(),
             steps,
         },
-        vec![clients_converged(["alice", "bob"], Some(1), Some(2))],
+        vec![
+            clients_converged(["alice", "bob"], Some(1), Some(2)),
+            // Bob sits only in the quiet group, so his transcript is the
+            // noisy-neighbor isolation claim: exactly the quiet-group payload
+            // and none of the noise.
+            client_state("bob", 1, 2, vec![format!("quiet-progress-{case_index}")]),
+        ],
     )
 }
 
@@ -2527,7 +2560,20 @@ fn adversarial_reliability_multi_device_account(
             topology,
             steps,
         },
-        vec![clients_converged_vec(clients, Some(1), Some(3))],
+        vec![
+            clients_converged_vec(clients, Some(1), Some(3)),
+            // Bob is the cross-account observer: both same-account device
+            // payloads must reach him in send order.
+            client_state(
+                "bob",
+                1,
+                3,
+                vec![
+                    format!("phone-{case_index}"),
+                    format!("laptop-{case_index}"),
+                ],
+            ),
+        ],
     )
 }
 
@@ -2602,7 +2648,21 @@ fn adversarial_reliability_app_witness_value(
         "adversarial-reliability/app-witness-value/v1".into(),
         GeneratedSubjectKind::Engine,
         scenario,
-        vec![clients_converged(["alice", "bob", "carol"], None, None)],
+        vec![
+            clients_converged(["alice", "bob", "carol"], None, None),
+            // Bob's branch carries two app witnesses against alice's one, so
+            // witness-decided selection deterministically keeps eve's and
+            // frank's payloads and never emits david's on carol.
+            client_state(
+                "carol",
+                2,
+                5,
+                vec![
+                    format!("eve-witness-{case_index}"),
+                    format!("frank-witness-{case_index}"),
+                ],
+            ),
+        ],
     )
 }
 
@@ -2707,7 +2767,12 @@ fn adversarial_reliability_clock_cursor_attack(
             topology: adversarial_reliability_single_relay_topology(&clients),
             steps,
         },
-        vec![clients_converged(["alice", "bob"], Some(1), Some(2))],
+        vec![
+            clients_converged(["alice", "bob"], Some(1), Some(2)),
+            // Reverse-ordered, duplicated relay history plus the year-long
+            // clock jump must still deliver the payload exactly once.
+            client_state("bob", 1, 2, vec![format!("before-clock-jump-{case_index}")]),
+        ],
     )
 }
 
@@ -2986,6 +3051,32 @@ fn confirmed(step_index: usize, client: &str, pending: &str) -> TraceExpectation
     }
 }
 
+/// Pin every scripted accepted labelled acknowledgement as a confirmed
+/// pending-resolution expectation. Scripted acknowledgements are pure
+/// functions of the case, so these expectations are delivery-schedule
+/// invariant, and they give the strict oracle its `CreateGroup` /
+/// `PublishConfirm` stimulus coverage without hand-maintained step indices.
+fn push_labelled_confirmation_expectations(
+    scenario: &ScenarioSpec,
+    expected: &mut Vec<TraceExpectation>,
+) {
+    for (step_index, step) in scenario.steps.iter().enumerate() {
+        let ScenarioStep::AcknowledgeOutbound {
+            client,
+            publication: Some(publication),
+            outcome: SubjectOutboundOutcome::Accepted,
+            ..
+        } = step
+        else {
+            continue;
+        };
+        let expectation = confirmed(step_index, client, publication);
+        if !expected.contains(&expectation) {
+            expected.push(expectation);
+        }
+    }
+}
+
 fn rolled_back(step_index: usize, client: &str, pending: &str) -> TraceExpectation {
     TraceExpectation::PendingResolution {
         step_index,
@@ -3048,7 +3139,10 @@ fn recovery_summary(
     }
 }
 
-fn convergence_e2e_delivery_case(rng: &mut StdRng, case_index: u64) -> ScenarioSpec {
+fn convergence_e2e_delivery_case(
+    rng: &mut StdRng,
+    case_index: u64,
+) -> (ScenarioSpec, Vec<TraceExpectation>) {
     let clients = vec![
         "alice".to_string(),
         "bob".to_string(),
@@ -3141,13 +3235,62 @@ fn convergence_e2e_delivery_case(rng: &mut StdRng, case_index: u64) -> ScenarioS
         clients: vec!["carol".into(), "frank".into()],
     });
 
-    ScenarioSpec {
-        name: format!("convergence-e2e-delivery/v1/case-{case_index}"),
-        spec_version: "2".into(),
-        topology: Default::default(),
-        clients,
-        steps,
+    // Settle the founders on the canonical branch, then actively prove
+    // post-selection application delivery in every direction and exact
+    // canonical agreement. The mid-schedule observation above stays
+    // branch-dependent, and so does the selected branch itself: app-witness
+    // scoring can hand the win to either committer depending on the delivery
+    // schedule, and the losing branch's commits deliberately remain
+    // reconsiderable deferred candidates on non-committing clients. That makes
+    // final epoch/member-count and no-pending-work schedule-DEPENDENT, so this
+    // family pins agreement, exact equivalence, and active bidirectional
+    // decryptability instead of the standard strict reliability tail.
+    let founders = vec![
+        "alice".to_string(),
+        "bob".to_string(),
+        "carol".to_string(),
+        "frank".to_string(),
+    ];
+    steps.push(ScenarioStep::DeliverAll);
+    steps.push(ScenarioStep::Tick {
+        clients: founders.clone(),
+    });
+    for founder in &founders {
+        steps.push(accept_all_outbound(founder));
     }
+    steps.push(ScenarioStep::DeliverAll);
+    steps.push(ScenarioStep::Tick {
+        clients: founders.clone(),
+    });
+    steps.push(ScenarioStep::ProbeBidirectionalDecryptability {
+        clients: founders.clone(),
+    });
+    steps.push(ScenarioStep::ObserveExact {
+        clients: founders.clone(),
+    });
+
+    let expected = vec![
+        TraceExpectation::ClientsConverged {
+            clients: founders.clone(),
+            epoch: None,
+            member_count: None,
+        },
+        TraceExpectation::ClientsExactlyEquivalent {
+            clients: founders.clone(),
+        },
+        TraceExpectation::ClientsBidirectionallyDecryptable { clients: founders },
+    ];
+
+    (
+        ScenarioSpec {
+            name: format!("convergence-e2e-delivery/v1/case-{case_index}"),
+            spec_version: "2".into(),
+            topology: Default::default(),
+            clients,
+            steps,
+        },
+        expected,
+    )
 }
 
 fn convergence_e2e_prefix_steps(case_index: u64) -> Vec<ScenarioStep> {

--- a/crates/cgka-conformance-simulator/src/oracle.rs
+++ b/crates/cgka-conformance-simulator/src/oracle.rs
@@ -163,6 +163,38 @@ pub fn build_scenario_oracle_report(
         observed_behaviors.push(OracleBehavior::ExactStateNonEquivalence);
         observed_behaviors.sort();
     }
+    // The global heuristics in `trace_behaviors` compare every observation in
+    // the trace, so they cannot see subset agreement when a scenario also
+    // observes intentionally divergent branch devices or earlier mid-schedule
+    // states. A passing equivalence/convergence expectation is direct observed
+    // evidence for exactly that subset; both expectations fail on missing
+    // observations, so they cannot pass vacuously.
+    if expected_outcomes.iter().any(|expectation| {
+        matches!(
+            expectation,
+            TraceExpectation::ClientsExactlyEquivalent { .. }
+        ) && compare_trace_expectations(None, std::slice::from_ref(expectation), observed_trace)
+            .is_empty()
+    }) {
+        for behavior in [
+            OracleBehavior::ExactStateEquivalence,
+            OracleBehavior::ClientConvergence,
+        ] {
+            if !observed_behaviors.contains(&behavior) {
+                observed_behaviors.push(behavior);
+            }
+        }
+        observed_behaviors.sort();
+    }
+    if expected_outcomes.iter().any(|expectation| {
+        matches!(expectation, TraceExpectation::ClientsConverged { .. })
+            && compare_trace_expectations(None, std::slice::from_ref(expectation), observed_trace)
+                .is_empty()
+    }) && !observed_behaviors.contains(&OracleBehavior::ClientConvergence)
+    {
+        observed_behaviors.push(OracleBehavior::ClientConvergence);
+        observed_behaviors.sort();
+    }
     if quiescence_observations
         .iter()
         .any(|observation| observation.status.is_quiescent())
@@ -937,6 +969,53 @@ mod tests {
             report
                 .observed_behaviors
                 .contains(&OracleBehavior::ExactStateNonEquivalence)
+        );
+        assert!(report.missing_observed_behaviors.is_empty());
+    }
+
+    #[test]
+    fn strict_oracle_records_subset_exact_equivalence_beside_divergent_branch_devices() {
+        // alice and bob share one exact snapshot; david stays on a divergent
+        // branch. The global all-observations heuristic cannot see the
+        // alice/bob agreement, so the passing subset expectation must carry
+        // the observed-equivalence evidence.
+        let mut alice = observation("alice", 2, 3, "winner");
+        alice.canonical_state = Some(ConformanceCanonicalStateSnapshot::Live(Box::default()));
+        let mut bob = observation("bob", 2, 3, "winner");
+        bob.canonical_state = alice.canonical_state.clone();
+        let mut david = observation("david", 2, 3, "loser");
+        let mut david_state =
+            Box::<cgka_engine::conformance_snapshot::ConformanceGroupSnapshot>::default();
+        david_state.epoch = 9;
+        david.canonical_state = Some(ConformanceCanonicalStateSnapshot::Live(david_state));
+        let expectation = TraceExpectation::ClientsExactlyEquivalent {
+            clients: vec!["alice".into(), "bob".into()],
+        };
+        let spec = ScenarioSpec {
+            name: "oracle/subset-equivalence".into(),
+            spec_version: "2".into(),
+            clients: vec!["alice".into(), "bob".into(), "david".into()],
+            topology: Default::default(),
+            steps: Vec::new(),
+        };
+
+        let report = build_scenario_oracle_report(
+            &spec,
+            None,
+            std::slice::from_ref(&expectation),
+            &trace(vec![alice, bob, david]),
+            &[],
+        );
+
+        assert!(
+            report
+                .observed_behaviors
+                .contains(&OracleBehavior::ExactStateEquivalence)
+        );
+        assert!(
+            report
+                .observed_behaviors
+                .contains(&OracleBehavior::ClientConvergence)
         );
         assert!(report.missing_observed_behaviors.is_empty());
     }

--- a/crates/cgka-conformance-simulator/tests/adversarial_reliability_campaigns.rs
+++ b/crates/cgka-conformance-simulator/tests/adversarial_reliability_campaigns.rs
@@ -32,14 +32,14 @@ fn generator_versions_track_the_renamed_output_contract() {
     assert!(
         generate_adversarial_reliability_family(7, 12)
             .iter()
-            .all(|case| case.generator_version == "2")
+            .all(|case| case.generator_version == "3")
     );
     for case in [
         generate_adversarial_reliability_offline_regression(7),
         generate_adversarial_reliability_sustained_regression(7),
         generate_adversarial_reliability_self_update_regression(7),
     ] {
-        assert_eq!(case.generator_version, "2-regression");
+        assert_eq!(case.generator_version, "3-regression");
     }
 }
 

--- a/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
+++ b/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
@@ -1536,7 +1536,7 @@ async fn convergence_e2e_delivery_family_runs_generated_variants() {
 
     for (case_index, case) in cases.iter().enumerate() {
         assert_eq!(case.family_name, "convergence-e2e-delivery/v1");
-        assert_eq!(case.generator_version, "1");
+        assert_eq!(case.generator_version, "2");
         assert_eq!(case.seed, 99);
         assert_eq!(case.case_index, case_index as u64);
 
@@ -1544,15 +1544,17 @@ async fn convergence_e2e_delivery_family_runs_generated_variants() {
             .await
             .expect("generated convergence variant reports");
         assert!(report.invariant_failures.is_empty());
-        assert_real_peeler_convergence_trace(report.observed_trace.as_ref().expect("trace"));
         assert!(
-            matches!(report.epoch_change_observations.len(), 2 | 4),
-            "case {case_index} produced {} epoch-change observations; steps={:?}; expectations={:?}",
-            report.epoch_change_observations.len(),
-            report.step_log,
+            report.expectation_failures.is_empty(),
+            "case {case_index} failed generated expectations: {:?}",
             report.expectation_failures
         );
-        assert!(report.app_invalidation_observations.is_empty());
+        assert_real_peeler_convergence_trace(report.observed_trace.as_ref().expect("trace"));
+        assert!(
+            !report.epoch_change_observations.is_empty(),
+            "case {case_index} produced no epoch-change observations; steps={:?}",
+            report.step_log,
+        );
     }
 }
 
@@ -3004,7 +3006,26 @@ fn assert_canonical_application_event(
 }
 
 fn assert_real_peeler_convergence_trace(trace: &ScenarioTrace) {
+    // The settle tail observes the founders with `observe_client_exact` after
+    // canonical branch selection; those snapshots must agree with each other,
+    // and the family's own `clients_exactly_equivalent` expectation carries
+    // the exact claim. The branch-shape match below applies to the
+    // mid-schedule legacy observations only.
+    let settled = trace
+        .observations
+        .iter()
+        .filter(|observation| observation.canonical_state.is_some())
+        .collect::<Vec<_>>();
+    if let Some(first) = settled.first() {
+        for observation in &settled {
+            assert_eq!(observation.epoch, first.epoch);
+            assert_eq!(observation.member_count, first.member_count);
+        }
+    }
     for observation in &trace.observations {
+        if observation.canonical_state.is_some() {
+            continue;
+        }
         match observation.received_payloads.as_slice() {
             [payload] if payload == "alice canonical payload" => {
                 assert_eq!(observation.epoch, 3);

--- a/crates/cgka-conformance-simulator/tests/report_runner.rs
+++ b/crates/cgka-conformance-simulator/tests/report_runner.rs
@@ -416,11 +416,25 @@ async fn report_runner_strict_oracle_counts_weak_warnings_as_failures() {
         fs::remove_dir_all(&out_dir).expect("remove stale output dir");
     }
 
+    // Every built-in family now carries strict oracle coverage, so the
+    // weak-oracle failure path is pinned through a generated input whose
+    // expectations were deliberately stripped.
+    let mut case = cgka_conformance_simulator::generate_convergence_e2e_delivery_family(42, 1)
+        .pop()
+        .expect("family generates one case");
+    case.expected_outcomes.clear();
+    fs::create_dir_all(&out_dir).expect("create output dir");
+    let input_path = out_dir.join("stripped-weak-oracle-input.json");
+    fs::write(
+        &input_path,
+        serde_json::to_string(&GeneratedScenarioInputV1::new(case)).expect("serialize input"),
+    )
+    .expect("write stripped generated input");
+
     let summary = run_report(&ReportArgs {
-        input: ReportInput::GeneratedFamily {
-            family: "convergence-e2e-delivery/v1".into(),
-            seed: 42,
-            cases: 1,
+        input: ReportInput::GeneratedInputs {
+            paths: vec![input_path],
+            adapter: None,
         },
         out: out_dir.clone(),
         strict_oracle: true,
@@ -494,16 +508,17 @@ async fn report_runner_writes_convergence_delivery_json_reports() {
         "convergence-e2e-delivery/v1"
     );
     assert_eq!(
-        report["app_invalidation_observations"]
-            .as_array()
-            .map(Vec::len),
+        report["expectation_failures"].as_array().map(Vec::len),
         Some(0)
     );
+    // The settle tail makes late-branch flips (and therefore invalidation and
+    // per-client epoch-change counts) delivery-schedule dependent; the exact
+    // convergence claims live in the family's generated expectations.
     let epoch_change_count = report["epoch_change_observations"]
         .as_array()
         .map(Vec::len)
         .expect("epoch changes array");
-    assert!(matches!(epoch_change_count, 2 | 4));
+    assert!(epoch_change_count >= 2);
 
     fs::remove_dir_all(out_dir).expect("clean output dir");
 }


### PR DESCRIPTION
A full strict report-CLI sweep over every generated family found two families that failed while every declared expectation passed. The engine behaved correctly in all of them; the marmot referee was miscounting its own scorecard.

`convergence-e2e-delivery/v1` failed 8/8 cases at every seed because its generator emitted `expected_outcomes: vec![]`. It was the only family never upgraded when strict oracle coverage became the default. `adversarial-reliability/v1` failed 9 of its 12 arms: most arms carried no expectation covering their `CreateGroup`/`PublishConfirm`/`AppMessage` stimuli, and `losing-invite-unrecoverable` hit a real classifier bug. The observed-behavior heuristic marks `ExactStateEquivalence` only when every canonical snapshot in the trace matches globally, so a scenario that asserts both `clients_exactly_equivalent(alice, bob)` and `clients_not_equivalent(david, eve)` could never observe the equivalence it proved.

Changes:

- `oracle.rs`: a passing `ClientsExactlyEquivalent` or `ClientsConverged` expectation now counts as observed evidence for its subset, mirroring the existing `ClientsNotEquivalent` rule. Both expectations fail on missing observations, so they cannot pass vacuously. A unit test pins the equivalent-pair-beside-divergent-device shape.
- `convergence-e2e-delivery/v1` (generator v2): the case builder appends a settle tail, an active bidirectional decryptability probe, an exact founder observation, and schedule-invariant expectations. The selected branch stays unpinned on purpose: app-witness scoring can hand the win to either committer depending on the delivery schedule, and losing-branch commits stay reconsiderable deferred candidates on non-committing clients, so final epoch/member-count and whole-roster no-pending-work are not asserted. SCENARIOS.md documents the reasoning.
- `adversarial-reliability/v1` (generator v3): a new `push_labelled_confirmation_expectations` helper pins every scripted accepted acknowledgement as a confirmed pending-resolution without hand-maintained step indices, and the six delivery-shaped arms get deterministic transcript expectations (offline catch-up, cross-sender rounds, noisy-neighbor isolation, multi-device, witness-decided selection, relay dedup after a year-long clock jump).
- The strict-oracle report test now pins the weak-oracle failure path through a deliberately expectation-stripped generated input, since no built-in family is weak anymore.

Verified: all 28 vectors, six families at seeds 1/42/1337 (full 12-arm adversarial catalog included) strict-green, the whole crate suite, the `test-policy-overrides` campaigns gate, and `just fast-ci`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced convergence validation for delivered messages, acknowledgements, decryptability, and client equivalence.
  * Expanded reliability scenarios to cover catch-up, sustained traffic, multi-device delivery, branch selection, and replay behavior.
  * Reports now accurately recognize client convergence and exact equivalence, including cases with divergent clients.
* **Tests**
  * Updated scenario versions and strengthened generated-case validation.
  * Added coverage for weak-oracle failures and more flexible epoch-change reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->