### PR TITLE
Generalize isolated convergence campaigns

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -306,6 +306,7 @@ adversarial-reliability-ci:
     cargo nextest run -p cgka-conformance-simulator --features test-policy-overrides --test adversarial_reliability_campaigns --locked
     cargo test -p cgka-conformance-simulator --features test-policy-overrides --test adversarial_reliability_campaigns --locked -- --ignored
     cargo nextest run -p cgka-conformance-simulator --features test-policy-overrides --test policy_sweeps --locked
+    rm -rf -- target/cgka-adversarial-reliability-ci
     cargo run -p cgka-conformance-simulator --features test-policy-overrides --bin cgka-conformance-campaign --locked -- --cases 1 --case-timeout-secs 300 --out target/cgka-adversarial-reliability-ci --storage file
 
 # Independent convergence model, lifecycle/fairness, mutation adequacy, and
@@ -335,6 +336,7 @@ convergence-nightly-lane: convergence-lane-policy convergence-failure-corpus sim
     cargo nextest run -p convergence-campaign-runner --locked
 
 convergence-weekly-lane: convergence-nightly-lane
+    rm -rf -- target/cgka-weekly-reliability
     cargo run -p cgka-conformance-simulator --features test-policy-overrides --bin cgka-conformance-campaign --locked -- --cases 4 --case-timeout-secs 300 --out target/cgka-weekly-reliability --storage file
 
 # A release run must name a reviewed mixed-build manifest rather

--- a/crates/cgka-conformance-simulator/AGENTS.md
+++ b/crates/cgka-conformance-simulator/AGENTS.md
@@ -179,8 +179,12 @@ the property-test registry. This file is the agent-facing model.
 
 - **Module:** `src/bin/cgka-conformance-campaign.rs`
   - **Role:** Parent/worker campaign runner. Executes each generated case in an isolated child process and combines the
-    durable scenario report with `wait4` wall/CPU/peak-RSS/write measurements. This is the engine campaign boundary for
-    real process isolation; the app-runtime and child-process adapters are separate production-shaped boundaries.
+    durable scenario report with `wait4` wall/CPU/peak-RSS/write measurements. The parent persists the exact generated
+    input before spawning each worker, verifies report provenance and artifact integrity afterward, and refuses to
+    overwrite an earlier campaign. Workers emit the report CLI's fixture and failure-capsule artifacts. Every generated
+    family exposes direct case-index generation so a large isolated campaign does not regenerate the complete earlier
+    prefix for each worker. This is the engine campaign boundary for real process isolation; the app-runtime and
+    child-process adapters are separate production-shaped boundaries.
 
 - **Module:** `src/bin/cgka-policy-casegen.rs`
   - **Role:** Policy-case generator CLI; reads `formal/tamarin/policy_cases.json` and parses/reasons over the bounded

--- a/crates/cgka-conformance-simulator/README.md
+++ b/crates/cgka-conformance-simulator/README.md
@@ -163,10 +163,13 @@ cargo run -p cgka-conformance-simulator --bin cgka-conformance-campaign -- \
 cargo run -p cgka-conformance-simulator --bin cgka-conformance-campaign -- \
   --family convergence-chaos/v1 --seed 42 --cases 22 --case-timeout-secs 300 \
   --out target/cgka-convergence-chaos-process-campaign --storage file
+```
 
-# Use a new output directory for each run. The runner refuses to overwrite a
-# prior summary, generated input, report, fixture, or failure capsule.
+Use a new output directory for each ad-hoc run. The runner refuses to overwrite a prior summary, generated input,
+report, fixture, or failure capsule. The committed `adversarial-reliability-ci` and `convergence-weekly-lane` gates
+remove their fixed output directories before invoking the runner, so those recipes remain rerunnable.
 
+```sh
 # Test-only one-variable policy curves around fixed retained inputs/horizons.
 cargo test -p cgka-conformance-simulator --features test-policy-overrides \
   --test policy_sweeps

--- a/crates/cgka-conformance-simulator/README.md
+++ b/crates/cgka-conformance-simulator/README.md
@@ -156,6 +156,17 @@ cargo run -p cgka-conformance-simulator --bin cgka-conformance-campaign -- \
   --seed 7 --cases 12 --case-timeout-secs 300 \
   --out target/cgka-adversarial-reliability-process-campaign --storage file
 
+# Isolate any generated family case-by-case. The parent writes each exact
+# generated input before spawning its deadline-bounded worker; workers write
+# the same reports, fixture candidates, and portable failure capsules as the
+# report CLI.
+cargo run -p cgka-conformance-simulator --bin cgka-conformance-campaign -- \
+  --family convergence-chaos/v1 --seed 42 --cases 22 --case-timeout-secs 300 \
+  --out target/cgka-convergence-chaos-process-campaign --storage file
+
+# Use a new output directory for each run. The runner refuses to overwrite a
+# prior summary, generated input, report, fixture, or failure capsule.
+
 # Test-only one-variable policy curves around fixed retained inputs/horizons.
 cargo test -p cgka-conformance-simulator --features test-policy-overrides \
   --test policy_sweeps
@@ -163,6 +174,12 @@ cargo test -p cgka-conformance-simulator --features test-policy-overrides \
 # Independent convergence model, liveness, mutation, and protocol-decision gate.
 just convergence-verification-ci
 ```
+
+The process-campaign summary records the selected family, seed, storage mode, timeout, sensitive-capture setting,
+per-case process measurements, and every generated-input/report/fixture/capsule path. A normally exiting worker must
+leave a parseable report whose generated metadata and source digest match the saved input, plus its fixture candidate;
+otherwise `artifact_integrity_errors` makes the campaign fail. Case indices are generated directly rather than by
+rebuilding and discarding the complete earlier prefix, so increasing `--cases` keeps generation work linear.
 
 Every `ScenarioReport` embeds `campaign_measurements` v1. Its convergence latency is the measured wall time of the
 final successful `await_quiescence` action, or explicitly unavailable when the scenario does not request one;

--- a/crates/cgka-conformance-simulator/src/bin/cgka-conformance-campaign.rs
+++ b/crates/cgka-conformance-simulator/src/bin/cgka-conformance-campaign.rs
@@ -1,6 +1,9 @@
 use cgka_conformance_simulator::{
-    HarnessStorageMode, ScenarioReport, generate_adversarial_reliability_case,
-    run_generated_case_report_with_storage_mode,
+    GeneratedScenarioCase, GeneratedScenarioInputV1, HarnessStorageMode, ReportArgs, ReportInput,
+    ScenarioReport, generate_admin_churn_case, generate_adversarial_reliability_case,
+    generate_convergence_chaos_case, generate_convergence_e2e_delivery_case,
+    generate_send_leave_case, generate_stateful_chat_journey_case, resolve_scenario_input_bytes,
+    run_report,
 };
 use serde::{Deserialize, Serialize};
 use std::error::Error;
@@ -10,26 +13,39 @@ use std::time::{Duration, Instant};
 
 #[derive(Debug)]
 struct Args {
+    family: String,
     seed: u64,
     cases: usize,
-    case_index: Option<usize>,
     out: PathBuf,
     storage: HarnessStorageMode,
     case_timeout: Duration,
+    input: Option<PathBuf>,
+    capture_sensitive_replay: bool,
     worker: bool,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 struct ProcessCampaignReportV1 {
     schema_version: String,
+    family: String,
     seed: u64,
+    storage: String,
+    case_timeout_ms: u64,
+    capture_sensitive_replay: bool,
     cases: Vec<ProcessCaseMeasurementV1>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 struct ProcessCaseMeasurementV1 {
     case_index: usize,
+    generated_input: PathBuf,
     report: PathBuf,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    fixture_candidate: Option<PathBuf>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    failure_capsule: Option<PathBuf>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    sensitive_replay_capsule: Option<PathBuf>,
     exit_code: Option<i32>,
     signal: Option<i32>,
     timed_out: bool,
@@ -41,6 +57,16 @@ struct ProcessCaseMeasurementV1 {
     filesystem_block_write_lower_bound_bytes: Option<u64>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     unavailable_process_fields: Vec<String>,
+    #[serde(default)]
+    artifact_integrity_errors: Vec<String>,
+}
+
+struct CaseArtifactPaths {
+    generated_input: PathBuf,
+    report: PathBuf,
+    fixture_candidate: PathBuf,
+    failure_capsule: PathBuf,
+    sensitive_replay_capsule: PathBuf,
 }
 
 #[tokio::main]
@@ -59,31 +85,68 @@ async fn run() -> Result<ExitCode, Box<dyn Error>> {
     if args.worker {
         return run_worker(&args).await;
     }
+    #[cfg(unix)]
+    let _output_dir_guard = fs_private::prepare_directory_path(
+        &args.out,
+        fs_private::PRIVATE_DIR_MODE,
+        fs_private::ExistingDirectoryMode::Preserve,
+    )?;
+    #[cfg(not(unix))]
     fs_private::create_dir_all_private(&args.out)?;
+    let summary_path = args.out.join("process-campaign.v1.json");
+    ensure_path_absent(&summary_path)?;
 
     let executable = std::env::current_exe()?;
     let mut observations = Vec::with_capacity(args.cases);
     for case_index in 0..args.cases {
-        let report = args.out.join(format!("case-{case_index}.json"));
+        let case = generate_case(&args.family, args.seed, case_index)?;
+        let paths = case_artifact_paths(&args.out, &case);
+        for path in [
+            &paths.generated_input,
+            &paths.report,
+            &paths.fixture_candidate,
+            &paths.failure_capsule,
+            &paths.sensitive_replay_capsule,
+        ] {
+            ensure_path_absent(path)?;
+        }
+        fs_private::write_private(
+            &paths.generated_input,
+            &serde_json::to_vec_pretty(&GeneratedScenarioInputV1::new(case.clone()))?,
+        )?;
         let mut command = Command::new(&executable);
-        command.args([
-            "--worker",
-            "--seed",
-            &args.seed.to_string(),
-            "--case-index",
-            &case_index.to_string(),
-            "--out",
-            report.to_str().ok_or("non-UTF-8 report path")?,
-            "--storage",
-            storage_label(args.storage),
-        ]);
+        command
+            .arg("--worker")
+            .arg("--input")
+            .arg(&paths.generated_input)
+            .arg("--out")
+            .arg(&args.out)
+            .arg("--storage")
+            .arg(storage_label(args.storage));
+        if args.capture_sensitive_replay {
+            command.arg("--capture-sensitive-replay");
+        }
         let started = Instant::now();
         let child = command.spawn()?;
         let usage = wait_with_usage(child, args.case_timeout)?;
-        let database_bytes = read_database_bytes(&report);
+        let artifact_integrity_errors = inspect_case_artifacts(&case, &paths, &usage);
+        let database_bytes = read_database_bytes(&paths.report);
         observations.push(ProcessCaseMeasurementV1 {
             case_index,
-            report,
+            generated_input: paths.generated_input,
+            report: paths.report,
+            fixture_candidate: paths
+                .fixture_candidate
+                .exists()
+                .then_some(paths.fixture_candidate),
+            failure_capsule: paths
+                .failure_capsule
+                .exists()
+                .then_some(paths.failure_capsule),
+            sensitive_replay_capsule: paths
+                .sensitive_replay_capsule
+                .exists()
+                .then_some(paths.sensitive_replay_capsule),
             exit_code: usage.exit_code,
             signal: usage.signal,
             timed_out: usage.timed_out,
@@ -95,17 +158,24 @@ async fn run() -> Result<ExitCode, Box<dyn Error>> {
             filesystem_block_write_lower_bound_bytes: usage
                 .filesystem_block_write_lower_bound_bytes,
             unavailable_process_fields: usage.unavailable_process_fields,
+            artifact_integrity_errors,
         });
     }
-    let failed = observations
-        .iter()
-        .any(|case| case.timed_out || case.exit_code != Some(0) || case.signal.is_some());
+    let failed = observations.iter().any(|case| {
+        case.timed_out
+            || case.exit_code != Some(0)
+            || case.signal.is_some()
+            || !case.artifact_integrity_errors.is_empty()
+    });
     let summary = ProcessCampaignReportV1 {
         schema_version: "1".into(),
+        family: args.family,
         seed: args.seed,
+        storage: storage_label(args.storage).into(),
+        case_timeout_ms: elapsed_ms(args.case_timeout),
+        capture_sensitive_replay: args.capture_sensitive_replay,
         cases: observations,
     };
-    let summary_path = args.out.join("process-campaign.v1.json");
     fs_private::write_private(&summary_path, &serde_json::to_vec_pretty(&summary)?)?;
     println!("Process campaign report: {}", summary_path.display());
     Ok(if failed {
@@ -116,14 +186,19 @@ async fn run() -> Result<ExitCode, Box<dyn Error>> {
 }
 
 async fn run_worker(args: &Args) -> Result<ExitCode, Box<dyn Error>> {
-    let case_index = args.case_index.ok_or("worker requires --case-index")?;
-    let case = generate_adversarial_reliability_case(args.seed, case_index as u64);
-    let report = run_generated_case_report_with_storage_mode(&case, None, args.storage).await?;
-    if let Some(parent) = args.out.parent() {
-        fs_private::create_dir_all_private(parent)?;
-    }
-    fs_private::write_private(&args.out, &serde_json::to_vec_pretty(&report)?)?;
-    let failed = !report.expectation_failures.is_empty() || !report.invariant_failures.is_empty();
+    let input = args.input.clone().ok_or("worker requires --input")?;
+    let summary = run_report(&ReportArgs {
+        input: ReportInput::GeneratedInputs {
+            paths: vec![input],
+            adapter: None,
+        },
+        out: args.out.clone(),
+        strict_oracle: true,
+        storage_mode: args.storage,
+        capture_sensitive_replay: args.capture_sensitive_replay,
+    })
+    .await?;
+    let failed = summary.failed() > 0;
     Ok(if failed {
         ExitCode::FAILURE
     } else {
@@ -139,24 +214,104 @@ fn read_database_bytes(path: &Path) -> Option<u64> {
         .database_bytes
 }
 
+fn inspect_case_artifacts(
+    case: &GeneratedScenarioCase,
+    paths: &CaseArtifactPaths,
+    usage: &ChildUsage,
+) -> Vec<String> {
+    let mut errors = Vec::new();
+    let input_bytes = match std::fs::read(&paths.generated_input) {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            errors.push(format!("generated_input_unreadable:{error}"));
+            Vec::new()
+        }
+    };
+    let expected_source_sha256 = if input_bytes.is_empty() {
+        None
+    } else {
+        match resolve_scenario_input_bytes(&input_bytes) {
+            Ok(resolved) => {
+                if resolved.generated_case.as_ref() != Some(case) {
+                    errors.push("generated_input_case_mismatch".into());
+                }
+                Some(resolved.provenance.source_sha256)
+            }
+            Err(error) => {
+                errors.push(format!("generated_input_invalid:{error}"));
+                None
+            }
+        }
+    };
+
+    // A timeout or signal may interrupt the worker before it can publish a
+    // report. A normally exiting worker, including a strict-oracle failure,
+    // must leave a parseable report and fixture candidate.
+    if !usage.timed_out && usage.signal.is_none() {
+        match std::fs::read(&paths.report) {
+            Ok(bytes) => match serde_json::from_slice::<ScenarioReport>(&bytes) {
+                Ok(report) => {
+                    let generated = report.metadata.generated.as_ref();
+                    if generated.map(|value| {
+                        (
+                            value.family_name.as_str(),
+                            value.generator_version.as_str(),
+                            value.seed,
+                            value.case_index,
+                        )
+                    }) != Some((
+                        case.family_name.as_str(),
+                        case.generator_version.as_str(),
+                        case.seed,
+                        case.case_index,
+                    )) {
+                        errors.push("report_generated_metadata_mismatch".into());
+                    }
+                    if report
+                        .metadata
+                        .input_provenance
+                        .as_ref()
+                        .map(|value| value.source_sha256.as_str())
+                        != expected_source_sha256.as_deref()
+                    {
+                        errors.push("report_input_digest_mismatch".into());
+                    }
+                }
+                Err(error) => errors.push(format!("report_invalid:{error}")),
+            },
+            Err(error) => errors.push(format!("report_unreadable:{error}")),
+        }
+        if !paths.fixture_candidate.is_file() {
+            errors.push("fixture_candidate_missing".into());
+        }
+        if usage.exit_code != Some(0) && paths.report.is_file() && !paths.failure_capsule.is_file()
+        {
+            errors.push("failure_capsule_missing".into());
+        }
+    }
+    errors
+}
+
 fn parse_args(args: impl Iterator<Item = String>) -> Result<Args, Box<dyn Error>> {
+    let mut family = "adversarial-reliability/v1".to_owned();
     let mut seed = 7;
     let mut cases = 12;
-    let mut case_index = None;
     let mut out = PathBuf::from("target/cgka-adversarial-reliability-process-campaign");
     let mut storage = HarnessStorageMode::TempFileBackedSqlite;
     let mut case_timeout = Duration::from_secs(300);
+    let mut input = None;
+    let mut capture_sensitive_replay = false;
     let mut worker = false;
     let mut args = args.peekable();
     while let Some(arg) = args.next() {
         match arg.as_str() {
             "--worker" => worker = true,
+            "--family" => family = args.next().ok_or("missing --family value")?,
             "--seed" => seed = args.next().ok_or("missing --seed value")?.parse()?,
             "--cases" => cases = args.next().ok_or("missing --cases value")?.parse()?,
-            "--case-index" => {
-                case_index = Some(args.next().ok_or("missing --case-index value")?.parse()?)
-            }
             "--out" => out = PathBuf::from(args.next().ok_or("missing --out value")?),
+            "--input" => input = Some(PathBuf::from(args.next().ok_or("missing --input value")?)),
+            "--capture-sensitive-replay" => capture_sensitive_replay = true,
             "--storage" => {
                 storage = match args.next().ok_or("missing --storage value")?.as_str() {
                     "memory" => HarnessStorageMode::InMemorySqlite,
@@ -174,15 +329,74 @@ fn parse_args(args: impl Iterator<Item = String>) -> Result<Args, Box<dyn Error>
             other => return Err(format!("unknown argument {other}").into()),
         }
     }
+    if worker && input.is_none() {
+        return Err("worker requires --input".into());
+    }
+    if !worker && input.is_some() {
+        return Err("--input is reserved for campaign workers".into());
+    }
+    if !worker && cases == 0 {
+        return Err("--cases must be greater than zero".into());
+    }
+    if !worker && case_timeout.is_zero() {
+        return Err("--case-timeout-secs must be greater than zero".into());
+    }
     Ok(Args {
+        family,
         seed,
         cases,
-        case_index,
         out,
         storage,
         case_timeout,
+        input,
+        capture_sensitive_replay,
         worker,
     })
+}
+
+fn generate_case(
+    family: &str,
+    seed: u64,
+    case_index: usize,
+) -> Result<GeneratedScenarioCase, Box<dyn Error>> {
+    let case_index = u64::try_from(case_index)?;
+    let case = match family {
+        "send-leave/v1" => generate_send_leave_case(seed, case_index),
+        "convergence-e2e-delivery/v1" => generate_convergence_e2e_delivery_case(seed, case_index),
+        "convergence-chaos/v1" => generate_convergence_chaos_case(seed, case_index),
+        "admin-churn/v1" => generate_admin_churn_case(seed, case_index),
+        "adversarial-reliability/v1" => generate_adversarial_reliability_case(seed, case_index),
+        "chat-journey/v1" => generate_stateful_chat_journey_case(seed, case_index),
+        other => return Err(format!("unsupported family {other}").into()),
+    };
+    Ok(case)
+}
+
+fn case_artifact_paths(out: &Path, case: &GeneratedScenarioCase) -> CaseArtifactPaths {
+    let stem = format!(
+        "{}-seed-{}-case-{}",
+        case.family_name.replace('/', "-"),
+        case.seed,
+        case.case_index
+    );
+    CaseArtifactPaths {
+        generated_input: out.join(format!("{stem}-generated-input.json")),
+        report: out.join(format!("{stem}.json")),
+        fixture_candidate: out.join(format!("{stem}-fixture.v1.json")),
+        failure_capsule: out.join(format!("{stem}-failure-capsule.v1.json")),
+        sensitive_replay_capsule: out.join(format!("{stem}-sensitive-replay-capsule.v1.json")),
+    }
+}
+
+fn ensure_path_absent(path: &Path) -> Result<(), Box<dyn Error>> {
+    if path.exists() {
+        return Err(format!(
+            "refusing to overwrite existing campaign artifact: {}",
+            path.display()
+        )
+        .into());
+    }
+    Ok(())
 }
 
 fn storage_label(storage: HarnessStorageMode) -> &'static str {
@@ -194,6 +408,10 @@ fn storage_label(storage: HarnessStorageMode) -> &'static str {
 
 fn elapsed_us(duration: std::time::Duration) -> u64 {
     u64::try_from(duration.as_micros()).unwrap_or(u64::MAX)
+}
+
+fn elapsed_ms(duration: std::time::Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
 }
 
 struct ChildUsage {
@@ -364,6 +582,83 @@ mod tests {
         assert_eq!(args.case_timeout, Duration::from_secs(17));
     }
 
+    #[test]
+    fn parses_family_and_sensitive_capture() {
+        let args = parse_args(
+            ["--family", "chat-journey/v1", "--capture-sensitive-replay"]
+                .into_iter()
+                .map(str::to_owned),
+        )
+        .expect("arguments parse");
+        assert_eq!(args.family, "chat-journey/v1");
+        assert!(args.capture_sensitive_replay);
+    }
+
+    #[test]
+    fn every_report_family_generates_an_exact_case() {
+        for family in [
+            "send-leave/v1",
+            "convergence-e2e-delivery/v1",
+            "convergence-chaos/v1",
+            "admin-churn/v1",
+            "adversarial-reliability/v1",
+            "chat-journey/v1",
+        ] {
+            let case = generate_case(family, 42, 3).expect("family case generates");
+            assert_eq!(case.seed, 42);
+            assert_eq!(case.case_index, 3);
+            let legacy_prefix_case = match family {
+                "send-leave/v1" => cgka_conformance_simulator::generate_send_leave_family(42, 4),
+                "convergence-e2e-delivery/v1" => {
+                    cgka_conformance_simulator::generate_convergence_e2e_delivery_family(42, 4)
+                }
+                "convergence-chaos/v1" => {
+                    cgka_conformance_simulator::generate_convergence_chaos_family(42, 4)
+                }
+                "admin-churn/v1" => cgka_conformance_simulator::generate_admin_churn_family(42, 4),
+                "adversarial-reliability/v1" => {
+                    cgka_conformance_simulator::generate_adversarial_reliability_family(42, 4)
+                }
+                "chat-journey/v1" => {
+                    cgka_conformance_simulator::generate_stateful_chat_journey_family(42, 4)
+                }
+                _ => unreachable!("family list is exhaustive"),
+            }
+            .pop()
+            .expect("prefix contains requested case");
+            assert_eq!(case, legacy_prefix_case);
+        }
+    }
+
+    #[test]
+    fn rejects_empty_or_worker_only_parent_inputs() {
+        for args in [
+            vec!["--cases", "0"],
+            vec!["--case-timeout-secs", "0"],
+            vec!["--input", "case.json"],
+            vec!["--worker"],
+        ] {
+            let parsed = parse_args(args.iter().copied().map(str::to_owned));
+            assert!(parsed.is_err(), "{args:?} must fail");
+        }
+    }
+
+    #[test]
+    fn case_artifacts_use_the_report_cli_stem() {
+        let case = generate_case("convergence-chaos/v1", 42, 3).expect("case generates");
+        let paths = case_artifact_paths(Path::new("out"), &case);
+        let stem = "convergence-chaos-v1-seed-42-case-3";
+        assert_eq!(
+            paths.generated_input,
+            Path::new("out").join(format!("{stem}-generated-input.json"))
+        );
+        assert_eq!(paths.report, Path::new("out").join(format!("{stem}.json")));
+        assert_eq!(
+            paths.fixture_candidate,
+            Path::new("out").join(format!("{stem}-fixture.v1.json"))
+        );
+    }
+
     #[cfg(unix)]
     #[test]
     fn kills_and_reaps_a_worker_that_exceeds_its_timeout() {
@@ -374,5 +669,18 @@ mod tests {
         let usage = wait_with_usage(child, Duration::from_millis(10)).expect("reap child");
         assert!(usage.timed_out);
         assert!(usage.signal.is_some());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn preserves_a_workers_nonzero_exit_code() {
+        let child = Command::new("sh")
+            .args(["-c", "exit 7"])
+            .spawn()
+            .expect("spawn failing child");
+        let usage = wait_with_usage(child, Duration::from_secs(1)).expect("reap child");
+        assert!(!usage.timed_out);
+        assert_eq!(usage.exit_code, Some(7));
+        assert_eq!(usage.signal, None);
     }
 }

--- a/crates/cgka-conformance-simulator/src/bin/cgka-conformance-campaign.rs
+++ b/crates/cgka-conformance-simulator/src/bin/cgka-conformance-campaign.rs
@@ -1,9 +1,6 @@
 use cgka_conformance_simulator::{
     GeneratedScenarioCase, GeneratedScenarioInputV1, HarnessStorageMode, ReportArgs, ReportInput,
-    ScenarioReport, generate_admin_churn_case, generate_adversarial_reliability_case,
-    generate_convergence_chaos_case, generate_convergence_e2e_delivery_case,
-    generate_send_leave_case, generate_stateful_chat_journey_case, resolve_scenario_input_bytes,
-    run_report,
+    ScenarioReport, generate_family_case, resolve_scenario_input_bytes, run_report,
 };
 use serde::{Deserialize, Serialize};
 use std::error::Error;
@@ -69,6 +66,17 @@ struct CaseArtifactPaths {
     sensitive_replay_capsule: PathBuf,
 }
 
+struct PlannedCase {
+    case: GeneratedScenarioCase,
+    paths: CaseArtifactPaths,
+    generated_input_bytes: Vec<u8>,
+}
+
+struct CaseArtifactInspection {
+    integrity_errors: Vec<String>,
+    database_bytes: Option<u64>,
+}
+
 #[tokio::main]
 async fn main() -> ExitCode {
     match run().await {
@@ -85,6 +93,8 @@ async fn run() -> Result<ExitCode, Box<dyn Error>> {
     if args.worker {
         return run_worker(&args).await;
     }
+    let executable = std::env::current_exe()?;
+    let (summary_path, planned_cases) = preflight_campaign(&args)?;
     #[cfg(unix)]
     let _output_dir_guard = fs_private::prepare_directory_path(
         &args.out,
@@ -93,27 +103,14 @@ async fn run() -> Result<ExitCode, Box<dyn Error>> {
     )?;
     #[cfg(not(unix))]
     fs_private::create_dir_all_private(&args.out)?;
-    let summary_path = args.out.join("process-campaign.v1.json");
-    ensure_path_absent(&summary_path)?;
-
-    let executable = std::env::current_exe()?;
     let mut observations = Vec::with_capacity(args.cases);
-    for case_index in 0..args.cases {
-        let case = generate_case(&args.family, args.seed, case_index)?;
-        let paths = case_artifact_paths(&args.out, &case);
-        for path in [
-            &paths.generated_input,
-            &paths.report,
-            &paths.fixture_candidate,
-            &paths.failure_capsule,
-            &paths.sensitive_replay_capsule,
-        ] {
-            ensure_path_absent(path)?;
-        }
-        fs_private::write_private(
-            &paths.generated_input,
-            &serde_json::to_vec_pretty(&GeneratedScenarioInputV1::new(case.clone()))?,
-        )?;
+    for (case_index, planned) in planned_cases.into_iter().enumerate() {
+        let PlannedCase {
+            case,
+            paths,
+            generated_input_bytes,
+        } = planned;
+        fs_private::write_private(&paths.generated_input, &generated_input_bytes)?;
         let mut command = Command::new(&executable);
         command
             .arg("--worker")
@@ -129,8 +126,7 @@ async fn run() -> Result<ExitCode, Box<dyn Error>> {
         let started = Instant::now();
         let child = command.spawn()?;
         let usage = wait_with_usage(child, args.case_timeout)?;
-        let artifact_integrity_errors = inspect_case_artifacts(&case, &paths, &usage);
-        let database_bytes = read_database_bytes(&paths.report);
+        let inspection = inspect_case_artifacts(&case, &paths, &usage);
         observations.push(ProcessCaseMeasurementV1 {
             case_index,
             generated_input: paths.generated_input,
@@ -154,11 +150,11 @@ async fn run() -> Result<ExitCode, Box<dyn Error>> {
             user_cpu_us: usage.user_cpu_us,
             system_cpu_us: usage.system_cpu_us,
             peak_rss_bytes: usage.peak_rss_bytes,
-            database_bytes,
+            database_bytes: inspection.database_bytes,
             filesystem_block_write_lower_bound_bytes: usage
                 .filesystem_block_write_lower_bound_bytes,
             unavailable_process_fields: usage.unavailable_process_fields,
-            artifact_integrity_errors,
+            artifact_integrity_errors: inspection.integrity_errors,
         });
     }
     let failed = observations.iter().any(|case| {
@@ -198,6 +194,7 @@ async fn run_worker(args: &Args) -> Result<ExitCode, Box<dyn Error>> {
         capture_sensitive_replay: args.capture_sensitive_replay,
     })
     .await?;
+    println!("{}", summary.to_human_text());
     let failed = summary.failed() > 0;
     Ok(if failed {
         ExitCode::FAILURE
@@ -206,19 +203,11 @@ async fn run_worker(args: &Args) -> Result<ExitCode, Box<dyn Error>> {
     })
 }
 
-fn read_database_bytes(path: &Path) -> Option<u64> {
-    let bytes = std::fs::read(path).ok()?;
-    serde_json::from_slice::<ScenarioReport>(&bytes)
-        .ok()?
-        .campaign_measurements
-        .database_bytes
-}
-
 fn inspect_case_artifacts(
     case: &GeneratedScenarioCase,
     paths: &CaseArtifactPaths,
     usage: &ChildUsage,
-) -> Vec<String> {
+) -> CaseArtifactInspection {
     let mut errors = Vec::new();
     let input_bytes = match std::fs::read(&paths.generated_input) {
         Ok(bytes) => bytes,
@@ -244,42 +233,58 @@ fn inspect_case_artifacts(
         }
     };
 
+    let normally_exited = !usage.timed_out && usage.signal.is_none();
+    let report = match std::fs::read(&paths.report) {
+        Ok(bytes) => match serde_json::from_slice::<ScenarioReport>(&bytes) {
+            Ok(report) => Some(report),
+            Err(error) => {
+                if normally_exited {
+                    errors.push(format!("report_invalid:{error}"));
+                }
+                None
+            }
+        },
+        Err(error) => {
+            if normally_exited {
+                errors.push(format!("report_unreadable:{error}"));
+            }
+            None
+        }
+    };
+    let database_bytes = report
+        .as_ref()
+        .and_then(|report| report.campaign_measurements.database_bytes);
+
     // A timeout or signal may interrupt the worker before it can publish a
     // report. A normally exiting worker, including a strict-oracle failure,
     // must leave a parseable report and fixture candidate.
-    if !usage.timed_out && usage.signal.is_none() {
-        match std::fs::read(&paths.report) {
-            Ok(bytes) => match serde_json::from_slice::<ScenarioReport>(&bytes) {
-                Ok(report) => {
-                    let generated = report.metadata.generated.as_ref();
-                    if generated.map(|value| {
-                        (
-                            value.family_name.as_str(),
-                            value.generator_version.as_str(),
-                            value.seed,
-                            value.case_index,
-                        )
-                    }) != Some((
-                        case.family_name.as_str(),
-                        case.generator_version.as_str(),
-                        case.seed,
-                        case.case_index,
-                    )) {
-                        errors.push("report_generated_metadata_mismatch".into());
-                    }
-                    if report
-                        .metadata
-                        .input_provenance
-                        .as_ref()
-                        .map(|value| value.source_sha256.as_str())
-                        != expected_source_sha256.as_deref()
-                    {
-                        errors.push("report_input_digest_mismatch".into());
-                    }
-                }
-                Err(error) => errors.push(format!("report_invalid:{error}")),
-            },
-            Err(error) => errors.push(format!("report_unreadable:{error}")),
+    if normally_exited {
+        if let Some(report) = report.as_ref() {
+            let generated = report.metadata.generated.as_ref();
+            if generated.map(|value| {
+                (
+                    value.family_name.as_str(),
+                    value.generator_version.as_str(),
+                    value.seed,
+                    value.case_index,
+                )
+            }) != Some((
+                case.family_name.as_str(),
+                case.generator_version.as_str(),
+                case.seed,
+                case.case_index,
+            )) {
+                errors.push("report_generated_metadata_mismatch".into());
+            }
+            if report
+                .metadata
+                .input_provenance
+                .as_ref()
+                .map(|value| value.source_sha256.as_str())
+                != expected_source_sha256.as_deref()
+            {
+                errors.push("report_input_digest_mismatch".into());
+            }
         }
         if !paths.fixture_candidate.is_file() {
             errors.push("fixture_candidate_missing".into());
@@ -289,7 +294,10 @@ fn inspect_case_artifacts(
             errors.push("failure_capsule_missing".into());
         }
     }
-    errors
+    CaseArtifactInspection {
+        integrity_errors: errors,
+        database_bytes,
+    }
 }
 
 fn parse_args(args: impl Iterator<Item = String>) -> Result<Args, Box<dyn Error>> {
@@ -354,22 +362,31 @@ fn parse_args(args: impl Iterator<Item = String>) -> Result<Args, Box<dyn Error>
     })
 }
 
-fn generate_case(
-    family: &str,
-    seed: u64,
-    case_index: usize,
-) -> Result<GeneratedScenarioCase, Box<dyn Error>> {
-    let case_index = u64::try_from(case_index)?;
-    let case = match family {
-        "send-leave/v1" => generate_send_leave_case(seed, case_index),
-        "convergence-e2e-delivery/v1" => generate_convergence_e2e_delivery_case(seed, case_index),
-        "convergence-chaos/v1" => generate_convergence_chaos_case(seed, case_index),
-        "admin-churn/v1" => generate_admin_churn_case(seed, case_index),
-        "adversarial-reliability/v1" => generate_adversarial_reliability_case(seed, case_index),
-        "chat-journey/v1" => generate_stateful_chat_journey_case(seed, case_index),
-        other => return Err(format!("unsupported family {other}").into()),
-    };
-    Ok(case)
+fn preflight_campaign(args: &Args) -> Result<(PathBuf, Vec<PlannedCase>), Box<dyn Error>> {
+    let summary_path = args.out.join("process-campaign.v1.json");
+    ensure_path_absent(&summary_path)?;
+    let mut planned_cases = Vec::with_capacity(args.cases);
+    for case_index in 0..args.cases {
+        let case = generate_family_case(&args.family, args.seed, u64::try_from(case_index)?)?;
+        let paths = case_artifact_paths(&args.out, &case);
+        for path in [
+            &paths.generated_input,
+            &paths.report,
+            &paths.fixture_candidate,
+            &paths.failure_capsule,
+            &paths.sensitive_replay_capsule,
+        ] {
+            ensure_path_absent(path)?;
+        }
+        let generated_input_bytes =
+            serde_json::to_vec_pretty(&GeneratedScenarioInputV1::new(case.clone()))?;
+        planned_cases.push(PlannedCase {
+            case,
+            paths,
+            generated_input_bytes,
+        });
+    }
+    Ok((summary_path, planned_cases))
 }
 
 fn case_artifact_paths(out: &Path, case: &GeneratedScenarioCase) -> CaseArtifactPaths {
@@ -604,7 +621,7 @@ mod tests {
             "adversarial-reliability/v1",
             "chat-journey/v1",
         ] {
-            let case = generate_case(family, 42, 3).expect("family case generates");
+            let case = generate_family_case(family, 42, 3).expect("family case generates");
             assert_eq!(case.seed, 42);
             assert_eq!(case.case_index, 3);
             let legacy_prefix_case = match family {
@@ -645,7 +662,7 @@ mod tests {
 
     #[test]
     fn case_artifacts_use_the_report_cli_stem() {
-        let case = generate_case("convergence-chaos/v1", 42, 3).expect("case generates");
+        let case = generate_family_case("convergence-chaos/v1", 42, 3).expect("case generates");
         let paths = case_artifact_paths(Path::new("out"), &case);
         let stem = "convergence-chaos-v1-seed-42-case-3";
         assert_eq!(
@@ -657,6 +674,31 @@ mod tests {
             paths.fixture_candidate,
             Path::new("out").join(format!("{stem}-fixture.v1.json"))
         );
+    }
+
+    #[test]
+    fn preflight_rejects_an_unknown_family_without_creating_output() {
+        let temp = tempfile::tempdir().expect("temporary campaign root");
+        let out = temp.path().join("not-created");
+        let args = parse_args(
+            [
+                "--family",
+                "unknown/v1",
+                "--cases",
+                "1",
+                "--out",
+                out.to_str().expect("UTF-8 test path"),
+            ]
+            .into_iter()
+            .map(str::to_owned),
+        )
+        .expect("arguments parse");
+        let error = preflight_campaign(&args)
+            .err()
+            .expect("unknown family must fail")
+            .to_string();
+        assert!(error.contains("unsupported family unknown/v1"));
+        assert!(!out.exists());
     }
 
     #[cfg(unix)]

--- a/crates/cgka-conformance-simulator/src/family.rs
+++ b/crates/cgka-conformance-simulator/src/family.rs
@@ -118,65 +118,72 @@ impl GeneratedScenarioCase {
 }
 
 pub fn generate_send_leave_family(seed: u64, cases: usize) -> Vec<GeneratedScenarioCase> {
-    let mut out = Vec::with_capacity(cases);
-    for case_index in 0..cases {
-        let mut rng = StdRng::seed_from_u64(seed ^ ((case_index as u64) << 32));
-        let (mut scenario, mut expected_outcomes) = send_leave_case(&mut rng, case_index as u64);
-        add_strict_reliability_oracle(&mut scenario, &mut expected_outcomes);
-        out.push(GeneratedScenarioCase {
-            family_name: "send-leave/v1".into(),
-            generator_version: "2".into(),
-            seed,
-            case_index: case_index as u64,
-            subject: GeneratedSubjectKind::Engine,
-            scenario,
-            expected_outcomes,
-        });
+    (0..cases)
+        .map(|case_index| generate_send_leave_case(seed, case_index as u64))
+        .collect()
+}
+
+/// Generate one send/leave case without regenerating earlier case indices.
+pub fn generate_send_leave_case(seed: u64, case_index: u64) -> GeneratedScenarioCase {
+    let mut rng = StdRng::seed_from_u64(seed ^ (case_index << 32));
+    let (mut scenario, mut expected_outcomes) = send_leave_case(&mut rng, case_index);
+    add_strict_reliability_oracle(&mut scenario, &mut expected_outcomes);
+    GeneratedScenarioCase {
+        family_name: "send-leave/v1".into(),
+        generator_version: "2".into(),
+        seed,
+        case_index,
+        subject: GeneratedSubjectKind::Engine,
+        scenario,
+        expected_outcomes,
     }
-    out
 }
 
 pub fn generate_convergence_e2e_delivery_family(
     seed: u64,
     cases: usize,
 ) -> Vec<GeneratedScenarioCase> {
-    let mut out = Vec::with_capacity(cases);
-    for case_index in 0..cases {
-        let mut rng = StdRng::seed_from_u64(seed ^ 0xC0A7_C0A7 ^ ((case_index as u64) << 32));
-        let (scenario, mut expected_outcomes) =
-            convergence_e2e_delivery_case(&mut rng, case_index as u64);
-        push_labelled_confirmation_expectations(&scenario, &mut expected_outcomes);
-        out.push(GeneratedScenarioCase {
-            family_name: "convergence-e2e-delivery/v1".into(),
-            generator_version: "2".into(),
-            seed,
-            case_index: case_index as u64,
-            subject: GeneratedSubjectKind::Engine,
-            scenario,
-            expected_outcomes,
-        });
+    (0..cases)
+        .map(|case_index| generate_convergence_e2e_delivery_case(seed, case_index as u64))
+        .collect()
+}
+
+/// Generate one convergence-delivery case without regenerating earlier case indices.
+pub fn generate_convergence_e2e_delivery_case(seed: u64, case_index: u64) -> GeneratedScenarioCase {
+    let mut rng = StdRng::seed_from_u64(seed ^ 0xC0A7_C0A7 ^ (case_index << 32));
+    let (scenario, mut expected_outcomes) = convergence_e2e_delivery_case(&mut rng, case_index);
+    push_labelled_confirmation_expectations(&scenario, &mut expected_outcomes);
+    GeneratedScenarioCase {
+        family_name: "convergence-e2e-delivery/v1".into(),
+        generator_version: "2".into(),
+        seed,
+        case_index,
+        subject: GeneratedSubjectKind::Engine,
+        scenario,
+        expected_outcomes,
     }
-    out
 }
 
 pub fn generate_convergence_chaos_family(seed: u64, cases: usize) -> Vec<GeneratedScenarioCase> {
-    let mut out = Vec::with_capacity(cases);
-    for case_index in 0..cases {
-        let mut rng = StdRng::seed_from_u64(seed ^ 0xC0A7_1CE5 ^ ((case_index as u64) << 32));
-        let (mut scenario, mut expected_outcomes) =
-            convergence_chaos_case(&mut rng, case_index as u64);
-        add_strict_reliability_oracle(&mut scenario, &mut expected_outcomes);
-        out.push(GeneratedScenarioCase {
-            family_name: "convergence-chaos/v1".into(),
-            generator_version: "6".into(),
-            seed,
-            case_index: case_index as u64,
-            subject: GeneratedSubjectKind::Engine,
-            scenario,
-            expected_outcomes,
-        });
+    (0..cases)
+        .map(|case_index| generate_convergence_chaos_case(seed, case_index as u64))
+        .collect()
+}
+
+/// Generate one convergence-chaos case without regenerating earlier case indices.
+pub fn generate_convergence_chaos_case(seed: u64, case_index: u64) -> GeneratedScenarioCase {
+    let mut rng = StdRng::seed_from_u64(seed ^ 0xC0A7_1CE5 ^ (case_index << 32));
+    let (mut scenario, mut expected_outcomes) = convergence_chaos_case(&mut rng, case_index);
+    add_strict_reliability_oracle(&mut scenario, &mut expected_outcomes);
+    GeneratedScenarioCase {
+        family_name: "convergence-chaos/v1".into(),
+        generator_version: "6".into(),
+        seed,
+        case_index,
+        subject: GeneratedSubjectKind::Engine,
+        scenario,
+        expected_outcomes,
     }
-    out
 }
 
 /// Generate the admin-churn catalog ported from the external multi-VM harness
@@ -185,39 +192,42 @@ pub fn generate_convergence_chaos_family(seed: u64, cases: usize) -> Vec<Generat
 /// admin-policy commits, restart during a commit burst, and a latecomer added
 /// under commit pressure with a pre-join mailbox-isolation check.
 pub fn generate_admin_churn_family(seed: u64, cases: usize) -> Vec<GeneratedScenarioCase> {
-    let mut out = Vec::with_capacity(cases);
-    for case_index in 0..cases {
-        let mut rng = StdRng::seed_from_u64(seed ^ 0xAD41_C4B2 ^ ((case_index as u64) << 32));
-        let (mut scenario, mut expected_outcomes) = admin_churn_case(&mut rng, case_index as u64);
-        if case_index % 4 == 3 {
-            // The latecomer arm scopes the pending-work oracle away from the
-            // joiner: a welcome-joined member currently retains its own join
-            // commit as a permanently deferred transport input, so the strict
-            // whole-roster oracle would flag every latecomer scenario.
-            add_scoped_reliability_oracle(
-                &mut scenario,
-                &mut expected_outcomes,
-                admin_churn_core_labels(),
-            );
-            // The joiner is not exempt from pending-work coverage: it must
-            // retain exactly its own deferred join commit and nothing else.
-            expected_outcomes.push(TraceExpectation::NoPendingWorkExceptRetainedJoinCommit {
-                client: "dave".into(),
-            });
-        } else {
-            add_strict_reliability_oracle(&mut scenario, &mut expected_outcomes);
-        }
-        out.push(GeneratedScenarioCase {
-            family_name: "admin-churn/v1".into(),
-            generator_version: "1".into(),
-            seed,
-            case_index: case_index as u64,
-            subject: GeneratedSubjectKind::Engine,
-            scenario,
-            expected_outcomes,
+    (0..cases)
+        .map(|case_index| generate_admin_churn_case(seed, case_index as u64))
+        .collect()
+}
+
+/// Generate one admin-churn case without regenerating earlier case indices.
+pub fn generate_admin_churn_case(seed: u64, case_index: u64) -> GeneratedScenarioCase {
+    let mut rng = StdRng::seed_from_u64(seed ^ 0xAD41_C4B2 ^ (case_index << 32));
+    let (mut scenario, mut expected_outcomes) = admin_churn_case(&mut rng, case_index);
+    if case_index % 4 == 3 {
+        // The latecomer arm scopes the pending-work oracle away from the
+        // joiner: a welcome-joined member currently retains its own join
+        // commit as a permanently deferred transport input, so the strict
+        // whole-roster oracle would flag every latecomer scenario.
+        add_scoped_reliability_oracle(
+            &mut scenario,
+            &mut expected_outcomes,
+            admin_churn_core_labels(),
+        );
+        // The joiner is not exempt from pending-work coverage: it must retain
+        // exactly its own deferred join commit and nothing else.
+        expected_outcomes.push(TraceExpectation::NoPendingWorkExceptRetainedJoinCommit {
+            client: "dave".into(),
         });
+    } else {
+        add_strict_reliability_oracle(&mut scenario, &mut expected_outcomes);
     }
-    out
+    GeneratedScenarioCase {
+        family_name: "admin-churn/v1".into(),
+        generator_version: "1".into(),
+        seed,
+        case_index,
+        subject: GeneratedSubjectKind::Engine,
+        scenario,
+        expected_outcomes,
+    }
 }
 
 /// Generate the adversarial reliability catalog. Case indices rotate through

--- a/crates/cgka-conformance-simulator/src/family.rs
+++ b/crates/cgka-conformance-simulator/src/family.rs
@@ -18,6 +18,7 @@ use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
+use std::fmt;
 
 pub const GENERATED_SCENARIO_INPUT_SCHEMA_VERSION: &str = "1";
 
@@ -115,6 +116,44 @@ impl GeneratedScenarioCase {
             expected_outcomes: self.expected_outcomes.clone(),
         }
     }
+}
+
+/// Error returned when a generated-family name is not registered.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UnsupportedGeneratedFamily {
+    family: String,
+}
+
+impl fmt::Display for UnsupportedGeneratedFamily {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "unsupported family {}", self.family)
+    }
+}
+
+impl std::error::Error for UnsupportedGeneratedFamily {}
+
+/// Generate one indexed case from any registered scenario family.
+pub fn generate_family_case(
+    family: &str,
+    seed: u64,
+    case_index: u64,
+) -> Result<GeneratedScenarioCase, UnsupportedGeneratedFamily> {
+    let case = match family {
+        "send-leave/v1" => generate_send_leave_case(seed, case_index),
+        "convergence-e2e-delivery/v1" => generate_convergence_e2e_delivery_case(seed, case_index),
+        "convergence-chaos/v1" => generate_convergence_chaos_case(seed, case_index),
+        "admin-churn/v1" => generate_admin_churn_case(seed, case_index),
+        "adversarial-reliability/v1" => generate_adversarial_reliability_case(seed, case_index),
+        "chat-journey/v1" => {
+            crate::stateful_generator::generate_stateful_chat_journey_case(seed, case_index)
+        }
+        other => {
+            return Err(UnsupportedGeneratedFamily {
+                family: other.to_owned(),
+            });
+        }
+    };
+    Ok(case)
 }
 
 pub fn generate_send_leave_family(seed: u64, cases: usize) -> Vec<GeneratedScenarioCase> {

--- a/crates/cgka-conformance-simulator/src/lib.rs
+++ b/crates/cgka-conformance-simulator/src/lib.rs
@@ -91,14 +91,14 @@ pub use failure_capsule::{
 };
 pub use family::{
     GENERATED_SCENARIO_INPUT_SCHEMA_VERSION, GeneratedScenarioCase, GeneratedScenarioInputV1,
-    GeneratedSubjectKind, generate_admin_churn_case, generate_admin_churn_family,
-    generate_adversarial_reliability_case, generate_adversarial_reliability_family,
-    generate_adversarial_reliability_offline_regression,
+    GeneratedSubjectKind, UnsupportedGeneratedFamily, generate_admin_churn_case,
+    generate_admin_churn_family, generate_adversarial_reliability_case,
+    generate_adversarial_reliability_family, generate_adversarial_reliability_offline_regression,
     generate_adversarial_reliability_self_update_regression,
     generate_adversarial_reliability_sustained_regression, generate_convergence_chaos_case,
     generate_convergence_chaos_family, generate_convergence_e2e_delivery_case,
-    generate_convergence_e2e_delivery_family, generate_send_leave_case, generate_send_leave_family,
-    run_generated_case_report, run_generated_case_report_with_capture,
+    generate_convergence_e2e_delivery_family, generate_family_case, generate_send_leave_case,
+    generate_send_leave_family, run_generated_case_report, run_generated_case_report_with_capture,
     run_generated_case_report_with_capture_on_subject, run_generated_case_report_with_storage_mode,
     semantic_reduction_units,
 };

--- a/crates/cgka-conformance-simulator/src/lib.rs
+++ b/crates/cgka-conformance-simulator/src/lib.rs
@@ -91,11 +91,13 @@ pub use failure_capsule::{
 };
 pub use family::{
     GENERATED_SCENARIO_INPUT_SCHEMA_VERSION, GeneratedScenarioCase, GeneratedScenarioInputV1,
-    GeneratedSubjectKind, generate_admin_churn_family, generate_adversarial_reliability_case,
-    generate_adversarial_reliability_family, generate_adversarial_reliability_offline_regression,
+    GeneratedSubjectKind, generate_admin_churn_case, generate_admin_churn_family,
+    generate_adversarial_reliability_case, generate_adversarial_reliability_family,
+    generate_adversarial_reliability_offline_regression,
     generate_adversarial_reliability_self_update_regression,
-    generate_adversarial_reliability_sustained_regression, generate_convergence_chaos_family,
-    generate_convergence_e2e_delivery_family, generate_send_leave_family,
+    generate_adversarial_reliability_sustained_regression, generate_convergence_chaos_case,
+    generate_convergence_chaos_family, generate_convergence_e2e_delivery_case,
+    generate_convergence_e2e_delivery_family, generate_send_leave_case, generate_send_leave_family,
     run_generated_case_report, run_generated_case_report_with_capture,
     run_generated_case_report_with_capture_on_subject, run_generated_case_report_with_storage_mode,
     semantic_reduction_units,

--- a/crates/cgka-conformance-simulator/src/report.rs
+++ b/crates/cgka-conformance-simulator/src/report.rs
@@ -5,10 +5,7 @@ use crate::scenario_input::generated_scenario_input_provenance;
 use crate::{
     CoverageMatrixEntry, FailureCapsuleSensitivity, FailureCapsuleV1, GeneratedScenarioCase,
     GeneratedScenarioInputV1, HarnessStorageMode, ScenarioInputProvenanceV1, ScenarioReport,
-    VectorFixture, coverage_matrix_entry, generate_admin_churn_family,
-    generate_adversarial_reliability_family, generate_convergence_chaos_family,
-    generate_convergence_e2e_delivery_family, generate_send_leave_family,
-    generate_stateful_chat_journey_family, resolve_scenario_input_bytes,
+    VectorFixture, coverage_matrix_entry, generate_family_case, resolve_scenario_input_bytes,
     run_vector_fixture_report_with_capture, write_failure_capsule,
 };
 
@@ -253,18 +250,9 @@ async fn run_generated_family_reports(
     storage_mode: HarnessStorageMode,
     capture_sensitive_replay: bool,
 ) -> Result<Vec<ScenarioReportSummary>, Box<dyn Error>> {
-    let cases = match family {
-        "send-leave/v1" => generate_send_leave_family(seed, cases),
-        "convergence-e2e-delivery/v1" => generate_convergence_e2e_delivery_family(seed, cases),
-        "convergence-chaos/v1" => generate_convergence_chaos_family(seed, cases),
-        "admin-churn/v1" => generate_admin_churn_family(seed, cases),
-        "adversarial-reliability/v1" => generate_adversarial_reliability_family(seed, cases),
-        "chat-journey/v1" => generate_stateful_chat_journey_family(seed, cases),
-        other => return Err(format!("unsupported family {other}").into()),
-    };
-
-    let mut summaries = Vec::with_capacity(cases.len());
-    for case in cases {
+    let mut summaries = Vec::with_capacity(cases);
+    for case_index in 0..cases {
+        let case = generate_family_case(family, seed, u64::try_from(case_index)?)?;
         let input_output = out.join(format!(
             "{}-seed-{}-case-{}-generated-input.json",
             case.family_name.replace('/', "-"),

--- a/crates/cgka-conformance-simulator/tests/AGENTS.md
+++ b/crates/cgka-conformance-simulator/tests/AGENTS.md
@@ -44,6 +44,10 @@ Map for simulator tests.
   - **Owns:** Property tests for selector order, canonicalization, capability matrices, lifecycle/restart behavior,
     generated send/leave histories, and delivery-profile convergence.
 
+- **File:** `process_campaign_runner.rs`
+  - **Owns:** Real child-process campaign execution, exact saved-input/report provenance, fixture/capsule artifacts, and
+    refusal to overwrite prior campaign evidence.
+
 - **File:** `report_runner.rs`
   - **Owns:** Report artifact runner, oracle evidence, and coverage matrix coverage.
 

--- a/crates/cgka-conformance-simulator/tests/process_campaign_runner.rs
+++ b/crates/cgka-conformance-simulator/tests/process_campaign_runner.rs
@@ -1,0 +1,126 @@
+use cgka_conformance_simulator::{
+    GeneratedScenarioInputV1, ScenarioReport, generate_convergence_e2e_delivery_case,
+    resolve_scenario_input_bytes,
+};
+use std::process::Command;
+
+fn campaign_binary() -> &'static str {
+    env!("CARGO_BIN_EXE_cgka-conformance-campaign")
+}
+
+#[test]
+fn isolated_campaign_preserves_input_provenance_and_refuses_overwrite() {
+    let temp = tempfile::tempdir().expect("temporary campaign root");
+    let out = temp.path().join("campaign");
+    let status = Command::new(campaign_binary())
+        .args([
+            "--family",
+            "send-leave/v1",
+            "--seed",
+            "42",
+            "--cases",
+            "1",
+            "--case-timeout-secs",
+            "60",
+            "--out",
+        ])
+        .arg(&out)
+        .args(["--storage", "memory"])
+        .status()
+        .expect("campaign starts");
+    assert!(status.success(), "campaign must pass");
+
+    let stem = "send-leave-v1-seed-42-case-0";
+    let input_path = out.join(format!("{stem}-generated-input.json"));
+    let report_path = out.join(format!("{stem}.json"));
+    let fixture_path = out.join(format!("{stem}-fixture.v1.json"));
+    let summary_path = out.join("process-campaign.v1.json");
+    for path in [&input_path, &report_path, &fixture_path, &summary_path] {
+        assert!(path.is_file(), "missing {}", path.display());
+    }
+
+    let input_bytes = std::fs::read(&input_path).expect("saved input reads");
+    let resolved = resolve_scenario_input_bytes(&input_bytes).expect("saved input resolves");
+    let report: ScenarioReport =
+        serde_json::from_slice(&std::fs::read(&report_path).expect("scenario report reads"))
+            .expect("scenario report parses");
+    assert_eq!(
+        report
+            .metadata
+            .input_provenance
+            .as_ref()
+            .map(|value| value.source_sha256.as_str()),
+        Some(resolved.provenance.source_sha256.as_str())
+    );
+
+    let summary: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&summary_path).expect("campaign summary reads"))
+            .expect("campaign summary parses");
+    assert_eq!(summary["family"], "send-leave/v1");
+    assert_eq!(summary["storage"], "memory");
+    assert_eq!(summary["case_timeout_ms"], 60_000);
+    assert_eq!(
+        summary["cases"][0]["artifact_integrity_errors"],
+        serde_json::json!([])
+    );
+    assert_eq!(
+        summary["cases"][0]["fixture_candidate"],
+        fixture_path.to_string_lossy().as_ref()
+    );
+
+    let second = Command::new(campaign_binary())
+        .args([
+            "--family",
+            "send-leave/v1",
+            "--seed",
+            "42",
+            "--cases",
+            "1",
+            "--out",
+        ])
+        .arg(&out)
+        .status()
+        .expect("second campaign starts");
+    assert!(
+        !second.success(),
+        "existing evidence must not be overwritten"
+    );
+    assert_eq!(
+        std::fs::read(&input_path).expect("saved input remains"),
+        input_bytes
+    );
+}
+
+#[test]
+fn strict_worker_failure_writes_a_portable_capsule() {
+    let temp = tempfile::tempdir().expect("temporary campaign root");
+    let out = temp.path().join("failure");
+    fs_private::create_dir_all_private(&out).expect("private output directory");
+    let mut case = generate_convergence_e2e_delivery_case(42, 0);
+    case.expected_outcomes.clear();
+    let input_path = out.join("stripped-generated-input.json");
+    fs_private::write_private(
+        &input_path,
+        &serde_json::to_vec_pretty(&GeneratedScenarioInputV1::new(case))
+            .expect("generated input serializes"),
+    )
+    .expect("generated input writes");
+
+    let status = Command::new(campaign_binary())
+        .arg("--worker")
+        .arg("--input")
+        .arg(&input_path)
+        .arg("--out")
+        .arg(&out)
+        .args(["--storage", "memory"])
+        .status()
+        .expect("worker starts");
+    assert_eq!(status.code(), Some(1));
+
+    let stem = "convergence-e2e-delivery-v1-seed-42-case-0";
+    assert!(out.join(format!("{stem}.json")).is_file());
+    assert!(
+        out.join(format!("{stem}-failure-capsule.v1.json"))
+            .is_file()
+    );
+}

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "Convergence Reliability And Simulation Plan"
 created: 2026-07-30
-updated: 2026-08-09
+updated: 2026-08-10
 tags: [marmot, cgka, convergence, simulation, verification, reliability]
 status: working-plan
 ---
@@ -81,8 +81,12 @@ The baseline is now a functioning reliability lab, but it does not yet justify t
   repair seam exist, while systematic container/VM evidence for those paths remains open;
 - the engine and process adapters have distinct complete quiescence contracts, but every new adapter and scenario still
   has to prove that its observable contract detects all unfinished work it can own;
+- every built-in generated family now carries strict-oracle coverage, and the reviewed seeds `1`, `42`, and `1337`
+  pass without weak-oracle warnings, including all twelve adversarial workload arms; this establishes that those runs
+  ask and observe meaningful questions, not that the engine is universally correct or the current constants are
+  optimal;
 - small and sustained generated storms exist, but the reviewed run volume, constant-boundary coverage, and accumulated
-  evidence are not yet sufficient to claim that the current constants are optimal;
+  evidence are not yet sufficient to characterize the current constants across realistic operating envelopes;
 - scenario seeds do not reproduce randomized MLS bytes;
 - the independent selector/canonicalization model covers bounded authenticated input, dependency, witness, selection,
   and disposition behavior, while production persistence remains exercised by engine and retained-relay subjects;
@@ -1195,14 +1199,26 @@ residual gap.
 2. [x] Finish scenario-catalog consolidation. #1292 and #1294 imported the portable scenario catalog, and
    [MDK #1295](https://github.com/marmot-protocol/mdk/pull/1295) added the simulator-only seeded admin-churn family
    without introducing a second scenario language.
-3. [ ] Complete the #1285 cross-route regression across every capable adapter. The engine checkpoint is now permanent
+3. [x] Close the known strict-oracle coverage gaps in every built-in generated family. [MDK #1349](https://github.com/marmot-protocol/mdk/pull/1349)
+   gave `convergence-e2e-delivery/v1` an exact/decryptable settle tail, added deterministic delivery and accepted-publish
+   expectations across `adversarial-reliability/v1`, and taught the oracle to recognize a passing exact-equivalence
+   expectation over a subset even when other observed clients intentionally diverge. The reviewed all-family seeds
+   `1`, `42`, and `1337` are strict-green; this removes known oracle false positives but is not an engine-correctness
+   claim.
+4. [ ] Generalize the isolated child-process campaign runner from the adversarial catalog to every built-in generated
+   family, persist the exact generated input before each worker starts, run the worker through the strict report path,
+   and retain its report, fixture candidate, and failure capsule. Then execute a reviewed file-backed seed/case matrix
+   and classify every failure as a product defect, protocol ambiguity, environment failure, or expected resource
+   refusal. Verification must include one smoke case from every family, exact saved-input replay, deadline kill/reap,
+   nonzero exit propagation, and artifact-path integrity. This is the current in-progress slice.
+5. [ ] Complete the #1285 cross-route regression across every capable adapter. The engine checkpoint is now permanent
    as `cross-route-own-commit-recovery/v1` and pins exact cryptographic, decryptability, commit-disposition, pending-work,
    and projection agreement after restart. `cross-route-retained-history-recovery/v1` now establishes the same contract
    through retained relay histories; app-runtime, process, container, and VM evidence remains.
    The decision-route inventory is machine checked; keep the remaining assurance artifacts independent of the
    production behavior under review in #1329/#1293.
-4. [ ] Feed real workflow observations into the lane budgets and produce a reviewed evidence bundle.
-5. [ ] Accumulate container soak evidence, then use the external VM driver only for the remaining
+6. [ ] Feed real workflow observations into the lane budgets and produce a reviewed evidence bundle.
+7. [ ] Accumulate container soak evidence, then use the external VM driver only for the remaining
    host/kernel/block-device dimensions.
 
 The local smoke path is a usability and integration checkpoint, not an assurance exit gate. A visually successful run
@@ -1346,6 +1362,7 @@ incorrect result.
 | 2026-08-09 | Campaign follow-up: strict clock oracle and fixture fidelity | Accepted exact no-pending evidence as temporal closure after an explicit virtual-time advance, while retaining fixed-point quiescence as the stronger option; kept semantic minimizers diagnostic and made fixture candidates preserve the original executed scenario so broad failure identity cannot silently replace a five-of-six delivery failure with a zero-delivery case | Oracle coverage unit tests; fixture-candidate fidelity unit test; strict seed-2001 convergence-chaos replay |
 | 2026-08-09 | 6.1 four-party engine cross-route checkpoint | Promoted the #1285 topology into a portable vector with two simultaneous source-epoch committers, pairwise committer displacement, observer-side stored convergence, ordering-key-versus-depth disagreement, branch growth by a third member, encrypted-SQLite restart of the displaced own-commit author, exact cryptographic equality, durable selected/invalidated commit dispositions, no pending work, and active application decryptability in all twelve directions; retained external-adapter and transition-permutation work explicitly open | `cross-route-own-commit-recovery/v1`; strict file-backed report; focused canonical-scenario regression; [`CONVERGENCE_ROUTE_MATRIX.md`](../../crates/cgka-conformance-simulator/CONVERGENCE_ROUTE_MATRIX.md) |
 | 2026-08-10 | 6.1 retained-history cross-route checkpoint | Replayed the four-party #1285 topology through explicit retained relay history rather than semantic packet-bus withholding: participant-specific visibility advances incremental cursors past hidden roots/children, restart reopens encrypted SQLite after pairwise displacement, and full-history queries restore the complete set before exact settlement. Also normalized active-probe evidence from authenticated account identities to stable scenario labels after logical-id correlation. App-runtime and distributed permutations remain open. | `cross-route-retained-history-recovery/v1`; strict file-backed regression; retained-object injection assertions; [`CONVERGENCE_ROUTE_MATRIX.md`](../../crates/cgka-conformance-simulator/CONVERGENCE_ROUTE_MATRIX.md) |
+| 2026-08-10 | Strict generated-family oracle closure | Closed the known strict-oracle false positives across every built-in generated family without changing production convergence behavior: subset exact-equivalence now counts as observed evidence when its executable expectation passes, convergence delivery has an exact/decryptable settle tail, and adversarial arms pin accepted publication plus deterministic delivery claims. Generator versions changed where scenario meaning changed. | [MDK #1349](https://github.com/marmot-protocol/mdk/pull/1349); all 28 vectors; all six families at seeds `1`, `42`, and `1337`; full simulator suite; `test-policy-overrides` campaign gate; `just fast-ci` |
 
 ## Capability Naming Cleanup
 


### PR DESCRIPTION
## Summary

- generalize `cgka-conformance-campaign` from the adversarial family to all six generated scenario families
- run every case in an isolated child process with bounded wall-clock time and process resource accounting
- persist the exact generated input before execution, then validate report and fixture provenance
- retain portable failure capsules and record artifact-integrity failures in the campaign summary
- add direct per-case generators so campaign construction remains linear rather than regenerating family prefixes
- document the workflow and update the convergence reliability tracking plan

## Why

The generated families now have strict oracle coverage, but larger discovery runs still need a common isolation and evidence boundary. This makes timeouts, crashes, normal oracle failures, and incomplete artifacts distinguishable and reproducible across both memory and file-backed storage.

This PR changes simulator/testing code and documentation only. It does not change production convergence-engine or application behavior.

## Validation

- `cargo test -p cgka-conformance-simulator --bin cgka-conformance-campaign`
- `cargo test -p cgka-conformance-simulator --test process_campaign_runner`
- `cargo test -p cgka-conformance-simulator --test canonical_scenarios family`
- one isolated smoke case for each of the six generated families
- isolated file-backed `send-leave/v1` smoke case
- `just fast-ci`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added isolated, case-by-case campaign execution across multiple scenario families.
  * Added generated-input files, configurable worker timeouts, storage options, and sensitive replay capture.
  * Added detailed per-case reports, provenance metadata, failure capsules, replay artifacts, and integrity validation.
  * Added direct generation for individual scenario cases without regenerating earlier cases.

* **Bug Fixes**
  * Campaigns now reject invalid configurations, incomplete artifacts, mismatched inputs, and attempts to overwrite existing evidence.
  * Strict worker failures now return a nonzero result with a recorded failure capsule.

* **Documentation**
  * Expanded simulator usage instructions and updated reliability-plan progress tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->