### PR TITLE
chore(deps): update Nostr 0.44 patches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3484,8 +3484,9 @@ dependencies = [
 
 [[package]]
 name = "nostr"
-version = "0.44.6"
-source = "git+https://github.com/agent-p1p/nostr.git?rev=c209c22aab4883a01b1d6017752b23245afce9b3#c209c22aab4883a01b1d6017752b23245afce9b3"
+version = "0.44.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ff7b77ef428b40aa2834a6acbae38a0e104c98b306208ca4b87a420d579a4b"
 dependencies = [
  "base64",
  "bech32",
@@ -3545,9 +3546,9 @@ dependencies = [
 
 [[package]]
 name = "nostr-relay-pool"
-version = "0.44.0"
+version = "0.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b1073ccfbaea5549fb914a9d52c68dab2aecda61535e5143dd73e95445a804b"
+checksum = "c85c54d6ca9aae4ae2bf19a7663ba9db5f45f783f1d24aff55f006386b8b99a1"
 dependencies = [
  "async-utility",
  "async-wsocket",
@@ -6107,6 +6108,7 @@ version = "0.9.11"
 dependencies = [
  "async-trait",
  "cgka-traits",
+ "futures",
  "hex",
  "nostr",
  "nostr-relay-builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ rustls = { version = "0.23.40", default-features = false, features = ["ring", "s
 # Already in the graph through quinn's platform-verifier feature; direct dep so
 # the broker can build ALPN-carrying rustls client configs with platform trust.
 rustls-platform-verifier = "0.6"
-nostr = { version = "0.44.6", default-features = false, features = ["std", "nip49", "nip59"] }
+nostr = { version = "0.44.8", default-features = false, features = ["std", "nip49", "nip59"] }
 nostr-sdk = { version = "0.44", features = ["nip59"] }
 nostr-relay-builder = "0.44"
 # OTLP export (behind the marmot-app `otlp-export` feature): map pre-aggregated
@@ -140,6 +140,3 @@ marmot-terminal-harness = { path = "integrations/terminal-harness" }
 # release contains it, then remove this patch and update the libcrux path.
 [patch.crates-io]
 hax-lib-macros = { git = "https://github.com/cryspen/hax.git", rev = "8f9cb576e58f6cc7e9ed249a7d4439b0f7ed0da7" }
-# nostr 0.44.6 leaves NIP-49 normalized passwords and derived keys in ordinary
-# buffers. Pin the upstream v0.44 fix until PR #1406 is released.
-nostr = { git = "https://github.com/agent-p1p/nostr.git", rev = "c209c22aab4883a01b1d6017752b23245afce9b3" }

--- a/crates/transport-nostr-adapter/Cargo.toml
+++ b/crates/transport-nostr-adapter/Cargo.toml
@@ -24,6 +24,7 @@ tracing.workspace = true
 transport-nostr-peeler.workspace = true
 
 [dev-dependencies]
+futures.workspace = true
 nostr-relay-builder.workspace = true
 tokio = { workspace = true, features = ["net", "test-util"] }
 tokio-tungstenite = "0.26"

--- a/crates/transport-nostr-adapter/src/sdk_client.rs
+++ b/crates/transport-nostr-adapter/src/sdk_client.rs
@@ -1170,8 +1170,9 @@ mod tests {
     use crate::NostrKeyPackagePublication;
     use cgka_traits::Timestamp;
     use cgka_traits::engine::KeyPackage;
+    use futures::{SinkExt, StreamExt};
     use nostr_relay_builder::MockRelay;
-    use nostr_sdk::prelude::{EventBuilder, Keys, Kind, Tag};
+    use nostr_sdk::prelude::{DatabaseEventStatus, EventBuilder, Keys, Kind, Tag};
     use tokio::net::TcpListener;
     use tokio::time::{Duration, advance, timeout};
     use transport_nostr_peeler::KIND_MARMOT_GROUP_MESSAGE;
@@ -2020,6 +2021,118 @@ mod tests {
             Some(&1)
         );
         assert_eq!(sdk.relay_health().await.total_relays, 0);
+    }
+
+    #[tokio::test]
+    async fn sdk_does_not_cache_failed_signature_verification() {
+        let transport_group_id = vec![0xCC; 32];
+        let event = EventBuilder::new(Kind::MlsGroupMessage, "outer encrypted body")
+            .tags([Tag::custom(
+                TagKind::SingleLetter(SingleLetterTag::lowercase(Alphabet::H)),
+                [hex::encode(&transport_group_id)],
+            )])
+            .sign_with_keys(&Keys::generate())
+            .expect("sign test event");
+        let mut first_invalid = event.clone();
+        first_invalid.sig = EventBuilder::new(Kind::TextNote, "wrong signature")
+            .sign_with_keys(&Keys::generate())
+            .expect("sign replacement signature")
+            .sig;
+        let mut second_invalid = event.clone();
+        second_invalid.sig = EventBuilder::new(Kind::TextNote, "another wrong signature")
+            .sign_with_keys(&Keys::generate())
+            .expect("sign second replacement signature")
+            .sig;
+        assert!(first_invalid.verify().is_err());
+        assert!(second_invalid.verify().is_err());
+        assert_eq!(first_invalid.id, second_invalid.id);
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let endpoint_text = format!("ws://{}", listener.local_addr().unwrap());
+        let endpoint = RelayUrl::parse(&endpoint_text).unwrap();
+        let relay = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut socket = tokio_tungstenite::accept_async(stream).await.unwrap();
+            while let Some(message) = socket.next().await {
+                let Ok(tokio_tungstenite::tungstenite::Message::Text(message)) = message else {
+                    continue;
+                };
+                let request: serde_json::Value = serde_json::from_str(&message).unwrap();
+                if request[0] != "REQ" {
+                    continue;
+                }
+                let subscription_id = request[1].as_str().unwrap();
+                for invalid in [&first_invalid, &second_invalid] {
+                    socket
+                        .send(
+                            serde_json::json!(["EVENT", subscription_id, invalid])
+                                .to_string()
+                                .into(),
+                        )
+                        .await
+                        .unwrap();
+                }
+                socket
+                    .send(
+                        serde_json::json!(["EOSE", subscription_id])
+                            .to_string()
+                            .into(),
+                    )
+                    .await
+                    .unwrap();
+                return;
+            }
+        });
+
+        let client = Client::builder().build();
+        // Subscribe before the relay connects: unlike `handle_notifications`,
+        // this synchronous receiver is installed before the first event can
+        // arrive and cannot race the test relay's immediate response.
+        let mut notifications = client.notifications();
+
+        client.add_relay(endpoint.clone()).await.unwrap();
+        client.connect().await;
+        let subscription_id = SubscriptionId::new("cache-poisoning-regression");
+        client
+            .subscribe_with_id_to(
+                [endpoint],
+                subscription_id,
+                Filter::new().kind(Kind::MlsGroupMessage).custom_tags(
+                    SingleLetterTag::lowercase(Alphabet::H),
+                    [hex::encode(&transport_group_id)],
+                ),
+                None,
+            )
+            .await
+            .unwrap();
+
+        timeout(Duration::from_secs(5), relay)
+            .await
+            .unwrap()
+            .unwrap();
+        loop {
+            match timeout(Duration::from_secs(5), notifications.recv())
+                .await
+                .expect("the relay EOSE must arrive")
+                .expect("notification channel remains open")
+            {
+                RelayPoolNotification::Event { .. } => {
+                    panic!("failed signature verification must not emit a trusted event")
+                }
+                RelayPoolNotification::Message {
+                    message: RelayMessage::EndOfStoredEvents(_),
+                    ..
+                } => break,
+                _ => {}
+            }
+        }
+        assert_eq!(
+            client.database().check_id(&event.id).await.unwrap(),
+            DatabaseEventStatus::NotExistent,
+            "events that fail verification must not be stored"
+        );
+
+        client.shutdown().await;
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- update the Nostr 0.44 dependency line to `nostr 0.44.8` and `nostr-relay-pool 0.44.3`
- replace the temporary `nostr` git patch with the released crates.io version
- add a relay-level regression that sends two differently invalid signatures with the same event ID and verifies the SDK neither stores nor forwards either as a trusted event
- track the larger Nostr 0.45 migration separately in #1358

## Validation

- `cargo test -p transport-nostr-adapter --features sdk`
- `cargo test -p transport-nostr-peeler`
- `cargo test -p marmot-app`
- `cargo audit --json` (zero vulnerabilities)
- `just fast-ci`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Invalidly signed events are now rejected consistently, even when multiple invalid events share the same identifier.
  - Rejected events are no longer surfaced as trusted notifications or saved to local client data.
- **Reliability**
  - Improved validation handling helps prevent untrusted event data from entering the application through the Nostr transport.
  - Connection completion notifications continue to be delivered correctly when invalid events are received.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->