### PR TITLE
fix: preserve relay rejection diagnostics

### DIFF
--- a/crates/cgka-session/tests/support/nostr_stack.rs
+++ b/crates/cgka-session/tests/support/nostr_stack.rs
@@ -128,6 +128,7 @@ impl NostrRelayClient for FakeRelayClient {
                 .map(|endpoint| TransportEndpointFailure {
                     endpoint,
                     reason: "not accepted by in-memory relay".into(),
+                    rejection_category: None,
                 })
                 .collect(),
         })

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -9,6 +9,14 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ## [Unreleased]
 
+### Fixed
+
+- KeyPackage NIP-09 deletions now surface privacy-safe per-relay rejection
+  categories (for example `blocked` or `auth-required`) instead of repeating a
+  generic `relay rejected event` summary, while successful deletions still
+  clear only matching local KeyPackage publication metadata after at least one
+  relay acknowledgement.
+
 ## [0.9.11] - 2026-08-09
 
 ### Added

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -3253,6 +3253,7 @@ fn frozen_fanout_report(fanout: &OutboundFanout) -> TransportPublishReport {
                 failed.push(TransportEndpointFailure {
                     endpoint: endpoint.clone(),
                     reason: "publish attempt failed".into(),
+                    rejection_category: None,
                 });
             }
             cgka_traits::FanoutTargetStatus::NotAttempted

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -11,7 +11,7 @@ use cgka_traits::agent_text_stream::AGENT_TEXT_STREAM_EXPORTER_CACHE_KEY;
 use cgka_traits::app_event::MarmotAppEvent as MarmotInnerEvent;
 use cgka_traits::engine::GroupEvent;
 use cgka_traits::storage::{KeyPackageBundleStorage, MaintenanceStorage};
-use cgka_traits::{GroupId, SecretBytes, TransportEndpoint};
+use cgka_traits::{GroupId, SecretBytes, TransportAdapterError, TransportEndpoint};
 use marmot_account::{
     AccountHome, AccountHomeError, AccountSetupKind, AccountSetupPhase, AccountSummary,
     NostrAccountImport,
@@ -716,6 +716,9 @@ pub struct SignOutOutcome {
 fn wipe_failure_reason(err: &AppError) -> String {
     let category = match err {
         AppError::RuntimeStopping => "runtime is shutting down",
+        AppError::Transport(TransportAdapterError::PublishEndpoints(failure)) => {
+            return failure.summary.clone();
+        }
         AppError::Transport(_) | AppError::TransportClosed => "transport error",
         AppError::Publish(_) => "relay publish failed",
         AppError::Storage(_) | AppError::Sqlite(_) | AppError::SqlcipherKeyDerivation(_) => {
@@ -2369,10 +2372,25 @@ impl MarmotAppRuntime {
                     event_id_hex: result.event_id_hex,
                     reason: "relay publish failed".to_owned(),
                 }),
-                Err(error) => failures.push(RelayFailure {
-                    event_id_hex: result.event_id_hex,
-                    reason: wipe_failure_reason(&error),
-                }),
+                Err(error) => {
+                    let endpoint_failures = match &error {
+                        AppError::Transport(error) => error.publish_endpoint_failures(),
+                        _ => &[],
+                    };
+                    if endpoint_failures.is_empty() {
+                        failures.push(RelayFailure {
+                            event_id_hex: result.event_id_hex,
+                            reason: wipe_failure_reason(&error),
+                        });
+                    } else {
+                        for endpoint_failure in endpoint_failures {
+                            failures.push(RelayFailure {
+                                event_id_hex: result.event_id_hex.clone(),
+                                reason: endpoint_failure.reason.clone(),
+                            });
+                        }
+                    }
+                }
             }
         }
         (deleted, failures)

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -11,6 +11,7 @@ use cgka_traits::agent_text_stream::AGENT_TEXT_STREAM_EXPORTER_CACHE_KEY;
 use cgka_traits::app_event::MarmotAppEvent as MarmotInnerEvent;
 use cgka_traits::engine::GroupEvent;
 use cgka_traits::storage::{KeyPackageBundleStorage, MaintenanceStorage};
+use cgka_traits::transport_adapter::TransportEndpointRejectionCategory;
 use cgka_traits::{GroupId, SecretBytes, TransportAdapterError, TransportEndpoint};
 use marmot_account::{
     AccountHome, AccountHomeError, AccountSetupKind, AccountSetupPhase, AccountSummary,
@@ -38,16 +39,17 @@ use crate::{
     AppMessageRecord, AppProjectionUpdate, AppQuarantinedGroup, AuditLogDeleteOutcome,
     AuditLogFile, AuditLogSettings, AuditLogTrackerConfig, AuditLogTrackerUpdateResult,
     AuditLogUploadResult, BackgroundNotificationCollection, ChatListRow, ChatNotificationSettings,
-    ChatPinState, GroupInviteDeclineResult, GroupPushDebugInfo, KeyPackageDeletionTarget,
-    MAX_SEEN_EVENT_IDS, MarmotApp, MarmotRelayPlane, MarmotServiceEndpoints,
-    MediaAttachmentReference, MediaDownloadResult, MediaUploadRequest, MediaUploadResult,
-    MessageDraft, MessageDraftAttachment, MessageDraftSummary, NotificationCollectionStatus,
-    NotificationSettings, NotificationUpdate, NotificationWakeSource, PendingWelcomeDelivery,
-    PushPlatform, PushRegistration, PushRegistrationShareOutcome, PushRegistrationSyncResult,
-    ReceivedMessage, RelayTelemetryExportConfig, RelayTelemetryRuntimeConfig,
-    RelayTelemetrySettings, RetentionSweepReport, SecureDeleteExpiredResult, SendSummary,
-    TimelineMessageQuery, TimelineMessageRecord, TimelinePage, UserDirectoryRefresh,
-    UserProfileMetadata, default_profile_pseudonym, unix_now_seconds,
+    ChatPinState, GroupInviteDeclineResult, GroupPushDebugInfo, KeyPackageDeletionResult,
+    KeyPackageDeletionTarget, MAX_SEEN_EVENT_IDS, MarmotApp, MarmotRelayPlane,
+    MarmotServiceEndpoints, MediaAttachmentReference, MediaDownloadResult, MediaUploadRequest,
+    MediaUploadResult, MessageDraft, MessageDraftAttachment, MessageDraftSummary,
+    NotificationCollectionStatus, NotificationSettings, NotificationUpdate, NotificationWakeSource,
+    PendingWelcomeDelivery, PushPlatform, PushRegistration, PushRegistrationShareOutcome,
+    PushRegistrationSyncResult, ReceivedMessage, RelayTelemetryExportConfig,
+    RelayTelemetryRuntimeConfig, RelayTelemetrySettings, RetentionSweepReport,
+    SecureDeleteExpiredResult, SendSummary, TimelineMessageQuery, TimelineMessageRecord,
+    TimelinePage, UserDirectoryRefresh, UserProfileMetadata, default_profile_pseudonym,
+    unix_now_seconds,
 };
 
 mod account_worker;
@@ -716,10 +718,16 @@ pub struct SignOutOutcome {
 fn wipe_failure_reason(err: &AppError) -> String {
     let category = match err {
         AppError::RuntimeStopping => "runtime is shutting down",
-        AppError::Transport(TransportAdapterError::PublishEndpoints(failure)) => {
-            return failure.summary.clone();
+        AppError::Transport(transport) => {
+            if let Some(reason) = transport_publish_endpoint_failures_app_reason(transport) {
+                return reason;
+            }
+            if matches!(transport, TransportAdapterError::PublishEndpoints(_)) {
+                return "relay publish failed".to_owned();
+            }
+            return "transport error".to_owned();
         }
-        AppError::Transport(_) | AppError::TransportClosed => "transport error",
+        AppError::TransportClosed => "transport error",
         AppError::Publish(_) => "relay publish failed",
         AppError::Storage(_) | AppError::Sqlite(_) | AppError::SqlcipherKeyDerivation(_) => {
             "local storage error"
@@ -732,6 +740,53 @@ fn wipe_failure_reason(err: &AppError) -> String {
         _ => "operation failed",
     };
     category.to_owned()
+}
+
+fn transport_rejection_category_app_reason(
+    category: Option<TransportEndpointRejectionCategory>,
+) -> String {
+    match category {
+        Some(category) => format!("relay rejected event ({})", category.as_str()),
+        None => "relay publish failed".to_owned(),
+    }
+}
+
+fn transport_publish_endpoint_failures_app_reason(
+    transport: &TransportAdapterError,
+) -> Option<String> {
+    let failures = transport.publish_endpoint_failures();
+    if failures.is_empty() {
+        return None;
+    }
+    let mut unique = Vec::new();
+    for failure in failures {
+        let reason = transport_rejection_category_app_reason(failure.rejection_category);
+        if !unique.contains(&reason) {
+            unique.push(reason);
+        }
+    }
+    Some(unique.join("; "))
+}
+
+fn relay_failures_from_key_package_deletion_results(
+    results: Vec<KeyPackageDeletionResult>,
+) -> (u32, Vec<RelayFailure>) {
+    let mut deleted = 0;
+    let mut failures = Vec::new();
+    for result in results {
+        match result.result {
+            Ok(accepted) if accepted > 0 => deleted += 1,
+            Ok(_) => failures.push(RelayFailure {
+                event_id_hex: result.event_id_hex,
+                reason: "relay publish failed".to_owned(),
+            }),
+            Err(error) => failures.push(RelayFailure {
+                event_id_hex: result.event_id_hex,
+                reason: wipe_failure_reason(&error),
+            }),
+        }
+    }
+    (deleted, failures)
 }
 
 #[derive(Default, PartialEq, Eq)]
@@ -2363,37 +2418,7 @@ impl MarmotAppRuntime {
             }
         };
 
-        let mut deleted = 0;
-        let mut failures = Vec::new();
-        for result in results {
-            match result.result {
-                Ok(accepted) if accepted > 0 => deleted += 1,
-                Ok(_) => failures.push(RelayFailure {
-                    event_id_hex: result.event_id_hex,
-                    reason: "relay publish failed".to_owned(),
-                }),
-                Err(error) => {
-                    let endpoint_failures = match &error {
-                        AppError::Transport(error) => error.publish_endpoint_failures(),
-                        _ => &[],
-                    };
-                    if endpoint_failures.is_empty() {
-                        failures.push(RelayFailure {
-                            event_id_hex: result.event_id_hex,
-                            reason: wipe_failure_reason(&error),
-                        });
-                    } else {
-                        for endpoint_failure in endpoint_failures {
-                            failures.push(RelayFailure {
-                                event_id_hex: result.event_id_hex.clone(),
-                                reason: endpoint_failure.reason.clone(),
-                            });
-                        }
-                    }
-                }
-            }
-        }
-        (deleted, failures)
+        relay_failures_from_key_package_deletion_results(results)
     }
 
     /// Non-destructive sign-out: deactivate the account on this device and

--- a/crates/marmot-app/src/runtime/tests.rs
+++ b/crates/marmot-app/src/runtime/tests.rs
@@ -1,3 +1,9 @@
+use cgka_traits::TransportAdapterError;
+use cgka_traits::transport_adapter::{
+    TransportEndpoint, TransportEndpointFailure, TransportEndpointRejectionCategory,
+    TransportPublishFailure,
+};
+
 use super::subscriptions::chat_list_mute_expiries;
 use super::*;
 
@@ -1915,4 +1921,45 @@ async fn concurrent_reconcile_cannot_lose_workers_to_failed_rollback() {
         "successful reconcile B must retain both running workers"
     );
     runtime.shutdown().await;
+}
+
+#[test]
+fn key_package_deletion_relay_failures_dedupe_privacy_safe_publish_endpoint_categories() {
+    use crate::KeyPackageDeletionResult;
+
+    let hostile_summary = "publish failed: https://evil.example/nip42";
+    let hostile_reason = "blocked: attacker-controlled suffix at wss://leak.example";
+    let transport_error =
+        TransportAdapterError::PublishEndpoints(TransportPublishFailure::with_endpoint_failures(
+            hostile_summary,
+            vec![
+                TransportEndpointFailure {
+                    endpoint: TransportEndpoint("wss://relay-a.example".into()),
+                    reason: hostile_reason.to_owned(),
+                    rejection_category: Some(TransportEndpointRejectionCategory::Blocked),
+                },
+                TransportEndpointFailure {
+                    endpoint: TransportEndpoint("wss://relay-b.example".into()),
+                    reason: hostile_reason.to_owned(),
+                    rejection_category: Some(TransportEndpointRejectionCategory::Blocked),
+                },
+            ],
+        ));
+    let err = AppError::Transport(transport_error);
+
+    let wipe_reason = wipe_failure_reason(&err);
+    assert_eq!(wipe_reason, "relay rejected event (blocked)");
+    assert!(!wipe_reason.contains("evil.example"));
+
+    let (deleted, failures) =
+        relay_failures_from_key_package_deletion_results(vec![KeyPackageDeletionResult {
+            event_id_hex: "11".repeat(32),
+            result: Err(err),
+        }]);
+    assert_eq!(deleted, 0);
+    assert_eq!(failures.len(), 1);
+    assert_eq!(failures[0].reason, "relay rejected event (blocked)");
+    assert!(!failures[0].reason.contains("evil.example"));
+    assert!(!failures[0].reason.contains("leak.example"));
+    assert!(!failures[0].reason.contains("attacker-controlled"));
 }

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -7482,6 +7482,70 @@ async fn app_runtime_sign_out_and_wipe_removes_account_and_deletes_key_package()
 }
 
 #[tokio::test]
+async fn app_runtime_delete_key_package_event_nip09_succeeds_and_clears_matching_cache() {
+    let dir = tempfile::tempdir().unwrap();
+    let (_relay, app, url) = mock_app(&dir).await;
+    let runtime = MarmotAppRuntime::new(app.clone());
+    let created = runtime
+        .create_identity(AccountSetupRequest {
+            default_relays: vec![endpoint(&url)],
+            bootstrap_relays: vec![endpoint(&url)],
+            publish_initial_key_package: true,
+            ..AccountSetupRequest::default()
+        })
+        .await
+        .unwrap();
+    let packages = runtime
+        .account_key_packages(&created.account.account_id_hex, vec![endpoint(&url)])
+        .await
+        .unwrap();
+    let relay_package = packages
+        .iter()
+        .find(|package| package.relay)
+        .expect("setup should publish a relay key package");
+    let event_id = relay_package.key_package_event_id.clone();
+    let record_path = dir
+        .path()
+        .join("key-packages")
+        .join(format!("{}.json", created.account.label));
+    std::fs::create_dir_all(record_path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &record_path,
+        serde_json::json!({
+            "account_label": created.account.label,
+            "account_id_hex": created.account.account_id_hex,
+            "key_package_id": "integration-slot",
+            "key_package_ref_hex": "aa".repeat(32),
+            "key_package_event_id": event_id,
+            "published_at": 1,
+            "key_package_hex": "00",
+        })
+        .to_string(),
+    )
+    .unwrap();
+    assert!(
+        record_path.exists(),
+        "local publication metadata should exist before deletion"
+    );
+
+    let deleted = runtime
+        .delete_key_package(
+            &created.account.account_id_hex,
+            &event_id,
+            vec![endpoint(&url)],
+        )
+        .await
+        .unwrap();
+    assert!(deleted >= 1);
+    assert!(
+        !record_path.exists(),
+        "successful deletion must remove matching local publication metadata"
+    );
+
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
 async fn app_runtime_wipe_reports_deletion_failure_and_still_removes_local_account() {
     let dir = tempfile::tempdir().unwrap();
     let (_relay, app, url) = deletion_rejecting_app(&dir).await;

--- a/crates/traits/src/lib.rs
+++ b/crates/traits/src/lib.rs
@@ -113,8 +113,9 @@ pub use transport_adapter::{
     FanoutMlsState, FanoutTargetStatus, OutboundFanout, OutboundFanoutOutcome,
     TransportAccountActivation, TransportAdapter, TransportAdapterError, TransportDelivery,
     TransportDeliveryPlane, TransportDeliverySource, TransportEndpoint, TransportEndpointFailure,
-    TransportEndpointReceipt, TransportGroupSubscription, TransportGroupSync,
-    TransportPublishReport, TransportPublishRequest, TransportPublishTarget, TransportWireMetadata,
+    TransportEndpointReceipt, TransportEndpointRejectionCategory, TransportGroupSubscription,
+    TransportGroupSync, TransportPublishFailure, TransportPublishReport, TransportPublishRequest,
+    TransportPublishTarget, TransportWireMetadata, collapse_publish_failure_summaries,
 };
 pub use types::{Backend, EpochId, GroupId, MemberId, MessageId};
 pub use welcome::PendingWelcome;

--- a/crates/traits/src/transport_adapter.rs
+++ b/crates/traits/src/transport_adapter.rs
@@ -514,12 +514,95 @@ pub struct TransportEndpointReceipt {
     pub accepted_at: Option<Timestamp>,
 }
 
+/// Privacy-safe endpoint publish-rejection category.
+///
+/// Transport adapters may map wire-level rejection signals into this enum
+/// (for example authentication-required, policy-blocked, or invalid-payload).
+/// Only the category is retained; arbitrary remote suffix text is discarded.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TransportEndpointRejectionCategory {
+    Duplicate,
+    Pow,
+    Blocked,
+    RateLimited,
+    Invalid,
+    Error,
+    Unsupported,
+    AuthRequired,
+    Restricted,
+}
+
+impl TransportEndpointRejectionCategory {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Duplicate => "duplicate",
+            Self::Pow => "pow",
+            Self::Blocked => "blocked",
+            Self::RateLimited => "rate-limited",
+            Self::Invalid => "invalid",
+            Self::Error => "error",
+            Self::Unsupported => "unsupported",
+            Self::AuthRequired => "auth-required",
+            Self::Restricted => "restricted",
+        }
+    }
+}
+
 /// Endpoint-level publish failure. The overall publish may still succeed if
 /// enough other endpoints acknowledge the message.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TransportEndpointFailure {
     pub endpoint: TransportEndpoint,
     pub reason: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rejection_category: Option<TransportEndpointRejectionCategory>,
+}
+
+/// Publish failure surfaced by transport adapters.
+///
+/// `summary` is safe for `Display`/logging. Per-endpoint diagnostics live in
+/// `endpoint_failures` and may include endpoint identifiers only for structured
+/// telemetry boundaries that do not log them verbatim.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TransportPublishFailure {
+    pub summary: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub endpoint_failures: Vec<TransportEndpointFailure>,
+}
+
+impl TransportPublishFailure {
+    pub fn with_endpoint_failures(
+        summary: impl Into<String>,
+        endpoint_failures: Vec<TransportEndpointFailure>,
+    ) -> Self {
+        Self {
+            summary: summary.into(),
+            endpoint_failures,
+        }
+    }
+}
+
+impl std::fmt::Display for TransportPublishFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.summary)
+    }
+}
+
+/// Collapse identical publish failure summaries for user-facing `Display`.
+///
+/// Preserves first-seen order while dropping duplicates so multiple endpoints
+/// rejecting with the same sanitized category do not repeat in UI text.
+pub fn collapse_publish_failure_summaries<'a>(
+    reasons: impl IntoIterator<Item = &'a str>,
+) -> String {
+    let mut unique = Vec::new();
+    for reason in reasons {
+        if !unique.contains(&reason) {
+            unique.push(reason);
+        }
+    }
+    unique.join("; ")
 }
 
 /// Aggregate publish result from a transport adapter.
@@ -635,11 +718,26 @@ pub enum TransportAdapterError {
     #[error("publish failed: {0}")]
     Publish(String),
 
+    /// Publish reached endpoints but every required acknowledgement failed.
+    /// `summary` is safe for `Display`/logging; per-endpoint diagnostics are
+    /// structured separately and may carry endpoint labels for non-log surfaces.
+    #[error("publish failed: {0}")]
+    PublishEndpoints(TransportPublishFailure),
+
     #[error("transport backend failure: {0}")]
     Backend(String),
 
     #[error("other transport adapter error: {0}")]
     Other(String),
+}
+
+impl TransportAdapterError {
+    pub fn publish_endpoint_failures(&self) -> &[TransportEndpointFailure] {
+        match self {
+            Self::PublishEndpoints(failure) => failure.endpoint_failures.as_slice(),
+            _ => &[],
+        }
+    }
 }
 
 /// Account-aware network adapter that moves wrapped transport messages.
@@ -819,6 +917,7 @@ mod tests {
                 .map(|i| TransportEndpointFailure {
                     endpoint: TransportEndpoint(format!("wss://failed-{i}.example")),
                     reason: "unreachable".into(),
+                    rejection_category: None,
                 })
                 .collect(),
             required_acks,
@@ -843,5 +942,29 @@ mod tests {
         assert!(report(1, 0, 1).met_required_acks());
         assert!(!report(1, 1, 2).met_required_acks());
         assert!(report(2, 0, 2).met_required_acks());
+    }
+
+    #[test]
+    fn collapse_publish_failure_summaries_dedupes_while_preserving_order() {
+        let collapsed = collapse_publish_failure_summaries([
+            "relay rejected event (blocked)",
+            "connect relay failed",
+            "relay rejected event (blocked)",
+        ]);
+        assert_eq!(
+            collapsed,
+            "relay rejected event (blocked); connect relay failed"
+        );
+    }
+
+    #[test]
+    fn endpoint_failure_deserializes_legacy_records_without_rejection_category() {
+        let failure: TransportEndpointFailure = serde_json::from_value(serde_json::json!({
+            "endpoint": "wss://relay.example",
+            "reason": "connect relay failed"
+        }))
+        .unwrap();
+
+        assert_eq!(failure.rejection_category, None);
     }
 }

--- a/crates/transport-nostr-adapter/src/sdk_client.rs
+++ b/crates/transport-nostr-adapter/src/sdk_client.rs
@@ -1312,7 +1312,10 @@ mod tests {
     }
 
     #[test]
-    fn finish_publish_outcome_success_retains_rejected_endpoint_diagnostics() {
+    fn finish_publish_outcome_success_retains_failures_supplied_to_helper() {
+        // Exercises `finish_publish_outcome` directly. Production fan-out stops
+        // once quorum is met and does not append failures from aborted tasks;
+        // see `publish_event_does_not_wait_for_silent_relays_once_required_acks_are_met`.
         let message_id = cgka_traits::MessageId::new(vec![0xD7; 32]);
         let accepted = vec![TransportEndpointReceipt {
             endpoint: TransportEndpoint("wss://good.example".into()),
@@ -1816,6 +1819,10 @@ mod tests {
 
         assert_eq!(outcome.accepted.len(), 1);
         assert_eq!(outcome.accepted[0].endpoint, reachable);
+        assert!(
+            outcome.failed.is_empty(),
+            "aborted fan-out tasks must not add failures after quorum"
+        );
         assert_eq!(sdk.relay_health().await.total_relays, 0);
     }
 
@@ -1839,6 +1846,10 @@ mod tests {
 
         assert_eq!(outcome.accepted.len(), 1);
         assert_eq!(outcome.accepted[0].endpoint, reachable);
+        assert!(
+            outcome.failed.is_empty(),
+            "aborted fan-out tasks must not add failures after quorum"
+        );
         assert_eq!(sdk.relay_health().await.total_relays, 0);
     }
 
@@ -2199,6 +2210,39 @@ mod tests {
                 )
             })
         }
+    }
+
+    #[tokio::test]
+    async fn publish_event_nip42_write_relay_authenticates_kind5_key_package_deletion() {
+        use crate::KIND_MARMOT_KEY_PACKAGE;
+        use nostr_relay_builder::builder::{RelayBuilderNip42, RelayBuilderNip42Mode};
+        use nostr_relay_builder::{LocalRelay, RelayBuilder};
+
+        let relay = LocalRelay::new(RelayBuilder::default().nip42(RelayBuilderNip42 {
+            mode: RelayBuilderNip42Mode::Write,
+        }));
+        relay.run().await.unwrap();
+        let endpoint = TransportEndpoint(relay.url().await.to_string());
+        let keys = Keys::generate();
+        let client = Client::builder().signer(keys.clone()).build();
+        let sdk = NostrSdkRelayClient::new(client);
+        let deletion = NostrTransportEvent::new_unsigned(
+            keys.public_key().to_hex(),
+            5,
+            vec![
+                vec!["e".into(), "11".repeat(32)],
+                vec!["k".into(), KIND_MARMOT_KEY_PACKAGE.to_string()],
+            ],
+            String::new(),
+        );
+
+        let outcome = sdk
+            .publish_event(&[endpoint], &deletion, 1)
+            .await
+            .expect("signer-backed SDK client must complete NIP-42 auth and publish");
+
+        assert_eq!(outcome.accepted.len(), 1);
+        assert!(outcome.failed.is_empty());
     }
 
     #[tokio::test]

--- a/crates/transport-nostr-adapter/src/sdk_client.rs
+++ b/crates/transport-nostr-adapter/src/sdk_client.rs
@@ -5,7 +5,8 @@ use std::time::Duration;
 use async_trait::async_trait;
 use cgka_traits::{
     MemberId, TransportAdapterError, TransportEndpoint, TransportEndpointFailure,
-    TransportEndpointReceipt,
+    TransportEndpointReceipt, TransportEndpointRejectionCategory, TransportPublishFailure,
+    collapse_publish_failure_summaries,
 };
 use nostr_sdk::prelude::{
     Alphabet, Client, Event, EventBuilder, Filter, Kind, PublicKey, RelayMessage,
@@ -460,10 +461,12 @@ impl NostrSdkRelayClient {
             Ok(Err(_)) => Err(TransportEndpointFailure {
                 endpoint: transport_endpoint,
                 reason: "connect relay failed".to_owned(),
+                rejection_category: None,
             }),
             Err(_) => Err(TransportEndpointFailure {
                 endpoint: transport_endpoint,
                 reason: "connect relay timed out".to_owned(),
+                rejection_category: None,
             }),
         }
     }
@@ -474,7 +477,11 @@ impl NostrSdkRelayClient {
         event: Event,
     ) -> Result<TransportEndpointReceipt, TransportEndpointFailure> {
         let transport_endpoint = TransportEndpoint(endpoint.to_string());
-        let mut last_error = "send event failed".to_owned();
+        let mut last_failure = TransportEndpointFailure {
+            endpoint: transport_endpoint.clone(),
+            reason: "send event failed".to_owned(),
+            rejection_category: None,
+        };
         for attempt in 1..=SDK_RELAY_PUBLISH_ATTEMPTS {
             match timeout(
                 SDK_RELAY_PUBLISH_WAIT,
@@ -494,25 +501,28 @@ impl NostrSdkRelayClient {
                     });
                 }
                 Ok(Ok(output)) => {
-                    // The relay's rejection text is remote-controlled and can
-                    // embed the relay URL, event ids, or arbitrary content, so
-                    // it must not reach the display-bearing publish error
-                    // (`finish_publish_outcome` joins these reasons into
-                    // `TransportAdapterError::Publish`). Map to a stable
-                    // reason instead of echoing it.
-                    last_error = if output.failed.contains_key(&endpoint) {
-                        "relay rejected event".to_owned()
+                    if output.failed.contains_key(&endpoint) {
+                        let remote = output
+                            .failed
+                            .get(&endpoint)
+                            .map(String::as_str)
+                            .unwrap_or_default();
+                        last_failure =
+                            relay_rejection_endpoint_failure(transport_endpoint.clone(), remote);
                     } else {
-                        "relay did not acknowledge event".to_owned()
-                    };
+                        last_failure.reason = "relay did not acknowledge event".to_owned();
+                        last_failure.rejection_category = None;
+                    }
                 }
                 Ok(Err(_)) => {
                     // No sdk error Display here either — it can carry the
                     // relay URL.
-                    last_error = "send event failed".to_owned();
+                    last_failure.reason = "send event failed".to_owned();
+                    last_failure.rejection_category = None;
                 }
                 Err(_) => {
-                    last_error = "send event timed out".to_owned();
+                    last_failure.reason = "send event timed out".to_owned();
+                    last_failure.rejection_category = None;
                 }
             }
             if attempt < SDK_RELAY_PUBLISH_ATTEMPTS {
@@ -520,10 +530,7 @@ impl NostrSdkRelayClient {
             }
         }
 
-        Err(TransportEndpointFailure {
-            endpoint: transport_endpoint,
-            reason: last_error,
-        })
+        Err(last_failure)
     }
 
     async fn publish_prepared_event(
@@ -773,6 +780,7 @@ impl NostrSdkRelayClient {
             Err(_) => Err(TransportEndpointFailure {
                 endpoint: transport_endpoint,
                 reason: "add publish relay failed".to_owned(),
+                rejection_category: None,
             }),
         }
     }
@@ -848,11 +856,7 @@ impl NostrSdkRelayClient {
                 required_acks
             )
         } else if accepted.is_empty() && !failed.is_empty() {
-            failed
-                .iter()
-                .map(|failure| failure.reason.as_str())
-                .collect::<Vec<_>>()
-                .join("; ")
+            collapse_publish_failure_summaries(failed.iter().map(|failure| failure.reason.as_str()))
         } else {
             format!(
                 "insufficient publish acknowledgements: accepted {} of required {}",
@@ -860,7 +864,13 @@ impl NostrSdkRelayClient {
                 required_acks
             )
         };
-        Err(TransportAdapterError::Publish(reason))
+        if failed.is_empty() {
+            Err(TransportAdapterError::Publish(reason))
+        } else {
+            Err(TransportAdapterError::PublishEndpoints(
+                TransportPublishFailure::with_endpoint_failures(reason, failed),
+            ))
+        }
     }
 }
 
@@ -1164,6 +1174,42 @@ fn relay_endpoint_publish_accepted(success: bool, failure_reason: Option<&str>) 
     success || failure_reason.is_some_and(relay_duplicate_acknowledgement)
 }
 
+fn map_relay_rejection_category(
+    prefix: nostr::message::MachineReadablePrefix,
+) -> TransportEndpointRejectionCategory {
+    use nostr::message::MachineReadablePrefix as Prefix;
+    match prefix {
+        Prefix::Duplicate => TransportEndpointRejectionCategory::Duplicate,
+        Prefix::Pow => TransportEndpointRejectionCategory::Pow,
+        Prefix::Blocked => TransportEndpointRejectionCategory::Blocked,
+        Prefix::RateLimited => TransportEndpointRejectionCategory::RateLimited,
+        Prefix::Invalid => TransportEndpointRejectionCategory::Invalid,
+        Prefix::Error => TransportEndpointRejectionCategory::Error,
+        Prefix::Unsupported => TransportEndpointRejectionCategory::Unsupported,
+        Prefix::AuthRequired => TransportEndpointRejectionCategory::AuthRequired,
+        Prefix::Restricted => TransportEndpointRejectionCategory::Restricted,
+    }
+}
+
+fn relay_rejection_endpoint_failure(
+    endpoint: TransportEndpoint,
+    relay_message: &str,
+) -> TransportEndpointFailure {
+    if let Some(prefix) = nostr::message::MachineReadablePrefix::parse(relay_message) {
+        let category = map_relay_rejection_category(prefix);
+        return TransportEndpointFailure {
+            endpoint,
+            reason: format!("relay rejected event ({})", category.as_str()),
+            rejection_category: Some(category),
+        };
+    }
+    TransportEndpointFailure {
+        endpoint,
+        reason: "relay rejected event".to_owned(),
+        rejection_category: None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1190,6 +1236,102 @@ mod tests {
             .sign_with_keys(&ephemeral)
             .expect("sign ephemeral 445");
         NostrTransportEvent::from_nostr_event(&signed).expect("dto from signed event")
+    }
+
+    #[test]
+    fn relay_rejection_endpoint_failure_maps_machine_readable_prefix() {
+        for (message, category, summary) in [
+            (
+                "auth-required: account secret at https://evil.example/auth",
+                TransportEndpointRejectionCategory::AuthRequired,
+                "relay rejected event (auth-required)",
+            ),
+            (
+                "restricted: kind 5 disabled at https://evil.example/policy",
+                TransportEndpointRejectionCategory::Restricted,
+                "relay rejected event (restricted)",
+            ),
+            (
+                "invalid: leaked event payload",
+                TransportEndpointRejectionCategory::Invalid,
+                "relay rejected event (invalid)",
+            ),
+            (
+                "unsupported: kind 5",
+                TransportEndpointRejectionCategory::Unsupported,
+                "relay rejected event (unsupported)",
+            ),
+        ] {
+            let failure = relay_rejection_endpoint_failure(
+                TransportEndpoint("wss://relay.example".into()),
+                message,
+            );
+            assert_eq!(failure.rejection_category, Some(category));
+            assert_eq!(failure.reason, summary);
+            assert!(!failure.reason.contains("evil.example"));
+            assert!(!failure.reason.contains("leaked event payload"));
+        }
+    }
+
+    #[test]
+    fn finish_publish_outcome_collapses_duplicate_relay_rejection_summaries() {
+        let message_id = cgka_traits::MessageId::new(vec![0xD6; 32]);
+        let err = NostrSdkRelayClient::finish_publish_outcome(
+            message_id,
+            Vec::new(),
+            vec![
+                TransportEndpointFailure {
+                    endpoint: TransportEndpoint("wss://first.example".into()),
+                    reason: "relay rejected event (blocked)".to_owned(),
+                    rejection_category: Some(TransportEndpointRejectionCategory::Blocked),
+                },
+                TransportEndpointFailure {
+                    endpoint: TransportEndpoint("wss://second.example".into()),
+                    reason: "relay rejected event (blocked)".to_owned(),
+                    rejection_category: Some(TransportEndpointRejectionCategory::Blocked),
+                },
+            ],
+            1,
+            false,
+        )
+        .unwrap_err();
+
+        let rendered = err.to_string();
+        assert_eq!(rendered, "publish failed: relay rejected event (blocked)");
+        assert!(!rendered.contains("first.example"));
+        assert!(!rendered.contains("injected"));
+        if let TransportAdapterError::PublishEndpoints(failure) = err {
+            assert_eq!(failure.endpoint_failures.len(), 2);
+            assert_eq!(
+                failure.endpoint_failures[0].rejection_category,
+                Some(TransportEndpointRejectionCategory::Blocked)
+            );
+        } else {
+            panic!("expected publish failure");
+        }
+    }
+
+    #[test]
+    fn finish_publish_outcome_success_retains_rejected_endpoint_diagnostics() {
+        let message_id = cgka_traits::MessageId::new(vec![0xD7; 32]);
+        let accepted = vec![TransportEndpointReceipt {
+            endpoint: TransportEndpoint("wss://good.example".into()),
+            accepted_at: None,
+        }];
+        let failed = vec![TransportEndpointFailure {
+            endpoint: TransportEndpoint("wss://bad.example".into()),
+            reason: "relay rejected event (auth-required)".to_owned(),
+            rejection_category: Some(TransportEndpointRejectionCategory::AuthRequired),
+        }];
+        let outcome = NostrSdkRelayClient::finish_publish_outcome(
+            message_id,
+            accepted,
+            failed.clone(),
+            1,
+            false,
+        )
+        .unwrap();
+        assert_eq!(outcome.failed, failed);
     }
 
     #[test]
@@ -1233,6 +1375,7 @@ mod tests {
             vec![TransportEndpointFailure {
                 endpoint: endpoint.clone(),
                 reason: "connect relay failed".to_owned(),
+                rejection_category: None,
             }],
             1,
             false,
@@ -2038,6 +2181,67 @@ mod tests {
         // The privacy invariant forbids relay URLs in error Display: the bad
         // endpoint itself must not be echoed back.
         assert!(!rendered.contains("not a relay url"), "{rendered}");
+    }
+
+    #[derive(Debug)]
+    struct RejectAllWrites;
+
+    impl nostr_relay_builder::prelude::WritePolicy for RejectAllWrites {
+        fn admit_event<'a>(
+            &'a self,
+            _event: &'a nostr::Event,
+            _addr: &'a std::net::SocketAddr,
+        ) -> nostr_relay_builder::prelude::BoxedFuture<'a, nostr_relay_builder::prelude::PolicyResult>
+        {
+            Box::pin(async move {
+                nostr_relay_builder::prelude::PolicyResult::Reject(
+                    "injected write rejection".into(),
+                )
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn publish_event_reports_per_relay_rejection_categories_with_collapsed_display() {
+        use crate::KIND_MARMOT_KEY_PACKAGE;
+        use nostr_relay_builder::{LocalRelay, RelayBuilder};
+
+        let relay_a = LocalRelay::new(RelayBuilder::default().write_policy(RejectAllWrites));
+        relay_a.run().await.unwrap();
+        let relay_b = LocalRelay::new(RelayBuilder::default().write_policy(RejectAllWrites));
+        relay_b.run().await.unwrap();
+        let endpoint_a = TransportEndpoint(relay_a.url().await.to_string());
+        let endpoint_b = TransportEndpoint(relay_b.url().await.to_string());
+        let keys = Keys::generate();
+        let client = Client::builder().signer(keys.clone()).build();
+        let sdk = NostrSdkRelayClient::new(client);
+        let deletion = NostrTransportEvent::new_unsigned(
+            keys.public_key().to_hex(),
+            5,
+            vec![
+                vec!["e".into(), "11".repeat(32)],
+                vec!["k".into(), KIND_MARMOT_KEY_PACKAGE.to_string()],
+            ],
+            String::new(),
+        );
+
+        let err = sdk
+            .publish_event(&[endpoint_a, endpoint_b], &deletion, 1)
+            .await
+            .expect_err("both relays reject writes");
+
+        let rendered = err.to_string();
+        assert_eq!(rendered, "publish failed: relay rejected event (blocked)");
+        assert!(!rendered.contains("injected write rejection"));
+        if let TransportAdapterError::PublishEndpoints(failure) = err {
+            assert_eq!(failure.endpoint_failures.len(), 2);
+            assert!(failure.endpoint_failures.iter().all(|endpoint_failure| {
+                endpoint_failure.rejection_category
+                    == Some(TransportEndpointRejectionCategory::Blocked)
+            }));
+        } else {
+            panic!("expected structured publish failure");
+        }
     }
 
     async fn silent_relay_url() -> String {


### PR DESCRIPTION
Fixes #1155

## Summary
- preserve privacy-safe machine-readable relay rejection categories per endpoint without retaining relay-controlled suffix text
- collapse duplicate endpoint failures into one concise Display/UI summary while retaining structured diagnostics
- keep mixed accepted/rejected publishes successful and gate KeyPackage metadata removal on at least one deletion acknowledgement
- add real SDK/MockRelay coverage for valid NIP-09 KeyPackage deletion and cache cleanup

## Root cause
The KeyPackage deletion shape (`kind:5` with `e` and `k=30443`) is accepted by compatible relays. The failure was diagnostic: `send_event_to_relay` replaced every `OK:false` message with one generic string, then `finish_publish_outcome` duplicated that string and discarded endpoint failures on the all-rejected path.

## Verification
- `cargo test -p cgka-traits --locked`
- `cargo test -p transport-nostr-adapter --features sdk --locked`
- `cargo test -p marmot-app --lib key_package_deletion --locked`
- `cargo test -p marmot-app --test relay_runtime --features test-policy-overrides --locked -- --test-threads=1` — 97 passed
- `just fast-ci`
- CI-exact default/all-feature workspace `cargo check` and `cargo clippy` commands — passed

## NIP-42
The production deletion client continues to use `NostrSdkClient::builder().signer(signer).build()`. No auth options are overridden, so nostr-sdk automatic authentication remains enabled by default. The local relay harness does not model the complete NIP-42 challenge flow; no fake auth path was added.

## Sensitive paths
- `crates/transport-nostr-adapter/src/sdk_client.rs` — signed event publication and relay rejection handling
- `crates/marmot-app/src/runtime/mod.rs` — KeyPackage deletion failure projection during sign-out/wipe

No cryptographic primitives, MLS/CGKA state, key material, NIP-09 event shape, versions, conformance fixtures, or `Cargo.lock` were changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added privacy-safe categories for relay publication failures, making errors more actionable without exposing relay URLs or remote rejection text.
  - Key-package deletion now removes matching local publication metadata after successful relay acknowledgement.
  - Added support for structured failure details and clearer aggregated publish errors.

- **Bug Fixes**
  - Improved handling of relay failures during key-package deletion.
  - Preserved compatibility with older failure records that lack rejection categories.

- **Documentation**
  - Added unreleased changelog notes covering deletion behavior and privacy-safe relay diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->