### PR TITLE
fix: accept Hermes runtime tool context

### DIFF
--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -9,6 +9,13 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ## [Unreleased]
 
+### Fixed
+
+- Hermes Marmot `marmot_history` and `delete_marmot_message` tools now accept
+  Hermes ToolRegistry runtime keyword arguments (`task_id`, `session_id`, and
+  future dispatch metadata) instead of failing with `TypeError` during gateway
+  tool calls.
+
 ## [0.9.11] - 2026-08-09
 
 ### Added

--- a/integrations/hermes/marmot/adapter.py
+++ b/integrations/hermes/marmot/adapter.py
@@ -3748,7 +3748,7 @@ async def _standalone_send(
     return {"error": result.error or "Marmot send failed"}
 
 
-def _delete_marmot_message_tool(args: Dict[str, Any]) -> str:
+def _delete_marmot_message_tool(args: Dict[str, Any], **_kwargs: Any) -> str:
     message_id = str(args.get("message_id") or "").strip()
     if not message_id:
         return json.dumps({"ok": False, "error": "message_id required"})
@@ -3782,7 +3782,7 @@ def _delete_marmot_message_tool(args: Dict[str, Any]) -> str:
         return json.dumps({"ok": False, "error": str(exc)})
 
 
-def _marmot_history_tool(args: Dict[str, Any]) -> str:
+def _marmot_history_tool(args: Dict[str, Any], **_kwargs: Any) -> str:
     group_id_hex = str(args.get("group_id_hex") or "").strip()
     if not group_id_hex:
         return json.dumps({"ok": False, "error": "group_id_hex required"})

--- a/integrations/hermes/marmot/tests/e2e_deterministic.py
+++ b/integrations/hermes/marmot/tests/e2e_deterministic.py
@@ -29,6 +29,11 @@ SENDER_ACCOUNT_ID_HEX = "44" * 32
 INBOUND_TEXT = "ping from marmot"
 DETERMINISTIC_RESPONSE = f"marmot-e2e-ok: {INBOUND_TEXT}"
 PROTOCOL = "marmot.agent-control.v2"
+TOOL_RUNTIME_KWARGS = {
+    "task_id": "task-runtime-kwargs-regression",
+    "session_id": "session-runtime-kwargs-regression",
+    "future_runtime_kwarg": "probe",
+}
 
 
 async def read_json_line(reader: asyncio.StreamReader) -> dict[str, Any]:
@@ -177,12 +182,33 @@ def assert_plugin_discovery_registers_marmot_platform() -> None:
         raise AssertionError("Hermes plugin discovery did not register Marmot platform")
 
 
+def assert_registered_marmot_tools_accept_runtime_kwargs() -> None:
+    from tools.registry import registry
+
+    cases = (
+        ("marmot_history", {"group_id_hex": GROUP_ID_HEX}),
+        ("delete_marmot_message", {"message_id": MESSAGE_ID_HEX}),
+    )
+    for name, args in cases:
+        if registry.get_entry(name) is None:
+            raise AssertionError(f"Hermes plugin discovery did not register {name}")
+        raw = registry.dispatch(name, args, **TOOL_RUNTIME_KWARGS)
+        if not isinstance(raw, str):
+            raise AssertionError(f"{name} returned a non-string result: {type(raw).__name__}")
+        payload = json.loads(raw)
+        if "unexpected keyword argument" in raw:
+            raise AssertionError(f"{name} rejected Hermes runtime kwargs: {raw}")
+        if payload.get("ok") is not False or "error" not in payload:
+            raise AssertionError(f"{name} did not fail closed without a live gateway: {raw}")
+
+
 async def run() -> None:
     plugin_path = Path(os.environ.get("HERMES_HOME", "")) / "plugins" / "marmot" / "adapter.py"
     if not plugin_path.exists():
         raise SystemExit(f"plugin adapter not found: {plugin_path}")
 
     assert_plugin_discovery_registers_marmot_platform()
+    assert_registered_marmot_tools_accept_runtime_kwargs()
     module = load_marmot_adapter_module(plugin_path)
 
     from gateway.config import PlatformConfig


### PR DESCRIPTION
Fixes #1221

## Summary

- accept Hermes registry runtime keyword context in both Marmot model-tool handlers without changing their validation or routing
- extend the pinned-Hermes deterministic E2E to discover the plugin, dispatch both registered tools through the real `ToolRegistry` with `task_id`, `session_id`, and future metadata, and verify unresolved gateway context still fails closed
- document the fix in the MDK compatibility-cohort changelog

## Verification

- RED before the handler fix: actual pinned `ToolRegistry.dispatch()` returned `TypeError` for both handlers on `task_id`
- `env -i HOME="$HOME" PATH="$PATH" USER="${USER:-runner}" python3 -m unittest discover -s integrations/hermes/marmot/tests -v` — 188 passed
- `integrations/hermes/marmot/tests/test_dev_scripts.sh` — passed
- `python3 -m py_compile integrations/hermes/marmot/adapter.py integrations/hermes/marmot/tests/e2e_deterministic.py` — passed
- `./scripts/hermes_marmot_deterministic_e2e.sh --root /tmp/mdk-1221-hermes-dev` against Hermes Agent `3ef6bbd201263d354fd83ec55b3c306ded2eb72a` — passed

## Sensitive paths

None.

## Release hygiene

- changelog: `crates/cli/CHANGELOG.md` (`Unreleased`)
- version bump: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Marmot history and message deletion tools to handle runtime metadata reliably.
  * Prevented gateway-call failures caused by unexpected runtime arguments.
  * Ensured tool errors are returned in a consistent JSON format.

* **Documentation**
  * Added an unreleased changelog entry describing the compatibility improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->