### PR TITLE
Turn refused harness leaves into failed scenario steps

### DIFF
--- a/crates/cgka-conformance-simulator/src/client.rs
+++ b/crates/cgka-conformance-simulator/src/client.rs
@@ -1361,20 +1361,22 @@ impl HarnessClient {
     }
 
     /// Send a SelfRemove proposal (Leave intent).
-    pub async fn leave(&mut self) {
-        self.leave_capture().await;
+    pub async fn leave(&mut self) -> Result<(), EngineError> {
+        self.leave_capture().await.map(|_| ())
     }
 
     /// Send a SelfRemove proposal and return the wrapped transport message.
-    pub async fn leave_capture(&mut self) -> TransportMessage {
-        let gid = self.default_group.clone().expect("group");
+    pub async fn leave_capture(&mut self) -> Result<TransportMessage, EngineError> {
+        let gid = self
+            .default_group
+            .clone()
+            .ok_or_else(|| EngineError::Other("leave without a default group".into()))?;
         let res = self
             .engine_mut()
             .send(SendIntent::Leave {
                 group_id: gid.clone(),
             })
-            .await
-            .expect("send leave");
+            .await?;
         if let SendResult::Proposal { msg } = res {
             let scenario_input =
                 self.next_scenario_input_metadata(ScenarioInputKind::Proposal, None, None);
@@ -1386,9 +1388,11 @@ impl HarnessClient {
             self.register_published_scenario_input(&routed, scenario_input)
                 .await;
             self.bus.send(self.bus_id, routed.clone());
-            routed
+            Ok(routed)
         } else {
-            panic!("expected Proposal");
+            Err(EngineError::Other(format!(
+                "expected Proposal, got {res:?}"
+            )))
         }
     }
 

--- a/crates/cgka-conformance-simulator/src/client.rs
+++ b/crates/cgka-conformance-simulator/src/client.rs
@@ -503,6 +503,21 @@ fn key_package_with_harness_source(key_package: KeyPackage) -> KeyPackage {
     .with_protocol_profile(protocol_profile)
 }
 
+/// Stable variant name for unexpected-result errors. Debug-formatting a
+/// [`SendResult`] would embed transport payload bytes in the error string.
+fn send_result_kind(res: &SendResult) -> &'static str {
+    match res {
+        SendResult::NoChange { .. } => "NoChange",
+        SendResult::DisbandRequested { .. } => "DisbandRequested",
+        SendResult::ApplicationMessage { .. } => "ApplicationMessage",
+        SendResult::Queued { .. } => "Queued",
+        SendResult::Proposal { .. } => "Proposal",
+        SendResult::GroupEvolution { .. } => "GroupEvolution",
+        SendResult::GroupCreated { .. } => "GroupCreated",
+        SendResult::FoundingGroupCreated { .. } => "FoundingGroupCreated",
+    }
+}
+
 #[derive(Clone)]
 struct NostrAccountIdentityProofSigner {
     keys: nostr::Keys,
@@ -1366,11 +1381,24 @@ impl HarnessClient {
     }
 
     /// Send a SelfRemove proposal and return the wrapped transport message.
+    ///
+    /// A refused leave releases any id reserved via
+    /// [`Self::name_next_scenario_input`]; only a sent proposal consumes it,
+    /// so the next named action neither trips the unconsumed-id assertion nor
+    /// inherits the failed leave's id.
     pub async fn leave_capture(&mut self) -> Result<TransportMessage, EngineError> {
+        let result = self.leave_capture_inner().await;
+        if result.is_err() {
+            self.next_scenario_input_id = None;
+        }
+        result
+    }
+
+    async fn leave_capture_inner(&mut self) -> Result<TransportMessage, EngineError> {
         let gid = self
             .default_group
             .clone()
-            .ok_or_else(|| EngineError::Other("leave without a default group".into()))?;
+            .ok_or_else(|| EngineError::Other("must create or join a group first".into()))?;
         let res = self
             .engine_mut()
             .send(SendIntent::Leave {
@@ -1391,7 +1419,8 @@ impl HarnessClient {
             Ok(routed)
         } else {
             Err(EngineError::Other(format!(
-                "expected Proposal, got {res:?}"
+                "expected Proposal, got {}",
+                send_result_kind(&res)
             )))
         }
     }

--- a/crates/cgka-conformance-simulator/src/subject.rs
+++ b/crates/cgka-conformance-simulator/src/subject.rs
@@ -1400,7 +1400,7 @@ impl ConvergenceSubject for EngineHarnessSubject {
     async fn leave(&mut self, action_id: &str, client: &str) -> Result<(), SubjectError> {
         let client = self.client_mut(client)?;
         client.name_next_scenario_input(action_id);
-        client.leave().await;
+        client.leave().await.map_err(subject_engine_error)?;
         Ok(())
     }
 

--- a/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
+++ b/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
@@ -2448,7 +2448,7 @@ async fn add_then_self_remove_via_harness() {
     carol.tick().await;
 
     // Bob (non-admin) leaves.
-    bob.leave().await;
+    bob.leave().await.expect("leave");
     bus.deliver_all();
     let alice_proposal_outcomes = alice.tick().await; // ingests proposal + auto-commits
     let carol_proposal_outcomes = carol.tick().await; // same: no deterministic election

--- a/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
+++ b/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
@@ -2422,6 +2422,42 @@ async fn three_client_message_exchange_trace() -> ScenarioTrace {
 }
 
 #[tokio::test]
+async fn refused_leave_releases_named_scenario_input_reservation() {
+    // A refused leave must release the id reserved by
+    // name_next_scenario_input; otherwise the next named action panics on the
+    // unconsumed-id assertion or inherits the failed leave's id.
+    let bus = TransportBus::ordered();
+    let mut alice = ClientBuilder::new(pad32(b"alice"))
+        .registry(selfremove_registry())
+        .attach(&bus);
+    let mut bob = ClientBuilder::new(pad32(b"bob"))
+        .registry(selfremove_registry())
+        .attach(&bus);
+
+    let bob_kp = bob.fresh_key_package().await;
+    let (_gid, pending) = alice
+        .create_group("leave-refusal", vec![bob_kp], vec![])
+        .await;
+    alice.confirm(pending).await;
+    bus.deliver_all();
+    bob.tick().await;
+
+    // Alice is the sole admin, so the engine refuses her SelfRemove.
+    alice.name_next_scenario_input("refused-leave");
+    alice
+        .leave()
+        .await
+        .expect_err("sole admin self-remove must be refused");
+
+    // Naming the next action must not trip the unconsumed-id assertion, and
+    // the app send consumes the fresh reservation (proven by naming again).
+    alice.name_next_scenario_input("post-refusal-app");
+    alice.send_app(b"still alive".to_vec()).await;
+    alice.name_next_scenario_input("post-refusal-consumed");
+    alice.send_app(b"second".to_vec()).await;
+}
+
+#[tokio::test]
 async fn add_then_self_remove_via_harness() {
     // Alice creates with Bob and Carol; Bob, a non-admin, leaves; remaining
     // members may both publish SelfRemove-only commits, and convergence handles

--- a/crates/cgka-conformance-simulator/tests/openmls_replay_probe.rs
+++ b/crates/cgka-conformance-simulator/tests/openmls_replay_probe.rs
@@ -323,7 +323,7 @@ async fn openmls_probe_replays_consumed_proposal_without_mutating_live_state() {
     bob.tick().await;
     carol.tick().await;
 
-    let proposal_msg = bob.leave_capture().await;
+    let proposal_msg = bob.leave_capture().await.expect("leave proposal");
     let proposal_msg = openmls_projection_message(&carol, &proposal_msg).await;
     assert_projected_kind(&proposal_msg, OpenMlsContentKind::Proposal, 1);
 
@@ -532,7 +532,7 @@ async fn openmls_canonicalization_maps_consumed_proposal_refs_to_pending_proposa
     bob.tick().await;
     carol.tick().await;
 
-    let proposal_msg = bob.leave_capture().await;
+    let proposal_msg = bob.leave_capture().await.expect("leave proposal");
     let proposal_msg = openmls_projection_message(&carol, &proposal_msg).await;
     bus.deliver_all();
     let alice_outcomes = alice.tick().await;

--- a/crates/cgka-conformance-simulator/tests/scenario_ir.rs
+++ b/crates/cgka-conformance-simulator/tests/scenario_ir.rs
@@ -283,6 +283,46 @@ async fn typoed_group_label_fails_closed_at_execution() {
 }
 
 #[tokio::test]
+async fn refused_admin_leave_fails_the_step_without_unwinding() {
+    // A sole admin may not self-remove (MIP-03 admin policy), so the engine
+    // refuses this leave. The refusal must surface as a failed scenario step
+    // in the report, not unwind the harness.
+    let scenario = ScenarioSpec {
+        name: "scenario-ir/refused-admin-leave".into(),
+        spec_version: "2".into(),
+        clients: vec!["alice".into()],
+        topology: Default::default(),
+        steps: vec![
+            ScenarioStep::InGroup {
+                group: "red".into(),
+                action: Box::new(ScenarioStep::CreateGroup {
+                    creator: "alice".into(),
+                    name: "red".into(),
+                    invitees: vec![],
+                    required_features: vec![],
+                    initial_admins: Some(vec!["alice".into()]),
+                    pending: "red-create".into(),
+                }),
+            },
+            ScenarioStep::InGroup {
+                group: "red".into(),
+                action: Box::new(ScenarioStep::Leave {
+                    client: "alice".into(),
+                }),
+            },
+        ],
+    };
+    let report = run_scenario_report(&scenario, None)
+        .await
+        .expect("engine refusals are reported structurally");
+    assert!(report.step_log.iter().any(|step| matches!(
+        &step.status,
+        cgka_conformance_simulator::ScenarioStepStatus::Failed { kind, .. }
+            if kind == "admin_policy"
+    )));
+}
+
+#[tokio::test]
 async fn wrapped_action_id_is_used_by_fault_selectors_and_the_runtime_ledger() {
     let in_group = |action| ScenarioStep::InGroup {
         group: "red".into(),


### PR DESCRIPTION
A conformance vector that scripts a `leave` the engine refuses used to kill the whole report run. `HarnessClient::leave_capture` called `.expect("send leave")`, so an engine error such as `AdminCannotSelfRemove` panicked the process, aborted every remaining vector, and wrote no failure capsule. A marmot turned away at the burrow door should mark its map and keep walking, not collapse the whole colony.

Found while probing new scenarios: a sole-admin self-leave trial hit the intended `AdminCannotSelfRemove` policy and took down the runner instead of failing one step.

Changes:

- `HarnessClient::leave` and `leave_capture` return `Result`. The missing default group, an engine refusal, and a non-proposal send result all become typed errors.
- The engine subject maps the error through the existing `subject_engine_error` classifier, so a refused leave reports `scenario_step_failed:admin_policy` with a failure capsule while sibling vectors keep running.
- Three test call sites now `.expect(...)` because their scenarios require the leave to succeed.

Verification: a report run with the refused-leave trial vector plus two passing leave vectors gives 2 pass, 1 clean FAIL with capsule, exit 1, no panic. The leave-touching test suites (`canonical_scenarios`, `openmls_replay_probe`, `report_runner`: 45 + 14 + 23 tests) pass, and `just fast-ci` is green.

`send_app` and a few sibling harness methods keep the same `.expect` pattern and would panic the same way on an engine refusal. The same fix shape applies there if we want a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of leave failures by reporting errors instead of silently ignoring them or terminating unexpectedly.
  * Leave operations now clearly indicate whether they succeeded and provide the resulting proposal when applicable.
  * Failed self-removal attempts now release reserved scenario inputs and allow scenario execution to continue correctly.

* **Tests**
  * Strengthened removal, replay, and conformance scenarios to fail explicitly when leave operations do not produce the expected result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->