### PR TITLE
fix(marmot-app): run armed backfill after catch-up

### DIFF
--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -9,6 +9,13 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ## [Unreleased]
 
+### Fixed
+
+- Runtime catch-up, key-package maintenance, and every other incremental sync
+  seam now execute an armed epoch-gap full-history replay immediately instead of
+  waiting for unrelated later relay traffic. Explicit full-history repair also
+  consumes a pending replay without issuing the same account-wide query twice.
+
 ## [0.9.11] - 2026-08-09
 
 ### Added

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -760,6 +760,18 @@ impl AppClient {
         self.epoch_backfill_pending
     }
 
+    /// Consume a pending epoch-gap replay after an unfloored transport
+    /// activation has succeeded. Shared by the automatic replay path and the
+    /// explicit full-history repair path, which already performed the same
+    /// account-wide replay and must not issue it twice.
+    pub(crate) fn finish_pending_epoch_backfill_after_replay(&mut self) {
+        if !self.epoch_backfill_pending {
+            return;
+        }
+        self.epoch_stall.mark_replayed();
+        self.epoch_backfill_pending = false;
+    }
+
     /// Recover any group that stalled below its live epoch during ingest by
     /// replaying the account's full transport history (`since = None`). One replay
     /// re-fetches every group, so the detector collapses simultaneously-stuck
@@ -769,8 +781,7 @@ impl AppClient {
             return Ok(());
         }
         self.runtime.activate_transport(None).await?;
-        self.epoch_stall.mark_replayed();
-        self.epoch_backfill_pending = false;
+        self.finish_pending_epoch_backfill_after_replay();
         Ok(())
     }
 

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -666,7 +666,7 @@ async fn run_app_runtime_account_worker(
         Ok(summary) => {
             publish_app_runtime_summary(&events, &account_id_hex, &account_label, &summary);
             schedule_pending_convergence_groups(&mut scheduled_convergence, &mut client);
-            run_pending_epoch_backfill_reporting_arm(
+            let backfill_result = run_pending_epoch_backfill_reporting_arm(
                 &mut client,
                 &events,
                 &account_id_hex,
@@ -677,7 +677,7 @@ async fn run_app_runtime_account_worker(
             if sync_summary_triggers_audit_tracker_update(&summary) {
                 shared.schedule_audit_log_tracker_update("startup_sync");
             }
-            Ok(())
+            backfill_result
         }
         Err(err) => {
             // A failed initial catch-up surfaces as an account error but must not
@@ -817,7 +817,7 @@ async fn run_app_runtime_account_worker(
                                         &mut scheduled_convergence,
                                         &mut client,
                                     );
-                                    run_pending_epoch_backfill_reporting_arm(
+                                    let _ = run_pending_epoch_backfill_reporting_arm(
                                         &mut client,
                                         &events,
                                         &account_id_hex,
@@ -936,7 +936,7 @@ async fn run_app_runtime_account_worker(
                             &mut scheduled_convergence,
                             &mut client,
                         );
-                        run_pending_epoch_backfill_reporting_arm(
+                        let _ = run_pending_epoch_backfill_reporting_arm(
                             &mut client,
                             &events,
                             &account_id_hex,
@@ -1148,6 +1148,14 @@ async fn run_app_runtime_account_worker(
                         }
                     }
                 }
+                let _ = run_pending_epoch_backfill_reporting_arm(
+                    &mut client,
+                    &events,
+                    &account_id_hex,
+                    &account_label,
+                    &shared,
+                )
+                .await;
                 if let Err(err) = client.advance_post_join_maintenance_subscriptions().await {
                     publish_app_runtime_account_error(
                         &events,
@@ -1311,15 +1319,18 @@ async fn handle_account_worker_catch_up(
                 context.account_label,
                 &summary,
             );
-            if client.has_pending_epoch_backfill() {
-                context
-                    .shared
-                    .schedule_audit_log_tracker_update("epoch_backfill_armed");
-            }
+            let backfill_result = run_pending_epoch_backfill_reporting_arm(
+                client,
+                context.events,
+                context.account_id_hex,
+                context.account_label,
+                context.shared,
+            )
+            .await;
             if sync_summary_triggers_audit_tracker_update(&summary) {
                 context.shared.schedule_audit_log_tracker_update("catch_up");
             }
-            Ok(())
+            backfill_result
         }
         Err(err) => {
             let message = account_error_message("runtime catch-up failed", &err);
@@ -1597,18 +1608,18 @@ async fn handle_account_worker_command(
             let result = match client.sync().await {
                 Ok(summary) => {
                     publish_app_runtime_summary(events, account_id_hex, account_label, &summary);
-                    // Catch-up arms without running the backfill (the next
-                    // receive pass runs it), but the arm row is already durable
-                    // and the arming traffic never trips the summary gate below
-                    // — push it to the tracker from the seam that observed the
-                    // arm rather than a hoped-for later delivery.
-                    if client.has_pending_epoch_backfill() {
-                        shared.schedule_audit_log_tracker_update("epoch_backfill_armed");
-                    }
+                    let backfill_result = run_pending_epoch_backfill_reporting_arm(
+                        client,
+                        events,
+                        account_id_hex,
+                        account_label,
+                        shared,
+                    )
+                    .await;
                     if sync_summary_triggers_audit_tracker_update(&summary) {
                         shared.schedule_audit_log_tracker_update("catch_up");
                     }
-                    Ok(())
+                    backfill_result
                 }
                 Err(err) => {
                     let message = account_error_message("runtime catch-up failed", &err);
@@ -1640,6 +1651,7 @@ async fn handle_account_worker_command(
                 Ok(summary) => {
                     publish_app_runtime_summary(events, account_id_hex, account_label, &summary);
                     if client.has_pending_epoch_backfill() {
+                        client.finish_pending_epoch_backfill_after_replay();
                         shared.schedule_audit_log_tracker_update("epoch_backfill_armed");
                     }
                     if sync_summary_triggers_audit_tracker_update(&summary) {
@@ -2894,29 +2906,29 @@ fn sync_summary_triggers_audit_tracker_update(summary: &SyncSummary) -> bool {
 /// tracker is scheduled unconditionally on the replay outcome: the
 /// `epoch_stall_backfill_armed` row is already durable, a failing replay is the
 /// highest-value upload, and the arming pass returns an empty summary that
-/// never trips the visible-activity gate. Shared by the startup and receive
-/// seams so the capture-before-run ordering cannot drift between them; the
-/// catch-up seam schedules the upload without running the backfill and stays
-/// separate.
+/// never trips the visible-activity gate. Shared by every incremental sync and
+/// ingest seam so the capture-before-run ordering cannot drift. A replay
+/// activation failure is both published and returned: explicit catch-up fails
+/// its response while background seams retain their existing event-only
+/// reporting behavior. Explicit full-history repair already performed the
+/// unfloored replay and consumes the same intent without calling this helper.
 async fn run_pending_epoch_backfill_reporting_arm(
     client: &mut AppClient,
     events: &broadcast::Sender<MarmotAppEvent>,
     account_id_hex: &str,
     account_label: &str,
     shared: &RuntimeSharedServices,
-) {
+) -> Result<(), String> {
     let backfill_armed = client.has_pending_epoch_backfill();
-    if let Err(err) = client.run_pending_epoch_backfill().await {
-        publish_app_runtime_account_error(
-            events,
-            account_id_hex,
-            account_label,
-            account_error_message("epoch-gap backfill failed", &err),
-        );
-    }
+    let result = client.run_pending_epoch_backfill().await.map_err(|err| {
+        let message = account_error_message("epoch-gap backfill failed", &err);
+        publish_app_runtime_account_error(events, account_id_hex, account_label, message.clone());
+        message
+    });
     if backfill_armed {
         shared.schedule_audit_log_tracker_update("epoch_backfill_armed");
     }
+    result
 }
 
 fn publish_app_runtime_summary(
@@ -3102,6 +3114,12 @@ fn publish_app_runtime_account_error(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+
+    use marmot_account::AccountHome;
+
+    use crate::client::epoch_stall::BackfillDecision;
+    use crate::tests::ScriptedPushRelayClient;
 
     fn test_group_id(byte: u8) -> GroupId {
         GroupId::new(vec![byte])
@@ -3119,6 +3137,140 @@ mod tests {
         let message = account_error_message("runtime receive failed", &err);
         assert_eq!(message, "runtime receive failed: transport");
         assert!(!message.contains("private-relay.example"), "{message}");
+    }
+
+    #[tokio::test]
+    async fn pending_epoch_backfill_failure_is_reported_retained_and_coalesced() {
+        let dir = tempfile::tempdir().unwrap();
+        AccountHome::open(dir.path())
+            .create_account("alice")
+            .unwrap();
+        let relay = Arc::new(ScriptedPushRelayClient::default());
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+            .with_test_relay_client(relay.clone());
+        let mut client = app.client("alice").await.unwrap();
+        client.apply_backfill_decision(&test_group_id(7), 3, BackfillDecision::Arm);
+
+        let (events, mut subscriber) = broadcast::channel(4);
+        let shared = RuntimeSharedServices::default();
+        relay.fail_next_subscribe();
+        let error = run_pending_epoch_backfill_reporting_arm(
+            &mut client,
+            &events,
+            "account-id",
+            "alice",
+            &shared,
+        )
+        .await
+        .expect_err("failed replay activation must be returned");
+
+        assert_eq!(error, "epoch-gap backfill failed: account_transport");
+        assert!(client.has_pending_epoch_backfill());
+        assert!(matches!(
+            subscriber.try_recv().unwrap(),
+            MarmotAppEvent::AccountError(RuntimeAccountError { message, .. })
+                if message == "epoch-gap backfill failed: account_transport"
+        ));
+
+        run_pending_epoch_backfill_reporting_arm(
+            &mut client,
+            &events,
+            "account-id",
+            "alice",
+            &shared,
+        )
+        .await
+        .unwrap();
+        assert!(!client.has_pending_epoch_backfill());
+        let subscriptions_after_replay = relay.subscription_count();
+
+        run_pending_epoch_backfill_reporting_arm(
+            &mut client,
+            &events,
+            "account-id",
+            "alice",
+            &shared,
+        )
+        .await
+        .unwrap();
+        assert_eq!(relay.subscription_count(), subscriptions_after_replay);
+    }
+
+    #[tokio::test]
+    async fn explicit_catch_up_runs_prearmed_backfill_before_success_response() {
+        let dir = tempfile::tempdir().unwrap();
+        AccountHome::open(dir.path())
+            .create_account("alice")
+            .unwrap();
+        let relay = Arc::new(ScriptedPushRelayClient::default());
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+            .with_test_relay_client(relay.clone());
+        let mut client = app.client("alice").await.unwrap();
+        client.apply_backfill_decision(&test_group_id(8), 3, BackfillDecision::Arm);
+
+        let (events, _subscriber) = broadcast::channel(4);
+        let shared = RuntimeSharedServices::default();
+        let (command_tx, mut commands) = mpsc::channel(1);
+        let mut pending = VecDeque::new();
+        let context = AccountWorkerCatchUpContext {
+            app: &app,
+            events: &events,
+            shared: &shared,
+            account_id_hex: "account-id",
+            account_label: "alice",
+        };
+        let (respond, response) = oneshot::channel();
+
+        handle_account_worker_catch_up(&mut client, respond, &mut commands, &mut pending, context)
+            .await;
+
+        response.await.unwrap().unwrap();
+        assert!(
+            !client.has_pending_epoch_backfill(),
+            "catch-up must consume the replay intent before sending success",
+        );
+        assert!(
+            relay.subscription_count() >= 2,
+            "catch-up must perform its floored sync and the pending unfloored replay",
+        );
+        drop(command_tx);
+    }
+
+    #[tokio::test]
+    async fn full_history_repair_consumes_prearmed_backfill_without_replaying_twice() {
+        let dir = tempfile::tempdir().unwrap();
+        AccountHome::open(dir.path())
+            .create_account("alice")
+            .unwrap();
+        let relay = Arc::new(ScriptedPushRelayClient::default());
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+            .with_test_relay_client(relay.clone());
+        let mut client = app.client("alice").await.unwrap();
+        client.apply_backfill_decision(&test_group_id(9), 3, BackfillDecision::Arm);
+
+        let (events, _subscriber) = broadcast::channel(4);
+        let shared = RuntimeSharedServices::default();
+        let (respond, response) = oneshot::channel();
+        handle_account_worker_command(
+            &mut client,
+            AccountWorkerCommand::RepairFullHistory { respond },
+            &events,
+            "account-id",
+            "alice",
+            &shared,
+        )
+        .await;
+
+        response.await.unwrap().unwrap();
+        assert!(
+            !client.has_pending_epoch_backfill(),
+            "every successful sync seam must consume an armed replay intent",
+        );
+        assert_eq!(
+            relay.subscription_count(),
+            2,
+            "the explicit unfloored repair already fulfills the pending replay",
+        );
     }
 
     #[test]

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -36,7 +36,7 @@ use crate::messages::STREAM_ROUTE_QUIC;
 use crate::messages::{AppMessageIntent, build_inner_event};
 
 #[derive(Default)]
-struct ScriptedPushRelayClient {
+pub(crate) struct ScriptedPushRelayClient {
     publish_results: std::sync::Mutex<std::collections::VecDeque<bool>>,
     published_events: std::sync::Mutex<Vec<NostrTransportEvent>>,
     subscriptions: std::sync::Mutex<Vec<NostrSubscription>>,
@@ -96,9 +96,13 @@ impl ScriptedPushRelayClient {
     /// Fail the next `subscribe` immediately instead of parking it first, for
     /// tests that need a transport activation to error inside a straight-line
     /// call (no second task to release the block).
-    fn fail_next_subscribe(&self) {
+    pub(crate) fn fail_next_subscribe(&self) {
         self.fail_next_subscribe
             .store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    pub(crate) fn subscription_count(&self) -> usize {
+        self.subscriptions.lock().unwrap().len()
     }
 
     async fn wait_for_blocked_subscribe(&self) {

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -13,14 +13,21 @@ use cgka_traits::app_event::{
 };
 use cgka_traits::storage::{DisbandCandidate, DisbandCandidateStorage};
 use marmot_account::AccountHomeError;
+use nostr::base64::Engine as _;
+use nostr::base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use nostr_sdk::prelude::{
+    Alphabet, EventBuilder, Keys, Kind, SingleLetterTag, Tag, TagKind, Timestamp as NostrTimestamp,
+};
 use storage_sqlite::StoredRelayTelemetrySettings;
 use transport_nostr_adapter::{
-    NostrEventPublishRequest, NostrPublishOutcome, NostrRelayClient, NostrSubscription,
+    NostrEventPublishRequest, NostrPublishOutcome, NostrRelayClient, NostrRelayEvent,
+    NostrSubscription,
 };
-use transport_nostr_peeler::NostrTransportEvent;
+use transport_nostr_peeler::{NOSTR_GROUP_CONTENT_MIN_LEN, NostrTransportEvent};
 use transport_quic_broker::BrokerServerTrust;
 
 use crate::audit_log::AUDIT_ID_BYTES;
+use crate::client::epoch_stall::EPOCH_STALL_BACKFILL_THRESHOLD;
 use crate::conversions::{
     app_group_from_stored_group, stored_components_from_app_group, stored_group_from_app_group,
 };
@@ -41,6 +48,8 @@ pub(crate) struct ScriptedPushRelayClient {
     published_events: std::sync::Mutex<Vec<NostrTransportEvent>>,
     subscriptions: std::sync::Mutex<Vec<NostrSubscription>>,
     block_next_subscribe: std::sync::atomic::AtomicBool,
+    block_subscribe_count: std::sync::atomic::AtomicUsize,
+    blocked_subscribe_count: std::sync::atomic::AtomicUsize,
     fail_blocked_subscribe: std::sync::atomic::AtomicBool,
     fail_next_subscribe: std::sync::atomic::AtomicBool,
     block_next_publish: std::sync::atomic::AtomicBool,
@@ -87,6 +96,11 @@ impl ScriptedPushRelayClient {
             .store(true, std::sync::atomic::Ordering::SeqCst);
     }
 
+    fn block_next_subscribes(&self, count: usize) {
+        self.block_subscribe_count
+            .store(count, std::sync::atomic::Ordering::SeqCst);
+    }
+
     fn block_and_fail_next_subscribe(&self) {
         self.fail_blocked_subscribe
             .store(true, std::sync::atomic::Ordering::SeqCst);
@@ -105,8 +119,32 @@ impl ScriptedPushRelayClient {
         self.subscriptions.lock().unwrap().len()
     }
 
+    fn unfloored_account_subscription_count(&self) -> usize {
+        self.subscriptions
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|subscription| {
+                matches!(
+                    subscription,
+                    NostrSubscription::AccountInbox { since: None, .. }
+                )
+            })
+            .count()
+    }
+
     async fn wait_for_blocked_subscribe(&self) {
         self.subscribe_started.notified().await;
+    }
+
+    async fn wait_for_blocked_subscribes(&self, count: usize) {
+        while self
+            .blocked_subscribe_count
+            .load(std::sync::atomic::Ordering::SeqCst)
+            < count
+        {
+            self.subscribe_started.notified().await;
+        }
     }
 
     fn release_subscribe(&self) {
@@ -183,8 +221,18 @@ impl NostrRelayClient for ScriptedPushRelayClient {
         let blocked = block_for_account
             || self
                 .block_next_subscribe
-                .swap(false, std::sync::atomic::Ordering::SeqCst);
+                .swap(false, std::sync::atomic::Ordering::SeqCst)
+            || self
+                .block_subscribe_count
+                .fetch_update(
+                    std::sync::atomic::Ordering::SeqCst,
+                    std::sync::atomic::Ordering::SeqCst,
+                    |remaining| remaining.checked_sub(1),
+                )
+                .is_ok();
         if blocked {
+            self.blocked_subscribe_count
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             self.subscribe_started.notify_one();
             self.subscribe_release.notified().await;
             if self
@@ -283,6 +331,166 @@ impl NostrRelayClient for ScriptedPushRelayClient {
         }
         outcomes
     }
+}
+
+const EXPLICIT_CATCH_UP_BACKFILL_DEADLINE: Duration = Duration::from_secs(5);
+
+fn epoch_gap_probe(nostr_group_id_hex: &str, created_at: u64, marker: &str) -> NostrTransportEvent {
+    let mut envelope = vec![0_u8; 12];
+    envelope.extend_from_slice(format!("explicit-catch-up-probe:{marker}").as_bytes());
+    assert!(envelope.len() >= NOSTR_GROUP_CONTENT_MIN_LEN);
+    let event = EventBuilder::new(Kind::MlsGroupMessage, BASE64_STANDARD.encode(envelope))
+        .tags([Tag::custom(
+            TagKind::SingleLetter(SingleLetterTag::lowercase(Alphabet::H)),
+            [nostr_group_id_hex.to_owned()],
+        )])
+        .custom_created_at(NostrTimestamp::from_secs(created_at))
+        .sign_with_keys(&Keys::generate())
+        .expect("sign epoch-gap probe");
+    NostrTransportEvent::from_nostr_event(&event).expect("convert epoch-gap probe")
+}
+
+async fn inject_epoch_gap_probe(app: &MarmotApp, event: NostrTransportEvent) {
+    let delivered = app
+        .relay_plane
+        .handle_relay_event_for_test(NostrRelayEvent {
+            endpoint: TransportEndpoint("wss://relay.example".to_owned()),
+            subscription_id: Some("explicit-catch-up-test".to_owned()),
+            event,
+        })
+        .await
+        .expect("route epoch-gap probe");
+    assert_eq!(
+        delivered, 1,
+        "the active group route must receive the probe"
+    );
+}
+
+#[test]
+fn explicit_catch_up_arms_and_replays_without_later_traffic() {
+    run_composed_app_runtime_test("explicit-catch-up-backfill", || async {
+        let dir = tempfile::tempdir().unwrap();
+        AccountHome::open(dir.path())
+            .create_account("alice")
+            .unwrap();
+        let relay = Arc::new(ScriptedPushRelayClient::default());
+        let mut app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+            .with_test_relay_client(relay.clone());
+        app.relay_plane = MarmotRelayPlane::new_with_loopback(
+            Some(Duration::from_secs(120)),
+            relay.clone(),
+            true,
+        );
+
+        let cursor = crate::unix_now_seconds();
+        let group_id = {
+            let mut client = app.client("alice").await.unwrap();
+            let group_id = client
+                .create_group("explicit catch-up epoch-gap replay", &[])
+                .await
+                .unwrap();
+            client.state.last_transport_timestamp = Some(cursor);
+            app.save_state(&client.state).unwrap();
+            group_id
+        };
+        let group = app
+            .group("alice", &hex::encode(group_id.as_slice()))
+            .unwrap()
+            .expect("local group projection");
+
+        let runtime = MarmotAppRuntime::new(app.clone());
+        runtime.start().await.unwrap();
+        // This command is deferred behind startup catch-up, so its response is
+        // also the steady-state barrier this regression needs.
+        runtime.pause_maintenance("alice").await.unwrap();
+        let unfloored_before = relay.unfloored_account_subscription_count();
+
+        // Hold the ordinary, floored activation inside explicit CatchUp. The
+        // worker is now committed to the command path and cannot consume these
+        // queued deliveries through its live receive arm instead.
+        relay.block_next_subscribes(2);
+        let catch_up_runtime = runtime.clone();
+        let catch_up = tokio::spawn(async move { catch_up_runtime.catch_up_accounts().await });
+        tokio::time::timeout(
+            EXPLICIT_CATCH_UP_BACKFILL_DEADLINE,
+            relay.wait_for_blocked_subscribes(2),
+        )
+        .await
+        .expect("explicit catch-up must park its complete floored activation");
+
+        let above_floor = cursor;
+        for arm in 0..EPOCH_STALL_BACKFILL_THRESHOLD {
+            inject_epoch_gap_probe(
+                &app,
+                epoch_gap_probe(
+                    &group.nostr_routing.nostr_group_id_hex,
+                    above_floor,
+                    &format!("arm-{arm}"),
+                ),
+            )
+            .await;
+        }
+
+        // The next two blocked subscribes are the complete unfloored replay.
+        // Without the post-CatchUp replay seam the catch-up task returns after
+        // the first release and this wait times out: the regression's RED signal.
+        relay.block_next_subscribes(2);
+        relay.release_subscribe();
+        tokio::time::timeout(
+            EXPLICIT_CATCH_UP_BACKFILL_DEADLINE,
+            relay.wait_for_blocked_subscribes(4),
+        )
+        .await
+        .expect("armed explicit catch-up must park one complete unfloored replay");
+
+        // Model the relay's stored-event response to that unfloored REQ. The
+        // target is older than the persisted cursor's 120-second floor and is
+        // offered only after replay starts; no later live delivery is published.
+        let below_floor_target = epoch_gap_probe(
+            &group.nostr_routing.nostr_group_id_hex,
+            cursor.saturating_sub(600),
+            "below-floor-target",
+        );
+        let below_floor_target_id = below_floor_target.id.clone();
+        inject_epoch_gap_probe(&app, below_floor_target).await;
+        relay.release_subscribe();
+
+        tokio::time::timeout(EXPLICIT_CATCH_UP_BACKFILL_DEADLINE, catch_up)
+            .await
+            .expect("explicit catch-up must finish after replay activation")
+            .expect("catch-up task must not panic")
+            .expect("explicit catch-up must report replay success");
+        assert_eq!(
+            relay.unfloored_account_subscription_count(),
+            unfloored_before + 1,
+            "the arming catch-up must issue exactly one account-wide replay",
+        );
+
+        tokio::time::timeout(EXPLICIT_CATCH_UP_BACKFILL_DEADLINE, async {
+            loop {
+                if app
+                    .load_state("alice")
+                    .unwrap()
+                    .seen_events
+                    .iter()
+                    .any(|event_id| event_id == &below_floor_target_id)
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("the below-floor target must be ingested without later traffic");
+
+        runtime.catch_up_accounts().await.unwrap();
+        assert_eq!(
+            relay.unfloored_account_subscription_count(),
+            unfloored_before + 1,
+            "consumed evidence must not trigger a second full-history replay",
+        );
+        runtime.shutdown().await;
+    });
 }
 
 /// Run app-runtime integration chains on a stack large enough for debug


### PR DESCRIPTION
## Summary

- execute an armed epoch-gap full-history replay immediately after successful runtime catch-up, maintenance, convergence, startup, and receive sync seams
- return replay activation failures to explicit catch-up callers while retaining the coalesced replay intent for retry
- let explicit full-history repair satisfy an armed replay without issuing the same account-wide query twice
- add regression coverage for catch-up completion, failure retention/error reporting, and one-replay coalescing

## Test plan

- `CARGO_INCREMENTAL=0 just fast-ci`
- focused account-worker regression tests (3 passed)
- `cargo test -p marmot-app --test since_floor -- --nocapture`
- `cargo test -p marmot-app --test next_event_backfill -- --nocapture`
- `cargo test -p marmot-app --test epoch_stall_backfill_audit -- --nocapture`

Full `cargo test -p marmot-app` was also run locally. It reached `relay_runtime` with six failures outside this diff. Five reproduce individually on unmodified `origin/master`; the sixth passes in isolation and failed only in the parallel suite.

Fixes #1180


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incremental synchronization when an epoch gap requires full-history replay.
  * Prevented duplicate account-wide queries during explicit repair.
  * Improved handling and reporting of replay failures across startup, scheduled, receive, maintenance, and catch-up flows.
  * Ensured pending repairs are cleared after successful replay and retained when replay fails.
* **Documentation**
  * Added an Unreleased changelog entry describing the synchronization fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->