### PR TITLE
Let a removed member rejoin: skip evicted-era snapshots in the past-epoch peel probe

### DIFF
--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -226,8 +226,19 @@ These are the scenarios another implementation should be able to load from JSON 
   the full transcript minus the departed members' silence and converge at epoch 3 with two members. `no_pending_work`
   covers Alice and Bob only: like the latecomer vector's pre-join input, Dave and Carol legitimately retain their
   undecryptable post-departure inputs as deferred transport work. The original harness scenario's re-add leg (removed
-  member rejoins via a fresh KeyPackage) is deliberately absent: welcome-after-eviction currently fails in the engine
-  harness with `GroupStateError(UseAfterEviction)` and is tracked as a coverage gap.
+  member rejoins via a fresh KeyPackage) lives in `readd-after-eviction/v1`.
+
+### `readd-after-eviction/v1`
+
+- File: `vectors/readd-after-eviction.v1.json`
+- Setup: Alice creates a group with Bob and Carol, removes Carol, then re-invites her with a fresh KeyPackage. Carol
+  sends the first post-rejoin application message.
+- Pressure: the rejoin Welcome lands on stale evicted local state, and the re-add commit reaches Carol as an
+  old-epoch group message whose only retained peel snapshots are from her evicted era.
+- Expected: the Welcome supersedes the stale live OpenMLS state, evicted-era retained snapshots are skipped as peel
+  sources instead of failing ingest with `UseAfterEviction`, and all three clients converge at epoch 3 with Carol's
+  post-rejoin payload delivered. The Rust regression for this shape is
+  `removed_member_rejoins_via_fresh_welcome` in `tests/canonical_scenarios.rs`.
 
 ### `incremental-growth/v1`
 

--- a/crates/cgka-conformance-simulator/src/subject.rs
+++ b/crates/cgka-conformance-simulator/src/subject.rs
@@ -1393,7 +1393,10 @@ impl ConvergenceSubject for EngineHarnessSubject {
     ) -> Result<(), SubjectError> {
         let sender = self.client_mut(action.sender)?;
         sender.name_next_scenario_input(action.action_id);
-        sender.send_app(action.payload.as_bytes().to_vec()).await;
+        sender
+            .try_send_app(action.payload.as_bytes().to_vec())
+            .await
+            .map_err(subject_engine_error)?;
         Ok(())
     }
 

--- a/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
+++ b/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
@@ -3547,3 +3547,82 @@ async fn failed_invite_staging_does_not_poison_fork_detection_via_harness() {
     alice.confirm(probe_pending).await;
     assert_eq!(alice.epoch().0, 3);
 }
+
+#[tokio::test]
+async fn removed_member_rejoins_via_fresh_welcome() {
+    // Alice removes Carol, then re-invites her with a fresh KeyPackage. The
+    // re-add is product-legal (leaver.rb re-add leg); Carol must land on the
+    // new epoch and exchange application traffic again.
+    let bus = TransportBus::ordered();
+    let mut alice = ClientBuilder::new(pad32(b"alice"))
+        .registry(selfremove_registry())
+        .attach(&bus);
+    let mut bob = ClientBuilder::new(pad32(b"bob"))
+        .registry(selfremove_registry())
+        .attach(&bus);
+    let mut carol = ClientBuilder::new(pad32(b"carol"))
+        .registry(selfremove_registry())
+        .attach(&bus);
+
+    let bob_kp = bob.fresh_key_package().await;
+    let carol_kp = carol.fresh_key_package().await;
+    let (_gid, pending) = alice
+        .create_group("readd", vec![bob_kp, carol_kp], vec![])
+        .await;
+    alice.confirm(pending).await;
+    bus.deliver_all();
+    bob.tick().await;
+    carol.tick().await;
+
+    let pending = alice.remove_members(vec![carol.member_id()]).await;
+    alice.confirm(pending).await;
+    bus.deliver_all();
+    let bob_outcomes = bob.tick().await;
+    assert!(
+        bob_outcomes.iter().all(Result::is_ok),
+        "bob removal outcomes: {bob_outcomes:?}"
+    );
+    let carol_outcomes = carol.tick().await;
+    assert!(
+        carol_outcomes.iter().all(Result::is_ok),
+        "carol removal outcomes: {carol_outcomes:?}"
+    );
+    assert_eq!(alice.members().len(), 2);
+
+    let carol_kp2 = carol.fresh_key_package().await;
+    let pending = alice.invite(vec![carol_kp2]).await;
+    alice.confirm(pending).await;
+    bus.deliver_all();
+    let bob_outcomes = bob.tick().await;
+    assert!(
+        bob_outcomes.iter().all(Result::is_ok),
+        "bob re-add outcomes: {bob_outcomes:?}"
+    );
+    let carol_outcomes = carol.tick().await;
+    assert!(
+        carol_outcomes.iter().all(Result::is_ok),
+        "carol re-add outcomes: {carol_outcomes:?}"
+    );
+
+    assert_eq!(alice.epoch().0, 3);
+    assert_eq!(carol.epoch().0, 3);
+    assert_eq!(alice.members().len(), 3);
+    assert_eq!(carol.members().len(), 3);
+
+    carol.send_app(b"carol is back".to_vec()).await;
+    bus.deliver_all();
+    let alice_outcomes = alice.tick().await;
+    assert!(
+        alice_outcomes.iter().all(Result::is_ok),
+        "alice app outcomes: {alice_outcomes:?}"
+    );
+    let received = alice
+        .drain_events()
+        .into_iter()
+        .filter(|e| matches!(e, GroupEvent::MessageReceived { .. }))
+        .count();
+    assert_eq!(
+        received, 1,
+        "alice must receive carol's post-rejoin message"
+    );
+}

--- a/crates/cgka-conformance-simulator/tests/report_runner.rs
+++ b/crates/cgka-conformance-simulator/tests/report_runner.rs
@@ -766,7 +766,7 @@ async fn refused_application_send_fails_step_without_aborting_the_run() {
         fs::remove_dir_all(&base).expect("remove stale test dir");
     }
     let vectors_dir = base.join("vectors");
-    fs::create_dir_all(&vectors_dir).expect("create vectors dir");
+    fs_private::create_dir_all_private(&vectors_dir).expect("create private vectors dir");
     let out_dir = base.join("out");
 
     let refused = serde_json::json!({
@@ -821,14 +821,14 @@ async fn refused_application_send_fails_step_without_aborting_the_run() {
              "member_count": 2, "received_payloads": []}
         ]
     });
-    fs::write(
-        vectors_dir.join("a-refused-send.v1.json"),
-        serde_json::to_string_pretty(&refused).expect("encode refused fixture"),
+    fs_private::write_private(
+        &vectors_dir.join("a-refused-send.v1.json"),
+        &serde_json::to_vec_pretty(&refused).expect("encode refused fixture"),
     )
     .expect("write refused fixture");
-    fs::write(
-        vectors_dir.join("zz-sibling.v1.json"),
-        serde_json::to_string_pretty(&sibling).expect("encode sibling fixture"),
+    fs_private::write_private(
+        &vectors_dir.join("zz-sibling.v1.json"),
+        &serde_json::to_vec_pretty(&sibling).expect("encode sibling fixture"),
     )
     .expect("write sibling fixture");
 

--- a/crates/cgka-conformance-simulator/tests/report_runner.rs
+++ b/crates/cgka-conformance-simulator/tests/report_runner.rs
@@ -751,3 +751,143 @@ async fn failed_campaign_capsule_contains_a_replayable_tick_witness() {
         String::from_utf8_lossy(&cli.stderr)
     );
 }
+
+#[tokio::test]
+async fn refused_application_send_fails_step_without_aborting_the_run() {
+    // A scripted send_app_message from a client in `Leaving` is refused by
+    // the engine (InvalidTransition). The report run must record a
+    // structured invalid_transition step failure with a failure capsule,
+    // keep executing sibling vectors, and report the run as failed.
+    let base = std::env::temp_dir().join(format!(
+        "mdk-cgka-refused-send-report-test-{}",
+        std::process::id()
+    ));
+    if base.exists() {
+        fs::remove_dir_all(&base).expect("remove stale test dir");
+    }
+    let vectors_dir = base.join("vectors");
+    fs::create_dir_all(&vectors_dir).expect("create vectors dir");
+    let out_dir = base.join("out");
+
+    let refused = serde_json::json!({
+        "scenario_name": "refused-send-after-leave/v1",
+        "vector_version": "1",
+        "conformance_version": "0.0.0-test",
+        "seed": null,
+        "scenario": {
+            "name": "refused-send-after-leave/v1",
+            "spec_version": "2",
+            "clients": ["alice", "bob", "carol"],
+            "steps": [
+                {"type": "create_group", "creator": "alice", "name": "refused-send",
+                 "invitees": ["bob", "carol"], "required_features": [], "pending": "create"},
+                {"type": "acknowledge_outbound", "client": "alice",
+                 "publication": "create", "outcome": "accepted"},
+                {"type": "deliver_all"},
+                {"type": "tick", "clients": ["bob", "carol"]},
+                {"type": "leave", "client": "carol"},
+                {"type": "send_app_message", "sender": "carol", "payload": "carol:refused"},
+                {"type": "observe", "clients": ["alice"]}
+            ]
+        },
+        "expected_outcomes": [
+            {"type": "client_state", "client": "alice", "epoch": 1,
+             "member_count": 3, "received_payloads": []}
+        ]
+    });
+    let sibling = serde_json::json!({
+        "scenario_name": "zz-sibling-after-refusal/v1",
+        "vector_version": "1",
+        "conformance_version": "0.0.0-test",
+        "seed": null,
+        "scenario": {
+            "name": "zz-sibling-after-refusal/v1",
+            "spec_version": "2",
+            "clients": ["alice", "bob"],
+            "steps": [
+                {"type": "create_group", "creator": "alice", "name": "sibling",
+                 "invitees": ["bob"], "required_features": [], "pending": "create"},
+                {"type": "acknowledge_outbound", "client": "alice",
+                 "publication": "create", "outcome": "accepted"},
+                {"type": "deliver_all"},
+                {"type": "tick", "clients": ["bob"]},
+                {"type": "observe", "clients": ["alice", "bob"]}
+            ]
+        },
+        "expected_outcomes": [
+            {"type": "client_state", "client": "alice", "epoch": 1,
+             "member_count": 2, "received_payloads": []},
+            {"type": "client_state", "client": "bob", "epoch": 1,
+             "member_count": 2, "received_payloads": []}
+        ]
+    });
+    fs::write(
+        vectors_dir.join("a-refused-send.v1.json"),
+        serde_json::to_string_pretty(&refused).expect("encode refused fixture"),
+    )
+    .expect("write refused fixture");
+    fs::write(
+        vectors_dir.join("zz-sibling.v1.json"),
+        serde_json::to_string_pretty(&sibling).expect("encode sibling fixture"),
+    )
+    .expect("write sibling fixture");
+
+    let summary = run_report(&ReportArgs {
+        input: ReportInput::VectorFixtures {
+            paths: vec![vectors_dir],
+        },
+        out: out_dir.clone(),
+        strict_oracle: false,
+        storage_mode: HarnessStorageMode::InMemorySqlite,
+        capture_sensitive_replay: false,
+    })
+    .await
+    .expect("runner completes despite the refused send");
+
+    // The refused send fails its scenario; the run reports it and continues.
+    assert_eq!(summary.total(), 2, "both vectors execute");
+    assert_eq!(summary.failed(), 1);
+    assert_eq!(summary.passed(), 1, "sibling vector still runs and passes");
+    assert!(summary.to_human_text().contains("1 passed, 1 failed"));
+
+    let refused_summary = summary
+        .scenarios
+        .iter()
+        .find(|scenario| scenario.scenario_name == "refused-send-after-leave/v1")
+        .expect("refused scenario summarized");
+    assert!(
+        refused_summary.failures.iter().any(|failure| {
+            failure.kind.contains("invalid_transition")
+                || failure.message.contains("invalid_transition")
+        }),
+        "failures must name invalid_transition: {:?}",
+        refused_summary.failures
+    );
+    let capsule = refused_summary
+        .failure_capsule
+        .as_ref()
+        .expect("refused scenario writes a failure capsule");
+    assert!(capsule.exists(), "failure capsule file exists");
+
+    let report: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(&refused_summary.output).expect("read refused report"),
+    )
+    .expect("refused report parses");
+    let failed_step = report["step_log"]
+        .as_array()
+        .expect("step log")
+        .iter()
+        .find(|step| step["status"]["status"] == "failed")
+        .expect("one step fails");
+    assert_eq!(failed_step["step_type"], "send_app_message");
+    assert_eq!(failed_step["status"]["kind"], "invalid_transition");
+
+    let sibling_summary = summary
+        .scenarios
+        .iter()
+        .find(|scenario| scenario.scenario_name == "zz-sibling-after-refusal/v1")
+        .expect("sibling scenario summarized");
+    assert_eq!(sibling_summary.failure_count, 0);
+
+    fs::remove_dir_all(&base).expect("clean up test dir");
+}

--- a/crates/cgka-conformance-simulator/vectors/manifest.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/manifest.v1.json
@@ -422,7 +422,7 @@
         "self-leave witness commit",
         "post-leave secrecy: departed member receives and processes all post-leave ciphertext, decrypts none"
       ],
-      "next": "Add the removed-member re-add leg once welcome-after-eviction is supported by the engine harness."
+      "next": "Keep as the departure-secrecy fixture; the removed-member re-add leg is covered by readd-after-eviction/v1."
     },
     {
       "id": "incremental-growth/v1",

--- a/crates/cgka-conformance-simulator/vectors/manifest.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/manifest.v1.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": "1",
-  "updated": "2026-08-09",
+  "updated": "2026-08-11",
   "purpose": "Inventory of current CGKA conformance artifacts and the next vectorization state for each one.",
   "entries": [
     {
@@ -486,6 +486,20 @@
         "latecomer joining in the same delivery flight as a rename commit, with pre-join mailbox-isolation zero-count assertions (ciphertext-exposure forward secrecy stays with latecomer-forward-secrecy/v1) and the joiner pinned to exactly its retained join commit"
       ],
       "next": "Promote a reviewed case into vectors/ once the joiner join-commit deferral is resolved."
+    },
+    {
+      "id": "readd-after-eviction/v1",
+      "kind": "scenario_vector",
+      "status": "portable",
+      "artifact": "readd-after-eviction.v1.json",
+      "coverage": [
+        "admin removal of a member",
+        "re-invite of the removed member with a fresh KeyPackage",
+        "welcome rejoin over stale evicted local state",
+        "evicted-era retained snapshots skipped as peel sources",
+        "post-rejoin application traffic"
+      ],
+      "next": "Keep as the re-add regression fixture; extend leaver-removal-secrecy with its re-add leg separately."
     }
   ]
 }

--- a/crates/cgka-conformance-simulator/vectors/readd-after-eviction.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/readd-after-eviction.v1.json
@@ -1,0 +1,37 @@
+{
+  "scenario_name": "readd-after-eviction/v1",
+  "vector_version": "1",
+  "conformance_version": "0.9.11",
+  "seed": null,
+  "scenario": {
+    "name": "readd-after-eviction/v1",
+    "spec_version": "2",
+    "clients": ["alice", "bob", "carol"],
+    "steps": [
+      {"type": "create_group", "creator": "alice", "name": "readd", "invitees": ["bob", "carol"], "required_features": [], "pending": "create"},
+      {"type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted"},
+      {"type": "deliver_all"},
+      {"type": "tick", "clients": ["bob", "carol"]},
+      {"type": "clear_events", "clients": ["alice", "bob", "carol"]},
+      {"type": "remove_members", "remover": "alice", "members": ["carol"], "pending": "remove-carol"},
+      {"type": "acknowledge_outbound", "client": "alice", "publication": "remove-carol", "outcome": "accepted"},
+      {"type": "deliver_all"},
+      {"type": "tick", "clients": ["bob", "carol"]},
+      {"type": "invite_members", "inviter": "alice", "invitees": ["carol"], "pending": "readd-carol"},
+      {"type": "acknowledge_outbound", "client": "alice", "publication": "readd-carol", "outcome": "accepted"},
+      {"type": "deliver_all"},
+      {"type": "tick", "clients": ["bob", "carol"]},
+      {"type": "send_app_message", "sender": "carol", "payload": "carol:back"},
+      {"type": "deliver_all"},
+      {"type": "tick", "clients": ["alice", "bob"]},
+      {"type": "observe", "clients": ["alice", "bob", "carol"]}
+    ]
+  },
+  "expected_outcomes": [
+    {"type": "pending_resolution", "step_index": 6, "client": "alice", "pending": "remove-carol", "resolution": "confirmed"},
+    {"type": "pending_resolution", "step_index": 10, "client": "alice", "pending": "readd-carol", "resolution": "confirmed"},
+    {"type": "client_state", "client": "alice", "epoch": 3, "member_count": 3, "received_payloads": ["carol:back"]},
+    {"type": "client_state", "client": "bob", "epoch": 3, "member_count": 3, "received_payloads": ["carol:back"]},
+    {"type": "client_state", "client": "carol", "epoch": 3, "member_count": 3, "received_payloads": []}
+  ]
+}

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -2624,7 +2624,13 @@ impl<S: StorageProvider> Engine<S> {
                 SnapshotRollbackGuard::create(&self.storage, group_id.clone(), restore_snapshot)?;
             let (ctx, message_retention_seconds) =
                 match self.context_from_group_snapshot(group_id, &snapshot_name) {
-                    Ok(context) => context,
+                    Ok(Some(context)) => context,
+                    Ok(None) => {
+                        // Evicted-era snapshot: no exporter secret exists for
+                        // it. Restore live state and try the next snapshot.
+                        guard.commit()?;
+                        continue;
+                    }
                     Err(err) => {
                         // Drop on `guard` rolls back to live + releases.
                         guard.commit()?;
@@ -2747,15 +2753,20 @@ impl<S: StorageProvider> Engine<S> {
         Ok(snapshots)
     }
 
+    /// `Ok(None)` means the retained snapshot cannot serve as a peel source:
+    /// its own leaf is evicted, so OpenMLS refuses every exporter derivation
+    /// (`UseAfterEviction`). A re-added member keeps such snapshots from its
+    /// pre-removal era; they must be skipped like an undecryptable snapshot,
+    /// not surfaced as an ingest failure.
     fn context_from_group_snapshot(
         &self,
         group_id: &GroupId,
         snapshot_name: &str,
     ) -> Result<
-        (
+        Option<(
             cgka_traits::group_context::GroupContextSnapshot,
             Option<u64>,
-        ),
+        )>,
         EngineError,
     > {
         self.storage
@@ -2768,12 +2779,15 @@ impl<S: StorageProvider> Engine<S> {
         )
         .map_err(|e| EngineError::Backend(format!("load snapshot group: {e:?}")))?
         .ok_or_else(|| EngineError::UnknownGroup(group_id.clone()))?;
+        if !mls_group.is_active() {
+            return Ok(None);
+        }
         let message_retention_seconds =
             crate::app_components::message_retention_seconds_of_group(&mls_group)?;
-        Ok((
+        Ok(Some((
             group_lifecycle::build_group_context_snapshot(&mls_group, &provider)?,
             message_retention_seconds,
-        ))
+        )))
     }
 }
 


### PR DESCRIPTION
Stacked on #1364.

A marmot evicted from the burrow and invited back in should walk through the new door, not explode in the tunnel. Before this change, a member removed and then re-invited with a fresh KeyPackage rejoined through the Welcome (the mdk#557 stale-state repair), but the re-add commit still reached it as an old-epoch group message. The past-epoch peel probe rolled the group back to a retained snapshot from the member's evicted era, and `build_group_context_snapshot` failed the whole ingest with `export_secret: GroupStateError(UseAfterEviction)`. This is the engine gap that forced `leaver-removal-secrecy/v1` to drop its re-add leg.

Changes:

- `context_from_group_snapshot` reports an evicted snapshot group as unusable (`Ok(None)`) instead of erroring: no exporter secret can exist for it. `try_peel_group_message_from_available_snapshots` skips such snapshots the same way it skips an undecryptable one, so the re-add commit stays on its normal deferred path.
- New harness regression `removed_member_rejoins_via_fresh_welcome`: remove Carol, re-invite her, and require post-rejoin application traffic to flow.
- New portable vector `readd-after-eviction/v1` (registered in the manifest and `SCENARIOS.md`), which passes the strict oracle. The stale `SCENARIOS.md` note about the dropped re-add leg now points here.
- Second commit: the engine subject's `send_application` now routes a refused app send through `try_send_app` + `subject_engine_error`, the same shape as the leave fix in #1364. A send refused with `InvalidTransition` (for example after a requested leave) becomes a failed scenario step with a failure capsule instead of a process panic.

Verification: the new regression and vector pass; all 29 portable vectors pass strict; the full cgka-engine suite passes under the CI invocation (459 tests); the full simulator suite and `just fast-ci` are green. Leave-then-re-add, double re-add, and duplicated-Welcome trial scenarios also pass with this change.

Found and confirmed while probing, deliberately not fixed here: an invitee welcomed onto a fork branch that loses recovery stays stranded even after an admin re-invites it with a fresh KeyPackage. The `self_is_recorded_member` guard in `do_join_peeled_welcome` refuses the replacement Welcome as `WelcomeAlreadyProcessed`. Relaxing that guard is a protocol decision and needs its own design pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for members rejoining a group after removal using a fresh invitation.
  - Rejoined members can resume sending and receiving application messages.
  - Added conformance coverage for removal, re-invitation, state recovery, and group convergence.

- **Bug Fixes**
  - Improved recovery from inactive historical group states by continuing with available recovery data.
  - Failed application sends after leaving now produce clear validation failures without stopping subsequent processing.

- **Documentation**
  - Documented the rejoin-after-removal scenario and added its portable test vector.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->