### PR TITLE
Add cross-adapter convergence assurance

### DIFF
--- a/crates/cgka-conformance-simulator/CONVERGENCE_ROUTE_MATRIX.md
+++ b/crates/cgka-conformance-simulator/CONVERGENCE_ROUTE_MATRIX.md
@@ -13,12 +13,12 @@ below is deliberately not treated as passing evidence.
 
 | Route id | Production owner | Independent model | Mutation sentinel | Current campaign evidence | Current limitation |
 | --- | --- | --- | --- | --- | --- |
-| `ordinary_ingest` | `message_processor/ingest.rs` | partial: `reference_convergence::evaluate` | covered: cutoff admission and output invalidation | observer vectors plus both cross-route recovery regressions | Engine and retained-history committer/observer equivalence are covered; app-runtime and distributed adapters remain open. |
+| `ordinary_ingest` | `message_processor/ingest.rs` | partial: `reference_convergence::evaluate` | covered: cutoff admission and output invalidation | observer vectors, both cross-route recovery regressions, and the shared engine/app/process restart journey | Public protocol and application projection overlap now crosses engine, app-runtime, and process adapters; the adversarial four-party topology and exact state remain open outside engine/retained-history. |
 | `pairwise_fork_recovery` | `message_processor/ingest.rs`, `fork_recovery.rs` | partial: bounded abstract route lifecycle | partial: sibling-model pairwise-loser terminalization | both cross-route recovery regressions plus the pairwise reconsideration tests | Pairwise displacement and deeper-branch reconsideration are covered through retained-history delivery; app-runtime, distributed, and durable-transition permutations remain open. |
 | `stored_convergence` | `distributed_convergence.rs` | partial: selector plus lifecycle models | covered: comparator and frozen membership | both cross-route regressions, restart properties, and convergence chaos | Route choice is not represented in the models, and app-runtime/distributed equivalence remains open. |
 | `candidate_materialization` | `openmls_projection.rs` | partial: dependency/disposition model | covered: retention and frozen membership | engine and retained-history cross-route recovery plus OpenMLS replay | One live pairwise/materialization topology is covered through two delivery routes; app-runtime and distributed equivalence remains open. |
-| `retained_history_replay` | `message_processor/ingest.rs`, `openmls_projection.rs` | partial: unequal-history lifecycle | covered: retention and witness deduplication | `cross-route-retained-history-recovery/v1`, retained-relay equality, and offline journeys | Multi-relay ordering, retention-boundary, and external-adapter permutations remain open. |
-| `crash_restart_recovery` | `engine.rs`, `distributed_convergence.rs` | covered: crash/restart lifecycle | covered: frozen membership and scheduler re-arm | both cross-route encrypted-SQLite regressions plus durable-phase kill properties | Every durable transition and external adapter has not yet been crossed. |
+| `retained_history_replay` | `message_processor/ingest.rs`, `openmls_projection.rs` | partial: unequal-history lifecycle | covered: retention and witness deduplication | `cross-route-retained-history-recovery/v1`, retained-relay equality, offline journeys, and shared app/process offline full-history recovery | One public-projection recovery journey now crosses app-runtime and process; multi-relay ordering, retention boundaries, the four-party adversarial topology, and distributed adapters remain open. |
+| `crash_restart_recovery` | `engine.rs`, `distributed_convergence.rs` | covered: crash/restart lifecycle | covered: frozen membership and scheduler re-arm | both cross-route encrypted-SQLite regressions, durable-phase kill properties, and the shared engine/app/process restart journey | One shared public-state restart checkpoint now crosses engine, app-runtime, and process; every durable transition, the adversarial four-party topology, and distributed adapters remain open. |
 | `application_disposition` | `message_processor/ingest.rs`, `openmls_projection.rs` | covered: reference dispositions | covered: output invalidation | scenario-input ledgers and bidirectional decryptability probes in both cross-route regressions | Sender-visible application invalidation during branch replacement remains incomplete. |
 
 ## Assurance claims
@@ -39,8 +39,8 @@ must be resolved by explicit reviewed evidence.
 
 ## Active production work
 
-MDK #1329 and its stacked #1293 are reviewing production behavior in the
-missing-anchor and pairwise-route areas. This inventory intentionally describes
-current `master` and does not encode either open PR's proposed result as an
-oracle. If a route is removed or its source marker changes, the source audit
-fails and the inventory must be reviewed before evidence is carried forward.
+MDK #1329 has merged the fail-closed missing-anchor behavior and Welcome-repair
+retirement. Its formerly stacked #1293 remains open. This inventory describes
+current `master` and does not encode #1293's proposed result as an oracle. If a
+route is removed or its source marker changes, the source audit fails and the
+inventory must be reviewed before evidence is carried forward.

--- a/crates/cgka-conformance-simulator/PROPERTY_TESTS.md
+++ b/crates/cgka-conformance-simulator/PROPERTY_TESTS.md
@@ -130,8 +130,10 @@ helpers. Shared harness generators live in `src/proptest_support.rs`.
   state commitment.
 - Boundary: the engine harness exposes inbound delivery events, not the app's durable local-sender projection, and its
   event window is intentionally cleared by restart. The test compares those narrower engine observations only where
-  their semantics overlap. It does not claim exact MLS-state or active-decryptability evidence from app/process
-  adapters.
+  their semantics overlap. On app/process adapters, a labelled accepted acknowledgement attests that the mutation's
+  production command returned after publishing; the resulting `PendingResolution { resolution: "confirmed" }` is not
+  independent transport-delivery evidence on those subjects. It does not claim exact MLS-state or
+  active-decryptability evidence from app/process adapters.
 - Why: fixture portability and capability preflight alone do not prove that production-shaped adapters execute the
   same scenario meaning.
 
@@ -141,7 +143,8 @@ helpers. Shared harness generators live in `src/proptest_support.rs`.
   two subjects that declare participant-connectivity and retained-history capabilities.
 - Checks: Bob misses a profile commit and application message while offline, Carol durably restarts, Bob reconnects,
   every participant performs a full-history repair, and both adapters reach the same public protocol commitment,
-  roster, profile, administration, and duplicate-free application-message set.
+  roster, profile, administration, and duplicate-free application-message set. Bob's app-local online, reopen, and
+  catch-up diagnostics pin the offline/recovery precondition rather than inferring it only from the final projection.
 - Boundary: this is public projection evidence. Adapter-local message ids, runtime event counts, database paths, and
   other execution-specific observations are deliberately not compared.
 

--- a/crates/cgka-conformance-simulator/PROPERTY_TESTS.md
+++ b/crates/cgka-conformance-simulator/PROPERTY_TESTS.md
@@ -118,6 +118,33 @@ helpers. Shared harness generators live in `src/proptest_support.rs`.
 - Checks: confirm advances one epoch. Fail restores the prior epoch and a retry can advance normally.
 - Why: pending-publish rollback must leave the group in a reusable stable state.
 
+## Cross-Adapter Contract Tests
+
+### `engine_app_runtime_and_process_adapters_reach_equivalent_public_state`
+
+- Runs: one canonical three-participant IR through the engine harness, the in-process `MarmotAppRuntime` adapter, and
+  three isolated app participant processes.
+- Checks: explicit accepted-publication checkpoints retain the same meaning for the engine's staged transport and the
+  app adapters' already-published commands; all participants agree on epoch, roster, profile, and administrator state
+  after a durable restart; app-runtime and process projections retain the same application-message multiset and public
+  state commitment.
+- Boundary: the engine harness exposes inbound delivery events, not the app's durable local-sender projection, and its
+  event window is intentionally cleared by restart. The test compares those narrower engine observations only where
+  their semantics overlap. It does not claim exact MLS-state or active-decryptability evidence from app/process
+  adapters.
+- Why: fixture portability and capability preflight alone do not prove that production-shaped adapters execute the
+  same scenario meaning.
+
+### `app_runtime_and_process_adapters_recover_the_same_offline_projection`
+
+- Runs: a companion form of the same three-participant IR through the app-runtime and separate-process adapters, the
+  two subjects that declare participant-connectivity and retained-history capabilities.
+- Checks: Bob misses a profile commit and application message while offline, Carol durably restarts, Bob reconnects,
+  every participant performs a full-history repair, and both adapters reach the same public protocol commitment,
+  roster, profile, administration, and duplicate-free application-message set.
+- Boundary: this is public projection evidence. Adapter-local message ids, runtime event counts, database paths, and
+  other execution-specific observations are deliberately not compared.
+
 ## Shared Generators
 
 ### `intent_seq(3, range)`

--- a/crates/cgka-conformance-simulator/README.md
+++ b/crates/cgka-conformance-simulator/README.md
@@ -279,8 +279,11 @@ retired or re-armed from the same acknowledgement. A state transition with no tr
 no-op publication rather than inventing a synthetic artifact. ScenarioSpec v2 and v3 drive the same contract through
 `acknowledge_outbound`: the runner polls opaque artifacts, optionally selects a stable scenario publication label and
 artifact role, and applies the declared transport outcome. Engine-generated work has no publication label and can be
-acknowledged as the client's current unresolved outbound set. There is no compatibility constructor, silent
-auto-confirmation mode, or second subject publication capability. `ProtocolProfile::Legacy` is separate from that
+acknowledged as the client's current unresolved outbound set. Production-shaped app adapters publish inside their
+command surface rather than exposing transport artifacts; after a successful named mutation they report that its
+publication is already accepted, allowing the same accepted checkpoint to remain in canonical IR. They reject a later
+`reached_no_endpoint` outcome because an accepted publication cannot be rolled back. There is no compatibility
+constructor or silent auto-confirmation mode in the engine subject. `ProtocolProfile::Legacy` is separate from that
 removed lifecycle: it selects the engine's legacy application-profile compatibility through
 `legacy_compatibility_profile()`, but it uses the same explicit outbound contract as `ProtocolProfile::Current`.
 ScenarioSpec v1 is intentionally unsupported after the repository-owned v2 cutover and is rejected before any subject
@@ -410,10 +413,13 @@ omitted values and clear explicitly empty values. At least one field is required
 `group_profile` to assert the requested values directly; `clients_converged` also compares both profile fields.
 
 Staged publications are referenced by string labels chosen inside the scenario. `acknowledge_outbound.publication`
-selects artifacts emitted by that operation; omitting it selects all currently unresolved artifacts for the client.
-The optional `selection` further restricts the set to `all`, `state_confirmation`, `welcome`, `group_message`, or
+selects artifacts emitted by that operation; on an auto-publishing app adapter, the same label identifies the completed
+mutation whose command already returned successfully. Omitting the label selects all currently unresolved artifacts
+for adapters that expose them.
+The optional `selection` further restricts an exposed artifact set to `all`, `state_confirmation`, `welcome`, `group_message`, or
 `regenerated_queued_intent`. `outcome` is either `accepted` or `reached_no_endpoint`. A labelled acknowledgement fails
-when no unresolved artifact matches, while an unlabelled acknowledgement is an idempotent drain and may match nothing.
+when neither an unresolved artifact nor an already-accepted named app mutation matches, while an unlabelled
+acknowledgement is an idempotent drain and may match nothing.
 `group_message` includes both application messages and proposals because both use the group-message transport envelope.
 Proposal artifacts are engine-generated and have no scenario publication label, so scenarios select them with an
 unlabelled `group_message` acknowledgement unless a future proposal action introduces labels. Client labels are stable

--- a/crates/cgka-conformance-simulator/src/app_runtime.rs
+++ b/crates/cgka-conformance-simulator/src/app_runtime.rs
@@ -25,8 +25,8 @@ use crate::{
     ClientEventCounts, ClientObservation, ConvergenceSubject, ForkRecoveryObservation,
     ScenarioAdminPolicyObservation, ScenarioInputLedgerEntry, SubjectCapability,
     SubjectCreateGroup, SubjectDescriptor, SubjectError, SubjectFailureCategory,
-    SubjectInviteMembers, SubjectRemoveMembers, SubjectSelfUpdate, SubjectSendApplication,
-    SubjectUpdateAdminPolicy, SubjectUpdateGroupData,
+    SubjectInviteMembers, SubjectOutboundArtifact, SubjectOutboundOutcome, SubjectRemoveMembers,
+    SubjectSelfUpdate, SubjectSendApplication, SubjectUpdateAdminPolicy, SubjectUpdateGroupData,
 };
 
 pub const APP_RUNTIME_OBSERVATION_SCHEMA_VERSION: &str = "1";
@@ -119,7 +119,7 @@ pub struct AppRuntimeHarness {
     participants: BTreeMap<String, Participant>,
     scenario_groups: BTreeMap<String, GroupId>,
     active_scenario_group: Option<String>,
-    accepted_publications: BTreeSet<(String, String)>,
+    accepted_publications: BTreeMap<String, BTreeSet<String>>,
 }
 
 impl AppRuntimeHarness {
@@ -174,7 +174,7 @@ impl AppRuntimeHarness {
             participants,
             scenario_groups: BTreeMap::new(),
             active_scenario_group: None,
-            accepted_publications: BTreeSet::new(),
+            accepted_publications: BTreeMap::new(),
         })
     }
 
@@ -347,6 +347,13 @@ impl AppRuntimeHarness {
             .iter()
             .map(|label| Ok(self.participant(label)?.account_id.clone()))
             .collect()
+    }
+
+    fn record_accepted_publication(&mut self, client: &str, publication: &str) {
+        self.accepted_publications
+            .entry(client.to_owned())
+            .or_default()
+            .insert(publication.to_owned());
     }
 
     async fn refresh_cached_members(&mut self, clients: &[String]) -> Result<(), SubjectError> {
@@ -641,8 +648,7 @@ impl ConvergenceSubject for AppRuntimeHarness {
         self.scenario_groups.insert(group_label, group_id.clone());
         self.apply_admin_set(action.creator, &group_id, action.initial_admins)
             .await?;
-        self.accepted_publications
-            .insert((action.creator.to_owned(), action.pending.to_owned()));
+        self.record_accepted_publication(action.creator, action.pending);
         Ok(())
     }
 
@@ -658,8 +664,7 @@ impl ConvergenceSubject for AppRuntimeHarness {
             .invite_members(&participant.account_id, &group_id, &invitees)
             .await
             .map_err(app_error)?;
-        self.accepted_publications
-            .insert((action.inviter.to_owned(), action.pending.to_owned()));
+        self.record_accepted_publication(action.inviter, action.pending);
         Ok(())
     }
 
@@ -679,8 +684,7 @@ impl ConvergenceSubject for AppRuntimeHarness {
             )
             .await
             .map_err(app_error)?;
-        self.accepted_publications
-            .insert((action.client.to_owned(), action.pending.to_owned()));
+        self.record_accepted_publication(action.client, action.pending);
         Ok(())
     }
 
@@ -696,8 +700,7 @@ impl ConvergenceSubject for AppRuntimeHarness {
             .remove_members(&participant.account_id, &group_id, &members)
             .await
             .map_err(app_error)?;
-        self.accepted_publications
-            .insert((action.remover.to_owned(), action.pending.to_owned()));
+        self.record_accepted_publication(action.remover, action.pending);
         Ok(())
     }
 
@@ -709,8 +712,7 @@ impl ConvergenceSubject for AppRuntimeHarness {
             .schedule_manual_self_update(&participant.account_id, &group_id)
             .await
             .map_err(app_error)?;
-        self.accepted_publications
-            .insert((action.client.to_owned(), action.pending.to_owned()));
+        self.record_accepted_publication(action.client, action.pending);
         Ok(())
     }
 
@@ -722,20 +724,47 @@ impl ConvergenceSubject for AppRuntimeHarness {
         self.apply_admin_set(action.client, &group_id, action.admins)
             .await?;
         if let Some(pending) = action.pending {
-            self.accepted_publications
-                .insert((action.client.to_owned(), pending.to_owned()));
+            self.record_accepted_publication(action.client, pending);
         }
         Ok(())
     }
 
-    fn scenario_publication_already_accepted(
-        &self,
+    fn scenario_publication_already_accepted(&self, client: &str, publication: &str) -> bool {
+        self.accepted_publications
+            .get(client)
+            .is_some_and(|publications| publications.contains(publication))
+    }
+
+    fn poll_outbound(
+        &mut self,
+        _client: &str,
+    ) -> Result<Vec<SubjectOutboundArtifact>, SubjectError> {
+        // App commands publish before returning, so this adapter never has an
+        // unresolved transport-ready artifact for the scenario runner.
+        Ok(Vec::new())
+    }
+
+    async fn acknowledge_outbound(
+        &mut self,
         client: &str,
         publication: &str,
-    ) -> Result<bool, SubjectError> {
-        Ok(self
-            .accepted_publications
-            .contains(&(client.to_owned(), publication.to_owned())))
+        outcome: SubjectOutboundOutcome,
+    ) -> Result<(), SubjectError> {
+        if !self.scenario_publication_already_accepted(client, publication) {
+            return Err(SubjectError::classified(
+                SubjectFailureCategory::ExpectedRefusal,
+                "publication_not_found",
+                "the app runtime has no accepted publication with that label",
+            ));
+        }
+        if outcome != SubjectOutboundOutcome::Accepted {
+            return Err(SubjectError::classified(
+                SubjectFailureCategory::ExpectedRefusal,
+                "publication_rollback_rejected",
+                "an app-runtime publication already accepted by transport cannot be rolled back",
+            ));
+        }
+        Ok(())
     }
 
     async fn send_application(

--- a/crates/cgka-conformance-simulator/src/app_runtime.rs
+++ b/crates/cgka-conformance-simulator/src/app_runtime.rs
@@ -119,6 +119,7 @@ pub struct AppRuntimeHarness {
     participants: BTreeMap<String, Participant>,
     scenario_groups: BTreeMap<String, GroupId>,
     active_scenario_group: Option<String>,
+    accepted_publications: BTreeSet<(String, String)>,
 }
 
 impl AppRuntimeHarness {
@@ -173,6 +174,7 @@ impl AppRuntimeHarness {
             participants,
             scenario_groups: BTreeMap::new(),
             active_scenario_group: None,
+            accepted_publications: BTreeSet::new(),
         })
     }
 
@@ -585,6 +587,7 @@ impl ConvergenceSubject for AppRuntimeHarness {
                 SubjectCapability::EventObservation,
                 SubjectCapability::AdminPolicyObservation,
                 SubjectCapability::CrashReopen,
+                SubjectCapability::OutboundPublication,
                 SubjectCapability::ParticipantConnectivity,
                 SubjectCapability::MultiGroup,
                 SubjectCapability::RetainedRelayHistory,
@@ -638,6 +641,8 @@ impl ConvergenceSubject for AppRuntimeHarness {
         self.scenario_groups.insert(group_label, group_id.clone());
         self.apply_admin_set(action.creator, &group_id, action.initial_admins)
             .await?;
+        self.accepted_publications
+            .insert((action.creator.to_owned(), action.pending.to_owned()));
         Ok(())
     }
 
@@ -653,6 +658,8 @@ impl ConvergenceSubject for AppRuntimeHarness {
             .invite_members(&participant.account_id, &group_id, &invitees)
             .await
             .map_err(app_error)?;
+        self.accepted_publications
+            .insert((action.inviter.to_owned(), action.pending.to_owned()));
         Ok(())
     }
 
@@ -672,6 +679,8 @@ impl ConvergenceSubject for AppRuntimeHarness {
             )
             .await
             .map_err(app_error)?;
+        self.accepted_publications
+            .insert((action.client.to_owned(), action.pending.to_owned()));
         Ok(())
     }
 
@@ -687,6 +696,8 @@ impl ConvergenceSubject for AppRuntimeHarness {
             .remove_members(&participant.account_id, &group_id, &members)
             .await
             .map_err(app_error)?;
+        self.accepted_publications
+            .insert((action.remover.to_owned(), action.pending.to_owned()));
         Ok(())
     }
 
@@ -698,6 +709,8 @@ impl ConvergenceSubject for AppRuntimeHarness {
             .schedule_manual_self_update(&participant.account_id, &group_id)
             .await
             .map_err(app_error)?;
+        self.accepted_publications
+            .insert((action.client.to_owned(), action.pending.to_owned()));
         Ok(())
     }
 
@@ -707,7 +720,22 @@ impl ConvergenceSubject for AppRuntimeHarness {
     ) -> Result<(), SubjectError> {
         let group_id = self.active_group()?;
         self.apply_admin_set(action.client, &group_id, action.admins)
-            .await
+            .await?;
+        if let Some(pending) = action.pending {
+            self.accepted_publications
+                .insert((action.client.to_owned(), pending.to_owned()));
+        }
+        Ok(())
+    }
+
+    fn scenario_publication_already_accepted(
+        &self,
+        client: &str,
+        publication: &str,
+    ) -> Result<bool, SubjectError> {
+        Ok(self
+            .accepted_publications
+            .contains(&(client.to_owned(), publication.to_owned())))
     }
 
     async fn send_application(

--- a/crates/cgka-conformance-simulator/src/process_orchestrator.rs
+++ b/crates/cgka-conformance-simulator/src/process_orchestrator.rs
@@ -20,8 +20,8 @@ use crate::node_protocol::{
 use crate::{
     CompiledScenarioV2, ResolvedScenarioInputV1, ScenarioActionScheduleV2,
     ScenarioInputProvenanceV1, ScenarioRelaySyncModeV2, ScenarioSpec, ScenarioStep,
-    SubjectCapability, SubjectDescriptor, SubjectFailureCategory, TraceExpectation,
-    canonical_scenario_ir_sha256, compile_scenario, preflight_compiled_scenario,
+    SubjectCapability, SubjectDescriptor, SubjectFailureCategory, SubjectOutboundOutcome,
+    TraceExpectation, canonical_scenario_ir_sha256, compile_scenario, preflight_compiled_scenario,
 };
 
 pub const PROCESS_SCENARIO_REPORT_SCHEMA_VERSION: &str = "1";
@@ -190,6 +190,7 @@ pub struct ProcessOrchestrator {
     input_provenance: Option<ScenarioInputProvenanceV1>,
     executed_scenario_ir_sha256: String,
     expected_outcomes: Vec<TraceExpectation>,
+    accepted_publications: BTreeMap<String, BTreeSet<String>>,
 }
 
 struct NodeProcess {
@@ -330,6 +331,7 @@ impl ProcessOrchestrator {
             input_provenance: None,
             executed_scenario_ir_sha256,
             expected_outcomes: Vec::new(),
+            accepted_publications: BTreeMap::new(),
         };
         for client in &clients {
             orchestrator.launch_participant(client, "launch").await?;
@@ -454,6 +456,13 @@ impl ProcessOrchestrator {
         }
     }
 
+    fn record_accepted_publication(&mut self, client: &str, publication: &str) {
+        self.accepted_publications
+            .entry(client.to_owned())
+            .or_default()
+            .insert(publication.to_owned());
+    }
+
     async fn execute_action(
         &mut self,
         action: &crate::CompiledScenarioActionV2,
@@ -471,6 +480,7 @@ impl ProcessOrchestrator {
                 name,
                 invitees,
                 initial_admins,
+                pending,
                 ..
             } => {
                 let members = self.account_ids(invitees).map_err(orchestrator_failure)?;
@@ -516,10 +526,13 @@ impl ProcessOrchestrator {
                     )
                     .await?;
                 }
+                self.record_accepted_publication(creator, pending);
                 Ok((vec![creator.clone()], ProcessActionStatusV1::Completed))
             }
             ScenarioStep::InviteMembers {
-                inviter, invitees, ..
+                inviter,
+                invitees,
+                pending,
             } => {
                 self.select_group(inviter, &group).await?;
                 let member_accounts = self.account_ids(invitees).map_err(orchestrator_failure)?;
@@ -531,10 +544,13 @@ impl ProcessOrchestrator {
                     },
                 )
                 .await?;
+                self.record_accepted_publication(inviter, pending);
                 Ok((vec![inviter.clone()], ProcessActionStatusV1::Completed))
             }
             ScenarioStep::RemoveMembers {
-                remover, members, ..
+                remover,
+                members,
+                pending,
             } => {
                 self.select_group(remover, &group).await?;
                 let member_accounts = self.account_ids(members).map_err(orchestrator_failure)?;
@@ -546,9 +562,10 @@ impl ProcessOrchestrator {
                     },
                 )
                 .await?;
+                self.record_accepted_publication(remover, pending);
                 Ok((vec![remover.clone()], ProcessActionStatusV1::Completed))
             }
-            ScenarioStep::SelfUpdate { client, .. } => {
+            ScenarioStep::SelfUpdate { client, pending } => {
                 self.select_group(client, &group).await?;
                 self.expect_ack(
                     client,
@@ -557,9 +574,14 @@ impl ProcessOrchestrator {
                     },
                 )
                 .await?;
+                self.record_accepted_publication(client, pending);
                 Ok((vec![client.clone()], ProcessActionStatusV1::Completed))
             }
-            ScenarioStep::UpdateGroupData { client, name, .. } => {
+            ScenarioStep::UpdateGroupData {
+                client,
+                name,
+                pending,
+            } => {
                 self.select_group(client, &group).await?;
                 self.expect_ack(
                     client,
@@ -569,13 +591,14 @@ impl ProcessOrchestrator {
                     },
                 )
                 .await?;
+                self.record_accepted_publication(client, pending);
                 Ok((vec![client.clone()], ProcessActionStatusV1::Completed))
             }
             ScenarioStep::UpdateGroupProfile {
                 client,
                 name,
                 description,
-                ..
+                pending,
             } => {
                 self.select_group(client, &group).await?;
                 self.expect_ack(
@@ -587,9 +610,14 @@ impl ProcessOrchestrator {
                     },
                 )
                 .await?;
+                self.record_accepted_publication(client, pending);
                 Ok((vec![client.clone()], ProcessActionStatusV1::Completed))
             }
-            ScenarioStep::UpdateAdminPolicy { client, admins, .. } => {
+            ScenarioStep::UpdateAdminPolicy {
+                client,
+                admins,
+                pending,
+            } => {
                 self.select_group(client, &group).await?;
                 let admin_accounts = self.account_ids(admins).map_err(orchestrator_failure)?;
                 self.expect_ack(
@@ -600,6 +628,7 @@ impl ProcessOrchestrator {
                     },
                 )
                 .await?;
+                self.record_accepted_publication(client, pending);
                 Ok((vec![client.clone()], ProcessActionStatusV1::Completed))
             }
             ScenarioStep::SendAppMessage { sender, payload } => {
@@ -671,10 +700,24 @@ impl ProcessOrchestrator {
                 report.observations.extend(observations);
                 Ok((labels, ProcessActionStatusV1::Completed))
             }
-            ScenarioStep::AcknowledgeOutbound { client, .. } => Ok((
-                vec![client.clone()],
-                ProcessActionStatusV1::AlreadyPublished,
-            )),
+            ScenarioStep::AcknowledgeOutbound {
+                client,
+                publication,
+                outcome,
+                ..
+            } => {
+                validate_auto_published_acknowledgement(
+                    &self.accepted_publications,
+                    client,
+                    publication.as_deref(),
+                    *outcome,
+                )
+                .map_err(|error| (Some(client.clone()), error))?;
+                Ok((
+                    vec![client.clone()],
+                    ProcessActionStatusV1::AlreadyPublished,
+                ))
+            }
             ScenarioStep::Barrier { name } => {
                 hook.before_barrier(name)
                     .await
@@ -1374,6 +1417,38 @@ fn action_participant(step: &ScenarioStep) -> Option<String> {
     }
 }
 
+fn validate_auto_published_acknowledgement(
+    accepted_publications: &BTreeMap<String, BTreeSet<String>>,
+    client: &str,
+    publication: Option<&str>,
+    outcome: SubjectOutboundOutcome,
+) -> Result<(), NodeErrorV1> {
+    let Some(publication) = publication else {
+        return Ok(());
+    };
+    let known = accepted_publications
+        .get(client)
+        .is_some_and(|publications| publications.contains(publication));
+    if !known {
+        return Err(NodeErrorV1 {
+            code: "publication_not_found".into(),
+            category: SubjectFailureCategory::ExpectedRefusal,
+            retryable: false,
+            message: "the process adapter has no accepted publication with that label".into(),
+        });
+    }
+    if outcome != SubjectOutboundOutcome::Accepted {
+        return Err(NodeErrorV1 {
+            code: "publication_rollback_rejected".into(),
+            category: SubjectFailureCategory::ExpectedRefusal,
+            retryable: false,
+            message: "a process publication already accepted by transport cannot be rolled back"
+                .into(),
+        });
+    }
+    Ok(())
+}
+
 fn process_action_error(error: (Option<String>, NodeErrorV1)) -> ProcessOrchestratorError {
     ProcessOrchestratorError::new(error.1.code, error.1.message)
 }
@@ -1496,6 +1571,46 @@ mod tests {
         let error = render_node_arg("{shell}", "p", "r", host, child).unwrap_err();
         assert_eq!(error.code, "unknown_node_command_placeholder");
     }
+
+    #[test]
+    fn process_auto_published_acknowledgements_validate_labels_and_outcomes() {
+        let accepted = BTreeMap::from([("alice".into(), BTreeSet::from(["create".into()]))]);
+        validate_auto_published_acknowledgement(
+            &accepted,
+            "alice",
+            Some("create"),
+            SubjectOutboundOutcome::Accepted,
+        )
+        .unwrap();
+        validate_auto_published_acknowledgement(
+            &accepted,
+            "alice",
+            None,
+            SubjectOutboundOutcome::Accepted,
+        )
+        .unwrap();
+
+        let unknown = validate_auto_published_acknowledgement(
+            &accepted,
+            "alice",
+            Some("missing"),
+            SubjectOutboundOutcome::Accepted,
+        )
+        .unwrap_err();
+        assert_eq!(unknown.code, "publication_not_found");
+        assert_eq!(unknown.category, SubjectFailureCategory::ExpectedRefusal);
+
+        let rollback = validate_auto_published_acknowledgement(
+            &accepted,
+            "alice",
+            Some("create"),
+            SubjectOutboundOutcome::ReachedNoEndpoint,
+        )
+        .unwrap_err();
+        assert_eq!(rollback.code, "publication_rollback_rejected");
+        assert_eq!(rollback.category, SubjectFailureCategory::ExpectedRefusal);
+    }
+
     #[test]
     fn observation_schema_is_rejected_before_typed_observation_decoding() {
         let line = format!(

--- a/crates/cgka-conformance-simulator/src/scenario.rs
+++ b/crates/cgka-conformance-simulator/src/scenario.rs
@@ -906,18 +906,20 @@ async fn execute_scenario_step(
         } => {
             let client_label = client.clone();
             let already_accepted = if let Some(publication) = publication {
-                subject
-                    .scenario_publication_already_accepted(client, publication)
-                    .map_err(|error| subject_step_error(step_index, error))?
+                subject.scenario_publication_already_accepted(client, publication)
             } else {
                 false
             };
             if already_accepted {
                 if *outcome != SubjectOutboundOutcome::Accepted {
-                    return Err(err(
+                    return Err(subject_step_error(
                         step_index,
-                        format!(
-                            "publication {publication:?} for client {client} was already accepted and cannot be rolled back"
+                        SubjectError::classified(
+                            SubjectFailureCategory::ExpectedRefusal,
+                            "publication_rollback_rejected",
+                            format!(
+                                "publication {publication:?} for client {client} was already accepted and cannot be rolled back"
+                            ),
                         ),
                     ));
                 }
@@ -933,10 +935,14 @@ async fn execute_scenario_step(
                     })
                     .collect::<Vec<_>>();
                 if artifacts.is_empty() && publication.is_some() {
-                    return Err(err(
+                    return Err(subject_step_error(
                         step_index,
-                        format!(
-                            "no unresolved outbound artifacts matched client {client}, publication {publication:?}, selection {selection:?}"
+                        SubjectError::classified(
+                            SubjectFailureCategory::ExpectedRefusal,
+                            "publication_not_found",
+                            format!(
+                                "no unresolved outbound artifacts matched client {client}, publication {publication:?}, selection {selection:?}"
+                            ),
                         ),
                     ));
                 }

--- a/crates/cgka-conformance-simulator/src/scenario.rs
+++ b/crates/cgka-conformance-simulator/src/scenario.rs
@@ -905,29 +905,47 @@ async fn execute_scenario_step(
             outcome,
         } => {
             let client_label = client.clone();
-            let artifacts = subject
-                .poll_outbound(client)
-                .map_err(|error| subject_step_error(step_index, error))?
-                .into_iter()
-                .filter(|artifact| {
-                    publication.as_ref().is_none_or(|publication| {
-                        artifact.publication.as_ref() == Some(publication)
-                    }) && selection.matches(artifact)
-                })
-                .collect::<Vec<_>>();
-            if artifacts.is_empty() && publication.is_some() {
-                return Err(err(
-                    step_index,
-                    format!(
-                        "no unresolved outbound artifacts matched client {client}, publication {publication:?}, selection {selection:?}"
-                    ),
-                ));
-            }
-            for artifact in artifacts {
+            let already_accepted = if let Some(publication) = publication {
                 subject
-                    .acknowledge_outbound(client, &artifact.outbound_id, *outcome)
-                    .await
-                    .map_err(|error| subject_step_error(step_index, error))?;
+                    .scenario_publication_already_accepted(client, publication)
+                    .map_err(|error| subject_step_error(step_index, error))?
+            } else {
+                false
+            };
+            if already_accepted {
+                if *outcome != SubjectOutboundOutcome::Accepted {
+                    return Err(err(
+                        step_index,
+                        format!(
+                            "publication {publication:?} for client {client} was already accepted and cannot be rolled back"
+                        ),
+                    ));
+                }
+            } else {
+                let artifacts = subject
+                    .poll_outbound(client)
+                    .map_err(|error| subject_step_error(step_index, error))?
+                    .into_iter()
+                    .filter(|artifact| {
+                        publication.as_ref().is_none_or(|publication| {
+                            artifact.publication.as_ref() == Some(publication)
+                        }) && selection.matches(artifact)
+                    })
+                    .collect::<Vec<_>>();
+                if artifacts.is_empty() && publication.is_some() {
+                    return Err(err(
+                        step_index,
+                        format!(
+                            "no unresolved outbound artifacts matched client {client}, publication {publication:?}, selection {selection:?}"
+                        ),
+                    ));
+                }
+                for artifact in artifacts {
+                    subject
+                        .acknowledge_outbound(client, &artifact.outbound_id, *outcome)
+                        .await
+                        .map_err(|error| subject_step_error(step_index, error))?;
+                }
             }
             if let Some(publication) = publication {
                 pending_resolutions.push(PendingResolutionObservation {

--- a/crates/cgka-conformance-simulator/src/subject.rs
+++ b/crates/cgka-conformance-simulator/src/subject.rs
@@ -366,12 +366,8 @@ pub trait ConvergenceSubject: Send {
     /// subjects return `false` and expose transport-ready artifacts for an
     /// explicit acknowledgement; auto-publishing app adapters override this
     /// so the same canonical IR can retain its publication checkpoint.
-    fn scenario_publication_already_accepted(
-        &self,
-        _client: &str,
-        _publication: &str,
-    ) -> Result<bool, SubjectError> {
-        Ok(false)
+    fn scenario_publication_already_accepted(&self, _client: &str, _publication: &str) -> bool {
+        false
     }
 
     fn poll_outbound(

--- a/crates/cgka-conformance-simulator/src/subject.rs
+++ b/crates/cgka-conformance-simulator/src/subject.rs
@@ -361,6 +361,19 @@ pub trait ConvergenceSubject: Send {
         Err(SubjectError::unsupported(SubjectCapability::VirtualTime))
     }
 
+    /// Return whether an adapter already published and accepted a named
+    /// scenario action through its production-shaped command surface. Engine
+    /// subjects return `false` and expose transport-ready artifacts for an
+    /// explicit acknowledgement; auto-publishing app adapters override this
+    /// so the same canonical IR can retain its publication checkpoint.
+    fn scenario_publication_already_accepted(
+        &self,
+        _client: &str,
+        _publication: &str,
+    ) -> Result<bool, SubjectError> {
+        Ok(false)
+    }
+
     fn poll_outbound(
         &mut self,
         _client: &str,

--- a/crates/cgka-conformance-simulator/tests/app_runtime_adapter.rs
+++ b/crates/cgka-conformance-simulator/tests/app_runtime_adapter.rs
@@ -5,7 +5,8 @@ use std::time::Duration;
 
 use cgka_conformance_simulator::{
     AppRuntimeHarness, ConvergenceSubject, GeneratedScenarioCase, GeneratedSubjectKind,
-    HarnessStorageMode, ScenarioSpec, ScenarioStep, TraceExpectation,
+    HarnessStorageMode, ScenarioOutboundSelection, ScenarioSpec, ScenarioStep, ScenarioStepStatus,
+    SubjectFailureCategory, SubjectOutboundOutcome, TraceExpectation,
     run_generated_case_report_with_capture_on_subject, run_scenario_report_with_subject,
 };
 
@@ -56,6 +57,38 @@ fn two_client_scenario() -> ScenarioSpec {
                     clients: clients.clone(),
                 },
             ),
+        ],
+    }
+}
+
+fn publication_acknowledgement_scenario(
+    name: &str,
+    publication: Option<&str>,
+    outcome: SubjectOutboundOutcome,
+) -> ScenarioSpec {
+    ScenarioSpec {
+        name: name.into(),
+        spec_version: "2".into(),
+        clients: vec!["alice".into()],
+        topology: Default::default(),
+        steps: vec![
+            in_group(
+                "main",
+                ScenarioStep::CreateGroup {
+                    creator: "alice".into(),
+                    name: "publication contract".into(),
+                    invitees: Vec::new(),
+                    required_features: Vec::new(),
+                    initial_admins: Some(vec!["alice".into()]),
+                    pending: "create".into(),
+                },
+            ),
+            ScenarioStep::AcknowledgeOutbound {
+                client: "alice".into(),
+                publication: publication.map(str::to_owned),
+                selection: ScenarioOutboundSelection::All,
+                outcome,
+            },
         ],
     }
 }
@@ -144,6 +177,46 @@ async fn app_runtime_adapter_is_selectable_for_a_saved_generated_case() {
         "marmot_app_runtime"
     );
     assert!(report.expectation_failures.is_empty(), "{report:#?}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn app_runtime_publication_acknowledgements_fail_closed_without_mid_run_capability_errors() {
+    for (name, publication, outcome, expected_failure) in [
+        (
+            "accepted-publication-cannot-roll-back",
+            Some("create"),
+            SubjectOutboundOutcome::ReachedNoEndpoint,
+            Some("publication_rollback_rejected"),
+        ),
+        (
+            "unknown-publication-is-refused",
+            Some("missing"),
+            SubjectOutboundOutcome::Accepted,
+            Some("publication_not_found"),
+        ),
+        (
+            "unlabelled-publication-drain-is-idempotent",
+            None,
+            SubjectOutboundOutcome::Accepted,
+            None,
+        ),
+    ] {
+        let spec = publication_acknowledgement_scenario(name, publication, outcome);
+        let mut subject = AppRuntimeHarness::new(&spec.clients).await.unwrap();
+        let report = run_scenario_report_with_subject(&spec, None, Vec::new(), &mut subject)
+            .await
+            .unwrap();
+        match expected_failure {
+            Some(expected_kind) => assert!(matches!(
+                &report.step_log[1].status,
+                ScenarioStepStatus::Failed { kind, category, .. }
+                    if kind == expected_kind
+                        && *category == SubjectFailureCategory::ExpectedRefusal
+            )),
+            None => assert!(report.step_log[1].status.is_completed()),
+        }
+        subject.shutdown().await;
+    }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/crates/cgka-conformance-simulator/tests/process_orchestrator.rs
+++ b/crates/cgka-conformance-simulator/tests/process_orchestrator.rs
@@ -149,44 +149,116 @@ fn controlled_relay_topology() -> ScenarioTopologyV2 {
     }
 }
 
-fn cross_adapter_scenario() -> ScenarioSpec {
-    ScenarioSpec {
-        name: "cross-adapter-public-state".into(),
-        spec_version: "3".into(),
-        clients: vec!["alice".into()],
-        topology: Default::default(),
-        steps: vec![
-            in_group(
-                "main",
-                ScenarioStep::CreateGroup {
-                    creator: "alice".into(),
-                    name: "initial".into(),
-                    invitees: Vec::new(),
-                    required_features: Vec::new(),
-                    initial_admins: Some(vec!["alice".into()]),
-                    pending: "create".into(),
-                },
-            ),
-            in_group(
-                "main",
-                ScenarioStep::UpdateGroupProfile {
-                    client: "alice".into(),
-                    name: Some("equivalent result".into()),
-                    description: Some("equivalent description".into()),
-                    pending: "rename".into(),
-                },
-            ),
-            ScenarioStep::DeliverAll,
-            ScenarioStep::Tick {
-                clients: vec!["alice".into()],
+fn cross_adapter_scenario(include_offline_recovery: bool) -> ScenarioSpec {
+    let clients = vec!["alice".into(), "bob".into(), "carol".into()];
+    let mut steps = vec![
+        in_group(
+            "main",
+            ScenarioStep::CreateGroup {
+                creator: "alice".into(),
+                name: "initial".into(),
+                invitees: vec!["bob".into(), "carol".into()],
+                required_features: Vec::new(),
+                initial_admins: Some(vec!["alice".into()]),
+                pending: "create".into(),
             },
-            in_group(
-                "main",
-                ScenarioStep::Observe {
-                    clients: vec!["alice".into()],
-                },
-            ),
-        ],
+        ),
+        ScenarioStep::AcknowledgeOutbound {
+            client: "alice".into(),
+            publication: Some("create".into()),
+            selection: Default::default(),
+            outcome: cgka_conformance_simulator::SubjectOutboundOutcome::Accepted,
+        },
+        ScenarioStep::DeliverAll,
+        ScenarioStep::Tick {
+            clients: vec!["bob".into(), "carol".into()],
+        },
+        in_group(
+            "main",
+            ScenarioStep::ClearEvents {
+                clients: clients.clone(),
+            },
+        ),
+    ];
+    if include_offline_recovery {
+        steps.push(ScenarioStep::SetClientOffline {
+            client: "bob".into(),
+        });
+    }
+    steps.extend([
+        in_group(
+            "main",
+            ScenarioStep::UpdateGroupProfile {
+                client: "alice".into(),
+                name: Some("equivalent result".into()),
+                description: Some("equivalent description".into()),
+                pending: "rename".into(),
+            },
+        ),
+        ScenarioStep::AcknowledgeOutbound {
+            client: "alice".into(),
+            publication: Some("rename".into()),
+            selection: Default::default(),
+            outcome: cgka_conformance_simulator::SubjectOutboundOutcome::Accepted,
+        },
+        in_group(
+            "main",
+            ScenarioStep::SendAppMessage {
+                sender: "alice".into(),
+                payload: "sent before restart".into(),
+            },
+        ),
+        ScenarioStep::DeliverAll,
+        ScenarioStep::Tick {
+            clients: vec!["alice".into(), "carol".into()],
+        },
+        ScenarioStep::RestartClient {
+            client: "carol".into(),
+        },
+    ]);
+    if include_offline_recovery {
+        steps.extend([
+            ScenarioStep::ReconnectClient {
+                client: "bob".into(),
+            },
+            ScenarioStep::SyncRelayHistory {
+                clients: clients.clone(),
+                sync: cgka_conformance_simulator::ScenarioRelaySyncModeV2::FullHistory,
+            },
+        ]);
+    }
+    steps.extend([
+        ScenarioStep::Tick {
+            clients: clients.clone(),
+        },
+        in_group(
+            "main",
+            ScenarioStep::SendAppMessage {
+                sender: "alice".into(),
+                payload: "sent after restart".into(),
+            },
+        ),
+        ScenarioStep::DeliverAll,
+        ScenarioStep::Tick {
+            clients: clients.clone(),
+        },
+        in_group(
+            "main",
+            ScenarioStep::Observe {
+                clients: clients.clone(),
+            },
+        ),
+    ]);
+    ScenarioSpec {
+        name: if include_offline_recovery {
+            "app-process-offline-restart-recovery".into()
+        } else {
+            "cross-adapter-restart-recovery".into()
+        },
+        spec_version: "3".into(),
+        clients,
+        topology: Default::default(),
+        steps,
     }
 }
 
@@ -242,22 +314,29 @@ async fn orchestrator_runs_canonical_schedule_with_isolated_process_roots() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn engine_app_runtime_and_process_adapters_reach_equivalent_public_state() {
-    let spec = cross_adapter_scenario();
+    let spec = cross_adapter_scenario(false);
     let engine_report = run_scenario_report(&spec, None).await.unwrap();
     let engine = engine_report
         .observed_trace
         .as_ref()
         .unwrap()
         .observations
-        .last()
-        .unwrap();
+        .iter()
+        .map(|observation| (observation.client.as_str(), observation))
+        .collect::<BTreeMap<_, _>>();
 
     let mut app = AppRuntimeHarness::new(&spec.clients).await.unwrap();
     let app_report = run_scenario_report_with_subject(&spec, None, Vec::new(), &mut app)
         .await
         .unwrap();
     assert!(app_report.invariant_failures.is_empty(), "{app_report:#?}");
-    let app_observation = app.observations(&spec.clients).await.unwrap().remove(0);
+    let app_observations = app
+        .observations(&spec.clients)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|observation| (observation.participant.clone(), observation))
+        .collect::<BTreeMap<_, _>>();
 
     let process_artifacts = tempfile::tempdir().unwrap();
     let mut process = ProcessOrchestrator::launch(
@@ -269,32 +348,177 @@ async fn engine_app_runtime_and_process_adapters_reach_equivalent_public_state()
     .unwrap();
     let process_report = process.run().await.unwrap();
     assert!(process_report.completed, "{process_report:#?}");
-    let process_observation = process_report.observations.last().unwrap();
+    let process_observations = process_report
+        .observations
+        .iter()
+        .rev()
+        .take(spec.clients.len())
+        .map(|observation| (observation.participant.clone(), observation))
+        .collect::<BTreeMap<_, _>>();
 
-    assert_eq!(engine.epoch, app_observation.protocol.epoch);
-    assert_eq!(engine.epoch, process_observation.protocol.epoch);
-    assert_eq!(engine.member_count, app_observation.protocol.member_count);
-    assert_eq!(
-        engine.member_count,
-        process_observation.protocol.member_count
-    );
-    assert_eq!(engine.group_name, app_observation.protocol.group_name);
-    assert_eq!(engine.group_name, process_observation.protocol.group_name);
-    assert_eq!(
-        engine.group_description,
-        app_observation.protocol.group_description
-    );
-    assert_eq!(
-        engine.group_description,
-        process_observation.protocol.group_description
-    );
-    assert_eq!(engine.group_description, "equivalent description");
-    assert_eq!(
-        app_observation.protocol.state_commitment_sha256,
-        process_observation.protocol.state_commitment_sha256
-    );
-    assert_eq!(app_observation.protocol.member_identities, ["alice"]);
-    assert_eq!(app_observation.protocol.admin_identities, ["alice"]);
+    for client in &spec.clients {
+        let engine = engine[client.as_str()];
+        let app = &app_observations[client];
+        let process = process_observations[client];
+
+        assert_eq!(engine.epoch, app.protocol.epoch, "{client} app epoch");
+        assert_eq!(
+            engine.epoch, process.protocol.epoch,
+            "{client} process epoch"
+        );
+        assert_eq!(
+            engine.member_count, app.protocol.member_count,
+            "{client} app roster"
+        );
+        assert_eq!(
+            engine.member_count, process.protocol.member_count,
+            "{client} process roster"
+        );
+        assert_eq!(
+            engine.group_name, app.protocol.group_name,
+            "{client} app name"
+        );
+        assert_eq!(
+            engine.group_name, process.protocol.group_name,
+            "{client} process name"
+        );
+        assert_eq!(
+            engine.group_description, app.protocol.group_description,
+            "{client} app description"
+        );
+        assert_eq!(
+            engine.group_description, process.protocol.group_description,
+            "{client} process description"
+        );
+        assert_eq!(engine.group_description, "equivalent description");
+        let app_payloads = app
+            .application
+            .visible_plaintexts
+            .iter()
+            .map(String::as_str)
+            .collect::<BTreeSet<_>>();
+        let process_payloads = process
+            .application
+            .visible_plaintexts
+            .iter()
+            .map(String::as_str)
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            app_payloads, process_payloads,
+            "{client} app/process projection"
+        );
+        assert_eq!(app.application.visible_plaintexts.len(), app_payloads.len());
+        assert_eq!(
+            process.application.visible_plaintexts.len(),
+            process_payloads.len()
+        );
+        if client == "alice" {
+            // The engine harness observes inbound delivery only, while the app
+            // projection also includes the sender's locally authored rows.
+            assert!(engine.received_payloads.is_empty());
+        } else if client == "carol" {
+            // Restart clears the engine harness's in-memory event window; the
+            // app/process projection correctly retains already-projected rows.
+            assert_eq!(engine.received_payloads, ["sent after restart"]);
+        } else {
+            let engine_payloads = engine
+                .received_payloads
+                .iter()
+                .map(String::as_str)
+                .collect::<BTreeSet<_>>();
+            assert_eq!(
+                engine_payloads, app_payloads,
+                "{client} inbound application projection"
+            );
+            assert_eq!(engine.received_payloads.len(), engine_payloads.len());
+        }
+        assert_eq!(
+            app.protocol.state_commitment_sha256, process.protocol.state_commitment_sha256,
+            "{client} public commitment"
+        );
+        assert_eq!(app.protocol.member_identities, ["alice", "bob", "carol"]);
+        assert_eq!(app.protocol.admin_identities, ["alice"]);
+        assert!(app.application.invalidated_message_ids.is_empty());
+        assert!(process.application.invalidated_message_ids.is_empty());
+    }
+
+    process.shutdown().await;
+    app.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn app_runtime_and_process_adapters_recover_the_same_offline_projection() {
+    let spec = cross_adapter_scenario(true);
+    let mut app = AppRuntimeHarness::new(&spec.clients).await.unwrap();
+    let app_report = run_scenario_report_with_subject(&spec, None, Vec::new(), &mut app)
+        .await
+        .unwrap();
+    assert!(app_report.invariant_failures.is_empty(), "{app_report:#?}");
+    let app_observations = app
+        .observations(&spec.clients)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|observation| (observation.participant.clone(), observation))
+        .collect::<BTreeMap<_, _>>();
+
+    let process_artifacts = tempfile::tempdir().unwrap();
+    let mut process = ProcessOrchestrator::launch(
+        env!("CARGO_BIN_EXE_cgka-conformance-node"),
+        &spec,
+        process_artifacts.path(),
+    )
+    .await
+    .unwrap();
+    let process_report = process.run().await.unwrap();
+    assert!(process_report.completed, "{process_report:#?}");
+    let process_observations = process_report
+        .observations
+        .iter()
+        .rev()
+        .take(spec.clients.len())
+        .map(|observation| (observation.participant.clone(), observation))
+        .collect::<BTreeMap<_, _>>();
+
+    let expected_payloads = BTreeSet::from(["sent after restart", "sent before restart"]);
+    for client in &spec.clients {
+        let app = &app_observations[client];
+        let process = process_observations[client];
+        assert_eq!(
+            app.protocol, process.protocol,
+            "{client} protocol projection"
+        );
+        let app_payloads = app
+            .application
+            .visible_plaintexts
+            .iter()
+            .map(String::as_str)
+            .collect::<BTreeSet<_>>();
+        let process_payloads = process
+            .application
+            .visible_plaintexts
+            .iter()
+            .map(String::as_str)
+            .collect::<BTreeSet<_>>();
+        assert_eq!(app_payloads, expected_payloads, "{client} app message set");
+        assert_eq!(
+            process_payloads, expected_payloads,
+            "{client} process message set"
+        );
+        assert_eq!(app.application.visible_plaintexts.len(), app_payloads.len());
+        assert_eq!(
+            process.application.visible_plaintexts.len(),
+            process_payloads.len()
+        );
+        assert!(app.application.invalidated_message_ids.is_empty());
+        assert!(process.application.invalidated_message_ids.is_empty());
+        assert!(!app.application.pending_confirmation);
+        assert!(!process.application.pending_confirmation);
+        assert_eq!(
+            app.application.stored_member_count,
+            process.application.stored_member_count
+        );
+    }
 
     process.shutdown().await;
     app.shutdown().await;
@@ -302,7 +526,7 @@ async fn engine_app_runtime_and_process_adapters_reach_equivalent_public_state()
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn process_adapter_executes_the_ir_embedded_in_a_saved_generated_input() {
-    let spec = cross_adapter_scenario();
+    let spec = cross_adapter_scenario(false);
     let input = GeneratedScenarioInputV1::new(GeneratedScenarioCase {
         family_name: "selectable-process/v1".into(),
         generator_version: "4".into(),
@@ -538,7 +762,7 @@ fn process_cli_writes_a_private_versioned_report() {
     let report_path = root.path().join("report.json");
     fs_private::write_private(
         &scenario_path,
-        &serde_json::to_vec_pretty(&cross_adapter_scenario()).unwrap(),
+        &serde_json::to_vec_pretty(&cross_adapter_scenario(false)).unwrap(),
     )
     .unwrap();
     let output = std::process::Command::new(env!("CARGO_BIN_EXE_cgka-conformance-process"))

--- a/crates/cgka-conformance-simulator/tests/process_orchestrator.rs
+++ b/crates/cgka-conformance-simulator/tests/process_orchestrator.rs
@@ -4,10 +4,11 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use cgka_conformance_simulator::process_orchestrator::{ProcessNodeLaunchV1, ProcessOrchestrator};
 use cgka_conformance_simulator::{
-    AppRuntimeHarness, GeneratedScenarioCase, GeneratedScenarioInputV1, GeneratedSubjectKind,
-    ScenarioAccountV2, ScenarioDeviceV2, ScenarioProcessV2, ScenarioRelayV2, ScenarioSpec,
-    ScenarioStep, ScenarioTopologyV2, TraceExpectation, compile_scenario,
-    resolve_scenario_input_bytes, run_scenario_report, run_scenario_report_with_subject,
+    AppRuntimeHarness, AppRuntimeObservationV1, GeneratedScenarioCase, GeneratedScenarioInputV1,
+    GeneratedSubjectKind, ScenarioAccountV2, ScenarioDeviceV2, ScenarioProcessV2, ScenarioRelayV2,
+    ScenarioSpec, ScenarioStep, ScenarioTopologyV2, TraceExpectation, compile_scenario,
+    node_protocol::NodeObservationV1, resolve_scenario_input_bytes, run_scenario_report,
+    run_scenario_report_with_subject,
 };
 
 fn in_group(group: &str, action: ScenarioStep) -> ScenarioStep {
@@ -149,7 +150,14 @@ fn controlled_relay_topology() -> ScenarioTopologyV2 {
     }
 }
 
-fn cross_adapter_scenario(include_offline_recovery: bool) -> ScenarioSpec {
+#[derive(Clone, Copy)]
+enum CrossAdapterRecovery {
+    Restart,
+    OfflineFullHistory,
+}
+
+fn build_cross_adapter_scenario(recovery: CrossAdapterRecovery) -> ScenarioSpec {
+    let include_offline_recovery = matches!(recovery, CrossAdapterRecovery::OfflineFullHistory);
     let clients = vec!["alice".into(), "bob".into(), "carol".into()];
     let mut steps = vec![
         in_group(
@@ -262,6 +270,56 @@ fn cross_adapter_scenario(include_offline_recovery: bool) -> ScenarioSpec {
     }
 }
 
+fn cross_adapter_restart_scenario() -> ScenarioSpec {
+    build_cross_adapter_scenario(CrossAdapterRecovery::Restart)
+}
+
+fn cross_adapter_offline_scenario() -> ScenarioSpec {
+    build_cross_adapter_scenario(CrossAdapterRecovery::OfflineFullHistory)
+}
+
+async fn run_app_and_process_adapters(
+    spec: &ScenarioSpec,
+) -> (
+    BTreeMap<String, AppRuntimeObservationV1>,
+    BTreeMap<String, NodeObservationV1>,
+) {
+    let mut app = AppRuntimeHarness::new(&spec.clients).await.unwrap();
+    let app_report = run_scenario_report_with_subject(spec, None, Vec::new(), &mut app)
+        .await
+        .unwrap();
+    assert!(app_report.invariant_failures.is_empty(), "{app_report:#?}");
+    let app_observations = app
+        .observations(&spec.clients)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|observation| (observation.participant.clone(), observation))
+        .collect::<BTreeMap<_, _>>();
+
+    let process_artifacts = tempfile::tempdir().unwrap();
+    let mut process = ProcessOrchestrator::launch(
+        env!("CARGO_BIN_EXE_cgka-conformance-node"),
+        spec,
+        process_artifacts.path(),
+    )
+    .await
+    .unwrap();
+    let process_report = process.run().await.unwrap();
+    assert!(process_report.completed, "{process_report:#?}");
+    let process_observations = process_report
+        .observations
+        .iter()
+        .rev()
+        .take(spec.clients.len())
+        .map(|observation| (observation.participant.clone(), observation.clone()))
+        .collect::<BTreeMap<_, _>>();
+
+    process.shutdown().await;
+    app.shutdown().await;
+    (app_observations, process_observations)
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn orchestrator_runs_canonical_schedule_with_isolated_process_roots() {
     let spec = process_scenario("app-process-canonical-schedule", false);
@@ -314,7 +372,7 @@ async fn orchestrator_runs_canonical_schedule_with_isolated_process_roots() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn engine_app_runtime_and_process_adapters_reach_equivalent_public_state() {
-    let spec = cross_adapter_scenario(false);
+    let spec = cross_adapter_restart_scenario();
     let engine_report = run_scenario_report(&spec, None).await.unwrap();
     let engine = engine_report
         .observed_trace
@@ -325,41 +383,12 @@ async fn engine_app_runtime_and_process_adapters_reach_equivalent_public_state()
         .map(|observation| (observation.client.as_str(), observation))
         .collect::<BTreeMap<_, _>>();
 
-    let mut app = AppRuntimeHarness::new(&spec.clients).await.unwrap();
-    let app_report = run_scenario_report_with_subject(&spec, None, Vec::new(), &mut app)
-        .await
-        .unwrap();
-    assert!(app_report.invariant_failures.is_empty(), "{app_report:#?}");
-    let app_observations = app
-        .observations(&spec.clients)
-        .await
-        .unwrap()
-        .into_iter()
-        .map(|observation| (observation.participant.clone(), observation))
-        .collect::<BTreeMap<_, _>>();
-
-    let process_artifacts = tempfile::tempdir().unwrap();
-    let mut process = ProcessOrchestrator::launch(
-        env!("CARGO_BIN_EXE_cgka-conformance-node"),
-        &spec,
-        process_artifacts.path(),
-    )
-    .await
-    .unwrap();
-    let process_report = process.run().await.unwrap();
-    assert!(process_report.completed, "{process_report:#?}");
-    let process_observations = process_report
-        .observations
-        .iter()
-        .rev()
-        .take(spec.clients.len())
-        .map(|observation| (observation.participant.clone(), observation))
-        .collect::<BTreeMap<_, _>>();
+    let (app_observations, process_observations) = run_app_and_process_adapters(&spec).await;
 
     for client in &spec.clients {
         let engine = engine[client.as_str()];
         let app = &app_observations[client];
-        let process = process_observations[client];
+        let process = &process_observations[client];
 
         assert_eq!(engine.epoch, app.protocol.epoch, "{client} app epoch");
         assert_eq!(
@@ -441,49 +470,27 @@ async fn engine_app_runtime_and_process_adapters_reach_equivalent_public_state()
         assert!(app.application.invalidated_message_ids.is_empty());
         assert!(process.application.invalidated_message_ids.is_empty());
     }
-
-    process.shutdown().await;
-    app.shutdown().await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn app_runtime_and_process_adapters_recover_the_same_offline_projection() {
-    let spec = cross_adapter_scenario(true);
-    let mut app = AppRuntimeHarness::new(&spec.clients).await.unwrap();
-    let app_report = run_scenario_report_with_subject(&spec, None, Vec::new(), &mut app)
-        .await
-        .unwrap();
-    assert!(app_report.invariant_failures.is_empty(), "{app_report:#?}");
-    let app_observations = app
-        .observations(&spec.clients)
-        .await
-        .unwrap()
-        .into_iter()
-        .map(|observation| (observation.participant.clone(), observation))
-        .collect::<BTreeMap<_, _>>();
-
-    let process_artifacts = tempfile::tempdir().unwrap();
-    let mut process = ProcessOrchestrator::launch(
-        env!("CARGO_BIN_EXE_cgka-conformance-node"),
-        &spec,
-        process_artifacts.path(),
-    )
-    .await
-    .unwrap();
-    let process_report = process.run().await.unwrap();
-    assert!(process_report.completed, "{process_report:#?}");
-    let process_observations = process_report
-        .observations
-        .iter()
-        .rev()
-        .take(spec.clients.len())
-        .map(|observation| (observation.participant.clone(), observation))
-        .collect::<BTreeMap<_, _>>();
+    let spec = cross_adapter_offline_scenario();
+    let (app_observations, process_observations) = run_app_and_process_adapters(&spec).await;
 
     let expected_payloads = BTreeSet::from(["sent after restart", "sent before restart"]);
+    let bob = &app_observations["bob"];
+    assert!(bob.local.online, "bob must be reconnected at the end");
+    assert!(
+        bob.local.reopen_count > 0,
+        "bob's offline runtime must have reopened"
+    );
+    assert!(
+        bob.local.catch_up_attempts > 0,
+        "bob must have executed retained-history catch-up"
+    );
     for client in &spec.clients {
         let app = &app_observations[client];
-        let process = process_observations[client];
+        let process = &process_observations[client];
         assert_eq!(
             app.protocol, process.protocol,
             "{client} protocol projection"
@@ -519,14 +526,11 @@ async fn app_runtime_and_process_adapters_recover_the_same_offline_projection() 
             process.application.stored_member_count
         );
     }
-
-    process.shutdown().await;
-    app.shutdown().await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn process_adapter_executes_the_ir_embedded_in_a_saved_generated_input() {
-    let spec = cross_adapter_scenario(false);
+    let spec = cross_adapter_restart_scenario();
     let input = GeneratedScenarioInputV1::new(GeneratedScenarioCase {
         family_name: "selectable-process/v1".into(),
         generator_version: "4".into(),
@@ -762,7 +766,7 @@ fn process_cli_writes_a_private_versioned_report() {
     let report_path = root.path().join("report.json");
     fs_private::write_private(
         &scenario_path,
-        &serde_json::to_vec_pretty(&cross_adapter_scenario(false)).unwrap(),
+        &serde_json::to_vec_pretty(&cross_adapter_restart_scenario()).unwrap(),
     )
     .unwrap();
     let output = std::process::Command::new(env!("CARGO_BIN_EXE_cgka-conformance-process"))

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -1214,16 +1214,17 @@ residual gap.
    six generated families with zero failures, timeouts, signals, integrity errors, missing artifacts, or failure
    capsules. It tested commit `7b0480604a84b8f5728289c18018dd71d8d33e77` on base
    `5e90b22e`, so it is retained evidence for that snapshot rather than evidence for later production changes.
-5. [ ] Complete the #1285 cross-route regression across every capable adapter. The engine checkpoint is now permanent
+5. [ ] Complete the #1285 cross-route regression across every capable adapter. The `CgkaEngine` checkpoint is now permanent
    as `cross-route-own-commit-recovery/v1` and pins exact cryptographic, decryptability, commit-disposition, pending-work,
    and projection agreement after restart. `cross-route-retained-history-recovery/v1` now establishes the same contract
-   through retained relay histories; app-runtime, process, container, and VM evidence remains.
-   The first implementation slice runs one capability-overlap restart journey unchanged through engine, app-runtime,
-   and separate-process adapters, plus a companion offline/full-history journey through the app-runtime and process
-   adapters that implement participant connectivity. It compares their public protocol and application projections
-   without weakening the four-party vector or claiming exact cryptographic/disposition evidence from adapters that
-   cannot expose it. The decision-route inventory is machine checked; keep the remaining assurance artifacts
-   independent of #1293.
+   through retained relay histories; full app-runtime, process, container, and VM evidence remains.
+   The first implementation slice runs one capability-overlap restart journey unchanged through the `CgkaEngine`
+   harness and the full app-runtime/separate-process adapters, crossing the production-shaped `CgkaEngine`,
+   `TransportPeeler`, and `TransportAdapter` seams in the latter two. A companion offline/full-history journey runs
+   through the app-runtime and process adapters that implement participant connectivity. It compares their public
+   protocol and application projections without weakening the four-party vector or claiming exact
+   cryptographic/disposition evidence from adapters that cannot expose it. The decision-route inventory is machine
+   checked; keep the remaining assurance artifacts independent of #1293.
 6. [ ] Feed real workflow observations into the lane budgets and produce a reviewed evidence bundle.
 7. [ ] Accumulate container soak evidence, then use the external VM driver only for the remaining
    host/kernel/block-device dimensions.
@@ -1382,7 +1383,7 @@ incorrect result.
 | 2026-08-10 | Strict generated-family oracle closure | Closed the known strict-oracle false positives across every built-in generated family without changing production convergence behavior: subset exact-equivalence now counts as observed evidence when its executable expectation passes, convergence delivery has an exact/decryptable settle tail, and adversarial arms pin accepted publication plus deterministic delivery claims. Generator versions changed where scenario meaning changed. | [MDK #1349](https://github.com/marmot-protocol/mdk/pull/1349); all 28 vectors; all six families at seeds `1`, `42`, and `1337`; full simulator suite; `test-policy-overrides` campaign gate; `just fast-ci` |
 | 2026-08-11 | All-family isolated campaign evidence | Generalized the isolated worker runner to all six generated families, then reviewed 60 file-backed campaigns and 1,170 cases with exact inputs, reports, fixture candidates, process accounting, deadlines, and failure-capsule paths preserved per case. No case failed, timed out, signaled, lost artifact integrity, or emitted a failure capsule. Recorded the exact tested snapshot and corrected the aggregate slowest-case bookkeeping limitation rather than carrying the result forward to newer production code. | [MDK #1357](https://github.com/marmot-protocol/mdk/pull/1357); tested commit `7b0480604a84b8f5728289c18018dd71d8d33e77` on base `5e90b22e`; 1,170/1,170 cases passed |
 | 2026-08-11 | Post-campaign convergence deltas | Merged fail-closed missing-anchor handling and Welcome-repair retirement, atomic self-removal persistence, and armed backfill after catch-up. These changes postdate the reviewed all-family matrix and therefore require focused current-`master` delta evidence rather than being covered by the older green result. | [MDK #1329](https://github.com/marmot-protocol/mdk/pull/1329); [MDK #1360](https://github.com/marmot-protocol/mdk/pull/1360); [MDK #1365](https://github.com/marmot-protocol/mdk/pull/1365) |
-| 2026-08-11 | 6.1 cross-adapter public projection checkpoint | Made accepted publication checkpoints portable across the engine's staged transport and the app runtime's already-published command surface, then ran a three-participant profile/message/restart IR unchanged through engine, app-runtime, and isolated app processes. A companion app/process permutation takes one member offline across the commit and message, restarts another member, performs full-history repair, and requires equivalent duplicate-free public projections. Exact MLS state, active decryptability, the four-party adversarial topology, containers, and VMs remain open. | `engine_app_runtime_and_process_adapters_reach_equivalent_public_state`; `app_runtime_and_process_adapters_recover_the_same_offline_projection`; simulator-only adapter seam and focused process/app tests |
+| 2026-08-11 | 6.1 cross-adapter public projection checkpoint | Made accepted publication checkpoints portable across the `CgkaEngine` harness's staged transport and the app runtime's already-published command surface, then ran a three-participant profile/message/restart IR unchanged through the `CgkaEngine` harness, full app-runtime adapter, and isolated app processes. The production-shaped adapters cross the `CgkaEngine`, `TransportPeeler`, and `TransportAdapter` seams. A companion app/process permutation takes one member offline across the commit and message, restarts another member, performs full-history repair, and requires equivalent duplicate-free public projections. Exact MLS state, active decryptability, the four-party adversarial topology, containers, and VMs remain open. | `engine_app_runtime_and_process_adapters_reach_equivalent_public_state`; `app_runtime_and_process_adapters_recover_the_same_offline_projection`; simulator-only adapter seam and focused process/app tests |
 
 ## Capability Naming Cleanup
 

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "Convergence Reliability And Simulation Plan"
 created: 2026-07-30
-updated: 2026-08-10
+updated: 2026-08-11
 tags: [marmot, cgka, convergence, simulation, verification, reliability]
 status: working-plan
 ---
@@ -1033,12 +1033,11 @@ The remaining 6.1 work is assurance closure, not another speculative engine rewr
 on `master`; the next test must reproduce the cross-route topology against that design and either confirm equivalent
 results or produce a new minimized counterexample.
 
-Production fork behavior is being considered separately in
-[MDK #1329](https://github.com/marmot-protocol/mdk/pull/1329) and its stacked
-[MDK #1293](https://github.com/marmot-protocol/mdk/pull/1293). The route inventory, assurance claims, and campaign
-inputs must remain independently reviewable and runnable against current `master`; they must not encode either open
-PR's proposed result as the oracle. Saved counterexamples from current `master` become before/after evidence if that
-production stack lands.
+[MDK #1329](https://github.com/marmot-protocol/mdk/pull/1329) has now merged the fail-closed missing-anchor behavior and
+Welcome-repair retirement. Its formerly stacked [MDK #1293](https://github.com/marmot-protocol/mdk/pull/1293) remains
+open and is not part of the oracle. The route inventory, assurance claims, and campaign inputs remain independently
+reviewable and runnable against current `master`; a production PR may change the implementation under test, but not
+silently redefine the expected result.
 
 ### 6.2 Container and VM execution
 
@@ -1205,24 +1204,42 @@ residual gap.
    expectation over a subset even when other observed clients intentionally diverge. The reviewed all-family seeds
    `1`, `42`, and `1337` are strict-green; this removes known oracle false positives but is not an engine-correctness
    claim.
-4. [ ] Generalize the isolated child-process campaign runner from the adversarial catalog to every built-in generated
+4. [x] Generalize the isolated child-process campaign runner from the adversarial catalog to every built-in generated
    family, persist the exact generated input before each worker starts, run the worker through the strict report path,
    and retain its report, fixture candidate, and failure capsule. Then execute a reviewed file-backed seed/case matrix
    and classify every failure as a product defect, protocol ambiguity, environment failure, or expected resource
    refusal. Verification must include one smoke case from every family, exact saved-input replay, deadline kill/reap,
-   nonzero exit propagation, and artifact-path integrity. This is the current in-progress slice.
+   nonzero exit propagation, and artifact-path integrity. [MDK #1357](https://github.com/marmot-protocol/mdk/pull/1357)
+   completed the runner. The reviewed campaign executed 60 isolated campaigns and 1,170 file-backed cases across all
+   six generated families with zero failures, timeouts, signals, integrity errors, missing artifacts, or failure
+   capsules. It tested commit `7b0480604a84b8f5728289c18018dd71d8d33e77` on base
+   `5e90b22e`, so it is retained evidence for that snapshot rather than evidence for later production changes.
 5. [ ] Complete the #1285 cross-route regression across every capable adapter. The engine checkpoint is now permanent
    as `cross-route-own-commit-recovery/v1` and pins exact cryptographic, decryptability, commit-disposition, pending-work,
    and projection agreement after restart. `cross-route-retained-history-recovery/v1` now establishes the same contract
    through retained relay histories; app-runtime, process, container, and VM evidence remains.
-   The decision-route inventory is machine checked; keep the remaining assurance artifacts independent of the
-   production behavior under review in #1329/#1293.
+   The first implementation slice runs one capability-overlap restart journey unchanged through engine, app-runtime,
+   and separate-process adapters, plus a companion offline/full-history journey through the app-runtime and process
+   adapters that implement participant connectivity. It compares their public protocol and application projections
+   without weakening the four-party vector or claiming exact cryptographic/disposition evidence from adapters that
+   cannot expose it. The decision-route inventory is machine checked; keep the remaining assurance artifacts
+   independent of #1293.
 6. [ ] Feed real workflow observations into the lane budgets and produce a reviewed evidence bundle.
 7. [ ] Accumulate container soak evidence, then use the external VM driver only for the remaining
    host/kernel/block-device dimensions.
 
 The local smoke path is a usability and integration checkpoint, not an assurance exit gate. A visually successful run
 does not substitute for the cross-route campaign or the reviewed distributed evidence above.
+
+The reviewed all-family campaign's per-process reports identify the slowest case as `convergence-chaos/v1`, seed `7`,
+case `9`, at 211.849220 seconds under the 300-second limit. The aggregate summary reported 205.307222 seconds because
+its slowest-case rollup considered only the soak subset; future evidence generation must derive this field from every
+included campaign. The case artifacts and directories were owner-only, while the three top-level hand-authored summary
+files were mode `0644`; future bundles should create aggregate manifests through the same private-file boundary.
+
+Because #1329, #1360, and #1365 changed production behavior after that campaign snapshot, a focused current-`master`
+delta matrix must cover missing-anchor repair, atomic self-removal persistence, and armed backfill after catch-up. A
+full 1,170-case rerun is useful release evidence but is not a prerequisite for the cross-adapter slice.
 
 ### Milestone 6 Exit Gate
 
@@ -1363,6 +1380,9 @@ incorrect result.
 | 2026-08-09 | 6.1 four-party engine cross-route checkpoint | Promoted the #1285 topology into a portable vector with two simultaneous source-epoch committers, pairwise committer displacement, observer-side stored convergence, ordering-key-versus-depth disagreement, branch growth by a third member, encrypted-SQLite restart of the displaced own-commit author, exact cryptographic equality, durable selected/invalidated commit dispositions, no pending work, and active application decryptability in all twelve directions; retained external-adapter and transition-permutation work explicitly open | `cross-route-own-commit-recovery/v1`; strict file-backed report; focused canonical-scenario regression; [`CONVERGENCE_ROUTE_MATRIX.md`](../../crates/cgka-conformance-simulator/CONVERGENCE_ROUTE_MATRIX.md) |
 | 2026-08-10 | 6.1 retained-history cross-route checkpoint | Replayed the four-party #1285 topology through explicit retained relay history rather than semantic packet-bus withholding: participant-specific visibility advances incremental cursors past hidden roots/children, restart reopens encrypted SQLite after pairwise displacement, and full-history queries restore the complete set before exact settlement. Also normalized active-probe evidence from authenticated account identities to stable scenario labels after logical-id correlation. App-runtime and distributed permutations remain open. | `cross-route-retained-history-recovery/v1`; strict file-backed regression; retained-object injection assertions; [`CONVERGENCE_ROUTE_MATRIX.md`](../../crates/cgka-conformance-simulator/CONVERGENCE_ROUTE_MATRIX.md) |
 | 2026-08-10 | Strict generated-family oracle closure | Closed the known strict-oracle false positives across every built-in generated family without changing production convergence behavior: subset exact-equivalence now counts as observed evidence when its executable expectation passes, convergence delivery has an exact/decryptable settle tail, and adversarial arms pin accepted publication plus deterministic delivery claims. Generator versions changed where scenario meaning changed. | [MDK #1349](https://github.com/marmot-protocol/mdk/pull/1349); all 28 vectors; all six families at seeds `1`, `42`, and `1337`; full simulator suite; `test-policy-overrides` campaign gate; `just fast-ci` |
+| 2026-08-11 | All-family isolated campaign evidence | Generalized the isolated worker runner to all six generated families, then reviewed 60 file-backed campaigns and 1,170 cases with exact inputs, reports, fixture candidates, process accounting, deadlines, and failure-capsule paths preserved per case. No case failed, timed out, signaled, lost artifact integrity, or emitted a failure capsule. Recorded the exact tested snapshot and corrected the aggregate slowest-case bookkeeping limitation rather than carrying the result forward to newer production code. | [MDK #1357](https://github.com/marmot-protocol/mdk/pull/1357); tested commit `7b0480604a84b8f5728289c18018dd71d8d33e77` on base `5e90b22e`; 1,170/1,170 cases passed |
+| 2026-08-11 | Post-campaign convergence deltas | Merged fail-closed missing-anchor handling and Welcome-repair retirement, atomic self-removal persistence, and armed backfill after catch-up. These changes postdate the reviewed all-family matrix and therefore require focused current-`master` delta evidence rather than being covered by the older green result. | [MDK #1329](https://github.com/marmot-protocol/mdk/pull/1329); [MDK #1360](https://github.com/marmot-protocol/mdk/pull/1360); [MDK #1365](https://github.com/marmot-protocol/mdk/pull/1365) |
+| 2026-08-11 | 6.1 cross-adapter public projection checkpoint | Made accepted publication checkpoints portable across the engine's staged transport and the app runtime's already-published command surface, then ran a three-participant profile/message/restart IR unchanged through engine, app-runtime, and isolated app processes. A companion app/process permutation takes one member offline across the commit and message, restarts another member, performs full-history repair, and requires equivalent duplicate-free public projections. Exact MLS state, active decryptability, the four-party adversarial topology, containers, and VMs remain open. | `engine_app_runtime_and_process_adapters_reach_equivalent_public_state`; `app_runtime_and_process_adapters_recover_the_same_offline_projection`; simulator-only adapter seam and focused process/app tests |
 
 ## Capability Naming Cleanup
 


### PR DESCRIPTION
## Summary

- reconcile the convergence reliability tracker with the merged all-family isolated runner, the reviewed 1,170-case campaign, and the production convergence changes that landed afterward
- preserve canonical accepted-publication checkpoints across the staged engine harness and the auto-publishing app-runtime/process adapters
- enforce the same accepted-label, unknown-label, unlabelled-drain, and rollback-refusal semantics across app and process adapters
- run one three-participant profile/message/restart scenario unchanged through the engine, in-process app runtime, and isolated app processes
- run a companion offline/full-history recovery scenario through the app-runtime and process adapters that declare participant-connectivity support
- update the route matrix and property documentation with the exact evidence boundary

## Why

The existing cross-adapter check used one participant and no publication lifecycle. A realistic multi-member scenario could not run unchanged: the engine harness requires explicit acknowledgement of staged transport artifacts, while the production-shaped app runtime publishes inside a successful command and exposes no unresolved transport artifact to acknowledge.

The simulator-only adapter seam records that a named app/process mutation already succeeded through that production command surface. An `accepted` checkpoint can therefore remain in canonical Scenario IR. Auto-publishing adapters implement an empty idempotent outbound poll, reject unknown labels, and classify a later `reached_no_endpoint` outcome as an expected refusal because an accepted publication cannot be rolled back.

## Assurance boundary

This PR adds public protocol/application projection evidence. It does **not** change production convergence or app behavior, weaken the four-party cross-route vectors, or claim exact MLS-state commitments, active decryptability, complete application dispositions, container evidence, or VM evidence from adapters that cannot expose those surfaces.

On app/process subjects, a labelled accepted checkpoint is command-success evidence; the resulting pending-resolution observation is not an independent transport-delivery proof.

The reviewed 1,170-case campaign is recorded against its exact tested snapshot. Later production changes (#1329, #1360, and #1365) remain scoped current-`master` delta work rather than being treated as covered by that historical green run.

## Verification

- `cargo test -p cgka-conformance-simulator --lib` (139 passed)
- `cargo test -p cgka-conformance-simulator --test app_runtime_adapter` (6 passed)
- `cargo test -p cgka-conformance-simulator --test process_orchestrator` (10 passed)
- `just fast-ci`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking and acknowledging outbound publications that were already accepted.
  * Expanded cross-adapter scenarios covering messaging, restarts, offline recovery, membership, and protocol state.
  * Added validation for publication labels and clearer handling of accepted, rejected, unknown, and missing acknowledgements.

* **Documentation**
  * Updated conformance guidance, route evidence, adapter behavior, and reliability progress documentation.
  * Added details on publication-label matching and recovery equivalence checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->