### PR TITLE
test(cgka-engine): cover pinned rewind horizon

### DIFF
--- a/crates/cgka-engine/tests/fork_detection.rs
+++ b/crates/cgka-engine/tests/fork_detection.rs
@@ -19,7 +19,7 @@ use async_trait::async_trait;
 use cgka_engine::canonicalization::{
     CanonicalizationError, CanonicalizationPolicy, CanonicalizationState, ConvergenceStatus,
 };
-use cgka_engine::convergence::ConvergencePolicy;
+use cgka_engine::convergence::V1_MAX_REWIND_COMMITS;
 use cgka_engine::feature_registry::FeatureRegistry;
 use cgka_engine::openmls_projection::{
     OpenMlsProjectionError, apply_openmls_canonicalization_result,
@@ -991,21 +991,10 @@ async fn stale_commit_outside_rewind_horizon_is_not_treated_as_recoverable_fork(
     };
     bob.join_welcome(bob_welcome).await.unwrap();
 
-    let policy = CanonicalizationPolicy {
-        convergence: ConvergencePolicy {
-            max_rewind_commits: 1,
-            ..ConvergencePolicy::default()
-        },
-        ..CanonicalizationPolicy::default()
-    };
-    alice
-        .set_group_convergence_policy(&group_id, policy)
-        .unwrap();
-
     // Bob produces a same-source-epoch commit from epoch 1, then Alice advances
-    // two epochs without seeing it. Once Alice is at epoch 3 and the policy
-    // keeps only one rewind commit, source epoch 1 is outside the recovery
-    // horizon and must be classified as a stale commit, not a recoverable fork.
+    // past the pinned v1 rewind horizon without seeing it. Once Alice is beyond
+    // epoch 1 + V1_MAX_REWIND_COMMITS, source epoch 1 is outside recovery and
+    // must be classified as a stale commit, not a recoverable fork.
     let dave_kp = dave.fresh_key_package().await.unwrap();
     let late_invite = bob
         .send(SendIntent::Invite {
@@ -1022,7 +1011,8 @@ async fn stale_commit_outside_rewind_horizon_is_not_treated_as_recoverable_fork(
         other => panic!("expected Bob invite GroupEvolution, got {other:?}"),
     };
 
-    for i in 0..2 {
+    let advance_epochs = V1_MAX_REWIND_COMMITS + 1;
+    for i in 0..advance_epochs {
         let update = alice
             .send(SendIntent::UpdateGroupData {
                 group_id: group_id.clone(),
@@ -1037,7 +1027,8 @@ async fn stale_commit_outside_rewind_horizon_is_not_treated_as_recoverable_fork(
         };
         alice.confirm_published(pending).await.unwrap();
     }
-    assert_eq!(alice.epoch(&group_id).unwrap(), EpochId(3));
+    let terminal_epoch = EpochId(1 + advance_epochs);
+    assert_eq!(alice.epoch(&group_id).unwrap(), terminal_epoch);
 
     let routed = TransportMessage {
         envelope: TransportEnvelope::GroupMessage {
@@ -1051,10 +1042,10 @@ async fn stale_commit_outside_rewind_horizon_is_not_treated_as_recoverable_fork(
         outcome,
         IngestOutcome::Stale {
             reason: StaleReason::AlreadyAtEpoch {
-                current: EpochId(3),
+                current,
                 msg_epoch: EpochId(1),
             }
-        }
+        } if current == terminal_epoch
     ));
     let events = alice.drain_events();
     assert!(

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -11,6 +11,9 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ### Fixed
 
+- Engine fork-detection integration tests now exercise the pinned v1
+  five-commit rewind horizon in normal builds instead of overriding
+  `max_rewind_commits` to one.
 - Runtime catch-up, key-package maintenance, and every other incremental sync
   seam now execute an armed epoch-gap full-history replay immediately instead of
   waiting for unrelated later relay traffic. Explicit full-history repair also


### PR DESCRIPTION
Fixes #1219

Supersedes #1371, which is permanently ineligible for merge after code-owned red CI in an unrelated load-sensitive Nostr-adapter test. The flake is tracked separately in #1375.

## Summary
- remove the non-pinned one-commit policy override from the normal-build fork test
- advance the local branch beyond `V1_MAX_REWIND_COMMITS` before ingesting the stale epoch-1 commit
- keep the terminal-stale and no-`ForkRecovered` assertions tied to the computed pinned-horizon epoch
- document the regression fix under `Unreleased`

## Verification
- `cargo test -p cgka-engine --test fork_detection --locked` — 16 passed
- `just test-convergence-policy-pin` — 5 passed
- `cargo test -p cgka-engine --features test-policy-overrides --test fork_detection stale_commit_outside_rewind_horizon_is_not_treated_as_recoverable_fork --locked` — 1 passed
- `cargo fmt --all -- --check`
- `git diff --check origin/master...HEAD`
- no `Cargo.toml` or `Cargo.lock` changes

## Sensitive paths
- `crates/cgka-engine/tests/fork_detection.rs` — test-only fork recovery / rewind-horizon coverage

No production convergence constants or policy guards changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved validation of fork detection across the full supported commit rewind horizon.
  - Confirmed that commits arriving beyond the recovery window are correctly identified as stale.

- **Documentation**
  - Updated the unreleased changelog to reflect expanded fork-detection coverage in standard builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->