### PR TITLE
Keep unknown-group drops out of the ingest seen cache

### DIFF
--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -293,6 +293,19 @@ These are the scenarios another implementation should be able to load from JSON 
   replay from retained histories) stays in the `adversarial-reliability` generated family per `retained_relay.rs`
   doctrine; this vector models mailbox catch-up.
 
+### `late-welcome-backfill/v1`
+
+- File: `vectors/late-welcome-backfill.v1.json`
+- Setup: Alice creates a group with Bob, invites Dave, and the group advances two epochs while Dave's Welcome is
+  withheld. The commits reach Dave before he can resolve the group. After the Welcome arrives and Dave joins at the
+  invite epoch, duplicates of the missed commits are released, standing in for relay redelivery.
+- Pressure: pre-join traffic is dropped without a durable record (the deliberate unknown-route flood posture), so
+  the post-join redelivery must not be misclassified as a duplicate of terminal input.
+- Expected: Dave joins at epoch 2, applies the redelivered commits to reach epoch 4, and sends the first post-join
+  application message; all three clients converge on the tip. The Rust regression for this shape is
+  `late_welcome_join_catches_up_via_redelivered_commits` in `tests/canonical_scenarios.rs`, and
+  `commit_missing_proposal_defers_and_applies_after_proposal_backfill` pins the sibling missing-proposal deferral.
+
 ## Incident-Replay Vectors
 
 These vectors are synthesized from Goggles `agent-state.json` forensic exports by the `incident-replay` adapter, then

--- a/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
+++ b/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
@@ -3626,3 +3626,151 @@ async fn removed_member_rejoins_via_fresh_welcome() {
         "alice must receive carol's post-rejoin message"
     );
 }
+
+#[tokio::test]
+async fn commit_missing_proposal_defers_and_applies_after_proposal_backfill() {
+    // Carol's SelfRemove proposal never reaches Bob (partition drop), so
+    // Alice's removal commit arrives at Bob referencing a proposal he does
+    // not hold. The commit must stay deferred, and a later re-delivery of
+    // the proposal (relay backfill) must complete the removal at Bob.
+    let bus = TransportBus::ordered();
+    let mut alice = ClientBuilder::new(pad32(b"alice"))
+        .registry(selfremove_registry())
+        .attach(&bus);
+    let mut bob = ClientBuilder::new(pad32(b"bob"))
+        .registry(selfremove_registry())
+        .attach(&bus);
+    let mut carol = ClientBuilder::new(pad32(b"carol"))
+        .registry(selfremove_registry())
+        .attach(&bus);
+
+    let bob_kp = bob.fresh_key_package().await;
+    let carol_kp = carol.fresh_key_package().await;
+    let (_gid, pending) = alice
+        .create_group("missing-proposal", vec![bob_kp, carol_kp], vec![])
+        .await;
+    alice.confirm(pending).await;
+    bus.deliver_all();
+    bob.tick().await;
+    carol.tick().await;
+
+    // Carol leaves while only Alice can hear her.
+    bus.set_partition(Some(vec![alice.bus_id]));
+    let proposal_msg = carol.leave_capture().await.expect("leave proposal");
+    bus.deliver_all();
+    bus.set_partition(None);
+    let alice_outcomes = alice.tick().await; // ingest proposal + auto-commit
+    assert!(
+        alice_outcomes.iter().all(Result::is_ok),
+        "alice outcomes: {alice_outcomes:?}"
+    );
+
+    // The removal commit reaches Bob without its proposal.
+    bus.deliver_all();
+    let bob_outcomes = bob.tick().await;
+    assert!(
+        bob_outcomes.iter().all(Result::is_ok),
+        "bob outcomes: {bob_outcomes:?}"
+    );
+    assert_eq!(alice.epoch().0, 2);
+    assert_eq!(
+        bob.epoch().0,
+        1,
+        "bob cannot apply a commit whose proposal he never saw"
+    );
+
+    // Relay backfill: the proposal is re-delivered, and Bob completes.
+    bus.send(carol.bus_id, proposal_msg);
+    bus.deliver_all();
+    let bob_backfill = bob.tick().await;
+    assert!(
+        bob_backfill.iter().all(Result::is_ok),
+        "bob backfill outcomes: {bob_backfill:?}"
+    );
+    let bob_settle = bob.tick().await;
+    assert!(
+        bob_settle.iter().all(Result::is_ok),
+        "bob settle outcomes: {bob_settle:?}"
+    );
+    assert_eq!(
+        bob.epoch().0,
+        2,
+        "backfilled proposal must let bob apply the retained commit"
+    );
+    assert_eq!(bob.members().len(), 2);
+}
+
+#[tokio::test]
+async fn late_welcome_join_catches_up_via_redelivered_commits() {
+    // Dave's Welcome is delayed while the group advances, so the commits
+    // reach him before he can resolve the group and are dropped without a
+    // durable record (#740 unknown-route posture). Once he joins, relay
+    // redelivery of those same events must process rather than dedup
+    // against the pre-join drop.
+    let bus = TransportBus::ordered();
+    let mut alice = ClientBuilder::new(pad32(b"alice"))
+        .registry(selfremove_registry())
+        .attach(&bus);
+    let mut bob = ClientBuilder::new(pad32(b"bob"))
+        .registry(selfremove_registry())
+        .attach(&bus);
+    let mut dave = ClientBuilder::new(pad32(b"dave"))
+        .registry(selfremove_registry())
+        .attach(&bus);
+
+    let bob_kp = bob.fresh_key_package().await;
+    let (_gid, pending) = alice
+        .create_group("late-welcome", vec![bob_kp], vec![])
+        .await;
+    alice.confirm(pending).await;
+    bus.deliver_all();
+    bob.tick().await;
+
+    // Invite Dave but delay his Welcome; the invite commit still broadcasts.
+    let dave_kp = dave.fresh_key_package().await;
+    let pending = alice.invite(vec![dave_kp]).await;
+    alice.confirm(pending).await;
+    assert!(bus.delay_queued(0, "dave-welcome"), "welcome sits first");
+    bus.deliver_all();
+    bob.tick().await;
+    dave.tick().await; // pre-join commit lands as unknown-group input
+
+    // The group moves on without Dave. Keep a delayed duplicate of every
+    // post-invite commit: it stands in for relay redelivery after his join.
+    for (name, backfill) in [("rename-1", "bf-1"), ("rename-2", "bf-2")] {
+        let pending = alice.update_group_data(name).await;
+        alice.confirm(pending).await;
+        assert!(bus.duplicate_queued(0), "commit sits first in the queue");
+        assert!(bus.delay_queued(1, backfill));
+        bus.deliver_all();
+        bob.tick().await;
+        dave.tick().await; // pre-join commit is dropped without a record
+    }
+    assert_eq!(alice.epoch().0, 4);
+
+    // The Welcome finally arrives; Dave joins at the invite epoch.
+    assert!(bus.release_delayed("dave-welcome"));
+    bus.deliver_all();
+    let join_outcomes = dave.tick().await;
+    assert!(
+        join_outcomes.iter().all(Result::is_ok),
+        "dave join outcomes: {join_outcomes:?}"
+    );
+    assert_eq!(dave.epoch().0, 2);
+
+    // Relay redelivery of the commits he dropped pre-join.
+    assert!(bus.release_delayed("bf-1"));
+    assert!(bus.release_delayed("bf-2"));
+    bus.deliver_all();
+    let catchup_outcomes = dave.tick().await;
+    assert!(
+        catchup_outcomes.iter().all(Result::is_ok),
+        "dave catchup outcomes: {catchup_outcomes:?}"
+    );
+    assert_eq!(
+        dave.epoch().0,
+        4,
+        "redelivered commits must catch dave up after his late join"
+    );
+    assert_eq!(dave.members().len(), 3);
+}

--- a/crates/cgka-conformance-simulator/vectors/late-welcome-backfill.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/late-welcome-backfill.v1.json
@@ -1,0 +1,281 @@
+{
+ "scenario_name": "late-welcome-backfill/v1",
+ "vector_version": "1",
+ "conformance_version": "0.9.11",
+ "seed": null,
+ "scenario": {
+  "name": "late-welcome-backfill/v1",
+  "spec_version": "2",
+  "clients": [
+   "alice",
+   "bob",
+   "dave"
+  ],
+  "steps": [
+   {
+    "type": "create_group",
+    "creator": "alice",
+    "name": "late-backfill",
+    "invitees": [
+     "bob"
+    ],
+    "required_features": [],
+    "pending": "create"
+   },
+   {
+    "type": "acknowledge_outbound",
+    "client": "alice",
+    "publication": "create",
+    "outcome": "accepted"
+   },
+   {
+    "type": "deliver_all"
+   },
+   {
+    "type": "tick",
+    "clients": [
+     "bob"
+    ]
+   },
+   {
+    "type": "clear_events",
+    "clients": [
+     "alice",
+     "bob",
+     "dave"
+    ]
+   },
+   {
+    "type": "invite_members",
+    "inviter": "alice",
+    "invitees": [
+     "dave"
+    ],
+    "pending": "inv-dave"
+   },
+   {
+    "type": "acknowledge_outbound",
+    "client": "alice",
+    "publication": "inv-dave",
+    "outcome": "accepted"
+   },
+   {
+    "type": "withhold_message",
+    "selector": {
+     "class": "welcome"
+    },
+    "label": "dave-welcome"
+   },
+   {
+    "type": "deliver_all"
+   },
+   {
+    "type": "tick",
+    "clients": [
+     "bob"
+    ]
+   },
+   {
+    "type": "update_group_data",
+    "client": "alice",
+    "name": "rename-1",
+    "pending": "u1"
+   },
+   {
+    "type": "acknowledge_outbound",
+    "client": "alice",
+    "publication": "u1",
+    "outcome": "accepted"
+   },
+   {
+    "type": "duplicate_message",
+    "selector": {
+     "publication": "u1"
+    }
+   },
+   {
+    "type": "withhold_message",
+    "selector": {
+     "publication": "u1",
+     "occurrence": 1
+    },
+    "label": "bf1"
+   },
+   {
+    "type": "deliver_all"
+   },
+   {
+    "type": "tick",
+    "clients": [
+     "bob"
+    ]
+   },
+   {
+    "type": "update_group_data",
+    "client": "alice",
+    "name": "rename-2",
+    "pending": "u2"
+   },
+   {
+    "type": "acknowledge_outbound",
+    "client": "alice",
+    "publication": "u2",
+    "outcome": "accepted"
+   },
+   {
+    "type": "duplicate_message",
+    "selector": {
+     "publication": "u2"
+    }
+   },
+   {
+    "type": "withhold_message",
+    "selector": {
+     "publication": "u2",
+     "occurrence": 1
+    },
+    "label": "bf2"
+   },
+   {
+    "type": "deliver_all"
+   },
+   {
+    "type": "tick",
+    "clients": [
+     "bob"
+    ]
+   },
+   {
+    "type": "release_withheld",
+    "label": "dave-welcome"
+   },
+   {
+    "type": "deliver_all"
+   },
+   {
+    "type": "tick",
+    "clients": [
+     "dave"
+    ]
+   },
+   {
+    "type": "release_withheld",
+    "label": "bf1"
+   },
+   {
+    "type": "release_withheld",
+    "label": "bf2"
+   },
+   {
+    "type": "deliver_all"
+   },
+   {
+    "type": "tick",
+    "clients": [
+     "alice",
+     "bob",
+     "dave"
+    ]
+   },
+   {
+    "type": "deliver_all"
+   },
+   {
+    "type": "tick",
+    "clients": [
+     "alice",
+     "bob",
+     "dave"
+    ]
+   },
+   {
+    "type": "send_app_message",
+    "sender": "dave",
+    "payload": "dave:caught-up"
+   },
+   {
+    "type": "deliver_all"
+   },
+   {
+    "type": "tick",
+    "clients": [
+     "alice",
+     "bob"
+    ]
+   },
+   {
+    "type": "observe",
+    "clients": [
+     "alice",
+     "bob",
+     "dave"
+    ]
+   }
+  ]
+ },
+ "expected_outcomes": [
+  {
+   "type": "pending_resolution",
+   "step_index": 1,
+   "client": "alice",
+   "pending": "create",
+   "resolution": "confirmed"
+  },
+  {
+   "type": "pending_resolution",
+   "step_index": 6,
+   "client": "alice",
+   "pending": "inv-dave",
+   "resolution": "confirmed"
+  },
+  {
+   "type": "pending_resolution",
+   "step_index": 11,
+   "client": "alice",
+   "pending": "u1",
+   "resolution": "confirmed"
+  },
+  {
+   "type": "pending_resolution",
+   "step_index": 17,
+   "client": "alice",
+   "pending": "u2",
+   "resolution": "confirmed"
+  },
+  {
+   "type": "clients_converged",
+   "clients": [
+    "alice",
+    "bob",
+    "dave"
+   ],
+   "epoch": 4,
+   "member_count": 3
+  },
+  {
+   "type": "client_state",
+   "client": "alice",
+   "epoch": 4,
+   "member_count": 3,
+   "received_payloads": [
+    "dave:caught-up"
+   ]
+  },
+  {
+   "type": "client_state",
+   "client": "bob",
+   "epoch": 4,
+   "member_count": 3,
+   "received_payloads": [
+    "dave:caught-up"
+   ]
+  },
+  {
+   "type": "client_state",
+   "client": "dave",
+   "epoch": 4,
+   "member_count": 3,
+   "received_payloads": []
+  }
+ ]
+}

--- a/crates/cgka-conformance-simulator/vectors/manifest.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/manifest.v1.json
@@ -500,6 +500,19 @@
         "post-rejoin application traffic"
       ],
       "next": "Keep as the re-add regression fixture; extend leaver-removal-secrecy with its re-add leg separately."
+    },
+    {
+      "id": "late-welcome-backfill/v1",
+      "kind": "scenario_vector",
+      "status": "portable",
+      "artifact": "late-welcome-backfill.v1.json",
+      "coverage": [
+        "commits delivered before the recipient's delayed Welcome",
+        "unknown-route drop without a durable record",
+        "post-join relay redelivery of the same events",
+        "late joiner catch-up to the group tip"
+      ],
+      "next": "Keep as the late-welcome recovery regression; unknown-route retention stays deliberately absent per the flood posture."
     }
   ]
 }

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -270,6 +270,15 @@ impl<S: StorageProvider> Engine<S> {
                         EpochId(0),
                         MessageState::Retryable,
                     )?;
+                    // Unknown-group traffic is deliberately not retained when
+                    // no group row exists (#740: unknown-route floods must
+                    // not consume storage), so this ignore is not terminal
+                    // evidence either. Keep the id out of the in-memory seen
+                    // cache: if this client later joins the group (a Welcome
+                    // that raced behind its commits), relay redelivery of the
+                    // same event must process instead of classifying as a
+                    // duplicate of a message that left no durable record.
+                    self.retryable_unpersisted_ingest_id = Some(msg.id.clone());
                     return Ok(IngestOutcome::Ignored {
                         category: InputRejectionCategory::UnknownGroup,
                     });


### PR DESCRIPTION
Stacked on #1367.

A marmot that knocked before the burrow existed should not be turned away when it knocks again after the door goes up. Commits that reach a client before its delayed Welcome cannot resolve the transport route, and the unknown-route posture (#740) deliberately drops them without a durable record. The ingest loop still inserted each dropped message id into the in-memory seen cache. When the client later joined and the relay redelivered the same events (the designed recovery path), the copies were classified as duplicates of input that left no record. The late joiner stayed epochs behind the group forever while reporting no pending work.

Changes:

- The unknown-group ignore in `ingest_group_message` is now marked retryable-unpersisted, so the seen cache skips it. Redelivered events after the join resolve the freshly indexed route and apply normally. The #740 flood posture is unchanged: unknown-route traffic still consumes no storage.
- New harness regression `late_welcome_join_catches_up_via_redelivered_commits`: Dave's Welcome is delayed while the group advances two epochs, and redelivery after his join must catch him up to the tip.
- New harness regression `commit_missing_proposal_defers_and_applies_after_proposal_backfill`, pinning behavior that was already correct: a commit whose referenced proposal never arrived stays convergence-deferred, and a later proposal backfill completes it at the recipient.
- New portable vector `late-welcome-backfill/v1` (strict-oracle green), registered in the manifest and `SCENARIOS.md`.

Verification: both regressions pass; all 30 portable vectors pass the strict oracle; the cgka-engine suite passes under the CI invocation; `just fast-ci` is green. The stack was rebased onto master `d34629e7` and re-verified against the adjacent leave-persistence and replacement-Welcome retirement changes.
