### PR TITLE
test(transport-nostr): stabilize failed-signature EOSE wait

### DIFF
--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -30,6 +30,9 @@ versioning through the workspace version in the root `Cargo.toml`.
 - Leave-proposal persistence now commits the signed proposal, durable leave
   request, and content-dedup marker atomically, so a storage failure cannot
   strand a same-epoch leave retry without a publishable proposal.
+- The Nostr SDK failed-signature regression test now observes EOSE under one
+  bounded CI-safe window, avoiding sharded CI flakes without weakening
+  failed-event non-emission and non-caching assertions.
 
 ## [0.9.11] - 2026-08-09
 

--- a/crates/transport-nostr-adapter/src/sdk_client.rs
+++ b/crates/transport-nostr-adapter/src/sdk_client.rs
@@ -2262,22 +2262,27 @@ mod tests {
             .await
             .unwrap();
 
-        loop {
-            match timeout(Duration::from_secs(5), notifications.recv())
-                .await
-                .expect("the relay EOSE must arrive")
-                .expect("notification channel remains open")
-            {
-                RelayPoolNotification::Event { .. } => {
-                    panic!("failed signature verification must not emit a trusted event")
+        const RELAY_EOSE_TIMEOUT: Duration = Duration::from_secs(30);
+        timeout(RELAY_EOSE_TIMEOUT, async {
+            loop {
+                match notifications
+                    .recv()
+                    .await
+                    .expect("notification channel remains open")
+                {
+                    RelayPoolNotification::Event { .. } => {
+                        panic!("failed signature verification must not emit a trusted event")
+                    }
+                    RelayPoolNotification::Message {
+                        message: RelayMessage::EndOfStoredEvents(_),
+                        ..
+                    } => break,
+                    _ => {}
                 }
-                RelayPoolNotification::Message {
-                    message: RelayMessage::EndOfStoredEvents(_),
-                    ..
-                } => break,
-                _ => {}
             }
-        }
+        })
+        .await
+        .expect("the relay EOSE must arrive within the CI-safe timeout");
         assert_eq!(
             client.database().check_id(&event.id).await.unwrap(),
             DatabaseEventStatus::NotExistent,


### PR DESCRIPTION
Fixes #1375

## Summary

- replace the per-notification five-second EOSE wait with one bounded 30-second observation window
- preserve strict failure on trusted-event emission or notification-channel failure, plus the invalid-event non-caching assertion
- document the test-harness stabilization in the compatibility-cohort changelog

The change is test-only. It composes with current master's relay-lifetime oneshot, which keeps the socket open until the EOSE and database assertions complete.

## Verification

- `cargo fmt --all -- --check`
- focused failed-signature regression: 20/20 passes under concurrent host load
- `cargo test -p transport-nostr-adapter --features sdk --locked` — 61 unit and 30 integration tests passed
- `cargo clippy -p transport-nostr-adapter --features sdk --all-targets --locked -- -D warnings`
- workflow-exact nextest shard 1/4 rerun — 898/898 passed; target regression passed in 0.057s

The first local full-shard run also passed the target regression, but an unrelated existing OpenCode idle-timeout boundary test exhausted both retries. Its focused run reproduced a fail/pass timing race, the full shard rerun passed, and follow-up is tracked in #1381.

## Sensitive paths

- `crates/transport-nostr-adapter/src/sdk_client.rs` — test-only synchronization; no production transport behavior changed
