### PR TITLE
fix(timeline): converge group history ordering

### DIFF
--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -21,6 +21,10 @@ versioning through the workspace version in the root `Cargo.toml`.
 - Engine fork-detection integration tests now exercise the pinned v1
   five-commit rewind horizon in normal builds instead of overriding
   `max_rewind_commits` to one.
+- Group timelines now derive their durable order from authenticated MLS source
+  epochs instead of local receive time. State-change rows lead the application
+  messages they authorize, pagination/live windows and read markers share that
+  order, and delayed catch-up converges to the same sequence on every device.
 - Runtime catch-up, key-package maintenance, and every other incremental sync
   seam now execute an armed epoch-gap full-history replay immediately instead of
   waiting for unrelated later relay traffic. Explicit full-history repair also

--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -732,13 +732,13 @@ pub(crate) enum MessageCommand {
         group_id: Option<String>,
         #[arg(long, help = "Group id to list")]
         group: Option<String>,
-        #[arg(long, help = "Only include messages before this unix timestamp")]
+        #[arg(long, help = "Before-cursor timestamp; requires --before-message-id")]
         before: Option<u64>,
-        #[arg(long, help = "Only include messages before this message id")]
+        #[arg(long, help = "Before-cursor message id; requires --before")]
         before_message_id: Option<String>,
-        #[arg(long, help = "Only include messages after this unix timestamp")]
+        #[arg(long, help = "After-cursor timestamp; requires --after-message-id")]
         after: Option<u64>,
-        #[arg(long, help = "Only include messages after this message id")]
+        #[arg(long, help = "After-cursor message id; requires --after")]
         after_message_id: Option<String>,
         #[arg(long, help = "Maximum number of messages to return")]
         limit: Option<usize>,
@@ -781,13 +781,13 @@ pub(crate) enum MessageTimelineCommand {
         group_id: Option<String>,
         #[arg(long, help = "Group id to list")]
         group: Option<String>,
-        #[arg(long, help = "Only include timeline rows before this unix timestamp")]
+        #[arg(long, help = "Before-cursor timestamp; requires --before-message-id")]
         before: Option<u64>,
-        #[arg(long, help = "Only include timeline rows before this message id")]
+        #[arg(long, help = "Before-cursor message id; requires --before")]
         before_message_id: Option<String>,
-        #[arg(long, help = "Only include timeline rows after this unix timestamp")]
+        #[arg(long, help = "After-cursor timestamp; requires --after-message-id")]
         after: Option<u64>,
-        #[arg(long, help = "Only include timeline rows after this message id")]
+        #[arg(long, help = "After-cursor message id; requires --after")]
         after_message_id: Option<String>,
         #[arg(long, help = "Maximum number of timeline rows to return")]
         limit: Option<usize>,

--- a/crates/marmot-app/src/client/retention.rs
+++ b/crates/marmot-app/src/client/retention.rs
@@ -205,7 +205,7 @@ impl AppClient {
         );
 
         loop {
-            let page = self.app.timeline_messages_with_query(
+            let page = self.app.timeline_messages_by_wall_clock_with_query(
                 &self.state.label,
                 TimelineMessageQuery {
                     group_id_hex: Some(input.group_id_hex.clone()),

--- a/crates/marmot-app/src/error.rs
+++ b/crates/marmot-app/src/error.rs
@@ -296,6 +296,7 @@ fn storage_error_kind(error: &StorageError) -> &'static str {
         StorageError::NotFound => "storage_not_found",
         StorageError::AlreadyExists => "storage_already_exists",
         StorageError::SnapshotMissing(_) => "storage_snapshot_missing",
+        StorageError::TimelineCursorExpired => "storage_timeline_cursor_expired",
         StorageError::Busy(_) => "storage_busy",
         StorageError::Closed(_) => "storage_closed",
         StorageError::Backend(_) => "storage_backend",

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -1924,6 +1924,17 @@ impl MarmotApp {
         Ok(self.account_storage(label)?.message_timeline(query)?)
     }
 
+    pub(crate) fn timeline_messages_by_wall_clock_with_query(
+        &self,
+        label: &str,
+        query: TimelineMessageQuery,
+    ) -> Result<TimelinePage, AppError> {
+        self.ensure_account_state(label)?;
+        Ok(self
+            .account_storage(label)?
+            .message_timeline_by_wall_clock(query)?)
+    }
+
     pub fn timeline_message(
         &self,
         label: &str,

--- a/crates/marmot-app/src/runtime/event_routing.rs
+++ b/crates/marmot-app/src/runtime/event_routing.rs
@@ -56,10 +56,14 @@ pub(crate) fn projection_update_matches_query(
 }
 
 pub(crate) fn timeline_query_can_apply_projection_delta(query: &TimelineMessageQuery) -> bool {
-    query
-        .search
-        .as_ref()
-        .is_none_or(|search| search.trim().is_empty())
+    // Canonical source epochs are comparable only within one group. A global
+    // subscription keeps the store's wall-clock ordering by refreshing instead
+    // of locally merging per-group deltas.
+    query.group_id_hex.is_some()
+        && query
+            .search
+            .as_ref()
+            .is_none_or(|search| search.trim().is_empty())
         && query.pagination.before.is_none()
         && query.pagination.before_message_id.is_none()
         && query.pagination.after.is_none()

--- a/crates/marmot-app/src/runtime/event_routing.rs
+++ b/crates/marmot-app/src/runtime/event_routing.rs
@@ -56,14 +56,12 @@ pub(crate) fn projection_update_matches_query(
 }
 
 pub(crate) fn timeline_query_can_apply_projection_delta(query: &TimelineMessageQuery) -> bool {
-    // Canonical source epochs are comparable only within one group. A global
-    // subscription keeps the store's wall-clock ordering by refreshing instead
-    // of locally merging per-group deltas.
-    query.group_id_hex.is_some()
-        && query
-            .search
-            .as_ref()
-            .is_none_or(|search| search.trim().is_empty())
+    // Projection application already derives canonical-vs-wall ordering from
+    // this field, so global windows can safely merge per-group deltas.
+    query
+        .search
+        .as_ref()
+        .is_none_or(|search| search.trim().is_empty())
         && query.pagination.before.is_none()
         && query.pagination.before_message_id.is_none()
         && query.pagination.after.is_none()

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -94,7 +94,7 @@ pub(crate) use agent_stream_watch::{
 pub(crate) use subscriptions::{
     TIMELINE_WINDOW_LIMIT, TimelineQueryFn, TimelineSubscriptionSignal, TimelineWindow,
     TimelineWindowEdge, apply_projection_to_window, chat_list_row_fingerprint,
-    merge_timeline_window, messages_recovery_query, received_message_update_from_record,
+    merge_timeline_window_with_order, messages_recovery_query, received_message_update_from_record,
     reconcile_chat_list_snapshot, recovery_row_is_pre_subscription, send_atomic_chat_list_snapshot,
     send_chat_list_remove_update,
 };

--- a/crates/marmot-app/src/runtime/subscriptions.rs
+++ b/crates/marmot-app/src/runtime/subscriptions.rs
@@ -138,9 +138,9 @@ impl TimelineWindow {
         query.pagination = match self.page.messages.last() {
             // Detached: re-fetch the loaded range ending exactly at the newest
             // message using an *inclusive* upper-bound cursor. The store applies
-            // the descending `LIMIT` against `<= (timeline_at, message_id_hex)`,
-            // so newer same-second rows are excluded at the SQL level and can't
-            // starve the window — no post-fetch trimming required.
+            // the descending `LIMIT` against the row-resolved canonical key, so
+            // newer rows are excluded at the SQL level and can't starve the
+            // window — no post-fetch trimming required.
             Some(newest) if !self.anchored_to_head() => TimelinePagination {
                 before: Some(newest.timeline_at),
                 before_message_id: Some(newest.message_id_hex.clone()),
@@ -206,7 +206,14 @@ impl TimelineWindowHandle {
         let older = blocking_app_task(move || query_fn(query)).await?;
         let mut window = self.lock();
         let limit = window.window_limit;
-        merge_timeline_window(&mut window.page, older, TimelineWindowEdge::Older, limit);
+        let canonical_group_order = window.base_query.group_id_hex.is_some();
+        merge_timeline_window_with_order(
+            &mut window.page,
+            older,
+            TimelineWindowEdge::Older,
+            limit,
+            canonical_group_order,
+        );
         window.bump_generation();
         Ok(window.page.clone())
     }
@@ -236,7 +243,14 @@ impl TimelineWindowHandle {
         let newer = blocking_app_task(move || query_fn(query)).await?;
         let mut window = self.lock();
         let limit = window.window_limit;
-        merge_timeline_window(&mut window.page, newer, TimelineWindowEdge::Newer, limit);
+        let canonical_group_order = window.base_query.group_id_hex.is_some();
+        merge_timeline_window_with_order(
+            &mut window.page,
+            newer,
+            TimelineWindowEdge::Newer,
+            limit,
+            canonical_group_order,
+        );
         window.bump_generation();
         Ok(window.page.clone())
     }
@@ -346,30 +360,45 @@ impl RuntimeTimelineMessagesSubscription {
     }
 }
 
-/// Sort a timeline by the canonical `(timeline_at, message_id_hex)` ascending
-/// order the store and clients agree on.
-fn sort_timeline_records(messages: &mut [TimelineMessageRecord]) {
-    messages.sort_by(|left, right| {
-        left.timeline_at
-            .cmp(&right.timeline_at)
-            .then_with(|| left.message_id_hex.cmp(&right.message_id_hex))
-    });
+/// Sort a group timeline by the accepted-history order the store and clients
+/// agree on.
+fn sort_timeline_records(messages: &mut [TimelineMessageRecord], canonical_group_order: bool) {
+    if canonical_group_order {
+        messages
+            .sort_by(|left, right| left.canonical_order_key().cmp(&right.canonical_order_key()));
+    } else {
+        messages.sort_by(|left, right| {
+            (left.timeline_at, &left.message_id_hex)
+                .cmp(&(right.timeline_at, &right.message_id_hex))
+        });
+    }
 }
 
 /// Merge a freshly-queried page into `window` on the given edge, then enforce
 /// the cap from the opposite edge. The single piece of windowing logic shared
 /// by both pagination directions.
+#[cfg(test)]
 pub(crate) fn merge_timeline_window(
     window: &mut TimelinePage,
     incoming: TimelinePage,
     edge: TimelineWindowEdge,
     limit: usize,
 ) {
+    merge_timeline_window_with_order(window, incoming, edge, limit, true);
+}
+
+fn merge_timeline_window_with_order(
+    window: &mut TimelinePage,
+    incoming: TimelinePage,
+    edge: TimelineWindowEdge,
+    limit: usize,
+    canonical_group_order: bool,
+) {
     let mut messages = std::mem::take(&mut window.messages);
     for message in incoming.messages {
         upsert_window_message(&mut messages, message);
     }
-    sort_timeline_records(&mut messages);
+    sort_timeline_records(&mut messages, canonical_group_order);
     match edge {
         TimelineWindowEdge::Older => {
             // The older side now reflects whatever the store reported. The
@@ -405,21 +434,16 @@ pub(crate) fn apply_projection_to_window(
     limit: usize,
 ) {
     let anchored = !window.has_more_after;
-    // Canonical upper bound of the window is the pair `(timeline_at,
-    // message_id_hex)`, not just the timestamp. A detached window must suppress
-    // anything sorting strictly after this — including same-second messages with
-    // a larger id, which `timeline_at`-only comparison would have admitted.
-    let newest_key = window
-        .messages
-        .last()
-        .map(|message| (message.timeline_at, message.message_id_hex.clone()));
+    // A detached window must suppress anything sorting strictly after its
+    // canonical accepted-history upper bound.
+    let newest_message = window.messages.last().cloned();
     if update.timeline_changes.is_empty() {
         for message in &update.timeline_messages {
             insert_live_message(
                 &mut window.messages,
                 message.clone(),
                 anchored,
-                newest_key.as_ref(),
+                newest_message.as_ref(),
             );
         }
     } else {
@@ -430,7 +454,7 @@ pub(crate) fn apply_projection_to_window(
                         &mut window.messages,
                         (**message).clone(),
                         anchored,
-                        newest_key.as_ref(),
+                        newest_message.as_ref(),
                     );
                 }
                 TimelineMessageChange::Remove { message_id_hex, .. } => {
@@ -441,7 +465,7 @@ pub(crate) fn apply_projection_to_window(
             }
         }
     }
-    sort_timeline_records(&mut window.messages);
+    sort_timeline_records(&mut window.messages, true);
     // Live growth only ever adds at or below the head, so trim the oldest rows
     // on overflow; the head boundary (`has_more_after`) is preserved.
     if window.messages.len() > limit {
@@ -454,15 +478,15 @@ pub(crate) fn apply_projection_to_window(
 /// Apply one live upsert. Existing messages are replaced in place (edits,
 /// reactions, delivery-state changes). A brand-new message is appended only when
 /// the window is anchored to the head, or when it sorts at or below the detached
-/// window's newest message in canonical `(timeline_at, message_id_hex)` order.
-/// `newest_key` is `None` only for an empty window, where a detached window has
+/// window's newest message in canonical accepted-history order.
+/// `newest_message` is `None` only for an empty window, where a detached window has
 /// nothing in range and therefore suppresses (an anchored empty window still
 /// appends, as the head).
 fn insert_live_message(
     messages: &mut Vec<TimelineMessageRecord>,
     message: TimelineMessageRecord,
     anchored: bool,
-    newest_key: Option<&(u64, String)>,
+    newest_message: Option<&TimelineMessageRecord>,
 ) {
     if let Some(existing) = messages
         .iter_mut()
@@ -471,9 +495,8 @@ fn insert_live_message(
         *existing = message;
         return;
     }
-    let within_window = newest_key.is_some_and(|(at, id)| {
-        (message.timeline_at, message.message_id_hex.as_str()) <= (*at, id.as_str())
-    });
+    let within_window = newest_message
+        .is_some_and(|newest| message.canonical_order_key() <= newest.canonical_order_key());
     if anchored || within_window {
         messages.push(message);
     }

--- a/crates/marmot-app/src/runtime/subscriptions.rs
+++ b/crates/marmot-app/src/runtime/subscriptions.rs
@@ -301,7 +301,8 @@ impl TimelineWindowHandle {
     fn apply_projection(&self, update: &AppProjectionUpdate) {
         let mut window = self.lock();
         let limit = window.window_limit;
-        apply_projection_to_window(&mut window.page, update, limit);
+        let canonical_group_order = window.base_query.group_id_hex.is_some();
+        apply_projection_to_window(&mut window.page, update, limit, canonical_group_order);
         window.bump_generation();
     }
 
@@ -410,34 +411,30 @@ impl RuntimeTimelineMessagesSubscription {
     }
 }
 
-/// Sort a group timeline by the accepted-history order the store and clients
-/// agree on.
-fn sort_timeline_records(messages: &mut [TimelineMessageRecord], canonical_group_order: bool) {
+fn timeline_record_order_key(
+    message: &TimelineMessageRecord,
+    canonical_group_order: bool,
+) -> (u8, u64, u8, u64, &str) {
     if canonical_group_order {
-        messages
-            .sort_by(|left, right| left.canonical_order_key().cmp(&right.canonical_order_key()));
+        message.canonical_order_key()
     } else {
-        messages.sort_by(|left, right| {
-            (left.timeline_at, &left.message_id_hex)
-                .cmp(&(right.timeline_at, &right.message_id_hex))
-        });
+        (0, message.timeline_at, 0, 0, &message.message_id_hex)
     }
+}
+
+/// Sort a timeline by the same group-canonical or global wall-clock order used
+/// by its storage query.
+fn sort_timeline_records(messages: &mut [TimelineMessageRecord], canonical_group_order: bool) {
+    messages.sort_by(|left, right| {
+        timeline_record_order_key(left, canonical_group_order)
+            .cmp(&timeline_record_order_key(right, canonical_group_order))
+    });
 }
 
 /// Merge a freshly-queried page into `window` on the given edge, then enforce
 /// the cap from the opposite edge. The single piece of windowing logic shared
 /// by both pagination directions.
-#[cfg(test)]
-pub(crate) fn merge_timeline_window(
-    window: &mut TimelinePage,
-    incoming: TimelinePage,
-    edge: TimelineWindowEdge,
-    limit: usize,
-) {
-    merge_timeline_window_with_order(window, incoming, edge, limit, true);
-}
-
-fn merge_timeline_window_with_order(
+pub(crate) fn merge_timeline_window_with_order(
     window: &mut TimelinePage,
     incoming: TimelinePage,
     edge: TimelineWindowEdge,
@@ -482,18 +479,25 @@ pub(crate) fn apply_projection_to_window(
     window: &mut TimelinePage,
     update: &AppProjectionUpdate,
     limit: usize,
+    canonical_group_order: bool,
 ) {
     let anchored = !window.has_more_after;
     // A detached window must suppress anything sorting strictly after its
-    // canonical accepted-history upper bound.
-    let newest_message = window.messages.last().cloned();
+    // query-order upper bound. Own only the message id so delta application can
+    // mutate the window without cloning the newest record's payload.
+    let newest_order = window.messages.last().map(|newest| {
+        let (class, primary, phase, at, id) =
+            timeline_record_order_key(newest, canonical_group_order);
+        (class, primary, phase, at, id.to_owned())
+    });
     if update.timeline_changes.is_empty() {
         for message in &update.timeline_messages {
             insert_live_message(
                 &mut window.messages,
                 message.clone(),
                 anchored,
-                newest_message.as_ref(),
+                newest_order.as_ref(),
+                canonical_group_order,
             );
         }
     } else {
@@ -504,7 +508,8 @@ pub(crate) fn apply_projection_to_window(
                         &mut window.messages,
                         (**message).clone(),
                         anchored,
-                        newest_message.as_ref(),
+                        newest_order.as_ref(),
+                        canonical_group_order,
                     );
                 }
                 TimelineMessageChange::Remove { message_id_hex, .. } => {
@@ -515,7 +520,7 @@ pub(crate) fn apply_projection_to_window(
             }
         }
     }
-    sort_timeline_records(&mut window.messages, true);
+    sort_timeline_records(&mut window.messages, canonical_group_order);
     // Live growth only ever adds at or below the head, so trim the oldest rows
     // on overflow; the head boundary (`has_more_after`) is preserved.
     if window.messages.len() > limit {
@@ -528,15 +533,16 @@ pub(crate) fn apply_projection_to_window(
 /// Apply one live upsert. Existing messages are replaced in place (edits,
 /// reactions, delivery-state changes). A brand-new message is appended only when
 /// the window is anchored to the head, or when it sorts at or below the detached
-/// window's newest message in canonical accepted-history order.
-/// `newest_message` is `None` only for an empty window, where a detached window has
+/// window's newest message in that query's canonical or wall-clock order.
+/// `newest_order` is `None` only for an empty window, where a detached window has
 /// nothing in range and therefore suppresses (an anchored empty window still
 /// appends, as the head).
 fn insert_live_message(
     messages: &mut Vec<TimelineMessageRecord>,
     message: TimelineMessageRecord,
     anchored: bool,
-    newest_message: Option<&TimelineMessageRecord>,
+    newest_order: Option<&(u8, u64, u8, u64, String)>,
+    canonical_group_order: bool,
 ) {
     if let Some(existing) = messages
         .iter_mut()
@@ -545,8 +551,10 @@ fn insert_live_message(
         *existing = message;
         return;
     }
-    let within_window = newest_message
-        .is_some_and(|newest| message.canonical_order_key() <= newest.canonical_order_key());
+    let within_window = newest_order.is_some_and(|newest| {
+        timeline_record_order_key(&message, canonical_group_order)
+            <= (newest.0, newest.1, newest.2, newest.3, newest.4.as_str())
+    });
     if anchored || within_window {
         messages.push(message);
     }

--- a/crates/marmot-app/src/runtime/subscriptions.rs
+++ b/crates/marmot-app/src/runtime/subscriptions.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 
 use cgka_traits::app_event::MARMOT_APP_EVENT_KIND_AGENT_STREAM_START;
-use cgka_traits::{GroupId, MessageId};
+use cgka_traits::{GroupId, MessageId, storage::StorageError};
 use serde::{Deserialize, Serialize};
 use storage_sqlite::AppEventReplayCursor;
 use tokio::sync::{broadcast, mpsc, oneshot, watch};
@@ -126,6 +126,15 @@ impl TimelineWindow {
         self.generation = self.generation.wrapping_add(1);
     }
 
+    fn head_refresh_query(&self) -> TimelineMessageQuery {
+        let mut query = self.base_query.clone();
+        query.pagination = TimelinePagination {
+            limit: Some(self.page.messages.len().max(1)),
+            ..TimelinePagination::default()
+        };
+        query
+    }
+
     /// Cursor query that re-materializes the current window from the store.
     /// Anchored windows refresh the head; detached (scrolled-back) windows
     /// refresh the loaded range ending at the current newest message so the
@@ -133,13 +142,14 @@ impl TimelineWindow {
     /// Because the window is capped at the store's single-query limit, one query
     /// always reconstitutes it.
     pub(crate) fn refresh_query(&self) -> TimelineMessageQuery {
-        let mut query = self.base_query.clone();
+        let mut query = self.head_refresh_query();
         let limit = self.page.messages.len().max(1);
         query.pagination = match self.page.messages.last() {
             // Detached: re-fetch the loaded range ending exactly at the newest
-            // message using an *inclusive* upper-bound cursor. The store applies
-            // the descending `LIMIT` against the row-resolved canonical key, so
-            // newer rows are excluded at the SQL level and can't starve the
+            // message using an *inclusive* upper-bound cursor. Group queries
+            // apply the descending `LIMIT` against the row-resolved canonical
+            // key; global queries use the wall-clock timestamp/message-id key.
+            // Either order excludes newer rows in SQL so they cannot starve the
             // window — no post-fetch trimming required.
             Some(newest) if !self.anchored_to_head() => TimelinePagination {
                 before: Some(newest.timeline_at),
@@ -149,12 +159,25 @@ impl TimelineWindow {
                 ..TimelinePagination::default()
             },
             // Anchored or empty: refresh the head.
-            _ => TimelinePagination {
-                limit: Some(limit),
-                ..TimelinePagination::default()
-            },
+            _ => query.pagination,
         };
         query
+    }
+}
+
+async fn query_timeline_page_with_cursor_refresh(
+    query_fn: Arc<TimelineQueryFn>,
+    query: TimelineMessageQuery,
+    head_query: TimelineMessageQuery,
+) -> Result<(TimelinePage, bool), AppError> {
+    let first_query_fn = query_fn.clone();
+    match blocking_app_task(move || first_query_fn(query)).await {
+        Ok(page) => Ok((page, false)),
+        Err(AppError::Storage(StorageError::TimelineCursorExpired)) => {
+            let page = blocking_app_task(move || query_fn(head_query)).await?;
+            Ok((page, true))
+        }
+        Err(error) => Err(error),
     }
 }
 
@@ -186,7 +209,7 @@ impl TimelineWindowHandle {
     /// return the updated window. A no-op (returns the current window) when no
     /// older messages exist. The store read runs off the caller thread.
     pub async fn paginate_backwards(&self, count: usize) -> Result<TimelinePage, AppError> {
-        let (query_fn, query) = {
+        let (query_fn, query, head_query, generation) = {
             let window = self.lock();
             if !window.page.has_more_before {
                 return Ok(window.page.clone());
@@ -201,9 +224,18 @@ impl TimelineWindowHandle {
                 limit: Some(count),
                 ..TimelinePagination::default()
             };
-            (window.query.clone(), query)
+            (
+                window.query.clone(),
+                query,
+                window.head_refresh_query(),
+                window.generation,
+            )
         };
-        let older = blocking_app_task(move || query_fn(query)).await?;
+        let (older, refreshed) =
+            query_timeline_page_with_cursor_refresh(query_fn, query, head_query).await?;
+        if refreshed {
+            return Ok(self.install_refresh(older, generation));
+        }
         let mut window = self.lock();
         let limit = window.window_limit;
         let canonical_group_order = window.base_query.group_id_hex.is_some();
@@ -223,7 +255,7 @@ impl TimelineWindowHandle {
     /// window already includes the head. Reaching the head re-anchors the
     /// window (`has_more_after` becomes false).
     pub async fn paginate_forwards(&self, count: usize) -> Result<TimelinePage, AppError> {
-        let (query_fn, query) = {
+        let (query_fn, query, head_query, generation) = {
             let window = self.lock();
             if !window.page.has_more_after {
                 return Ok(window.page.clone());
@@ -238,9 +270,18 @@ impl TimelineWindowHandle {
                 limit: Some(count),
                 ..TimelinePagination::default()
             };
-            (window.query.clone(), query)
+            (
+                window.query.clone(),
+                query,
+                window.head_refresh_query(),
+                window.generation,
+            )
         };
-        let newer = blocking_app_task(move || query_fn(query)).await?;
+        let (newer, refreshed) =
+            query_timeline_page_with_cursor_refresh(query_fn, query, head_query).await?;
+        if refreshed {
+            return Ok(self.install_refresh(newer, generation));
+        }
         let mut window = self.lock();
         let limit = window.window_limit;
         let canonical_group_order = window.base_query.group_id_hex.is_some();
@@ -266,11 +307,19 @@ impl TimelineWindowHandle {
 
     /// Read the store handle, the refresh cursor, and the window generation the
     /// refresh is based on (so a stale install can be detected).
-    pub(crate) fn refresh_request(&self) -> (Arc<TimelineQueryFn>, TimelineMessageQuery, u64) {
+    pub(crate) fn refresh_request(
+        &self,
+    ) -> (
+        Arc<TimelineQueryFn>,
+        TimelineMessageQuery,
+        TimelineMessageQuery,
+        u64,
+    ) {
         let window = self.lock();
         (
             window.query.clone(),
             window.refresh_query(),
+            window.head_refresh_query(),
             window.generation,
         )
     }
@@ -343,9 +392,10 @@ impl RuntimeTimelineMessagesSubscription {
                     return Some(RuntimeTimelineMessageUpdate::Projection(*update));
                 }
                 TimelineSubscriptionSignal::Refresh => {
-                    let (query_fn, query, generation) = self.window.refresh_request();
-                    match blocking_app_task(move || query_fn(query)).await {
-                        Ok(page) => {
+                    let (query_fn, query, head_query, generation) = self.window.refresh_request();
+                    match query_timeline_page_with_cursor_refresh(query_fn, query, head_query).await
+                    {
+                        Ok((page, _)) => {
                             let page = self.window.install_refresh(page, generation);
                             return Some(RuntimeTimelineMessageUpdate::Page { page });
                         }

--- a/crates/marmot-app/src/runtime/subscriptions.rs
+++ b/crates/marmot-app/src/runtime/subscriptions.rs
@@ -513,9 +513,10 @@ pub(crate) fn apply_projection_to_window(
                     );
                 }
                 TimelineMessageChange::Remove { message_id_hex, .. } => {
-                    window
-                        .messages
-                        .retain(|message| &message.message_id_hex != message_id_hex);
+                    window.messages.retain(|message| {
+                        message.group_id_hex != update.group_id_hex
+                            || &message.message_id_hex != message_id_hex
+                    });
                 }
             }
         }
@@ -544,10 +545,10 @@ fn insert_live_message(
     newest_order: Option<&(u8, u64, u8, u64, String)>,
     canonical_group_order: bool,
 ) {
-    if let Some(existing) = messages
-        .iter_mut()
-        .find(|existing| existing.message_id_hex == message.message_id_hex)
-    {
+    if let Some(existing) = messages.iter_mut().find(|existing| {
+        existing.group_id_hex == message.group_id_hex
+            && existing.message_id_hex == message.message_id_hex
+    }) {
         *existing = message;
         return;
     }
@@ -566,10 +567,10 @@ fn upsert_window_message(
     messages: &mut Vec<TimelineMessageRecord>,
     message: TimelineMessageRecord,
 ) {
-    if let Some(existing) = messages
-        .iter_mut()
-        .find(|existing| existing.message_id_hex == message.message_id_hex)
-    {
+    if let Some(existing) = messages.iter_mut().find(|existing| {
+        existing.group_id_hex == message.group_id_hex
+            && existing.message_id_hex == message.message_id_hex
+    }) {
         *existing = message;
     } else {
         messages.push(message);

--- a/crates/marmot-app/src/runtime/tests.rs
+++ b/crates/marmot-app/src/runtime/tests.rs
@@ -499,6 +499,37 @@ fn timeline_subscription_take_snapshot_retains_window_for_pagination() {
 }
 
 #[test]
+fn merge_timeline_window_orders_epoch_boundaries_canonically() {
+    let mut system_seven = timeline_test_record("system-7", 900);
+    system_seven.source_epoch = Some(7);
+    system_seven.kind = 1210;
+    let mut message_seven = timeline_test_record("message-7", 200);
+    message_seven.source_epoch = Some(7);
+    let mut system_eight = timeline_test_record("system-8", 901);
+    system_eight.source_epoch = Some(8);
+    system_eight.kind = 1210;
+    let mut message_eight = timeline_test_record("message-8", 150);
+    message_eight.source_epoch = Some(8);
+    let mut window = TimelinePage {
+        messages: vec![message_eight, system_seven],
+        has_more_before: false,
+        has_more_after: false,
+    };
+    let incoming = TimelinePage {
+        messages: vec![system_eight, message_seven],
+        has_more_before: false,
+        has_more_after: false,
+    };
+
+    merge_timeline_window(&mut window, incoming, TimelineWindowEdge::Newer, 300);
+
+    assert_eq!(
+        timeline_ids(&window),
+        ["system-7", "message-7", "system-8", "message-8"]
+    );
+}
+
+#[test]
 fn merge_timeline_window_prepends_older_and_keeps_head_flag() {
     let mut window = timeline_test_page(&[("c", 30), ("d", 40)], true, false);
     let older = timeline_test_page(&[("a", 10), ("b", 20)], false, true);

--- a/crates/marmot-app/src/runtime/tests.rs
+++ b/crates/marmot-app/src/runtime/tests.rs
@@ -524,7 +524,7 @@ fn merge_timeline_window_orders_epoch_boundaries_canonically() {
         has_more_after: false,
     };
 
-    merge_timeline_window(&mut window, incoming, TimelineWindowEdge::Newer, 300);
+    merge_timeline_window_with_order(&mut window, incoming, TimelineWindowEdge::Newer, 300, true);
 
     assert_eq!(
         timeline_ids(&window),
@@ -537,7 +537,7 @@ fn merge_timeline_window_prepends_older_and_keeps_head_flag() {
     let mut window = timeline_test_page(&[("c", 30), ("d", 40)], true, false);
     let older = timeline_test_page(&[("a", 10), ("b", 20)], false, true);
 
-    merge_timeline_window(&mut window, older, TimelineWindowEdge::Older, 300);
+    merge_timeline_window_with_order(&mut window, older, TimelineWindowEdge::Older, 300, true);
 
     assert_eq!(timeline_ids(&window), vec!["a", "b", "c", "d"]);
     // The store reported no more history before; the head side is untouched.
@@ -550,7 +550,7 @@ fn merge_timeline_window_older_caps_by_dropping_newest() {
     let mut window = timeline_test_page(&[("c", 30), ("d", 40)], true, false);
     let older = timeline_test_page(&[("a", 10), ("b", 20)], true, true);
 
-    merge_timeline_window(&mut window, older, TimelineWindowEdge::Older, 3);
+    merge_timeline_window_with_order(&mut window, older, TimelineWindowEdge::Older, 3, true);
 
     // Cap forces dropping the newest row, opening a gap to the head.
     assert_eq!(timeline_ids(&window), vec!["a", "b", "c"]);
@@ -563,7 +563,7 @@ fn merge_timeline_window_newer_caps_by_dropping_oldest() {
     let mut window = timeline_test_page(&[("a", 10), ("b", 20)], true, true);
     let newer = timeline_test_page(&[("c", 30), ("d", 40)], true, false);
 
-    merge_timeline_window(&mut window, newer, TimelineWindowEdge::Newer, 3);
+    merge_timeline_window_with_order(&mut window, newer, TimelineWindowEdge::Newer, 3, true);
 
     assert_eq!(timeline_ids(&window), vec!["b", "c", "d"]);
     assert!(window.has_more_before);
@@ -576,7 +576,7 @@ fn merge_timeline_window_dedupes_overlap() {
     let mut window = timeline_test_page(&[("b", 20), ("c", 30)], true, false);
     let older = timeline_test_page(&[("a", 10), ("b", 20)], false, true);
 
-    merge_timeline_window(&mut window, older, TimelineWindowEdge::Older, 300);
+    merge_timeline_window_with_order(&mut window, older, TimelineWindowEdge::Older, 300, true);
 
     assert_eq!(timeline_ids(&window), vec!["a", "b", "c"]);
 }
@@ -596,7 +596,7 @@ fn apply_projection_appends_new_message_when_anchored() {
     let mut window = timeline_test_page(&[("a", 10), ("b", 20)], false, false);
     let update = projection_for(vec![timeline_test_record("c", 30)]);
 
-    apply_projection_to_window(&mut window, &update, 300);
+    apply_projection_to_window(&mut window, &update, 300, true);
 
     assert_eq!(timeline_ids(&window), vec!["a", "b", "c"]);
     assert!(!window.has_more_after);
@@ -607,7 +607,7 @@ fn apply_projection_suppresses_new_head_message_when_detached() {
     let mut window = timeline_test_page(&[("a", 10), ("b", 20)], true, true);
     let update = projection_for(vec![timeline_test_record("c", 30)]);
 
-    apply_projection_to_window(&mut window, &update, 300);
+    apply_projection_to_window(&mut window, &update, 300, true);
 
     // Detached window stays put; the new head message is dropped.
     assert_eq!(timeline_ids(&window), vec!["a", "b"]);
@@ -621,7 +621,7 @@ fn apply_projection_applies_in_window_edit_when_detached() {
     edited.plaintext = "edited".to_owned();
     let update = projection_for(vec![edited]);
 
-    apply_projection_to_window(&mut window, &update, 300);
+    apply_projection_to_window(&mut window, &update, 300, true);
 
     assert_eq!(timeline_ids(&window), vec!["a", "b"]);
     assert_eq!(window.messages[1].plaintext, "edited");
@@ -635,7 +635,7 @@ fn apply_projection_suppresses_same_second_head_when_detached() {
     let mut window = timeline_test_page(&[("a", 10), ("b", 20)], true, true);
     let update = projection_for(vec![timeline_test_record("c", 20)]);
 
-    apply_projection_to_window(&mut window, &update, 300);
+    apply_projection_to_window(&mut window, &update, 300, true);
 
     assert_eq!(timeline_ids(&window), vec!["a", "b"]);
     assert!(window.has_more_after);
@@ -648,7 +648,7 @@ fn apply_projection_applies_same_second_in_range_message_when_detached() {
     let mut window = timeline_test_page(&[("a", 10), ("c", 20)], true, true);
     let update = projection_for(vec![timeline_test_record("b", 20)]);
 
-    apply_projection_to_window(&mut window, &update, 300);
+    apply_projection_to_window(&mut window, &update, 300, true);
 
     assert_eq!(timeline_ids(&window), vec!["a", "b", "c"]);
 }
@@ -660,7 +660,7 @@ fn apply_projection_suppresses_new_message_when_detached_window_empty() {
     let mut window = timeline_test_page(&[], true, true);
     let update = projection_for(vec![timeline_test_record("a", 10)]);
 
-    apply_projection_to_window(&mut window, &update, 300);
+    apply_projection_to_window(&mut window, &update, 300, true);
 
     assert!(window.messages.is_empty());
     assert!(window.has_more_after);
@@ -680,7 +680,7 @@ fn apply_projection_removes_message() {
         chat_list_trigger: Default::default(),
     };
 
-    apply_projection_to_window(&mut window, &update, 300);
+    apply_projection_to_window(&mut window, &update, 300, true);
 
     assert_eq!(timeline_ids(&window), vec!["b"]);
 }
@@ -690,11 +690,28 @@ fn apply_projection_caps_anchored_window_by_dropping_oldest() {
     let mut window = timeline_test_page(&[("a", 10), ("b", 20), ("c", 30)], false, false);
     let update = projection_for(vec![timeline_test_record("d", 40)]);
 
-    apply_projection_to_window(&mut window, &update, 3);
+    apply_projection_to_window(&mut window, &update, 3, true);
 
     assert_eq!(timeline_ids(&window), vec!["b", "c", "d"]);
     assert!(window.has_more_before);
     assert!(!window.has_more_after);
+}
+
+#[test]
+fn apply_projection_preserves_wall_clock_order_for_global_windows() {
+    let mut older_epoch = timeline_test_record("older-epoch", 200);
+    older_epoch.source_epoch = Some(7);
+    let mut newer_epoch = timeline_test_record("newer-epoch", 100);
+    newer_epoch.source_epoch = Some(8);
+    let mut window = TimelinePage {
+        messages: vec![older_epoch, newer_epoch],
+        has_more_before: false,
+        has_more_after: false,
+    };
+
+    apply_projection_to_window(&mut window, &projection_for(Vec::new()), 300, false);
+
+    assert_eq!(timeline_ids(&window), ["newer-epoch", "older-epoch"]);
 }
 
 #[tokio::test]

--- a/crates/marmot-app/src/runtime/tests.rs
+++ b/crates/marmot-app/src/runtime/tests.rs
@@ -354,12 +354,16 @@ fn timeline_ids(page: &TimelinePage) -> Vec<String> {
 /// pagination/refresh call issued.
 #[derive(Clone, Default)]
 struct ScriptedTimelineStore {
-    responses: Arc<StdMutex<std::collections::VecDeque<TimelinePage>>>,
+    responses: Arc<StdMutex<std::collections::VecDeque<Result<TimelinePage, AppError>>>>,
     queries: Arc<StdMutex<Vec<TimelineMessageQuery>>>,
 }
 
 impl ScriptedTimelineStore {
     fn new(responses: Vec<TimelinePage>) -> Self {
+        Self::new_results(responses.into_iter().map(Ok).collect())
+    }
+
+    fn new_results(responses: Vec<Result<TimelinePage, AppError>>) -> Self {
         Self {
             responses: Arc::new(StdMutex::new(responses.into_iter().collect())),
             queries: Arc::new(StdMutex::new(Vec::new())),
@@ -371,12 +375,11 @@ impl ScriptedTimelineStore {
         let queries = self.queries.clone();
         Arc::new(move |query: TimelineMessageQuery| {
             queries.lock().expect("queries lock").push(query);
-            let page = responses
+            responses
                 .lock()
                 .expect("responses lock")
                 .pop_front()
-                .expect("scripted timeline store exhausted");
-            Ok(page)
+                .expect("scripted timeline store exhausted")
         })
     }
 
@@ -925,6 +928,38 @@ async fn recv_refresh_detached_issues_inclusive_upper_cursor() {
 }
 
 #[tokio::test]
+async fn pagination_refreshes_head_when_canonical_cursor_was_pruned() {
+    let store = ScriptedTimelineStore::new_results(vec![
+        Err(AppError::Storage(
+            cgka_traits::storage::StorageError::TimelineCursorExpired,
+        )),
+        Ok(timeline_test_page(&[("x", 40), ("y", 50)], true, false)),
+    ]);
+    let handle = timeline_window_handle(
+        &store,
+        timeline_test_page(&[("a", 10), ("b", 20)], true, true),
+        300,
+    );
+
+    let page = handle
+        .paginate_backwards(2)
+        .await
+        .expect("expired cursor refreshes the window");
+
+    assert_eq!(timeline_ids(&page), vec!["x", "y"]);
+    let queries = store.recorded_queries();
+    assert_eq!(queries.len(), 2);
+    assert_eq!(queries[0].pagination.before, Some(10));
+    assert_eq!(
+        queries[0].pagination.before_message_id.as_deref(),
+        Some("a")
+    );
+    assert_eq!(queries[1].pagination.before, None);
+    assert_eq!(queries[1].pagination.after, None);
+    assert_eq!(queries[1].pagination.limit, Some(2));
+}
+
+#[tokio::test]
 async fn refresh_install_is_dropped_when_window_paginated_during_query() {
     // Deterministic model of the P1(b) race: a refresh captures the window
     // generation before its store read; a pagination completes during that
@@ -943,7 +978,7 @@ async fn refresh_install_is_dropped_when_window_paginated_during_query() {
 
     // recv() captures the refresh request (a generation snapshot) before
     // awaiting the store.
-    let (_query_fn, _query, generation) = handle.refresh_request();
+    let (_query_fn, _query, _head_query, generation) = handle.refresh_request();
 
     // A concurrent pagination lands while the refresh query is "in flight".
     let paginated = handle.paginate_backwards(2).await.expect("paginate");

--- a/crates/marmot-app/src/runtime/tests.rs
+++ b/crates/marmot-app/src/runtime/tests.rs
@@ -714,6 +714,72 @@ fn apply_projection_preserves_wall_clock_order_for_global_windows() {
     assert_eq!(timeline_ids(&window), ["newer-epoch", "older-epoch"]);
 }
 
+#[test]
+fn apply_projection_scopes_global_window_changes_by_group() {
+    let mut group_a = timeline_test_record("shared-id", 10);
+    group_a.group_id_hex = "group-a".to_owned();
+    let mut group_b = timeline_test_record("shared-id", 20);
+    group_b.group_id_hex = "group-b".to_owned();
+    let mut window = TimelinePage {
+        messages: vec![group_a, group_b],
+        has_more_before: false,
+        has_more_after: false,
+    };
+
+    let mut edited_group_a = timeline_test_record("shared-id", 30);
+    edited_group_a.group_id_hex = "group-a".to_owned();
+    edited_group_a.plaintext = "edited group A".to_owned();
+    let edit = AppProjectionUpdate {
+        group_id_hex: "group-a".to_owned(),
+        timeline_messages: Vec::new(),
+        timeline_changes: vec![TimelineMessageChange::Upsert {
+            trigger: crate::TimelineUpdateTrigger::MessageEditedOrReprojected,
+            message: Box::new(edited_group_a),
+        }],
+        chat_list_row: None,
+        chat_list_trigger: Default::default(),
+    };
+
+    apply_projection_to_window(&mut window, &edit, 300, false);
+
+    assert_eq!(window.messages.len(), 2);
+    assert_eq!(
+        window
+            .messages
+            .iter()
+            .find(|message| message.group_id_hex == "group-a")
+            .expect("group A row")
+            .plaintext,
+        "edited group A"
+    );
+    assert_eq!(
+        window
+            .messages
+            .iter()
+            .find(|message| message.group_id_hex == "group-b")
+            .expect("group B row")
+            .plaintext,
+        "shared-id"
+    );
+
+    let remove = AppProjectionUpdate {
+        group_id_hex: "group-a".to_owned(),
+        timeline_messages: Vec::new(),
+        timeline_changes: vec![TimelineMessageChange::Remove {
+            message_id_hex: "shared-id".to_owned(),
+            reason: crate::TimelineRemoveReason::Invalidated,
+        }],
+        chat_list_row: None,
+        chat_list_trigger: Default::default(),
+    };
+
+    apply_projection_to_window(&mut window, &remove, 300, false);
+
+    assert_eq!(window.messages.len(), 1);
+    assert_eq!(window.messages[0].group_id_hex, "group-b");
+    assert_eq!(window.messages[0].message_id_hex, "shared-id");
+}
+
 #[tokio::test]
 async fn paginate_backwards_extends_window_and_clears_more_before() {
     let store = ScriptedTimelineStore::new(vec![timeline_test_page(

--- a/crates/marmot-app/src/runtime/tests.rs
+++ b/crates/marmot-app/src/runtime/tests.rs
@@ -952,11 +952,17 @@ async fn pagination_refreshes_head_when_canonical_cursor_was_pruned() {
         )),
         Ok(timeline_test_page(&[("x", 40), ("y", 50)], true, false)),
     ]);
-    let handle = timeline_window_handle(
+    let mut handle = timeline_window_handle(
         &store,
         timeline_test_page(&[("a", 10), ("b", 20)], true, true),
         300,
     );
+    Arc::get_mut(&mut handle.inner)
+        .expect("exclusive window")
+        .get_mut()
+        .expect("window lock")
+        .base_query
+        .group_id_hex = Some("group-a".to_owned());
 
     let page = handle
         .paginate_backwards(2)
@@ -966,11 +972,13 @@ async fn pagination_refreshes_head_when_canonical_cursor_was_pruned() {
     assert_eq!(timeline_ids(&page), vec!["x", "y"]);
     let queries = store.recorded_queries();
     assert_eq!(queries.len(), 2);
+    assert_eq!(queries[0].group_id_hex.as_deref(), Some("group-a"));
     assert_eq!(queries[0].pagination.before, Some(10));
     assert_eq!(
         queries[0].pagination.before_message_id.as_deref(),
         Some("a")
     );
+    assert_eq!(queries[1].group_id_hex.as_deref(), Some("group-a"));
     assert_eq!(queries[1].pagination.before, None);
     assert_eq!(queries[1].pagination.after, None);
     assert_eq!(queries[1].pagination.limit, Some(2));

--- a/crates/storage-sqlite/src/chat_list.rs
+++ b/crates/storage-sqlite/src/chat_list.rs
@@ -251,6 +251,26 @@ struct ConversationReadState {
     manually_marked_unread: bool,
 }
 
+#[derive(Clone, Debug)]
+struct TimelineReadMarker {
+    message_id_hex: String,
+    source_message_id_hex: Option<String>,
+    source_epoch: Option<u64>,
+    timeline_at: u64,
+}
+
+impl TimelineReadMarker {
+    fn canonical_order_key(&self) -> (u8, u64, u8, u64, &str) {
+        crate::timeline::canonical_timeline_order_key(
+            self.source_message_id_hex.as_deref(),
+            self.source_epoch,
+            MARMOT_APP_EVENT_KIND_CHAT,
+            self.timeline_at,
+            &self.message_id_hex,
+        )
+    }
+}
+
 impl SqliteAccountStorage {
     pub fn chat_list_rows(&self, query: ChatListQuery) -> StorageResult<Vec<ChatListRow>> {
         let conn = self.lock()?;
@@ -553,15 +573,31 @@ impl SqliteAccountStorage {
             if let Some(target) =
                 timeline_message_for_read_marker_tx(&conn, group_id_hex, message_id_hex)?
             {
-                let should_advance = read_state_tx(&conn, group_id_hex)?
-                    .and_then(|state| {
-                        state
-                            .last_read_timeline_at
-                            .zip(state.last_read_message_id_hex)
-                    })
-                    .is_none_or(|(at, id)| {
-                        timeline_tuple_after(target.timeline_at, &target.message_id_hex, at, &id)
-                    });
+                let should_advance = match read_state_tx(&conn, group_id_hex)? {
+                    None => true,
+                    Some(state) => match state
+                        .last_read_timeline_at
+                        .zip(state.last_read_message_id_hex)
+                    {
+                        None => true,
+                        Some((at, id)) => {
+                            match timeline_message_for_read_marker_tx(&conn, group_id_hex, &id)? {
+                                Some(current) => {
+                                    target.canonical_order_key() > current.canonical_order_key()
+                                }
+                                // A retained read marker can outlive its pruned
+                                // timeline row. Its epoch is then unknowable, so
+                                // preserve the legacy wall-clock fallback.
+                                None => timeline_tuple_after(
+                                    target.timeline_at,
+                                    &target.message_id_hex,
+                                    at,
+                                    &id,
+                                ),
+                            }
+                        }
+                    },
+                };
 
                 if should_advance {
                     conn.execute(
@@ -828,7 +864,16 @@ fn chat_list_projection_complete_tx(
                                   AND mt.invalidation_status = 'local_publish_failed'
                               )
                           )
-                        ORDER BY mt.timeline_at DESC, mt.message_id_hex DESC
+                        ORDER BY CASE
+                            WHEN mt.source_epoch IS NOT NULL THEN 1
+                            WHEN mt.source_message_id_hex IS NULL THEN 2
+                            ELSE 0
+                          END DESC,
+                          CASE
+                            WHEN mt.source_epoch IS NOT NULL THEN mt.source_epoch
+                            ELSE mt.timeline_at
+                          END DESC,
+                          mt.timeline_at DESC, mt.message_id_hex DESC
                         LIMIT 1
                      )
                    OR row.last_message_sender IS NOT (
@@ -843,7 +888,16 @@ fn chat_list_projection_complete_tx(
                                   AND mt.invalidation_status = 'local_publish_failed'
                               )
                           )
-                        ORDER BY mt.timeline_at DESC, mt.message_id_hex DESC
+                        ORDER BY CASE
+                            WHEN mt.source_epoch IS NOT NULL THEN 1
+                            WHEN mt.source_message_id_hex IS NULL THEN 2
+                            ELSE 0
+                          END DESC,
+                          CASE
+                            WHEN mt.source_epoch IS NOT NULL THEN mt.source_epoch
+                            ELSE mt.timeline_at
+                          END DESC,
+                          mt.timeline_at DESC, mt.message_id_hex DESC
                         LIMIT 1
                      )
                    OR row.last_message_preview IS NOT (
@@ -858,7 +912,16 @@ fn chat_list_projection_complete_tx(
                                   AND mt.invalidation_status = 'local_publish_failed'
                               )
                           )
-                        ORDER BY mt.timeline_at DESC, mt.message_id_hex DESC
+                        ORDER BY CASE
+                            WHEN mt.source_epoch IS NOT NULL THEN 1
+                            WHEN mt.source_message_id_hex IS NULL THEN 2
+                            ELSE 0
+                          END DESC,
+                          CASE
+                            WHEN mt.source_epoch IS NOT NULL THEN mt.source_epoch
+                            ELSE mt.timeline_at
+                          END DESC,
+                          mt.timeline_at DESC, mt.message_id_hex DESC
                         LIMIT 1
                      )
                    OR row.last_message_kind IS NOT (
@@ -873,7 +936,16 @@ fn chat_list_projection_complete_tx(
                                   AND mt.invalidation_status = 'local_publish_failed'
                               )
                           )
-                        ORDER BY mt.timeline_at DESC, mt.message_id_hex DESC
+                        ORDER BY CASE
+                            WHEN mt.source_epoch IS NOT NULL THEN 1
+                            WHEN mt.source_message_id_hex IS NULL THEN 2
+                            ELSE 0
+                          END DESC,
+                          CASE
+                            WHEN mt.source_epoch IS NOT NULL THEN mt.source_epoch
+                            ELSE mt.timeline_at
+                          END DESC,
+                          mt.timeline_at DESC, mt.message_id_hex DESC
                         LIMIT 1
                      )
                    OR row.last_message_timeline_at IS NOT (
@@ -888,7 +960,16 @@ fn chat_list_projection_complete_tx(
                                   AND mt.invalidation_status = 'local_publish_failed'
                               )
                           )
-                        ORDER BY mt.timeline_at DESC, mt.message_id_hex DESC
+                        ORDER BY CASE
+                            WHEN mt.source_epoch IS NOT NULL THEN 1
+                            WHEN mt.source_message_id_hex IS NULL THEN 2
+                            ELSE 0
+                          END DESC,
+                          CASE
+                            WHEN mt.source_epoch IS NOT NULL THEN mt.source_epoch
+                            ELSE mt.timeline_at
+                          END DESC,
+                          mt.timeline_at DESC, mt.message_id_hex DESC
                         LIMIT 1
                      )
                    OR row.last_message_deleted IS NOT COALESCE((
@@ -903,7 +984,16 @@ fn chat_list_projection_complete_tx(
                                   AND mt.invalidation_status = 'local_publish_failed'
                               )
                           )
-                        ORDER BY mt.timeline_at DESC, mt.message_id_hex DESC
+                        ORDER BY CASE
+                            WHEN mt.source_epoch IS NOT NULL THEN 1
+                            WHEN mt.source_message_id_hex IS NULL THEN 2
+                            ELSE 0
+                          END DESC,
+                          CASE
+                            WHEN mt.source_epoch IS NOT NULL THEN mt.source_epoch
+                            ELSE mt.timeline_at
+                          END DESC,
+                          mt.timeline_at DESC, mt.message_id_hex DESC
                         LIMIT 1
                      ), 0)
                    OR row.last_message_media_json IS NOT (
@@ -918,7 +1008,16 @@ fn chat_list_projection_complete_tx(
                                   AND mt.invalidation_status = 'local_publish_failed'
                               )
                           )
-                        ORDER BY mt.timeline_at DESC, mt.message_id_hex DESC
+                        ORDER BY CASE
+                            WHEN mt.source_epoch IS NOT NULL THEN 1
+                            WHEN mt.source_message_id_hex IS NULL THEN 2
+                            ELSE 0
+                          END DESC,
+                          CASE
+                            WHEN mt.source_epoch IS NOT NULL THEN mt.source_epoch
+                            ELSE mt.timeline_at
+                          END DESC,
+                          mt.timeline_at DESC, mt.message_id_hex DESC
                         LIMIT 1
                      )
                    OR row.last_message_delivery_state IS NOT COALESCE((
@@ -938,7 +1037,16 @@ fn chat_list_projection_complete_tx(
                                   AND mt.invalidation_status = 'local_publish_failed'
                               )
                           )
-                        ORDER BY mt.timeline_at DESC, mt.message_id_hex DESC
+                        ORDER BY CASE
+                            WHEN mt.source_epoch IS NOT NULL THEN 1
+                            WHEN mt.source_message_id_hex IS NULL THEN 2
+                            ELSE 0
+                          END DESC,
+                          CASE
+                            WHEN mt.source_epoch IS NOT NULL THEN mt.source_epoch
+                            ELSE mt.timeline_at
+                          END DESC,
+                          mt.timeline_at DESC, mt.message_id_hex DESC
                         LIMIT 1
                      ), 'not_applicable')
                    OR row.activity_sort_at IS NOT MAX(
@@ -955,7 +1063,16 @@ fn chat_list_projection_complete_tx(
                                       AND mt.invalidation_status = 'local_publish_failed'
                                   )
                               )
-                            ORDER BY mt.timeline_at DESC, mt.message_id_hex DESC
+                            ORDER BY CASE
+                            WHEN mt.source_epoch IS NOT NULL THEN 1
+                            WHEN mt.source_message_id_hex IS NULL THEN 2
+                            ELSE 0
+                          END DESC,
+                          CASE
+                            WHEN mt.source_epoch IS NOT NULL THEN mt.source_epoch
+                            ELSE mt.timeline_at
+                          END DESC,
+                          mt.timeline_at DESC, mt.message_id_hex DESC
                             LIMIT 1
                         ), 0),
                         COALESCE((
@@ -1201,28 +1318,51 @@ fn unread_summary_tx(
             first_message_id: None,
         });
     };
-    let (where_sql, marker_at, marker_id) =
-        if let Some(last_read_at) = read_state.last_read_timeline_at {
+    let (where_sql, marker_params) = if let Some(last_read_at) = read_state.last_read_timeline_at {
+        let marker_id = read_state.last_read_message_id_hex.as_deref().unwrap_or("");
+        if let Some(marker) = timeline_message_for_read_marker_tx(tx, group_id_hex, marker_id)? {
+            let (class, primary, _phase, at, id) = marker.canonical_order_key();
             (
-                "(timeline_at > ?4 OR (timeline_at = ?4 AND message_id_hex > ?5))",
-                last_read_at,
-                read_state.last_read_message_id_hex.as_deref().unwrap_or(""),
+                "(CASE
+                    WHEN source_epoch IS NOT NULL THEN 1
+                    WHEN source_message_id_hex IS NULL THEN 2
+                    ELSE 0
+                  END,
+                  CASE
+                    WHEN source_epoch IS NOT NULL THEN source_epoch
+                    ELSE timeline_at
+                  END,
+                  timeline_at,
+                  message_id_hex) > (?4, ?5, ?6, ?7)",
+                vec![
+                    rusqlite::types::Value::Integer(i64::from(class)),
+                    rusqlite::types::Value::Integer(u64_to_i64(primary)?),
+                    rusqlite::types::Value::Integer(u64_to_i64(at)?),
+                    rusqlite::types::Value::Text(id.to_owned()),
+                ],
             )
         } else {
             (
-                "timeline_at > ?4 AND (?5 = ?5)",
-                read_state.initialized_at,
-                "",
+                "(timeline_at > ?4 OR (timeline_at = ?4 AND message_id_hex > ?5))",
+                vec![
+                    rusqlite::types::Value::Integer(u64_to_i64(last_read_at)?),
+                    rusqlite::types::Value::Text(marker_id.to_owned()),
+                ],
             )
-        };
-    // #704: derive count + first-unread id + mention_count from ONE ordered scan
-    // over the unread window, instead of a separate COUNT(*), a LIMIT 1, and a
-    // full mention scan over the identical predicate. Ordered by the
-    // materialized-timeline key `(timeline_at, message_id_hex)` so the first row
-    // is the first-unread message. Mention classification is injected (the
-    // storage layer never parses nostr/NIP-21); a tag blob that fails to decode
-    // is treated as no tags (no mention) so one malformed row never errors the
-    // whole projection.
+        }
+    } else {
+        (
+            "timeline_at > ?4 AND (?5 = ?5)",
+            vec![
+                rusqlite::types::Value::Integer(u64_to_i64(read_state.initialized_at)?),
+                rusqlite::types::Value::Text(String::new()),
+            ],
+        )
+    };
+    // Derive count + first-unread id + mention_count from one ordered scan over
+    // the unread window. For a retained marker row the predicate and ordering use
+    // the same canonical accepted-history key as timeline pagination. A marker
+    // whose row was pruned falls back to its retained wall-clock tuple.
     let scan_sql = format!(
         "SELECT message_id_hex, plaintext, tags_json
          FROM message_timeline
@@ -1232,17 +1372,26 @@ fn unread_summary_tx(
            AND invalidation_status IS NULL
            AND sender != ?3
            AND {where_sql}
-         ORDER BY timeline_at ASC, message_id_hex ASC"
+         ORDER BY CASE
+                    WHEN source_epoch IS NOT NULL THEN 1
+                    WHEN source_message_id_hex IS NULL THEN 2
+                    ELSE 0
+                  END ASC,
+                  CASE
+                    WHEN source_epoch IS NOT NULL THEN source_epoch
+                    ELSE timeline_at
+                  END ASC,
+                  timeline_at ASC, message_id_hex ASC"
     );
+    let mut query_params = vec![
+        rusqlite::types::Value::Text(group_id_hex.to_owned()),
+        rusqlite::types::Value::Integer(u64_to_i64(MARMOT_APP_EVENT_KIND_CHAT)?),
+        rusqlite::types::Value::Text(local_account_id_hex.to_owned()),
+    ];
+    query_params.extend(marker_params);
     let mut scan_stmt = tx.prepare(&scan_sql).storage()?;
     let mut scan_rows = scan_stmt
-        .query(params![
-            group_id_hex,
-            u64_to_i64(MARMOT_APP_EVENT_KIND_CHAT)?,
-            local_account_id_hex,
-            u64_to_i64(marker_at)?,
-            marker_id,
-        ])
+        .query(rusqlite::params_from_iter(query_params))
         .storage()?;
     let mut count: u64 = 0;
     let mut mention_count: u64 = 0;
@@ -1383,7 +1532,16 @@ fn latest_kind9_message_tx(
                invalidation_status IS NULL
                OR (direction = 'sent' AND invalidation_status = 'local_publish_failed')
            )
-         ORDER BY timeline_at DESC, message_id_hex DESC
+         ORDER BY CASE
+                    WHEN source_epoch IS NOT NULL THEN 1
+                    WHEN source_message_id_hex IS NULL THEN 2
+                    ELSE 0
+                  END DESC,
+                  CASE
+                    WHEN source_epoch IS NOT NULL THEN source_epoch
+                    ELSE timeline_at
+                  END DESC,
+                  timeline_at DESC, message_id_hex DESC
          LIMIT 1",
         params![group_id_hex, u64_to_i64(MARMOT_APP_EVENT_KIND_CHAT)?],
         chat_list_message_from_row,
@@ -1396,10 +1554,9 @@ fn timeline_message_for_read_marker_tx(
     tx: &Connection,
     group_id_hex: &str,
     message_id_hex: &str,
-) -> StorageResult<Option<ChatListMessagePreview>> {
+) -> StorageResult<Option<TimelineReadMarker>> {
     tx.query_row(
-        "SELECT message_id_hex, sender, plaintext, kind, timeline_at, deleted,
-                media_json, direction, source_message_id_hex, invalidation_status
+        "SELECT message_id_hex, source_message_id_hex, source_epoch, timeline_at
          FROM message_timeline
          WHERE group_id_hex = ?1 AND message_id_hex = ?2 AND kind = ?3",
         params![
@@ -1407,7 +1564,16 @@ fn timeline_message_for_read_marker_tx(
             message_id_hex,
             u64_to_i64(MARMOT_APP_EVENT_KIND_CHAT)?
         ],
-        chat_list_message_from_row,
+        |row| {
+            Ok(TimelineReadMarker {
+                message_id_hex: row.get(0)?,
+                source_message_id_hex: row.get(1)?,
+                source_epoch: row
+                    .get::<_, Option<i64>>(2)?
+                    .and_then(|value| value.try_into().ok()),
+                timeline_at: row.get::<_, i64>(3)?.try_into().unwrap_or_default(),
+            })
+        },
     )
     .optional()
     .storage()

--- a/crates/storage-sqlite/src/chat_list.rs
+++ b/crates/storage-sqlite/src/chat_list.rs
@@ -249,6 +249,8 @@ struct ConversationReadState {
     last_read_timeline_at: Option<u64>,
     last_read_order_class: Option<u8>,
     last_read_order_primary: Option<u64>,
+    last_read_order_phase: Option<u8>,
+    last_read_order_at: Option<u64>,
     initialized_at: u64,
     manually_marked_unread: bool,
 }
@@ -258,8 +260,8 @@ impl ConversationReadState {
         Some((
             self.last_read_order_class?,
             self.last_read_order_primary?,
-            1,
-            self.last_read_timeline_at?,
+            self.last_read_order_phase?,
+            self.last_read_order_at?,
             self.last_read_message_id_hex.as_deref()?,
         ))
     }
@@ -566,19 +568,22 @@ impl SqliteAccountStorage {
                 };
 
                 if should_advance {
-                    let (order_class, order_primary, _phase, _at, _id) = target_order;
+                    let (order_class, order_primary, order_phase, order_at, _id) = target_order;
                     conn.execute(
                         "INSERT INTO conversation_read_state (
                             group_id_hex, last_read_message_id_hex, last_read_timeline_at,
                             last_read_order_class, last_read_order_primary,
+                            last_read_order_phase, last_read_order_at,
                             initialized_at, updated_at, manually_marked_unread
                          )
-                         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?6, 0)
+                         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?8, 0)
                          ON CONFLICT(group_id_hex) DO UPDATE SET
                             last_read_message_id_hex = excluded.last_read_message_id_hex,
                             last_read_timeline_at = excluded.last_read_timeline_at,
                             last_read_order_class = excluded.last_read_order_class,
                             last_read_order_primary = excluded.last_read_order_primary,
+                            last_read_order_phase = excluded.last_read_order_phase,
+                            last_read_order_at = excluded.last_read_order_at,
                             updated_at = excluded.updated_at,
                             manually_marked_unread = 0",
                         params![
@@ -587,6 +592,8 @@ impl SqliteAccountStorage {
                             u64_to_i64(target.timeline_at)?,
                             i64::from(order_class),
                             u64_to_i64(order_primary)?,
+                            i64::from(order_phase),
+                            u64_to_i64(order_at)?,
                             u64_to_i64(unix_now_seconds())?
                         ],
                     )
@@ -1450,7 +1457,12 @@ fn latest_kind9_message_tx(
                invalidation_status IS NULL
                OR (direction = 'sent' AND invalidation_status = 'local_publish_failed')
            )
-         ORDER BY timeline_order_class DESC,
+         ORDER BY CASE
+                      WHEN direction = 'sent'
+                       AND invalidation_status = 'local_publish_failed' THEN 0
+                      ELSE 1
+                  END DESC,
+                  timeline_order_class DESC,
                   timeline_order_primary DESC,
                   timeline_order_phase DESC,
                   timeline_order_at DESC,
@@ -1528,7 +1540,8 @@ fn insert_initial_read_state_tx(
     manually_marked_unread: bool,
 ) -> StorageResult<()> {
     let latest = latest_kind9_message_tx(tx, group_id_hex)?;
-    let (message_id, timeline_at, order_class, order_primary) = match latest {
+    let (message_id, timeline_at, order_class, order_primary, order_phase, order_at) = match latest
+    {
         Some(message) => {
             let marker =
                 timeline_message_for_read_marker_tx(tx, group_id_hex, &message.message_id_hex)?
@@ -1537,15 +1550,17 @@ fn insert_initial_read_state_tx(
                             "latest chat message disappeared while creating read state".to_owned(),
                         )
                     })?;
-            let (class, primary, _phase, _at, _id) = marker.canonical_order_key();
+            let (class, primary, phase, at, _id) = marker.canonical_order_key();
             (
                 Some(message.message_id_hex),
                 Some(message.timeline_at),
                 Some(class),
                 Some(primary),
+                Some(phase),
+                Some(at),
             )
         }
-        None => (None, None, None, None),
+        None => (None, None, None, None, None, None),
     };
     // Match first-open semantics: with no retained kind-9 history there is no
     // read anchor yet, so a subsequently recorded message counts even when its
@@ -1555,15 +1570,18 @@ fn insert_initial_read_state_tx(
         "INSERT INTO conversation_read_state (
             group_id_hex, last_read_message_id_hex, last_read_timeline_at,
             last_read_order_class, last_read_order_primary,
+            last_read_order_phase, last_read_order_at,
             initialized_at, updated_at, manually_marked_unread
          )
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
         params![
             group_id_hex,
             message_id,
             optional_u64_to_i64(timeline_at)?,
             order_class.map(i64::from),
             optional_u64_to_i64(order_primary)?,
+            order_phase.map(i64::from),
+            optional_u64_to_i64(order_at)?,
             u64_to_i64(initialized_at)?,
             u64_to_i64(unix_now_seconds())?,
             bool_i64(manually_marked_unread),
@@ -1580,6 +1598,7 @@ fn read_state_tx(
     tx.query_row(
         "SELECT last_read_message_id_hex, last_read_timeline_at,
                 last_read_order_class, last_read_order_primary,
+                last_read_order_phase, last_read_order_at,
                 initialized_at, manually_marked_unread
          FROM conversation_read_state
          WHERE group_id_hex = ?1",
@@ -1596,8 +1615,14 @@ fn read_state_tx(
                 last_read_order_primary: row
                     .get::<_, Option<i64>>(3)?
                     .and_then(|value| value.try_into().ok()),
-                initialized_at: row.get::<_, i64>(4)?.try_into().unwrap_or_default(),
-                manually_marked_unread: row.get::<_, i64>(5)? != 0,
+                last_read_order_phase: row
+                    .get::<_, Option<i64>>(4)?
+                    .and_then(|value| value.try_into().ok()),
+                last_read_order_at: row
+                    .get::<_, Option<i64>>(5)?
+                    .and_then(|value| value.try_into().ok()),
+                initialized_at: row.get::<_, i64>(6)?.try_into().unwrap_or_default(),
+                manually_marked_unread: row.get::<_, i64>(7)? != 0,
             })
         },
     )

--- a/crates/storage-sqlite/src/chat_list.rs
+++ b/crates/storage-sqlite/src/chat_list.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use cgka_traits::app_components::{GROUP_AVATAR_URL_COMPONENT_ID, decode_group_avatar_url_v1};
 use cgka_traits::app_event::MARMOT_APP_EVENT_KIND_CHAT;
-use cgka_traits::storage::{StorageError, StorageResult};
+use cgka_traits::storage::StorageResult;
 use rusqlite::{Connection, OptionalExtension, Params, params};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -708,6 +708,25 @@ fn refresh_chat_list_row_tx(
 /// again leave the counts stale.
 const CHAT_LIST_MENTION_COUNTS_VERSION: i64 = 1;
 
+/// One authoritative latest-preview order for rebuild, completeness, and
+/// secure-prune repair. Failed local sends remain visible in the timeline but
+/// do not outrank accepted history in the chat-list projection.
+pub(crate) const CHAT_LIST_PREVIEW_ORDER_DESC: &str = "CASE
+        WHEN direction = 'sent'
+         AND invalidation_status = 'local_publish_failed' THEN 0
+        ELSE 1
+    END DESC,
+    timeline_order_class DESC,
+    timeline_order_primary DESC,
+    timeline_order_phase DESC,
+    timeline_order_at DESC,
+    message_id_hex DESC";
+
+struct LatestChatListMessage {
+    preview: ChatListMessagePreview,
+    canonical_order_prefix: (u8, u64, u8, u64),
+}
+
 fn chat_list_mention_counts_version_tx(tx: &Connection) -> StorageResult<i64> {
     Ok(tx
         .query_row(
@@ -821,7 +840,8 @@ fn chat_list_projection_complete_tx(
     }
     if projection_has_rows_tx(
         tx,
-        "SELECT EXISTS(
+        &format!(
+            "SELECT EXISTS(
                 SELECT 1
                 FROM account_groups AS ag
                 JOIN chat_list_rows AS row
@@ -843,11 +863,7 @@ fn chat_list_projection_complete_tx(
                                   AND mt.invalidation_status = 'local_publish_failed'
                               )
                           )
-                        ORDER BY mt.timeline_order_class DESC,
-                          mt.timeline_order_primary DESC,
-                          mt.timeline_order_phase DESC,
-                          mt.timeline_order_at DESC,
-                          mt.message_id_hex DESC
+                        ORDER BY {CHAT_LIST_PREVIEW_ORDER_DESC}
                         LIMIT 1
                      )
                    OR row.last_message_sender IS NOT (
@@ -862,11 +878,7 @@ fn chat_list_projection_complete_tx(
                                   AND mt.invalidation_status = 'local_publish_failed'
                               )
                           )
-                        ORDER BY mt.timeline_order_class DESC,
-                          mt.timeline_order_primary DESC,
-                          mt.timeline_order_phase DESC,
-                          mt.timeline_order_at DESC,
-                          mt.message_id_hex DESC
+                        ORDER BY {CHAT_LIST_PREVIEW_ORDER_DESC}
                         LIMIT 1
                      )
                    OR row.last_message_preview IS NOT (
@@ -881,11 +893,7 @@ fn chat_list_projection_complete_tx(
                                   AND mt.invalidation_status = 'local_publish_failed'
                               )
                           )
-                        ORDER BY mt.timeline_order_class DESC,
-                          mt.timeline_order_primary DESC,
-                          mt.timeline_order_phase DESC,
-                          mt.timeline_order_at DESC,
-                          mt.message_id_hex DESC
+                        ORDER BY {CHAT_LIST_PREVIEW_ORDER_DESC}
                         LIMIT 1
                      )
                    OR row.last_message_kind IS NOT (
@@ -900,11 +908,7 @@ fn chat_list_projection_complete_tx(
                                   AND mt.invalidation_status = 'local_publish_failed'
                               )
                           )
-                        ORDER BY mt.timeline_order_class DESC,
-                          mt.timeline_order_primary DESC,
-                          mt.timeline_order_phase DESC,
-                          mt.timeline_order_at DESC,
-                          mt.message_id_hex DESC
+                        ORDER BY {CHAT_LIST_PREVIEW_ORDER_DESC}
                         LIMIT 1
                      )
                    OR row.last_message_timeline_at IS NOT (
@@ -919,11 +923,7 @@ fn chat_list_projection_complete_tx(
                                   AND mt.invalidation_status = 'local_publish_failed'
                               )
                           )
-                        ORDER BY mt.timeline_order_class DESC,
-                          mt.timeline_order_primary DESC,
-                          mt.timeline_order_phase DESC,
-                          mt.timeline_order_at DESC,
-                          mt.message_id_hex DESC
+                        ORDER BY {CHAT_LIST_PREVIEW_ORDER_DESC}
                         LIMIT 1
                      )
                    OR row.last_message_deleted IS NOT COALESCE((
@@ -938,11 +938,7 @@ fn chat_list_projection_complete_tx(
                                   AND mt.invalidation_status = 'local_publish_failed'
                               )
                           )
-                        ORDER BY mt.timeline_order_class DESC,
-                          mt.timeline_order_primary DESC,
-                          mt.timeline_order_phase DESC,
-                          mt.timeline_order_at DESC,
-                          mt.message_id_hex DESC
+                        ORDER BY {CHAT_LIST_PREVIEW_ORDER_DESC}
                         LIMIT 1
                      ), 0)
                    OR row.last_message_media_json IS NOT (
@@ -957,11 +953,7 @@ fn chat_list_projection_complete_tx(
                                   AND mt.invalidation_status = 'local_publish_failed'
                               )
                           )
-                        ORDER BY mt.timeline_order_class DESC,
-                          mt.timeline_order_primary DESC,
-                          mt.timeline_order_phase DESC,
-                          mt.timeline_order_at DESC,
-                          mt.message_id_hex DESC
+                        ORDER BY {CHAT_LIST_PREVIEW_ORDER_DESC}
                         LIMIT 1
                      )
                    OR row.last_message_delivery_state IS NOT COALESCE((
@@ -981,11 +973,7 @@ fn chat_list_projection_complete_tx(
                                   AND mt.invalidation_status = 'local_publish_failed'
                               )
                           )
-                        ORDER BY mt.timeline_order_class DESC,
-                          mt.timeline_order_primary DESC,
-                          mt.timeline_order_phase DESC,
-                          mt.timeline_order_at DESC,
-                          mt.message_id_hex DESC
+                        ORDER BY {CHAT_LIST_PREVIEW_ORDER_DESC}
                         LIMIT 1
                      ), 'not_applicable')
                    OR row.activity_sort_at IS NOT MAX(
@@ -1002,11 +990,7 @@ fn chat_list_projection_complete_tx(
                                       AND mt.invalidation_status = 'local_publish_failed'
                                   )
                               )
-                            ORDER BY mt.timeline_order_class DESC,
-                              mt.timeline_order_primary DESC,
-                              mt.timeline_order_phase DESC,
-                              mt.timeline_order_at DESC,
-                              mt.message_id_hex DESC
+                        ORDER BY {CHAT_LIST_PREVIEW_ORDER_DESC}
                             LIMIT 1
                         ), 0),
                         COALESCE((
@@ -1016,7 +1000,8 @@ fn chat_list_projection_complete_tx(
                         ), 0),
                         ag.conversation_created_at
                      )
-             )",
+             )"
+        ),
         params![u64_to_i64(MARMOT_APP_EVENT_KIND_CHAT)?],
     )? {
         return Ok(false);
@@ -1084,6 +1069,7 @@ fn rebuild_chat_list_row_for_group_tx(
     mention_classifier: &MentionClassifier<'_>,
 ) -> StorageResult<()> {
     let latest = latest_kind9_message_tx(tx, &group.group_id_hex)?;
+    let latest_message = latest.as_ref().map(|latest| &latest.preview);
     let read_state = read_state_tx(tx, &group.group_id_hex)?;
     let unread = unread_summary_tx(
         tx,
@@ -1092,8 +1078,7 @@ fn rebuild_chat_list_row_for_group_tx(
         read_state.as_ref(),
         mention_classifier,
     )?;
-    let activity_sort_at = latest
-        .as_ref()
+    let activity_sort_at = latest_message
         .map(|message| message.timeline_at)
         .into_iter()
         .chain(
@@ -1187,22 +1172,16 @@ fn rebuild_chat_list_row_for_group_tx(
                 .avatar
                 .as_ref()
                 .and_then(|avatar| avatar.media_type.as_deref()),
-            latest
-                .as_ref()
-                .map(|message| message.message_id_hex.as_str()),
-            latest.as_ref().map(|message| message.sender.as_str()),
-            latest.as_ref().map(|message| message.plaintext.as_str()),
-            optional_u64_to_i64(latest.as_ref().map(|message| message.kind))?,
-            optional_u64_to_i64(latest.as_ref().map(|message| message.timeline_at))?,
-            latest
-                .as_ref()
+            latest_message.map(|message| message.message_id_hex.as_str()),
+            latest_message.map(|message| message.sender.as_str()),
+            latest_message.map(|message| message.plaintext.as_str()),
+            optional_u64_to_i64(latest_message.map(|message| message.kind))?,
+            optional_u64_to_i64(latest_message.map(|message| message.timeline_at))?,
+            latest_message
                 .map(|message| bool_i64(message.deleted))
                 .unwrap_or(0),
-            latest
-                .as_ref()
-                .and_then(|message| message.media_json.as_deref()),
-            latest
-                .as_ref()
+            latest_message.and_then(|message| message.media_json.as_deref()),
+            latest_message
                 .map(|message| message.delivery_state.as_str())
                 .unwrap_or_else(|| ChatListMessageDeliveryState::NotApplicable.as_str()),
             u64_to_i64(unread.count)?,
@@ -1447,29 +1426,35 @@ fn account_group_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<AccountGr
 fn latest_kind9_message_tx(
     tx: &Connection,
     group_id_hex: &str,
-) -> StorageResult<Option<ChatListMessagePreview>> {
-    tx.query_row(
+) -> StorageResult<Option<LatestChatListMessage>> {
+    let sql = format!(
         "SELECT message_id_hex, sender, plaintext, kind, timeline_at, deleted,
-                media_json, direction, source_message_id_hex, invalidation_status
+                media_json, direction, source_message_id_hex, invalidation_status,
+                timeline_order_class, timeline_order_primary,
+                timeline_order_phase, timeline_order_at
          FROM message_timeline
          WHERE group_id_hex = ?1 AND kind = ?2
            AND (
                invalidation_status IS NULL
                OR (direction = 'sent' AND invalidation_status = 'local_publish_failed')
            )
-         ORDER BY CASE
-                      WHEN direction = 'sent'
-                       AND invalidation_status = 'local_publish_failed' THEN 0
-                      ELSE 1
-                  END DESC,
-                  timeline_order_class DESC,
-                  timeline_order_primary DESC,
-                  timeline_order_phase DESC,
-                  timeline_order_at DESC,
-                  message_id_hex DESC
-         LIMIT 1",
+         ORDER BY {CHAT_LIST_PREVIEW_ORDER_DESC}
+         LIMIT 1"
+    );
+    tx.query_row(
+        &sql,
         params![group_id_hex, u64_to_i64(MARMOT_APP_EVENT_KIND_CHAT)?],
-        chat_list_message_from_row,
+        |row| {
+            Ok(LatestChatListMessage {
+                preview: chat_list_message_from_row(row)?,
+                canonical_order_prefix: (
+                    row.get::<_, i64>(10)?.try_into().unwrap_or_default(),
+                    row.get::<_, i64>(11)?.try_into().unwrap_or_default(),
+                    row.get::<_, i64>(12)?.try_into().unwrap_or_default(),
+                    row.get::<_, i64>(13)?.try_into().unwrap_or_default(),
+                ),
+            })
+        },
     )
     .optional()
     .storage()
@@ -1542,24 +1527,14 @@ fn insert_initial_read_state_tx(
     let latest = latest_kind9_message_tx(tx, group_id_hex)?;
     let (message_id, timeline_at, order_class, order_primary, order_phase, order_at) = match latest
     {
-        Some(message) => {
-            let marker =
-                timeline_message_for_read_marker_tx(tx, group_id_hex, &message.message_id_hex)?
-                    .ok_or_else(|| {
-                        StorageError::Backend(
-                            "latest chat message disappeared while creating read state".to_owned(),
-                        )
-                    })?;
-            let (class, primary, phase, at, _id) = marker.canonical_order_key();
-            (
-                Some(message.message_id_hex),
-                Some(message.timeline_at),
-                Some(class),
-                Some(primary),
-                Some(phase),
-                Some(at),
-            )
-        }
+        Some(latest) => (
+            Some(latest.preview.message_id_hex),
+            Some(latest.preview.timeline_at),
+            Some(latest.canonical_order_prefix.0),
+            Some(latest.canonical_order_prefix.1),
+            Some(latest.canonical_order_prefix.2),
+            Some(latest.canonical_order_prefix.3),
+        ),
         None => (None, None, None, None, None, None),
     };
     // Match first-open semantics: with no retained kind-9 history there is no

--- a/crates/storage-sqlite/src/chat_list.rs
+++ b/crates/storage-sqlite/src/chat_list.rs
@@ -554,7 +554,7 @@ impl SqliteAccountStorage {
                         None => state
                             .last_read_timeline_at
                             .zip(state.last_read_message_id_hex.as_deref())
-                            .map_or(true, |(at, id)| {
+                            .is_none_or(|(at, id)| {
                                 timeline_tuple_after(
                                     target.timeline_at,
                                     &target.message_id_hex,

--- a/crates/storage-sqlite/src/chat_list.rs
+++ b/crates/storage-sqlite/src/chat_list.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use cgka_traits::app_components::{GROUP_AVATAR_URL_COMPONENT_ID, decode_group_avatar_url_v1};
 use cgka_traits::app_event::MARMOT_APP_EVENT_KIND_CHAT;
-use cgka_traits::storage::StorageResult;
+use cgka_traits::storage::{StorageError, StorageResult};
 use rusqlite::{Connection, OptionalExtension, Params, params};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -247,8 +247,22 @@ struct AccountGroupRow {
 struct ConversationReadState {
     last_read_message_id_hex: Option<String>,
     last_read_timeline_at: Option<u64>,
+    last_read_order_class: Option<u8>,
+    last_read_order_primary: Option<u64>,
     initialized_at: u64,
     manually_marked_unread: bool,
+}
+
+impl ConversationReadState {
+    fn canonical_order_key(&self) -> Option<(u8, u64, u8, u64, &str)> {
+        Some((
+            self.last_read_order_class?,
+            self.last_read_order_primary?,
+            1,
+            self.last_read_timeline_at?,
+            self.last_read_message_id_hex.as_deref()?,
+        ))
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -256,6 +270,7 @@ struct TimelineReadMarker {
     message_id_hex: String,
     source_message_id_hex: Option<String>,
     source_epoch: Option<u64>,
+    invalidation_status: Option<String>,
     timeline_at: u64,
 }
 
@@ -264,6 +279,7 @@ impl TimelineReadMarker {
         crate::timeline::canonical_timeline_order_key(
             self.source_message_id_hex.as_deref(),
             self.source_epoch,
+            self.invalidation_status.as_deref(),
             MARMOT_APP_EVENT_KIND_CHAT,
             self.timeline_at,
             &self.message_id_hex,
@@ -467,26 +483,7 @@ impl SqliteAccountStorage {
                 return Ok(None);
             };
             if read_state_tx(&conn, group_id_hex)?.is_none() {
-                let latest = latest_kind9_message_tx(&conn, group_id_hex)?;
-                let (last_read_message_id_hex, last_read_timeline_at) = latest
-                    .map(|message| (Some(message.message_id_hex), Some(message.timeline_at)))
-                    .unwrap_or((None, None));
-                let initialized_at = last_read_timeline_at.unwrap_or(0);
-                conn.execute(
-                    "INSERT INTO conversation_read_state (
-                        group_id_hex, last_read_message_id_hex, last_read_timeline_at,
-                        initialized_at, updated_at, manually_marked_unread
-                     )
-                     VALUES (?1, ?2, ?3, ?4, ?5, 0)",
-                    params![
-                        group_id_hex,
-                        last_read_message_id_hex,
-                        optional_u64_to_i64(last_read_timeline_at)?,
-                        u64_to_i64(initialized_at)?,
-                        u64_to_i64(unix_now_seconds())?
-                    ],
-                )
-                .storage()?;
+                insert_initial_read_state_tx(&conn, group_id_hex, false)?;
             }
             rebuild_chat_list_row_for_group_tx(
                 &conn,
@@ -517,31 +514,7 @@ impl SqliteAccountStorage {
                 // Before a read-state row exists, retained history is implicitly
                 // read. Preserve that baseline when creating the manual flag so
                 // "mark unread" does not suddenly count the whole backlog.
-                let latest = latest_kind9_message_tx(&conn, group_id_hex)?;
-                let (last_read_message_id_hex, last_read_timeline_at) = latest
-                    .map(|message| (Some(message.message_id_hex), Some(message.timeline_at)))
-                    .unwrap_or((None, None));
-                // Match first-open semantics: with no retained kind-9 history
-                // there is no read anchor yet, so a subsequently recorded
-                // message must count even when its sender timestamp predates
-                // this local interaction.
-                let initialized_at = last_read_timeline_at.unwrap_or(0);
-                conn.execute(
-                    "INSERT INTO conversation_read_state (
-                        group_id_hex, last_read_message_id_hex, last_read_timeline_at,
-                        initialized_at, updated_at, manually_marked_unread
-                     )
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-                    params![
-                        group_id_hex,
-                        last_read_message_id_hex,
-                        optional_u64_to_i64(last_read_timeline_at)?,
-                        u64_to_i64(initialized_at)?,
-                        u64_to_i64(now)?,
-                        bool_i64(manually_unread),
-                    ],
-                )
-                .storage()?;
+                insert_initial_read_state_tx(&conn, group_id_hex, manually_unread)?;
             } else {
                 conn.execute(
                     "UPDATE conversation_read_state
@@ -573,48 +546,47 @@ impl SqliteAccountStorage {
             if let Some(target) =
                 timeline_message_for_read_marker_tx(&conn, group_id_hex, message_id_hex)?
             {
+                let target_order = target.canonical_order_key();
                 let should_advance = match read_state_tx(&conn, group_id_hex)? {
                     None => true,
-                    Some(state) => match state
-                        .last_read_timeline_at
-                        .zip(state.last_read_message_id_hex)
-                    {
-                        None => true,
-                        Some((at, id)) => {
-                            match timeline_message_for_read_marker_tx(&conn, group_id_hex, &id)? {
-                                Some(current) => {
-                                    target.canonical_order_key() > current.canonical_order_key()
-                                }
-                                // A retained read marker can outlive its pruned
-                                // timeline row. Its epoch is then unknowable, so
-                                // preserve the legacy wall-clock fallback.
-                                None => timeline_tuple_after(
+                    Some(state) => match state.canonical_order_key() {
+                        Some(current_order) => target_order > current_order,
+                        None => state
+                            .last_read_timeline_at
+                            .zip(state.last_read_message_id_hex.as_deref())
+                            .map_or(true, |(at, id)| {
+                                timeline_tuple_after(
                                     target.timeline_at,
                                     &target.message_id_hex,
                                     at,
-                                    &id,
-                                ),
-                            }
-                        }
+                                    id,
+                                )
+                            }),
                     },
                 };
 
                 if should_advance {
+                    let (order_class, order_primary, _phase, _at, _id) = target_order;
                     conn.execute(
                         "INSERT INTO conversation_read_state (
                             group_id_hex, last_read_message_id_hex, last_read_timeline_at,
+                            last_read_order_class, last_read_order_primary,
                             initialized_at, updated_at, manually_marked_unread
                          )
-                         VALUES (?1, ?2, ?3, ?4, ?4, 0)
+                         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?6, 0)
                          ON CONFLICT(group_id_hex) DO UPDATE SET
                             last_read_message_id_hex = excluded.last_read_message_id_hex,
                             last_read_timeline_at = excluded.last_read_timeline_at,
+                            last_read_order_class = excluded.last_read_order_class,
+                            last_read_order_primary = excluded.last_read_order_primary,
                             updated_at = excluded.updated_at,
                             manually_marked_unread = 0",
                         params![
                             group_id_hex,
                             &target.message_id_hex,
                             u64_to_i64(target.timeline_at)?,
+                            i64::from(order_class),
+                            u64_to_i64(order_primary)?,
                             u64_to_i64(unix_now_seconds())?
                         ],
                     )
@@ -864,16 +836,11 @@ fn chat_list_projection_complete_tx(
                                   AND mt.invalidation_status = 'local_publish_failed'
                               )
                           )
-                        ORDER BY CASE
-                            WHEN mt.source_epoch IS NOT NULL THEN 1
-                            WHEN mt.source_message_id_hex IS NULL THEN 2
-                            ELSE 0
-                          END DESC,
-                          CASE
-                            WHEN mt.source_epoch IS NOT NULL THEN mt.source_epoch
-                            ELSE mt.timeline_at
-                          END DESC,
-                          mt.timeline_at DESC, mt.message_id_hex DESC
+                        ORDER BY mt.timeline_order_class DESC,
+                          mt.timeline_order_primary DESC,
+                          mt.timeline_order_phase DESC,
+                          mt.timeline_order_at DESC,
+                          mt.message_id_hex DESC
                         LIMIT 1
                      )
                    OR row.last_message_sender IS NOT (
@@ -888,16 +855,11 @@ fn chat_list_projection_complete_tx(
                                   AND mt.invalidation_status = 'local_publish_failed'
                               )
                           )
-                        ORDER BY CASE
-                            WHEN mt.source_epoch IS NOT NULL THEN 1
-                            WHEN mt.source_message_id_hex IS NULL THEN 2
-                            ELSE 0
-                          END DESC,
-                          CASE
-                            WHEN mt.source_epoch IS NOT NULL THEN mt.source_epoch
-                            ELSE mt.timeline_at
-                          END DESC,
-                          mt.timeline_at DESC, mt.message_id_hex DESC
+                        ORDER BY mt.timeline_order_class DESC,
+                          mt.timeline_order_primary DESC,
+                          mt.timeline_order_phase DESC,
+                          mt.timeline_order_at DESC,
+                          mt.message_id_hex DESC
                         LIMIT 1
                      )
                    OR row.last_message_preview IS NOT (
@@ -912,16 +874,11 @@ fn chat_list_projection_complete_tx(
                                   AND mt.invalidation_status = 'local_publish_failed'
                               )
                           )
-                        ORDER BY CASE
-                            WHEN mt.source_epoch IS NOT NULL THEN 1
-                            WHEN mt.source_message_id_hex IS NULL THEN 2
-                            ELSE 0
-                          END DESC,
-                          CASE
-                            WHEN mt.source_epoch IS NOT NULL THEN mt.source_epoch
-                            ELSE mt.timeline_at
-                          END DESC,
-                          mt.timeline_at DESC, mt.message_id_hex DESC
+                        ORDER BY mt.timeline_order_class DESC,
+                          mt.timeline_order_primary DESC,
+                          mt.timeline_order_phase DESC,
+                          mt.timeline_order_at DESC,
+                          mt.message_id_hex DESC
                         LIMIT 1
                      )
                    OR row.last_message_kind IS NOT (
@@ -936,16 +893,11 @@ fn chat_list_projection_complete_tx(
                                   AND mt.invalidation_status = 'local_publish_failed'
                               )
                           )
-                        ORDER BY CASE
-                            WHEN mt.source_epoch IS NOT NULL THEN 1
-                            WHEN mt.source_message_id_hex IS NULL THEN 2
-                            ELSE 0
-                          END DESC,
-                          CASE
-                            WHEN mt.source_epoch IS NOT NULL THEN mt.source_epoch
-                            ELSE mt.timeline_at
-                          END DESC,
-                          mt.timeline_at DESC, mt.message_id_hex DESC
+                        ORDER BY mt.timeline_order_class DESC,
+                          mt.timeline_order_primary DESC,
+                          mt.timeline_order_phase DESC,
+                          mt.timeline_order_at DESC,
+                          mt.message_id_hex DESC
                         LIMIT 1
                      )
                    OR row.last_message_timeline_at IS NOT (
@@ -960,16 +912,11 @@ fn chat_list_projection_complete_tx(
                                   AND mt.invalidation_status = 'local_publish_failed'
                               )
                           )
-                        ORDER BY CASE
-                            WHEN mt.source_epoch IS NOT NULL THEN 1
-                            WHEN mt.source_message_id_hex IS NULL THEN 2
-                            ELSE 0
-                          END DESC,
-                          CASE
-                            WHEN mt.source_epoch IS NOT NULL THEN mt.source_epoch
-                            ELSE mt.timeline_at
-                          END DESC,
-                          mt.timeline_at DESC, mt.message_id_hex DESC
+                        ORDER BY mt.timeline_order_class DESC,
+                          mt.timeline_order_primary DESC,
+                          mt.timeline_order_phase DESC,
+                          mt.timeline_order_at DESC,
+                          mt.message_id_hex DESC
                         LIMIT 1
                      )
                    OR row.last_message_deleted IS NOT COALESCE((
@@ -984,16 +931,11 @@ fn chat_list_projection_complete_tx(
                                   AND mt.invalidation_status = 'local_publish_failed'
                               )
                           )
-                        ORDER BY CASE
-                            WHEN mt.source_epoch IS NOT NULL THEN 1
-                            WHEN mt.source_message_id_hex IS NULL THEN 2
-                            ELSE 0
-                          END DESC,
-                          CASE
-                            WHEN mt.source_epoch IS NOT NULL THEN mt.source_epoch
-                            ELSE mt.timeline_at
-                          END DESC,
-                          mt.timeline_at DESC, mt.message_id_hex DESC
+                        ORDER BY mt.timeline_order_class DESC,
+                          mt.timeline_order_primary DESC,
+                          mt.timeline_order_phase DESC,
+                          mt.timeline_order_at DESC,
+                          mt.message_id_hex DESC
                         LIMIT 1
                      ), 0)
                    OR row.last_message_media_json IS NOT (
@@ -1008,16 +950,11 @@ fn chat_list_projection_complete_tx(
                                   AND mt.invalidation_status = 'local_publish_failed'
                               )
                           )
-                        ORDER BY CASE
-                            WHEN mt.source_epoch IS NOT NULL THEN 1
-                            WHEN mt.source_message_id_hex IS NULL THEN 2
-                            ELSE 0
-                          END DESC,
-                          CASE
-                            WHEN mt.source_epoch IS NOT NULL THEN mt.source_epoch
-                            ELSE mt.timeline_at
-                          END DESC,
-                          mt.timeline_at DESC, mt.message_id_hex DESC
+                        ORDER BY mt.timeline_order_class DESC,
+                          mt.timeline_order_primary DESC,
+                          mt.timeline_order_phase DESC,
+                          mt.timeline_order_at DESC,
+                          mt.message_id_hex DESC
                         LIMIT 1
                      )
                    OR row.last_message_delivery_state IS NOT COALESCE((
@@ -1037,16 +974,11 @@ fn chat_list_projection_complete_tx(
                                   AND mt.invalidation_status = 'local_publish_failed'
                               )
                           )
-                        ORDER BY CASE
-                            WHEN mt.source_epoch IS NOT NULL THEN 1
-                            WHEN mt.source_message_id_hex IS NULL THEN 2
-                            ELSE 0
-                          END DESC,
-                          CASE
-                            WHEN mt.source_epoch IS NOT NULL THEN mt.source_epoch
-                            ELSE mt.timeline_at
-                          END DESC,
-                          mt.timeline_at DESC, mt.message_id_hex DESC
+                        ORDER BY mt.timeline_order_class DESC,
+                          mt.timeline_order_primary DESC,
+                          mt.timeline_order_phase DESC,
+                          mt.timeline_order_at DESC,
+                          mt.message_id_hex DESC
                         LIMIT 1
                      ), 'not_applicable')
                    OR row.activity_sort_at IS NOT MAX(
@@ -1063,16 +995,11 @@ fn chat_list_projection_complete_tx(
                                       AND mt.invalidation_status = 'local_publish_failed'
                                   )
                               )
-                            ORDER BY CASE
-                            WHEN mt.source_epoch IS NOT NULL THEN 1
-                            WHEN mt.source_message_id_hex IS NULL THEN 2
-                            ELSE 0
-                          END DESC,
-                          CASE
-                            WHEN mt.source_epoch IS NOT NULL THEN mt.source_epoch
-                            ELSE mt.timeline_at
-                          END DESC,
-                          mt.timeline_at DESC, mt.message_id_hex DESC
+                            ORDER BY mt.timeline_order_class DESC,
+                              mt.timeline_order_primary DESC,
+                              mt.timeline_order_phase DESC,
+                              mt.timeline_order_at DESC,
+                              mt.message_id_hex DESC
                             LIMIT 1
                         ), 0),
                         COALESCE((
@@ -1318,51 +1245,51 @@ fn unread_summary_tx(
             first_message_id: None,
         });
     };
-    let (where_sql, marker_params) = if let Some(last_read_at) = read_state.last_read_timeline_at {
-        let marker_id = read_state.last_read_message_id_hex.as_deref().unwrap_or("");
-        if let Some(marker) = timeline_message_for_read_marker_tx(tx, group_id_hex, marker_id)? {
-            let (class, primary, _phase, at, id) = marker.canonical_order_key();
+    let (where_sql, marker_params, order_sql) =
+        if let Some((class, primary, phase, at, id)) = read_state.canonical_order_key() {
             (
-                "(CASE
-                    WHEN source_epoch IS NOT NULL THEN 1
-                    WHEN source_message_id_hex IS NULL THEN 2
-                    ELSE 0
-                  END,
-                  CASE
-                    WHEN source_epoch IS NOT NULL THEN source_epoch
-                    ELSE timeline_at
-                  END,
-                  timeline_at,
-                  message_id_hex) > (?4, ?5, ?6, ?7)",
+                "(timeline_order_class,
+              timeline_order_primary,
+              timeline_order_phase,
+              timeline_order_at,
+              message_id_hex) > (?4, ?5, ?6, ?7, ?8)",
                 vec![
                     rusqlite::types::Value::Integer(i64::from(class)),
                     rusqlite::types::Value::Integer(u64_to_i64(primary)?),
+                    rusqlite::types::Value::Integer(i64::from(phase)),
                     rusqlite::types::Value::Integer(u64_to_i64(at)?),
                     rusqlite::types::Value::Text(id.to_owned()),
                 ],
+                "timeline_order_class ASC,
+              timeline_order_primary ASC,
+              timeline_order_phase ASC,
+              timeline_order_at ASC,
+              message_id_hex ASC",
             )
-        } else {
+        } else if let Some(last_read_at) = read_state.last_read_timeline_at {
+            let marker_id = read_state.last_read_message_id_hex.as_deref().unwrap_or("");
             (
                 "(timeline_at > ?4 OR (timeline_at = ?4 AND message_id_hex > ?5))",
                 vec![
                     rusqlite::types::Value::Integer(u64_to_i64(last_read_at)?),
                     rusqlite::types::Value::Text(marker_id.to_owned()),
                 ],
+                "timeline_at ASC, message_id_hex ASC",
             )
-        }
-    } else {
-        (
-            "timeline_at > ?4 AND (?5 = ?5)",
-            vec![
-                rusqlite::types::Value::Integer(u64_to_i64(read_state.initialized_at)?),
-                rusqlite::types::Value::Text(String::new()),
-            ],
-        )
-    };
+        } else {
+            (
+                "timeline_at > ?4 AND (?5 = ?5)",
+                vec![
+                    rusqlite::types::Value::Integer(u64_to_i64(read_state.initialized_at)?),
+                    rusqlite::types::Value::Text(String::new()),
+                ],
+                "timeline_at ASC, message_id_hex ASC",
+            )
+        };
     // Derive count + first-unread id + mention_count from one ordered scan over
-    // the unread window. For a retained marker row the predicate and ordering use
-    // the same canonical accepted-history key as timeline pagination. A marker
-    // whose row was pruned falls back to its retained wall-clock tuple.
+    // the unread window. Persisted canonical anchors use the same accepted-history
+    // key as timeline pagination even after retention prunes the marker row.
+    // Legacy states without a canonical anchor use wall-clock predicate + order.
     let scan_sql = format!(
         "SELECT message_id_hex, plaintext, tags_json
          FROM message_timeline
@@ -1372,16 +1299,7 @@ fn unread_summary_tx(
            AND invalidation_status IS NULL
            AND sender != ?3
            AND {where_sql}
-         ORDER BY CASE
-                    WHEN source_epoch IS NOT NULL THEN 1
-                    WHEN source_message_id_hex IS NULL THEN 2
-                    ELSE 0
-                  END ASC,
-                  CASE
-                    WHEN source_epoch IS NOT NULL THEN source_epoch
-                    ELSE timeline_at
-                  END ASC,
-                  timeline_at ASC, message_id_hex ASC"
+         ORDER BY {order_sql}"
     );
     let mut query_params = vec![
         rusqlite::types::Value::Text(group_id_hex.to_owned()),
@@ -1532,16 +1450,11 @@ fn latest_kind9_message_tx(
                invalidation_status IS NULL
                OR (direction = 'sent' AND invalidation_status = 'local_publish_failed')
            )
-         ORDER BY CASE
-                    WHEN source_epoch IS NOT NULL THEN 1
-                    WHEN source_message_id_hex IS NULL THEN 2
-                    ELSE 0
-                  END DESC,
-                  CASE
-                    WHEN source_epoch IS NOT NULL THEN source_epoch
-                    ELSE timeline_at
-                  END DESC,
-                  timeline_at DESC, message_id_hex DESC
+         ORDER BY timeline_order_class DESC,
+                  timeline_order_primary DESC,
+                  timeline_order_phase DESC,
+                  timeline_order_at DESC,
+                  message_id_hex DESC
          LIMIT 1",
         params![group_id_hex, u64_to_i64(MARMOT_APP_EVENT_KIND_CHAT)?],
         chat_list_message_from_row,
@@ -1556,7 +1469,8 @@ fn timeline_message_for_read_marker_tx(
     message_id_hex: &str,
 ) -> StorageResult<Option<TimelineReadMarker>> {
     tx.query_row(
-        "SELECT message_id_hex, source_message_id_hex, source_epoch, timeline_at
+        "SELECT message_id_hex, source_message_id_hex, source_epoch,
+                invalidation_status, timeline_at
          FROM message_timeline
          WHERE group_id_hex = ?1 AND message_id_hex = ?2 AND kind = ?3",
         params![
@@ -1571,7 +1485,8 @@ fn timeline_message_for_read_marker_tx(
                 source_epoch: row
                     .get::<_, Option<i64>>(2)?
                     .and_then(|value| value.try_into().ok()),
-                timeline_at: row.get::<_, i64>(3)?.try_into().unwrap_or_default(),
+                invalidation_status: row.get(3)?,
+                timeline_at: row.get::<_, i64>(4)?.try_into().unwrap_or_default(),
             })
         },
     )
@@ -1607,13 +1522,65 @@ fn chat_list_message_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<ChatL
     })
 }
 
+fn insert_initial_read_state_tx(
+    tx: &Connection,
+    group_id_hex: &str,
+    manually_marked_unread: bool,
+) -> StorageResult<()> {
+    let latest = latest_kind9_message_tx(tx, group_id_hex)?;
+    let (message_id, timeline_at, order_class, order_primary) = match latest {
+        Some(message) => {
+            let marker =
+                timeline_message_for_read_marker_tx(tx, group_id_hex, &message.message_id_hex)?
+                    .ok_or_else(|| {
+                        StorageError::Backend(
+                            "latest chat message disappeared while creating read state".to_owned(),
+                        )
+                    })?;
+            let (class, primary, _phase, _at, _id) = marker.canonical_order_key();
+            (
+                Some(message.message_id_hex),
+                Some(message.timeline_at),
+                Some(class),
+                Some(primary),
+            )
+        }
+        None => (None, None, None, None),
+    };
+    // Match first-open semantics: with no retained kind-9 history there is no
+    // read anchor yet, so a subsequently recorded message counts even when its
+    // sender timestamp predates this local interaction.
+    let initialized_at = timeline_at.unwrap_or(0);
+    tx.execute(
+        "INSERT INTO conversation_read_state (
+            group_id_hex, last_read_message_id_hex, last_read_timeline_at,
+            last_read_order_class, last_read_order_primary,
+            initialized_at, updated_at, manually_marked_unread
+         )
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        params![
+            group_id_hex,
+            message_id,
+            optional_u64_to_i64(timeline_at)?,
+            order_class.map(i64::from),
+            optional_u64_to_i64(order_primary)?,
+            u64_to_i64(initialized_at)?,
+            u64_to_i64(unix_now_seconds())?,
+            bool_i64(manually_marked_unread),
+        ],
+    )
+    .storage()?;
+    Ok(())
+}
+
 fn read_state_tx(
     tx: &Connection,
     group_id_hex: &str,
 ) -> StorageResult<Option<ConversationReadState>> {
     tx.query_row(
-        "SELECT last_read_message_id_hex, last_read_timeline_at, initialized_at,
-                manually_marked_unread
+        "SELECT last_read_message_id_hex, last_read_timeline_at,
+                last_read_order_class, last_read_order_primary,
+                initialized_at, manually_marked_unread
          FROM conversation_read_state
          WHERE group_id_hex = ?1",
         params![group_id_hex],
@@ -1623,8 +1590,14 @@ fn read_state_tx(
                 last_read_timeline_at: row
                     .get::<_, Option<i64>>(1)?
                     .and_then(|value| value.try_into().ok()),
-                initialized_at: row.get::<_, i64>(2)?.try_into().unwrap_or_default(),
-                manually_marked_unread: row.get::<_, i64>(3)? != 0,
+                last_read_order_class: row
+                    .get::<_, Option<i64>>(2)?
+                    .and_then(|value| value.try_into().ok()),
+                last_read_order_primary: row
+                    .get::<_, Option<i64>>(3)?
+                    .and_then(|value| value.try_into().ok()),
+                initialized_at: row.get::<_, i64>(4)?.try_into().unwrap_or_default(),
+                manually_marked_unread: row.get::<_, i64>(5)? != 0,
             })
         },
     )

--- a/crates/storage-sqlite/src/chat_list/tests.rs
+++ b/crates/storage-sqlite/src/chat_list/tests.rs
@@ -979,6 +979,130 @@ fn chat_list_read_state_and_preview_follow_canonical_epoch_order() {
 }
 
 #[test]
+fn read_marker_follows_pending_send_into_authenticated_history() {
+    let store = setup_store();
+    let mut pending = chat("pending", LOCAL, 500, "optimistic send");
+    pending.source_message_id_hex = None;
+    pending.source_epoch = None;
+    store.record_app_event(&pending).unwrap();
+    store
+        .initialize_chat_read_state(LOCAL, GROUP, &no_mentions)
+        .unwrap();
+
+    pending.source_message_id_hex = Some("source-pending".to_owned());
+    pending.source_epoch = Some(7);
+    store.record_app_event(&pending).unwrap();
+
+    let mut incoming = chat("incoming", REMOTE, 100, "newer authenticated message");
+    incoming.source_epoch = Some(8);
+    store.record_app_event(&incoming).unwrap();
+
+    let row = store
+        .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+        .unwrap()
+        .expect("chat row");
+    assert_eq!(row.last_read_message_id_hex.as_deref(), Some("pending"));
+    assert_eq!(row.unread_count, 1);
+    assert_eq!(row.first_unread_message_id_hex.as_deref(), Some("incoming"));
+}
+
+#[test]
+fn failed_pending_read_marker_does_not_hide_authenticated_history() {
+    let store = setup_store();
+    let mut pending = chat("pending", LOCAL, 500, "optimistic send");
+    pending.source_message_id_hex = None;
+    pending.source_epoch = None;
+    store.record_app_event(&pending).unwrap();
+    store
+        .initialize_chat_read_state(LOCAL, GROUP, &no_mentions)
+        .unwrap();
+
+    store
+        .invalidate_app_event_by_message_id(GROUP, "pending", "local_publish_failed")
+        .unwrap();
+    let mut incoming = chat("incoming", REMOTE, 100, "authenticated message");
+    incoming.source_epoch = Some(8);
+    store.record_app_event(&incoming).unwrap();
+
+    let row = store
+        .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+        .unwrap()
+        .expect("chat row");
+    assert_eq!(row.last_read_message_id_hex.as_deref(), Some("pending"));
+    assert_eq!(row.unread_count, 1);
+    assert_eq!(row.first_unread_message_id_hex.as_deref(), Some("incoming"));
+}
+
+#[test]
+fn pruned_read_marker_keeps_canonical_epoch_anchor() {
+    let store = setup_store();
+    store
+        .initialize_chat_read_state(LOCAL, GROUP, &no_mentions)
+        .unwrap();
+
+    let mut marker = chat("marker", REMOTE, 150, "newer epoch");
+    marker.source_epoch = Some(8);
+    store.record_app_event(&marker).unwrap();
+    store
+        .mark_timeline_message_read(LOCAL, GROUP, "marker", &no_mentions)
+        .unwrap();
+
+    {
+        let conn = store.lock().unwrap();
+        conn.execute(
+            "DELETE FROM message_timeline
+             WHERE group_id_hex = ?1 AND message_id_hex = ?2",
+            params![GROUP, "marker"],
+        )
+        .unwrap();
+    }
+
+    let mut late_older = chat("late-older", REMOTE, 900, "older epoch");
+    late_older.source_epoch = Some(7);
+    store.record_app_event(&late_older).unwrap();
+
+    let row = store
+        .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+        .unwrap()
+        .expect("chat row");
+    assert_eq!(row.unread_count, 0);
+    assert_eq!(row.last_read_message_id_hex.as_deref(), Some("marker"));
+
+    let row = store
+        .mark_timeline_message_read(LOCAL, GROUP, "late-older", &no_mentions)
+        .unwrap()
+        .expect("chat row");
+    assert_eq!(row.last_read_message_id_hex.as_deref(), Some("marker"));
+    assert_eq!(row.last_read_timeline_at, Some(150));
+}
+
+#[test]
+fn failed_local_send_does_not_replace_delivered_chat_preview() {
+    let store = setup_store();
+    let mut failed = chat("failed", LOCAL, 300, "did not reach the group");
+    failed.source_message_id_hex = None;
+    store.record_app_event(&failed).unwrap();
+    store
+        .invalidate_app_event_by_message_id(GROUP, "failed", "local_publish_failed")
+        .unwrap();
+
+    let mut delivered = chat("delivered", REMOTE, 150, "accepted history");
+    delivered.source_epoch = Some(8);
+    store.record_app_event(&delivered).unwrap();
+
+    let row = store
+        .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+        .unwrap()
+        .expect("chat row");
+    assert_eq!(
+        row.last_message
+            .as_ref()
+            .map(|message| message.message_id_hex.as_str()),
+        Some("delivered")
+    );
+}
+
+#[test]
 fn secure_prune_keeps_chat_preview_on_canonical_latest_epoch() {
     let store = setup_store();
     let mut pruned = chat("pruned", REMOTE, 10, "old");

--- a/crates/storage-sqlite/src/chat_list/tests.rs
+++ b/crates/storage-sqlite/src/chat_list/tests.rs
@@ -935,6 +935,77 @@ fn ensure_chat_list_rows_rebuilds_stale_read_state_rows() {
 }
 
 #[test]
+fn chat_list_read_state_and_preview_follow_canonical_epoch_order() {
+    let store = setup_store();
+    store
+        .initialize_chat_read_state(LOCAL, GROUP, &no_mentions)
+        .unwrap();
+    let mut epoch_seven = chat("message-7", REMOTE, 200, "epoch seven");
+    epoch_seven.source_epoch = Some(7);
+    store.record_app_event(&epoch_seven).unwrap();
+    let mut epoch_eight = chat("message-8", REMOTE, 150, "epoch eight");
+    epoch_eight.source_epoch = Some(8);
+    store.record_app_event(&epoch_eight).unwrap();
+
+    let row = store
+        .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+        .unwrap()
+        .expect("chat row");
+    assert_eq!(row.last_message.unwrap().message_id_hex, "message-8");
+
+    let row = store
+        .mark_timeline_message_read(LOCAL, GROUP, "message-7", &no_mentions)
+        .unwrap()
+        .expect("chat row");
+    assert_eq!(row.unread_count, 1);
+    assert_eq!(
+        row.first_unread_message_id_hex.as_deref(),
+        Some("message-8")
+    );
+
+    store
+        .mark_timeline_message_read(LOCAL, GROUP, "message-8", &no_mentions)
+        .unwrap();
+    let row = store
+        .mark_timeline_message_read(LOCAL, GROUP, "message-7", &no_mentions)
+        .unwrap()
+        .expect("chat row");
+    assert_eq!(
+        row.last_read_message_id_hex.as_deref(),
+        Some("message-8"),
+        "a later wall timestamp from an older epoch must not move the marker backward"
+    );
+    assert_eq!(row.unread_count, 0);
+}
+
+#[test]
+fn secure_prune_keeps_chat_preview_on_canonical_latest_epoch() {
+    let store = setup_store();
+    let mut pruned = chat("pruned", REMOTE, 10, "old");
+    pruned.source_epoch = Some(6);
+    store.record_app_event(&pruned).unwrap();
+    let mut epoch_seven = chat("message-7", REMOTE, 200, "epoch seven");
+    epoch_seven.source_epoch = Some(7);
+    store.record_app_event(&epoch_seven).unwrap();
+    let mut epoch_eight = chat("message-8", REMOTE, 150, "epoch eight");
+    epoch_eight.source_epoch = Some(8);
+    store.record_app_event(&epoch_eight).unwrap();
+
+    let before = store
+        .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+        .unwrap()
+        .expect("chat row");
+    assert_eq!(before.last_message.unwrap().message_id_hex, "message-8");
+
+    store
+        .secure_prune_app_events_before(GROUP, 20, LOCAL, &no_mentions)
+        .unwrap();
+
+    let after = store.chat_list_row(GROUP).unwrap().expect("chat row");
+    assert_eq!(after.last_message.unwrap().message_id_hex, "message-8");
+}
+
+#[test]
 fn unread_starts_after_first_open_and_advances_by_visible_kind9() {
     let store = setup_store();
     store

--- a/crates/storage-sqlite/src/chat_list/tests.rs
+++ b/crates/storage-sqlite/src/chat_list/tests.rs
@@ -1095,8 +1095,11 @@ fn pruned_read_marker_keeps_canonical_epoch_anchor() {
 }
 
 #[test]
-fn failed_local_send_does_not_replace_delivered_chat_preview() {
+fn failed_local_send_does_not_replace_delivered_preview_after_prune_or_ensure() {
     let store = setup_store();
+    let mut pruned = chat("pruned", REMOTE, 10, "expired history");
+    pruned.source_epoch = Some(6);
+    store.record_app_event(&pruned).unwrap();
     let mut failed = chat("failed", LOCAL, 300, "did not reach the group");
     failed.source_message_id_hex = None;
     store.record_app_event(&failed).unwrap();
@@ -1114,6 +1117,35 @@ fn failed_local_send_does_not_replace_delivered_chat_preview() {
         .expect("chat row");
     assert_eq!(
         row.last_message
+            .as_ref()
+            .map(|message| message.message_id_hex.as_str()),
+        Some("delivered")
+    );
+
+    store
+        .secure_prune_app_events_before(GROUP, 20, LOCAL, &no_mentions)
+        .unwrap();
+    let after_prune = store.chat_list_row(GROUP).unwrap().expect("chat row");
+    assert_eq!(
+        after_prune
+            .last_message
+            .as_ref()
+            .map(|message| message.message_id_hex.as_str()),
+        Some("delivered")
+    );
+
+    {
+        let conn = store.lock().unwrap();
+        assert!(
+            chat_list_projection_complete_tx(&conn, LOCAL, &no_mentions).unwrap(),
+            "failed-send preview priority must match the completeness query"
+        );
+    }
+    store.ensure_chat_list_rows(LOCAL, &no_mentions).unwrap();
+    let after_ensure = store.chat_list_row(GROUP).unwrap().expect("chat row");
+    assert_eq!(
+        after_ensure
+            .last_message
             .as_ref()
             .map(|message| message.message_id_hex.as_str()),
         Some("delivered")

--- a/crates/storage-sqlite/src/chat_list/tests.rs
+++ b/crates/storage-sqlite/src/chat_list/tests.rs
@@ -1009,26 +1009,44 @@ fn read_marker_follows_pending_send_into_authenticated_history() {
 #[test]
 fn failed_pending_read_marker_does_not_hide_authenticated_history() {
     let store = setup_store();
+    for epoch in 1..=8 {
+        let mut accepted = chat(
+            &format!("accepted-{epoch}"),
+            REMOTE,
+            epoch * 10,
+            "accepted history",
+        );
+        accepted.source_epoch = Some(epoch);
+        store.record_app_event(&accepted).unwrap();
+    }
+    store
+        .initialize_chat_read_state(LOCAL, GROUP, &no_mentions)
+        .unwrap();
+
     let mut pending = chat("pending", LOCAL, 500, "optimistic send");
     pending.source_message_id_hex = None;
     pending.source_epoch = None;
     store.record_app_event(&pending).unwrap();
     store
-        .initialize_chat_read_state(LOCAL, GROUP, &no_mentions)
-        .unwrap();
-
-    store
         .invalidate_app_event_by_message_id(GROUP, "pending", "local_publish_failed")
         .unwrap();
+
+    let row = store
+        .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+        .unwrap()
+        .expect("chat row");
+    assert_eq!(row.unread_count, 0);
+    assert_eq!(row.last_read_message_id_hex.as_deref(), Some("accepted-8"));
+
     let mut incoming = chat("incoming", REMOTE, 100, "authenticated message");
-    incoming.source_epoch = Some(8);
+    incoming.source_epoch = Some(9);
     store.record_app_event(&incoming).unwrap();
 
     let row = store
         .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
         .unwrap()
         .expect("chat row");
-    assert_eq!(row.last_read_message_id_hex.as_deref(), Some("pending"));
+    assert_eq!(row.last_read_message_id_hex.as_deref(), Some("accepted-8"));
     assert_eq!(row.unread_count, 1);
     assert_eq!(row.first_unread_message_id_hex.as_deref(), Some("incoming"));
 }

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -86,6 +86,8 @@ mod migration_0042_group_state_checkpoints;
 mod migration_0043_transport_group_routes;
 #[path = "migrations/0044_local_group_deletion_frontiers.rs"]
 mod migration_0044_local_group_deletion_frontiers;
+#[path = "migrations/0045_timeline_canonical_order.rs"]
+mod migration_0045_timeline_canonical_order;
 
 use crate::SqliteResultExt;
 use cgka_traits::storage::{StorageError, StorageResult};
@@ -317,6 +319,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 44,
         name: "0044_local_group_deletion_frontiers",
         apply: migration_0044_local_group_deletion_frontiers::apply,
+    },
+    Migration {
+        version: 45,
+        name: "0045_timeline_canonical_order",
+        apply: migration_0045_timeline_canonical_order::apply,
     },
 ];
 

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -684,7 +684,7 @@ mod tests {
         assert_eq!(
             keys,
             vec![
-                ("failed".to_owned(), 0, 1_000, 1, 1_000),
+                ("failed".to_owned(), 2, 1_000, 1, 1_000),
                 ("marker".to_owned(), 1, 8, 1, 150),
                 ("pending".to_owned(), 2, 999, 1, 999),
             ]

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -611,6 +611,87 @@ mod tests {
     }
 
     #[test]
+    fn canonical_timeline_order_migration_backfills_read_anchor_and_virtual_keys() {
+        let mut connection = rusqlite::Connection::open_in_memory().unwrap();
+        connection
+            .pragma_update(None, "foreign_keys", true)
+            .unwrap();
+        run(&mut connection, &MIGRATIONS[..44]).unwrap();
+        connection
+            .execute(
+                "INSERT INTO account_groups (group_id_hex, endpoint, updated_at)
+                 VALUES ('aa', 'relay', 1)",
+                [],
+            )
+            .unwrap();
+        for (id, source_id, epoch, timeline_at, invalidation) in [
+            ("marker", Some("source-marker"), Some(8_i64), 150_i64, None),
+            ("pending", None, None, 999, None),
+            ("failed", None, None, 1_000, Some("local_publish_failed")),
+        ] {
+            connection
+                .execute(
+                    "INSERT INTO message_timeline (
+                         group_id_hex, message_id_hex, source_message_id_hex, source_epoch,
+                         direction, sender, plaintext, kind, tags_json, timeline_at,
+                         received_at, reactions_json, invalidation_status
+                     ) VALUES ('aa', ?1, ?2, ?3, 'received', 'sender', '', 9, '[]', ?4,
+                         ?4, '[]', ?5)",
+                    params![id, source_id, epoch, timeline_at, invalidation],
+                )
+                .unwrap();
+        }
+        connection
+            .execute(
+                "INSERT INTO conversation_read_state (
+                     group_id_hex, last_read_message_id_hex, last_read_timeline_at,
+                     initialized_at, updated_at
+                 ) VALUES ('aa', 'marker', 150, 1, 1)",
+                [],
+            )
+            .unwrap();
+
+        run(&mut connection, MIGRATIONS).unwrap();
+
+        let read_anchor: (i64, i64) = connection
+            .query_row(
+                "SELECT last_read_order_class, last_read_order_primary
+                 FROM conversation_read_state WHERE group_id_hex = 'aa'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(read_anchor, (1, 8));
+        let keys = connection
+            .prepare(
+                "SELECT message_id_hex, timeline_order_class, timeline_order_primary,
+                        timeline_order_phase, timeline_order_at
+                 FROM message_timeline ORDER BY message_id_hex",
+            )
+            .unwrap()
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, i64>(2)?,
+                    row.get::<_, i64>(3)?,
+                    row.get::<_, i64>(4)?,
+                ))
+            })
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(
+            keys,
+            vec![
+                ("failed".to_owned(), 0, 1_000, 1, 1_000),
+                ("marker".to_owned(), 1, 8, 1, 150),
+                ("pending".to_owned(), 2, 999, 1, 999),
+            ]
+        );
+    }
+
+    #[test]
     fn media_secret_reference_migration_backfills_known_rows_conservatively() {
         let mut connection = rusqlite::Connection::open_in_memory().unwrap();
         connection

--- a/crates/storage-sqlite/src/migrations/0045_timeline_canonical_order.rs
+++ b/crates/storage-sqlite/src/migrations/0045_timeline_canonical_order.rs
@@ -12,8 +12,7 @@ ALTER TABLE message_timeline
 ADD COLUMN timeline_order_class INTEGER GENERATED ALWAYS AS (
     CASE
         WHEN source_epoch IS NOT NULL THEN 1
-        WHEN source_message_id_hex IS NULL
-         AND invalidation_status IS NULL THEN 2
+        WHEN source_message_id_hex IS NULL THEN 2
         ELSE 0
     END
 ) VIRTUAL;
@@ -62,6 +61,12 @@ ADD COLUMN last_read_order_class INTEGER;
 ALTER TABLE conversation_read_state
 ADD COLUMN last_read_order_primary INTEGER;
 
+ALTER TABLE conversation_read_state
+ADD COLUMN last_read_order_phase INTEGER;
+
+ALTER TABLE conversation_read_state
+ADD COLUMN last_read_order_at INTEGER;
+
 UPDATE conversation_read_state
 SET last_read_order_class = (
         SELECT timeline.timeline_order_class
@@ -71,6 +76,18 @@ SET last_read_order_class = (
     ),
     last_read_order_primary = (
         SELECT timeline.timeline_order_primary
+        FROM message_timeline AS timeline
+        WHERE timeline.group_id_hex = conversation_read_state.group_id_hex
+          AND timeline.message_id_hex = conversation_read_state.last_read_message_id_hex
+    ),
+    last_read_order_phase = (
+        SELECT timeline.timeline_order_phase
+        FROM message_timeline AS timeline
+        WHERE timeline.group_id_hex = conversation_read_state.group_id_hex
+          AND timeline.message_id_hex = conversation_read_state.last_read_message_id_hex
+    ),
+    last_read_order_at = (
+        SELECT timeline.timeline_order_at
         FROM message_timeline AS timeline
         WHERE timeline.group_id_hex = conversation_read_state.group_id_hex
           AND timeline.message_id_hex = conversation_read_state.last_read_message_id_hex

--- a/crates/storage-sqlite/src/migrations/0045_timeline_canonical_order.rs
+++ b/crates/storage-sqlite/src/migrations/0045_timeline_canonical_order.rs
@@ -1,0 +1,51 @@
+use crate::SqliteResultExt;
+use cgka_traits::storage::StorageResult;
+use rusqlite::Transaction;
+
+/// Index the accepted-history timeline order introduced by mdk#1172. The key is
+/// computed from existing projection columns, so upgraded databases immediately
+/// gain canonical ordering without rewriting or re-projecting rows.
+pub(crate) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
+    tx.execute_batch(
+        r#"
+CREATE INDEX idx_message_timeline_group_canonical_order
+    ON message_timeline (
+        group_id_hex,
+        (CASE
+            WHEN source_epoch IS NOT NULL THEN 1
+            WHEN source_message_id_hex IS NULL THEN 2
+            ELSE 0
+         END),
+        (CASE
+            WHEN source_epoch IS NOT NULL THEN source_epoch
+            ELSE timeline_at
+         END),
+        (CASE
+            WHEN kind = 1210
+             AND source_message_id_hex IS NULL
+             AND source_epoch IS NOT NULL THEN 0
+            ELSE 1
+         END),
+        (CASE
+            WHEN kind = 1210
+             AND source_message_id_hex IS NULL
+             AND source_epoch IS NOT NULL THEN 0
+            ELSE timeline_at
+         END),
+        message_id_hex
+    );
+
+-- Timeline rows themselves need no rewrite: the canonical key is computed from
+-- columns already populated by migration 0009. Chat-list rows do cache latest
+-- and unread projections, so force one normal projection rebuild on next open.
+UPDATE chat_list_rows
+SET updated_at = 0
+WHERE EXISTS (
+    SELECT 1
+    FROM message_timeline AS timeline
+    WHERE timeline.group_id_hex = chat_list_rows.group_id_hex
+);
+"#,
+    )
+    .storage()
+}

--- a/crates/storage-sqlite/src/migrations/0045_timeline_canonical_order.rs
+++ b/crates/storage-sqlite/src/migrations/0045_timeline_canonical_order.rs
@@ -2,38 +2,80 @@ use crate::SqliteResultExt;
 use cgka_traits::storage::StorageResult;
 use rusqlite::Transaction;
 
-/// Index the accepted-history timeline order introduced by mdk#1172. The key is
-/// computed from existing projection columns, so upgraded databases immediately
-/// gain canonical ordering without rewriting or re-projecting rows.
+/// Index the accepted-history timeline order introduced by mdk#1172. Virtual
+/// columns keep the SQL definition in one place while deriving it from existing
+/// projection columns, so upgrades need no row rewrite or reprojection.
 pub(crate) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
     tx.execute_batch(
         r#"
+ALTER TABLE message_timeline
+ADD COLUMN timeline_order_class INTEGER GENERATED ALWAYS AS (
+    CASE
+        WHEN source_epoch IS NOT NULL THEN 1
+        WHEN source_message_id_hex IS NULL
+         AND invalidation_status IS NULL THEN 2
+        ELSE 0
+    END
+) VIRTUAL;
+
+ALTER TABLE message_timeline
+ADD COLUMN timeline_order_primary INTEGER GENERATED ALWAYS AS (
+    CASE
+        WHEN source_epoch IS NOT NULL THEN source_epoch
+        ELSE timeline_at
+    END
+) VIRTUAL;
+
+ALTER TABLE message_timeline
+ADD COLUMN timeline_order_phase INTEGER GENERATED ALWAYS AS (
+    CASE
+        WHEN kind = 1210
+         AND source_message_id_hex IS NULL
+         AND source_epoch IS NOT NULL THEN 0
+        ELSE 1
+    END
+) VIRTUAL;
+
+ALTER TABLE message_timeline
+ADD COLUMN timeline_order_at INTEGER GENERATED ALWAYS AS (
+    CASE
+        WHEN kind = 1210
+         AND source_message_id_hex IS NULL
+         AND source_epoch IS NOT NULL THEN 0
+        ELSE timeline_at
+    END
+) VIRTUAL;
+
 CREATE INDEX idx_message_timeline_group_canonical_order
     ON message_timeline (
         group_id_hex,
-        (CASE
-            WHEN source_epoch IS NOT NULL THEN 1
-            WHEN source_message_id_hex IS NULL THEN 2
-            ELSE 0
-         END),
-        (CASE
-            WHEN source_epoch IS NOT NULL THEN source_epoch
-            ELSE timeline_at
-         END),
-        (CASE
-            WHEN kind = 1210
-             AND source_message_id_hex IS NULL
-             AND source_epoch IS NOT NULL THEN 0
-            ELSE 1
-         END),
-        (CASE
-            WHEN kind = 1210
-             AND source_message_id_hex IS NULL
-             AND source_epoch IS NOT NULL THEN 0
-            ELSE timeline_at
-         END),
+        timeline_order_class,
+        timeline_order_primary,
+        timeline_order_phase,
+        timeline_order_at,
         message_id_hex
     );
+
+ALTER TABLE conversation_read_state
+ADD COLUMN last_read_order_class INTEGER;
+
+ALTER TABLE conversation_read_state
+ADD COLUMN last_read_order_primary INTEGER;
+
+UPDATE conversation_read_state
+SET last_read_order_class = (
+        SELECT timeline.timeline_order_class
+        FROM message_timeline AS timeline
+        WHERE timeline.group_id_hex = conversation_read_state.group_id_hex
+          AND timeline.message_id_hex = conversation_read_state.last_read_message_id_hex
+    ),
+    last_read_order_primary = (
+        SELECT timeline.timeline_order_primary
+        FROM message_timeline AS timeline
+        WHERE timeline.group_id_hex = conversation_read_state.group_id_hex
+          AND timeline.message_id_hex = conversation_read_state.last_read_message_id_hex
+    )
+WHERE last_read_message_id_hex IS NOT NULL;
 
 -- Timeline rows themselves need no rewrite: the canonical key is computed from
 -- columns already populated by migration 0009. Chat-list rows do cache latest

--- a/crates/storage-sqlite/src/timeline.rs
+++ b/crates/storage-sqlite/src/timeline.rs
@@ -27,53 +27,22 @@ use serde_json::{Value, json};
 /// sorts before the state row for N+1. The local observation timestamp remains a
 /// display/retention value, not the group-history authority.
 ///
-/// The leading class keeps pre-source-epoch legacy rows ahead of canonical
-/// history and optimistic local rows (no source id and no epoch yet) at the head.
+/// The leading class keeps pre-source-epoch legacy and failed-local rows ahead of
+/// canonical history, while unresolved optimistic local rows (no source id, no
+/// epoch, and no invalidation) remain at the head.
 /// Global, cross-group queries retain wall-clock order because epochs are local
 /// to a group and therefore cannot be compared across groups.
-pub(crate) const TIMELINE_GROUP_ORDER_BY_ASC: &str = "ORDER BY CASE
-        WHEN timeline.source_epoch IS NOT NULL THEN 1
-        WHEN timeline.source_message_id_hex IS NULL THEN 2
-        ELSE 0
-     END ASC,
-     CASE
-        WHEN timeline.source_epoch IS NOT NULL THEN timeline.source_epoch
-        ELSE timeline.timeline_at
-     END ASC,
-     CASE
-        WHEN timeline.kind = 1210
-         AND timeline.source_message_id_hex IS NULL
-         AND timeline.source_epoch IS NOT NULL THEN 0
-        ELSE 1
-     END ASC,
-     CASE
-        WHEN timeline.kind = 1210
-         AND timeline.source_message_id_hex IS NULL
-         AND timeline.source_epoch IS NOT NULL THEN 0
-        ELSE timeline.timeline_at
-     END ASC,
+pub(crate) const TIMELINE_GROUP_ORDER_BY_ASC: &str = "ORDER BY
+     timeline.timeline_order_class ASC,
+     timeline.timeline_order_primary ASC,
+     timeline.timeline_order_phase ASC,
+     timeline.timeline_order_at ASC,
      timeline.message_id_hex ASC";
-pub(crate) const TIMELINE_GROUP_ORDER_BY_DESC: &str = "ORDER BY CASE
-        WHEN timeline.source_epoch IS NOT NULL THEN 1
-        WHEN timeline.source_message_id_hex IS NULL THEN 2
-        ELSE 0
-     END DESC,
-     CASE
-        WHEN timeline.source_epoch IS NOT NULL THEN timeline.source_epoch
-        ELSE timeline.timeline_at
-     END DESC,
-     CASE
-        WHEN timeline.kind = 1210
-         AND timeline.source_message_id_hex IS NULL
-         AND timeline.source_epoch IS NOT NULL THEN 0
-        ELSE 1
-     END DESC,
-     CASE
-        WHEN timeline.kind = 1210
-         AND timeline.source_message_id_hex IS NULL
-         AND timeline.source_epoch IS NOT NULL THEN 0
-        ELSE timeline.timeline_at
-     END DESC,
+pub(crate) const TIMELINE_GROUP_ORDER_BY_DESC: &str = "ORDER BY
+     timeline.timeline_order_class DESC,
+     timeline.timeline_order_primary DESC,
+     timeline.timeline_order_phase DESC,
+     timeline.timeline_order_at DESC,
      timeline.message_id_hex DESC";
 pub(crate) const TIMELINE_WALL_ORDER_BY_ASC: &str =
     "ORDER BY timeline.timeline_at ASC, timeline.message_id_hex ASC";
@@ -181,6 +150,7 @@ impl TimelineMessageRecord {
         canonical_timeline_order_key(
             self.source_message_id_hex.as_deref(),
             self.source_epoch,
+            self.invalidation_status.as_deref(),
             self.kind,
             self.timeline_at,
             &self.message_id_hex,
@@ -1220,16 +1190,11 @@ fn refresh_chat_list_last_message_after_secure_prune_tx(
                    invalidation_status IS NULL
                    OR (direction = 'sent' AND invalidation_status = 'local_publish_failed')
                )
-             ORDER BY CASE
-                        WHEN source_epoch IS NOT NULL THEN 1
-                        WHEN source_message_id_hex IS NULL THEN 2
-                        ELSE 0
-                      END DESC,
-                      CASE
-                        WHEN source_epoch IS NOT NULL THEN source_epoch
-                        ELSE timeline_at
-                      END DESC,
-                      timeline_at DESC, message_id_hex DESC
+             ORDER BY timeline_order_class DESC,
+                      timeline_order_primary DESC,
+                      timeline_order_phase DESC,
+                      timeline_order_at DESC,
+                      message_id_hex DESC
              LIMIT 1",
             params![group_id_hex, u64_to_i64(MARMOT_APP_EVENT_KIND_CHAT)?],
             |row| {
@@ -1705,6 +1670,35 @@ fn upsert_message_timeline_row_tx(tx: &Connection, row: &TimelineRow) -> Storage
             if row.deleted { 1_i64 } else { 0_i64 },
             &row.deleted_by_message_id_hex,
             &row.invalidation_status,
+        ],
+    )
+    .storage()?;
+    // A read marker can point at an optimistic local row whose canonical key
+    // changes when the send is reconciled to authenticated MLS history. Keep
+    // the durable anchor synchronized with that row while it exists; if
+    // retention later removes the row, the last synchronized key remains.
+    let (order_class, order_primary, _phase, _at, _id) = canonical_timeline_order_key(
+        row.source_message_id_hex.as_deref(),
+        row.source_epoch,
+        row.invalidation_status.as_deref(),
+        row.kind,
+        row.timeline_at,
+        &row.message_id_hex,
+    );
+    tx.execute(
+        "UPDATE conversation_read_state
+         SET last_read_timeline_at = ?3,
+             last_read_order_class = ?4,
+             last_read_order_primary = ?5,
+             updated_at = ?6
+         WHERE group_id_hex = ?1 AND last_read_message_id_hex = ?2",
+        params![
+            &row.group_id_hex,
+            &row.message_id_hex,
+            u64_to_i64(row.timeline_at)?,
+            i64::from(order_class),
+            u64_to_i64(order_primary)?,
+            u64_to_i64(unix_now_seconds())?
         ],
     )
     .storage()?;
@@ -2453,7 +2447,8 @@ fn timeline_order_cursor_tx(
 ) -> StorageResult<OwnedTimelineOrderKey> {
     let row = tx
         .query_row(
-            "SELECT source_message_id_hex, source_epoch, kind, timeline_at, message_id_hex
+            "SELECT source_message_id_hex, source_epoch, invalidation_status,
+                    kind, timeline_at, message_id_hex
              FROM message_timeline
              WHERE group_id_hex = ?1 AND message_id_hex = ?2",
             params![group_id_hex, message_id_hex],
@@ -2461,18 +2456,25 @@ fn timeline_order_cursor_tx(
                 Ok((
                     row.get::<_, Option<String>>(0)?,
                     row.get::<_, Option<i64>>(1)?,
-                    row.get::<_, i64>(2)?,
+                    row.get::<_, Option<String>>(2)?,
                     row.get::<_, i64>(3)?,
-                    row.get::<_, String>(4)?,
+                    row.get::<_, i64>(4)?,
+                    row.get::<_, String>(5)?,
                 ))
             },
         )
         .optional()
         .storage()?;
-    let Some((source_message_id_hex, source_epoch, kind, timeline_at, message_id_hex)) = row else {
-        return Err(StorageError::Backend(
-            "group timeline cursor no longer exists; refresh the timeline".to_owned(),
-        ));
+    let Some((
+        source_message_id_hex,
+        source_epoch,
+        invalidation_status,
+        kind,
+        timeline_at,
+        message_id_hex,
+    )) = row
+    else {
+        return Err(StorageError::TimelineCursorExpired);
     };
     let source_epoch = source_epoch.map(i64_to_u64).transpose()?;
     let kind = i64_to_u64(kind)?;
@@ -2480,6 +2482,7 @@ fn timeline_order_cursor_tx(
     let (class, primary, phase, at, _) = canonical_timeline_order_key(
         source_message_id_hex.as_deref(),
         source_epoch,
+        invalidation_status.as_deref(),
         kind,
         timeline_at,
         &message_id_hex,
@@ -2572,54 +2575,20 @@ fn timeline_query_sql(
         (CursorDirection::Before, Some((class, primary, phase, at, id))) => {
             let comparison = if pagination.inclusive { "<=" } else { "<" };
             clauses.push(format!(
-                "(CASE
-                    WHEN timeline.source_epoch IS NOT NULL THEN 1
-                    WHEN timeline.source_message_id_hex IS NULL THEN 2
-                    ELSE 0
-                  END,
-                  CASE
-                    WHEN timeline.source_epoch IS NOT NULL THEN timeline.source_epoch
-                    ELSE timeline.timeline_at
-                  END,
-                  CASE
-                    WHEN timeline.kind = 1210
-                     AND timeline.source_message_id_hex IS NULL
-                     AND timeline.source_epoch IS NOT NULL THEN 0
-                    ELSE 1
-                  END,
-                  CASE
-                    WHEN timeline.kind = 1210
-                     AND timeline.source_message_id_hex IS NULL
-                     AND timeline.source_epoch IS NOT NULL THEN 0
-                    ELSE timeline.timeline_at
-                  END,
+                "(timeline.timeline_order_class,
+                  timeline.timeline_order_primary,
+                  timeline.timeline_order_phase,
+                  timeline.timeline_order_at,
                   timeline.message_id_hex) {comparison} (?, ?, ?, ?, ?)"
             ));
             params.extend(canonical_cursor_params(*class, *primary, *phase, *at, id)?);
         }
         (CursorDirection::After, Some((class, primary, phase, at, id))) => {
             clauses.push(
-                "(CASE
-                    WHEN timeline.source_epoch IS NOT NULL THEN 1
-                    WHEN timeline.source_message_id_hex IS NULL THEN 2
-                    ELSE 0
-                  END,
-                  CASE
-                    WHEN timeline.source_epoch IS NOT NULL THEN timeline.source_epoch
-                    ELSE timeline.timeline_at
-                  END,
-                  CASE
-                    WHEN timeline.kind = 1210
-                     AND timeline.source_message_id_hex IS NULL
-                     AND timeline.source_epoch IS NOT NULL THEN 0
-                    ELSE 1
-                  END,
-                  CASE
-                    WHEN timeline.kind = 1210
-                     AND timeline.source_message_id_hex IS NULL
-                     AND timeline.source_epoch IS NOT NULL THEN 0
-                    ELSE timeline.timeline_at
-                  END,
+                "(timeline.timeline_order_class,
+                  timeline.timeline_order_primary,
+                  timeline.timeline_order_phase,
+                  timeline.timeline_order_at,
                   timeline.message_id_hex) > (?, ?, ?, ?, ?)"
                     .to_owned(),
             );
@@ -2652,9 +2621,7 @@ fn timeline_query_sql(
             ));
         }
         (CursorDirection::Before | CursorDirection::After, None) => {
-            return Err(StorageError::Backend(
-                "canonical group timeline pagination requires a retained cursor row".to_owned(),
-            ));
+            return Err(StorageError::TimelineCursorExpired);
         }
         (CursorDirection::None, _) => {}
     }
@@ -2707,13 +2674,16 @@ fn escape_like_literal(value: &str) -> String {
 pub(crate) fn canonical_timeline_order_key<'a>(
     source_message_id_hex: Option<&str>,
     source_epoch: Option<u64>,
+    invalidation_status: Option<&str>,
     kind: u64,
     timeline_at: u64,
     message_id_hex: &'a str,
 ) -> (u8, u64, u8, u64, &'a str) {
     let (class, primary) = match source_epoch {
         Some(epoch) => (1, epoch),
-        None if source_message_id_hex.is_none() => (2, timeline_at),
+        None if source_message_id_hex.is_none() && invalidation_status.is_none() => {
+            (2, timeline_at)
+        }
         None => (0, timeline_at),
     };
     let phase = if kind == MARMOT_APP_EVENT_KIND_GROUP_SYSTEM

--- a/crates/storage-sqlite/src/timeline.rs
+++ b/crates/storage-sqlite/src/timeline.rs
@@ -878,14 +878,16 @@ impl SqliteAccountStorage {
         let mut pagination = validate_pagination(&query.pagination)?;
         let conn = self.lock()?;
         if canonical_group_order
-            && let (Some(group_id_hex), Some(cursor_at), Some(cursor_message_id_hex)) = (
+            && let (Some(group_id_hex), Some(cursor_message_id_hex)) = (
                 query.group_id_hex.as_deref(),
-                pagination.cursor_at,
                 pagination.cursor_message_id_hex.as_deref(),
             )
         {
-            pagination.cursor_order =
-                timeline_order_cursor_tx(&conn, group_id_hex, cursor_at, cursor_message_id_hex)?;
+            pagination.cursor_order = Some(timeline_order_cursor_tx(
+                &conn,
+                group_id_hex,
+                cursor_message_id_hex,
+            )?);
         }
         let (sql, params) = timeline_query_sql(&query, &pagination, canonical_group_order)?;
         let rows = {
@@ -2447,15 +2449,14 @@ fn timeline_records_by_ids_tx(
 fn timeline_order_cursor_tx(
     tx: &Connection,
     group_id_hex: &str,
-    timeline_at: u64,
     message_id_hex: &str,
-) -> StorageResult<Option<OwnedTimelineOrderKey>> {
+) -> StorageResult<OwnedTimelineOrderKey> {
     let row = tx
         .query_row(
             "SELECT source_message_id_hex, source_epoch, kind, timeline_at, message_id_hex
              FROM message_timeline
-             WHERE group_id_hex = ?1 AND timeline_at = ?2 AND message_id_hex = ?3",
-            params![group_id_hex, u64_to_i64(timeline_at)?, message_id_hex],
+             WHERE group_id_hex = ?1 AND message_id_hex = ?2",
+            params![group_id_hex, message_id_hex],
             |row| {
                 Ok((
                     row.get::<_, Option<String>>(0)?,
@@ -2469,7 +2470,9 @@ fn timeline_order_cursor_tx(
         .optional()
         .storage()?;
     let Some((source_message_id_hex, source_epoch, kind, timeline_at, message_id_hex)) = row else {
-        return Ok(None);
+        return Err(StorageError::Backend(
+            "group timeline cursor no longer exists; refresh the timeline".to_owned(),
+        ));
     };
     let source_epoch = source_epoch.map(i64_to_u64).transpose()?;
     let kind = i64_to_u64(kind)?;
@@ -2481,7 +2484,7 @@ fn timeline_order_cursor_tx(
         timeline_at,
         &message_id_hex,
     );
-    Ok(Some((class, primary, phase, at, message_id_hex)))
+    Ok((class, primary, phase, at, message_id_hex))
 }
 
 fn validate_pagination(pagination: &TimelinePagination) -> StorageResult<ValidatedPagination> {
@@ -2622,10 +2625,9 @@ fn timeline_query_sql(
             );
             params.extend(canonical_cursor_params(*class, *primary, *phase, *at, id)?);
         }
-        (CursorDirection::Before, None) => {
-            // Unknown/synthetic cursors keep the timestamp API's legacy wall-clock
-            // semantics. Row cursors returned by a group query take the canonical
-            // branch above.
+        (CursorDirection::Before, None) if !canonical_group_order => {
+            // Wall-clock-only queries retain the timestamp cursor semantics.
+            // Canonical group queries resolve a retained row above instead.
             let id_comparison = if pagination.inclusive { "<=" } else { "<" };
             clauses.push(format!(
                 "(timeline.timeline_at < ? OR (timeline.timeline_at = ? AND timeline.message_id_hex {id_comparison} ?))"
@@ -2637,7 +2639,7 @@ fn timeline_query_sql(
                 pagination.cursor_message_id_hex.clone().unwrap_or_default(),
             ));
         }
-        (CursorDirection::After, None) => {
+        (CursorDirection::After, None) if !canonical_group_order => {
             clauses.push(
                 "(timeline.timeline_at > ? OR (timeline.timeline_at = ? AND timeline.message_id_hex > ?))"
                     .to_owned(),
@@ -2647,6 +2649,11 @@ fn timeline_query_sql(
             params.push(rusqlite::types::Value::Integer(cursor_at));
             params.push(rusqlite::types::Value::Text(
                 pagination.cursor_message_id_hex.clone().unwrap_or_default(),
+            ));
+        }
+        (CursorDirection::Before | CursorDirection::After, None) => {
+            return Err(StorageError::Backend(
+                "canonical group timeline pagination requires a retained cursor row".to_owned(),
             ));
         }
         (CursorDirection::None, _) => {}

--- a/crates/storage-sqlite/src/timeline.rs
+++ b/crates/storage-sqlite/src/timeline.rs
@@ -1173,29 +1173,29 @@ fn refresh_chat_list_last_message_after_secure_prune_tx(
     tx: &Connection,
     group_id_hex: &str,
 ) -> StorageResult<()> {
+    let sql = format!(
+        "SELECT message_id_hex, sender, plaintext, kind, timeline_at, deleted,
+                media_json,
+                CASE
+                    WHEN direction != 'sent' THEN 'not_applicable'
+                    WHEN invalidation_status = 'local_publish_failed' THEN 'failed'
+                    WHEN source_message_id_hex IS NULL THEN 'pending'
+                    ELSE 'delivered'
+                END
+         FROM message_timeline
+         WHERE group_id_hex = ?1
+           AND kind = ?2
+           AND (
+               invalidation_status IS NULL
+               OR (direction = 'sent' AND invalidation_status = 'local_publish_failed')
+           )
+         ORDER BY {}
+         LIMIT 1",
+        crate::chat_list::CHAT_LIST_PREVIEW_ORDER_DESC
+    );
     let latest = tx
         .query_row(
-            "SELECT message_id_hex, sender, plaintext, kind, timeline_at, deleted,
-                    media_json,
-                    CASE
-                        WHEN direction != 'sent' THEN 'not_applicable'
-                        WHEN invalidation_status = 'local_publish_failed' THEN 'failed'
-                        WHEN source_message_id_hex IS NULL THEN 'pending'
-                        ELSE 'delivered'
-                    END
-             FROM message_timeline
-             WHERE group_id_hex = ?1
-               AND kind = ?2
-               AND (
-                   invalidation_status IS NULL
-                   OR (direction = 'sent' AND invalidation_status = 'local_publish_failed')
-               )
-             ORDER BY timeline_order_class DESC,
-                      timeline_order_primary DESC,
-                      timeline_order_phase DESC,
-                      timeline_order_at DESC,
-                      message_id_hex DESC
-             LIMIT 1",
+            &sql,
             params![group_id_hex, u64_to_i64(MARMOT_APP_EVENT_KIND_CHAT)?],
             |row| {
                 Ok((

--- a/crates/storage-sqlite/src/timeline.rs
+++ b/crates/storage-sqlite/src/timeline.rs
@@ -1677,7 +1677,7 @@ fn upsert_message_timeline_row_tx(tx: &Connection, row: &TimelineRow) -> Storage
     // changes when the send is reconciled to authenticated MLS history. Keep
     // the durable anchor synchronized with that row while it exists; if
     // retention later removes the row, the last synchronized key remains.
-    let (order_class, order_primary, _phase, _at, _id) = canonical_timeline_order_key(
+    let (order_class, order_primary, order_phase, order_at, _id) = canonical_timeline_order_key(
         row.source_message_id_hex.as_deref(),
         row.source_epoch,
         row.invalidation_status.as_deref(),
@@ -1690,7 +1690,9 @@ fn upsert_message_timeline_row_tx(tx: &Connection, row: &TimelineRow) -> Storage
          SET last_read_timeline_at = ?3,
              last_read_order_class = ?4,
              last_read_order_primary = ?5,
-             updated_at = ?6
+             last_read_order_phase = ?6,
+             last_read_order_at = ?7,
+             updated_at = ?8
          WHERE group_id_hex = ?1 AND last_read_message_id_hex = ?2",
         params![
             &row.group_id_hex,
@@ -1698,6 +1700,8 @@ fn upsert_message_timeline_row_tx(tx: &Connection, row: &TimelineRow) -> Storage
             u64_to_i64(row.timeline_at)?,
             i64::from(order_class),
             u64_to_i64(order_primary)?,
+            i64::from(order_phase),
+            u64_to_i64(order_at)?,
             u64_to_i64(unix_now_seconds())?
         ],
     )
@@ -2674,16 +2678,17 @@ fn escape_like_literal(value: &str) -> String {
 pub(crate) fn canonical_timeline_order_key<'a>(
     source_message_id_hex: Option<&str>,
     source_epoch: Option<u64>,
-    invalidation_status: Option<&str>,
+    _invalidation_status: Option<&str>,
     kind: u64,
     timeline_at: u64,
     message_id_hex: &'a str,
 ) -> (u8, u64, u8, u64, &'a str) {
+    // All unresolved local projections, including failed sends, stay at the
+    // optimistic head. Chat-list preview selection independently deprioritizes
+    // permanent failures once accepted history exists.
     let (class, primary) = match source_epoch {
         Some(epoch) => (1, epoch),
-        None if source_message_id_hex.is_none() && invalidation_status.is_none() => {
-            (2, timeline_at)
-        }
+        None if source_message_id_hex.is_none() => (2, timeline_at),
         None => (0, timeline_at),
     };
     let phase = if kind == MARMOT_APP_EVENT_KIND_GROUP_SYSTEM

--- a/crates/storage-sqlite/src/timeline.rs
+++ b/crates/storage-sqlite/src/timeline.rs
@@ -7,7 +7,7 @@ use crate::{
         replace_encrypted_media_secret_references_tx,
         retire_unreferenced_encrypted_media_secret_epochs_tx,
     },
-    optional_u64_to_i64, tags_from_json, u64_to_i64, unix_now_seconds,
+    i64_to_u64, optional_u64_to_i64, tags_from_json, u64_to_i64, unix_now_seconds,
 };
 use cgka_traits::app_event::{
     AppMessageRetentionDecision, EVENT_REF_TAG, MARMOT_APP_EVENT_KIND_AGENT_ACTIVITY,
@@ -21,19 +21,63 @@ use rusqlite::{Connection, OptionalExtension, params, params_from_iter};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
-/// The ONE display order for the materialized message-timeline / chat-list
-/// surface: `(timeline_at, message_id_hex)` (#736 boundary contract 1). This is
-/// the cross-client user-visible order (`timeline_at == recorded_at` at
-/// projection). It is a SEPARATE surface from the raw-event replay cursor
-/// (`AppEventReplayCursor`, which additionally tie-breaks on the LOCAL
-/// `insert_order` and is used only for lag-recovery watermark/suppression). Keep
-/// the two distinct: the replay cursor MUST NOT be applied to timeline
-/// pagination. Timeline record queries alias the materialized table as
-/// `timeline` and reference these constants; a few other lookups and the
-/// keyset-pagination predicates express the SAME order inline.
-pub(crate) const TIMELINE_ORDER_BY_ASC: &str =
+/// Canonical per-group display order for the materialized timeline. Authenticated
+/// source epochs establish the durable boundaries: a kind-1210 row establishing
+/// epoch N sorts before application rows authenticated in N, and every row in N
+/// sorts before the state row for N+1. The local observation timestamp remains a
+/// display/retention value, not the group-history authority.
+///
+/// The leading class keeps pre-source-epoch legacy rows ahead of canonical
+/// history and optimistic local rows (no source id and no epoch yet) at the head.
+/// Global, cross-group queries retain wall-clock order because epochs are local
+/// to a group and therefore cannot be compared across groups.
+pub(crate) const TIMELINE_GROUP_ORDER_BY_ASC: &str = "ORDER BY CASE
+        WHEN timeline.source_epoch IS NOT NULL THEN 1
+        WHEN timeline.source_message_id_hex IS NULL THEN 2
+        ELSE 0
+     END ASC,
+     CASE
+        WHEN timeline.source_epoch IS NOT NULL THEN timeline.source_epoch
+        ELSE timeline.timeline_at
+     END ASC,
+     CASE
+        WHEN timeline.kind = 1210
+         AND timeline.source_message_id_hex IS NULL
+         AND timeline.source_epoch IS NOT NULL THEN 0
+        ELSE 1
+     END ASC,
+     CASE
+        WHEN timeline.kind = 1210
+         AND timeline.source_message_id_hex IS NULL
+         AND timeline.source_epoch IS NOT NULL THEN 0
+        ELSE timeline.timeline_at
+     END ASC,
+     timeline.message_id_hex ASC";
+pub(crate) const TIMELINE_GROUP_ORDER_BY_DESC: &str = "ORDER BY CASE
+        WHEN timeline.source_epoch IS NOT NULL THEN 1
+        WHEN timeline.source_message_id_hex IS NULL THEN 2
+        ELSE 0
+     END DESC,
+     CASE
+        WHEN timeline.source_epoch IS NOT NULL THEN timeline.source_epoch
+        ELSE timeline.timeline_at
+     END DESC,
+     CASE
+        WHEN timeline.kind = 1210
+         AND timeline.source_message_id_hex IS NULL
+         AND timeline.source_epoch IS NOT NULL THEN 0
+        ELSE 1
+     END DESC,
+     CASE
+        WHEN timeline.kind = 1210
+         AND timeline.source_message_id_hex IS NULL
+         AND timeline.source_epoch IS NOT NULL THEN 0
+        ELSE timeline.timeline_at
+     END DESC,
+     timeline.message_id_hex DESC";
+pub(crate) const TIMELINE_WALL_ORDER_BY_ASC: &str =
     "ORDER BY timeline.timeline_at ASC, timeline.message_id_hex ASC";
-pub(crate) const TIMELINE_ORDER_BY_DESC: &str =
+pub(crate) const TIMELINE_WALL_ORDER_BY_DESC: &str =
     "ORDER BY timeline.timeline_at DESC, timeline.message_id_hex DESC";
 
 const DEFAULT_TIMELINE_LIMIT: usize = 50;
@@ -128,6 +172,20 @@ pub struct TimelineMessageRecord {
     /// tombstone instead of silently disappearing. Carries the engine invalidation
     /// reason (e.g. `LosingBranch`, `BeyondAnchor`). `None` for delivered messages.
     pub invalidation_status: Option<String>,
+}
+
+impl TimelineMessageRecord {
+    /// Stable per-group order derived only from accepted history plus the
+    /// authenticated inner event time. Local receive time never participates.
+    pub fn canonical_order_key(&self) -> (u8, u64, u8, u64, &str) {
+        canonical_timeline_order_key(
+            self.source_message_id_hex.as_deref(),
+            self.source_epoch,
+            self.kind,
+            self.timeline_at,
+            &self.message_id_hex,
+        )
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -314,11 +372,14 @@ enum CursorDirection {
     After,
 }
 
+type OwnedTimelineOrderKey = (u8, u64, u8, u64, String);
+
 #[derive(Clone, Debug)]
 struct ValidatedPagination {
     direction: CursorDirection,
     cursor_at: Option<u64>,
     cursor_message_id_hex: Option<String>,
+    cursor_order: Option<OwnedTimelineOrderKey>,
     /// Inclusive upper bound for a `Before` cursor (see
     /// [`TimelinePagination::before_inclusive`]); ignored for other directions.
     inclusive: bool,
@@ -795,9 +856,38 @@ impl SqliteAccountStorage {
     }
 
     pub fn message_timeline(&self, query: TimelineMessageQuery) -> StorageResult<TimelinePage> {
-        let pagination = validate_pagination(&query.pagination)?;
-        let (sql, params) = timeline_query_sql(&query, &pagination)?;
+        self.message_timeline_ordered(query, true)
+    }
+
+    /// Query by the legacy wall-clock tuple regardless of group source epochs.
+    /// Retention uses this because expiry cutoffs are timestamps, not display
+    /// cursors; ordinary group timelines should use [`Self::message_timeline`].
+    pub fn message_timeline_by_wall_clock(
+        &self,
+        query: TimelineMessageQuery,
+    ) -> StorageResult<TimelinePage> {
+        self.message_timeline_ordered(query, false)
+    }
+
+    fn message_timeline_ordered(
+        &self,
+        query: TimelineMessageQuery,
+        canonical_group_order: bool,
+    ) -> StorageResult<TimelinePage> {
+        let canonical_group_order = canonical_group_order && query.group_id_hex.is_some();
+        let mut pagination = validate_pagination(&query.pagination)?;
         let conn = self.lock()?;
+        if canonical_group_order
+            && let (Some(group_id_hex), Some(cursor_at), Some(cursor_message_id_hex)) = (
+                query.group_id_hex.as_deref(),
+                pagination.cursor_at,
+                pagination.cursor_message_id_hex.as_deref(),
+            )
+        {
+            pagination.cursor_order =
+                timeline_order_cursor_tx(&conn, group_id_hex, cursor_at, cursor_message_id_hex)?;
+        }
+        let (sql, params) = timeline_query_sql(&query, &pagination, canonical_group_order)?;
         let rows = {
             let _span = tracing::debug_span!(
                 target: "storage_sqlite::timeline",
@@ -1128,7 +1218,16 @@ fn refresh_chat_list_last_message_after_secure_prune_tx(
                    invalidation_status IS NULL
                    OR (direction = 'sent' AND invalidation_status = 'local_publish_failed')
                )
-             ORDER BY timeline_at DESC, message_id_hex DESC
+             ORDER BY CASE
+                        WHEN source_epoch IS NOT NULL THEN 1
+                        WHEN source_message_id_hex IS NULL THEN 2
+                        ELSE 0
+                      END DESC,
+                      CASE
+                        WHEN source_epoch IS NOT NULL THEN source_epoch
+                        ELSE timeline_at
+                      END DESC,
+                      timeline_at DESC, message_id_hex DESC
              LIMIT 1",
             params![group_id_hex, u64_to_i64(MARMOT_APP_EVENT_KIND_CHAT)?],
             |row| {
@@ -2340,11 +2439,49 @@ fn timeline_records_by_ids_tx(
             .storage()?;
         messages.extend(chunk_messages);
     }
-    messages.sort_by(|left, right| {
-        (left.timeline_at, &left.message_id_hex).cmp(&(right.timeline_at, &right.message_id_hex))
-    });
+    messages.sort_by(|left, right| left.canonical_order_key().cmp(&right.canonical_order_key()));
     attach_reply_previews(tx, &mut messages)?;
     Ok(messages)
+}
+
+fn timeline_order_cursor_tx(
+    tx: &Connection,
+    group_id_hex: &str,
+    timeline_at: u64,
+    message_id_hex: &str,
+) -> StorageResult<Option<OwnedTimelineOrderKey>> {
+    let row = tx
+        .query_row(
+            "SELECT source_message_id_hex, source_epoch, kind, timeline_at, message_id_hex
+             FROM message_timeline
+             WHERE group_id_hex = ?1 AND timeline_at = ?2 AND message_id_hex = ?3",
+            params![group_id_hex, u64_to_i64(timeline_at)?, message_id_hex],
+            |row| {
+                Ok((
+                    row.get::<_, Option<String>>(0)?,
+                    row.get::<_, Option<i64>>(1)?,
+                    row.get::<_, i64>(2)?,
+                    row.get::<_, i64>(3)?,
+                    row.get::<_, String>(4)?,
+                ))
+            },
+        )
+        .optional()
+        .storage()?;
+    let Some((source_message_id_hex, source_epoch, kind, timeline_at, message_id_hex)) = row else {
+        return Ok(None);
+    };
+    let source_epoch = source_epoch.map(i64_to_u64).transpose()?;
+    let kind = i64_to_u64(kind)?;
+    let timeline_at = i64_to_u64(timeline_at)?;
+    let (class, primary, phase, at, _) = canonical_timeline_order_key(
+        source_message_id_hex.as_deref(),
+        source_epoch,
+        kind,
+        timeline_at,
+        &message_id_hex,
+    );
+    Ok(Some((class, primary, phase, at, message_id_hex)))
 }
 
 fn validate_pagination(pagination: &TimelinePagination) -> StorageResult<ValidatedPagination> {
@@ -2383,14 +2520,32 @@ fn validate_pagination(pagination: &TimelinePagination) -> StorageResult<Validat
         direction,
         cursor_at,
         cursor_message_id_hex,
+        cursor_order: None,
         inclusive: pagination.before_inclusive,
         limit,
     })
 }
 
+fn canonical_cursor_params(
+    class: u8,
+    primary: u64,
+    phase: u8,
+    timeline_at: u64,
+    message_id_hex: &str,
+) -> StorageResult<Vec<rusqlite::types::Value>> {
+    Ok(vec![
+        rusqlite::types::Value::Integer(i64::from(class)),
+        rusqlite::types::Value::Integer(u64_to_i64(primary)?),
+        rusqlite::types::Value::Integer(i64::from(phase)),
+        rusqlite::types::Value::Integer(u64_to_i64(timeline_at)?),
+        rusqlite::types::Value::Text(message_id_hex.to_owned()),
+    ])
+}
+
 fn timeline_query_sql(
     query: &TimelineMessageQuery,
     pagination: &ValidatedPagination,
+    canonical_group_order: bool,
 ) -> StorageResult<(String, Vec<rusqlite::types::Value>)> {
     let mut clauses = Vec::new();
     let mut params = Vec::new();
@@ -2410,10 +2565,67 @@ fn timeline_query_sql(
             escape_like_literal(search)
         )));
     }
-    match pagination.direction {
-        CursorDirection::Before => {
-            // An inclusive cursor returns the row equal to the bound too, so the
-            // tie-break comparison flips from `<` to `<=`.
+    match (pagination.direction, pagination.cursor_order.as_ref()) {
+        (CursorDirection::Before, Some((class, primary, phase, at, id))) => {
+            let comparison = if pagination.inclusive { "<=" } else { "<" };
+            clauses.push(format!(
+                "(CASE
+                    WHEN timeline.source_epoch IS NOT NULL THEN 1
+                    WHEN timeline.source_message_id_hex IS NULL THEN 2
+                    ELSE 0
+                  END,
+                  CASE
+                    WHEN timeline.source_epoch IS NOT NULL THEN timeline.source_epoch
+                    ELSE timeline.timeline_at
+                  END,
+                  CASE
+                    WHEN timeline.kind = 1210
+                     AND timeline.source_message_id_hex IS NULL
+                     AND timeline.source_epoch IS NOT NULL THEN 0
+                    ELSE 1
+                  END,
+                  CASE
+                    WHEN timeline.kind = 1210
+                     AND timeline.source_message_id_hex IS NULL
+                     AND timeline.source_epoch IS NOT NULL THEN 0
+                    ELSE timeline.timeline_at
+                  END,
+                  timeline.message_id_hex) {comparison} (?, ?, ?, ?, ?)"
+            ));
+            params.extend(canonical_cursor_params(*class, *primary, *phase, *at, id)?);
+        }
+        (CursorDirection::After, Some((class, primary, phase, at, id))) => {
+            clauses.push(
+                "(CASE
+                    WHEN timeline.source_epoch IS NOT NULL THEN 1
+                    WHEN timeline.source_message_id_hex IS NULL THEN 2
+                    ELSE 0
+                  END,
+                  CASE
+                    WHEN timeline.source_epoch IS NOT NULL THEN timeline.source_epoch
+                    ELSE timeline.timeline_at
+                  END,
+                  CASE
+                    WHEN timeline.kind = 1210
+                     AND timeline.source_message_id_hex IS NULL
+                     AND timeline.source_epoch IS NOT NULL THEN 0
+                    ELSE 1
+                  END,
+                  CASE
+                    WHEN timeline.kind = 1210
+                     AND timeline.source_message_id_hex IS NULL
+                     AND timeline.source_epoch IS NOT NULL THEN 0
+                    ELSE timeline.timeline_at
+                  END,
+                  timeline.message_id_hex) > (?, ?, ?, ?, ?)"
+                    .to_owned(),
+            );
+            params.extend(canonical_cursor_params(*class, *primary, *phase, *at, id)?);
+        }
+        (CursorDirection::Before, None) => {
+            // Unknown/synthetic cursors keep the timestamp API's legacy wall-clock
+            // semantics. Row cursors returned by a group query take the canonical
+            // branch above.
             let id_comparison = if pagination.inclusive { "<=" } else { "<" };
             clauses.push(format!(
                 "(timeline.timeline_at < ? OR (timeline.timeline_at = ? AND timeline.message_id_hex {id_comparison} ?))"
@@ -2425,7 +2637,7 @@ fn timeline_query_sql(
                 pagination.cursor_message_id_hex.clone().unwrap_or_default(),
             ));
         }
-        CursorDirection::After => {
+        (CursorDirection::After, None) => {
             clauses.push(
                 "(timeline.timeline_at > ? OR (timeline.timeline_at = ? AND timeline.message_id_hex > ?))"
                     .to_owned(),
@@ -2437,7 +2649,7 @@ fn timeline_query_sql(
                 pagination.cursor_message_id_hex.clone().unwrap_or_default(),
             ));
         }
-        CursorDirection::None => {}
+        (CursorDirection::None, _) => {}
     }
     params.push(rusqlite::types::Value::Integer(
         i64::try_from(pagination.limit + 1).unwrap_or(i64::MAX),
@@ -2447,9 +2659,11 @@ fn timeline_query_sql(
     } else {
         format!("WHERE {}", clauses.join(" AND "))
     };
-    let order_sql = match pagination.direction {
-        CursorDirection::After => TIMELINE_ORDER_BY_ASC,
-        CursorDirection::None | CursorDirection::Before => TIMELINE_ORDER_BY_DESC,
+    let order_sql = match (canonical_group_order, pagination.direction) {
+        (true, CursorDirection::After) => TIMELINE_GROUP_ORDER_BY_ASC,
+        (true, CursorDirection::None | CursorDirection::Before) => TIMELINE_GROUP_ORDER_BY_DESC,
+        (false, CursorDirection::After) => TIMELINE_WALL_ORDER_BY_ASC,
+        (false, CursorDirection::None | CursorDirection::Before) => TIMELINE_WALL_ORDER_BY_DESC,
     };
     Ok((
         format!(
@@ -2481,6 +2695,30 @@ fn escape_like_literal(value: &str) -> String {
         escaped.push(ch);
     }
     escaped
+}
+
+pub(crate) fn canonical_timeline_order_key<'a>(
+    source_message_id_hex: Option<&str>,
+    source_epoch: Option<u64>,
+    kind: u64,
+    timeline_at: u64,
+    message_id_hex: &'a str,
+) -> (u8, u64, u8, u64, &'a str) {
+    let (class, primary) = match source_epoch {
+        Some(epoch) => (1, epoch),
+        None if source_message_id_hex.is_none() => (2, timeline_at),
+        None => (0, timeline_at),
+    };
+    let phase = if kind == MARMOT_APP_EVENT_KIND_GROUP_SYSTEM
+        && source_message_id_hex.is_none()
+        && source_epoch.is_some()
+    {
+        0
+    } else {
+        1
+    };
+    let intra_epoch_at = if phase == 0 { 0 } else { timeline_at };
+    (class, primary, phase, intra_epoch_at, message_id_hex)
 }
 
 fn project_group_events(events: Vec<RawAppEvent>) -> (Vec<TimelineRow>, Vec<StreamStartRow>) {

--- a/crates/storage-sqlite/src/timeline/tests.rs
+++ b/crates/storage-sqlite/src/timeline/tests.rs
@@ -726,6 +726,91 @@ fn group_timeline_order_is_stable_across_delayed_system_projection() {
 }
 
 #[test]
+fn virtual_order_columns_match_the_rust_canonical_key() {
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    let mut legacy = chat("legacy", "alice", 400, "legacy");
+    legacy.source_epoch = None;
+    store.record_app_event(&legacy).unwrap();
+
+    let mut pending = chat("pending", "local", 500, "pending");
+    pending.source_message_id_hex = None;
+    pending.source_epoch = None;
+    pending.direction = "sent".to_owned();
+    store.record_app_event(&pending).unwrap();
+
+    let mut system = group_system("system", "member_added", 900);
+    system.source_epoch = Some(7);
+    store.record_app_event(&system).unwrap();
+
+    let mut authenticated = chat("authenticated", "bob", 300, "authenticated");
+    authenticated.source_epoch = Some(7);
+    store.record_app_event(&authenticated).unwrap();
+
+    let expected = [&legacy, &pending, &system, &authenticated]
+        .into_iter()
+        .map(|event| {
+            let key = canonical_timeline_order_key(
+                event.source_message_id_hex.as_deref(),
+                event.source_epoch,
+                None,
+                event.kind,
+                event.recorded_at,
+                &event.message_id_hex,
+            );
+            (
+                event.message_id_hex.clone(),
+                i64::from(key.0),
+                i64::try_from(key.1).unwrap(),
+                i64::from(key.2),
+                i64::try_from(key.3).unwrap(),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let conn = store.lock().unwrap();
+    let actual = conn
+        .prepare(
+            "SELECT message_id_hex, timeline_order_class, timeline_order_primary,
+                    timeline_order_phase, timeline_order_at
+             FROM message_timeline
+             ORDER BY message_id_hex",
+        )
+        .unwrap()
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, i64>(2)?,
+                row.get::<_, i64>(3)?,
+                row.get::<_, i64>(4)?,
+            ))
+        })
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    let mut expected = expected;
+    expected.sort_by(|left, right| left.0.cmp(&right.0));
+    assert_eq!(actual, expected);
+
+    conn.execute(
+        "UPDATE message_timeline
+         SET invalidation_status = 'local_publish_failed'
+         WHERE message_id_hex = 'pending'",
+        [],
+    )
+    .unwrap();
+    let failed_class: i64 = conn
+        .query_row(
+            "SELECT timeline_order_class FROM message_timeline
+             WHERE message_id_hex = 'pending'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(failed_class, 0);
+}
+
+#[test]
 fn authenticated_kind_1210_message_does_not_establish_an_epoch_boundary() {
     let store = SqliteAccountStorage::in_memory().unwrap();
     let mut chat = chat("chat", "alice", 100, "before explicit system message");
@@ -844,11 +929,7 @@ fn group_timeline_pagination_rejects_missing_canonical_cursor() {
         ..TimelineMessageQuery::default()
     });
 
-    assert!(matches!(
-        result,
-        Err(StorageError::Backend(message))
-            if message == "group timeline cursor no longer exists; refresh the timeline"
-    ));
+    assert!(matches!(result, Err(StorageError::TimelineCursorExpired)));
 }
 
 #[test]

--- a/crates/storage-sqlite/src/timeline/tests.rs
+++ b/crates/storage-sqlite/src/timeline/tests.rs
@@ -677,6 +677,152 @@ fn timeline_orders_tied_timestamps_by_message_id() {
 }
 
 #[test]
+fn group_timeline_order_is_stable_across_delayed_system_projection() {
+    fn history(system_observed_at: [u64; 3]) -> SqliteAccountStorage {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let mut system_seven = group_system("system-7a", "member_added", system_observed_at[0]);
+        system_seven.source_epoch = Some(7);
+        store.record_app_event(&system_seven).unwrap();
+        let mut system_seven_second =
+            group_system("system-7b", "group_name_changed", system_observed_at[1]);
+        system_seven_second.source_epoch = Some(7);
+        store.record_app_event(&system_seven_second).unwrap();
+
+        let mut message_seven = chat("message-7", "alice", 200, "epoch seven");
+        message_seven.source_epoch = Some(7);
+        store.record_app_event(&message_seven).unwrap();
+
+        let mut system_eight = group_system("system-8", "member_removed", system_observed_at[2]);
+        system_eight.source_epoch = Some(8);
+        store.record_app_event(&system_eight).unwrap();
+
+        // The authenticated app timestamp may move backwards across senders or
+        // devices. Epoch boundaries, not wall-clock coincidence, establish the
+        // durable relative order.
+        let mut message_eight = chat("message-8", "bob", 150, "epoch eight");
+        message_eight.source_epoch = Some(8);
+        store.record_app_event(&message_eight).unwrap();
+        store
+    }
+
+    let online = history([100, 101, 300]);
+    // Catch-up observes the same epoch-seven system rows in the opposite local
+    // timestamp order. Their deterministic ids still decide their order.
+    let delayed = history([901, 900, 902]);
+    let ids = |store: &SqliteAccountStorage| {
+        list(store)
+            .into_iter()
+            .map(|message| message.message_id_hex)
+            .collect::<Vec<_>>()
+    };
+    let expected = vec![
+        "system-7a",
+        "system-7b",
+        "message-7",
+        "system-8",
+        "message-8",
+    ];
+
+    assert_eq!(ids(&online), expected);
+    assert_eq!(ids(&delayed), expected);
+}
+
+#[test]
+fn authenticated_kind_1210_message_does_not_establish_an_epoch_boundary() {
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    let mut chat = chat("chat", "alice", 100, "before explicit system message");
+    chat.source_epoch = Some(7);
+    store.record_app_event(&chat).unwrap();
+    let mut explicit_system = group_system("explicit-system", "custom", 200);
+    explicit_system.source_message_id_hex = Some("source-explicit-system".to_owned());
+    explicit_system.source_epoch = Some(7);
+    explicit_system.direction = "received".to_owned();
+    store.record_app_event(&explicit_system).unwrap();
+
+    assert_eq!(
+        list(&store)
+            .into_iter()
+            .map(|message| message.message_id_hex)
+            .collect::<Vec<_>>(),
+        ["chat", "explicit-system"]
+    );
+}
+
+#[test]
+fn group_timeline_pagination_uses_canonical_epoch_cursor() {
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    let mut system_seven = group_system("system-7", "member_added", 100);
+    system_seven.source_epoch = Some(7);
+    store.record_app_event(&system_seven).unwrap();
+    let mut message_seven = chat("message-7", "alice", 200, "epoch seven");
+    message_seven.source_epoch = Some(7);
+    store.record_app_event(&message_seven).unwrap();
+    let mut system_eight = group_system("system-8", "member_removed", 300);
+    system_eight.source_epoch = Some(8);
+    store.record_app_event(&system_eight).unwrap();
+    let mut message_eight = chat("message-8", "bob", 150, "epoch eight");
+    message_eight.source_epoch = Some(8);
+    store.record_app_event(&message_eight).unwrap();
+
+    let page = |pagination| {
+        store
+            .message_timeline(TimelineMessageQuery {
+                group_id_hex: Some("11".repeat(32)),
+                pagination,
+                ..TimelineMessageQuery::default()
+            })
+            .unwrap()
+    };
+    let older = page(TimelinePagination {
+        before: Some(300),
+        before_message_id: Some("system-8".to_owned()),
+        limit: Some(2),
+        ..TimelinePagination::default()
+    });
+    let newer = page(TimelinePagination {
+        after: Some(200),
+        after_message_id: Some("message-7".to_owned()),
+        limit: Some(2),
+        ..TimelinePagination::default()
+    });
+
+    assert_eq!(ids(&older), ["system-7", "message-7"]);
+    assert_eq!(ids(&newer), ["system-8", "message-8"]);
+}
+
+#[test]
+fn wall_clock_timeline_query_preserves_retention_scan_order() {
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    let mut system_seven = group_system("system-7", "member_added", 100);
+    system_seven.source_epoch = Some(7);
+    store.record_app_event(&system_seven).unwrap();
+    let mut message_seven = chat("message-7", "alice", 200, "epoch seven");
+    message_seven.source_epoch = Some(7);
+    store.record_app_event(&message_seven).unwrap();
+    let mut system_eight = group_system("system-8", "member_removed", 300);
+    system_eight.source_epoch = Some(8);
+    store.record_app_event(&system_eight).unwrap();
+    let mut message_eight = chat("message-8", "bob", 150, "epoch eight");
+    message_eight.source_epoch = Some(8);
+    store.record_app_event(&message_eight).unwrap();
+
+    let page = store
+        .message_timeline_by_wall_clock(TimelineMessageQuery {
+            group_id_hex: Some("11".repeat(32)),
+            pagination: TimelinePagination {
+                before: Some(300),
+                before_message_id: Some("system-8".to_owned()),
+                limit: Some(2),
+                ..TimelinePagination::default()
+            },
+            ..TimelineMessageQuery::default()
+        })
+        .unwrap();
+
+    assert_eq!(ids(&page), ["message-8", "message-7"]);
+}
+
+#[test]
 fn orphan_reaction_applies_when_target_arrives() {
     let store = SqliteAccountStorage::in_memory().unwrap();
     store
@@ -738,9 +884,9 @@ fn reply_preview_carries_parent_source_epoch_and_media() {
         "filename diagram.png".to_owned(),
     ]];
     store.record_app_event(&parent).unwrap();
-    store
-        .record_app_event(&reply("reply", "bob", "parent", 2, "answer"))
-        .unwrap();
+    let mut child = reply("reply", "bob", "parent", 2, "answer");
+    child.source_epoch = Some(5);
+    store.record_app_event(&child).unwrap();
 
     let page = store
         .message_timeline(TimelineMessageQuery {

--- a/crates/storage-sqlite/src/timeline/tests.rs
+++ b/crates/storage-sqlite/src/timeline/tests.rs
@@ -311,12 +311,10 @@ fn timeline_reads_preserve_every_pinned_retention_state() {
         )
         .unwrap();
 
-    let paginated = store
+    let queried = store
         .message_timeline(TimelineMessageQuery {
             group_id_hex: Some(group_id.clone()),
             pagination: TimelinePagination {
-                after: Some(0),
-                after_message_id: Some(String::new()),
                 limit: Some(10),
                 ..TimelinePagination::default()
             },
@@ -324,7 +322,7 @@ fn timeline_reads_preserve_every_pinned_retention_state() {
         })
         .unwrap()
         .messages;
-    let ids = paginated
+    let ids = queried
         .iter()
         .map(|record| record.message_id_hex.clone())
         .collect::<BTreeSet<_>>();
@@ -347,7 +345,7 @@ fn timeline_reads_preserve_every_pinned_retention_state() {
         ("legacy".to_owned(), (None, None)),
         ("overflow".to_owned(), (Some(1), None)),
     ]);
-    assert_eq!(retention_by_id(&paginated), expected);
+    assert_eq!(retention_by_id(&queried), expected);
     assert_eq!(retention_by_id(&by_id), expected);
 
     store.rebuild_message_timeline_for_group(&group_id).unwrap();
@@ -788,6 +786,69 @@ fn group_timeline_pagination_uses_canonical_epoch_cursor() {
 
     assert_eq!(ids(&older), ["system-7", "message-7"]);
     assert_eq!(ids(&newer), ["system-8", "message-8"]);
+}
+
+#[test]
+fn group_timeline_pagination_resolves_reprojected_system_cursor_by_stable_id() {
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    let mut system_seven = group_system("system-7", "member_added", 100);
+    system_seven.source_epoch = Some(7);
+    store.record_app_event(&system_seven).unwrap();
+    let mut message_seven = chat("message-7", "alice", 200, "epoch seven");
+    message_seven.source_epoch = Some(7);
+    store.record_app_event(&message_seven).unwrap();
+    let mut system_eight = group_system("system-8", "member_removed", 300);
+    system_eight.source_epoch = Some(8);
+    store.record_app_event(&system_eight).unwrap();
+    let mut message_eight = chat("message-8", "bob", 150, "epoch eight");
+    message_eight.source_epoch = Some(8);
+    store.record_app_event(&message_eight).unwrap();
+
+    // Reprocessing the same deterministic system row updates its local
+    // observation timestamp after a client has already retained the old cursor.
+    system_eight.recorded_at = 900;
+    system_eight.received_at = 900;
+    store.record_app_event(&system_eight).unwrap();
+
+    let older = store
+        .message_timeline(TimelineMessageQuery {
+            group_id_hex: Some("11".repeat(32)),
+            pagination: TimelinePagination {
+                before: Some(300),
+                before_message_id: Some("system-8".to_owned()),
+                limit: Some(2),
+                ..TimelinePagination::default()
+            },
+            ..TimelineMessageQuery::default()
+        })
+        .unwrap();
+
+    assert_eq!(ids(&older), ["system-7", "message-7"]);
+}
+
+#[test]
+fn group_timeline_pagination_rejects_missing_canonical_cursor() {
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    let mut message = chat("message-7", "alice", 200, "epoch seven");
+    message.source_epoch = Some(7);
+    store.record_app_event(&message).unwrap();
+
+    let result = store.message_timeline(TimelineMessageQuery {
+        group_id_hex: Some("11".repeat(32)),
+        pagination: TimelinePagination {
+            before: Some(300),
+            before_message_id: Some("pruned-system-8".to_owned()),
+            limit: Some(2),
+            ..TimelinePagination::default()
+        },
+        ..TimelineMessageQuery::default()
+    });
+
+    assert!(matches!(
+        result,
+        Err(StorageError::Backend(message))
+            if message == "group timeline cursor no longer exists; refresh the timeline"
+    ));
 }
 
 #[test]

--- a/crates/storage-sqlite/src/timeline/tests.rs
+++ b/crates/storage-sqlite/src/timeline/tests.rs
@@ -807,7 +807,24 @@ fn virtual_order_columns_match_the_rust_canonical_key() {
             |row| row.get(0),
         )
         .unwrap();
-    assert_eq!(failed_class, 0);
+    assert_eq!(failed_class, 2);
+    drop(conn);
+
+    let head = store
+        .message_timeline(TimelineMessageQuery {
+            group_id_hex: Some("11".repeat(32)),
+            pagination: TimelinePagination {
+                limit: Some(2),
+                ..TimelinePagination::default()
+            },
+            ..TimelineMessageQuery::default()
+        })
+        .unwrap();
+    assert_eq!(head.messages.last().unwrap().message_id_hex, "pending");
+    assert_eq!(
+        head.messages.last().unwrap().invalidation_status.as_deref(),
+        Some("local_publish_failed")
+    );
 }
 
 #[test]

--- a/crates/traits/src/storage.rs
+++ b/crates/traits/src/storage.rs
@@ -37,6 +37,10 @@ pub enum StorageError {
     AlreadyExists,
     #[error("snapshot not found: {0}")]
     SnapshotMissing(String),
+    /// A canonical timeline cursor row was removed by retention. Callers should
+    /// refresh from the timeline head instead of retrying the stale cursor.
+    #[error("timeline cursor no longer exists; refresh the timeline")]
+    TimelineCursorExpired,
     /// Transient lock contention: the backend could not acquire the database
     /// lock in time (for SQLite this is `SQLITE_BUSY` / `SQLITE_LOCKED`). It is
     /// distinct from [`StorageError::Backend`] so callers can recognise a

--- a/docs/marmot-architecture/overview/marmot-app-runtime.md
+++ b/docs/marmot-architecture/overview/marmot-app-runtime.md
@@ -1,7 +1,7 @@
 ---
 title: "Marmot App Runtime Shape"
 created: 2026-05-19
-updated: 2026-06-30
+updated: 2026-08-11
 tags: [marmot, overview, app-runtime, daemon, tui]
 status: implemented-first-slice
 ---
@@ -104,9 +104,14 @@ add the incremental, bounded, non-blocking, single-source properties around it s
      correct here because this cursor is only a per-client lag-recovery cut-point (never cross-client display). The
      third field is load-bearing for unscoped (all-groups) recovery, where the same `message_id_hex` can appear in two
      groups.
-   - **Materialized-timeline order** — `TIMELINE_ORDER_BY_ASC/_DESC` = `(timeline_at, message_id_hex)` over
-     `message_timeline`/chat-list; the cross-client user-visible display + pagination order (`timeline_at == recorded_at`
-     at projection). The replay cursor MUST NOT be applied to timeline pagination.
+   - **Materialized-timeline order** — authenticated `source_epoch` boundaries define the cross-client order for a
+     single group's `message_timeline`/chat-list rows. `TIMELINE_GROUP_ORDER_BY_ASC/_DESC` places synthesized state
+     changes before authenticated application messages in the epoch they establish and uses stable message ids to
+     break remaining ties. Group pagination resolves a retained cursor by `(group_id_hex, message_id_hex)` to recover
+     that canonical key; if the row was pruned, the caller must refresh instead of applying a wall-clock predicate to
+     canonical order. `TIMELINE_WALL_ORDER_BY_ASC/_DESC` = `(timeline_at, message_id_hex)` remains the order for
+     cross-group queries and retention scans, where epochs are not comparable. The replay cursor MUST NOT be applied
+     to either timeline order.
 2. **Runtime recovery** (`marmot-app` runtime). The lag-recovery watermark capture and `recovery_row_is_pre_subscription`
    suppression are the SAME `AppEventReplayCursor` the recovery query orders by, so the suppression boundary can never
    drift from the query order. Lag replay reads a bounded window (broadcast-depth/watermark-keyed), never the full
@@ -125,9 +130,10 @@ add the incremental, bounded, non-blocking, single-source properties around it s
 Canonical derived-state owners: timeline display order + raw-event replay cursor = `storage-sqlite` (the two helpers
 above); lag watermark/suppression = the subscription runtime, typed on `AppEventReplayCursor`; pending-convergence
 scheduling = `ScheduledConvergence`; transport routing = the engine + adapter indexes; message dedup = the engine's
-bounded `seen_message_ids` set (borrowed, not re-serialized, per convergence pass). `recorded_at` is cross-client-stable:
-the outer transport envelope's `created_at` is bound to the inner app event's `created_at` at wrap time, so a sender and
-every receiver record the same value.
+bounded `seen_message_ids` set (borrowed, not re-serialized, per convergence pass). Authenticated app-message
+`recorded_at` is cross-client-stable: the outer transport envelope's `created_at` is bound to the inner app event's
+`created_at` at wrap time, so a sender and every receiver record the same value. Synthesized state rows have only local
+observation time, which is a display/retention value and never the canonical group-history authority.
 
 The convergence branch-selection model is unchanged; see [`../distributed-convergence.md`](../distributed-convergence.md)
 and [`../cgka-engine-canonicalization-contract.md`](../cgka-engine-canonicalization-contract.md).

--- a/docs/marmot-architecture/overview/marmot-app-runtime.md
+++ b/docs/marmot-architecture/overview/marmot-app-runtime.md
@@ -110,8 +110,9 @@ add the incremental, bounded, non-blocking, single-source properties around it s
      break remaining ties. Group pagination resolves a retained cursor by `(group_id_hex, message_id_hex)` to recover
      that canonical key; if the row was pruned, the caller must refresh instead of applying a wall-clock predicate to
      canonical order. `TIMELINE_WALL_ORDER_BY_ASC/_DESC` = `(timeline_at, message_id_hex)` remains the order for
-     cross-group queries and retention scans, where epochs are not comparable. The replay cursor MUST NOT be applied
-     to either timeline order.
+     cross-group queries and retention scans. Cross-group queries use wall-clock order because epochs are not
+     comparable; retention scans use it for time-based expiry. The replay cursor MUST NOT be applied to either
+     timeline order.
 2. **Runtime recovery** (`marmot-app` runtime). The lag-recovery watermark capture and `recovery_row_is_pre_subscription`
    suppression are the SAME `AppEventReplayCursor` the recovery query orders by, so the suppression boundary can never
    drift from the query order. Lag replay reads a bounded window (broadcast-depth/watermark-keyed), never the full


### PR DESCRIPTION
## Summary

- derive per-group durable timeline order from authenticated MLS `source_epoch` boundaries instead of local observation time
- place synthesized state-change rows before application messages in the epoch they establish, with deterministic row-ID ordering for multiple same-epoch state changes
- use the same canonical order for pagination, runtime windows, chat previews, unread counts, and read-marker advancement while preserving wall-clock order for global queries and retention scans
- add migration 44 for the canonical SQLite index and chat-list projection refresh

## Test plan

- `RUSTFLAGS='-D warnings' cargo test -p storage-sqlite --locked` — 336 passed
- `RUSTFLAGS='-D warnings' cargo test -p marmot-app --lib --locked` — 608 passed
- `CARGO_INCREMENTAL=0 just fast-ci` — passed
- delayed/catch-up ordering regression demonstrated RED before deterministic same-epoch state-row ordering and GREEN after the fix

## Release hygiene

- updated `crates/cli/CHANGELOG.md` under Unreleased
- no version or conformance-fixture bump

Fixes #1172


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Timeline messages now appear in deterministic authenticated-history order, including across pagination, live updates, read markers, and device catch-up.
  * Chat previews and unread indicators consistently reflect the latest valid message.
  * Expired timeline cursors now recover by refreshing from the latest available messages.
  * Failed or pending sends no longer incorrectly replace delivered history or previews.
  * Retention scans continue using chronological ordering where appropriate.

* **Documentation**
  * Clarified timeline ordering, pagination, cursor behavior, and timestamp semantics.
  * Updated command-line help for timeline cursor options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->