### PR TITLE
test(opencode): separate idle timeout from mock exit

### DIFF
--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -11,6 +11,8 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ### Fixed
 
+- OpenCode harness idle-timeout regression test now keeps the mock child alive
+  past the idle deadline so CI load cannot race normal exit with `BackendIdle`.
 - Engine fork-detection integration tests now exercise the pinned v1
   five-commit rewind horizon in normal builds instead of overriding
   `max_rewind_commits` to one.

--- a/integrations/opencode/marmot/src/opencode.rs
+++ b/integrations/opencode/marmot/src/opencode.rs
@@ -353,9 +353,8 @@ mod tests {
         let (tx, _rx) = mpsc::channel(4);
         let failure = run(
             Invocation {
-                // The mock is a spawned shell process. Leave enough startup
-                // budget for this test to remain reliable under the full
-                // workspace nextest load.
+                // The mock child sleeps longer than this idle budget after the
+                // session line so CI load cannot race idle timeout with normal exit.
                 idle_timeout: Duration::from_secs(2),
                 ..mock_invocation(&dir, "idle")
             },

--- a/integrations/opencode/marmot/tests/fixtures/mock-opencode.sh
+++ b/integrations/opencode/marmot/tests/fixtures/mock-opencode.sh
@@ -9,7 +9,9 @@ case "$scenario" in
         ;;
     idle)
         printf '%s\n' '{"type":"step_start","sessionID":"ses_idle"}'
-        exec sleep 2
+        # Stay alive longer than the harness idle timeout so the test observes
+        # BackendIdle instead of racing normal exit at the same deadline.
+        exec sleep 3
         ;;
     streaming)
         for i in 1 2 3 4 5; do


### PR DESCRIPTION
Fixes #1381

## Summary
- Keep the OpenCode idle mock alive beyond the two-second harness idle deadline, eliminating the equal-deadline race with normal child exit.
- Preserve the regression assertion that `BackendIdle` fires after the session is observed.
- Document the CI test stabilization in the MDK compatibility-cohort changelog.

## Verification
- Baseline, retries disabled: 2/10 passed and 8/10 failed with normal exit at 2001–2002 ms.
- Fixed focused loop under concurrent host load: 20/20 passed.
- Final focused loop after rebasing onto `9ad13e00`: 10/10 passed.
- `cargo test -p wn-opencode --locked`: 14 passed; 1 ignored process-level test.
- `cargo fmt --all --check`: passed.
- `just fast-ci`: passed.
- Exact workflow shard 1/4: 898 passed; 2529 skipped.
- `bash -n integrations/opencode/marmot/tests/fixtures/mock-opencode.sh`: passed.

## Sensitive paths
None. Test harness, fixture, and changelog only.

## Release hygiene
- Changelog: `crates/cli/CHANGELOG.md` `Unreleased` / `Fixed` updated.
- Version bump: none.
