### PR TITLE
Support encrypted file delivery up to 512 MiB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3239,6 +3239,7 @@ name = "marmot-app"
 version = "0.9.11"
 dependencies = [
  "async-trait",
+ "bytes",
  "cgka-engine",
  "cgka-session",
  "cgka-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ url = "2"
 psl = "2"
 bech32 = "0.11"
 chacha20poly1305 = "0.10"
+bytes = "1"
 scrypt = "0.11"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "stream"] }
 zeroize = "1"

--- a/crates/agent-connector/src/lib.rs
+++ b/crates/agent-connector/src/lib.rs
@@ -94,11 +94,13 @@ pub(crate) const MEDIA_TEMP_MAX_AGE: Duration = Duration::from_secs(3600);
 pub(crate) const MEDIA_TEMP_SWEEP_INTERVAL: Duration = Duration::from_secs(60);
 /// Maximum attachments accepted by one connector `send_media` request.
 pub(crate) const MAX_MEDIA_UPLOAD_ATTACHMENTS: usize = 10;
-/// Largest plaintext whose 16-byte AEAD tag still fits the 64 MiB encrypted
+/// Largest plaintext whose 16-byte AEAD tag still fits the encrypted-media
 /// Blossom blob limit enforced by `marmot-app`.
-pub(crate) const MAX_MEDIA_UPLOAD_ATTACHMENT_BYTES: u64 = 64 * 1024 * 1024 - 16;
+pub(crate) const MAX_MEDIA_UPLOAD_ATTACHMENT_BYTES: u64 =
+    marmot_app::MAX_ENCRYPTED_MEDIA_BLOB_BYTES - 16;
 /// Maximum aggregate plaintext buffered by one connector `send_media` request.
-pub(crate) const MAX_MEDIA_UPLOAD_BATCH_BYTES: u64 = 128 * 1024 * 1024;
+pub(crate) const MAX_MEDIA_UPLOAD_BATCH_BYTES: u64 =
+    marmot_app::MAX_ENCRYPTED_MEDIA_BLOB_BYTES - 16;
 /// Capacity of the per-subscription delivered-inbound-id cursor used to dedup storage-backed
 /// replay after broadcast lag. Comfortably larger than the runtime broadcast channel depth
 /// (1024) so every message that could be re-queried after a single overflow is still tracked.

--- a/crates/agent-connector/src/tests.rs
+++ b/crates/agent-connector/src/tests.rs
@@ -44,6 +44,18 @@ use crate::{
 };
 use marmot_app::AppMessageRecord;
 
+#[test]
+fn connector_media_limits_follow_the_marmot_app_blob_limit() {
+    assert_eq!(
+        crate::MAX_MEDIA_UPLOAD_ATTACHMENT_BYTES + 16,
+        marmot_app::MAX_ENCRYPTED_MEDIA_BLOB_BYTES
+    );
+    assert_eq!(
+        crate::MAX_MEDIA_UPLOAD_BATCH_BYTES,
+        crate::MAX_MEDIA_UPLOAD_ATTACHMENT_BYTES
+    );
+}
+
 const CONTROL_RESPONSE_TIMEOUT: Duration = Duration::from_secs(120);
 
 #[tokio::test]

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -9,6 +9,17 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ## [Unreleased]
 
+### Changed
+
+- Encrypted media and Hermes/WN Agent file delivery now accept blobs up to
+  512 MiB (including the 16-byte authentication tag), enabling APKs and other
+  artifacts above the previous 64 MiB ceiling. Encryption/decryption is
+  performed in place, Blossom fallback retries share the same immutable upload
+  body, and large blob transfers have a 15-minute request budget. Receivers must
+  upgrade to this compatibility cohort before downloading blobs above 64 MiB;
+  the active blob remains memory-resident and one media request is bounded to
+  512 MiB total.
+
 ### Fixed
 
 - Engine fork-detection integration tests now exercise the pinned v1

--- a/crates/marmot-app/Cargo.toml
+++ b/crates/marmot-app/Cargo.toml
@@ -23,6 +23,7 @@ cgka-engine.workspace = true
 cgka-session.workspace = true
 cgka-traits.workspace = true
 chacha20poly1305.workspace = true
+bytes.workspace = true
 fs-private.workspace = true
 futures.workspace = true
 hex.workspace = true

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -168,9 +168,9 @@ pub use ids::{
 pub use marmot_forensics::AuditDataMode;
 pub use media::{
     DEFAULT_BLOSSOM_SERVER_URL, DEFAULT_BLOSSOM_SERVER_URLS, ENCRYPTED_MEDIA_VERSION,
-    EncryptedMediaVersion, MediaAttachmentReference, MediaDownloadResult, MediaLocator,
-    MediaUploadAttachmentRequest, MediaUploadAttachmentResult, MediaUploadRequest,
-    MediaUploadResult, download_profile_image, media_attachment_from_imeta_tag,
+    EncryptedMediaVersion, MAX_ENCRYPTED_MEDIA_BLOB_BYTES, MediaAttachmentReference,
+    MediaDownloadResult, MediaLocator, MediaUploadAttachmentRequest, MediaUploadAttachmentResult,
+    MediaUploadRequest, MediaUploadResult, download_profile_image, media_attachment_from_imeta_tag,
 };
 pub use messages::{is_stream_final_event, tag_value, tag_values};
 pub use nostr_secret::is_nostr_secret;

--- a/crates/marmot-app/src/media/blossom.rs
+++ b/crates/marmot-app/src/media/blossom.rs
@@ -1,6 +1,7 @@
 use std::net::{IpAddr, SocketAddr};
 use std::time::Duration;
 
+use bytes::Bytes;
 use nostr::base64::Engine as _;
 use nostr::base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64_URL_SAFE_NO_PAD;
 use nostr::{EventBuilder, JsonUtil, Kind, NostrSigner, Tag, Timestamp as NostrTimestamp};
@@ -23,8 +24,14 @@ pub(crate) const MAX_BLOSSOM_DESCRIPTOR_BYTES: u64 = 16 * 1024;
 const MEDIA_HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 const MEDIA_HTTP_READ_TIMEOUT: Duration = Duration::from_secs(15);
 const MEDIA_HTTP_TOTAL_TIMEOUT: Duration = Duration::from_secs(60);
+const MEDIA_BLOB_TRANSFER_TIMEOUT: Duration = Duration::from_secs(15 * 60);
 const BLOSSOM_REDIRECT_LIMIT: usize = 5;
-pub(crate) const MAX_ENCRYPTED_MEDIA_BLOB_BYTES: u64 = 64 * 1024 * 1024;
+/// Largest encrypted media blob this implementation will upload or download.
+///
+/// The encrypted-media wire format has no 64 MiB protocol limit. Keep this
+/// implementation bound finite for resource safety while allowing release APKs
+/// and other substantial application artifacts.
+pub const MAX_ENCRYPTED_MEDIA_BLOB_BYTES: u64 = 512 * 1024 * 1024;
 
 #[derive(Debug, Deserialize)]
 struct BlossomBlobDescriptor {
@@ -34,7 +41,7 @@ struct BlossomBlobDescriptor {
 
 pub(crate) async fn upload_blossom_blob(
     server: &str,
-    blob: &[u8],
+    blob: Bytes,
     blob_hash_hex: &str,
     signer: &dyn NostrSigner,
     allow_loopback_http: bool,
@@ -53,7 +60,7 @@ pub(crate) async fn upload_blossom_blob(
 
 pub(crate) async fn upload_blossom_blob_with_content_type(
     server: &str,
-    blob: &[u8],
+    blob: Bytes,
     blob_hash_hex: &str,
     signer: &dyn NostrSigner,
     allow_loopback_http: bool,
@@ -65,10 +72,11 @@ pub(crate) async fn upload_blossom_blob_with_content_type(
     let client = media_http_client_for_url(&upload_url, allow_loopback_http).await?;
     let response = client
         .put(upload_url.clone())
+        .timeout(MEDIA_BLOB_TRANSFER_TIMEOUT)
         .header(reqwest::header::AUTHORIZATION, authorization)
         .header(reqwest::header::CONTENT_TYPE, content_type)
         .header("X-SHA-256", blob_hash_hex)
-        .body(blob.to_vec())
+        .body(blob)
         .send()
         .await
         .map_err(reqwest_blob_error)?;
@@ -181,6 +189,7 @@ pub(crate) async fn fetch_blossom_blob(
     fetch_http_with_bounded_redirects(
         current,
         MAX_ENCRYPTED_MEDIA_BLOB_BYTES,
+        MEDIA_BLOB_TRANSFER_TIMEOUT,
         move |url| {
             let allow_loopback_http = allow_loopback_http;
             async move { media_http_client_for_url(&url, allow_loopback_http).await }
@@ -218,6 +227,7 @@ pub(crate) async fn fetch_profile_image_with_loopback(
     profile_operation_timeout(fetch_http_with_bounded_redirects(
         current,
         max_bytes,
+        MEDIA_HTTP_TOTAL_TIMEOUT,
         move |url| async move { media_http_client_for_url(&url, true).await },
         move |current, location| {
             let raw_location = location.trim();
@@ -251,6 +261,7 @@ async fn fetch_profile_image_impl(url: &str, max_bytes: u64) -> Result<Vec<u8>, 
     fetch_http_with_bounded_redirects(
         current,
         max_bytes,
+        MEDIA_HTTP_TOTAL_TIMEOUT,
         move |url| async move { media_http_client_for_profile(&url).await },
         move |current, location| {
             parse_profile_image_redirect_url(current, location).map_err(AppError::UnsafeMediaFetch)
@@ -274,6 +285,7 @@ pub(crate) fn vet_profile_fetch_resolved_addresses(addrs: &[SocketAddr]) -> Resu
 async fn fetch_http_with_bounded_redirects<C, CFut, R>(
     mut current: Url,
     max_body_bytes: u64,
+    request_timeout: Duration,
     mut client_for_url: C,
     mut redirect_target: R,
 ) -> Result<Vec<u8>, AppError>
@@ -283,11 +295,23 @@ where
     R: FnMut(&Url, &str) -> Result<Url, AppError>,
 {
     let mut redirects = 0_usize;
+    let deadline = tokio::time::Instant::now() + request_timeout;
 
     loop {
-        let client = client_for_url(current.clone()).await?;
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            return Err(AppError::BlobStore("request timed out".into()));
+        }
+        let client = tokio::time::timeout(remaining, client_for_url(current.clone()))
+            .await
+            .map_err(|_| AppError::BlobStore("request timed out".into()))??;
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            return Err(AppError::BlobStore("request timed out".into()));
+        }
         let response = client
             .get(current.clone())
+            .timeout(remaining)
             .send()
             .await
             .map_err(reqwest_blob_error)?;

--- a/crates/marmot-app/src/media/group_image.rs
+++ b/crates/marmot-app/src/media/group_image.rs
@@ -1,3 +1,4 @@
+use bytes::Bytes;
 use chacha20poly1305::aead::{Aead, Payload};
 use chacha20poly1305::{ChaCha20Poly1305, KeyInit, Nonce};
 use rand::RngCore;
@@ -94,7 +95,14 @@ pub(crate) async fn upload_group_image(
     // Group images upload to the public default Blossom server and are not part
     // of the loopback-blob-endpoint dev/test path, so loopback HTTP is never
     // permitted here.
-    upload_blossom_blob(server, &encrypted, &encrypted_hash_hex, &upload_keys, false).await?;
+    upload_blossom_blob(
+        server,
+        Bytes::from(encrypted),
+        &encrypted_hash_hex,
+        &upload_keys,
+        false,
+    )
+    .await?;
     Ok(GroupImageUpload {
         image_hash_hex: encrypted_hash_hex,
         image_key_hex: hex::encode(&content_key),

--- a/crates/marmot-app/src/media/mod.rs
+++ b/crates/marmot-app/src/media/mod.rs
@@ -1,9 +1,10 @@
+use bytes::Bytes;
 use cgka_traits::app_components::{
     BLOSSOM_LOCATOR_KIND_V1, ENCRYPTED_MEDIA_FORMAT_V1, ENCRYPTED_MEDIA_FORMAT_V2,
     GROUP_ENCRYPTED_MEDIA_V1_COMPONENT_ID, GROUP_ENCRYPTED_MEDIA_V2_COMPONENT_ID,
     canonicalize_marmot_media_type,
 };
-use chacha20poly1305::aead::{Aead, Payload};
+use chacha20poly1305::aead::AeadInPlace;
 use chacha20poly1305::{ChaCha20Poly1305, KeyInit, Nonce};
 use nostr::NostrSigner;
 use rand::RngCore;
@@ -27,6 +28,7 @@ use crypto::{
 };
 use host_safety::validate_locator;
 
+pub use blossom::MAX_ENCRYPTED_MEDIA_BLOB_BYTES;
 pub(crate) use blossom::{blossom_blob_url, fetch_blossom_blob};
 pub(crate) use group_image::{fetch_group_image, upload_group_image};
 pub(crate) use host_safety::is_loopback_http_endpoint;
@@ -179,7 +181,7 @@ pub(crate) async fn upload_profile_image_with_policy(
     let hash_hex = hex::encode(Sha256::digest(image));
     let url = upload_blossom_blob_with_content_type(
         server,
-        image,
+        Bytes::copy_from_slice(image),
         &hash_hex,
         signer,
         allow_loopback_http,
@@ -487,6 +489,7 @@ pub(crate) async fn upload_encrypted_media(
             "media upload requires at least one attachment".into(),
         ));
     }
+    validate_media_upload_batch(&request.attachments)?;
     let upload_servers = match request.blossom_server {
         Some(server) => vec![server],
         None => policy
@@ -520,6 +523,29 @@ pub(crate) async fn upload_encrypted_media(
     })
 }
 
+fn validate_media_upload_batch(
+    attachments: &[MediaUploadAttachmentRequest],
+) -> Result<(), AppError> {
+    validate_media_upload_batch_lengths(
+        attachments
+            .iter()
+            .map(|attachment| attachment.plaintext.len() as u64),
+    )
+}
+
+fn validate_media_upload_batch_lengths(
+    lengths: impl IntoIterator<Item = u64>,
+) -> Result<(), AppError> {
+    let max_plaintext_bytes = MAX_ENCRYPTED_MEDIA_BLOB_BYTES - 16;
+    let total_plaintext_bytes = lengths.into_iter().try_fold(0_u64, u64::checked_add);
+    if total_plaintext_bytes.is_none_or(|total| total > max_plaintext_bytes) {
+        return Err(AppError::InvalidEncryptedMedia(format!(
+            "media upload batch exceeds {max_plaintext_bytes} bytes"
+        )));
+    }
+    Ok(())
+}
+
 async fn upload_encrypted_media_attachment(
     request: MediaUploadAttachmentRequest,
     source_epoch: u64,
@@ -533,6 +559,7 @@ async fn upload_encrypted_media_attachment(
             "media plaintext cannot be empty".into(),
         ));
     }
+    validate_media_plaintext_len(request.plaintext.len() as u64)?;
     let file_name = match policy.version {
         EncryptedMediaVersion::V1 => request.file_name.trim().to_owned(),
         EncryptedMediaVersion::V2 => request.file_name,
@@ -556,19 +583,15 @@ async fn upload_encrypted_media_attachment(
     let aad = media_aad(policy.version, &plaintext_hash, &media_type, &file_name);
     let cipher = ChaCha20Poly1305::new_from_slice(&file_key)
         .map_err(|_| AppError::InvalidEncryptedMedia("invalid media key length".into()))?;
-    let encrypted = cipher
-        .encrypt(
-            Nonce::from_slice(&nonce),
-            Payload {
-                msg: &request.plaintext,
-                aad: &aad,
-            },
-        )
+    let mut encrypted = request.plaintext;
+    cipher
+        .encrypt_in_place(Nonce::from_slice(&nonce), &aad, &mut encrypted)
         .map_err(|_| AppError::InvalidEncryptedMedia("media encryption failed".into()))?;
+    let encrypted_size_bytes = encrypted.len() as u64;
     let ciphertext_sha256 = hex::encode(Sha256::digest(&encrypted));
     let url = upload_blossom_blob_with_fallback(
         upload_servers,
-        &encrypted,
+        Bytes::from(encrypted),
         &ciphertext_sha256,
         signer,
         policy.allow_loopback_http,
@@ -599,14 +622,24 @@ async fn upload_encrypted_media_attachment(
         policy.allow_loopback_http,
     )?;
     Ok(MediaUploadAttachmentResult {
-        encrypted_size_bytes: encrypted.len() as u64,
+        encrypted_size_bytes,
         reference,
     })
 }
 
+fn validate_media_plaintext_len(plaintext_bytes: u64) -> Result<(), AppError> {
+    let max_plaintext_bytes = MAX_ENCRYPTED_MEDIA_BLOB_BYTES - 16;
+    if plaintext_bytes > max_plaintext_bytes {
+        return Err(AppError::InvalidEncryptedMedia(format!(
+            "media plaintext exceeds {max_plaintext_bytes} bytes"
+        )));
+    }
+    Ok(())
+}
+
 async fn upload_blossom_blob_with_fallback(
     servers: &[String],
-    encrypted: &[u8],
+    encrypted: Bytes,
     encrypted_hash_hex: &str,
     signer: &dyn NostrSigner,
     allow_loopback_http: bool,
@@ -615,7 +648,7 @@ async fn upload_blossom_blob_with_fallback(
     for (idx, server) in servers.iter().enumerate() {
         match upload_blossom_blob(
             server,
-            encrypted,
+            encrypted.clone(),
             encrypted_hash_hex,
             signer,
             allow_loopback_http,
@@ -690,14 +723,9 @@ pub(crate) async fn download_encrypted_media(
     let aad = media_aad(version, &plaintext_hash, &media_type, &reference.file_name);
     let cipher = ChaCha20Poly1305::new_from_slice(&file_key)
         .map_err(|_| AppError::InvalidEncryptedMedia("invalid media key length".into()))?;
-    let plaintext = cipher
-        .decrypt(
-            Nonce::from_slice(&nonce),
-            Payload {
-                msg: &encrypted,
-                aad: &aad,
-            },
-        )
+    let mut plaintext = encrypted;
+    cipher
+        .decrypt_in_place(Nonce::from_slice(&nonce), &aad, &mut plaintext)
         .map_err(|_| AppError::InvalidEncryptedMedia("media decryption failed".into()))?;
     let actual_plaintext_hash: [u8; 32] = Sha256::digest(&plaintext).into();
     if actual_plaintext_hash != plaintext_hash {

--- a/crates/marmot-app/src/media/tests.rs
+++ b/crates/marmot-app/src/media/tests.rs
@@ -1,14 +1,61 @@
 use super::*;
-use std::io::{Read, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::net::TcpListener;
+use std::sync::mpsc;
 use std::thread;
 
+use chacha20poly1305::aead::{Aead, AeadInPlace, KeyInit, Payload};
+use chacha20poly1305::{ChaCha20Poly1305, Nonce};
 use url::Url;
 
 use super::blossom::{
     MAX_BLOSSOM_DESCRIPTOR_BYTES, MAX_ENCRYPTED_MEDIA_BLOB_BYTES, read_limited_blossom_body,
 };
 use super::host_safety::validate_blossom_fetch_url;
+
+#[test]
+fn encrypted_media_blob_limit_supports_large_application_artifacts() {
+    assert_eq!(MAX_ENCRYPTED_MEDIA_BLOB_BYTES, 512 * 1024 * 1024);
+}
+
+#[test]
+fn media_plaintext_limit_accounts_for_the_aead_tag_without_allocating_the_boundary() {
+    let max_plaintext = MAX_ENCRYPTED_MEDIA_BLOB_BYTES - 16;
+    assert!(validate_media_plaintext_len(max_plaintext).is_ok());
+    assert!(validate_media_plaintext_len(max_plaintext + 1).is_err());
+}
+
+#[test]
+fn media_upload_batch_enforces_the_same_aggregate_bound_as_the_connector() {
+    let max_plaintext = MAX_ENCRYPTED_MEDIA_BLOB_BYTES - 16;
+    assert!(validate_media_upload_batch_lengths([max_plaintext]).is_ok());
+    assert!(validate_media_upload_batch_lengths([max_plaintext - 3, 3]).is_ok());
+    assert!(validate_media_upload_batch_lengths([max_plaintext, 1]).is_err());
+    assert!(validate_media_upload_batch_lengths([u64::MAX, 1]).is_err());
+}
+
+#[test]
+fn in_place_encryption_is_wire_identical_to_the_previous_allocating_api() {
+    let key = [0x11_u8; 32];
+    let nonce = [0x22_u8; 12];
+    let aad = b"encrypted-media compatibility";
+    let plaintext = b"same key nonce aad and plaintext";
+    let cipher = ChaCha20Poly1305::new_from_slice(&key).unwrap();
+    let expected = cipher
+        .encrypt(
+            Nonce::from_slice(&nonce),
+            Payload {
+                msg: plaintext,
+                aad,
+            },
+        )
+        .unwrap();
+    let mut actual = plaintext.to_vec();
+    cipher
+        .encrypt_in_place(Nonce::from_slice(&nonce), aad, &mut actual)
+        .unwrap();
+    assert_eq!(actual, expected);
+}
 
 fn valid_imeta_tag() -> Vec<String> {
     vec![
@@ -297,6 +344,100 @@ pub(super) fn spawn_http_response(response: Vec<u8>) -> String {
     spawn_http_responses(vec![response])
 }
 
+fn spawn_roundtrip_blob_server() -> (String, mpsc::Receiver<(u64, String)>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind upload test server");
+    let addr = listener.local_addr().expect("upload test server addr");
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let (stream, _) = listener.accept().expect("accept upload");
+        let mut stream = BufReader::new(stream);
+        let mut content_length = None;
+        loop {
+            let mut line = String::new();
+            stream.read_line(&mut line).expect("read upload header");
+            if line == "\r\n" {
+                break;
+            }
+            if let Some(value) = line
+                .strip_prefix("content-length:")
+                .or_else(|| line.strip_prefix("Content-Length:"))
+            {
+                content_length = Some(value.trim().parse::<u64>().expect("content length"));
+            }
+        }
+        let content_length = content_length.expect("upload content length header");
+        let mut remaining = content_length;
+        let mut body = Vec::with_capacity(content_length as usize);
+        let mut buffer = [0_u8; 64 * 1024];
+        while remaining > 0 {
+            let take = remaining.min(buffer.len() as u64) as usize;
+            stream
+                .read_exact(&mut buffer[..take])
+                .expect("read complete upload body");
+            body.extend_from_slice(&buffer[..take]);
+            remaining -= take as u64;
+        }
+        let digest = hex::encode(Sha256::digest(&body));
+        stream
+            .get_mut()
+            .write_all(&http_json_response("{}"))
+            .expect("write upload descriptor");
+        drop(stream);
+        let (mut download, _) = listener.accept().expect("accept download");
+        let mut request = [0_u8; 4096];
+        let _ = download.read(&mut request).expect("read download request");
+        download
+            .write_all(&http_ok_response(&body))
+            .expect("write encrypted blob");
+        tx.send((content_length, digest))
+            .expect("report upload body");
+    });
+    (format!("http://{addr}"), rx)
+}
+
+fn spawn_hashing_upload_response(response: Vec<u8>) -> (String, mpsc::Receiver<(u64, String)>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind upload test server");
+    let addr = listener.local_addr().expect("upload test server addr");
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let (stream, _) = listener.accept().expect("accept upload");
+        let mut stream = BufReader::new(stream);
+        let mut content_length = None;
+        loop {
+            let mut line = String::new();
+            stream.read_line(&mut line).expect("read upload header");
+            if line == "\r\n" {
+                break;
+            }
+            if let Some(value) = line
+                .strip_prefix("content-length:")
+                .or_else(|| line.strip_prefix("Content-Length:"))
+            {
+                content_length = Some(value.trim().parse::<u64>().expect("content length"));
+            }
+        }
+        let content_length = content_length.expect("upload content length header");
+        let mut remaining = content_length;
+        let mut hash = Sha256::new();
+        let mut buffer = [0_u8; 64 * 1024];
+        while remaining > 0 {
+            let take = remaining.min(buffer.len() as u64) as usize;
+            stream
+                .read_exact(&mut buffer[..take])
+                .expect("read complete upload body");
+            hash.update(&buffer[..take]);
+            remaining -= take as u64;
+        }
+        stream
+            .get_mut()
+            .write_all(&response)
+            .expect("write upload response");
+        tx.send((content_length, hex::encode(hash.finalize())))
+            .expect("report upload body");
+    });
+    (format!("http://{addr}"), rx)
+}
+
 pub(super) fn http_redirect_response(location: &str) -> Vec<u8> {
     format!(
         "HTTP/1.1 302 Found\r\nLocation: {location}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
@@ -424,6 +565,77 @@ async fn upload_encrypted_media_falls_back_to_second_blossom_endpoint() {
 }
 
 #[tokio::test]
+async fn blossom_fallback_reuses_the_identical_encrypted_body() {
+    let (failing, first_body) =
+        spawn_hashing_upload_response(http_status_response(500, "Internal Server Error"));
+    let (succeeding, second_body) = spawn_hashing_upload_response(http_json_response("{}"));
+    let endpoints = [blossom_endpoint(failing), blossom_endpoint(succeeding)];
+    let allowed = [BLOSSOM_LOCATOR_KIND_V1.to_owned()];
+    let secret = media_secret();
+    let keys = signing_keys();
+
+    upload_encrypted_media(
+        media_upload_request(None),
+        42,
+        &secret,
+        &keys,
+        operation_policy(EncryptedMediaVersion::V1, &endpoints, &allowed, true),
+    )
+    .await
+    .expect("second Blossom endpoint should accept the retry body");
+
+    assert_eq!(first_body.recv().unwrap(), second_body.recv().unwrap());
+}
+
+#[tokio::test]
+async fn encrypted_media_round_trip_crosses_the_previous_64_mib_limit() {
+    let (server, received) = spawn_roundtrip_blob_server();
+    let endpoints = [blossom_endpoint(server)];
+    let allowed = [BLOSSOM_LOCATOR_KIND_V1.to_owned()];
+    let secret = media_secret();
+    let keys = signing_keys();
+    let plaintext_len = 64 * 1024 * 1024 + 1;
+    let request = MediaUploadRequest {
+        attachments: vec![MediaUploadAttachmentRequest {
+            file_name: "release.apk".to_owned(),
+            media_type: "application/vnd.android.package-archive".to_owned(),
+            plaintext: vec![0x5a; plaintext_len],
+            dim: None,
+            thumbhash: None,
+        }],
+        caption: None,
+        send: false,
+        blossom_server: None,
+    };
+
+    let result = upload_encrypted_media(
+        request,
+        42,
+        &secret,
+        &keys,
+        operation_policy(EncryptedMediaVersion::V2, &endpoints, &allowed, true),
+    )
+    .await
+    .expect("payload above the previous limit should upload");
+
+    let attachment = &result.attachments[0];
+    let downloaded = download_encrypted_media(
+        attachment.reference.clone(),
+        &secret,
+        &endpoints,
+        &allowed,
+        true,
+    )
+    .await
+    .expect("payload above the previous limit should download and decrypt");
+    let (received_len, received_hash) = received.recv().expect("upload body report");
+    assert_eq!(received_len, plaintext_len as u64 + 16);
+    assert_eq!(attachment.encrypted_size_bytes, received_len);
+    assert_eq!(attachment.reference.ciphertext_sha256, received_hash);
+    assert_eq!(downloaded.plaintext, vec![0x5a; plaintext_len]);
+}
+
+#[tokio::test]
 async fn encrypted_media_v2_upload_emits_v2_and_fresh_nonces() {
     let server = spawn_http_responses(vec![http_json_response("{}"), http_json_response("{}")]);
     let endpoints = [blossom_endpoint(server)];
@@ -471,9 +683,15 @@ async fn blossom_upload_rejects_oversized_descriptor_before_buffering() {
     let encrypted = b"encrypted bytes";
     let encrypted_hash = hex::encode(Sha256::digest(encrypted));
 
-    let error = upload_blossom_blob(&server, encrypted, &encrypted_hash, &signing_keys(), true)
-        .await
-        .unwrap_err();
+    let error = upload_blossom_blob(
+        &server,
+        bytes::Bytes::from_static(encrypted),
+        &encrypted_hash,
+        &signing_keys(),
+        true,
+    )
+    .await
+    .unwrap_err();
 
     assert_eq!(
         error.to_string(),

--- a/integrations/hermes/marmot/README.md
+++ b/integrations/hermes/marmot/README.md
@@ -442,15 +442,25 @@ the connector responds. `wn-agent` must independently allow that exact staging
 directory with `--media-allowed-root`; without one, path sends fail closed.
 
 Hermes multi-image responses are sent as one ordered Marmot media message, not
-as one message per image. The adapter accepts at most 10 attachments, caps each
-plaintext to the encrypted-blob limit (64 MiB minus authentication overhead),
-and caps the full batch at 128 MiB. It validates every source before staging or
+as one message per image. The adapter accepts at most 10 attachments and caps
+both each plaintext and the full batch to the encrypted-blob limit (512 MiB
+minus authentication overhead). It validates every source before staging or
 uploading any of them, applies the first non-empty caption once, and removes all
 staged copies on success, error, timeout, or cancellation. Retryable control-
 plane failures reuse one idempotency key; `wn-agent` binds that key to the
 destination, caption, ordered attachment metadata, and plaintext hashes before
 uploading, then returns the original durable message ids on a matching retry.
 Reply-targeted media sends remain unsupported and fail before upload.
+
+Large encrypted-media blobs retain the existing wire format, but every receiver
+must run an MDK version with the matching 512 MiB receive bound; older receivers
+still reject blobs above 64 MiB. MDK encrypts and decrypts each blob in place and
+passes upload retries a shared immutable body, avoiding separate full-size
+plaintext, ciphertext, and HTTP-body copies. The active blob still resides in
+memory, and the connector reads the validated batch before upload, so the
+aggregate 512 MiB request cap is also a deliberate peak-memory bound. This is
+appropriate for release APK delivery on a suitably provisioned connector; it is
+not a disk-streaming or low-memory-mobile transfer mode.
 
 ## Behavior
 

--- a/integrations/hermes/marmot/adapter.py
+++ b/integrations/hermes/marmot/adapter.py
@@ -64,11 +64,12 @@ STREAM_FINALIZE_RETRY_BACKOFF_S = (0.1, 0.3)
 # ten-item ceiling. Keeping one Marmot album within that bound also limits the
 # encrypted blobs an all-or-error upload can orphan before publication fails.
 MAX_OUTBOUND_MEDIA_ATTACHMENTS = 10
-# Marmot receivers cap encrypted Blossom blobs at 64 MiB. ChaCha20-Poly1305 adds
-# a 16-byte tag, so cap plaintext below that wire limit. The aggregate cap keeps
-# the connector's pre-upload in-memory batch bounded as well.
-MAX_OUTBOUND_MEDIA_FILE_BYTES = 64 * 1024 * 1024 - 16
-MAX_OUTBOUND_MEDIA_BATCH_BYTES = 128 * 1024 * 1024
+# MDK bounds encrypted Blossom blobs at 512 MiB. ChaCha20-Poly1305 adds a
+# 16-byte tag, so cap plaintext below that wire limit. Keep the entire batch
+# within the same bound because the connector validates and reads it before
+# beginning the upload.
+MAX_OUTBOUND_MEDIA_FILE_BYTES = 512 * 1024 * 1024 - 16
+MAX_OUTBOUND_MEDIA_BATCH_BYTES = 512 * 1024 * 1024 - 16
 DEFAULT_STREAMING_CURSOR = "\u2589"
 _DEFAULT_READ_TIMEOUT = object()
 MAX_TOOL_PROGRESS_MESSAGES = 512

--- a/integrations/hermes/marmot/tests/test_adapter.py
+++ b/integrations/hermes/marmot/tests/test_adapter.py
@@ -853,6 +853,17 @@ class TranscriptTests(unittest.TestCase):
         self.assertEqual(self.adapter._tool_events_from_progress_text("hello world"), [])
 
 
+class MediaLimitConfigurationTests(unittest.TestCase):
+    def test_defaults_support_large_application_artifacts(self):
+        adapter = load_adapter_module()
+        self.assertEqual(adapter.MAX_OUTBOUND_MEDIA_FILE_BYTES, 512 * 1024 * 1024 - 16)
+        self.assertEqual(
+            adapter.MAX_OUTBOUND_MEDIA_BATCH_BYTES,
+            adapter.MAX_OUTBOUND_MEDIA_FILE_BYTES,
+        )
+        self.assertGreater(adapter.MAX_OUTBOUND_MEDIA_FILE_BYTES, 250 * 1024 * 1024)
+
+
 class MarmotPlatformAdapterTests(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
         self.adapter_module = load_adapter_module()


### PR DESCRIPTION
## Summary

- raise the MDK encrypted-media and Hermes/WN Agent file-delivery ceiling from 64 MiB to 512 MiB, including the 16-byte authentication tag
- encrypt and decrypt media in place, then move ciphertext into a shared `Bytes` upload body so endpoint fallback retries do not duplicate the full file in memory
- enforce the same per-file and aggregate bounds in `marmot-app`, `agent-connector`, and the Hermes adapter
- give large blob transfers a 15-minute overall download budget while preserving the existing 60-second profile-image budget
- document the receiver upgrade requirement and the fact that this is bounded in-memory delivery, not disk streaming

This is a wire-compatible implementation fix for the immediate Hermes/APK failure reported in #1355. It does not close the broader policy-negotiation work described there: old receivers retain their old 64 MiB implementation limit and must upgrade before they can fetch larger blobs.

## Verification

- `just fast-ci`
- `python3 -m unittest discover -s integrations/hermes/marmot/tests -q` (189 passed)
- `cargo test -p marmot-app media:: --lib` (86 passed)
- `cargo test -p agent-connector --lib` (137 passed)
- 64 MiB + 1 byte encrypted upload/download/decrypt round trip
- byte-for-byte compatibility check between the previous allocating ChaCha20-Poly1305 API and the new in-place path
- identical encrypted-body verification across Blossom fallback endpoints
- independent Kimi K3 review: PASS after upload/batch enforcement and functional coverage corrections

`just hermes-dev-script-test` currently fails in an unchanged installer expectation (`Hermes installer dry-run did not describe active-service upgrade behavior`). This branch does not modify installer or dev-script files; all Hermes adapter unit tests pass.

## Compatibility and follow-up

- Existing encrypted-media references and ciphertext remain byte-compatible.
- Receivers on the previous cohort reject blobs above 64 MiB; the changelog and integration README make the coordinated-upgrade requirement explicit.
- The active request remains memory-resident and is bounded to 512 MiB aggregate. A future protocol/capability design can add negotiated limits or a chunked/disk-streaming format for low-memory mobile clients.

Addresses #1355


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased encrypted media and batch upload limits from 64 MiB to approximately 512 MiB.
  * Added support for larger media transfers with 15-minute request timeouts.
  * Improved retry handling by reusing encrypted upload data without unnecessary copying.
  * Added validation for individual and aggregate media size limits.

* **Bug Fixes**
  * Ensured media upload limits remain consistent across connectors and integrations.

* **Documentation**
  * Updated media compatibility, memory, transfer, and receiver requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->