### PR TITLE
fix(transport): preserve cancelled unsubscribe drains

### DIFF
--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -16,6 +16,10 @@ versioning through the workspace version in the root `Cargo.toml`.
   until a causally newer chat message arrives, while a durable engine-to-app
   delivery outbox makes that first crossing chat recoverable after a crash and
   does not affect other locally deleted groups.
+- Nostr group-sync unsubscribe draining now keeps unresolved relay teardowns
+  queued until teardown is confirmed, so cancelling a sync after routing
+  state commits retries pending unsubscribes and converges removal metrics
+  without double-counting.
 - OpenCode harness idle-timeout regression test now keeps the mock child alive
   past the idle deadline so CI load cannot race normal exit with `BackendIdle`.
 - Engine fork-detection integration tests now exercise the pinned v1

--- a/crates/transport-nostr-adapter/src/lib.rs
+++ b/crates/transport-nostr-adapter/src/lib.rs
@@ -263,8 +263,8 @@ pub struct NostrAdapterMetrics {
     pub active_group_subscriptions: usize,
     pub subscriptions_created: usize,
     pub subscriptions_removed: usize,
-    /// Gauge: relay unsubscribes that failed and await retry on a later group
-    /// sync. Routing state already reflects the removals.
+    /// Gauge: unconfirmed relay teardowns queued until an unsubscribe succeeds
+    /// or the route becomes live again. Routing state already reflects the removals.
     #[serde(default)]
     pub unsubscribe_retries_pending: usize,
     pub inbound_events_seen: usize,
@@ -446,6 +446,37 @@ impl NostrTransportAdapter {
         }
 
         Ok(())
+    }
+
+    /// Drain relay unsubscribes queued in `pending_unsubscribes`. A local
+    /// snapshot is iterated once; the authoritative queue is updated only on
+    /// confirmed relay teardown so cancellation cannot lose unresolved
+    /// cleanups.
+    async fn drain_pending_unsubscribes(&self) -> (usize, usize) {
+        let drain_snapshot = {
+            let mut state = self.state.write().await;
+            state.prune_live_pending_unsubscribes();
+            state.pending_unsubscribes.clone()
+        };
+
+        let mut confirmed = 0_usize;
+        let mut failed_count = 0_usize;
+        for subscription in drain_snapshot {
+            let subscription_id = subscription.subscription_id();
+            match self.relay_client.unsubscribe(subscription).await {
+                Ok(()) => {
+                    let mut state = self.state.write().await;
+                    if state.remove_pending_unsubscribe_by_id(&subscription_id) {
+                        state.record_confirmed_unsubscribes(1);
+                        confirmed += 1;
+                    }
+                }
+                Err(_) => {
+                    failed_count += 1;
+                }
+            }
+        }
+        (confirmed, failed_count)
     }
 
     /// Aggregate cross-relay arrival-spread snapshot for diagnostics and
@@ -787,23 +818,15 @@ impl TransportAdapter for NostrTransportAdapter {
         // earlier syncs); failures there are absorbed and retried, never
         // surfaced as an error.
         let now_ms = self.now_ms();
-        let drainable = {
+        {
             let mut state = self.state.write().await;
             state.forget_subscription_starts(&to_remove);
             state.record_subscription_starts(&to_add, now_ms);
             state.sync_groups(sync, to_add.len());
             state.queue_pending_unsubscribes(to_remove);
-            state.take_drainable_unsubscribes()
         };
 
-        let mut confirmed = 0_usize;
-        let mut requeue = Vec::new();
-        for subscription in drainable {
-            match self.relay_client.unsubscribe(subscription.clone()).await {
-                Ok(()) => confirmed += 1,
-                Err(_) => requeue.push(subscription),
-            }
-        }
+        let (confirmed, failed_unsubscribe_count) = self.drain_pending_unsubscribes().await;
 
         tracing::debug!(
             target: "transport_nostr_adapter::adapter",
@@ -812,16 +835,13 @@ impl TransportAdapter for NostrTransportAdapter {
             unsubscribes_confirmed = confirmed,
             "applied transport group subscription diff"
         );
-        let mut state = self.state.write().await;
-        state.record_confirmed_unsubscribes(confirmed);
-        if !requeue.is_empty() {
-            let failed_unsubscribe_count = requeue.len();
-            state.queue_pending_unsubscribes(requeue);
+        if failed_unsubscribe_count > 0 {
+            let pending_retry_total = self.state.read().await.pending_unsubscribes.len();
             tracing::warn!(
                 target: "transport_nostr_adapter::adapter",
                 method = "sync_account_groups",
                 failed_unsubscribe_count,
-                pending_retry_total = state.pending_unsubscribes.len(),
+                pending_retry_total,
                 "deferred relay unsubscribes; will retry on next group sync"
             );
         }
@@ -1050,10 +1070,10 @@ struct AdapterState {
     /// authoritative signed-routing state) at every mutation
     /// (activate/sync_groups/deactivate), so it can never drift.
     by_transport_group: HashMap<Vec<u8>, Vec<GroupRouteEntry>>,
-    /// Relay unsubscribes that failed and await retry. Routing state
-    /// (`accounts`/`by_transport_group`) already reflects the removal; these
-    /// are relay-side cleanups only, drained on later `sync_account_groups`
-    /// calls (never a reason to fail a sync).
+    /// Unconfirmed relay unsubscribes retained until teardown succeeds.
+    /// Routing state (`accounts`/`by_transport_group`) already reflects the
+    /// removal; these are relay-side cleanups only, drained on later
+    /// `sync_account_groups` calls (never a reason to fail a sync).
     pending_unsubscribes: Vec<NostrSubscription>,
     metrics: NostrAdapterMetrics,
     relay_index: RelayIndexRegistry,
@@ -1124,21 +1144,30 @@ impl AdapterState {
         }
     }
 
-    /// Take the queued unsubscribes that are safe to replay against relays.
-    ///
-    /// Entries whose route key is live again are silently dropped, never
-    /// drained: subscription ids are deterministic content hashes, so a group
-    /// removed (unsubscribe failed, queued here) and then re-added mints the
-    /// SAME id, and replaying the stale entry would tear down the
-    /// just-re-established subscription. Only group subscriptions enter this
-    /// queue, so liveness is checked against every account's stored groups.
-    fn take_drainable_unsubscribes(&mut self) -> Vec<NostrSubscription> {
-        let queued = std::mem::take(&mut self.pending_unsubscribes);
-        if queued.is_empty() {
-            return queued;
+    /// Drop queued unsubscribes whose route key is live again so a stale relay
+    /// teardown cannot tear down a just-re-established subscription.
+    fn prune_live_pending_unsubscribes(&mut self) {
+        let live_route_keys = self.live_group_route_keys();
+        self.pending_unsubscribes
+            .retain(|subscription| !live_route_keys.contains(&subscription.route_key()));
+    }
+
+    fn remove_pending_unsubscribe_by_id(&mut self, subscription_id: &str) -> bool {
+        let index = self
+            .pending_unsubscribes
+            .iter()
+            .position(|subscription| subscription.subscription_id() == subscription_id);
+        match index {
+            Some(index) => {
+                self.pending_unsubscribes.remove(index);
+                true
+            }
+            None => false,
         }
-        let live_route_keys = self
-            .accounts
+    }
+
+    fn live_group_route_keys(&self) -> HashSet<NostrSubscriptionRouteKey> {
+        self.accounts
             .iter()
             .flat_map(|(account_id, routes)| {
                 routes
@@ -1146,10 +1175,6 @@ impl AdapterState {
                     .iter()
                     .map(|group| group_subscription(account_id, group, None).route_key())
             })
-            .collect::<HashSet<_>>();
-        queued
-            .into_iter()
-            .filter(|subscription| !live_route_keys.contains(&subscription.route_key()))
             .collect()
     }
 

--- a/crates/transport-nostr-adapter/tests/inbound_routing.rs
+++ b/crates/transport-nostr-adapter/tests/inbound_routing.rs
@@ -9,7 +9,7 @@ use cgka_traits::{
     TransportEndpoint, TransportGroupSubscription, TransportGroupSync, TransportPublishRequest,
     TransportPublishTarget,
 };
-use tokio::sync::Barrier;
+use tokio::sync::{Barrier, Notify};
 use transport_nostr_adapter::{
     NostrPublishOutcome, NostrRelayClient, NostrRelayEvent, NostrSubscription,
     NostrTransportAdapter, RelayExportConsent, RelayIndex,
@@ -311,6 +311,74 @@ impl NostrRelayClient for FlakyUnsubscribeRelayClient {
             return Err(cgka_traits::TransportAdapterError::Subscription(
                 "injected unsubscribe failure".into(),
             ));
+        }
+        self.unsubscribed.lock().unwrap().push(subscription);
+        Ok(())
+    }
+
+    async fn unsubscribe_account(
+        &self,
+        account_id: &MemberId,
+    ) -> Result<(), cgka_traits::TransportAdapterError> {
+        self.unsubscribed_accounts
+            .lock()
+            .unwrap()
+            .push(account_id.clone());
+        Ok(())
+    }
+
+    async fn publish_event(
+        &self,
+        endpoints: &[TransportEndpoint],
+        _event: &NostrTransportEvent,
+        _required_acks: usize,
+    ) -> Result<NostrPublishOutcome, cgka_traits::TransportAdapterError> {
+        Ok(NostrPublishOutcome::accepted(endpoints.to_vec()))
+    }
+}
+
+/// Like [`FakeRelayClient`], but `unsubscribe` blocks on the call numbered by
+/// `block_on_call` (0 disables blocking). `unsubscribe_entered` increments when
+/// each `unsubscribe` call begins.
+#[derive(Default)]
+struct BlockingUnsubscribeRelayClient {
+    subscriptions: Mutex<Vec<transport_nostr_adapter::NostrSubscription>>,
+    unsubscribed: Mutex<Vec<transport_nostr_adapter::NostrSubscription>>,
+    unsubscribed_accounts: Mutex<Vec<MemberId>>,
+    /// 1-based call index to block on; 0 means never block.
+    block_on_call: AtomicUsize,
+    unsubscribe_entered: AtomicUsize,
+    unsubscribe_release: Notify,
+}
+
+impl BlockingUnsubscribeRelayClient {
+    fn release_blocked_unsubscribe(&self) {
+        self.block_on_call.store(0, Ordering::SeqCst);
+        self.unsubscribe_release.notify_one();
+    }
+}
+
+#[async_trait]
+impl NostrRelayClient for BlockingUnsubscribeRelayClient {
+    async fn subscribe(
+        &self,
+        subscription: transport_nostr_adapter::NostrSubscription,
+    ) -> Result<(), cgka_traits::TransportAdapterError> {
+        self.subscriptions.lock().unwrap().push(subscription);
+        Ok(())
+    }
+
+    async fn unsubscribe(
+        &self,
+        subscription: transport_nostr_adapter::NostrSubscription,
+    ) -> Result<(), cgka_traits::TransportAdapterError> {
+        let call = self.unsubscribe_entered.fetch_add(1, Ordering::SeqCst) + 1;
+        loop {
+            let released = self.unsubscribe_release.notified();
+            if self.block_on_call.load(Ordering::SeqCst) != call {
+                break;
+            }
+            released.await;
         }
         self.unsubscribed.lock().unwrap().push(subscription);
         Ok(())
@@ -1380,6 +1448,172 @@ async fn failed_unsubscribe_is_retried_and_drained_on_next_sync() {
     let metrics = adapter.metrics().await;
     assert_eq!(metrics.subscriptions_removed, 1);
     assert_eq!(metrics.unsubscribe_retries_pending, 0);
+}
+
+// Regression for mdk#1389: cancelling `sync_account_groups` during the
+// post-commit unsubscribe drain must retain confirmed progress and requeue only
+// unresolved relay teardowns.
+#[tokio::test]
+async fn cancelled_sync_drain_retries_unsubscribe_and_metrics_converge() {
+    let relay = Arc::new(BlockingUnsubscribeRelayClient::default());
+    let adapter = NostrTransportAdapter::new(relay.clone());
+    let account_id = MemberId::new(vec![0xA1; 32]);
+    let old_group_a = TransportGroupSubscription {
+        group_id: cgka_traits::GroupId::new(vec![0xB2; 32]),
+        transport_group_id: vec![0xC3; 32],
+        endpoints: vec![TransportEndpoint("wss://group.example".into())],
+    };
+    let old_group_b = TransportGroupSubscription {
+        group_id: cgka_traits::GroupId::new(vec![0xB3; 32]),
+        transport_group_id: vec![0xC4; 32],
+        endpoints: vec![TransportEndpoint("wss://group.example".into())],
+    };
+    let new_group_id = cgka_traits::GroupId::new(vec![0xD4; 32]);
+    let new_transport_group_id = vec![0xE5; 32];
+    let endpoint = TransportEndpoint("wss://group.example".into());
+    let new_group = TransportGroupSubscription {
+        group_id: new_group_id.clone(),
+        transport_group_id: new_transport_group_id.clone(),
+        endpoints: vec![endpoint.clone()],
+    };
+    let expected_unsubscribes = [
+        NostrSubscription::Group {
+            account_id: account_id.clone(),
+            group_id: old_group_a.group_id.clone(),
+            transport_group_id: old_group_a.transport_group_id.clone(),
+            endpoints: old_group_a.endpoints.clone(),
+            since: None,
+        },
+        NostrSubscription::Group {
+            account_id: account_id.clone(),
+            group_id: old_group_b.group_id.clone(),
+            transport_group_id: old_group_b.transport_group_id.clone(),
+            endpoints: old_group_b.endpoints.clone(),
+            since: None,
+        },
+    ];
+
+    adapter
+        .activate_account(TransportAccountActivation {
+            account_id: account_id.clone(),
+            inbox_endpoints: vec![TransportEndpoint("wss://inbox.example".into())],
+            group_subscriptions: vec![old_group_a.clone(), old_group_b.clone()],
+            since: None,
+        })
+        .await
+        .expect("activation succeeds");
+
+    relay.block_on_call.store(2, Ordering::SeqCst);
+    let adapter_for_sync = adapter.clone();
+    let sync_account_id = account_id.clone();
+    let sync_group = new_group.clone();
+    let sync_task = tokio::spawn(async move {
+        adapter_for_sync
+            .sync_account_groups(TransportGroupSync {
+                account_id: sync_account_id,
+                group_subscriptions: vec![sync_group],
+                since: None,
+            })
+            .await
+    });
+
+    tokio::time::timeout(concurrent_subscribe_timeout(), async {
+        while relay.unsubscribe_entered.load(Ordering::SeqCst) < 2 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("sync must enter the second relay unsubscribe");
+    sync_task.abort();
+    let join_err = sync_task
+        .await
+        .expect_err("aborted sync must not complete successfully");
+    assert!(
+        join_err.is_cancelled(),
+        "aborted sync must be cancelled, got {join_err:?}"
+    );
+
+    let old_a_delivered = adapter
+        .handle_relay_event(NostrRelayEvent {
+            endpoint: endpoint.clone(),
+            subscription_id: Some("old-group-a-sub".into()),
+            event: group_event("24", &old_group_a.transport_group_id),
+        })
+        .await
+        .expect("old group-a relay event handled");
+    let old_b_delivered = adapter
+        .handle_relay_event(NostrRelayEvent {
+            endpoint: endpoint.clone(),
+            subscription_id: Some("old-group-b-sub".into()),
+            event: group_event("26", &old_group_b.transport_group_id),
+        })
+        .await
+        .expect("old group-b relay event handled");
+    let new_delivered = adapter
+        .handle_relay_event(NostrRelayEvent {
+            endpoint,
+            subscription_id: Some("new-group-sub".into()),
+            event: group_event("25", &new_transport_group_id),
+        })
+        .await
+        .expect("new relay event handled");
+    assert_eq!(old_a_delivered, 0, "removed route A must not deliver");
+    assert_eq!(old_b_delivered, 0, "removed route B must not deliver");
+    assert_eq!(new_delivered, 1);
+    let delivery = adapter.receive().await.unwrap().unwrap();
+    assert_eq!(delivery.group_id_hint, Some(new_group_id));
+
+    let metrics = adapter.metrics().await;
+    assert_eq!(
+        metrics.subscriptions_removed, 1,
+        "first unsubscribe must be confirmed before cancellation"
+    );
+    assert_eq!(
+        metrics.unsubscribe_retries_pending, 1,
+        "cancelled drain must retain only the unresolved relay unsubscribe"
+    );
+
+    relay.release_blocked_unsubscribe();
+    tokio::time::timeout(
+        concurrent_subscribe_timeout(),
+        adapter.sync_account_groups(TransportGroupSync {
+            account_id: account_id.clone(),
+            group_subscriptions: vec![new_group.clone()],
+            since: None,
+        }),
+    )
+    .await
+    .expect("retry sync must complete before timeout")
+    .expect("retry sync succeeds");
+
+    {
+        let unsubscribed = relay.unsubscribed.lock().unwrap();
+        assert_eq!(
+            unsubscribed.as_slice(),
+            &expected_unsubscribes,
+            "both old subscription teardowns are recorded exactly once in vector order"
+        );
+    }
+    let metrics = adapter.metrics().await;
+    assert_eq!(metrics.subscriptions_removed, 2);
+    assert_eq!(metrics.unsubscribe_retries_pending, 0);
+
+    tokio::time::timeout(
+        concurrent_subscribe_timeout(),
+        adapter.sync_account_groups(TransportGroupSync {
+            account_id,
+            group_subscriptions: vec![new_group],
+            since: None,
+        }),
+    )
+    .await
+    .expect("follow-up sync must complete before timeout")
+    .expect("follow-up sync must not deadlock the lifecycle mutex");
+    assert_eq!(
+        adapter.metrics().await.subscriptions_removed,
+        2,
+        "follow-up sync must not double-count removals"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Fixes #1389

## Summary
- keep relay unsubscribe entries authoritative in `pending_unsubscribes` until relay teardown succeeds
- record confirmed removals per successful teardown while preserving only unresolved work across cancellation
- add a bounded partial-progress cancellation regression covering retry state, routing intent, metric convergence, and no double-counting
- document the fix in the Unreleased changelog

## Verification
- `cargo fmt --all --check`
- cancellation regression: 20 consecutive passes before rebase, 10 consecutive passes after rebase
- `cargo test -p transport-nostr-adapter --locked`
- `cargo test -p transport-nostr-adapter --features sdk --locked`
- `just focused-convergence-regressions`
- `RUSTFLAGS='-D warnings' cargo check --workspace --all-targets --locked`
- `RUSTFLAGS='-D warnings' cargo check --workspace --all-targets --all-features --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`

All checks pass. The focused convergence gate initially hit local disk exhaustion; after removing inactive build artifacts, the same command passed cleanly.

## Sensitive paths
None.

## Release hygiene
- Changelog: Unreleased entry added in `crates/cli/CHANGELOG.md`
- Version bump: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Nostr group synchronization cleanup when unsubscribe operations are interrupted or fail.
  * Pending relay teardowns now remain queued for retry until confirmed, preventing incomplete cleanup.
  * Improved synchronization reliability by avoiding duplicate removals and lifecycle deadlocks.
  * Removal metrics now accurately reflect confirmed teardown operations after retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->