### PR TITLE
fix(transport): stage group sync state before subscribe

### DIFF
--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -18,6 +18,9 @@ versioning through the workspace version in the root `Cargo.toml`.
   does not affect other locally deleted groups.
 - OpenCode harness idle-timeout regression test now keeps the mock child alive
   past the idle deadline so CI load cannot race normal exit with `BackendIdle`.
+- Nostr group-subscription sync now registers new routes and telemetry before
+  issuing relay REQs, so immediate stored-event replay cannot be dropped as
+  unroutable; failed subscriptions roll the staged state back for clean retry.
 - Engine fork-detection integration tests now exercise the pinned v1
   five-commit rewind horizon in normal builds instead of overriding
   `max_rewind_commits` to one.

--- a/crates/transport-nostr-adapter/src/lib.rs
+++ b/crates/transport-nostr-adapter/src/lib.rs
@@ -25,7 +25,7 @@ use cgka_traits::{
 };
 use nostr::RelayUrl;
 use sha2::{Digest, Sha256};
-use tokio::sync::{Mutex, RwLock, mpsc};
+use tokio::sync::{Mutex, RwLock, mpsc, oneshot};
 use tokio::task::JoinSet;
 use transport_nostr_peeler::{
     KIND_NIP59_GIFT_WRAP, NOSTR_SOURCE, NostrPeelerError, NostrTransportEvent,
@@ -745,7 +745,7 @@ impl TransportAdapter for NostrTransportAdapter {
         // Serialize against other subscription-lifecycle operations so the
         // drain's live-route filter and its relay unsubscribes cannot race a
         // concurrent re-add of the same deterministic subscription id.
-        let _subscription_guard = self.subscription_lock.lock().await;
+        let subscription_guard = self.subscription_lock.clone().lock_owned().await;
         tracing::debug!(
             target: "transport_nostr_adapter::adapter",
             method = "sync_account_groups",
@@ -776,21 +776,50 @@ impl TransportAdapter for NostrTransportAdapter {
             )
         };
 
-        // Additions stay fail-fast: on error the adapter state is untouched, a
-        // retry re-diffs against the old group set, and re-subscribing the same
-        // deterministic subscription id is idempotent.
-        self.subscribe_all("sync_account_groups", &to_add).await?;
+        // Stage new route coverage and a telemetry overlay BEFORE the relay REQs
+        // go out. Existing routes and committed telemetry remain live until the
+        // whole batch succeeds, while synchronous callbacks update the overlay.
+        let now_ms = self.now_ms();
+        {
+            let mut state = self.state.write().await;
+            state.stage_subscription_starts(&to_add, now_ms);
+            state.stage_group_routes(&to_add);
+        }
+        // Keep the lifecycle lock in a detached cleanup guard. If this future
+        // is cancelled at any later await, dropping the sender wakes the guard,
+        // which rolls back staged state before another lifecycle call can run.
+        let (staging_complete, staging_abandoned) = oneshot::channel();
+        let cleanup_state = Arc::clone(&self.state);
+        tokio::spawn(async move {
+            let _subscription_guard = subscription_guard;
+            if staging_abandoned.await.is_err() {
+                let mut state = cleanup_state.write().await;
+                state.rollback_staged_subscription_starts();
+                state.rebuild_transport_group_index();
+            }
+        });
+
+        if let Err(error) = self.subscribe_all("sync_account_groups", &to_add).await {
+            // The authoritative routes and committed telemetry were never
+            // replaced. Discard only this batch's staged callbacks and rebuild
+            // the derived route index to remove its temporary coverage.
+            let mut state = self.state.write().await;
+            state.rollback_staged_subscription_starts();
+            state.rebuild_transport_group_index();
+            drop(state);
+            let _ = staging_complete.send(());
+            return Err(error);
+        }
 
         // Commit routing intent BEFORE relay teardown: a failed unsubscribe
         // must never leave the routing index serving the old group set.
         // Removals are queued and drained below (plus any left over from
         // earlier syncs); failures there are absorbed and retried, never
         // surfaced as an error.
-        let now_ms = self.now_ms();
         let drainable = {
             let mut state = self.state.write().await;
+            state.commit_staged_subscription_starts();
             state.forget_subscription_starts(&to_remove);
-            state.record_subscription_starts(&to_add, now_ms);
             state.sync_groups(sync, to_add.len());
             state.queue_pending_unsubscribes(to_remove);
             state.take_drainable_unsubscribes()
@@ -825,6 +854,8 @@ impl TransportAdapter for NostrTransportAdapter {
                 "deferred relay unsubscribes; will retry on next group sync"
             );
         }
+        drop(state);
+        let _ = staging_complete.send(());
         Ok(())
     }
 
@@ -1047,8 +1078,9 @@ struct AdapterState {
     /// `transport_group_id` to its candidate routes, so an inbound group event is
     /// resolved in O(matching groups) instead of scanning O(accounts × groups)
     /// every event (attacker-floodable). Rebuilt wholesale from `accounts` (the
-    /// authoritative signed-routing state) at every mutation
-    /// (activate/sync_groups/deactivate), so it can never drift.
+    /// authoritative signed-routing state) at every committed mutation. Group
+    /// sync may append only missing pre-REQ routes while a subscribe batch is in
+    /// flight; both success and failure rebuild the index before returning.
     by_transport_group: HashMap<Vec<u8>, Vec<GroupRouteEntry>>,
     /// Relay unsubscribes that failed and await retry. Routing state
     /// (`accounts`/`by_transport_group`) already reflects the removal; these
@@ -1080,6 +1112,50 @@ impl AdapterState {
             }
         }
         self.by_transport_group = index;
+    }
+
+    /// Add the endpoint coverage needed by new group REQs without replacing
+    /// any live route. Existing coverage is skipped (including canonical URL
+    /// matches), preventing duplicate account deliveries during the staging
+    /// window. A later index rebuild commits or discards these entries.
+    fn stage_group_routes(&mut self, subscriptions: &[NostrSubscription]) {
+        for subscription in subscriptions {
+            let NostrSubscription::Group {
+                account_id,
+                group_id,
+                transport_group_id,
+                endpoints,
+                ..
+            } = subscription
+            else {
+                continue;
+            };
+            let entries = self
+                .by_transport_group
+                .entry(transport_group_id.clone())
+                .or_default();
+            let staged_endpoints = endpoints
+                .iter()
+                .filter(|endpoint| {
+                    let parsed_endpoint = RelayUrl::parse(endpoint.as_str()).ok();
+                    !entries.iter().any(|entry| {
+                        &entry.account_id == account_id
+                            && &entry.group_id == group_id
+                            && entry.endpoints.iter().any(|candidate| {
+                                candidate.matches(endpoint, parsed_endpoint.as_ref())
+                            })
+                    })
+                })
+                .map(CanonicalEndpoint::new)
+                .collect::<Vec<_>>();
+            if !staged_endpoints.is_empty() {
+                entries.push(GroupRouteEntry {
+                    account_id: account_id.clone(),
+                    group_id: group_id.clone(),
+                    endpoints: staged_endpoints,
+                });
+            }
+        }
     }
 
     fn activate(&mut self, activation: TransportAccountActivation, replaced: usize) {
@@ -1198,6 +1274,27 @@ impl AdapterState {
             self.sync
                 .record_subscription_start(&subscription.subscription_id(), &relays, now_ms);
         }
+    }
+
+    fn stage_subscription_starts(&mut self, subscriptions: &[NostrSubscription], now_ms: u64) {
+        self.sync.begin_staged_subscription_starts();
+        for subscription in subscriptions {
+            let relays: Vec<RelayIndex> = subscription
+                .endpoints()
+                .iter()
+                .map(|endpoint| self.relay_index.index_for(endpoint))
+                .collect();
+            self.sync
+                .stage_subscription_start(&subscription.subscription_id(), &relays, now_ms);
+        }
+    }
+
+    fn commit_staged_subscription_starts(&mut self) {
+        self.sync.commit_staged_subscription_starts();
+    }
+
+    fn rollback_staged_subscription_starts(&mut self) {
+        self.sync.rollback_staged_subscription_starts();
     }
 
     /// Evict sync-telemetry progress for subscriptions being removed, so the

--- a/crates/transport-nostr-adapter/src/telemetry.rs
+++ b/crates/transport-nostr-adapter/src/telemetry.rs
@@ -460,6 +460,17 @@ struct SubscriptionProgress {
     relays: HashMap<RelayIndex, RelayProgress>,
 }
 
+/// Subscription progress and aggregate samples buffered for one in-flight
+/// subscription batch. Keeping this separate from committed telemetry lets a
+/// failed batch roll back without erasing live-ID progress or unrelated relay
+/// callbacks that arrived concurrently.
+#[derive(Clone, Debug, Default)]
+struct StagedSubscriptionProgress {
+    subscriptions: HashMap<String, SubscriptionProgress>,
+    first_event: Vec<(RelayIndex, u64)>,
+    eose: Vec<(RelayIndex, u64)>,
+}
+
 /// Local recorder for subscription sync timing and the initial-sync gate.
 ///
 /// Diagnostic only; must never feed convergence or branch selection.
@@ -468,6 +479,7 @@ pub struct RelaySyncTelemetry {
     subscriptions: HashMap<String, SubscriptionProgress>,
     first_event: HashMap<RelayIndex, DurationHistogram>,
     eose: HashMap<RelayIndex, DurationHistogram>,
+    staged: StagedSubscriptionProgress,
 }
 
 impl RelaySyncTelemetry {
@@ -481,56 +493,97 @@ impl RelaySyncTelemetry {
         relays: &[RelayIndex],
         now_ms: u64,
     ) {
-        let progress = self
-            .subscriptions
-            .entry(subscription_id.to_string())
-            .or_default();
-        progress.relays = relays
-            .iter()
-            .map(|relay| {
-                (
-                    *relay,
-                    RelayProgress {
-                        started_ms: now_ms,
-                        first_event_seen: false,
-                        eose_seen: false,
-                    },
-                )
-            })
-            .collect();
+        self.subscriptions.insert(
+            subscription_id.to_string(),
+            subscription_progress(relays, now_ms),
+        );
+    }
+
+    /// Begin one serialized subscription batch whose callbacks must be visible
+    /// immediately but whose progress is not committed until every REQ succeeds.
+    pub fn begin_staged_subscription_starts(&mut self) {
+        debug_assert!(self.staged.subscriptions.is_empty());
+        debug_assert!(self.staged.first_event.is_empty());
+        debug_assert!(self.staged.eose.is_empty());
+        self.staged = StagedSubscriptionProgress::default();
+    }
+
+    /// Register one subscription attempt in the current staged batch.
+    pub fn stage_subscription_start(
+        &mut self,
+        subscription_id: &str,
+        relays: &[RelayIndex],
+        now_ms: u64,
+    ) {
+        self.staged.subscriptions.insert(
+            subscription_id.to_string(),
+            subscription_progress(relays, now_ms),
+        );
+    }
+
+    /// Atomically promote staged progress and its aggregate samples after the
+    /// relay subscription batch succeeds.
+    pub fn commit_staged_subscription_starts(&mut self) {
+        let staged = std::mem::take(&mut self.staged);
+        self.subscriptions.extend(staged.subscriptions);
+        for (relay, elapsed_ms) in staged.first_event {
+            self.first_event
+                .entry(relay)
+                .or_default()
+                .record(elapsed_ms);
+        }
+        for (relay, elapsed_ms) in staged.eose {
+            self.eose.entry(relay).or_default().record(elapsed_ms);
+        }
+    }
+
+    /// Discard callbacks and progress from a failed subscription batch while
+    /// leaving the previously committed state for reissued IDs untouched.
+    pub fn rollback_staged_subscription_starts(&mut self) {
+        self.staged = StagedSubscriptionProgress::default();
     }
 
     /// Record the first event from `relay` for `subscription_id`. Later events
     /// and unknown subscription/relay pairs are ignored.
     pub fn record_first_event(&mut self, subscription_id: &str, relay: RelayIndex, now_ms: u64) {
-        if let Some(progress) = self
-            .subscriptions
-            .get_mut(subscription_id)
-            .and_then(|sub| sub.relays.get_mut(&relay))
-            && !progress.first_event_seen
+        if self.staged.subscriptions.contains_key(subscription_id) {
+            if let Some(elapsed_ms) = mark_first_event(
+                &mut self.staged.subscriptions,
+                subscription_id,
+                relay,
+                now_ms,
+            ) {
+                self.staged.first_event.push((relay, elapsed_ms));
+            }
+            return;
+        }
+        if let Some(elapsed_ms) =
+            mark_first_event(&mut self.subscriptions, subscription_id, relay, now_ms)
         {
-            progress.first_event_seen = true;
             self.first_event
                 .entry(relay)
                 .or_default()
-                .record(now_ms.saturating_sub(progress.started_ms));
+                .record(elapsed_ms);
         }
     }
 
     /// Record EOSE from `relay` for `subscription_id`. Repeat EOSE and unknown
     /// subscription/relay pairs are ignored.
     pub fn record_eose(&mut self, subscription_id: &str, relay: RelayIndex, now_ms: u64) {
-        if let Some(progress) = self
-            .subscriptions
-            .get_mut(subscription_id)
-            .and_then(|sub| sub.relays.get_mut(&relay))
-            && !progress.eose_seen
+        if self.staged.subscriptions.contains_key(subscription_id) {
+            if let Some(elapsed_ms) = mark_eose(
+                &mut self.staged.subscriptions,
+                subscription_id,
+                relay,
+                now_ms,
+            ) {
+                self.staged.eose.push((relay, elapsed_ms));
+            }
+            return;
+        }
+        if let Some(elapsed_ms) = mark_eose(&mut self.subscriptions, subscription_id, relay, now_ms)
         {
-            progress.eose_seen = true;
-            self.eose
-                .entry(relay)
-                .or_default()
-                .record(now_ms.saturating_sub(progress.started_ms));
+            self.eose.entry(relay).or_default().record(elapsed_ms);
         }
     }
 
@@ -543,6 +596,7 @@ impl RelaySyncTelemetry {
     /// relay count and are intentionally retained.
     pub fn forget_subscription(&mut self, subscription_id: &str) {
         self.subscriptions.remove(subscription_id);
+        self.staged.subscriptions.remove(subscription_id);
     }
 
     /// Whether every relay of `subscription_id` has reached EOSE.
@@ -551,45 +605,65 @@ impl RelaySyncTelemetry {
     /// relay is still draining, `Some(true)` once all have completed. This is
     /// the initial-sync gate signal.
     pub fn subscription_synced(&self, subscription_id: &str) -> Option<bool> {
-        self.subscriptions
+        self.staged
+            .subscriptions
             .get(subscription_id)
+            .or_else(|| self.subscriptions.get(subscription_id))
             .map(subscription_is_synced)
     }
 
     /// Whether any relay for `subscription_id` has reached EOSE.
     pub fn subscription_any_eose(&self, subscription_id: &str) -> Option<bool> {
-        self.subscriptions
+        self.staged
+            .subscriptions
             .get(subscription_id)
+            .or_else(|| self.subscriptions.get(subscription_id))
             .map(|subscription| subscription.relays.values().any(|relay| relay.eose_seen))
     }
 
     /// Aggregate, privacy-safe snapshot of subscription sync timing.
     pub fn snapshot(&self) -> RelaySyncSnapshot {
+        let tracked = self.subscriptions.len()
+            + self
+                .staged
+                .subscriptions
+                .keys()
+                .filter(|id| !self.subscriptions.contains_key(id.as_str()))
+                .count();
         let synced = self
             .subscriptions
-            .values()
-            .filter(|sub| subscription_is_synced(sub))
-            .count() as u64;
+            .iter()
+            .filter(|(id, sub)| {
+                !self.staged.subscriptions.contains_key(id.as_str()) && subscription_is_synced(sub)
+            })
+            .count()
+            + self
+                .staged
+                .subscriptions
+                .values()
+                .filter(|sub| subscription_is_synced(sub))
+                .count();
 
-        let mut relays: Vec<RelayIndex> = self
-            .first_event
-            .keys()
-            .chain(self.eose.keys())
-            .copied()
-            .collect();
+        let mut first_event = self.first_event.clone();
+        for (relay, elapsed_ms) in &self.staged.first_event {
+            first_event.entry(*relay).or_default().record(*elapsed_ms);
+        }
+        let mut eose = self.eose.clone();
+        for (relay, elapsed_ms) in &self.staged.eose {
+            eose.entry(*relay).or_default().record(*elapsed_ms);
+        }
+        let mut relays: Vec<RelayIndex> = first_event.keys().chain(eose.keys()).copied().collect();
         relays.sort_unstable();
         relays.dedup();
         let per_relay = relays
             .into_iter()
             .map(|relay| RelayLatencyStats {
                 relay_index: relay.0,
-                first_event: self
-                    .first_event
+                first_event: first_event
                     .get(&relay)
                     .map(DurationHistogram::snapshot)
                     .unwrap_or_default(),
-                eose: self
-                    .eose
+                eose: eose
                     .get(&relay)
                     .map(DurationHistogram::snapshot)
                     .unwrap_or_default(),
@@ -597,13 +671,65 @@ impl RelaySyncTelemetry {
             .collect();
 
         RelaySyncSnapshot {
-            tracked_subscriptions: self.subscriptions.len() as u64,
-            synced_subscriptions: synced,
-            first_event: aggregate_histograms(self.first_event.values()),
-            eose: aggregate_histograms(self.eose.values()),
+            tracked_subscriptions: tracked as u64,
+            synced_subscriptions: synced as u64,
+            first_event: aggregate_histograms(first_event.values()),
+            eose: aggregate_histograms(eose.values()),
             per_relay,
         }
     }
+}
+
+fn subscription_progress(relays: &[RelayIndex], now_ms: u64) -> SubscriptionProgress {
+    SubscriptionProgress {
+        relays: relays
+            .iter()
+            .map(|relay| {
+                (
+                    *relay,
+                    RelayProgress {
+                        started_ms: now_ms,
+                        first_event_seen: false,
+                        eose_seen: false,
+                    },
+                )
+            })
+            .collect(),
+    }
+}
+
+fn mark_first_event(
+    subscriptions: &mut HashMap<String, SubscriptionProgress>,
+    subscription_id: &str,
+    relay: RelayIndex,
+    now_ms: u64,
+) -> Option<u64> {
+    let progress = subscriptions
+        .get_mut(subscription_id)?
+        .relays
+        .get_mut(&relay)?;
+    if progress.first_event_seen {
+        return None;
+    }
+    progress.first_event_seen = true;
+    Some(now_ms.saturating_sub(progress.started_ms))
+}
+
+fn mark_eose(
+    subscriptions: &mut HashMap<String, SubscriptionProgress>,
+    subscription_id: &str,
+    relay: RelayIndex,
+    now_ms: u64,
+) -> Option<u64> {
+    let progress = subscriptions
+        .get_mut(subscription_id)?
+        .relays
+        .get_mut(&relay)?;
+    if progress.eose_seen {
+        return None;
+    }
+    progress.eose_seen = true;
+    Some(now_ms.saturating_sub(progress.started_ms))
 }
 
 fn subscription_is_synced(sub: &SubscriptionProgress) -> bool {
@@ -894,5 +1020,54 @@ mod tests {
         // Reissued: the prior EOSE no longer counts.
         telem.record_subscription_start("sub", &[A], 100);
         assert_eq!(telem.subscription_synced("sub"), Some(false));
+    }
+
+    #[test]
+    fn committed_staged_reissue_keeps_synchronous_callback_progress() {
+        let mut telem = RelaySyncTelemetry::default();
+        telem.record_subscription_start("sub", &[A], 0);
+        telem.record_eose("sub", A, 10);
+
+        telem.begin_staged_subscription_starts();
+        telem.stage_subscription_start("sub", &[A], 100);
+        telem.record_first_event("sub", A, 115);
+        telem.record_eose("sub", A, 125);
+        telem.commit_staged_subscription_starts();
+
+        assert_eq!(telem.subscription_synced("sub"), Some(true));
+        let snapshot = telem.snapshot();
+        assert_eq!(snapshot.tracked_subscriptions, 1);
+        assert_eq!(snapshot.synced_subscriptions, 1);
+        assert_eq!(snapshot.first_event.sample_count(), 1);
+        assert_eq!(snapshot.first_event.sum_ms, 15);
+        assert_eq!(snapshot.eose.sample_count(), 2);
+        assert_eq!(snapshot.eose.sum_ms, 35);
+    }
+
+    #[test]
+    fn rolled_back_staged_callbacks_preserve_prior_and_unrelated_progress() {
+        let mut telem = RelaySyncTelemetry::default();
+        telem.record_subscription_start("reissued", &[A], 0);
+        telem.record_eose("reissued", A, 10);
+        telem.record_subscription_start("unrelated", &[B], 0);
+        let mut expected = telem.clone();
+        expected.record_first_event("unrelated", B, 30);
+        expected.record_eose("unrelated", B, 40);
+
+        telem.begin_staged_subscription_starts();
+        telem.stage_subscription_start("reissued", &[A], 100);
+        telem.stage_subscription_start("new", &[C], 100);
+        telem.record_first_event("reissued", A, 110);
+        telem.record_eose("reissued", A, 120);
+        telem.record_first_event("new", C, 130);
+        telem.record_eose("new", C, 140);
+        telem.record_first_event("unrelated", B, 30);
+        telem.record_eose("unrelated", B, 40);
+        telem.rollback_staged_subscription_starts();
+
+        assert_eq!(telem.snapshot(), expected.snapshot());
+        assert_eq!(telem.subscription_synced("reissued"), Some(true));
+        assert_eq!(telem.subscription_synced("unrelated"), Some(true));
+        assert_eq!(telem.subscription_synced("new"), None);
     }
 }

--- a/crates/transport-nostr-adapter/src/telemetry.rs
+++ b/crates/transport-nostr-adapter/src/telemetry.rs
@@ -469,6 +469,8 @@ struct StagedSubscriptionProgress {
     subscriptions: HashMap<String, SubscriptionProgress>,
     first_event: Vec<(RelayIndex, u64)>,
     eose: Vec<(RelayIndex, u64)>,
+    rollback_first_event: HashMap<(String, RelayIndex), u64>,
+    rollback_eose: HashMap<(String, RelayIndex), u64>,
 }
 
 /// Local recorder for subscription sync timing and the initial-sync gate.
@@ -505,6 +507,8 @@ impl RelaySyncTelemetry {
         debug_assert!(self.staged.subscriptions.is_empty());
         debug_assert!(self.staged.first_event.is_empty());
         debug_assert!(self.staged.eose.is_empty());
+        debug_assert!(self.staged.rollback_first_event.is_empty());
+        debug_assert!(self.staged.rollback_eose.is_empty());
         self.staged = StagedSubscriptionProgress::default();
     }
 
@@ -537,16 +541,42 @@ impl RelaySyncTelemetry {
         }
     }
 
-    /// Discard callbacks and progress from a failed subscription batch while
-    /// leaving the previously committed state for reissued IDs untouched.
+    /// Discard progress from a failed subscription batch. Callbacks for an ID
+    /// that was both staged and already committed are applied to the retained
+    /// committed progress, because they may have come from its still-live REQ.
     pub fn rollback_staged_subscription_starts(&mut self) {
-        self.staged = StagedSubscriptionProgress::default();
+        let staged = std::mem::take(&mut self.staged);
+        for ((subscription_id, relay), now_ms) in staged.rollback_first_event {
+            if let Some(elapsed_ms) =
+                mark_first_event(&mut self.subscriptions, &subscription_id, relay, now_ms)
+            {
+                self.first_event
+                    .entry(relay)
+                    .or_default()
+                    .record(elapsed_ms);
+            }
+        }
+        for ((subscription_id, relay), now_ms) in staged.rollback_eose {
+            if let Some(elapsed_ms) =
+                mark_eose(&mut self.subscriptions, &subscription_id, relay, now_ms)
+            {
+                self.eose.entry(relay).or_default().record(elapsed_ms);
+            }
+        }
     }
 
     /// Record the first event from `relay` for `subscription_id`. Later events
     /// and unknown subscription/relay pairs are ignored.
     pub fn record_first_event(&mut self, subscription_id: &str, relay: RelayIndex, now_ms: u64) {
         if self.staged.subscriptions.contains_key(subscription_id) {
+            if callback_pending(&self.subscriptions, subscription_id, relay, |progress| {
+                progress.first_event_seen
+            }) {
+                self.staged
+                    .rollback_first_event
+                    .entry((subscription_id.to_string(), relay))
+                    .or_insert(now_ms);
+            }
             if let Some(elapsed_ms) = mark_first_event(
                 &mut self.staged.subscriptions,
                 subscription_id,
@@ -571,6 +601,14 @@ impl RelaySyncTelemetry {
     /// subscription/relay pairs are ignored.
     pub fn record_eose(&mut self, subscription_id: &str, relay: RelayIndex, now_ms: u64) {
         if self.staged.subscriptions.contains_key(subscription_id) {
+            if callback_pending(&self.subscriptions, subscription_id, relay, |progress| {
+                progress.eose_seen
+            }) {
+                self.staged
+                    .rollback_eose
+                    .entry((subscription_id.to_string(), relay))
+                    .or_insert(now_ms);
+            }
             if let Some(elapsed_ms) = mark_eose(
                 &mut self.staged.subscriptions,
                 subscription_id,
@@ -605,19 +643,17 @@ impl RelaySyncTelemetry {
     /// relay is still draining, `Some(true)` once all have completed. This is
     /// the initial-sync gate signal.
     pub fn subscription_synced(&self, subscription_id: &str) -> Option<bool> {
-        self.staged
-            .subscriptions
+        self.subscriptions
             .get(subscription_id)
-            .or_else(|| self.subscriptions.get(subscription_id))
+            .or_else(|| self.staged.subscriptions.get(subscription_id))
             .map(subscription_is_synced)
     }
 
     /// Whether any relay for `subscription_id` has reached EOSE.
     pub fn subscription_any_eose(&self, subscription_id: &str) -> Option<bool> {
-        self.staged
-            .subscriptions
+        self.subscriptions
             .get(subscription_id)
-            .or_else(|| self.subscriptions.get(subscription_id))
+            .or_else(|| self.staged.subscriptions.get(subscription_id))
             .map(|subscription| subscription.relays.values().any(|relay| relay.eose_seen))
     }
 
@@ -632,16 +668,16 @@ impl RelaySyncTelemetry {
                 .count();
         let synced = self
             .subscriptions
-            .iter()
-            .filter(|(id, sub)| {
-                !self.staged.subscriptions.contains_key(id.as_str()) && subscription_is_synced(sub)
-            })
+            .values()
+            .filter(|sub| subscription_is_synced(sub))
             .count()
             + self
                 .staged
                 .subscriptions
-                .values()
-                .filter(|sub| subscription_is_synced(sub))
+                .iter()
+                .filter(|(id, sub)| {
+                    !self.subscriptions.contains_key(id.as_str()) && subscription_is_synced(sub)
+                })
                 .count();
 
         let mut first_event = self.first_event.clone();
@@ -730,6 +766,18 @@ fn mark_eose(
     }
     progress.eose_seen = true;
     Some(now_ms.saturating_sub(progress.started_ms))
+}
+
+fn callback_pending(
+    subscriptions: &HashMap<String, SubscriptionProgress>,
+    subscription_id: &str,
+    relay: RelayIndex,
+    seen: impl FnOnce(&RelayProgress) -> bool,
+) -> bool {
+    subscriptions
+        .get(subscription_id)
+        .and_then(|subscription| subscription.relays.get(&relay))
+        .is_some_and(|progress| !seen(progress))
 }
 
 fn subscription_is_synced(sub: &SubscriptionProgress) -> bool {
@@ -1045,12 +1093,50 @@ mod tests {
     }
 
     #[test]
+    fn staged_reissue_preserves_committed_gate_until_commit() {
+        let mut telem = RelaySyncTelemetry::default();
+        telem.record_subscription_start("sub", &[A], 0);
+        telem.record_eose("sub", A, 10);
+
+        telem.begin_staged_subscription_starts();
+        telem.stage_subscription_start("sub", &[A], 100);
+
+        assert_eq!(telem.subscription_synced("sub"), Some(true));
+        assert_eq!(telem.subscription_any_eose("sub"), Some(true));
+        assert_eq!(telem.snapshot().synced_subscriptions, 1);
+    }
+
+    #[test]
+    fn rolled_back_reissue_applies_callbacks_to_unsynced_committed_progress() {
+        let mut telem = RelaySyncTelemetry::default();
+        telem.record_subscription_start("sub", &[A], 0);
+
+        telem.begin_staged_subscription_starts();
+        telem.stage_subscription_start("sub", &[A], 100);
+        telem.record_first_event("sub", A, 110);
+        telem.record_eose("sub", A, 120);
+
+        assert_eq!(telem.subscription_synced("sub"), Some(false));
+        assert_eq!(telem.subscription_any_eose("sub"), Some(false));
+        telem.rollback_staged_subscription_starts();
+
+        assert_eq!(telem.subscription_synced("sub"), Some(true));
+        assert_eq!(telem.subscription_any_eose("sub"), Some(true));
+        let snapshot = telem.snapshot();
+        assert_eq!(snapshot.first_event.sample_count(), 1);
+        assert_eq!(snapshot.first_event.sum_ms, 110);
+        assert_eq!(snapshot.eose.sample_count(), 1);
+        assert_eq!(snapshot.eose.sum_ms, 120);
+    }
+
+    #[test]
     fn rolled_back_staged_callbacks_preserve_prior_and_unrelated_progress() {
         let mut telem = RelaySyncTelemetry::default();
         telem.record_subscription_start("reissued", &[A], 0);
         telem.record_eose("reissued", A, 10);
         telem.record_subscription_start("unrelated", &[B], 0);
         let mut expected = telem.clone();
+        expected.record_first_event("reissued", A, 110);
         expected.record_first_event("unrelated", B, 30);
         expected.record_eose("unrelated", B, 40);
 

--- a/crates/transport-nostr-adapter/tests/inbound_routing.rs
+++ b/crates/transport-nostr-adapter/tests/inbound_routing.rs
@@ -1277,6 +1277,148 @@ async fn cancelled_group_sync_rolls_back_staged_routes_and_telemetry() {
 }
 
 #[tokio::test]
+async fn cancelled_reissues_preserve_live_gates_and_apply_eose_on_rollback() {
+    let relay = Arc::new(BlockingSubscribeRelayClient::default());
+    let adapter = NostrTransportAdapter::new(relay.clone());
+    let account_id = MemberId::new(vec![0xA1; 32]);
+    let endpoint = TransportEndpoint("wss://group.example".into());
+    let synced_group_id = cgka_traits::GroupId::new(vec![0xB2; 32]);
+    let unsynced_group_id = cgka_traits::GroupId::new(vec![0xB3; 32]);
+    let synced_old = TransportGroupSubscription {
+        group_id: synced_group_id.clone(),
+        transport_group_id: vec![0xC2; 32],
+        endpoints: vec![endpoint.clone()],
+    };
+    let unsynced_old = TransportGroupSubscription {
+        group_id: unsynced_group_id.clone(),
+        transport_group_id: vec![0xC3; 32],
+        endpoints: vec![endpoint.clone()],
+    };
+    let synced_old_subscription_id = NostrSubscription::Group {
+        account_id: account_id.clone(),
+        group_id: synced_group_id.clone(),
+        transport_group_id: synced_old.transport_group_id.clone(),
+        endpoints: vec![endpoint.clone()],
+        since: None,
+    }
+    .subscription_id();
+    let unsynced_old_subscription_id = NostrSubscription::Group {
+        account_id: account_id.clone(),
+        group_id: unsynced_group_id.clone(),
+        transport_group_id: unsynced_old.transport_group_id.clone(),
+        endpoints: vec![endpoint.clone()],
+        since: None,
+    }
+    .subscription_id();
+
+    adapter
+        .activate_account(TransportAccountActivation {
+            account_id: account_id.clone(),
+            inbox_endpoints: vec![TransportEndpoint("wss://inbox.example".into())],
+            group_subscriptions: vec![synced_old.clone(), unsynced_old.clone()],
+            since: None,
+        })
+        .await
+        .expect("activation succeeds");
+    adapter
+        .handle_relay_eose(endpoint.clone(), synced_old_subscription_id.clone())
+        .await;
+    assert_eq!(
+        adapter
+            .subscription_synced(&synced_old_subscription_id)
+            .await,
+        Some(true)
+    );
+    assert_eq!(
+        adapter
+            .subscription_synced(&unsynced_old_subscription_id)
+            .await,
+        Some(false)
+    );
+
+    relay.block_subscribes.store(true, Ordering::SeqCst);
+    let cancelled_sync = tokio::spawn({
+        let adapter = adapter.clone();
+        let account_id = account_id.clone();
+        let endpoint = endpoint.clone();
+        let synced_group_id = synced_group_id.clone();
+        let unsynced_group_id = unsynced_group_id.clone();
+        let synced_old = synced_old.clone();
+        let unsynced_old = unsynced_old.clone();
+        async move {
+            adapter
+                .sync_account_groups(TransportGroupSync {
+                    account_id,
+                    group_subscriptions: vec![
+                        TransportGroupSubscription {
+                            group_id: synced_group_id,
+                            transport_group_id: vec![0xD2; 32],
+                            endpoints: vec![endpoint.clone()],
+                        },
+                        synced_old,
+                        TransportGroupSubscription {
+                            group_id: unsynced_group_id,
+                            transport_group_id: vec![0xD3; 32],
+                            endpoints: vec![endpoint],
+                        },
+                        unsynced_old,
+                    ],
+                    since: Some(Timestamp(1_700_000_100)),
+                })
+                .await
+        }
+    });
+    tokio::time::timeout(concurrent_subscribe_timeout(), relay.started.notified())
+        .await
+        .expect("reissued relay subscribe started");
+
+    assert_eq!(
+        adapter
+            .subscription_synced(&synced_old_subscription_id)
+            .await,
+        Some(true),
+        "staging a replacement REQ must not regress an already-open live gate"
+    );
+    adapter
+        .handle_relay_eose(endpoint, unsynced_old_subscription_id.clone())
+        .await;
+    assert_eq!(
+        adapter
+            .subscription_synced(&unsynced_old_subscription_id)
+            .await,
+        Some(false),
+        "an overlapping callback remains provisional until the batch outcome is known"
+    );
+
+    cancelled_sync.abort();
+    assert!(cancelled_sync.await.unwrap_err().is_cancelled());
+    relay.block_subscribes.store(false, Ordering::SeqCst);
+    adapter
+        .sync_account_groups(TransportGroupSync {
+            account_id,
+            group_subscriptions: vec![synced_old, unsynced_old],
+            since: None,
+        })
+        .await
+        .expect("follow-up sync waits for cancellation rollback");
+
+    assert_eq!(
+        adapter
+            .subscription_synced(&synced_old_subscription_id)
+            .await,
+        Some(true)
+    );
+    assert_eq!(
+        adapter
+            .subscription_synced(&unsynced_old_subscription_id)
+            .await,
+        Some(true),
+        "EOSE observed during the failed reissue must open the retained live gate"
+    );
+    assert_eq!(adapter.relay_sync().await.eose.sample_count(), 2);
+}
+
+#[tokio::test]
 async fn observe_relay_event_records_every_relay_copy_for_spread() {
     let relay = Arc::new(FakeRelayClient::default());
     let adapter = NostrTransportAdapter::new(relay);

--- a/crates/transport-nostr-adapter/tests/inbound_routing.rs
+++ b/crates/transport-nostr-adapter/tests/inbound_routing.rs
@@ -9,7 +9,7 @@ use cgka_traits::{
     TransportEndpoint, TransportGroupSubscription, TransportGroupSync, TransportPublishRequest,
     TransportPublishTarget,
 };
-use tokio::sync::Barrier;
+use tokio::sync::{Barrier, Notify};
 use transport_nostr_adapter::{
     NostrPublishOutcome, NostrRelayClient, NostrRelayEvent, NostrSubscription,
     NostrTransportAdapter, RelayExportConsent, RelayIndex,
@@ -94,6 +94,49 @@ impl NostrRelayClient for ConcurrentSubscribeRelayClient {
     }
 }
 
+#[derive(Default)]
+struct BlockingSubscribeRelayClient {
+    block_subscribes: AtomicBool,
+    started: Notify,
+}
+
+#[async_trait]
+impl NostrRelayClient for BlockingSubscribeRelayClient {
+    async fn subscribe(
+        &self,
+        _subscription: NostrSubscription,
+    ) -> Result<(), cgka_traits::TransportAdapterError> {
+        if self.block_subscribes.load(Ordering::SeqCst) {
+            self.started.notify_one();
+            std::future::pending::<()>().await;
+        }
+        Ok(())
+    }
+
+    async fn unsubscribe(
+        &self,
+        _subscription: NostrSubscription,
+    ) -> Result<(), cgka_traits::TransportAdapterError> {
+        Ok(())
+    }
+
+    async fn unsubscribe_account(
+        &self,
+        _account_id: &MemberId,
+    ) -> Result<(), cgka_traits::TransportAdapterError> {
+        Ok(())
+    }
+
+    async fn publish_event(
+        &self,
+        endpoints: &[TransportEndpoint],
+        _event: &NostrTransportEvent,
+        _required_acks: usize,
+    ) -> Result<NostrPublishOutcome, cgka_traits::TransportAdapterError> {
+        Ok(NostrPublishOutcome::accepted(endpoints.to_vec()))
+    }
+}
+
 /// Simulates a relay holding stored events: the moment it sees a group REQ it
 /// streams a matching stored event back through `handle_relay_event`, before
 /// `subscribe` returns — i.e. inside the activation's subscribe window. The
@@ -102,12 +145,17 @@ impl NostrRelayClient for ConcurrentSubscribeRelayClient {
 #[derive(Default)]
 struct StoredReplayRelayClient {
     adapter: Mutex<Option<NostrTransportAdapter>>,
+    additional_replay: Mutex<Option<NostrRelayEvent>>,
     replayed_deliveries: AtomicUsize,
 }
 
 impl StoredReplayRelayClient {
     fn attach(&self, adapter: &NostrTransportAdapter) {
         *self.adapter.lock().unwrap() = Some(adapter.clone());
+    }
+
+    fn replay_alongside_next_subscribe(&self, relay_event: NostrRelayEvent) {
+        *self.additional_replay.lock().unwrap() = Some(relay_event);
     }
 }
 
@@ -131,15 +179,23 @@ impl NostrRelayClient for StoredReplayRelayClient {
             .unwrap()
             .clone()
             .expect("adapter attached before subscribe");
-        let delivered = adapter
-            .handle_relay_event(NostrRelayEvent {
-                endpoint: endpoints[0].clone(),
-                subscription_id: Some(subscription.subscription_id()),
-                event: group_event("30", transport_group_id),
-            })
-            .await?;
+        let endpoint = endpoints[0].clone();
+        let subscription_id = subscription.subscription_id();
+        let relay_event = NostrRelayEvent {
+            endpoint: endpoint.clone(),
+            subscription_id: Some(subscription_id.clone()),
+            event: group_event("30", transport_group_id),
+        };
+        adapter.observe_relay_event(relay_event.clone()).await;
+        let mut delivered = adapter.handle_relay_event(relay_event).await?;
+        let additional_replay = self.additional_replay.lock().unwrap().take();
+        if let Some(relay_event) = additional_replay {
+            adapter.observe_relay_event(relay_event.clone()).await;
+            delivered += adapter.handle_relay_event(relay_event).await?;
+        }
         self.replayed_deliveries
             .fetch_add(delivered, Ordering::SeqCst);
+        adapter.handle_relay_eose(endpoint, subscription_id).await;
         Ok(())
     }
 
@@ -765,6 +821,390 @@ async fn stored_event_replayed_during_activation_subscribe_is_delivered() {
     assert_eq!(
         delivery.message.envelope,
         TransportEnvelope::GroupMessage { transport_group_id }
+    );
+}
+
+// Regression for mdk#910: group-sync REQs must not outrun routing and telemetry
+// registration. A relay can replay stored events synchronously from subscribe;
+// both the newly-added and still-live old routes must remain deliverable inside
+// that window, and the new route must contribute first-event timing.
+#[tokio::test]
+async fn stored_events_replayed_during_group_sync_subscribe_are_delivered() {
+    let relay = Arc::new(StoredReplayRelayClient::default());
+    let adapter = NostrTransportAdapter::new(relay.clone());
+    relay.attach(&adapter);
+    let account_id = MemberId::new(vec![0xA1; 32]);
+    let old_group_id = cgka_traits::GroupId::new(vec![0xB2; 32]);
+    let old_transport_group_id = vec![0xC3; 32];
+    let new_group_id = cgka_traits::GroupId::new(vec![0xD4; 32]);
+    let new_transport_group_id = vec![0xE5; 32];
+    let endpoint = TransportEndpoint("wss://group.example".into());
+
+    adapter
+        .activate_account(TransportAccountActivation {
+            account_id: account_id.clone(),
+            inbox_endpoints: vec![TransportEndpoint("wss://inbox.example".into())],
+            group_subscriptions: vec![],
+            since: None,
+        })
+        .await
+        .expect("activation succeeds");
+    adapter
+        .sync_account_groups(TransportGroupSync {
+            account_id: account_id.clone(),
+            group_subscriptions: vec![TransportGroupSubscription {
+                group_id: old_group_id.clone(),
+                transport_group_id: old_transport_group_id.clone(),
+                endpoints: vec![endpoint.clone()],
+            }],
+            since: Some(Timestamp(1_700_000_000)),
+        })
+        .await
+        .expect("initial group sync succeeds");
+    let initial_delivery = adapter.receive().await.unwrap().unwrap();
+    assert_eq!(initial_delivery.group_id_hint, Some(old_group_id.clone()));
+    relay.replayed_deliveries.store(0, Ordering::SeqCst);
+    relay.replay_alongside_next_subscribe(NostrRelayEvent {
+        endpoint: endpoint.clone(),
+        subscription_id: Some("still-live-old-group-sub".into()),
+        event: group_event("31", &old_transport_group_id),
+    });
+
+    adapter
+        .sync_account_groups(TransportGroupSync {
+            account_id: account_id.clone(),
+            group_subscriptions: vec![TransportGroupSubscription {
+                group_id: new_group_id.clone(),
+                transport_group_id: new_transport_group_id.clone(),
+                endpoints: vec![endpoint.clone()],
+            }],
+            since: Some(Timestamp(1_700_000_100)),
+        })
+        .await
+        .expect("replacement group sync succeeds");
+
+    assert_eq!(
+        relay.replayed_deliveries.load(Ordering::SeqCst),
+        2,
+        "new catch-up and still-live old-route events must both route during subscribe"
+    );
+    let new_delivery = adapter.receive().await.unwrap().unwrap();
+    let old_delivery = adapter.receive().await.unwrap().unwrap();
+    assert_eq!(new_delivery.account_id, account_id);
+    assert_eq!(new_delivery.group_id_hint, Some(new_group_id));
+    assert_eq!(new_delivery.source.plane, TransportDeliveryPlane::Group);
+    assert_eq!(new_delivery.source.endpoint, Some(endpoint.clone()));
+    assert_eq!(
+        new_delivery.message.envelope,
+        TransportEnvelope::GroupMessage {
+            transport_group_id: new_transport_group_id
+        }
+    );
+    assert_eq!(old_delivery.group_id_hint, Some(old_group_id));
+    assert_eq!(old_delivery.source.endpoint, Some(endpoint));
+    assert_eq!(
+        old_delivery.message.envelope,
+        TransportEnvelope::GroupMessage {
+            transport_group_id: old_transport_group_id
+        }
+    );
+    let sync = adapter.relay_sync().await;
+    assert_eq!(sync.tracked_subscriptions, 2);
+    assert_eq!(sync.first_event.sample_count(), 2);
+}
+
+#[tokio::test]
+async fn reissued_live_subscription_keeps_synchronous_callbacks() {
+    let relay = Arc::new(StoredReplayRelayClient::default());
+    let adapter = NostrTransportAdapter::new(relay.clone());
+    relay.attach(&adapter);
+    let account_id = MemberId::new(vec![0xA1; 32]);
+    let group_id = cgka_traits::GroupId::new(vec![0xB2; 32]);
+    let old_transport_group_id = vec![0xC3; 32];
+    let new_transport_group_id = vec![0xD4; 32];
+    let endpoint = TransportEndpoint("wss://group.example".into());
+    let old_group = TransportGroupSubscription {
+        group_id: group_id.clone(),
+        transport_group_id: old_transport_group_id.clone(),
+        endpoints: vec![endpoint.clone()],
+    };
+
+    adapter
+        .activate_account(TransportAccountActivation {
+            account_id: account_id.clone(),
+            inbox_endpoints: vec![TransportEndpoint("wss://inbox.example".into())],
+            group_subscriptions: vec![old_group.clone()],
+            since: None,
+        })
+        .await
+        .expect("activation succeeds");
+    adapter.receive().await.unwrap().unwrap();
+    relay.replayed_deliveries.store(0, Ordering::SeqCst);
+
+    adapter
+        .sync_account_groups(TransportGroupSync {
+            account_id: account_id.clone(),
+            group_subscriptions: vec![
+                TransportGroupSubscription {
+                    group_id: group_id.clone(),
+                    transport_group_id: new_transport_group_id.clone(),
+                    endpoints: vec![endpoint.clone()],
+                },
+                old_group,
+            ],
+            since: Some(Timestamp(1_700_000_000)),
+        })
+        .await
+        .expect("group sync succeeds");
+
+    let old_subscription_id = NostrSubscription::Group {
+        account_id: account_id.clone(),
+        group_id: group_id.clone(),
+        transport_group_id: old_transport_group_id,
+        endpoints: vec![endpoint.clone()],
+        since: None,
+    }
+    .subscription_id();
+    let new_subscription_id = NostrSubscription::Group {
+        account_id,
+        group_id,
+        transport_group_id: new_transport_group_id,
+        endpoints: vec![endpoint],
+        since: None,
+    }
+    .subscription_id();
+    assert_eq!(relay.replayed_deliveries.load(Ordering::SeqCst), 2);
+    assert_eq!(
+        adapter.subscription_synced(&old_subscription_id).await,
+        Some(true),
+        "the reissued live id must retain EOSE observed before subscribe returned"
+    );
+    assert_eq!(
+        adapter.subscription_synced(&new_subscription_id).await,
+        Some(true)
+    );
+    let sync = adapter.relay_sync().await;
+    assert_eq!(sync.tracked_subscriptions, 3);
+    assert_eq!(sync.synced_subscriptions, 2);
+    assert_eq!(sync.first_event.sample_count(), 3);
+    assert_eq!(sync.eose.sample_count(), 3);
+}
+
+#[tokio::test]
+async fn failed_group_sync_rolls_back_staged_routes_and_telemetry() {
+    let relay = Arc::new(FlakySubscribeRelayClient::default());
+    relay.fail_subscribes.store(false, Ordering::SeqCst);
+    let adapter = NostrTransportAdapter::new(relay.clone());
+    let account_id = MemberId::new(vec![0xA1; 32]);
+    let group_id = cgka_traits::GroupId::new(vec![0xB2; 32]);
+    let old_transport_group_id = vec![0xC3; 32];
+    let new_transport_group_id = vec![0xE5; 32];
+    let endpoint = TransportEndpoint("wss://group.example".into());
+    let old_group = TransportGroupSubscription {
+        group_id: group_id.clone(),
+        transport_group_id: old_transport_group_id.clone(),
+        endpoints: vec![endpoint.clone()],
+    };
+    let group_sync = TransportGroupSync {
+        account_id: account_id.clone(),
+        group_subscriptions: vec![
+            TransportGroupSubscription {
+                group_id: group_id.clone(),
+                transport_group_id: new_transport_group_id.clone(),
+                endpoints: vec![endpoint.clone()],
+            },
+            old_group.clone(),
+        ],
+        since: None,
+    };
+
+    adapter
+        .activate_account(TransportAccountActivation {
+            account_id: account_id.clone(),
+            inbox_endpoints: vec![TransportEndpoint("wss://inbox.example".into())],
+            group_subscriptions: vec![old_group],
+            since: None,
+        })
+        .await
+        .expect("activation succeeds");
+    let old_subscription_id = NostrSubscription::Group {
+        account_id: account_id.clone(),
+        group_id: group_id.clone(),
+        transport_group_id: old_transport_group_id.clone(),
+        endpoints: vec![endpoint.clone()],
+        since: None,
+    }
+    .subscription_id();
+    adapter
+        .handle_relay_eose(endpoint.clone(), old_subscription_id.clone())
+        .await;
+    assert_eq!(
+        adapter.subscription_synced(&old_subscription_id).await,
+        Some(true)
+    );
+    let relay_sync_before_failure = adapter.relay_sync().await;
+
+    relay.fail_subscribes.store(true, Ordering::SeqCst);
+    adapter
+        .sync_account_groups(group_sync.clone())
+        .await
+        .expect_err("group sync fails when relay subscribe fails");
+
+    let metrics = adapter.metrics().await;
+    assert_eq!(metrics.active_group_subscriptions, 1);
+    assert_eq!(metrics.subscriptions_created, 2);
+    assert_eq!(adapter.relay_sync().await, relay_sync_before_failure);
+    let old_delivered = adapter
+        .handle_relay_event(NostrRelayEvent {
+            endpoint: endpoint.clone(),
+            subscription_id: Some(old_subscription_id),
+            event: group_event("31", &old_transport_group_id),
+        })
+        .await
+        .expect("old relay event handled");
+    let failed_new_delivered = adapter
+        .handle_relay_event(NostrRelayEvent {
+            endpoint: endpoint.clone(),
+            subscription_id: Some("failed-new-group-sub".into()),
+            event: group_event("32", &new_transport_group_id),
+        })
+        .await
+        .expect("new relay event handled");
+    assert_eq!(old_delivered, 1, "failed sync must restore the old route");
+    assert_eq!(
+        failed_new_delivered, 0,
+        "failed sync must not leave the staged route"
+    );
+    let delivery = adapter.receive().await.unwrap().unwrap();
+    assert_eq!(delivery.group_id_hint, Some(group_id.clone()));
+
+    relay.fail_subscribes.store(false, Ordering::SeqCst);
+    adapter
+        .sync_account_groups(group_sync)
+        .await
+        .expect("retry succeeds from the prior group set");
+    let metrics = adapter.metrics().await;
+    assert_eq!(metrics.active_group_subscriptions, 2);
+    assert_eq!(metrics.subscriptions_created, 4);
+    assert_eq!(adapter.relay_sync().await.tracked_subscriptions, 3);
+    let delivered = adapter
+        .handle_relay_event(NostrRelayEvent {
+            endpoint,
+            subscription_id: Some("retried-group-sub".into()),
+            event: group_event("33", &new_transport_group_id),
+        })
+        .await
+        .expect("relay event handled");
+    assert_eq!(delivered, 1);
+    let delivery = adapter.receive().await.unwrap().unwrap();
+    assert_eq!(delivery.account_id, account_id);
+    assert_eq!(delivery.group_id_hint, Some(group_id));
+}
+
+#[tokio::test]
+async fn cancelled_group_sync_rolls_back_staged_routes_and_telemetry() {
+    let relay = Arc::new(BlockingSubscribeRelayClient::default());
+    let adapter = NostrTransportAdapter::new(relay.clone());
+    let account_id = MemberId::new(vec![0xA1; 32]);
+    let old_group_id = cgka_traits::GroupId::new(vec![0xB2; 32]);
+    let old_transport_group_id = vec![0xC3; 32];
+    let new_group_id = cgka_traits::GroupId::new(vec![0xD4; 32]);
+    let new_transport_group_id = vec![0xE5; 32];
+    let endpoint = TransportEndpoint("wss://group.example".into());
+    let old_group = TransportGroupSubscription {
+        group_id: old_group_id.clone(),
+        transport_group_id: old_transport_group_id.clone(),
+        endpoints: vec![endpoint.clone()],
+    };
+
+    adapter
+        .activate_account(TransportAccountActivation {
+            account_id: account_id.clone(),
+            inbox_endpoints: vec![TransportEndpoint("wss://inbox.example".into())],
+            group_subscriptions: vec![old_group.clone()],
+            since: None,
+        })
+        .await
+        .expect("activation succeeds");
+    let relay_sync_before = adapter.relay_sync().await;
+    let new_subscription_id = NostrSubscription::Group {
+        account_id: account_id.clone(),
+        group_id: new_group_id.clone(),
+        transport_group_id: new_transport_group_id.clone(),
+        endpoints: vec![endpoint.clone()],
+        since: None,
+    }
+    .subscription_id();
+
+    relay.block_subscribes.store(true, Ordering::SeqCst);
+    let cancelled_sync = tokio::spawn({
+        let adapter = adapter.clone();
+        let account_id = account_id.clone();
+        let endpoint = endpoint.clone();
+        let new_group_id = new_group_id.clone();
+        let new_transport_group_id = new_transport_group_id.clone();
+        async move {
+            adapter
+                .sync_account_groups(TransportGroupSync {
+                    account_id,
+                    group_subscriptions: vec![TransportGroupSubscription {
+                        group_id: new_group_id,
+                        transport_group_id: new_transport_group_id,
+                        endpoints: vec![endpoint],
+                    }],
+                    since: None,
+                })
+                .await
+        }
+    });
+    tokio::time::timeout(concurrent_subscribe_timeout(), relay.started.notified())
+        .await
+        .expect("relay subscribe started");
+    let staged_event = NostrRelayEvent {
+        endpoint: endpoint.clone(),
+        subscription_id: Some(new_subscription_id.clone()),
+        event: group_event("34", &new_transport_group_id),
+    };
+    adapter.observe_relay_event(staged_event.clone()).await;
+    assert_eq!(adapter.handle_relay_event(staged_event).await.unwrap(), 1);
+    adapter.receive().await.unwrap().unwrap();
+
+    cancelled_sync.abort();
+    assert!(cancelled_sync.await.unwrap_err().is_cancelled());
+    relay.block_subscribes.store(false, Ordering::SeqCst);
+    // This call waits for the detached cancellation guard to finish cleanup,
+    // then proves no stale stage assertion/state survives into the next sync.
+    adapter
+        .sync_account_groups(TransportGroupSync {
+            account_id: account_id.clone(),
+            group_subscriptions: vec![old_group],
+            since: None,
+        })
+        .await
+        .expect("sync after cancellation succeeds");
+
+    assert_eq!(adapter.relay_sync().await, relay_sync_before);
+    assert_eq!(
+        adapter
+            .handle_relay_event(NostrRelayEvent {
+                endpoint: endpoint.clone(),
+                subscription_id: Some("old-group-sub".into()),
+                event: group_event("35", &old_transport_group_id),
+            })
+            .await
+            .unwrap(),
+        1
+    );
+    assert_eq!(
+        adapter
+            .handle_relay_event(NostrRelayEvent {
+                endpoint,
+                subscription_id: Some(new_subscription_id),
+                event: group_event("36", &new_transport_group_id),
+            })
+            .await
+            .unwrap(),
+        0
     );
 }
 


### PR DESCRIPTION
## Summary
- Stage additive group routes and relay-sync telemetry before issuing relay REQs, so immediate stored-event replay is routable and measured.
- Commit staged telemetry only after the full subscription batch succeeds; roll it back on failure or caller cancellation without disturbing prior or unrelated progress.
- Keep still-live old routes available during replacement and cover deterministic subscription-ID reissues.

## Test plan
- `cargo test -p transport-nostr-adapter --locked`
- `cargo test -p transport-nostr-adapter --features sdk --locked`
- `just fast-ci`

Fixes #910

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved group subscription synchronization to handle stored-event replay without misclassifying events as unroutable.
  - Failed or canceled subscription attempts now roll back routing and telemetry changes, allowing safe retries.
  - Preserved existing routes, live callbacks, and synchronization metrics during subscription updates.

- **Tests**
  - Added coverage for replay handling, failed synchronization, cancellation cleanup, route preservation, and telemetry rollback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->