### PR TITLE
fix(openclaw): restore beta message dispatch

### DIFF
--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -11,6 +11,9 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ### Fixed
 
+- OpenClaw Marmot inbound turns now resolve agent-scoped session stores with the
+  routed agent id, and beta message sends bypass the delete-only action adapter
+  so they reach durable delivery.
 - Local-only group deletion now survives account restart and historical relay
   replay. A per-group deletion frontier suppresses projection reconciliation
   until a causally newer chat message arrives, while a durable engine-to-app

--- a/integrations/openclaw/marmot/src/bounded-keyed-async-queue.ts
+++ b/integrations/openclaw/marmot/src/bounded-keyed-async-queue.ts
@@ -19,6 +19,9 @@ export function classifyInboundDispatchFailure(error: unknown): string {
   if (error instanceof Error && error.message === OPENCLAW_DISPATCH_LIFECYCLE_ERROR) {
     return "openclaw_dispatch_lifecycle_contract";
   }
+  if (error instanceof Error && error.name === "SessionStoreAgentIdRequiredError") {
+    return "openclaw_session_store_agent_id_required";
+  }
   if (error instanceof Error) {
     return "error";
   }

--- a/integrations/openclaw/marmot/src/channel.ts
+++ b/integrations/openclaw/marmot/src/channel.ts
@@ -148,6 +148,7 @@ export function createMarmotDeleteActionAdapter(
 ): ChannelMessageActionAdapter {
   return {
     describeMessageTool: () => ({ actions: ["delete"] }),
+    supportsAction: ({ action }) => action === "delete",
     handleAction: async (ctx: ChannelMessageActionContext) => {
       if (ctx.action !== "delete") {
         return jsonResult({ ok: false, error: `unsupported action: ${ctx.action}` });

--- a/integrations/openclaw/marmot/src/dispatch.ts
+++ b/integrations/openclaw/marmot/src/dispatch.ts
@@ -538,7 +538,10 @@ export function createMarmotInboundDispatcher(
       suppressSelfQuoteBody: false,
     });
 
-    const storePath = deps.runtimeChannel.session.resolveStorePath();
+    const sessionStore = (deps.cfg as { session?: { store?: string } }).session?.store;
+    const storePath = deps.runtimeChannel.session.resolveStorePath(sessionStore, {
+      agentId: route.agentId,
+    });
     const turnCfg = buildMarmotTurnConfig(deps.cfg);
     const deliverInboundReply =
       deps.deliverInboundReply ?? deliverInboundReplyWithMessageSendContext;

--- a/integrations/openclaw/marmot/test/bounded-keyed-async-queue.test.ts
+++ b/integrations/openclaw/marmot/test/bounded-keyed-async-queue.test.ts
@@ -70,4 +70,13 @@ describe("BoundedKeyedAsyncQueue", () => {
       "error",
     );
   });
+
+  it("classifies beta's agent-scoped session-store requirement without exposing text", () => {
+    const error = new Error("potentially sensitive upstream detail");
+    error.name = "SessionStoreAgentIdRequiredError";
+
+    expect(classifyInboundDispatchFailure(error)).toBe(
+      "openclaw_session_store_agent_id_required",
+    );
+  });
 });

--- a/integrations/openclaw/marmot/test/channel.test.ts
+++ b/integrations/openclaw/marmot/test/channel.test.ts
@@ -119,6 +119,20 @@ describe("resolveMarmotChannelAccount", () => {
 });
 
 describe("createMarmotDeleteActionAdapter", () => {
+  it("owns only delete so core durable sends can fall through", () => {
+    const adapter = createMarmotDeleteActionAdapter({
+      deleteByMessageId: async () => false,
+      resolveTarget: async () => ({
+        client: { deleteMessage: async () => undefined },
+        marmotAccountIdHex: HEX32("aa"),
+      }),
+    });
+
+    expect(adapter.supportsAction?.({ action: "delete" })).toBe(true);
+    expect(adapter.supportsAction?.({ action: "send" })).toBe(false);
+    expect(adapter.supportsAction?.({ action: "react" })).toBe(false);
+  });
+
   it("declares the delete action through describeMessageTool", () => {
     const adapter = createMarmotDeleteActionAdapter({
       deleteByMessageId: async () => false,

--- a/integrations/openclaw/marmot/test/openclaw-host-contract.test.ts
+++ b/integrations/openclaw/marmot/test/openclaw-host-contract.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { AgentControlEvent, MarmotAgentControlClient } from "../src/client.js";
+import { createMarmotChannelPlugin } from "../src/channel.js";
 import {
   createMarmotInboundDispatcher,
   type MarmotDispatchClient,
@@ -39,6 +40,15 @@ describe("installed OpenClaw inbound host contract", () => {
       await deliver({ text: "host-compatible reply" }, { kind: "final" });
       return { counts: {} };
     });
+    const resolveStorePath = vi.fn((_store?: string, options?: unknown) => {
+      const agentId = (options as { agentId?: string } | undefined)?.agentId;
+      if (!agentId) {
+        const error = new Error("Session store path requires an explicit agent id.");
+        error.name = "SessionStoreAgentIdRequiredError";
+        throw error;
+      }
+      return "/tmp/openclaw-marmot-host-contract";
+    });
     const runtimeChannel: OpenClawChannelRuntime = {
       routing: {
         resolveAgentRoute: () => ({
@@ -48,7 +58,7 @@ describe("installed OpenClaw inbound host contract", () => {
         }),
       },
       session: {
-        resolveStorePath: () => "/tmp/openclaw-marmot-host-contract",
+        resolveStorePath,
         recordInboundSession: vi.fn(async () => undefined),
       },
       reply: { dispatchReplyWithBufferedBlockDispatcher: runDispatch },
@@ -85,6 +95,14 @@ describe("installed OpenClaw inbound host contract", () => {
 
     expect(runDispatch).toHaveBeenCalledOnce();
     expect(deliverInboundReply).toHaveBeenCalledOnce();
+    expect(resolveStorePath).toHaveBeenCalledWith(undefined, { agentId: "agent" });
+  });
+
+  it("leaves generic sends to beta's durable core while owning delete", () => {
+    const actions = createMarmotChannelPlugin().actions;
+
+    expect(actions?.supportsAction?.({ action: "send" })).toBe(false);
+    expect(actions?.supportsAction?.({ action: "delete" })).toBe(true);
   });
 
   const betaContract = process.env.OPENCLAW_HOST_COMPAT_EXPECT_FLUSH_PAIR === "1" ? it : it.skip;


### PR DESCRIPTION
## Summary
- resolve OpenClaw session stores with the routed agent id so beta inbound turns reach dispatch
- declare the channel action adapter as delete-only so generic sends fall through to core durable delivery
- preserve privacy-safe failure logging with a fixed bucket for the beta session-store contract

## Verification
- `pnpm typecheck`
- `pnpm build`
- `pnpm test` (224 passed, 2 skipped)
- `just openclaw-host-compat-test` against OpenClaw 2026.7.2-beta.7 (76 passed)
- `just openclaw-dev-e2e-connector` with real wn-agent debug controls (1 passed)

Fixes #1374

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inbound OpenClaw Marmot messages using the correct agent-specific session store.
  * Fixed beta message sends so they reach durable delivery instead of being blocked by delete-only handling.
  * Improved privacy-safe reporting for missing agent session-store configuration.
* **Tests**
  * Added coverage for agent-aware session resolution and action handling.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->