### PR TITLE
test(convergence): preserve app-runtime cross-route counterexample

### DIFF
--- a/crates/cgka-conformance-simulator/CONVERGENCE_ROUTE_MATRIX.md
+++ b/crates/cgka-conformance-simulator/CONVERGENCE_ROUTE_MATRIX.md
@@ -13,13 +13,13 @@ below is deliberately not treated as passing evidence.
 
 | Route id | Production owner | Independent model | Mutation sentinel | Current campaign evidence | Current limitation |
 | --- | --- | --- | --- | --- | --- |
-| `ordinary_ingest` | `message_processor/ingest.rs` | partial: `reference_convergence::evaluate` | covered: cutoff admission and output invalidation | observer vectors, both cross-route recovery regressions, and the shared engine/app/process restart journey | Public protocol and application projection overlap now crosses engine, app-runtime, and process adapters; the adversarial four-party topology and exact state remain open outside engine/retained-history. |
-| `pairwise_fork_recovery` | `message_processor/ingest.rs`, `fork_recovery.rs` | partial: bounded abstract route lifecycle | partial: sibling-model pairwise-loser terminalization | both cross-route recovery regressions plus the pairwise reconsideration tests | Pairwise displacement and deeper-branch reconsideration are covered through retained-history delivery; app-runtime, distributed, and durable-transition permutations remain open. |
+| `ordinary_ingest` | `message_processor/ingest.rs` | partial: `reference_convergence::evaluate` | covered: cutoff admission and output invalidation | observer vectors, both strict cross-route regressions, the shared engine/app/process restart journey, and the app-runtime cross-route characterization | The controlled app-runtime topology either leaves Zeta one epoch behind or reaches the reference public protocol state while losing one post-settlement application probe without an invalidation; process/distributed execution and exact state remain open. |
+| `pairwise_fork_recovery` | `message_processor/ingest.rs`, `fork_recovery.rs` | partial: bounded abstract route lifecycle | partial: sibling-model pairwise-loser terminalization | both strict cross-route regressions, app-runtime cross-route characterization, and pairwise reconsideration tests | Controlled app-runtime delivery reaches the intended split but does not reliably reach the same public winning branch and active application decryptability; process/distributed and durable-transition permutations remain open. |
 | `stored_convergence` | `distributed_convergence.rs` | partial: selector plus lifecycle models | covered: comparator and frozen membership | both cross-route regressions, restart properties, and convergence chaos | Route choice is not represented in the models, and app-runtime/distributed equivalence remains open. |
 | `candidate_materialization` | `openmls_projection.rs` | partial: dependency/disposition model | covered: retention and frozen membership | engine and retained-history cross-route recovery plus OpenMLS replay | One live pairwise/materialization topology is covered through two delivery routes; app-runtime and distributed equivalence remains open. |
-| `retained_history_replay` | `message_processor/ingest.rs`, `openmls_projection.rs` | partial: unequal-history lifecycle | covered: retention and witness deduplication | `cross-route-retained-history-recovery/v1`, retained-relay equality, offline journeys, and shared app/process offline full-history recovery | One public-projection recovery journey now crosses app-runtime and process; multi-relay ordering, retention boundaries, the four-party adversarial topology, and distributed adapters remain open. |
+| `retained_history_replay` | `message_processor/ingest.rs`, `openmls_projection.rs` | partial: unequal-history lifecycle | covered: retention and witness deduplication | `cross-route-retained-history-recovery/v1`, `cross-route-app-runtime-recovery/v1`, retained-relay equality, offline journeys, and shared app/process offline full-history recovery | The four-party app-runtime input schedule is controlled, but terminal executions either leave one participant behind or expose a missing, non-invalidated post-settlement application message; process, multi-relay, retention-boundary, and distributed evidence remain open. |
 | `crash_restart_recovery` | `engine.rs`, `distributed_convergence.rs` | covered: crash/restart lifecycle | covered: frozen membership and scheduler re-arm | both cross-route encrypted-SQLite regressions, durable-phase kill properties, and the shared engine/app/process restart journey | One shared public-state restart checkpoint now crosses engine, app-runtime, and process; every durable transition, the adversarial four-party topology, and distributed adapters remain open. |
-| `application_disposition` | `message_processor/ingest.rs`, `openmls_projection.rs` | covered: reference dispositions | covered: output invalidation | scenario-input ledgers and bidirectional decryptability probes in both cross-route regressions | Sender-visible application invalidation during branch replacement remains incomplete. |
+| `application_disposition` | `message_processor/ingest.rs`, `openmls_projection.rs` | covered: reference dispositions | covered: output invalidation | scenario-input ledgers and bidirectional decryptability probes in both strict cross-route regressions; app-runtime cross-route characterization | Alpha's post-settlement probe is absent and non-invalidated at Zeta in the app-runtime topology. Complete disposition and active decryptability claims are reopened in addition to the existing sender-visible branch-replacement gap. |
 
 ## Assurance claims
 
@@ -36,6 +36,12 @@ A passing campaign can move an open claim to covered. Any field, soak,
 mutation, or replay counterexample reopens it. Later green runs are retained as
 evidence but cannot silently clear a known falsification; the falsification
 must be resolved by explicit reviewed evidence.
+
+`cross-route-app-runtime-recovery/v1` currently falsifies `route_equivalence`,
+`active_bidirectional_decryptability`, and `complete_application_disposition`.
+Repeated executions either leave Zeta one epoch behind or reach the strict
+retained-engine public protocol projection while Alpha's active probe remains
+absent and non-invalidated at Zeta after repeated full-history repair.
 
 ## Active production work
 

--- a/crates/cgka-conformance-simulator/CONVERGENCE_ROUTE_MATRIX.md
+++ b/crates/cgka-conformance-simulator/CONVERGENCE_ROUTE_MATRIX.md
@@ -13,13 +13,13 @@ below is deliberately not treated as passing evidence.
 
 | Route id | Production owner | Independent model | Mutation sentinel | Current campaign evidence | Current limitation |
 | --- | --- | --- | --- | --- | --- |
-| `ordinary_ingest` | `message_processor/ingest.rs` | partial: `reference_convergence::evaluate` | covered: cutoff admission and output invalidation | observer vectors, both strict cross-route regressions, the shared engine/app/process restart journey, and the app-runtime cross-route characterization | The controlled app-runtime topology either leaves Zeta one epoch behind or reaches the reference public protocol state while losing one post-settlement application probe without an invalidation; process/distributed execution and exact state remain open. |
+| `ordinary_ingest` | `message_processor/ingest.rs` | partial: `reference_convergence::evaluate` | covered: cutoff admission and output invalidation | observer vectors, both strict cross-route regressions, the shared engine/app/process restart journey, and the app-runtime cross-route characterization | The controlled app-runtime topology can leave Zeta one epoch behind, lose one post-settlement probe after public agreement, or retain a two-branch protocol/probe split; process/distributed execution and exact state remain open. |
 | `pairwise_fork_recovery` | `message_processor/ingest.rs`, `fork_recovery.rs` | partial: bounded abstract route lifecycle | partial: sibling-model pairwise-loser terminalization | both strict cross-route regressions, app-runtime cross-route characterization, and pairwise reconsideration tests | Controlled app-runtime delivery reaches the intended split but does not reliably reach the same public winning branch and active application decryptability; process/distributed and durable-transition permutations remain open. |
 | `stored_convergence` | `distributed_convergence.rs` | partial: selector plus lifecycle models | covered: comparator and frozen membership | both cross-route regressions, restart properties, and convergence chaos | Route choice is not represented in the models, and app-runtime/distributed equivalence remains open. |
 | `candidate_materialization` | `openmls_projection.rs` | partial: dependency/disposition model | covered: retention and frozen membership | engine and retained-history cross-route recovery plus OpenMLS replay | One live pairwise/materialization topology is covered through two delivery routes; app-runtime and distributed equivalence remains open. |
-| `retained_history_replay` | `message_processor/ingest.rs`, `openmls_projection.rs` | partial: unequal-history lifecycle | covered: retention and witness deduplication | `cross-route-retained-history-recovery/v1`, `cross-route-app-runtime-recovery/v1`, retained-relay equality, offline journeys, and shared app/process offline full-history recovery | The four-party app-runtime input schedule is controlled, but terminal executions either leave one participant behind or expose a missing, non-invalidated post-settlement application message; process, multi-relay, retention-boundary, and distributed evidence remain open. |
+| `retained_history_replay` | `message_processor/ingest.rs`, `openmls_projection.rs` | partial: unequal-history lifecycle | covered: retention and witness deduplication | `cross-route-retained-history-recovery/v1`, `cross-route-app-runtime-recovery/v1`, retained-relay equality, offline journeys, and shared app/process offline full-history recovery | The four-party app-runtime input schedule is controlled, but terminal executions can leave one participant behind, expose a missing non-invalidated post-settlement application message, or preserve a two-branch protocol/probe split; process, multi-relay, retention-boundary, and distributed evidence remain open. |
 | `crash_restart_recovery` | `engine.rs`, `distributed_convergence.rs` | covered: crash/restart lifecycle | covered: frozen membership and scheduler re-arm | both cross-route encrypted-SQLite regressions, durable-phase kill properties, and the shared engine/app/process restart journey | One shared public-state restart checkpoint now crosses engine, app-runtime, and process; every durable transition, the adversarial four-party topology, and distributed adapters remain open. |
-| `application_disposition` | `message_processor/ingest.rs`, `openmls_projection.rs` | covered: reference dispositions | covered: output invalidation | scenario-input ledgers and bidirectional decryptability probes in both strict cross-route regressions; app-runtime cross-route characterization | Alpha's post-settlement probe is absent and non-invalidated at Zeta in the app-runtime topology. Complete disposition and active decryptability claims are reopened in addition to the existing sender-visible branch-replacement gap. |
+| `application_disposition` | `message_processor/ingest.rs`, `openmls_projection.rs` | covered: reference dispositions | covered: output invalidation | scenario-input ledgers and bidirectional decryptability probes in both strict cross-route regressions; app-runtime cross-route characterization | Alpha's post-settlement probe can remain absent and non-invalidated at Zeta, and a two-branch terminal run splits the complete probe set across participants. Complete disposition and active decryptability claims are reopened in addition to the existing sender-visible branch-replacement gap. |
 
 ## Assurance claims
 
@@ -39,9 +39,12 @@ must be resolved by explicit reviewed evidence.
 
 `cross-route-app-runtime-recovery/v1` currently falsifies `route_equivalence`,
 `active_bidirectional_decryptability`, and `complete_application_disposition`.
-Repeated executions either leave Zeta one epoch behind or reach the strict
-retained-engine public protocol projection while Alpha's active probe remains
-absent and non-invalidated at Zeta after repeated full-history repair.
+Repeated executions have three exact terminal counterexamples: Zeta one epoch
+behind with the complete probe set; strict retained-engine public protocol
+agreement while Alpha's active probe remains absent and non-invalidated at
+Zeta; or Alpha/Observer remaining on the competing root/baseline while
+Yankee/Zeta reach the reference branch and probes split along those boundaries.
+A fourth shape or complete equivalence fails the characterization.
 
 ## Active production work
 

--- a/crates/cgka-conformance-simulator/PROPERTY_TESTS.md
+++ b/crates/cgka-conformance-simulator/PROPERTY_TESTS.md
@@ -148,6 +148,25 @@ helpers. Shared harness generators live in `src/proptest_support.rs`.
 - Boundary: this is public projection evidence. Adapter-local message ids, runtime event counts, database paths, and
   other execution-specific observations are deliberately not compared.
 
+### `four_party_cross_route_recovery_records_app_runtime_equivalence_falsification`
+
+- Runs: the four-participant cross-route topology through both the strict retained-engine subject and the full
+  `MarmotAppRuntime` adapter. The app harness's real in-memory Nostr relay associates retained events with stable
+  Scenario IR action ids, removes a selected event only while every named recipient is offline, and reinserts it
+  before full-history repair. This avoids treating process timing or a live relay race as controlled delivery.
+- Checks: the retained-engine reference reaches exact canonical equality, durable accepted/invalidated/accepted commit
+  dispositions, no pending work, and all twelve active decryptability edges. The app run pins the intended split at
+  the intermediate checkpoint, compares final public protocol state and active probes with that reference, and keeps
+  the observed falsification explicit.
+- Known falsification: repeated executions have produced two non-equivalent terminal surfaces after the controlled
+  input schedule: either Zeta remains one epoch behind, or public protocol state agrees while Alpha's post-settlement
+  application probe remains neither visible nor invalidated at Zeta after two pre-probe and two post-probe
+  full-history repair/tick passes. The characterization requires at least one equivalence failure, rejects unexpected
+  or duplicate payloads, and fails deliberately if the complete equivalence oracle begins passing so the claim and
+  test must be reviewed together. It is not passing route-equivalence evidence.
+- Boundary: process, container, and VM adapters do not yet expose equivalent controlled retained-event staging. They
+  must not claim this topology from targeted catch-up alone because a live relay can deliver the competing root first.
+
 ## Shared Generators
 
 ### `intent_seq(3, range)`

--- a/crates/cgka-conformance-simulator/PROPERTY_TESTS.md
+++ b/crates/cgka-conformance-simulator/PROPERTY_TESTS.md
@@ -152,18 +152,24 @@ helpers. Shared harness generators live in `src/proptest_support.rs`.
 
 - Runs: the four-participant cross-route topology through both the strict retained-engine subject and the full
   `MarmotAppRuntime` adapter. The app harness's real in-memory Nostr relay associates retained events with stable
-  Scenario IR action ids, removes a selected event only while every named recipient is offline, and reinserts it
-  before full-history repair. This avoids treating process timing or a live relay race as controlled delivery.
+  Scenario IR action ids. After verifying every named recipient is offline, it removes a selected event from the
+  single shared relay database, making that event unavailable to every participant that has not already fetched it,
+  and reinserts it before full-history repair. This is deliberately relay-wide rather than the strict retained-relay
+  subject's per-recipient visibility model, and avoids treating process timing or a live relay race as controlled
+  delivery. Action selectors cover group-message events and action-local Welcome gift wraps admitted before a
+  successful serialized app command returns; publications deferred beyond that command boundary (for example, a
+  scheduled self-update) are not action-addressable on this adapter.
 - Checks: the retained-engine reference reaches exact canonical equality, durable accepted/invalidated/accepted commit
   dispositions, no pending work, and all twelve active decryptability edges. The app run pins the intended split at
   the intermediate checkpoint, compares final public protocol state and active probes with that reference, and keeps
   the observed falsification explicit.
-- Known falsification: repeated executions have produced two non-equivalent terminal surfaces after the controlled
-  input schedule: either Zeta remains one epoch behind, or public protocol state agrees while Alpha's post-settlement
-  application probe remains neither visible nor invalidated at Zeta after two pre-probe and two post-probe
-  full-history repair/tick passes. The characterization requires at least one equivalence failure, rejects unexpected
-  or duplicate payloads, and fails deliberately if the complete equivalence oracle begins passing so the claim and
-  test must be reviewed together. It is not passing route-equivalence evidence.
+- Known falsification: repeated executions have produced three exactly characterized non-equivalent terminal surfaces
+  after the controlled input schedule: Zeta remains one epoch behind with the complete probe set; public protocol state
+  agrees while only Alpha's post-settlement application probe remains neither visible nor invalidated at Zeta; or
+  Alpha remains on its competing root, Observer remains at the baseline, and only Yankee/Zeta reach the retained
+  reference branch, with the probe sets split along those same branch boundaries. The characterization rejects any
+  fourth divergence shape, unexpected or duplicate payloads, and complete equivalence so every changed outcome forces
+  review of the counterexample and claim together. It is not passing route-equivalence evidence.
 - Boundary: process, container, and VM adapters do not yet expose equivalent controlled retained-event staging. They
   must not claim this topology from targeted catch-up alone because a live relay can deliver the competing root first.
 

--- a/crates/cgka-conformance-simulator/PROPERTY_TESTS.md
+++ b/crates/cgka-conformance-simulator/PROPERTY_TESTS.md
@@ -152,7 +152,7 @@ helpers. Shared harness generators live in `src/proptest_support.rs`.
 
 - Runs: the four-participant cross-route topology through both the strict retained-engine subject and the full
   `MarmotAppRuntime` adapter. The app harness's real in-memory Nostr relay associates retained events with stable
-  Scenario IR action ids. After verifying every named recipient is offline, it removes a selected event from the
+  Scenario IR action ids. After verifying every harness participant is offline, it removes a selected event from the
   single shared relay database, making that event unavailable to every participant that has not already fetched it,
   and reinserts it before full-history repair. This is deliberately relay-wide rather than the strict retained-relay
   subject's per-recipient visibility model, and avoids treating process timing or a live relay race as controlled

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -132,6 +132,22 @@ These are the scenarios another implementation should be able to load from JSON 
   the state, profile, recovery, pending-work, and decryptability contract; the focused Rust regression owns the
   retained-injection observations and stable commit-disposition subset.
 
+### `cross-route-app-runtime-recovery/v1`
+
+- File: constructed by `four_party_cross_route_recovery_records_app_runtime_equivalence_falsification`; promotion to a
+  portable saved input waits until the falsified oracle has a reviewed resolution.
+- Subject: the strict half uses retained-engine exact observations; the black-box half uses the public
+  `MarmotAppRuntime` commands and projections with separate encrypted SQLite roots per participant and a real local
+  Nostr relay.
+- Pressure: Alpha and Observer are offline while Zeta's root is retained; Yankee ingests that root, then goes offline.
+  The harness removes Zeta's root from shared history before Alpha reconnects and authors its competing root, removes
+  Alpha's root before Yankee reconnects and extends Zeta's branch, restarts Zeta, restores both roots, and performs
+  repeated full-history repair.
+- Current result: exact retained-engine settlement passes. Across repeated app-runtime executions, either Zeta remains
+  one epoch behind or public protocol state agrees while Alpha's later application probe remains absent and
+  non-invalidated at Zeta after repeated repair. This is a retained counterexample and keeps route equivalence, active
+  decryptability, and complete application disposition open outside the engine/retained reference.
+
 ### `convergence-committer-selected/v1`
 
 - File: `vectors/convergence-committer-selected.v1.json`

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -140,13 +140,17 @@ These are the scenarios another implementation should be able to load from JSON 
   `MarmotAppRuntime` commands and projections with separate encrypted SQLite roots per participant and a real local
   Nostr relay.
 - Pressure: Alpha and Observer are offline while Zeta's root is retained; Yankee ingests that root, then goes offline.
-  The harness removes Zeta's root from shared history before Alpha reconnects and authors its competing root, removes
-  Alpha's root before Yankee reconnects and extends Zeta's branch, restarts Zeta, restores both roots, and performs
-  repeated full-history repair.
-- Current result: exact retained-engine settlement passes. Across repeated app-runtime executions, either Zeta remains
-  one epoch behind or public protocol state agrees while Alpha's later application probe remains absent and
-  non-invalidated at Zeta after repeated repair. This is a retained counterexample and keeps route equivalence, active
-  decryptability, and complete application disposition open outside the engine/retained reference.
+  The harness removes Zeta's root from the whole shared-relay history before Alpha reconnects and authors its competing
+  root, removes Alpha's root relay-wide before Yankee reconnects and extends Zeta's branch, restarts Zeta, restores both
+  roots, and performs repeated full-history repair. Named offline clients are a safety precondition for removal, not a
+  per-recipient visibility filter.
+- Current result: exact retained-engine settlement passes. Across repeated app-runtime executions, Zeta can remain one
+  epoch behind; public protocol state can agree while Alpha's later application probe remains absent and
+  non-invalidated at Zeta; or Alpha and Observer can remain on the competing root and baseline respectively while only
+  Yankee/Zeta reach the retained reference branch, with application probes split along those branch boundaries. Each
+  shape is asserted exactly, so a fourth shape or complete equivalence forces review. This is a retained counterexample
+  and keeps route equivalence, active decryptability, and complete application disposition open outside the
+  engine/retained reference.
 
 ### `convergence-committer-selected/v1`
 

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -142,8 +142,8 @@ These are the scenarios another implementation should be able to load from JSON 
 - Pressure: Alpha and Observer are offline while Zeta's root is retained; Yankee ingests that root, then goes offline.
   The harness removes Zeta's root from the whole shared-relay history before Alpha reconnects and authors its competing
   root, removes Alpha's root relay-wide before Yankee reconnects and extends Zeta's branch, restarts Zeta, restores both
-  roots, and performs repeated full-history repair. Named offline clients are a safety precondition for removal, not a
-  per-recipient visibility filter.
+  roots, and performs repeated full-history repair. Every harness participant must be offline before relay-wide
+  removal; the step's named clients are not a per-recipient visibility filter.
 - Current result: exact retained-engine settlement passes. Across repeated app-runtime executions, Zeta can remain one
   epoch behind; public protocol state can agree while Alpha's later application probe remains absent and
   non-invalidated at Zeta; or Alpha and Observer can remain on the competing root and baseline respectively while only

--- a/crates/cgka-conformance-simulator/src/app_runtime.rs
+++ b/crates/cgka-conformance-simulator/src/app_runtime.rs
@@ -15,7 +15,10 @@ use marmot_app::{
     AccountSetupRequest, AppError, AppMessageQuery, MarmotApp, MarmotAppConfig, MarmotAppEvent,
     MarmotAppRuntime,
 };
-use nostr_relay_builder::MockRelay;
+use nostr_relay_builder::LocalRelay;
+use nostr_relay_builder::prelude::{
+    Event, Filter, MemoryDatabase, MemoryDatabaseOptions, NostrDatabase, RelayBuilder,
+};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tempfile::TempDir;
@@ -114,17 +117,25 @@ impl Participant {
 
 /// In-process application harness backed by one real local Nostr relay.
 pub struct AppRuntimeHarness {
-    _relay: MockRelay,
+    _relay: LocalRelay,
+    relay_database: MemoryDatabase,
     relay_url: String,
     participants: BTreeMap<String, Participant>,
     scenario_groups: BTreeMap<String, GroupId>,
     active_scenario_group: Option<String>,
     accepted_publications: BTreeMap<String, BTreeSet<String>>,
+    relay_action_events: BTreeMap<String, Vec<Event>>,
+    hidden_relay_events: BTreeMap<String, Event>,
 }
 
 impl AppRuntimeHarness {
     pub async fn new(clients: &[String]) -> Result<Self, SubjectError> {
-        let relay = MockRelay::run().await.map_err(environment_error)?;
+        let relay_database = MemoryDatabase::with_opts(MemoryDatabaseOptions {
+            events: true,
+            max_events: Some(75_000),
+        });
+        let relay = LocalRelay::new(RelayBuilder::default().database(relay_database.clone()));
+        relay.run().await.map_err(environment_error)?;
         let relay_url = relay.url().await.to_string();
         let endpoint = TransportEndpoint::from(relay_url.clone());
         let mut participants = BTreeMap::new();
@@ -175,7 +186,132 @@ impl AppRuntimeHarness {
             scenario_groups: BTreeMap::new(),
             active_scenario_group: None,
             accepted_publications: BTreeMap::new(),
+            relay_action_events: BTreeMap::new(),
+            hidden_relay_events: BTreeMap::new(),
+            relay_database,
         })
+    }
+
+    async fn relay_events(&self) -> Result<Vec<Event>, SubjectError> {
+        let mut events = self
+            .relay_database
+            .query(Filter::new())
+            .await
+            .map_err(environment_error)?
+            .into_iter()
+            .collect::<Vec<_>>();
+        events.sort_by_key(|event| event.id);
+        Ok(events)
+    }
+
+    async fn record_relay_action_events(
+        &mut self,
+        action_id: &str,
+        before: BTreeSet<String>,
+    ) -> Result<(), SubjectError> {
+        let events = self
+            .relay_events()
+            .await?
+            .into_iter()
+            .filter(|event| !before.contains(&event.id.to_hex()))
+            .collect::<Vec<_>>();
+        if !events.is_empty() {
+            self.relay_action_events
+                .entry(action_id.to_owned())
+                .or_default()
+                .extend(events);
+        }
+        Ok(())
+    }
+
+    async fn relay_event_ids(&self) -> Result<BTreeSet<String>, SubjectError> {
+        Ok(self
+            .relay_events()
+            .await?
+            .into_iter()
+            .map(|event| event.id.to_hex())
+            .collect())
+    }
+
+    async fn set_shared_relay_event_visibility(
+        &mut self,
+        relay: &str,
+        selector: &crate::ScenarioMessageSelectorV2,
+        clients: &[String],
+        visible: bool,
+    ) -> Result<(), SubjectError> {
+        if relay != "relay:shared" {
+            return Err(SubjectError::classified(
+                SubjectFailureCategory::ExpectedRefusal,
+                "unknown_relay",
+                "the app-runtime adapter owns only relay:shared",
+            ));
+        }
+        if selector.publication.is_some() || selector.sender.is_some() || selector.class.is_some() {
+            return Err(SubjectError::classified(
+                SubjectFailureCategory::ExpectedRefusal,
+                "unsupported_relay_selector",
+                "the app-runtime relay gate requires an action_id-only selector",
+            ));
+        }
+        let action_id = selector.action_id.as_deref().ok_or_else(|| {
+            SubjectError::classified(
+                SubjectFailureCategory::ExpectedRefusal,
+                "missing_relay_action_id",
+                "the app-runtime relay gate requires an action id",
+            )
+        })?;
+        let event = self
+            .relay_action_events
+            .get(action_id)
+            .and_then(|events| events.get(selector.occurrence))
+            .cloned()
+            .ok_or_else(|| {
+                SubjectError::classified(
+                    SubjectFailureCategory::ExpectedRefusal,
+                    "relay_event_not_found",
+                    "no retained relay event matched the scenario action",
+                )
+            })?;
+        let event_id = event.id.to_hex();
+        if visible {
+            let event = self.hidden_relay_events.remove(&event_id).ok_or_else(|| {
+                SubjectError::classified(
+                    SubjectFailureCategory::ExpectedRefusal,
+                    "relay_event_not_hidden",
+                    "the selected relay event is not currently hidden",
+                )
+            })?;
+            self.relay_database
+                .save_event(&event)
+                .await
+                .map_err(environment_error)?;
+            return Ok(());
+        }
+        if self.hidden_relay_events.contains_key(&event_id) {
+            return Err(SubjectError::classified(
+                SubjectFailureCategory::ExpectedRefusal,
+                "relay_event_already_hidden",
+                "the selected relay event is already hidden",
+            ));
+        }
+        if clients.iter().any(|client| {
+            self.participants
+                .get(client)
+                .is_none_or(|participant| participant.online)
+        }) {
+            return Err(SubjectError::classified(
+                SubjectFailureCategory::ExpectedRefusal,
+                "relay_visibility_requires_offline_clients",
+                "shared-relay events can be hidden only while every named client is offline",
+            ));
+        }
+        self.relay_database
+            .delete(Filter::new().id(event.id))
+            .await
+            .map_err(environment_error)?;
+        self.hidden_relay_events.insert(event_id, event);
+        Ok(())
     }
 
     pub fn participant_roots(&self) -> BTreeMap<String, PathBuf> {
@@ -598,6 +734,7 @@ impl ConvergenceSubject for AppRuntimeHarness {
                 SubjectCapability::ParticipantConnectivity,
                 SubjectCapability::MultiGroup,
                 SubjectCapability::RetainedRelayHistory,
+                SubjectCapability::RetainedRelayControl,
             ]),
         }
     }
@@ -672,6 +809,7 @@ impl ConvergenceSubject for AppRuntimeHarness {
         &mut self,
         action: SubjectUpdateGroupData<'_>,
     ) -> Result<(), SubjectError> {
+        let before = self.relay_event_ids().await?;
         let group_id = self.active_group()?;
         let participant = self.participant(action.client)?;
         participant
@@ -684,6 +822,8 @@ impl ConvergenceSubject for AppRuntimeHarness {
             )
             .await
             .map_err(app_error)?;
+        self.record_relay_action_events(action.action_id, before)
+            .await?;
         self.record_accepted_publication(action.client, action.pending);
         Ok(())
     }
@@ -883,6 +1023,16 @@ impl ConvergenceSubject for AppRuntimeHarness {
                 block_on_subject(self.catch_up(clients))
             }
         }
+    }
+
+    fn set_relay_event_visibility(
+        &mut self,
+        relay: &str,
+        selector: &crate::ScenarioMessageSelectorV2,
+        clients: &[String],
+        visible: bool,
+    ) -> Result<(), SubjectError> {
+        block_on_subject(self.set_shared_relay_event_visibility(relay, selector, clients, visible))
     }
 }
 

--- a/crates/cgka-conformance-simulator/src/app_runtime.rs
+++ b/crates/cgka-conformance-simulator/src/app_runtime.rs
@@ -367,15 +367,25 @@ impl AppRuntimeHarness {
                 "the selected event is already removed from the shared relay",
             ));
         }
-        if clients.iter().any(|client| {
-            self.participants
-                .get(client)
-                .is_none_or(|participant| participant.online)
-        }) {
+        if clients
+            .iter()
+            .any(|client| !self.participants.contains_key(client))
+        {
             return Err(SubjectError::classified(
                 SubjectFailureCategory::ExpectedRefusal,
-                "relay_removal_requires_offline_clients",
-                "an event can be removed from the shared relay only while every named client is offline",
+                "unknown_relay_removal_client",
+                "every named relay-removal client must belong to the harness",
+            ));
+        }
+        if self
+            .participants
+            .values()
+            .any(|participant| participant.online)
+        {
+            return Err(SubjectError::classified(
+                SubjectFailureCategory::ExpectedRefusal,
+                "relay_removal_requires_all_participants_offline",
+                "an event can be removed from the shared relay only while every harness participant is offline",
             ));
         }
         self.relay_database

--- a/crates/cgka-conformance-simulator/src/app_runtime.rs
+++ b/crates/cgka-conformance-simulator/src/app_runtime.rs
@@ -7,6 +7,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -17,12 +18,13 @@ use marmot_app::{
 };
 use nostr_relay_builder::LocalRelay;
 use nostr_relay_builder::prelude::{
-    Event, Filter, MemoryDatabase, MemoryDatabaseOptions, NostrDatabase, RelayBuilder,
+    Backend, BoxedFuture, DatabaseError, DatabaseEventStatus, Event, EventId, Events, Filter, Kind,
+    MemoryDatabase, MemoryDatabaseOptions, NostrDatabase, RelayBuilder, SaveEventStatus,
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tempfile::TempDir;
-use tokio::sync::broadcast;
+use tokio::sync::{Mutex, broadcast};
 
 use crate::{
     ClientEventCounts, ClientObservation, ConvergenceSubject, ForkRecoveryObservation,
@@ -99,6 +101,67 @@ struct Participant {
     cached_epochs: BTreeMap<String, u64>,
 }
 
+#[derive(Clone, Debug)]
+struct RecordingRelayDatabase {
+    inner: MemoryDatabase,
+    publication_log: Arc<Mutex<Vec<Event>>>,
+}
+
+impl NostrDatabase for RecordingRelayDatabase {
+    fn backend(&self) -> Backend {
+        self.inner.backend()
+    }
+
+    fn save_event<'a>(
+        &'a self,
+        event: &'a Event,
+    ) -> BoxedFuture<'a, Result<SaveEventStatus, DatabaseError>> {
+        Box::pin(async move {
+            let status = self.inner.save_event(event).await?;
+            if status.is_success() {
+                self.publication_log.lock().await.push(event.clone());
+            }
+            Ok(status)
+        })
+    }
+
+    fn check_id<'a>(
+        &'a self,
+        event_id: &'a EventId,
+    ) -> BoxedFuture<'a, Result<DatabaseEventStatus, DatabaseError>> {
+        self.inner.check_id(event_id)
+    }
+
+    fn event_by_id<'a>(
+        &'a self,
+        event_id: &'a EventId,
+    ) -> BoxedFuture<'a, Result<Option<Event>, DatabaseError>> {
+        self.inner.event_by_id(event_id)
+    }
+
+    fn count(&self, filter: Filter) -> BoxedFuture<'_, Result<usize, DatabaseError>> {
+        self.inner.count(filter)
+    }
+
+    fn query(&self, filter: Filter) -> BoxedFuture<'_, Result<Events, DatabaseError>> {
+        self.inner.query(filter)
+    }
+
+    fn delete(&self, filter: Filter) -> BoxedFuture<'_, Result<(), DatabaseError>> {
+        self.inner.delete(filter)
+    }
+
+    fn wipe(&self) -> BoxedFuture<'_, Result<(), DatabaseError>> {
+        self.inner.wipe()
+    }
+}
+
+#[derive(Clone, Debug)]
+struct SequencedRelayEvent {
+    publication_sequence: usize,
+    event: Event,
+}
+
 impl Participant {
     fn root(&self) -> &Path {
         self.root.path()
@@ -124,17 +187,24 @@ pub struct AppRuntimeHarness {
     scenario_groups: BTreeMap<String, GroupId>,
     active_scenario_group: Option<String>,
     accepted_publications: BTreeMap<String, BTreeSet<String>>,
-    relay_action_events: BTreeMap<String, Vec<Event>>,
-    hidden_relay_events: BTreeMap<String, Event>,
+    relay_publication_log: Arc<Mutex<Vec<Event>>>,
+    relay_action_events: BTreeMap<String, Vec<SequencedRelayEvent>>,
+    removed_relay_events: BTreeMap<String, Event>,
 }
 
 impl AppRuntimeHarness {
     pub async fn new(clients: &[String]) -> Result<Self, SubjectError> {
+        // These are RelayBuilder's prior in-memory defaults. Keeping them
+        // explicit preserves MockRelay behavior while exposing the database.
         let relay_database = MemoryDatabase::with_opts(MemoryDatabaseOptions {
             events: true,
             max_events: Some(75_000),
         });
-        let relay = LocalRelay::new(RelayBuilder::default().database(relay_database.clone()));
+        let relay_publication_log = Arc::new(Mutex::new(Vec::new()));
+        let relay = LocalRelay::new(RelayBuilder::default().database(RecordingRelayDatabase {
+            inner: relay_database.clone(),
+            publication_log: Arc::clone(&relay_publication_log),
+        }));
         relay.run().await.map_err(environment_error)?;
         let relay_url = relay.url().await.to_string();
         let endpoint = TransportEndpoint::from(relay_url.clone());
@@ -186,54 +256,56 @@ impl AppRuntimeHarness {
             scenario_groups: BTreeMap::new(),
             active_scenario_group: None,
             accepted_publications: BTreeMap::new(),
+            relay_publication_log,
             relay_action_events: BTreeMap::new(),
-            hidden_relay_events: BTreeMap::new(),
+            removed_relay_events: BTreeMap::new(),
             relay_database,
         })
     }
 
-    async fn relay_events(&self) -> Result<Vec<Event>, SubjectError> {
-        let mut events = self
-            .relay_database
-            .query(Filter::new())
-            .await
-            .map_err(environment_error)?
-            .into_iter()
-            .collect::<Vec<_>>();
-        events.sort_by_key(|event| event.id);
-        Ok(events)
+    async fn relay_publication_cursor(&self) -> usize {
+        self.relay_publication_log.lock().await.len()
     }
 
     async fn record_relay_action_events(
         &mut self,
         action_id: &str,
-        before: BTreeSet<String>,
+        actor: &str,
+        before: usize,
+        include_welcomes: bool,
     ) -> Result<(), SubjectError> {
-        let events = self
-            .relay_events()
-            .await?
-            .into_iter()
-            .filter(|event| !before.contains(&event.id.to_hex()))
-            .collect::<Vec<_>>();
-        if !events.is_empty() {
-            self.relay_action_events
-                .entry(action_id.to_owned())
-                .or_default()
-                .extend(events);
+        self.participant(actor)?;
+        let publication_log = self.relay_publication_log.lock().await;
+        if before > publication_log.len() {
+            return Err(SubjectError::new(
+                "relay_publication_cursor_invalid",
+                "the retained relay publication cursor moved backwards",
+            ));
         }
+        // Scenario commands execute serially. Kind-445 outer authors are
+        // intentionally ephemeral, so the successful command boundary—not
+        // event.pubkey—is the actor attribution available at this layer.
+        // Filtering to group messages and action-local Welcome gift wraps
+        // excludes unrelated runtime projections.
+        let mut events = publication_log[before..]
+            .iter()
+            .enumerate()
+            .filter(|(_, event)| {
+                event.kind == Kind::MlsGroupMessage
+                    || (include_welcomes && event.kind == Kind::GiftWrap)
+            })
+            .map(|(offset, event)| SequencedRelayEvent {
+                publication_sequence: before + offset,
+                event: event.clone(),
+            })
+            .collect::<Vec<_>>();
+        events.sort_by_key(|event| event.publication_sequence);
+        self.relay_action_events
+            .insert(action_id.to_owned(), events);
         Ok(())
     }
 
-    async fn relay_event_ids(&self) -> Result<BTreeSet<String>, SubjectError> {
-        Ok(self
-            .relay_events()
-            .await?
-            .into_iter()
-            .map(|event| event.id.to_hex())
-            .collect())
-    }
-
-    async fn set_shared_relay_event_visibility(
+    async fn set_shared_relay_event_presence(
         &mut self,
         relay: &str,
         selector: &crate::ScenarioMessageSelectorV2,
@@ -265,21 +337,21 @@ impl AppRuntimeHarness {
             .relay_action_events
             .get(action_id)
             .and_then(|events| events.get(selector.occurrence))
-            .cloned()
+            .map(|event| event.event.clone())
             .ok_or_else(|| {
                 SubjectError::classified(
                     SubjectFailureCategory::ExpectedRefusal,
                     "relay_event_not_found",
-                    "no retained relay event matched the scenario action",
+                    "no immediately published group-message or Welcome relay event matched the scenario action; deferred publications are not action-addressable on this adapter",
                 )
             })?;
         let event_id = event.id.to_hex();
         if visible {
-            let event = self.hidden_relay_events.remove(&event_id).ok_or_else(|| {
+            let event = self.removed_relay_events.remove(&event_id).ok_or_else(|| {
                 SubjectError::classified(
                     SubjectFailureCategory::ExpectedRefusal,
-                    "relay_event_not_hidden",
-                    "the selected relay event is not currently hidden",
+                    "relay_event_not_removed",
+                    "the selected event is not currently removed from the shared relay",
                 )
             })?;
             self.relay_database
@@ -288,11 +360,11 @@ impl AppRuntimeHarness {
                 .map_err(environment_error)?;
             return Ok(());
         }
-        if self.hidden_relay_events.contains_key(&event_id) {
+        if self.removed_relay_events.contains_key(&event_id) {
             return Err(SubjectError::classified(
                 SubjectFailureCategory::ExpectedRefusal,
-                "relay_event_already_hidden",
-                "the selected relay event is already hidden",
+                "relay_event_already_removed",
+                "the selected event is already removed from the shared relay",
             ));
         }
         if clients.iter().any(|client| {
@@ -302,15 +374,15 @@ impl AppRuntimeHarness {
         }) {
             return Err(SubjectError::classified(
                 SubjectFailureCategory::ExpectedRefusal,
-                "relay_visibility_requires_offline_clients",
-                "shared-relay events can be hidden only while every named client is offline",
+                "relay_removal_requires_offline_clients",
+                "an event can be removed from the shared relay only while every named client is offline",
             ));
         }
         self.relay_database
             .delete(Filter::new().id(event.id))
             .await
             .map_err(environment_error)?;
-        self.hidden_relay_events.insert(event_id, event);
+        self.removed_relay_events.insert(event_id, event);
         Ok(())
     }
 
@@ -771,6 +843,7 @@ impl ConvergenceSubject for AppRuntimeHarness {
                 "app-runtime adapter does not synthesize feature-gated key packages",
             ));
         }
+        let before = self.relay_publication_cursor().await;
         let invitees = self.account_ids(action.invitees)?;
         let participant = self.participant(action.creator)?;
         let group_id = participant
@@ -785,6 +858,8 @@ impl ConvergenceSubject for AppRuntimeHarness {
         self.scenario_groups.insert(group_label, group_id.clone());
         self.apply_admin_set(action.creator, &group_id, action.initial_admins)
             .await?;
+        self.record_relay_action_events(action.action_id, action.creator, before, true)
+            .await?;
         self.record_accepted_publication(action.creator, action.pending);
         Ok(())
     }
@@ -793,6 +868,7 @@ impl ConvergenceSubject for AppRuntimeHarness {
         &mut self,
         action: SubjectInviteMembers<'_>,
     ) -> Result<(), SubjectError> {
+        let before = self.relay_publication_cursor().await;
         let group_id = self.active_group()?;
         let invitees = self.account_ids(action.invitees)?;
         let participant = self.participant(action.inviter)?;
@@ -801,6 +877,8 @@ impl ConvergenceSubject for AppRuntimeHarness {
             .invite_members(&participant.account_id, &group_id, &invitees)
             .await
             .map_err(app_error)?;
+        self.record_relay_action_events(action.action_id, action.inviter, before, true)
+            .await?;
         self.record_accepted_publication(action.inviter, action.pending);
         Ok(())
     }
@@ -809,7 +887,7 @@ impl ConvergenceSubject for AppRuntimeHarness {
         &mut self,
         action: SubjectUpdateGroupData<'_>,
     ) -> Result<(), SubjectError> {
-        let before = self.relay_event_ids().await?;
+        let before = self.relay_publication_cursor().await;
         let group_id = self.active_group()?;
         let participant = self.participant(action.client)?;
         participant
@@ -822,7 +900,7 @@ impl ConvergenceSubject for AppRuntimeHarness {
             )
             .await
             .map_err(app_error)?;
-        self.record_relay_action_events(action.action_id, before)
+        self.record_relay_action_events(action.action_id, action.client, before, false)
             .await?;
         self.record_accepted_publication(action.client, action.pending);
         Ok(())
@@ -832,6 +910,7 @@ impl ConvergenceSubject for AppRuntimeHarness {
         &mut self,
         action: SubjectRemoveMembers<'_>,
     ) -> Result<(), SubjectError> {
+        let before = self.relay_publication_cursor().await;
         let group_id = self.active_group()?;
         let members = self.account_ids(action.members)?;
         let participant = self.participant(action.remover)?;
@@ -840,11 +919,14 @@ impl ConvergenceSubject for AppRuntimeHarness {
             .remove_members(&participant.account_id, &group_id, &members)
             .await
             .map_err(app_error)?;
+        self.record_relay_action_events(action.action_id, action.remover, before, false)
+            .await?;
         self.record_accepted_publication(action.remover, action.pending);
         Ok(())
     }
 
     async fn self_update(&mut self, action: SubjectSelfUpdate<'_>) -> Result<(), SubjectError> {
+        let before = self.relay_publication_cursor().await;
         let group_id = self.active_group()?;
         let participant = self.participant(action.client)?;
         participant
@@ -852,6 +934,8 @@ impl ConvergenceSubject for AppRuntimeHarness {
             .schedule_manual_self_update(&participant.account_id, &group_id)
             .await
             .map_err(app_error)?;
+        self.record_relay_action_events(action.action_id, action.client, before, false)
+            .await?;
         self.record_accepted_publication(action.client, action.pending);
         Ok(())
     }
@@ -860,9 +944,14 @@ impl ConvergenceSubject for AppRuntimeHarness {
         &mut self,
         action: SubjectUpdateAdminPolicy<'_>,
     ) -> Result<(), SubjectError> {
+        let before = self.relay_publication_cursor().await;
         let group_id = self.active_group()?;
         self.apply_admin_set(action.client, &group_id, action.admins)
             .await?;
+        if let Some(action_id) = action.action_id {
+            self.record_relay_action_events(action_id, action.client, before, false)
+                .await?;
+        }
         if let Some(pending) = action.pending {
             self.record_accepted_publication(action.client, pending);
         }
@@ -911,6 +1000,7 @@ impl ConvergenceSubject for AppRuntimeHarness {
         &mut self,
         action: SubjectSendApplication<'_>,
     ) -> Result<(), SubjectError> {
+        let before = self.relay_publication_cursor().await;
         let group_id = self.active_group()?;
         let participant = self.participant(action.sender)?;
         participant
@@ -922,10 +1012,13 @@ impl ConvergenceSubject for AppRuntimeHarness {
             )
             .await
             .map_err(app_error)?;
+        self.record_relay_action_events(action.action_id, action.sender, before, false)
+            .await?;
         Ok(())
     }
 
-    async fn leave(&mut self, _action_id: &str, client: &str) -> Result<(), SubjectError> {
+    async fn leave(&mut self, action_id: &str, client: &str) -> Result<(), SubjectError> {
+        let before = self.relay_publication_cursor().await;
         let group_id = self.active_group()?;
         let participant = self.participant(client)?;
         participant
@@ -933,6 +1026,8 @@ impl ConvergenceSubject for AppRuntimeHarness {
             .leave_group(&participant.account_id, &group_id)
             .await
             .map_err(app_error)?;
+        self.record_relay_action_events(action_id, client, before, false)
+            .await?;
         Ok(())
     }
 
@@ -1032,7 +1127,7 @@ impl ConvergenceSubject for AppRuntimeHarness {
         clients: &[String],
         visible: bool,
     ) -> Result<(), SubjectError> {
-        block_on_subject(self.set_shared_relay_event_visibility(relay, selector, clients, visible))
+        block_on_subject(self.set_shared_relay_event_presence(relay, selector, clients, visible))
     }
 }
 
@@ -1360,6 +1455,36 @@ fn walk_file_bytes(root: &Path) -> Vec<u64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn recording_database_preserves_successful_relay_admission_order() {
+        let publication_log = Arc::new(Mutex::new(Vec::new()));
+        let database = RecordingRelayDatabase {
+            inner: MemoryDatabase::with_opts(MemoryDatabaseOptions {
+                events: true,
+                max_events: None,
+            }),
+            publication_log: Arc::clone(&publication_log),
+        };
+        let keys = nostr::Keys::generate();
+        let first = nostr::EventBuilder::new(Kind::MlsGroupMessage, "first admitted")
+            .custom_created_at(nostr::Timestamp::from_secs(200))
+            .sign_with_keys(&keys)
+            .unwrap();
+        let second = nostr::EventBuilder::new(Kind::MlsGroupMessage, "second admitted")
+            .custom_created_at(nostr::Timestamp::from_secs(100))
+            .sign_with_keys(&keys)
+            .unwrap();
+
+        assert!(database.save_event(&first).await.unwrap().is_success());
+        assert!(database.save_event(&second).await.unwrap().is_success());
+        assert!(!database.save_event(&first).await.unwrap().is_success());
+
+        let recorded = publication_log.lock().await;
+        assert_eq!(recorded.len(), 2);
+        assert_eq!(recorded[0].id, first.id);
+        assert_eq!(recorded[1].id, second.id);
+    }
 
     #[test]
     fn public_commitment_preserves_a_reported_zero_member_count() {

--- a/crates/cgka-conformance-simulator/tests/app_runtime_adapter.rs
+++ b/crates/cgka-conformance-simulator/tests/app_runtime_adapter.rs
@@ -5,9 +5,10 @@ use std::time::Duration;
 
 use cgka_conformance_simulator::{
     AppRuntimeHarness, ConvergenceSubject, GeneratedScenarioCase, GeneratedSubjectKind,
-    HarnessStorageMode, ScenarioOutboundSelection, ScenarioSpec, ScenarioStep, ScenarioStepStatus,
-    SubjectFailureCategory, SubjectOutboundOutcome, TraceExpectation,
-    run_generated_case_report_with_capture_on_subject, run_scenario_report_with_subject,
+    HarnessStorageMode, ScenarioMessageSelectorV2, ScenarioOutboundSelection, ScenarioSpec,
+    ScenarioStep, ScenarioStepStatus, SubjectFailureCategory, SubjectOutboundOutcome,
+    TraceExpectation, run_generated_case_report_with_capture_on_subject,
+    run_scenario_report_with_subject,
 };
 
 fn in_group(group: &str, action: ScenarioStep) -> ScenarioStep {
@@ -258,6 +259,60 @@ async fn observations_keep_pending_invites_until_an_explicit_tick() {
             .application
             .pending_confirmation
     );
+    subject.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn retained_relay_control_resolves_immediate_app_publication_action_ids() {
+    let clients = vec!["alice".to_owned(), "bob".to_owned()];
+    let mut subject = AppRuntimeHarness::new(&clients).await.unwrap();
+    subject.select_scenario_group("main", true).unwrap();
+    subject
+        .create_group(cgka_conformance_simulator::SubjectCreateGroup {
+            action_id: "create",
+            creator: "alice",
+            name: "relay action ids",
+            invitees: &["bob".into()],
+            required_features: &[],
+            initial_admins: &["alice".into()],
+            pending: "create",
+        })
+        .await
+        .unwrap();
+    subject.tick(&clients).await.unwrap();
+    subject
+        .update_group_data(cgka_conformance_simulator::SubjectUpdateGroupData {
+            action_id: "rename",
+            client: "alice",
+            name: Some("renamed"),
+            description: None,
+            pending: "rename",
+        })
+        .await
+        .unwrap();
+    subject
+        .send_application(cgka_conformance_simulator::SubjectSendApplication {
+            action_id: "send",
+            sender: "alice",
+            payload: "action-addressed application",
+        })
+        .await
+        .unwrap();
+
+    subject.set_online("alice", false).await.unwrap();
+    subject.set_online("bob", false).await.unwrap();
+    for action_id in ["create", "rename", "send"] {
+        let selector = ScenarioMessageSelectorV2 {
+            action_id: Some(action_id.into()),
+            ..ScenarioMessageSelectorV2::default()
+        };
+        subject
+            .set_relay_event_visibility("relay:shared", &selector, &clients, false)
+            .unwrap_or_else(|error| panic!("{action_id}: {error}"));
+        subject
+            .set_relay_event_visibility("relay:shared", &selector, &clients, true)
+            .unwrap();
+    }
     subject.shutdown().await;
 }
 

--- a/crates/cgka-conformance-simulator/tests/app_runtime_adapter.rs
+++ b/crates/cgka-conformance-simulator/tests/app_runtime_adapter.rs
@@ -317,6 +317,58 @@ async fn retained_relay_control_resolves_immediate_app_publication_action_ids() 
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn relay_wide_removal_refuses_an_omitted_online_participant() {
+    let clients = vec!["alice".to_owned(), "bob".to_owned(), "carol".to_owned()];
+    let mut subject = AppRuntimeHarness::new(&clients).await.unwrap();
+    subject.select_scenario_group("main", true).unwrap();
+    subject
+        .create_group(cgka_conformance_simulator::SubjectCreateGroup {
+            action_id: "create",
+            creator: "alice",
+            name: "relay-wide removal",
+            invitees: &["bob".into()],
+            required_features: &[],
+            initial_admins: &["alice".into()],
+            pending: "create",
+        })
+        .await
+        .unwrap();
+    subject.tick(&["alice".into(), "bob".into()]).await.unwrap();
+    subject
+        .send_application(cgka_conformance_simulator::SubjectSendApplication {
+            action_id: "send",
+            sender: "alice",
+            payload: "relay-wide event",
+        })
+        .await
+        .unwrap();
+    subject.set_online("alice", false).await.unwrap();
+    subject.set_online("bob", false).await.unwrap();
+
+    let selector = ScenarioMessageSelectorV2 {
+        action_id: Some("send".into()),
+        ..ScenarioMessageSelectorV2::default()
+    };
+    let named_subset = vec!["alice".into(), "bob".into()];
+    let error = subject
+        .set_relay_event_visibility("relay:shared", &selector, &named_subset, false)
+        .unwrap_err();
+    assert_eq!(
+        error.code,
+        "relay_removal_requires_all_participants_offline"
+    );
+
+    subject.set_online("carol", false).await.unwrap();
+    subject
+        .set_relay_event_visibility("relay:shared", &selector, &named_subset, false)
+        .unwrap();
+    subject
+        .set_relay_event_visibility("relay:shared", &selector, &named_subset, true)
+        .unwrap();
+    subject.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn cold_reopen_recovers_quiet_offline_history_without_a_live_trigger() {
     let clients = vec!["alice".to_owned(), "bob".to_owned()];
     let mut subject = AppRuntimeHarness::new(&clients).await.unwrap();

--- a/crates/cgka-conformance-simulator/tests/process_orchestrator.rs
+++ b/crates/cgka-conformance-simulator/tests/process_orchestrator.rs
@@ -5,11 +5,13 @@ use std::collections::{BTreeMap, BTreeSet};
 use cgka_conformance_simulator::process_orchestrator::{ProcessNodeLaunchV1, ProcessOrchestrator};
 use cgka_conformance_simulator::{
     AppRuntimeHarness, AppRuntimeObservationV1, GeneratedScenarioCase, GeneratedScenarioInputV1,
-    GeneratedSubjectKind, ScenarioAccountV2, ScenarioDeviceV2, ScenarioProcessV2, ScenarioRelayV2,
-    ScenarioSpec, ScenarioStep, ScenarioTopologyV2, TraceExpectation, compile_scenario,
-    node_protocol::NodeObservationV1, resolve_scenario_input_bytes, run_scenario_report,
-    run_scenario_report_with_subject,
+    GeneratedSubjectKind, HarnessStorageMode, RetainedRelaySubject, ScenarioAccountV2,
+    ScenarioDeviceV2, ScenarioInputDisposition, ScenarioMessageSelectorV2, ScenarioProcessV2,
+    ScenarioRelaySyncModeV2, ScenarioRelayV2, ScenarioSpec, ScenarioStep, ScenarioTopologyV2,
+    TraceExpectation, compile_scenario, node_protocol::NodeObservationV1,
+    resolve_scenario_input_bytes, run_scenario_report, run_scenario_report_with_subject,
 };
+use cgka_traits::group::ProtocolProfile;
 
 fn in_group(group: &str, action: ScenarioStep) -> ScenarioStep {
     ScenarioStep::InGroup {
@@ -150,6 +152,42 @@ fn controlled_relay_topology() -> ScenarioTopologyV2 {
     }
 }
 
+fn single_relay_topology(clients: &[String]) -> ScenarioTopologyV2 {
+    ScenarioTopologyV2 {
+        accounts: clients
+            .iter()
+            .map(|client| ScenarioAccountV2 {
+                id: format!("account:{client}"),
+                roles: vec!["member".into()],
+            })
+            .collect(),
+        devices: clients
+            .iter()
+            .map(|client| ScenarioDeviceV2 {
+                id: format!("device:{client}"),
+                account: format!("account:{client}"),
+                process: format!("process:{client}"),
+                client: client.clone(),
+            })
+            .collect(),
+        processes: clients
+            .iter()
+            .map(|client| ScenarioProcessV2 {
+                id: format!("process:{client}"),
+                binary_version: "current-test-node".into(),
+                policy_version: "marmot-convergence-v1".into(),
+                relays: vec!["relay:shared".into()],
+            })
+            .collect(),
+        groups: Vec::new(),
+        relays: vec![ScenarioRelayV2 {
+            id: "relay:shared".into(),
+            implementation_version: "mock-relay-v1".into(),
+            policy_version: "retain-all-v1".into(),
+        }],
+    }
+}
+
 #[derive(Clone, Copy)]
 enum CrossAdapterRecovery {
     Restart,
@@ -278,17 +316,336 @@ fn cross_adapter_offline_scenario() -> ScenarioSpec {
     build_cross_adapter_scenario(CrossAdapterRecovery::OfflineFullHistory)
 }
 
-async fn run_app_and_process_adapters(
+fn cross_route_app_runtime_scenario(strict_engine_tail: bool) -> ScenarioSpec {
+    let clients = vec![
+        "zeta".into(),
+        "alpha".into(),
+        "yankee".into(),
+        "observer".into(),
+    ];
+    let mut steps = vec![
+        in_group(
+            "main",
+            ScenarioStep::CreateGroup {
+                creator: "zeta".into(),
+                name: "cross-route".into(),
+                invitees: vec!["alpha".into(), "yankee".into(), "observer".into()],
+                required_features: Vec::new(),
+                initial_admins: Some(vec!["zeta".into()]),
+                pending: "create".into(),
+            },
+        ),
+        ScenarioStep::AcknowledgeOutbound {
+            client: "zeta".into(),
+            publication: Some("create".into()),
+            selection: Default::default(),
+            outcome: cgka_conformance_simulator::SubjectOutboundOutcome::Accepted,
+        },
+        ScenarioStep::SyncRelayHistory {
+            clients: vec!["alpha".into(), "yankee".into(), "observer".into()],
+            sync: ScenarioRelaySyncModeV2::FullHistory,
+        },
+        ScenarioStep::Tick {
+            clients: vec!["alpha".into(), "yankee".into(), "observer".into()],
+        },
+        in_group(
+            "main",
+            ScenarioStep::UpdateAdminPolicy {
+                client: "zeta".into(),
+                admins: vec!["zeta".into(), "alpha".into()],
+                pending: "promote-alpha".into(),
+            },
+        ),
+        ScenarioStep::AcknowledgeOutbound {
+            client: "zeta".into(),
+            publication: Some("promote-alpha".into()),
+            selection: Default::default(),
+            outcome: cgka_conformance_simulator::SubjectOutboundOutcome::Accepted,
+        },
+        ScenarioStep::SyncRelayHistory {
+            clients: clients.clone(),
+            sync: ScenarioRelaySyncModeV2::FullHistory,
+        },
+        ScenarioStep::Tick {
+            clients: clients.clone(),
+        },
+        in_group(
+            "main",
+            ScenarioStep::UpdateAdminPolicy {
+                client: "zeta".into(),
+                admins: vec!["zeta".into(), "alpha".into(), "yankee".into()],
+                pending: "promote-yankee".into(),
+            },
+        ),
+        ScenarioStep::AcknowledgeOutbound {
+            client: "zeta".into(),
+            publication: Some("promote-yankee".into()),
+            selection: Default::default(),
+            outcome: cgka_conformance_simulator::SubjectOutboundOutcome::Accepted,
+        },
+        ScenarioStep::SyncRelayHistory {
+            clients: clients.clone(),
+            sync: ScenarioRelaySyncModeV2::FullHistory,
+        },
+        ScenarioStep::Tick {
+            clients: clients.clone(),
+        },
+        in_group(
+            "main",
+            ScenarioStep::ClearEvents {
+                clients: clients.clone(),
+            },
+        ),
+        in_group(
+            "main",
+            ScenarioStep::Observe {
+                clients: clients.clone(),
+            },
+        ),
+        ScenarioStep::SetClientOffline {
+            client: "alpha".into(),
+        },
+        ScenarioStep::SetClientOffline {
+            client: "observer".into(),
+        },
+        in_group(
+            "main",
+            ScenarioStep::UpdateGroupData {
+                client: "zeta".into(),
+                name: "zeta-root".into(),
+                pending: "zeta-root".into(),
+            },
+        ),
+        ScenarioStep::AcknowledgeOutbound {
+            client: "zeta".into(),
+            publication: Some("zeta-root".into()),
+            selection: Default::default(),
+            outcome: cgka_conformance_simulator::SubjectOutboundOutcome::Accepted,
+        },
+        ScenarioStep::SyncRelayHistory {
+            clients: vec!["yankee".into()],
+            sync: ScenarioRelaySyncModeV2::Incremental,
+        },
+        ScenarioStep::Tick {
+            clients: vec!["yankee".into()],
+        },
+        in_group(
+            "main",
+            ScenarioStep::SendAppMessage {
+                sender: "yankee".into(),
+                payload: "zeta-branch-witness".into(),
+            },
+        ),
+        ScenarioStep::SetRelayEventVisibility {
+            relay: "relay:shared".into(),
+            selector: ScenarioMessageSelectorV2 {
+                action_id: Some("step-16:update_group_data@main".into()),
+                ..Default::default()
+            },
+            clients: vec!["alpha".into(), "observer".into()],
+            visible: false,
+        },
+        ScenarioStep::SetClientOffline {
+            client: "yankee".into(),
+        },
+        ScenarioStep::ReconnectClient {
+            client: "alpha".into(),
+        },
+        in_group(
+            "main",
+            ScenarioStep::UpdateGroupData {
+                client: "alpha".into(),
+                name: "alpha-root".into(),
+                pending: "alpha-root".into(),
+            },
+        ),
+        ScenarioStep::AcknowledgeOutbound {
+            client: "alpha".into(),
+            publication: Some("alpha-root".into()),
+            selection: Default::default(),
+            outcome: cgka_conformance_simulator::SubjectOutboundOutcome::Accepted,
+        },
+        ScenarioStep::SyncRelayHistory {
+            clients: vec!["zeta".into()],
+            sync: ScenarioRelaySyncModeV2::Incremental,
+        },
+        ScenarioStep::Tick {
+            clients: vec!["zeta".into()],
+        },
+        ScenarioStep::SetRelayEventVisibility {
+            relay: "relay:shared".into(),
+            selector: ScenarioMessageSelectorV2 {
+                action_id: Some("step-24:update_group_data@main".into()),
+                ..Default::default()
+            },
+            clients: vec!["yankee".into(), "observer".into()],
+            visible: false,
+        },
+        in_group(
+            "main",
+            ScenarioStep::Observe {
+                clients: clients.clone(),
+            },
+        ),
+        ScenarioStep::SetClientOffline {
+            client: "zeta".into(),
+        },
+        ScenarioStep::ReconnectClient {
+            client: "yankee".into(),
+        },
+        in_group(
+            "main",
+            ScenarioStep::UpdateGroupData {
+                client: "yankee".into(),
+                name: "zeta-branch-depth-two".into(),
+                pending: "zeta-child".into(),
+            },
+        ),
+        ScenarioStep::AcknowledgeOutbound {
+            client: "yankee".into(),
+            publication: Some("zeta-child".into()),
+            selection: Default::default(),
+            outcome: cgka_conformance_simulator::SubjectOutboundOutcome::Accepted,
+        },
+        ScenarioStep::RestartClient {
+            client: "zeta".into(),
+        },
+        ScenarioStep::ReconnectClient {
+            client: "zeta".into(),
+        },
+        ScenarioStep::SetRelayEventVisibility {
+            relay: "relay:shared".into(),
+            selector: ScenarioMessageSelectorV2 {
+                action_id: Some("step-16:update_group_data@main".into()),
+                ..Default::default()
+            },
+            clients: vec!["alpha".into(), "observer".into()],
+            visible: true,
+        },
+        ScenarioStep::SetRelayEventVisibility {
+            relay: "relay:shared".into(),
+            selector: ScenarioMessageSelectorV2 {
+                action_id: Some("step-24:update_group_data@main".into()),
+                ..Default::default()
+            },
+            clients: vec!["yankee".into(), "observer".into()],
+            visible: true,
+        },
+        ScenarioStep::ReconnectClient {
+            client: "observer".into(),
+        },
+        ScenarioStep::SyncRelayHistory {
+            clients: clients.clone(),
+            sync: ScenarioRelaySyncModeV2::FullHistory,
+        },
+        ScenarioStep::Tick {
+            clients: clients.clone(),
+        },
+        ScenarioStep::SyncRelayHistory {
+            clients: clients.clone(),
+            sync: ScenarioRelaySyncModeV2::FullHistory,
+        },
+        ScenarioStep::Tick {
+            clients: clients.clone(),
+        },
+    ];
+    if strict_engine_tail {
+        steps.push(ScenarioStep::AwaitQuiescence {
+            policy: cgka_conformance_simulator::QuiescencePolicy {
+                max_iterations: 200,
+                ..Default::default()
+            },
+        });
+    }
+    for client in &clients {
+        steps.push(in_group(
+            "main",
+            ScenarioStep::SendAppMessage {
+                sender: client.clone(),
+                payload: format!("probe-from-{client}"),
+            },
+        ));
+    }
+    steps.extend([
+        ScenarioStep::SyncRelayHistory {
+            clients: clients.clone(),
+            sync: ScenarioRelaySyncModeV2::FullHistory,
+        },
+        ScenarioStep::Tick {
+            clients: clients.clone(),
+        },
+        ScenarioStep::SyncRelayHistory {
+            clients: clients.clone(),
+            sync: ScenarioRelaySyncModeV2::FullHistory,
+        },
+        ScenarioStep::Tick {
+            clients: clients.clone(),
+        },
+    ]);
+    if strict_engine_tail {
+        steps.push(ScenarioStep::AwaitQuiescence {
+            policy: cgka_conformance_simulator::QuiescencePolicy {
+                max_iterations: 200,
+                ..Default::default()
+            },
+        });
+    }
+    steps.push(in_group(
+        "main",
+        ScenarioStep::Observe {
+            clients: clients.clone(),
+        },
+    ));
+    if !strict_engine_tail {
+        steps.push(in_group(
+            "main",
+            ScenarioStep::Observe {
+                clients: clients.clone(),
+            },
+        ));
+    }
+    if strict_engine_tail {
+        steps.extend([
+            in_group(
+                "main",
+                ScenarioStep::ProbeBidirectionalDecryptability {
+                    clients: clients.clone(),
+                },
+            ),
+            in_group(
+                "main",
+                ScenarioStep::ObserveExact {
+                    clients: clients.clone(),
+                },
+            ),
+        ]);
+    }
+    let topology = single_relay_topology(&clients);
+    ScenarioSpec {
+        name: "cross-route-app-runtime-recovery/v1".into(),
+        spec_version: "2".into(),
+        clients,
+        topology,
+        steps,
+    }
+}
+
+async fn run_app_runtime_adapter(
     spec: &ScenarioSpec,
 ) -> (
+    cgka_conformance_simulator::ScenarioReport,
     BTreeMap<String, AppRuntimeObservationV1>,
-    BTreeMap<String, NodeObservationV1>,
 ) {
     let mut app = AppRuntimeHarness::new(&spec.clients).await.unwrap();
     let app_report = run_scenario_report_with_subject(spec, None, Vec::new(), &mut app)
         .await
         .unwrap();
     assert!(app_report.invariant_failures.is_empty(), "{app_report:#?}");
+    assert_eq!(
+        app_report.step_log.len(),
+        compile_scenario(spec).unwrap().expanded_schedule().len(),
+        "{app_report:#?}"
+    );
     let app_observations = app
         .observations(&spec.clients)
         .await
@@ -296,6 +653,17 @@ async fn run_app_and_process_adapters(
         .into_iter()
         .map(|observation| (observation.participant.clone(), observation))
         .collect::<BTreeMap<_, _>>();
+    app.shutdown().await;
+    (app_report, app_observations)
+}
+
+async fn run_app_and_process_adapters(
+    spec: &ScenarioSpec,
+) -> (
+    BTreeMap<String, AppRuntimeObservationV1>,
+    BTreeMap<String, NodeObservationV1>,
+) {
+    let (_, app_observations) = run_app_runtime_adapter(spec).await;
 
     let process_artifacts = tempfile::tempdir().unwrap();
     let mut process = ProcessOrchestrator::launch(
@@ -316,7 +684,6 @@ async fn run_app_and_process_adapters(
         .collect::<BTreeMap<_, _>>();
 
     process.shutdown().await;
-    app.shutdown().await;
     (app_observations, process_observations)
 }
 
@@ -526,6 +893,169 @@ async fn app_runtime_and_process_adapters_recover_the_same_offline_projection() 
             process.application.stored_member_count
         );
     }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn four_party_cross_route_recovery_records_app_runtime_equivalence_falsification() {
+    let strict_spec = cross_route_app_runtime_scenario(true);
+    let clients = strict_spec.clients.clone();
+    let mut expectations = clients
+        .iter()
+        .map(|client| TraceExpectation::ClientState {
+            client: client.clone(),
+            epoch: 5,
+            member_count: 4,
+            received_payloads: None,
+            added_members: None,
+            removed_members: None,
+        })
+        .collect::<Vec<_>>();
+    expectations.extend([
+        TraceExpectation::GroupProfile {
+            client: "zeta".into(),
+            name: "zeta-branch-depth-two".into(),
+            description: String::new(),
+        },
+        TraceExpectation::ClientsExactlyEquivalent {
+            clients: clients.clone(),
+        },
+        TraceExpectation::ClientsBidirectionallyDecryptable {
+            clients: clients.clone(),
+        },
+        TraceExpectation::NoPendingWork {
+            clients: clients.clone(),
+        },
+    ]);
+    let mut retained = RetainedRelaySubject::new(
+        &clients,
+        &strict_spec.topology,
+        ProtocolProfile::Legacy,
+        HarnessStorageMode::TempFileBackedSqlite,
+    )
+    .unwrap();
+    let retained_report =
+        run_scenario_report_with_subject(&strict_spec, None, expectations, &mut retained)
+            .await
+            .unwrap();
+    assert!(
+        retained_report.invariant_failures.is_empty(),
+        "retained-engine invariants: {:#?}; steps: {:#?}",
+        retained_report.invariant_failures,
+        retained_report.step_log
+    );
+    assert!(
+        retained_report.expectation_failures.is_empty(),
+        "retained-engine expectations: {:#?}",
+        retained_report.expectation_failures
+    );
+    let retained_trace = retained_report.observed_trace.unwrap();
+    assert_eq!(retained_trace.observations.len(), clients.len() * 4);
+    let retained_baseline = retained_trace.observations[..clients.len()]
+        .iter()
+        .map(|observation| (observation.client.as_str(), observation))
+        .collect::<BTreeMap<_, _>>();
+    let retained_observations = retained_trace
+        .observations
+        .iter()
+        .rev()
+        .take(clients.len())
+        .map(|observation| (observation.client.clone(), observation))
+        .collect::<BTreeMap<_, _>>();
+    for observation in retained_observations.values() {
+        for (scenario_id, disposition) in [
+            (
+                "step-16:update_group_data@main",
+                ScenarioInputDisposition::Accepted,
+            ),
+            (
+                "step-24:update_group_data@main",
+                ScenarioInputDisposition::Invalidated,
+            ),
+            (
+                "step-32:update_group_data@main",
+                ScenarioInputDisposition::Accepted,
+            ),
+        ] {
+            let entry = observation
+                .scenario_input_ledger
+                .iter()
+                .find(|entry| entry.scenario_id == scenario_id)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "{} missing durable disposition for {scenario_id}",
+                        observation.client
+                    )
+                });
+            assert_eq!(
+                entry.disposition, disposition,
+                "{} disposition for {scenario_id}",
+                observation.client
+            );
+        }
+    }
+
+    let public_spec = cross_route_app_runtime_scenario(false);
+    let (app_report, app_observations) = run_app_runtime_adapter(&public_spec).await;
+    let app_trace = app_report.observed_trace.unwrap().observations;
+    assert_eq!(app_trace.len(), clients.len() * 4);
+    let app_baseline = app_trace[..clients.len()]
+        .iter()
+        .map(|observation| (observation.client.as_str(), observation))
+        .collect::<BTreeMap<_, _>>();
+    let app_routed = app_trace[clients.len()..clients.len() * 2]
+        .iter()
+        .map(|observation| (observation.client.as_str(), observation))
+        .collect::<BTreeMap<_, _>>();
+    assert_eq!(app_routed["zeta"].epoch, 4);
+    assert_eq!(app_routed["alpha"].epoch, 3);
+    assert_eq!(app_routed["yankee"].epoch, 4);
+    assert_eq!(app_routed["observer"].epoch, 3);
+    let mut expected_payloads = clients
+        .iter()
+        .map(|client| format!("probe-from-{client}"))
+        .collect::<BTreeSet<_>>();
+    expected_payloads.insert("zeta-branch-witness".into());
+    let mut protocol_equivalent = true;
+    let mut all_active_probes_visible = true;
+    for client in &clients {
+        let retained = retained_observations[client];
+        let app = &app_observations[client];
+        let retained_baseline = retained_baseline[client.as_str()];
+        let app_baseline = app_baseline[client.as_str()];
+        assert_eq!(
+            app_baseline.epoch, retained_baseline.epoch,
+            "{client} baseline epoch"
+        );
+        assert_eq!(
+            retained.epoch - retained_baseline.epoch,
+            2,
+            "{client} retained route depth"
+        );
+        protocol_equivalent &= app.protocol.epoch == retained.epoch
+            && app.protocol.member_count == retained.member_count
+            && app.protocol.group_name == retained.group_name
+            && app.protocol.group_description == retained.group_description;
+        assert_eq!(app.protocol.member_count, 4, "{client} roster size");
+        assert_eq!(app.protocol.admin_identities, ["alpha", "yankee", "zeta"]);
+        let app_payloads = app
+            .application
+            .visible_plaintexts
+            .iter()
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        assert!(
+            app_payloads.is_subset(&expected_payloads),
+            "{client} projected an unexpected application payload"
+        );
+        assert_eq!(app.application.visible_plaintexts.len(), app_payloads.len());
+        all_active_probes_visible &= app_payloads == expected_payloads;
+        assert!(app.application.invalidated_message_ids.is_empty());
+        assert!(!app.application.pending_confirmation);
+    }
+    assert!(
+        !protocol_equivalent || !all_active_probes_visible,
+        "the known app-runtime route-equivalence falsification unexpectedly disappeared; review and replace this characterization with a passing equivalence oracle"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/crates/cgka-conformance-simulator/tests/process_orchestrator.rs
+++ b/crates/cgka-conformance-simulator/tests/process_orchestrator.rs
@@ -182,7 +182,7 @@ fn single_relay_topology(clients: &[String]) -> ScenarioTopologyV2 {
         groups: Vec::new(),
         relays: vec![ScenarioRelayV2 {
             id: "relay:shared".into(),
-            implementation_version: "mock-relay-v1".into(),
+            implementation_version: "retained-memory/v1".into(),
             policy_version: "retain-all-v1".into(),
         }],
     }
@@ -1006,6 +1006,9 @@ async fn four_party_cross_route_recovery_records_app_runtime_equivalence_falsifi
         .iter()
         .map(|observation| (observation.client.as_str(), observation))
         .collect::<BTreeMap<_, _>>();
+    // Alpha and Observer have not ticked since the pre-split checkpoint, so
+    // these two values pin cached schedule state. Zeta and Yankee's refreshed
+    // epoch-4 observations are the independent evidence of the routed split.
     assert_eq!(app_routed["zeta"].epoch, 4);
     assert_eq!(app_routed["alpha"].epoch, 3);
     assert_eq!(app_routed["yankee"].epoch, 4);
@@ -1016,7 +1019,9 @@ async fn four_party_cross_route_recovery_records_app_runtime_equivalence_falsifi
         .collect::<BTreeSet<_>>();
     expected_payloads.insert("zeta-branch-witness".into());
     let mut protocol_equivalent = true;
-    let mut all_active_probes_visible = true;
+    let mut protocol_equivalent_by_client = BTreeMap::new();
+    let mut protocol_non_epoch_equivalent_by_client = BTreeMap::new();
+    let mut app_payloads_by_client = BTreeMap::new();
     for client in &clients {
         let retained = retained_observations[client];
         let app = &app_observations[client];
@@ -1031,10 +1036,14 @@ async fn four_party_cross_route_recovery_records_app_runtime_equivalence_falsifi
             2,
             "{client} retained route depth"
         );
-        protocol_equivalent &= app.protocol.epoch == retained.epoch
-            && app.protocol.member_count == retained.member_count
+        let non_epoch_equivalent = app.protocol.member_count == retained.member_count
             && app.protocol.group_name == retained.group_name
             && app.protocol.group_description == retained.group_description;
+        let client_protocol_equivalent =
+            app.protocol.epoch == retained.epoch && non_epoch_equivalent;
+        protocol_equivalent &= client_protocol_equivalent;
+        protocol_equivalent_by_client.insert(client.clone(), client_protocol_equivalent);
+        protocol_non_epoch_equivalent_by_client.insert(client.clone(), non_epoch_equivalent);
         assert_eq!(app.protocol.member_count, 4, "{client} roster size");
         assert_eq!(app.protocol.admin_identities, ["alpha", "yankee", "zeta"]);
         let app_payloads = app
@@ -1048,13 +1057,68 @@ async fn four_party_cross_route_recovery_records_app_runtime_equivalence_falsifi
             "{client} projected an unexpected application payload"
         );
         assert_eq!(app.application.visible_plaintexts.len(), app_payloads.len());
-        all_active_probes_visible &= app_payloads == expected_payloads;
+        app_payloads_by_client.insert(client.clone(), app_payloads);
         assert!(app.application.invalidated_message_ids.is_empty());
         assert!(!app.application.pending_confirmation);
     }
+
+    let zeta_one_epoch_behind = clients.iter().all(|client| {
+        if client == "zeta" {
+            let app = &app_observations[client];
+            let retained = retained_observations[client];
+            app.protocol.epoch.checked_add(1) == Some(retained.epoch)
+                && protocol_non_epoch_equivalent_by_client[client]
+        } else {
+            protocol_equivalent_by_client[client]
+        }
+    }) && app_payloads_by_client
+        .values()
+        .all(|payloads| payloads == &expected_payloads);
+
+    let mut zeta_missing_alpha_probe = expected_payloads.clone();
+    assert!(zeta_missing_alpha_probe.remove("probe-from-alpha"));
+    let missing_probe_after_agreement = protocol_equivalent
+        && clients.iter().all(|client| {
+            let expected = if client == "zeta" {
+                &zeta_missing_alpha_probe
+            } else {
+                &expected_payloads
+            };
+            &app_payloads_by_client[client] == expected
+        });
+
+    let payload_set = |payloads: &[&str]| {
+        payloads
+            .iter()
+            .map(|payload| (*payload).to_owned())
+            .collect::<BTreeSet<_>>()
+    };
+    let split_protocol_and_probe_surface = {
+        let alpha = &app_observations["alpha"];
+        let observer = &app_observations["observer"];
+        alpha.protocol.epoch == app_baseline["alpha"].epoch + 1
+            && alpha.protocol.group_name == "alpha-root"
+            && alpha.protocol.group_description.is_empty()
+            && observer.protocol.epoch == app_baseline["observer"].epoch
+            && observer.protocol.group_name == "cross-route"
+            && observer.protocol.group_description.is_empty()
+            && protocol_equivalent_by_client["yankee"]
+            && protocol_equivalent_by_client["zeta"]
+            && app_payloads_by_client["alpha"]
+                == payload_set(&["probe-from-alpha", "probe-from-observer"])
+            && app_payloads_by_client["observer"] == payload_set(&["probe-from-observer"])
+            && app_payloads_by_client["yankee"]
+                == payload_set(&[
+                    "probe-from-observer",
+                    "probe-from-yankee",
+                    "probe-from-zeta",
+                    "zeta-branch-witness",
+                ])
+            && app_payloads_by_client["zeta"] == app_payloads_by_client["yankee"]
+    };
     assert!(
-        !protocol_equivalent || !all_active_probes_visible,
-        "the known app-runtime route-equivalence falsification unexpectedly disappeared; review and replace this characterization with a passing equivalence oracle"
+        zeta_one_epoch_behind || missing_probe_after_agreement || split_protocol_and_probe_surface,
+        "app-runtime route result was neither documented counterexample shape; protocol_match={protocol_equivalent_by_client:#?}; payloads={app_payloads_by_client:#?}; observations={app_observations:#?}"
     );
 }
 

--- a/crates/cgka-conformance-simulator/tests/process_orchestrator.rs
+++ b/crates/cgka-conformance-simulator/tests/process_orchestrator.rs
@@ -436,6 +436,12 @@ fn cross_route_app_runtime_scenario(strict_engine_tail: bool) -> ScenarioSpec {
                 payload: "zeta-branch-witness".into(),
             },
         ),
+        ScenarioStep::SetClientOffline {
+            client: "zeta".into(),
+        },
+        ScenarioStep::SetClientOffline {
+            client: "yankee".into(),
+        },
         ScenarioStep::SetRelayEventVisibility {
             relay: "relay:shared".into(),
             selector: ScenarioMessageSelectorV2 {
@@ -444,9 +450,6 @@ fn cross_route_app_runtime_scenario(strict_engine_tail: bool) -> ScenarioSpec {
             },
             clients: vec!["alpha".into(), "observer".into()],
             visible: false,
-        },
-        ScenarioStep::SetClientOffline {
-            client: "yankee".into(),
         },
         ScenarioStep::ReconnectClient {
             client: "alpha".into(),
@@ -465,6 +468,9 @@ fn cross_route_app_runtime_scenario(strict_engine_tail: bool) -> ScenarioSpec {
             selection: Default::default(),
             outcome: cgka_conformance_simulator::SubjectOutboundOutcome::Accepted,
         },
+        ScenarioStep::ReconnectClient {
+            client: "zeta".into(),
+        },
         ScenarioStep::SyncRelayHistory {
             clients: vec!["zeta".into()],
             sync: ScenarioRelaySyncModeV2::Incremental,
@@ -472,10 +478,16 @@ fn cross_route_app_runtime_scenario(strict_engine_tail: bool) -> ScenarioSpec {
         ScenarioStep::Tick {
             clients: vec!["zeta".into()],
         },
+        ScenarioStep::SetClientOffline {
+            client: "alpha".into(),
+        },
+        ScenarioStep::SetClientOffline {
+            client: "zeta".into(),
+        },
         ScenarioStep::SetRelayEventVisibility {
             relay: "relay:shared".into(),
             selector: ScenarioMessageSelectorV2 {
-                action_id: Some("step-24:update_group_data@main".into()),
+                action_id: Some("step-25:update_group_data@main".into()),
                 ..Default::default()
             },
             clients: vec!["yankee".into(), "observer".into()],
@@ -487,9 +499,6 @@ fn cross_route_app_runtime_scenario(strict_engine_tail: bool) -> ScenarioSpec {
                 clients: clients.clone(),
             },
         ),
-        ScenarioStep::SetClientOffline {
-            client: "zeta".into(),
-        },
         ScenarioStep::ReconnectClient {
             client: "yankee".into(),
         },
@@ -525,11 +534,14 @@ fn cross_route_app_runtime_scenario(strict_engine_tail: bool) -> ScenarioSpec {
         ScenarioStep::SetRelayEventVisibility {
             relay: "relay:shared".into(),
             selector: ScenarioMessageSelectorV2 {
-                action_id: Some("step-24:update_group_data@main".into()),
+                action_id: Some("step-25:update_group_data@main".into()),
                 ..Default::default()
             },
             clients: vec!["yankee".into(), "observer".into()],
             visible: true,
+        },
+        ScenarioStep::ReconnectClient {
+            client: "alpha".into(),
         },
         ScenarioStep::ReconnectClient {
             client: "observer".into(),
@@ -968,11 +980,11 @@ async fn four_party_cross_route_recovery_records_app_runtime_equivalence_falsifi
                 ScenarioInputDisposition::Accepted,
             ),
             (
-                "step-24:update_group_data@main",
+                "step-25:update_group_data@main",
                 ScenarioInputDisposition::Invalidated,
             ),
             (
-                "step-32:update_group_data@main",
+                "step-35:update_group_data@main",
                 ScenarioInputDisposition::Accepted,
             ),
         ] {
@@ -1036,7 +1048,10 @@ async fn four_party_cross_route_recovery_records_app_runtime_equivalence_falsifi
             2,
             "{client} retained route depth"
         );
+        let exact_roster =
+            app.protocol.member_identities == ["alpha", "observer", "yankee", "zeta"];
         let non_epoch_equivalent = app.protocol.member_count == retained.member_count
+            && exact_roster
             && app.protocol.group_name == retained.group_name
             && app.protocol.group_description == retained.group_description;
         let client_protocol_equivalent =
@@ -1045,6 +1060,7 @@ async fn four_party_cross_route_recovery_records_app_runtime_equivalence_falsifi
         protocol_equivalent_by_client.insert(client.clone(), client_protocol_equivalent);
         protocol_non_epoch_equivalent_by_client.insert(client.clone(), non_epoch_equivalent);
         assert_eq!(app.protocol.member_count, 4, "{client} roster size");
+        assert!(exact_roster, "{client} exact roster");
         assert_eq!(app.protocol.admin_identities, ["alpha", "yankee", "zeta"]);
         let app_payloads = app
             .application

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -1024,9 +1024,10 @@ engine repair or scaling the existing corpus is sufficient.
     capability-overlap evidence, not execution of the four-party adversarial vector or a substitute for its exact
     cryptographic, disposition, pending-work, and active-decryptability assertions. The first controlled app-runtime
     execution now exists as `cross-route-app-runtime-recovery/v1`, but it is counterexample evidence: repeated runs
-    either leave Zeta one epoch behind or lose Alpha's non-invalidated post-settlement probe at Zeta. Keep this item
-    open until that falsification is resolved and the process/container/VM adapters gain equivalent retained-event
-    staging.
+    either leave Zeta one epoch behind, lose Alpha's non-invalidated post-settlement probe at Zeta despite public
+    protocol agreement, or strand Alpha/Observer on the competing root/baseline while Yankee/Zeta reach the reference
+    branch and probe sets split along those boundaries. Keep this item open until that falsification is resolved and
+    the process/container/VM adapters gain equivalent retained-event staging.
 - [x] Add a bounded abstract route-choice lifecycle and mutation sentinel for reconsiderable versus terminal loser
   disposition, volatile routing history, and restart; record that exhaustive shared-model and production-route
   comparison remains part of the open route-equivalence work above.
@@ -1241,9 +1242,11 @@ residual gap.
    adapters that cannot expose it. The actual four-party adversarial vector and its durable-transition permutations
    remain open. The next app-runtime slice now uses action-addressed shared-relay event staging, rather than timing a
    live relay, to reproduce the actual four-party branch split. Its strict retained-engine reference passes, and the
-   app runtime either leaves Zeta one epoch behind or reaches the same public protocol state while Alpha's
-   post-settlement application probe remains absent and non-invalidated at Zeta after repeated full-history repair.
-   That counterexample reopens route equivalence, active decryptability, and complete application disposition;
+   app runtime has three exactly characterized counterexample surfaces after repeated full-history repair: Zeta one
+   epoch behind; public protocol agreement with Alpha's post-settlement application probe absent and non-invalidated at
+   Zeta; or Alpha/Observer stranded on the competing root/baseline while Yankee/Zeta reach the reference branch and the
+   probe sets split along those boundaries. Any fourth shape or complete equivalence now fails the characterization.
+   Those counterexamples reopen route equivalence, active decryptability, and complete application disposition;
    process/container/VM execution still needs equivalent controlled retained-event staging. The decision-route
    inventory is machine checked; keep the remaining assurance artifacts independent of #1293.
 6. [x] Land and execute a focused current-`master` regression gate for the production convergence changes that landed
@@ -1417,7 +1420,7 @@ incorrect result.
 | 2026-08-11 | 6.1 cross-adapter public projection checkpoint | Made accepted publication checkpoints portable across the `CgkaEngine` harness's staged transport and the app runtime's already-published command surface, then ran a three-participant profile/message/restart IR unchanged through the `CgkaEngine` harness, full app-runtime adapter, and isolated app processes. The production-shaped adapters cross the `CgkaEngine`, `TransportPeeler`, and `TransportAdapter` seams. A companion app/process permutation takes one member offline across the commit and message, restarts another member, performs full-history repair, and requires equivalent duplicate-free public projections. Exact MLS state, active decryptability, the four-party adversarial topology, containers, and VMs remain open. | [MDK #1372](https://github.com/marmot-protocol/mdk/pull/1372); `engine_app_runtime_and_process_adapters_reach_equivalent_public_state`; `app_runtime_and_process_adapters_recover_the_same_offline_projection`; simulator-only adapter seam and focused process/app tests |
 | 2026-08-11 | Failure-input and pinned-policy boundary hardening | Rejected manifest-less or corrupt NDJSON stream remnants instead of silently classifying them as empty healthy incident exports, and restored normal-build coverage proving that a commit beyond the pinned five-commit rewind horizon is terminal stale without weakening the production policy guard. These strengthen failure-corpus admission and the P1 boundary sentinel; they do not replace incident-corpus lane execution or a delayed-history campaign. | [MDK #1140](https://github.com/marmot-protocol/mdk/pull/1140); [MDK #1377](https://github.com/marmot-protocol/mdk/pull/1377); incident-replay regressions; `stale_commit_outside_rewind_horizon_is_not_treated_as_recoverable_fork` |
 | 2026-08-11 | Focused post-campaign production-delta gate | Added a fail-closed named CI gate for the missing-anchor halt, verified Welcome repair, three-write atomic self-removal rollback/restart, armed post-catch-up backfill, and pinned rewind-horizon regressions. Every exact Nextest selector runs independently, so moving or removing one test cannot silently become a zero-test success. The squash-merge commit's successful named CI step will be the durable current-`master` evidence. This is targeted regression coverage, not a rerun of the historical generated matrix or distributed cross-route evidence. | `just focused-convergence-regressions`; `Run focused convergence regressions` CI step; five exact named engine/app tests |
-| 2026-08-11 | 6.1 app-runtime cross-route falsification | Added action-addressed event staging to the app-runtime harness's real retained Nostr relay so offline recipients cannot race the intended four-party branch topology. The strict retained-engine reference still reaches exact state, durable commit dispositions, no pending work, and twelve active decryptability edges; repeated app-runtime executions either leave Zeta one epoch behind or reach the same public protocol state while Alpha's post-settlement probe remains absent and non-invalidated at Zeta after repeated full-history repair. This is a retained counterexample, not passing route-equivalence evidence; no production convergence behavior changed. | `cross-route-app-runtime-recovery/v1`; `four_party_cross_route_recovery_records_app_runtime_equivalence_falsification`; route-assurance claims reopened |
+| 2026-08-11 | 6.1 app-runtime cross-route falsification | Added action-addressed event staging to the app-runtime harness's real retained Nostr relay so offline recipients cannot race the intended four-party branch topology. The strict retained-engine reference still reaches exact state, durable commit dispositions, no pending work, and twelve active decryptability edges; repeated app-runtime executions have three exact counterexample surfaces: Zeta one epoch behind, public agreement with Alpha's probe missing at Zeta, or an Alpha/Observer versus Yankee/Zeta protocol-and-probe split. A fourth shape or complete equivalence now fails the characterization. This is retained counterexample evidence, not passing route-equivalence evidence; no production convergence behavior changed. | `cross-route-app-runtime-recovery/v1`; `four_party_cross_route_recovery_records_app_runtime_equivalence_falsification`; route-assurance claims reopened |
 
 ## Capability Naming Cleanup
 

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -1022,7 +1022,11 @@ engine repair or scaling the existing corpus is sufficient.
   - [ ] Expand the core vector into app-runtime, process, container, and VM executions, with delivery permutations and
     restarts around each durable transition rather than the single post-displacement restart. The #1372 journeys are
     capability-overlap evidence, not execution of the four-party adversarial vector or a substitute for its exact
-    cryptographic, disposition, pending-work, and active-decryptability assertions.
+    cryptographic, disposition, pending-work, and active-decryptability assertions. The first controlled app-runtime
+    execution now exists as `cross-route-app-runtime-recovery/v1`, but it is counterexample evidence: repeated runs
+    either leave Zeta one epoch behind or lose Alpha's non-invalidated post-settlement probe at Zeta. Keep this item
+    open until that falsification is resolved and the process/container/VM adapters gain equivalent retained-event
+    staging.
 - [x] Add a bounded abstract route-choice lifecycle and mutation sentinel for reconsiderable versus terminal loser
   disposition, volatile routing history, and restart; record that exhaustive shared-model and production-route
   comparison remains part of the open route-equivalence work above.
@@ -1235,9 +1239,14 @@ residual gap.
    and process adapters that implement participant connectivity. It compares their public protocol and application
    projections without weakening the four-party vector or claiming exact cryptographic/disposition evidence from
    adapters that cannot expose it. The actual four-party adversarial vector and its durable-transition permutations
-   remain open. The decision-route inventory is machine checked; keep the remaining assurance artifacts independent
-   of #1293.
-6. [ ] Land and execute a focused current-`master` regression gate for the production convergence changes that landed
+   remain open. The next app-runtime slice now uses action-addressed shared-relay event staging, rather than timing a
+   live relay, to reproduce the actual four-party branch split. Its strict retained-engine reference passes, and the
+   app runtime either leaves Zeta one epoch behind or reaches the same public protocol state while Alpha's
+   post-settlement application probe remains absent and non-invalidated at Zeta after repeated full-history repair.
+   That counterexample reopens route equivalence, active decryptability, and complete application disposition;
+   process/container/VM execution still needs equivalent controlled retained-event staging. The decision-route
+   inventory is machine checked; keep the remaining assurance artifacts independent of #1293.
+6. [x] Land and execute a focused current-`master` regression gate for the production convergence changes that landed
    after the reviewed 1,170-case snapshot. Cover #1329 missing-anchor halt and authenticated Welcome repair, #1360
    atomic self-removal persistence across injected write failures and restart, #1365 armed full-history backfill after
    catch-up, and #1377's pinned rewind-horizon policy boundary. `just focused-convergence-regressions` runs each exact
@@ -1245,6 +1254,7 @@ residual gap.
    tests to run. The simulator CI job owns a separately named step for this gate. Close this item after that step passes
    on the squash-merge commit; the retained CI run and commit are the durable evidence, not machine-local timings,
    paths, logs, or digests. This is a small targeted matrix, not a requirement to repeat the entire historical campaign.
+   [MDK #1383](https://github.com/marmot-protocol/mdk/pull/1383) merged the gate at `fc3cae3e`.
 7. [ ] Feed real workflow observations into the lane budgets and produce a reviewed evidence bundle.
 8. [ ] Accumulate container soak evidence, then use the external VM driver only for the remaining
    host/kernel/block-device dimensions.
@@ -1407,6 +1417,7 @@ incorrect result.
 | 2026-08-11 | 6.1 cross-adapter public projection checkpoint | Made accepted publication checkpoints portable across the `CgkaEngine` harness's staged transport and the app runtime's already-published command surface, then ran a three-participant profile/message/restart IR unchanged through the `CgkaEngine` harness, full app-runtime adapter, and isolated app processes. The production-shaped adapters cross the `CgkaEngine`, `TransportPeeler`, and `TransportAdapter` seams. A companion app/process permutation takes one member offline across the commit and message, restarts another member, performs full-history repair, and requires equivalent duplicate-free public projections. Exact MLS state, active decryptability, the four-party adversarial topology, containers, and VMs remain open. | [MDK #1372](https://github.com/marmot-protocol/mdk/pull/1372); `engine_app_runtime_and_process_adapters_reach_equivalent_public_state`; `app_runtime_and_process_adapters_recover_the_same_offline_projection`; simulator-only adapter seam and focused process/app tests |
 | 2026-08-11 | Failure-input and pinned-policy boundary hardening | Rejected manifest-less or corrupt NDJSON stream remnants instead of silently classifying them as empty healthy incident exports, and restored normal-build coverage proving that a commit beyond the pinned five-commit rewind horizon is terminal stale without weakening the production policy guard. These strengthen failure-corpus admission and the P1 boundary sentinel; they do not replace incident-corpus lane execution or a delayed-history campaign. | [MDK #1140](https://github.com/marmot-protocol/mdk/pull/1140); [MDK #1377](https://github.com/marmot-protocol/mdk/pull/1377); incident-replay regressions; `stale_commit_outside_rewind_horizon_is_not_treated_as_recoverable_fork` |
 | 2026-08-11 | Focused post-campaign production-delta gate | Added a fail-closed named CI gate for the missing-anchor halt, verified Welcome repair, three-write atomic self-removal rollback/restart, armed post-catch-up backfill, and pinned rewind-horizon regressions. Every exact Nextest selector runs independently, so moving or removing one test cannot silently become a zero-test success. The squash-merge commit's successful named CI step will be the durable current-`master` evidence. This is targeted regression coverage, not a rerun of the historical generated matrix or distributed cross-route evidence. | `just focused-convergence-regressions`; `Run focused convergence regressions` CI step; five exact named engine/app tests |
+| 2026-08-11 | 6.1 app-runtime cross-route falsification | Added action-addressed event staging to the app-runtime harness's real retained Nostr relay so offline recipients cannot race the intended four-party branch topology. The strict retained-engine reference still reaches exact state, durable commit dispositions, no pending work, and twelve active decryptability edges; repeated app-runtime executions either leave Zeta one epoch behind or reach the same public protocol state while Alpha's post-settlement probe remains absent and non-invalidated at Zeta after repeated full-history repair. This is a retained counterexample, not passing route-equivalence evidence; no production convergence behavior changed. | `cross-route-app-runtime-recovery/v1`; `four_party_cross_route_recovery_records_app_runtime_equivalence_falsification`; route-assurance claims reopened |
 
 ## Capability Naming Cleanup
 


### PR DESCRIPTION
## Summary

- add action-addressed retained-relay controls to the simulator app-runtime adapter
- preserve a four-party cross-route Scenario IR and compare it with the strict retained-engine reference
- record the resulting app-runtime equivalence falsification and reopen the affected assurance claims

## What this demonstrates

The strict retained-engine reference reaches exact canonical equality, records the expected accepted/invalidated/accepted commit dispositions, drains pending work, and preserves all 12 active decryptability edges.

The production-shaped app-runtime adapter does not yet reproduce that result. Repeated executions have produced three exactly characterized failure forms:

- Zeta remains one epoch behind while the complete probe set is visible;
- public protocol state agrees, but Alpha's post-settlement probe is missing and non-invalidated at Zeta; or
- Alpha remains on its competing root, Observer remains at the baseline, and only Yankee/Zeta reach the retained reference branch, with probes split along those branch boundaries.

The characterization accepts only those three exact counterexamples. A fourth divergence shape or complete equivalence fails so the test and assurance claims must be reviewed together.

## Review hardening

- capture successful relay admissions in actual publication order instead of event-id order
- associate immediate group-message and Welcome publications with all applicable app commands
- document deferred-publication selector limits and relay-wide removal semantics
- pin the intermediate cached-epoch boundary and accurate retained-memory implementation metadata

## Scope

- simulator, scenario documentation, and convergence tracking documentation only
- no production convergence, app, protocol, or storage behavior changes
- diagnosis and correction of the production behavior will be a separate focused PR
- equivalent controlled staging for process, container, and VM adapters remains follow-up work

## Verification

- `just fast-ci`
- `cargo test -p cgka-conformance-simulator --test process_orchestrator four_party_cross_route_recovery_records_app_runtime_equivalence_falsification --locked -- --nocapture`
- `cargo test -p cgka-conformance-simulator --test app_runtime_adapter --locked`
- `cargo test -p cgka-conformance-simulator --lib app_runtime --locked`
- `cargo test -p cgka-conformance-simulator --test route_assurance --locked`
- `cargo fmt --all --check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added controls for hiding and restoring shared events during recovery.
  * Added a four-participant recovery scenario with restarts, selective synchronization, and state verification.
  * Added tracking for published relay events and their associated actions.

* **Documentation**
  * Documented cross-route recovery findings, limitations, decryptability, application delivery, and settlement behavior.

* **Tests**
  * Added regression coverage comparing recovery outcomes across execution paths.
  * Added validation for relay visibility, offline operations, and event restoration safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->