### PR TITLE
perf(marmot-app): gate encrypted-media secret sweeps on cached epoch

### DIFF
--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -9,6 +9,15 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ## [Unreleased]
 
+### Changed
+
+- App-runtime encrypted-media secret caching now skips the MLS group load,
+  exporter-secret derivation, and database write when the current epoch's
+  secret is already cached, and the cache sweep's `required` pre-check reads
+  the projected group record instead of loading MLS state. Message sends and
+  group syncs no longer pay three MLS group loads per media group per sweep.
+  ([#1396](https://github.com/marmot-protocol/mdk/pull/1396))
+
 ### Fixed
 
 - OpenClaw Marmot inbound turns now resolve agent-scoped session stores with the

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -13,9 +13,11 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 - App-runtime encrypted-media secret caching now skips the MLS group load,
   exporter-secret derivation, and database write when the current epoch's
-  secret is already cached, and the cache sweep's `required` pre-check reads
-  the projected group record instead of loading MLS state. Message sends and
-  group syncs no longer pay three MLS group loads per media group per sweep.
+  secret is already cached, and the cache sweep's `required` pre-check uses
+  the projected group record as a positive-only fast path, re-checking the
+  signed component only when the projection reports media disabled. Message
+  sends and group syncs no longer pay three MLS group loads per media group
+  per sweep.
   ([#1396](https://github.com/marmot-protocol/mdk/pull/1396))
 
 ### Fixed

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -3040,11 +3040,15 @@ impl AppClient {
                 continue;
             };
             let group_id = GroupId::new(group_id_bytes);
-            // The projected component mirrors the engine's signed component;
-            // reading it avoids an MLS group load per group on every sweep. A
-            // stale `required` only delays warming — decryption falls back to
-            // a live export.
-            if !group.encrypted_media.required {
+            // The projected component is a positive-only fast path: `true`
+            // warms without an MLS group load. A projected `false` may be
+            // stale (a rebuild error can leave it lagging the signed
+            // component), so it must re-check the authoritative component
+            // before skipping — a missed warm here can strand a
+            // historical epoch's media once the group advances.
+            if !group.encrypted_media.required
+                && !self.encrypted_media_for_group(&group_id).required
+            {
                 continue;
             }
             if self

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -3008,6 +3008,18 @@ impl AppClient {
     }
 
     fn remember_current_encrypted_media_secret(&self, group_id: &GroupId) -> Result<(), AppError> {
+        // Exporting the secret loads the full MLS group state, so skip it when
+        // the current epoch's secret is already cached. The record epoch can
+        // trail a staged commit by one epoch; that window is covered by the
+        // live-export fallback in `encrypted_media_secret_for_epoch`.
+        let record = self.runtime.group_record(group_id)?;
+        let component_id = Self::encrypted_media_component_id(record.protocol_profile);
+        if self
+            .cached_encrypted_media_epoch_secret(group_id, component_id, record.epoch.0)?
+            .is_some()
+        {
+            return Ok(());
+        }
         let (epoch, secret) = self.runtime.exporter_secret_with_epoch(
             group_id,
             GROUP_ENCRYPTED_MEDIA_EXPORTER_CACHE_KEY,
@@ -3028,7 +3040,11 @@ impl AppClient {
                 continue;
             };
             let group_id = GroupId::new(group_id_bytes);
-            if !self.encrypted_media_for_group(&group_id).required {
+            // The projected component mirrors the engine's signed component;
+            // reading it avoids an MLS group load per group on every sweep. A
+            // stale `required` only delays warming — decryption falls back to
+            // a live export.
+            if !group.encrypted_media.required {
                 continue;
             }
             if self

--- a/crates/marmot-app/src/client/projection.rs
+++ b/crates/marmot-app/src/client/projection.rs
@@ -618,6 +618,13 @@ impl AppClient {
             .unwrap_or_else(AppGroupAvatarUrlComponent::absent)
     }
 
+    pub(crate) fn encrypted_media_component_id(profile: ProtocolProfile) -> u16 {
+        match profile {
+            ProtocolProfile::Legacy => GROUP_ENCRYPTED_MEDIA_V1_COMPONENT_ID,
+            ProtocolProfile::Current => GROUP_ENCRYPTED_MEDIA_V2_COMPONENT_ID,
+        }
+    }
+
     pub(crate) fn encrypted_media_for_group(
         &self,
         group_id: &GroupId,
@@ -627,10 +634,7 @@ impl AppClient {
             .group_record(group_id)
             .map(|group| group.protocol_profile)
             .unwrap_or(ProtocolProfile::Legacy);
-        let component_id = match profile {
-            ProtocolProfile::Legacy => GROUP_ENCRYPTED_MEDIA_V1_COMPONENT_ID,
-            ProtocolProfile::Current => GROUP_ENCRYPTED_MEDIA_V2_COMPONENT_ID,
-        };
+        let component_id = Self::encrypted_media_component_id(profile);
         self.runtime
             .app_component(group_id, component_id)
             .ok()


### PR DESCRIPTION
Sending a message runs the encrypted-media secret sweep twice through `sync_runtime_groups`, and about 28 other runtime commands run it too. For every media group, each sweep loaded the full MLS group state three times: once in the `required` pre-check (`app_component` loads the group to read one boolean), and twice more to derive the exporter secret, ending in a database write inside its own fsynced transaction. All of that repeated even when no epoch had changed, so a busy account paid O(groups) MLS loads and HKDF exports on every send.

This PR gates the sweep on the persisted cache:

- `remember_current_encrypted_media_secret` reads the engine group record (one SELECT) and returns early when the cache already holds the secret for the current epoch. A miss takes the unchanged derive-and-persist path.
- The sweep's `required` pre-check reads the projected `AppGroupRecord` component instead of loading MLS state.
- The profile-to-component-id mapping moved into a shared helper, `encrypted_media_component_id`, so the gate and `encrypted_media_for_group` agree.

The engine record's epoch can trail a staged commit by one epoch. That window was already covered: `encrypted_media_secret_for_epoch` falls back to a live export when the cache misses.

Steady-state cost per sweep drops from three MLS group loads, three HKDF exports, and one write transaction per media group to two small SELECTs.

Another marmot cache warmed without waking the whole burrow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved encrypted-media secret caching to avoid redundant processing when secrets are already available.
  * Reduced unnecessary background work during cache maintenance, including repeated state loading and database updates.
  * Improved cache checks for groups using encrypted media, helping synchronization and media access perform more efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->