### PR TITLE
perf(marmot-account): batch relay fanout into one concurrent publish

### DIFF
--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -22,8 +22,9 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 - One publish's relay fanout now runs its per-relay attempts concurrently
   instead of one awaited relay at a time, so a slow relay no longer serially
-  delays every relay after it. The worst case drops from the sum of per-relay
-  budgets to the slowest single relay's budget.
+  delays every relay after it. Fanout duration can approach the slowest
+  individual attempt's budget when the transport makes concurrent progress,
+  instead of the sum of per-relay budgets.
   ([#1397](https://github.com/marmot-protocol/mdk/pull/1397))
 
 - App-runtime encrypted-media secret caching now skips the MLS group load,

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -20,10 +20,10 @@ versioning through the workspace version in the root `Cargo.toml`.
   the active blob remains memory-resident and one media request is bounded to
   512 MiB total.
 
-- One publish's relay fanout now goes out as a single concurrent batch instead
-  of one awaited relay at a time, so a slow relay no longer serially delays
-  every relay after it. The worst case drops from the sum of per-relay budgets
-  to one overall fanout budget per publish.
+- One publish's relay fanout now runs its per-relay attempts concurrently
+  instead of one awaited relay at a time, so a slow relay no longer serially
+  delays every relay after it. The worst case drops from the sum of per-relay
+  budgets to the slowest single relay's budget.
   ([#1397](https://github.com/marmot-protocol/mdk/pull/1397))
 
 - App-runtime encrypted-media secret caching now skips the MLS group load,

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -19,6 +19,13 @@ versioning through the workspace version in the root `Cargo.toml`.
   upgrade to this compatibility cohort before downloading blobs above 64 MiB;
   the active blob remains memory-resident and one media request is bounded to
   512 MiB total.
+
+- One publish's relay fanout now goes out as a single concurrent batch instead
+  of one awaited relay at a time, so a slow relay no longer serially delays
+  every relay after it. The worst case drops from the sum of per-relay budgets
+  to one overall fanout budget per publish.
+  ([#1397](https://github.com/marmot-protocol/mdk/pull/1397))
+
 - App-runtime encrypted-media secret caching now skips the MLS group load,
   exporter-secret derivation, and database write when the current epoch's
   secret is already cached, and the cache sweep's `required` pre-check uses

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -2489,49 +2489,53 @@ where
             .filter(|target| transport_fanout_target_retry_due(target, self.wall_clock.now()))
             .map(|target| target.endpoint.clone())
             .collect::<Vec<_>>();
-        for endpoint in remaining {
-            let target = publish_target_for_endpoint(&fanout.target, endpoint.clone());
+        if !remaining.is_empty() {
+            // One adapter call fans out to every retry-due endpoint
+            // concurrently; `required_acks` is the attempt count so the
+            // adapter does not abort the remainder once one relay accepts.
+            let target = publish_target_with_endpoints(&fanout.target, remaining.clone());
             match self
                 .adapter
                 .publish(TransportPublishRequest {
                     account_id: self.session.self_id(),
                     message: fanout.exact_message.clone(),
                     target,
-                    required_acks: 1,
+                    required_acks: remaining.len(),
                 })
                 .await
             {
                 Ok(report) => {
-                    apply_report_to_fanout(
-                        &mut fanout,
-                        std::slice::from_ref(&endpoint),
-                        &report,
-                        self.wall_clock.now(),
-                    );
-                    if !report.met_required_acks() {
-                        output.failures.push(PublishFailure {
-                            message_id: report.message_id.clone(),
-                            reason: "fanout endpoint did not acknowledge".into(),
-                        });
+                    apply_report_to_fanout(&mut fanout, &remaining, &report, self.wall_clock.now());
+                    for endpoint in &remaining {
+                        let accepted = report
+                            .accepted
+                            .iter()
+                            .any(|receipt| &receipt.endpoint == endpoint);
+                        if !accepted {
+                            output.failures.push(PublishFailure {
+                                message_id: report.message_id.clone(),
+                                reason: "fanout endpoint did not acknowledge".into(),
+                            });
+                        }
                     }
                     output.reports.push(report);
                 }
                 Err(_) => {
                     fanout.possible_exposure = true;
-                    if let Some(target) = fanout
+                    for target in fanout
                         .targets
                         .iter_mut()
-                        .find(|target| target.endpoint == endpoint)
+                        .filter(|target| remaining.contains(&target.endpoint))
                     {
                         target.attempt_count = target.attempt_count.saturating_add(1);
                         target.last_attempt_at = Some(self.wall_clock.now());
                         target.state = TransportFanoutAttemptState::AttemptedFailed;
                         target.failure_code = Some("adapter_error".into());
+                        output.failures.push(PublishFailure {
+                            message_id: message_id.clone(),
+                            reason: "fanout adapter error".into(),
+                        });
                     }
-                    output.failures.push(PublishFailure {
-                        message_id: message_id.clone(),
-                        reason: "fanout adapter error".into(),
-                    });
                 }
             }
             self.session.put_transport_fanout(&fanout)?;
@@ -2726,31 +2730,54 @@ where
         self.resolve_outbound_fanout_mls(&mut fanout, output, queue)
             .await?;
         let endpoints = fanout.request().target.endpoints().to_vec();
-        for index in fanout.outstanding_target_indexes() {
-            let endpoint = endpoints[index].clone();
-            fanout.mark_attempt_started(index)?;
+        let outstanding = fanout.outstanding_target_indexes();
+        if !outstanding.is_empty() {
+            for &index in &outstanding {
+                fanout.mark_attempt_started(index)?;
+            }
             self.session.put_outbound_fanout(&fanout)?;
 
+            // One adapter call fans out to every outstanding endpoint
+            // concurrently. `required_acks` is the attempt count — not the
+            // policy threshold — so the adapter waits for every endpoint
+            // instead of aborting the remainder once the threshold is met;
+            // the policy threshold is judged against the frozen record when
+            // the report below is built.
             let attempt = TransportPublishRequest {
                 account_id: fanout.request().account_id.clone(),
                 message: fanout.request().message.clone(),
-                target: single_endpoint_target(&fanout.request().target, endpoint.clone()),
-                required_acks: 1,
+                target: publish_target_with_endpoints(
+                    &fanout.request().target,
+                    outstanding
+                        .iter()
+                        .map(|&index| endpoints[index].clone())
+                        .collect(),
+                ),
+                required_acks: outstanding.len(),
             };
-            let accepted = match self.adapter.publish(attempt).await {
+            match self.adapter.publish(attempt).await {
                 Ok(report) => {
                     fanout.record_published_message_id(report.message_id)?;
-                    report
-                        .accepted
-                        .iter()
-                        .any(|receipt| receipt.endpoint == endpoint)
+                    for &index in &outstanding {
+                        let accepted = report
+                            .accepted
+                            .iter()
+                            .any(|receipt| receipt.endpoint == endpoints[index]);
+                        if accepted {
+                            fanout.mark_target_accepted(index)?;
+                        } else {
+                            fanout.mark_target_failed(index)?;
+                        }
+                    }
                 }
-                Err(_) => false,
-            };
-            if accepted {
-                fanout.mark_target_accepted(index)?;
-            } else {
-                fanout.mark_target_failed(index)?;
+                Err(_) => {
+                    // A whole-call adapter error is systemic (e.g. signing or
+                    // preparation), not endpoint-specific; per-endpoint
+                    // failures come back inside an `Ok` report.
+                    for &index in &outstanding {
+                        fanout.mark_target_failed(index)?;
+                    }
+                }
             }
             self.session.put_outbound_fanout(&fanout)?;
             self.resolve_outbound_fanout_mls(&mut fanout, output, queue)
@@ -3200,20 +3227,6 @@ where
             retry_deferred: false,
         })
     }
-}
-
-fn single_endpoint_target(
-    target: &TransportPublishTarget,
-    endpoint: TransportEndpoint,
-) -> TransportPublishTarget {
-    publish_target_with_endpoints(target, vec![endpoint])
-}
-
-fn publish_target_for_endpoint(
-    target: &TransportPublishTarget,
-    endpoint: TransportEndpoint,
-) -> TransportPublishTarget {
-    publish_target_with_endpoints(target, vec![endpoint])
 }
 
 fn publish_target_with_endpoints(

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -2490,47 +2490,50 @@ where
             .map(|target| target.endpoint.clone())
             .collect::<Vec<_>>();
         if !remaining.is_empty() {
-            // One adapter call fans out to every retry-due endpoint
-            // concurrently; `required_acks` is the attempt count so the
-            // adapter does not abort the remainder once one relay accepts.
-            let target = publish_target_with_endpoints(&fanout.target, remaining.clone());
-            match self
-                .adapter
-                .publish(TransportPublishRequest {
-                    account_id: self.session.self_id(),
+            // Concurrent single-endpoint publishes with `required_acks: 1`,
+            // the per-endpoint contract the old sequential loop used; see
+            // `drive_outbound_fanout` for why a multi-endpoint batch would
+            // turn partial acceptance into a whole-call error.
+            let adapter = &self.adapter;
+            let account_id = self.session.self_id();
+            let attempts = remaining.iter().map(|endpoint| {
+                let request = TransportPublishRequest {
+                    account_id: account_id.clone(),
                     message: fanout.exact_message.clone(),
-                    target,
-                    required_acks: remaining.len(),
-                })
-                .await
-            {
-                Ok(report) => {
-                    apply_report_to_fanout(&mut fanout, &remaining, &report, self.wall_clock.now());
-                    for endpoint in &remaining {
-                        let accepted = report
-                            .accepted
-                            .iter()
-                            .any(|receipt| &receipt.endpoint == endpoint);
-                        if !accepted {
+                    target: publish_target_with_endpoints(&fanout.target, vec![endpoint.clone()]),
+                    required_acks: 1,
+                };
+                async move { (endpoint.clone(), adapter.publish(request).await) }
+            });
+            for (endpoint, result) in futures::future::join_all(attempts).await {
+                match result {
+                    Ok(report) => {
+                        apply_report_to_fanout(
+                            &mut fanout,
+                            std::slice::from_ref(&endpoint),
+                            &report,
+                            self.wall_clock.now(),
+                        );
+                        if !report.met_required_acks() {
                             output.failures.push(PublishFailure {
                                 message_id: report.message_id.clone(),
                                 reason: "fanout endpoint did not acknowledge".into(),
                             });
                         }
+                        output.reports.push(report);
                     }
-                    output.reports.push(report);
-                }
-                Err(_) => {
-                    fanout.possible_exposure = true;
-                    for target in fanout
-                        .targets
-                        .iter_mut()
-                        .filter(|target| remaining.contains(&target.endpoint))
-                    {
-                        target.attempt_count = target.attempt_count.saturating_add(1);
-                        target.last_attempt_at = Some(self.wall_clock.now());
-                        target.state = TransportFanoutAttemptState::AttemptedFailed;
-                        target.failure_code = Some("adapter_error".into());
+                    Err(_) => {
+                        fanout.possible_exposure = true;
+                        if let Some(target) = fanout
+                            .targets
+                            .iter_mut()
+                            .find(|target| target.endpoint == endpoint)
+                        {
+                            target.attempt_count = target.attempt_count.saturating_add(1);
+                            target.last_attempt_at = Some(self.wall_clock.now());
+                            target.state = TransportFanoutAttemptState::AttemptedFailed;
+                            target.failure_code = Some("adapter_error".into());
+                        }
                         output.failures.push(PublishFailure {
                             message_id: message_id.clone(),
                             reason: "fanout adapter error".into(),
@@ -2737,46 +2740,45 @@ where
             }
             self.session.put_outbound_fanout(&fanout)?;
 
-            // One adapter call fans out to every outstanding endpoint
-            // concurrently. `required_acks` is the attempt count — not the
-            // policy threshold — so the adapter waits for every endpoint
-            // instead of aborting the remainder once the threshold is met;
-            // the policy threshold is judged against the frozen record when
-            // the report below is built.
-            let attempt = TransportPublishRequest {
-                account_id: fanout.request().account_id.clone(),
-                message: fanout.request().message.clone(),
-                target: publish_target_with_endpoints(
-                    &fanout.request().target,
-                    outstanding
-                        .iter()
-                        .map(|&index| endpoints[index].clone())
-                        .collect(),
-                ),
-                required_acks: outstanding.len(),
-            };
-            match self.adapter.publish(attempt).await {
-                Ok(report) => {
-                    fanout.record_published_message_id(report.message_id)?;
-                    for &index in &outstanding {
-                        let accepted = report
+            // Publish every outstanding endpoint concurrently as
+            // single-endpoint requests with `required_acks: 1`, the same
+            // per-endpoint contract the old sequential loop used. A
+            // multi-endpoint batch cannot be used here: the adapter treats an
+            // unmet `required_acks` as a whole-call error that discards the
+            // successful receipts, so an ordinary partial acceptance would
+            // read as "every endpoint failed" and roll back a commit that
+            // already reached a relay. Per-endpoint requests keep each
+            // endpoint's outcome independent while removing the
+            // one-awaited-ack-at-a-time serialization.
+            let adapter = &self.adapter;
+            let account_id = fanout.request().account_id.clone();
+            let attempts = outstanding.iter().map(|&index| {
+                let attempt = TransportPublishRequest {
+                    account_id: account_id.clone(),
+                    message: fanout.request().message.clone(),
+                    target: publish_target_with_endpoints(
+                        &fanout.request().target,
+                        vec![endpoints[index].clone()],
+                    ),
+                    required_acks: 1,
+                };
+                async move { (index, adapter.publish(attempt).await) }
+            });
+            for (index, result) in futures::future::join_all(attempts).await {
+                let accepted = match result {
+                    Ok(report) => {
+                        fanout.record_published_message_id(report.message_id)?;
+                        report
                             .accepted
                             .iter()
-                            .any(|receipt| receipt.endpoint == endpoints[index]);
-                        if accepted {
-                            fanout.mark_target_accepted(index)?;
-                        } else {
-                            fanout.mark_target_failed(index)?;
-                        }
+                            .any(|receipt| receipt.endpoint == endpoints[index])
                     }
-                }
-                Err(_) => {
-                    // A whole-call adapter error is systemic (e.g. signing or
-                    // preparation), not endpoint-specific; per-endpoint
-                    // failures come back inside an `Ok` report.
-                    for &index in &outstanding {
-                        fanout.mark_target_failed(index)?;
-                    }
+                    Err(_) => false,
+                };
+                if accepted {
+                    fanout.mark_target_accepted(index)?;
+                } else {
+                    fanout.mark_target_failed(index)?;
                 }
             }
             self.session.put_outbound_fanout(&fanout)?;

--- a/crates/marmot-account/tests/runtime.rs
+++ b/crates/marmot-account/tests/runtime.rs
@@ -338,9 +338,9 @@ struct RecordingAdapterInner {
     syncs: Mutex<Vec<TransportGroupSync>>,
     publishes: Mutex<Vec<TransportPublishRequest>>,
     accepted_counts: Mutex<VecDeque<usize>>,
+    accepted_endpoint_sets: Mutex<VecDeque<Vec<TransportEndpoint>>>,
     publish_errors: Mutex<VecDeque<bool>>,
     reported_message_ids: Mutex<VecDeque<MessageId>>,
-    timeout_pattern: Mutex<VecDeque<bool>>,
     welcome_gate: Mutex<Option<Arc<WelcomePublishGate>>>,
 }
 
@@ -379,16 +379,22 @@ impl RecordingAdapter {
             .push_back(accepted_count);
     }
 
+    /// Accept exactly this endpoint subset of the next publish call,
+    /// regardless of where those endpoints sit in the request's target.
+    fn accept_endpoints_next(&self, endpoints: Vec<TransportEndpoint>) {
+        self.inner
+            .accepted_endpoint_sets
+            .lock()
+            .unwrap()
+            .push_back(endpoints);
+    }
+
     fn report_message_id_next(&self, message_id: MessageId) {
         self.inner
             .reported_message_ids
             .lock()
             .unwrap()
             .push_back(message_id);
-    }
-
-    fn timeout_pattern(&self, pattern: impl IntoIterator<Item = bool>) {
-        self.inner.timeout_pattern.lock().unwrap().extend(pattern);
     }
 
     fn error_next(&self) {
@@ -447,13 +453,6 @@ impl TransportAdapter for RecordingAdapter {
             permit.forget();
             gate.active.fetch_sub(1, Ordering::SeqCst);
         }
-        let timed_out = self
-            .inner
-            .timeout_pattern
-            .lock()
-            .unwrap()
-            .pop_front()
-            .unwrap_or(false);
         let ambiguous_error = self
             .inner
             .publish_errors
@@ -461,15 +460,40 @@ impl TransportAdapter for RecordingAdapter {
             .unwrap()
             .pop_front()
             .unwrap_or(false);
-        if timed_out || ambiguous_error {
+        if ambiguous_error {
             return Err(TransportAdapterError::Publish(
-                if timed_out {
-                    "simulated timeout"
-                } else {
-                    "injected ambiguous adapter failure"
-                }
-                .into(),
+                "injected ambiguous adapter failure".into(),
             ));
+        }
+        let accepted_endpoints = self
+            .inner
+            .accepted_endpoint_sets
+            .lock()
+            .unwrap()
+            .pop_front();
+        if let Some(accepted_endpoints) = accepted_endpoints {
+            return Ok(TransportPublishReport {
+                message_id: self
+                    .inner
+                    .reported_message_ids
+                    .lock()
+                    .unwrap()
+                    .pop_front()
+                    .unwrap_or(request.message.id),
+                accepted: request
+                    .target
+                    .endpoints()
+                    .iter()
+                    .filter(|endpoint| accepted_endpoints.contains(endpoint))
+                    .cloned()
+                    .map(|endpoint| TransportEndpointReceipt {
+                        endpoint,
+                        accepted_at: None,
+                    })
+                    .collect(),
+                failed: Vec::new(),
+                required_acks: request.required_acks,
+            });
         }
         let accepted_count = self
             .inner
@@ -3310,8 +3334,9 @@ async fn group_evolution_confirms_pending_when_commit_was_partially_exposed() {
         .unwrap();
 
     let adapter = RecordingAdapter::default();
-    adapter.accept_next(1);
-    adapter.accept_next(0);
+    // The commit's batched fanout call: group-a accepts, group-b does not.
+    // The welcome publish afterwards falls back to accept-all.
+    adapter.accept_endpoints_next(vec![TransportEndpoint("wss://group-a.example".into())]);
     let policy =
         StaticTransportRouting::new(vec![TransportEndpoint("wss://alice-inbox.example".into())])
             .required_acks(2)
@@ -3368,17 +3393,13 @@ async fn group_evolution_confirms_pending_when_commit_was_partially_exposed() {
     );
 
     let publishes = adapter.publishes();
-    assert_eq!(publishes.len(), 3);
+    assert_eq!(publishes.len(), 2);
     assert!(matches!(
         publishes[0].message.envelope,
         TransportEnvelope::GroupMessage { .. }
     ));
     assert!(matches!(
         publishes[1].message.envelope,
-        TransportEnvelope::GroupMessage { .. }
-    ));
-    assert!(matches!(
-        publishes[2].message.envelope,
         TransportEnvelope::Welcome { .. }
     ));
 }

--- a/crates/marmot-account/tests/runtime.rs
+++ b/crates/marmot-account/tests/runtime.rs
@@ -338,7 +338,8 @@ struct RecordingAdapterInner {
     syncs: Mutex<Vec<TransportGroupSync>>,
     publishes: Mutex<Vec<TransportPublishRequest>>,
     accepted_counts: Mutex<VecDeque<usize>>,
-    accepted_endpoint_sets: Mutex<VecDeque<Vec<TransportEndpoint>>>,
+    accept_policy: Mutex<Option<Vec<TransportEndpoint>>>,
+    error_endpoints: Mutex<Vec<TransportEndpoint>>,
     publish_errors: Mutex<VecDeque<bool>>,
     reported_message_ids: Mutex<VecDeque<MessageId>>,
     welcome_gate: Mutex<Option<Arc<WelcomePublishGate>>>,
@@ -379,14 +380,17 @@ impl RecordingAdapter {
             .push_back(accepted_count);
     }
 
-    /// Accept exactly this endpoint subset of the next publish call,
-    /// regardless of where those endpoints sit in the request's target.
-    fn accept_endpoints_next(&self, endpoints: Vec<TransportEndpoint>) {
-        self.inner
-            .accepted_endpoint_sets
-            .lock()
-            .unwrap()
-            .push_back(endpoints);
+    /// Persistent endpoint accept policy: every publish call accepts exactly
+    /// the intersection of its target endpoints with this set. Deterministic
+    /// under concurrent single-endpoint publishes, unlike the FIFO knobs.
+    fn accept_only_endpoints(&self, endpoints: Vec<TransportEndpoint>) {
+        *self.inner.accept_policy.lock().unwrap() = Some(endpoints);
+    }
+
+    /// Persistent whole-call error policy: a publish call whose target
+    /// endpoints all sit in this set returns `Err` instead of a report.
+    fn error_for_endpoints(&self, endpoints: Vec<TransportEndpoint>) {
+        *self.inner.error_endpoints.lock().unwrap() = endpoints;
     }
 
     fn report_message_id_next(&self, message_id: MessageId) {
@@ -465,12 +469,21 @@ impl TransportAdapter for RecordingAdapter {
                 "injected ambiguous adapter failure".into(),
             ));
         }
-        let accepted_endpoints = self
-            .inner
-            .accepted_endpoint_sets
-            .lock()
-            .unwrap()
-            .pop_front();
+        {
+            let error_endpoints = self.inner.error_endpoints.lock().unwrap();
+            if !error_endpoints.is_empty()
+                && request
+                    .target
+                    .endpoints()
+                    .iter()
+                    .all(|endpoint| error_endpoints.contains(endpoint))
+            {
+                return Err(TransportAdapterError::Publish(
+                    "endpoint-policy adapter error".into(),
+                ));
+            }
+        }
+        let accepted_endpoints = self.inner.accept_policy.lock().unwrap().clone();
         if let Some(accepted_endpoints) = accepted_endpoints {
             return Ok(TransportPublishReport {
                 message_id: self
@@ -3334,9 +3347,13 @@ async fn group_evolution_confirms_pending_when_commit_was_partially_exposed() {
         .unwrap();
 
     let adapter = RecordingAdapter::default();
-    // The commit's batched fanout call: group-a accepts, group-b does not.
-    // The welcome publish afterwards falls back to accept-all.
-    adapter.accept_endpoints_next(vec![TransportEndpoint("wss://group-a.example".into())]);
+    // Endpoint policy: group-a accepts the commit, group-b does not, and both
+    // carol inbox endpoints accept the welcome.
+    adapter.accept_only_endpoints(vec![
+        TransportEndpoint("wss://group-a.example".into()),
+        TransportEndpoint("wss://carol-inbox-a.example".into()),
+        TransportEndpoint("wss://carol-inbox-b.example".into()),
+    ]);
     let policy =
         StaticTransportRouting::new(vec![TransportEndpoint("wss://alice-inbox.example".into())])
             .required_acks(2)
@@ -3393,13 +3410,17 @@ async fn group_evolution_confirms_pending_when_commit_was_partially_exposed() {
     );
 
     let publishes = adapter.publishes();
-    assert_eq!(publishes.len(), 2);
+    assert_eq!(publishes.len(), 3);
     assert!(matches!(
         publishes[0].message.envelope,
         TransportEnvelope::GroupMessage { .. }
     ));
     assert!(matches!(
         publishes[1].message.envelope,
+        TransportEnvelope::GroupMessage { .. }
+    ));
+    assert!(matches!(
+        publishes[2].message.envelope,
         TransportEnvelope::Welcome { .. }
     ));
 }

--- a/crates/marmot-account/tests/runtime/frozen_fanout.rs
+++ b/crates/marmot-account/tests/runtime/frozen_fanout.rs
@@ -1,17 +1,17 @@
 
 #[derive(Clone, Default)]
-struct CrashAfterFirstAcceptanceAdapter {
+struct CrashDuringFanoutPublishAdapter {
     publishes: Arc<Mutex<Vec<TransportPublishRequest>>>,
 }
 
-impl CrashAfterFirstAcceptanceAdapter {
+impl CrashDuringFanoutPublishAdapter {
     fn publishes(&self) -> Vec<TransportPublishRequest> {
         self.publishes.lock().unwrap().clone()
     }
 }
 
 #[async_trait]
-impl TransportAdapter for CrashAfterFirstAcceptanceAdapter {
+impl TransportAdapter for CrashDuringFanoutPublishAdapter {
     async fn activate_account(
         &self,
         _activation: TransportAccountActivation,
@@ -37,27 +37,10 @@ impl TransportAdapter for CrashAfterFirstAcceptanceAdapter {
         &self,
         request: TransportPublishRequest,
     ) -> Result<TransportPublishReport, TransportAdapterError> {
-        let call = {
-            let mut publishes = self.publishes.lock().unwrap();
-            publishes.push(request.clone());
-            publishes.len()
-        };
-        assert_ne!(call, 2, "simulated process crash after the first relay ack");
-        Ok(TransportPublishReport {
-            message_id: request.message.id,
-            accepted: request
-                .target
-                .endpoints()
-                .iter()
-                .cloned()
-                .map(|endpoint| TransportEndpointReceipt {
-                    endpoint,
-                    accepted_at: None,
-                })
-                .collect(),
-            failed: Vec::new(),
-            required_acks: request.required_acks,
-        })
+        self.publishes.lock().unwrap().push(request);
+        // The send-before-side-effect edge (`Attempting`) is already durable
+        // when the batched publish call runs; crash inside it.
+        panic!("simulated process crash during the batched fanout publish");
     }
 
     async fn receive(&self) -> Result<Option<TransportDelivery>, TransportAdapterError> {
@@ -65,7 +48,7 @@ impl TransportAdapter for CrashAfterFirstAcceptanceAdapter {
     }
 }
 
-async fn assert_frozen_fanout_case(accept_at: Option<usize>, timeout_at: Option<usize>) {
+async fn assert_frozen_fanout_case(accept_at: Option<usize>, adapter_error: bool) {
     let dir = tempfile::tempdir().unwrap();
     let key = SqlCipherKey::new("marmot fanout matrix key").unwrap();
     let mut alice = session(
@@ -99,11 +82,14 @@ async fn assert_frozen_fanout_case(accept_at: Option<usize>, timeout_at: Option<
         TransportEndpoint("wss://fanout-three.example".into()),
     ];
     let adapter = RecordingAdapter::default();
-    adapter.timeout_pattern((0..endpoints.len()).map(|index| timeout_at == Some(index)));
-    for index in 0..endpoints.len() {
-        if timeout_at != Some(index) {
-            adapter.accept_next(usize::from(accept_at == Some(index)));
-        }
+    if adapter_error {
+        adapter.error_next();
+    } else {
+        adapter.accept_endpoints_next(
+            accept_at
+                .map(|index| vec![endpoints[index].clone()])
+                .unwrap_or_default(),
+        );
     }
     let policy = StaticTransportRouting::new(vec![TransportEndpoint("wss://inbox.example".into())])
         .with_group_route(
@@ -127,7 +113,14 @@ async fn assert_frozen_fanout_case(accept_at: Option<usize>, timeout_at: Option<
         .await
         .unwrap();
 
-    assert_eq!(adapter.publishes().len(), endpoints.len());
+    // The whole outstanding fanout goes to the adapter as one batched call so
+    // endpoints are attempted concurrently instead of one awaited ack at a
+    // time; `required_acks` is the attempt count so the adapter does not
+    // abort the remainder once the policy threshold is met.
+    let publishes = adapter.publishes();
+    assert_eq!(publishes.len(), 1);
+    assert_eq!(publishes[0].target.endpoints(), endpoints.as_slice());
+    assert_eq!(publishes[0].required_acks, endpoints.len());
     assert_eq!(effects.reports.len(), 1);
     assert_eq!(effects.fanout.len(), 1);
     assert!(effects.fanout[0].fanout_complete);
@@ -167,13 +160,13 @@ async fn assert_frozen_fanout_case(accept_at: Option<usize>, timeout_at: Option<
 #[tokio::test]
 async fn frozen_fanout_first_middle_last_ack_and_all_fail_are_terminal() {
     for accept_at in [Some(0), Some(1), Some(2), None] {
-        assert_frozen_fanout_case(accept_at, None).await;
+        assert_frozen_fanout_case(accept_at, false).await;
     }
 }
 
 #[tokio::test]
-async fn frozen_fanout_mixed_ack_failure_and_timeout_still_completes() {
-    assert_frozen_fanout_case(Some(0), Some(1)).await;
+async fn frozen_fanout_whole_call_adapter_error_is_terminal() {
+    assert_frozen_fanout_case(None, true).await;
 }
 
 async fn assert_frozen_fanout_restart_edge(send_before_ack_persist: bool) {
@@ -288,17 +281,13 @@ async fn assert_frozen_fanout_restart_edge(send_before_ack_persist: bool) {
     assert_eq!(resumed.session().epoch(&group_id).unwrap().0, 2);
     let attempts = adapter.publishes();
     let resumed_attempts = &attempts[pre_restart_publish_count..];
-    assert_eq!(resumed_attempts.len(), endpoints.len());
+    // Every outstanding target — including the pre-restart `Attempting` one —
+    // resumes in a single batched adapter call over the frozen route.
+    assert_eq!(resumed_attempts.len(), 1);
     assert!(resumed_attempts.iter().all(|attempt| {
         attempt.message.id == message.id && attempt.message.payload == message.payload
     }));
-    assert_eq!(
-        resumed_attempts
-            .iter()
-            .flat_map(|attempt| attempt.target.endpoints())
-            .collect::<Vec<_>>(),
-        endpoints.iter().collect::<Vec<_>>()
-    );
+    assert_eq!(resumed_attempts[0].target.endpoints(), endpoints.as_slice());
 }
 
 #[tokio::test]
@@ -343,7 +332,7 @@ async fn frozen_fanout_survives_crash_and_ignores_changed_routing_on_resume() {
         TransportEndpoint("wss://original-two.example".into()),
         TransportEndpoint("wss://original-three.example".into()),
     ];
-    let crash_adapter = CrashAfterFirstAcceptanceAdapter::default();
+    let crash_adapter = CrashDuringFanoutPublishAdapter::default();
     let policy =
         StaticTransportRouting::new(vec![TransportEndpoint("wss://alice-inbox.example".into())])
             .with_group_route(
@@ -370,10 +359,10 @@ async fn frozen_fanout_survives_crash_and_ignores_changed_routing_on_resume() {
     assert!(crashed.unwrap_err().is_panic());
 
     let first_attempts = crash_adapter.publishes();
-    assert_eq!(first_attempts.len(), 2);
+    assert_eq!(first_attempts.len(), 1);
     assert_eq!(
         first_attempts[0].target.endpoints(),
-        &original_endpoints[..1]
+        original_endpoints.as_slice()
     );
     let frozen_id = first_attempts[0].message.id.clone();
     let frozen_bytes = first_attempts[0].message.payload.clone();
@@ -392,12 +381,12 @@ async fn frozen_fanout_survives_crash_and_ignores_changed_routing_on_resume() {
         assert_eq!(
             fanouts[0].target_statuses(),
             &[
-                FanoutTargetStatus::Accepted,
                 FanoutTargetStatus::Attempting,
-                FanoutTargetStatus::NotAttempted,
+                FanoutTargetStatus::Attempting,
+                FanoutTargetStatus::Attempting,
             ]
         );
-        assert_eq!(fanouts[0].mls_state(), FanoutMlsState::Confirmed);
+        assert!(matches!(fanouts[0].mls_state(), FanoutMlsState::Pending(_)));
     }
 
     let reopened = session(
@@ -429,13 +418,12 @@ async fn frozen_fanout_survives_crash_and_ignores_changed_routing_on_resume() {
     assert!(effects.fanout[0].fanout_complete);
 
     let resumed_attempts = resumed_adapter.publishes();
-    assert_eq!(resumed_attempts.len(), 2);
+    // The resumed fanout re-attempts every outstanding target in one batched
+    // call over the frozen route, ignoring the replacement routing policy.
+    assert_eq!(resumed_attempts.len(), 1);
     assert_eq!(
-        resumed_attempts
-            .iter()
-            .flat_map(|request| request.target.endpoints())
-            .collect::<Vec<_>>(),
-        vec![&original_endpoints[1], &original_endpoints[2]]
+        resumed_attempts[0].target.endpoints(),
+        original_endpoints.as_slice()
     );
     assert!(resumed_attempts.iter().all(|request| {
         request.message.id == frozen_id && request.message.payload == frozen_bytes
@@ -443,5 +431,5 @@ async fn frozen_fanout_survives_crash_and_ignores_changed_routing_on_resume() {
 
     let duplicate_resume = resumed.resume_outbound_fanouts().await.unwrap();
     assert!(duplicate_resume.reports.is_empty());
-    assert_eq!(resumed_adapter.publishes().len(), 2);
+    assert_eq!(resumed_adapter.publishes().len(), 1);
 }

--- a/crates/marmot-account/tests/runtime/frozen_fanout.rs
+++ b/crates/marmot-account/tests/runtime/frozen_fanout.rs
@@ -39,8 +39,9 @@ impl TransportAdapter for CrashDuringFanoutPublishAdapter {
     ) -> Result<TransportPublishReport, TransportAdapterError> {
         self.publishes.lock().unwrap().push(request);
         // The send-before-side-effect edge (`Attempting`) is already durable
-        // when the batched publish call runs; crash inside it.
-        panic!("simulated process crash during the batched fanout publish");
+        // for every target when the concurrent publishes run; crash inside
+        // the first one polled.
+        panic!("simulated process crash during the fanout publish");
     }
 
     async fn receive(&self) -> Result<Option<TransportDelivery>, TransportAdapterError> {
@@ -48,7 +49,7 @@ impl TransportAdapter for CrashDuringFanoutPublishAdapter {
     }
 }
 
-async fn assert_frozen_fanout_case(accept_at: Option<usize>, adapter_error: bool) {
+async fn assert_frozen_fanout_case(accept_at: Option<usize>, error_at: &[usize]) {
     let dir = tempfile::tempdir().unwrap();
     let key = SqlCipherKey::new("marmot fanout matrix key").unwrap();
     let mut alice = session(
@@ -82,15 +83,21 @@ async fn assert_frozen_fanout_case(accept_at: Option<usize>, adapter_error: bool
         TransportEndpoint("wss://fanout-three.example".into()),
     ];
     let adapter = RecordingAdapter::default();
-    if adapter_error {
-        adapter.error_next();
-    } else {
-        adapter.accept_endpoints_next(
-            accept_at
-                .map(|index| vec![endpoints[index].clone()])
-                .unwrap_or_default(),
-        );
-    }
+    adapter.accept_only_endpoints(
+        accept_at
+            .map(|index| vec![endpoints[index].clone()])
+            .unwrap_or_default(),
+    );
+    // The production adapter surfaces a rejected/unreachable relay as a
+    // whole-call `Err` on that endpoint's single-endpoint publish (an unmet
+    // `required_acks: 1` discards the report), so error endpoints model the
+    // real contract rather than an `Ok` report with no receipt.
+    adapter.error_for_endpoints(
+        error_at
+            .iter()
+            .map(|&index| endpoints[index].clone())
+            .collect(),
+    );
     let policy = StaticTransportRouting::new(vec![TransportEndpoint("wss://inbox.example".into())])
         .with_group_route(
             group_id.clone(),
@@ -113,14 +120,21 @@ async fn assert_frozen_fanout_case(accept_at: Option<usize>, adapter_error: bool
         .await
         .unwrap();
 
-    // The whole outstanding fanout goes to the adapter as one batched call so
-    // endpoints are attempted concurrently instead of one awaited ack at a
-    // time; `required_acks` is the attempt count so the adapter does not
-    // abort the remainder once the policy threshold is met.
+    // Every outstanding endpoint is attempted as its own concurrent
+    // single-endpoint publish with `required_acks: 1` — the per-endpoint
+    // adapter contract — instead of one awaited ack at a time. Completion
+    // order is nondeterministic, so compare the attempted set.
     let publishes = adapter.publishes();
-    assert_eq!(publishes.len(), 1);
-    assert_eq!(publishes[0].target.endpoints(), endpoints.as_slice());
-    assert_eq!(publishes[0].required_acks, endpoints.len());
+    assert_eq!(publishes.len(), endpoints.len());
+    let mut attempted = publishes
+        .iter()
+        .flat_map(|publish| publish.target.endpoints().to_vec())
+        .collect::<Vec<_>>();
+    attempted.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut expected = endpoints.clone();
+    expected.sort_by(|a, b| a.0.cmp(&b.0));
+    assert_eq!(attempted, expected);
+    assert!(publishes.iter().all(|publish| publish.required_acks == 1));
     assert_eq!(effects.reports.len(), 1);
     assert_eq!(effects.fanout.len(), 1);
     assert!(effects.fanout[0].fanout_complete);
@@ -160,13 +174,23 @@ async fn assert_frozen_fanout_case(accept_at: Option<usize>, adapter_error: bool
 #[tokio::test]
 async fn frozen_fanout_first_middle_last_ack_and_all_fail_are_terminal() {
     for accept_at in [Some(0), Some(1), Some(2), None] {
-        assert_frozen_fanout_case(accept_at, false).await;
+        assert_frozen_fanout_case(accept_at, &[]).await;
     }
 }
 
 #[tokio::test]
-async fn frozen_fanout_whole_call_adapter_error_is_terminal() {
-    assert_frozen_fanout_case(None, true).await;
+async fn frozen_fanout_whole_call_adapter_errors_are_terminal() {
+    assert_frozen_fanout_case(None, &[0, 1, 2]).await;
+}
+
+/// The production-adapter partial-accept shape: one relay accepts while its
+/// siblings surface whole-call `Err`s. The accepted endpoint must stay
+/// accepted and confirm pending MLS state — sibling errors must never read as
+/// "everything failed".
+#[tokio::test]
+async fn frozen_fanout_partial_accept_with_sibling_adapter_errors_confirms_mls() {
+    assert_frozen_fanout_case(Some(0), &[1, 2]).await;
+    assert_frozen_fanout_case(Some(2), &[0, 1]).await;
 }
 
 async fn assert_frozen_fanout_restart_edge(send_before_ack_persist: bool) {
@@ -282,12 +306,19 @@ async fn assert_frozen_fanout_restart_edge(send_before_ack_persist: bool) {
     let attempts = adapter.publishes();
     let resumed_attempts = &attempts[pre_restart_publish_count..];
     // Every outstanding target — including the pre-restart `Attempting` one —
-    // resumes in a single batched adapter call over the frozen route.
-    assert_eq!(resumed_attempts.len(), 1);
+    // resumes as concurrent single-endpoint publishes over the frozen route.
+    assert_eq!(resumed_attempts.len(), endpoints.len());
     assert!(resumed_attempts.iter().all(|attempt| {
         attempt.message.id == message.id && attempt.message.payload == message.payload
     }));
-    assert_eq!(resumed_attempts[0].target.endpoints(), endpoints.as_slice());
+    let mut resumed_endpoints = resumed_attempts
+        .iter()
+        .flat_map(|attempt| attempt.target.endpoints().to_vec())
+        .collect::<Vec<_>>();
+    resumed_endpoints.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut expected = endpoints.clone();
+    expected.sort_by(|a, b| a.0.cmp(&b.0));
+    assert_eq!(resumed_endpoints, expected);
 }
 
 #[tokio::test]
@@ -358,11 +389,13 @@ async fn frozen_fanout_survives_crash_and_ignores_changed_routing_on_resume() {
     .await;
     assert!(crashed.unwrap_err().is_panic());
 
+    // `join_all` polls the per-endpoint publishes in order; the crash lands
+    // in the first one, before its siblings are polled.
     let first_attempts = crash_adapter.publishes();
     assert_eq!(first_attempts.len(), 1);
     assert_eq!(
         first_attempts[0].target.endpoints(),
-        original_endpoints.as_slice()
+        &original_endpoints[..1]
     );
     let frozen_id = first_attempts[0].message.id.clone();
     let frozen_bytes = first_attempts[0].message.payload.clone();
@@ -418,18 +451,23 @@ async fn frozen_fanout_survives_crash_and_ignores_changed_routing_on_resume() {
     assert!(effects.fanout[0].fanout_complete);
 
     let resumed_attempts = resumed_adapter.publishes();
-    // The resumed fanout re-attempts every outstanding target in one batched
-    // call over the frozen route, ignoring the replacement routing policy.
-    assert_eq!(resumed_attempts.len(), 1);
-    assert_eq!(
-        resumed_attempts[0].target.endpoints(),
-        original_endpoints.as_slice()
-    );
+    // The resumed fanout re-attempts every outstanding target as concurrent
+    // single-endpoint publishes over the frozen route, ignoring the
+    // replacement routing policy.
+    assert_eq!(resumed_attempts.len(), original_endpoints.len());
+    let mut resumed_endpoints = resumed_attempts
+        .iter()
+        .flat_map(|request| request.target.endpoints().to_vec())
+        .collect::<Vec<_>>();
+    resumed_endpoints.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut expected = original_endpoints.clone();
+    expected.sort_by(|a, b| a.0.cmp(&b.0));
+    assert_eq!(resumed_endpoints, expected);
     assert!(resumed_attempts.iter().all(|request| {
         request.message.id == frozen_id && request.message.payload == frozen_bytes
     }));
 
     let duplicate_resume = resumed.resume_outbound_fanouts().await.unwrap();
     assert!(duplicate_resume.reports.is_empty());
-    assert_eq!(resumed_adapter.publishes().len(), 1);
+    assert_eq!(resumed_adapter.publishes().len(), original_endpoints.len());
 }


### PR DESCRIPTION
A publish's relay fanout previously went out one relay at a time: `drive_outbound_fanout` looped over endpoints, publishing to each with `required_acks: 1` and awaiting the ack before the next call. With per-relay budgets of 5 s connect plus 12 s publish wait across 3 attempts, one bad relay could stall a send for minutes.

This marmot now dispatches to all pigeons at once: every outstanding endpoint is published concurrently as its own single-endpoint request with `required_acks: 1`, joined with `futures::future::join_all`. That is the exact per-endpoint adapter contract the old loop used, so endpoint outcomes stay independent; only the one-awaited-ack-at-a-time serialization is gone. The first version of this PR sent one multi-endpoint batch with `required_acks` set to the attempt count; review caught that the production adapter turns an unmet `required_acks` into a whole-call error that discards successful receipts, which would have read an ordinary partial acceptance as total failure and rolled back a commit that had already reached a relay.

- `drive_outbound_fanout` marks every outstanding endpoint `Attempting`, persists the frozen record once, publishes them concurrently, then applies each endpoint's own `Ok`/`Err` outcome and persists once.
- `finish_transport_fanout`, the retry-remainder path, uses the same shape.
- The dead single-endpoint target helpers are removed.

Fanout no longer waits sequentially: its duration can approach the slowest individual attempt's budget when the transport makes concurrent progress, instead of the sum of per-relay budgets. The common case is one relay round trip.

Tests: the recording adapter gains persistent endpoint-keyed accept/error policies (deterministic under concurrent calls, unlike FIFO knobs), the fanout matrix covers first/middle/last/none acceptance plus whole-call adapter errors, a new regression test covers the production partial-accept shape (one relay accepts while siblings return whole-call errors, and pending MLS state still confirms), and the crash-resume test asserts resume re-attempts every outstanding target over the frozen route while ignoring changed routing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Relay and group-message delivery now publishes to multiple endpoints concurrently, reducing delivery delays.
  * Retry and recovery operations process outstanding destinations together rather than sequentially.

* **Reliability**
  * Individual endpoint results remain tracked during fanout, including partial successes and failures.
  * Improved crash recovery preserves delivery progress and safely resumes outstanding destinations.
  * Duplicate recovery attempts avoid repeating already completed deliveries.
  * Delivery continues correctly across terminal, failed, and partially accepted fanout attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->