### PR TITLE
Expose message reactions to agents

### DIFF
--- a/crates/agent-connector/src/connection.rs
+++ b/crates/agent-connector/src/connection.rs
@@ -306,11 +306,13 @@ impl AgentConnector {
                 account_id_hex,
                 group_id_hex,
                 target_message_id_hex,
+                emoji,
             } => {
                 self.remove_reaction_response(
                     &account_id_hex,
                     &group_id_hex,
                     &target_message_id_hex,
+                    emoji.as_deref(),
                 )
                 .await
             }

--- a/crates/agent-connector/src/connection.rs
+++ b/crates/agent-connector/src/connection.rs
@@ -288,6 +288,32 @@ impl AgentConnector {
                 self.delete_message_response(&account_id_hex, &group_id_hex, &target_message_id_hex)
                     .await
             }
+            AgentControlRequest::SendReaction {
+                account_id_hex,
+                group_id_hex,
+                target_message_id_hex,
+                emoji,
+            } => {
+                self.send_reaction_response(
+                    &account_id_hex,
+                    &group_id_hex,
+                    &target_message_id_hex,
+                    &emoji,
+                )
+                .await
+            }
+            AgentControlRequest::RemoveReaction {
+                account_id_hex,
+                group_id_hex,
+                target_message_id_hex,
+            } => {
+                self.remove_reaction_response(
+                    &account_id_hex,
+                    &group_id_hex,
+                    &target_message_id_hex,
+                )
+                .await
+            }
             AgentControlRequest::StreamBegin {
                 account_id_hex,
                 group_id_hex,

--- a/crates/agent-connector/src/error.rs
+++ b/crates/agent-connector/src/error.rs
@@ -50,6 +50,7 @@ impl ConnectorError {
     pub fn code(&self) -> &'static str {
         match self {
             Self::AccountHome(_) => "account_home_error",
+            Self::App(AppError::ReactionNotFound) => "reaction_not_found",
             Self::App(_) => "app_error",
             Self::Control(_) => "control_error",
             Self::Hex(_) => "invalid_hex",
@@ -93,6 +94,7 @@ impl ConnectorError {
                 "stream begin request id was reused with different inputs"
             }
             Self::Io(_) => "connector I/O failed",
+            Self::App(AppError::ReactionNotFound) => "no matching reaction to remove",
             Self::AccountHome(_) | Self::App(_) => "connector request failed",
         }
     }

--- a/crates/agent-connector/src/messaging.rs
+++ b/crates/agent-connector/src/messaging.rs
@@ -284,6 +284,47 @@ impl AgentConnector {
         })
     }
 
+    pub(crate) async fn send_reaction_response(
+        &self,
+        account_id_hex: &str,
+        group_id_hex: &str,
+        target_message_id_hex: &str,
+        emoji: &str,
+    ) -> Result<AgentControlResponse, ConnectorError> {
+        let account = self.local_account_for_account_id(account_id_hex)?;
+        let group_id_hex = normalize_hex(group_id_hex)?;
+        let group_id = GroupId::new(hex::decode(&group_id_hex)?);
+        let target_message_id = normalize_hex(target_message_id_hex)?;
+        let summary = self
+            .runtime
+            .react_to_message(&account.label, &group_id, &target_message_id, emoji)
+            .await?;
+        Ok(AgentControlResponse::AppEventSent {
+            message_ids_hex: summary.message_ids,
+            maintenance_disposition: agent_maintenance_disposition(summary.maintenance_disposition),
+        })
+    }
+
+    pub(crate) async fn remove_reaction_response(
+        &self,
+        account_id_hex: &str,
+        group_id_hex: &str,
+        target_message_id_hex: &str,
+    ) -> Result<AgentControlResponse, ConnectorError> {
+        let account = self.local_account_for_account_id(account_id_hex)?;
+        let group_id_hex = normalize_hex(group_id_hex)?;
+        let group_id = GroupId::new(hex::decode(&group_id_hex)?);
+        let target_message_id = normalize_hex(target_message_id_hex)?;
+        let summary = self
+            .runtime
+            .unreact_from_message(&account.label, &group_id, &target_message_id)
+            .await?;
+        Ok(AgentControlResponse::AppEventSent {
+            message_ids_hex: summary.message_ids,
+            maintenance_disposition: agent_maintenance_disposition(summary.maintenance_disposition),
+        })
+    }
+
     /// Report group membership for an account's group so a channel can decide
     /// activation policy: `is_direct` (exactly two members, i.e. an effective DM
     /// where the agent always replies) vs a multi-party group that gates on

--- a/crates/agent-connector/src/messaging.rs
+++ b/crates/agent-connector/src/messaging.rs
@@ -310,6 +310,7 @@ impl AgentConnector {
         account_id_hex: &str,
         group_id_hex: &str,
         target_message_id_hex: &str,
+        emoji: Option<&str>,
     ) -> Result<AgentControlResponse, ConnectorError> {
         let account = self.local_account_for_account_id(account_id_hex)?;
         let group_id_hex = normalize_hex(group_id_hex)?;
@@ -317,7 +318,7 @@ impl AgentConnector {
         let target_message_id = normalize_hex(target_message_id_hex)?;
         let summary = self
             .runtime
-            .unreact_from_message(&account.label, &group_id, &target_message_id)
+            .unreact_from_message_matching(&account.label, &group_id, &target_message_id, emoji)
             .await?;
         Ok(AgentControlResponse::AppEventSent {
             message_ids_hex: summary.message_ids,

--- a/crates/agent-connector/src/tests.rs
+++ b/crates/agent-connector/src/tests.rs
@@ -1193,13 +1193,50 @@ async fn connector_socket_subscribes_to_inbound_messages() {
     assert_eq!(reaction_message_ids.len(), 1);
     assert!(!reaction_message_ids[0].is_empty());
 
+    let repeated_add = send_control_request(
+        &socket,
+        "req-agent-reaction-add-retry",
+        AgentControlRequest::SendReaction {
+            account_id_hex: agent.account.account_id_hex.clone(),
+            group_id_hex: group_id_hex.clone(),
+            target_message_id_hex: human_message_id_hex.clone(),
+            emoji: "👀".to_owned(),
+        },
+    )
+    .await;
+    let AgentControlResponse::AppEventSent {
+        message_ids_hex: repeated_message_ids,
+        ..
+    } = repeated_add.payload
+    else {
+        panic!("expected idempotent reaction add response");
+    };
+    assert_eq!(repeated_message_ids, reaction_message_ids);
+
+    let completion_added = send_control_request(
+        &socket,
+        "req-agent-reaction-add-completion",
+        AgentControlRequest::SendReaction {
+            account_id_hex: agent.account.account_id_hex.clone(),
+            group_id_hex: group_id_hex.clone(),
+            target_message_id_hex: human_message_id_hex.clone(),
+            emoji: "✅".to_owned(),
+        },
+    )
+    .await;
+    assert!(matches!(
+        completion_added.payload,
+        AgentControlResponse::AppEventSent { .. }
+    ));
+
     let reaction_removed = send_control_request(
         &socket,
-        "req-agent-reaction-remove",
+        "req-agent-reaction-remove-matching",
         AgentControlRequest::RemoveReaction {
             account_id_hex: agent.account.account_id_hex.clone(),
             group_id_hex: group_id_hex.clone(),
             target_message_id_hex: human_message_id_hex.clone(),
+            emoji: Some("👀".to_owned()),
         },
     )
     .await;
@@ -1215,16 +1252,49 @@ async fn connector_socket_subscribes_to_inbound_messages() {
 
     let repeated_removal = send_control_request(
         &socket,
-        "req-agent-reaction-remove-repeat",
+        "req-agent-reaction-remove-matching-repeat",
         AgentControlRequest::RemoveReaction {
             account_id_hex: agent.account.account_id_hex.clone(),
             group_id_hex: group_id_hex.clone(),
             target_message_id_hex: human_message_id_hex.clone(),
+            emoji: Some("👀".to_owned()),
         },
     )
     .await;
     let AgentControlResponse::Error { code, .. } = repeated_removal.payload else {
         panic!("expected missing-reaction error on repeated removal");
+    };
+    assert_eq!(code, "reaction_not_found");
+
+    let remaining_removed = send_control_request(
+        &socket,
+        "req-agent-reaction-remove-all",
+        AgentControlRequest::RemoveReaction {
+            account_id_hex: agent.account.account_id_hex.clone(),
+            group_id_hex: group_id_hex.clone(),
+            target_message_id_hex: human_message_id_hex.clone(),
+            emoji: None,
+        },
+    )
+    .await;
+    assert!(matches!(
+        remaining_removed.payload,
+        AgentControlResponse::AppEventSent { .. }
+    ));
+
+    let repeated_remove_all = send_control_request(
+        &socket,
+        "req-agent-reaction-remove-all-repeat",
+        AgentControlRequest::RemoveReaction {
+            account_id_hex: agent.account.account_id_hex.clone(),
+            group_id_hex: group_id_hex.clone(),
+            target_message_id_hex: human_message_id_hex.clone(),
+            emoji: None,
+        },
+    )
+    .await;
+    let AgentControlResponse::Error { code, .. } = repeated_remove_all.payload else {
+        panic!("expected missing-reaction error after removing all reactions");
     };
     assert_eq!(code, "reaction_not_found");
 

--- a/crates/agent-connector/src/tests.rs
+++ b/crates/agent-connector/src/tests.rs
@@ -1165,6 +1165,47 @@ async fn connector_socket_subscribes_to_inbound_messages() {
     assert!(!reply_to.text_truncated);
     assert!(reply_to.recorded_at.is_some());
 
+    let reaction_added = send_control_request(
+        &socket,
+        "req-agent-reaction-add",
+        AgentControlRequest::SendReaction {
+            account_id_hex: agent.account.account_id_hex.clone(),
+            group_id_hex: group_id_hex.clone(),
+            target_message_id_hex: human_message_id_hex.clone(),
+            emoji: "👀".to_owned(),
+        },
+    )
+    .await;
+    let AgentControlResponse::AppEventSent {
+        message_ids_hex: reaction_message_ids,
+        ..
+    } = reaction_added.payload
+    else {
+        panic!("expected reaction add response");
+    };
+    assert_eq!(reaction_message_ids.len(), 1);
+    assert!(!reaction_message_ids[0].is_empty());
+
+    let reaction_removed = send_control_request(
+        &socket,
+        "req-agent-reaction-remove",
+        AgentControlRequest::RemoveReaction {
+            account_id_hex: agent.account.account_id_hex.clone(),
+            group_id_hex: group_id_hex.clone(),
+            target_message_id_hex: human_message_id_hex.clone(),
+        },
+    )
+    .await;
+    let AgentControlResponse::AppEventSent {
+        message_ids_hex: removal_message_ids,
+        ..
+    } = reaction_removed.payload
+    else {
+        panic!("expected reaction remove response");
+    };
+    assert_eq!(removal_message_ids.len(), 1);
+    assert!(!removal_message_ids[0].is_empty());
+
     let deleted = send_control_request(
         &socket,
         "req-human-delete",

--- a/crates/agent-connector/src/tests.rs
+++ b/crates/agent-connector/src/tests.rs
@@ -86,6 +86,13 @@ fn send_in_progress_has_a_distinct_retry_contract() {
     );
 }
 
+#[test]
+fn reaction_not_found_has_a_distinct_idempotency_contract() {
+    let error = crate::ConnectorError::App(marmot_app::AppError::ReactionNotFound);
+    assert_eq!(error.code(), "reaction_not_found");
+    assert_eq!(error.client_message(), "no matching reaction to remove");
+}
+
 #[tokio::test]
 async fn control_frame_write_timeout_includes_flush() {
     struct FlushStallingWriter;

--- a/crates/agent-connector/src/tests.rs
+++ b/crates/agent-connector/src/tests.rs
@@ -1213,6 +1213,21 @@ async fn connector_socket_subscribes_to_inbound_messages() {
     assert_eq!(removal_message_ids.len(), 1);
     assert!(!removal_message_ids[0].is_empty());
 
+    let repeated_removal = send_control_request(
+        &socket,
+        "req-agent-reaction-remove-repeat",
+        AgentControlRequest::RemoveReaction {
+            account_id_hex: agent.account.account_id_hex.clone(),
+            group_id_hex: group_id_hex.clone(),
+            target_message_id_hex: human_message_id_hex.clone(),
+        },
+    )
+    .await;
+    let AgentControlResponse::Error { code, .. } = repeated_removal.payload else {
+        panic!("expected missing-reaction error on repeated removal");
+    };
+    assert_eq!(code, "reaction_not_found");
+
     let deleted = send_control_request(
         &socket,
         "req-human-delete",

--- a/crates/agent-connector/src/validation.rs
+++ b/crates/agent-connector/src/validation.rs
@@ -106,6 +106,8 @@ pub(crate) fn agent_control_request_type(request: &AgentControlRequest) -> &'sta
         AgentControlRequest::TimelineList { .. } => "timeline_list",
         AgentControlRequest::SendFinal { .. } => "send_final",
         AgentControlRequest::DeleteMessage { .. } => "delete_message",
+        AgentControlRequest::SendReaction { .. } => "send_reaction",
+        AgentControlRequest::RemoveReaction { .. } => "remove_reaction",
         AgentControlRequest::StreamBegin { .. } => "stream_begin",
         AgentControlRequest::StreamAppend { .. } => "stream_append",
         AgentControlRequest::StreamStatus { .. } => "stream_status",

--- a/crates/agent-control/README.md
+++ b/crates/agent-control/README.md
@@ -27,6 +27,10 @@ begin inputs is an error, and trying to begin another active stream with an occu
 - Provides newline-delimited JSON framing with a 1 MiB per-frame cap.
 - Stays dependency-light: `serde` and Tokio IO only.
 
+`send_reaction` adds arbitrary non-blank reaction content to a durable message.
+`remove_reaction` takes the original target message id and retracts the calling
+account's matching reaction; callers do not need to discover the reaction event id.
+
 ## Materialized timeline reads
 
 `timeline_message_get` resolves one durable message id and `timeline_list` pages a

--- a/crates/agent-control/README.md
+++ b/crates/agent-control/README.md
@@ -30,7 +30,9 @@ begin inputs is an error, and trying to begin another active stream with an occu
 `send_reaction` adds arbitrary non-blank, control-free reaction content of at
 most 64 Unicode scalar values to a durable message.
 `remove_reaction` takes the original target message id and retracts the calling
-account's matching reaction; callers do not need to discover the reaction event id.
+account's most recent active reaction on that message, whichever reaction
+content it carries; callers do not need to discover the reaction event id. To
+swap a progress reaction for a completion reaction, remove first and then add.
 
 ## Materialized timeline reads
 

--- a/crates/agent-control/README.md
+++ b/crates/agent-control/README.md
@@ -28,11 +28,13 @@ begin inputs is an error, and trying to begin another active stream with an occu
 - Stays dependency-light: `serde` and Tokio IO only.
 
 `send_reaction` adds arbitrary non-blank, control-free reaction content of at
-most 64 Unicode scalar values to a durable message.
-`remove_reaction` takes the original target message id and retracts the calling
-account's most recent active reaction on that message, whichever reaction
-content it carries; callers do not need to discover the reaction event id. To
-swap a progress reaction for a completion reaction, remove first and then add.
+most 64 Unicode scalar values to a durable message. Repeating the same content
+from the same account on the same target is idempotent and returns the existing
+reaction id instead of publishing a duplicate.
+`remove_reaction` takes the original target message id; callers do not need to
+discover reaction event ids. An optional `emoji` retracts all of the calling
+account's active reactions with that exact content. Omitting `emoji` retracts
+all of the account's active reactions on the target in one durable delete event.
 
 ## Materialized timeline reads
 

--- a/crates/agent-control/README.md
+++ b/crates/agent-control/README.md
@@ -27,7 +27,8 @@ begin inputs is an error, and trying to begin another active stream with an occu
 - Provides newline-delimited JSON framing with a 1 MiB per-frame cap.
 - Stays dependency-light: `serde` and Tokio IO only.
 
-`send_reaction` adds arbitrary non-blank reaction content to a durable message.
+`send_reaction` adds arbitrary non-blank, control-free reaction content of at
+most 64 Unicode scalar values to a durable message.
 `remove_reaction` takes the original target message id and retracts the calling
 account's matching reaction; callers do not need to discover the reaction event id.
 

--- a/crates/agent-control/src/lib.rs
+++ b/crates/agent-control/src/lib.rs
@@ -115,6 +115,19 @@ pub enum AgentControlRequest {
         group_id_hex: String,
         target_message_id_hex: String,
     },
+    /// Add an arbitrary non-blank reaction to a durable message.
+    SendReaction {
+        account_id_hex: String,
+        group_id_hex: String,
+        target_message_id_hex: String,
+        emoji: String,
+    },
+    /// Retract this account's reaction to a durable message.
+    RemoveReaction {
+        account_id_hex: String,
+        group_id_hex: String,
+        target_message_id_hex: String,
+    },
     StreamBegin {
         account_id_hex: String,
         group_id_hex: String,
@@ -933,6 +946,37 @@ mod tests {
     }
 
     #[test]
+    fn reaction_requests_have_stable_wire_shapes() {
+        let send = AgentControlRequest::SendReaction {
+            account_id_hex: account(),
+            group_id_hex: group(),
+            target_message_id_hex: message(),
+            emoji: "👀".to_owned(),
+        };
+        let value = serde_json::to_value(&send).unwrap();
+        assert_eq!(value["type"], "send_reaction");
+        assert_eq!(value["emoji"], "👀");
+        assert_eq!(value["target_message_id_hex"], message());
+        assert_eq!(
+            serde_json::from_value::<AgentControlRequest>(value).unwrap(),
+            send
+        );
+
+        let remove = AgentControlRequest::RemoveReaction {
+            account_id_hex: account(),
+            group_id_hex: group(),
+            target_message_id_hex: message(),
+        };
+        let value = serde_json::to_value(&remove).unwrap();
+        assert_eq!(value["type"], "remove_reaction");
+        assert!(value.get("emoji").is_none());
+        assert_eq!(
+            serde_json::from_value::<AgentControlRequest>(value).unwrap(),
+            remove
+        );
+    }
+
+    #[test]
     fn send_final_idempotency_key_is_omitted_when_absent_and_present_when_set() {
         // Optional field: omitted from the wire when None; present and
         // round-tripping when
@@ -1262,6 +1306,23 @@ mod tests {
                     target_message_id_hex: message(),
                 },
                 "delete_message",
+            ),
+            (
+                AgentControlRequest::SendReaction {
+                    account_id_hex: account(),
+                    group_id_hex: group(),
+                    target_message_id_hex: message(),
+                    emoji: "👀".to_owned(),
+                },
+                "send_reaction",
+            ),
+            (
+                AgentControlRequest::RemoveReaction {
+                    account_id_hex: account(),
+                    group_id_hex: group(),
+                    target_message_id_hex: message(),
+                },
+                "remove_reaction",
             ),
             (
                 AgentControlRequest::StreamBegin {

--- a/crates/agent-control/src/lib.rs
+++ b/crates/agent-control/src/lib.rs
@@ -115,7 +115,7 @@ pub enum AgentControlRequest {
         group_id_hex: String,
         target_message_id_hex: String,
     },
-    /// Add an arbitrary non-blank reaction to a durable message.
+    /// Add bounded, control-free, non-blank reaction content to a durable message.
     SendReaction {
         account_id_hex: String,
         group_id_hex: String,

--- a/crates/agent-control/src/lib.rs
+++ b/crates/agent-control/src/lib.rs
@@ -122,12 +122,16 @@ pub enum AgentControlRequest {
         target_message_id_hex: String,
         emoji: String,
     },
-    /// Retract this account's most recent active reaction to a durable message,
-    /// whichever reaction content it carries.
+    /// Retract this account's active reactions from a durable message. When
+    /// `emoji` is present, only active reactions with that exact content are
+    /// retracted; when absent, all of this account's active reactions on the
+    /// target are retracted in one durable delete event.
     RemoveReaction {
         account_id_hex: String,
         group_id_hex: String,
         target_message_id_hex: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        emoji: Option<String>,
     },
     StreamBegin {
         account_id_hex: String,
@@ -967,6 +971,7 @@ mod tests {
             account_id_hex: account(),
             group_id_hex: group(),
             target_message_id_hex: message(),
+            emoji: None,
         };
         let value = serde_json::to_value(&remove).unwrap();
         assert_eq!(value["type"], "remove_reaction");
@@ -974,6 +979,19 @@ mod tests {
         assert_eq!(
             serde_json::from_value::<AgentControlRequest>(value).unwrap(),
             remove
+        );
+
+        let matching_remove = AgentControlRequest::RemoveReaction {
+            account_id_hex: account(),
+            group_id_hex: group(),
+            target_message_id_hex: message(),
+            emoji: Some("👀".to_owned()),
+        };
+        let value = serde_json::to_value(&matching_remove).unwrap();
+        assert_eq!(value["emoji"], "👀");
+        assert_eq!(
+            serde_json::from_value::<AgentControlRequest>(value).unwrap(),
+            matching_remove
         );
     }
 
@@ -1322,6 +1340,7 @@ mod tests {
                     account_id_hex: account(),
                     group_id_hex: group(),
                     target_message_id_hex: message(),
+                    emoji: None,
                 },
                 "remove_reaction",
             ),

--- a/crates/agent-control/src/lib.rs
+++ b/crates/agent-control/src/lib.rs
@@ -122,7 +122,8 @@ pub enum AgentControlRequest {
         target_message_id_hex: String,
         emoji: String,
     },
-    /// Retract this account's reaction to a durable message.
+    /// Retract this account's most recent active reaction to a durable message,
+    /// whichever reaction content it carries.
     RemoveReaction {
         account_id_hex: String,
         group_id_hex: String,

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -279,6 +279,10 @@ wn --account <npub-or-hex> messages timeline search <group-hex> <query> --limit 
 wn --account <npub-or-hex> messages timeline subscribe <group-hex>
 ```
 
+`messages react` is idempotent for an already-active reaction and reports
+`published=0` in that case. `messages unreact` removes all of the account's
+active reactions from the target in one deletion event.
+
 `messages send --reply-to <message-id>` sends the text as a reply to an existing message. It uses the same wire
 format other Marmot clients produce, so recipients see the row with its reply reference and a hydrated reply preview
 of the parent. Pass the group with `--group` and put `--reply-to` before the text when replying: the message text uses

--- a/crates/cli/src/commands/messages.rs
+++ b/crates/cli/src/commands/messages.rs
@@ -192,11 +192,16 @@ pub(crate) async fn message_command_with_runtime(
             let summary = runtime
                 .react_to_message(&account.label, &group_id, &message_id, &emoji)
                 .await?;
-            Ok(CommandOutput {
-                plain: format!(
+            let plain = if summary.published == 0 {
+                format!("reaction {emoji} already active on {message_id} published=0")
+            } else {
+                format!(
                     "reacted {emoji} to {message_id} published={}",
                     summary.published
-                ),
+                )
+            };
+            Ok(CommandOutput {
+                plain,
                 json: json!({
                     "account_id": account.account_id_hex,
                     "npub": npub_for_account_id(&account.account_id_hex)?,

--- a/crates/marmot-app/src/client/audit.rs
+++ b/crates/marmot-app/src/client/audit.rs
@@ -79,6 +79,7 @@ impl AppClient {
             AppMessageIntent::Edit { .. } => ("edit_message", None),
             AppMessageIntent::Reaction { .. } => ("react", None),
             AppMessageIntent::Unreact { .. } => ("unreact", None),
+            AppMessageIntent::DeleteReactions { .. } => ("unreact", None),
             AppMessageIntent::Delete { .. } => ("delete_message", None),
             AppMessageIntent::Media { attachments, .. } => {
                 ("send_media", Some(attachments.len() as u64))

--- a/crates/marmot-app/src/client/audit.rs
+++ b/crates/marmot-app/src/client/audit.rs
@@ -147,6 +147,15 @@ impl AppClient {
         );
     }
 
+    pub(crate) fn record_human_action_noop_succeeded(
+        &self,
+        group_id: &GroupId,
+        context: &AuditEventContext,
+        message_ids: Vec<String>,
+    ) {
+        self.record_human_action(group_id, context, "succeeded", message_ids, None, None);
+    }
+
     /// Record a `subscription_rebuild` forensic audit row for the just-completed
     /// relay-plane activation: the `since` floor requested (`since_secs`; `None`
     /// = full-history replay), the lookback subtracted from the durable cursor

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -2315,6 +2315,7 @@ impl AppClient {
     where
         F: FnMut(crate::AppProjectionUpdate),
     {
+        self.ensure_group_application_messages_allowed(group_id)?;
         crate::messages::validate_reaction_content(emoji)?;
         let sender = self
             .app
@@ -2323,9 +2324,22 @@ impl AppClient {
             .account_id_hex;
         match self.own_reaction_event_ids(group_id, &sender, target_message_id, Some(emoji)) {
             Ok(existing) => {
+                let existing_id = existing.last().expect("non-empty reaction ids").clone();
+                if let Some(context) =
+                    Self::message_human_action_context(&AppMessageIntent::Reaction {
+                        target_message_id: target_message_id.to_owned(),
+                        emoji: emoji.to_owned(),
+                    })
+                {
+                    self.record_human_action_noop_succeeded(
+                        group_id,
+                        &context,
+                        vec![existing_id.clone()],
+                    );
+                }
                 return Ok(SendSummary {
                     published: 0,
-                    message_ids: vec![existing.last().expect("non-empty reaction ids").clone()],
+                    message_ids: vec![existing_id],
                     maintenance_disposition: cgka_traits::SendMaintenanceDisposition::Ready,
                 });
             }

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -2062,22 +2062,30 @@ impl AppClient {
     {
         self.ensure_group_application_messages_allowed(group_id)?;
         // Capture the human-action descriptor before `Unreact` is rewritten to
-        // `Delete` below, so the audit log records the user's actual intent.
+        // `DeleteReactions` below, so the audit log records the user's actual
+        // intent.
         let audit_context = Self::message_human_action_context(&intent);
         let sender = self
             .app
             .account_home()
             .account(&self.state.label)?
             .account_id_hex;
-        // NIP-25 has no native un-react: a kind-7 reaction is retracted with a
-        // kind-5 delete of that reaction event. Resolve the user's own reaction
-        // event id from the projection before building the tombstone.
+        // NIP-25 has no native un-react: kind-7 reactions are retracted with a
+        // kind-5 delete. Resolve every matching active own reaction from the
+        // projection and place all ids in one tombstone so remove-all is atomic.
         let intent = match intent {
-            AppMessageIntent::Unreact { target_message_id } => {
-                let reaction_id =
-                    self.own_reaction_event_id(group_id, &sender, &target_message_id)?;
-                AppMessageIntent::Delete {
-                    target_message_id: reaction_id,
+            AppMessageIntent::Unreact {
+                target_message_id,
+                emoji,
+            } => {
+                let reaction_message_ids = self.own_reaction_event_ids(
+                    group_id,
+                    &sender,
+                    &target_message_id,
+                    emoji.as_deref(),
+                )?;
+                AppMessageIntent::DeleteReactions {
+                    reaction_message_ids,
                 }
             }
             other => other,
@@ -2251,28 +2259,37 @@ impl AppClient {
         }
     }
 
-    /// Most recent active reaction this account authored that targets
-    /// `target_message_id`, identified by its own message id. Used to build the
-    /// kind-5 retraction for an un-react.
-    fn own_reaction_event_id(
+    /// Active reactions this account authored on `target_message_id`, filtered
+    /// by exact content when requested and identified by their message ids.
+    fn own_reaction_event_ids(
         &self,
         group_id: &GroupId,
         sender: &str,
         target_message_id: &str,
-    ) -> Result<String, AppError> {
+        emoji: Option<&str>,
+    ) -> Result<Vec<String>, AppError> {
         let group_id_hex = hex::encode(group_id.as_slice());
-        self.app
+        let reaction_message_ids = self
+            .app
             .timeline_message(&self.state.label, &group_id_hex, target_message_id)?
-            .and_then(|message| {
+            .map(|message| {
                 message
                     .reactions
                     .user_reactions
                     .into_iter()
-                    .rev()
-                    .find(|reaction| reaction.sender == sender)
+                    .filter(|reaction| {
+                        reaction.sender == sender
+                            && emoji.is_none_or(|expected| reaction.emoji == expected)
+                    })
+                    .map(|reaction| reaction.reaction_message_id_hex)
+                    .collect::<Vec<_>>()
             })
-            .map(|reaction| reaction.reaction_message_id_hex)
-            .ok_or(AppError::ReactionNotFound)
+            .unwrap_or_default();
+        if reaction_message_ids.is_empty() {
+            Err(AppError::ReactionNotFound)
+        } else {
+            Ok(reaction_message_ids)
+        }
     }
 
     pub async fn react_to_message(
@@ -2281,13 +2298,43 @@ impl AppClient {
         target_message_id: &str,
         emoji: &str,
     ) -> Result<SendSummary, AppError> {
+        self.react_to_message_with_local_projection(group_id, target_message_id, emoji, |_| {})
+            .await
+    }
+
+    pub(crate) async fn react_to_message_with_local_projection<F>(
+        &mut self,
+        group_id: &GroupId,
+        target_message_id: &str,
+        emoji: &str,
+        on_local_projection: F,
+    ) -> Result<SendSummary, AppError>
+    where
+        F: FnMut(crate::AppProjectionUpdate),
+    {
+        crate::messages::validate_reaction_content(emoji)?;
+        let sender = self
+            .app
+            .account_home()
+            .account(&self.state.label)?
+            .account_id_hex;
+        if let Ok(existing) =
+            self.own_reaction_event_ids(group_id, &sender, target_message_id, Some(emoji))
+        {
+            return Ok(SendSummary {
+                published: 0,
+                message_ids: vec![existing.last().expect("non-empty reaction ids").clone()],
+                maintenance_disposition: cgka_traits::SendMaintenanceDisposition::Ready,
+            });
+        }
         let (_event, summary) = self
-            .send_app_event(
+            .send_app_event_with_local_projection(
                 group_id,
                 AppMessageIntent::Reaction {
                     target_message_id: target_message_id.to_owned(),
                     emoji: emoji.to_owned(),
                 },
+                on_local_projection,
             )
             .await?;
         Ok(summary)
@@ -2298,11 +2345,25 @@ impl AppClient {
         group_id: &GroupId,
         target_message_id: &str,
     ) -> Result<SendSummary, AppError> {
+        self.unreact_from_message_matching(group_id, target_message_id, None)
+            .await
+    }
+
+    pub async fn unreact_from_message_matching(
+        &mut self,
+        group_id: &GroupId,
+        target_message_id: &str,
+        emoji: Option<&str>,
+    ) -> Result<SendSummary, AppError> {
+        if let Some(emoji) = emoji {
+            crate::messages::validate_reaction_content(emoji)?;
+        }
         let (_event, summary) = self
             .send_app_event(
                 group_id,
                 AppMessageIntent::Unreact {
                     target_message_id: target_message_id.to_owned(),
+                    emoji: emoji.map(str::to_owned),
                 },
             )
             .await?;

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -45,7 +45,7 @@ use crate::{
     AppRuntime, AppTransportRouting, GroupInviteDeclineResult, MarmotApp, MarmotRelayPlane,
     MarmotRelayPlaneAccountAdapter, MediaAttachmentReference, MediaDownloadResult,
     MediaUploadRequest, MediaUploadResult, PendingWelcomeDelivery, SelfMembership, SendSummary,
-    TimelineMessageQuery, remember_seen_event, unix_now_seconds,
+    remember_seen_event, unix_now_seconds,
 };
 
 mod audit;
@@ -2261,17 +2261,8 @@ impl AppClient {
         target_message_id: &str,
     ) -> Result<String, AppError> {
         let group_id_hex = hex::encode(group_id.as_slice());
-        let timeline = self.app.timeline_messages_with_query(
-            &self.state.label,
-            TimelineMessageQuery {
-                group_id_hex: Some(group_id_hex),
-                ..TimelineMessageQuery::default()
-            },
-        )?;
-        timeline
-            .messages
-            .into_iter()
-            .find(|message| message.message_id_hex == target_message_id)
+        self.app
+            .timeline_message(&self.state.label, &group_id_hex, target_message_id)?
             .and_then(|message| {
                 message
                     .reactions

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -14,9 +14,7 @@ use cgka_traits::app_components::{
     GROUP_ENCRYPTED_MEDIA_EXPORTER_CACHE_KEY, GROUP_MESSAGE_RETENTION_COMPONENT_ID,
     GROUP_PROFILE_COMPONENT_ID, NOSTR_ROUTING_COMPONENT_ID, encode_nostr_routing_v1,
 };
-use cgka_traits::app_event::{
-    EVENT_REF_TAG, MARMOT_APP_EVENT_KIND_REACTION, MarmotAppEvent as MarmotInnerEvent,
-};
+use cgka_traits::app_event::MarmotAppEvent as MarmotInnerEvent;
 use cgka_traits::capabilities::GroupCapabilities;
 use cgka_traits::engine::{CreateGroupRequest, KeyPackage, SendIntent};
 use cgka_traits::group::ProtocolProfile;
@@ -36,18 +34,18 @@ use crate::media::{
     download_encrypted_media, fetch_group_image, is_loopback_http_endpoint, upload_encrypted_media,
     upload_group_image,
 };
-use crate::messages::{AppMessageIntent, build_inner_event, encode_inner_event, tag_value};
+use crate::messages::{AppMessageIntent, build_inner_event, encode_inner_event};
 use crate::notifications;
 use crate::{
     AccountState, AgentOperationEventRequest, AgentTextStreamFinishRequest, AppBlobEndpoint,
     AppDisbandRequest, AppError, AppGroupAdminPolicyComponent, AppGroupAvatarUrlComponent,
     AppGroupEncryptedMediaComponent, AppGroupImageComponent, AppGroupImageInput,
     AppGroupMemberRecord, AppGroupMessageRetentionComponent, AppGroupMlsState, AppGroupRecord,
-    AppInitialGroupImage, AppMessageQuery, AppPerformanceTelemetry, AppQuarantinedGroup,
-    AppRoutingState, AppRuntime, AppTransportRouting, GroupInviteDeclineResult, MarmotApp,
-    MarmotRelayPlane, MarmotRelayPlaneAccountAdapter, MediaAttachmentReference,
-    MediaDownloadResult, MediaUploadRequest, MediaUploadResult, PendingWelcomeDelivery,
-    SelfMembership, SendSummary, remember_seen_event, unix_now_seconds,
+    AppInitialGroupImage, AppPerformanceTelemetry, AppQuarantinedGroup, AppRoutingState,
+    AppRuntime, AppTransportRouting, GroupInviteDeclineResult, MarmotApp, MarmotRelayPlane,
+    MarmotRelayPlaneAccountAdapter, MediaAttachmentReference, MediaDownloadResult,
+    MediaUploadRequest, MediaUploadResult, PendingWelcomeDelivery, SelfMembership, SendSummary,
+    TimelineMessageQuery, remember_seen_event, unix_now_seconds,
 };
 
 mod audit;
@@ -2253,7 +2251,7 @@ impl AppClient {
         }
     }
 
-    /// Most recent kind-7 reaction this account authored that targets
+    /// Most recent active reaction this account authored that targets
     /// `target_message_id`, identified by its own message id. Used to build the
     /// kind-5 retraction for an un-react.
     fn own_reaction_event_id(
@@ -2263,23 +2261,26 @@ impl AppClient {
         target_message_id: &str,
     ) -> Result<String, AppError> {
         let group_id_hex = hex::encode(group_id.as_slice());
-        let messages = self.app.messages_with_query(
+        let timeline = self.app.timeline_messages_with_query(
             &self.state.label,
-            AppMessageQuery {
+            TimelineMessageQuery {
                 group_id_hex: Some(group_id_hex),
-                limit: None,
+                ..TimelineMessageQuery::default()
             },
         )?;
-        messages
+        timeline
+            .messages
             .into_iter()
-            .rev()
-            .find(|message| {
-                message.kind == MARMOT_APP_EVENT_KIND_REACTION
-                    && message.sender == sender
-                    && tag_value(&message.tags, EVENT_REF_TAG) == Some(target_message_id)
-                    && !message.message_id_hex.is_empty()
+            .find(|message| message.message_id_hex == target_message_id)
+            .and_then(|message| {
+                message
+                    .reactions
+                    .user_reactions
+                    .into_iter()
+                    .rev()
+                    .find(|reaction| reaction.sender == sender)
             })
-            .map(|message| message.message_id_hex)
+            .map(|reaction| reaction.reaction_message_id_hex)
             .ok_or(AppError::ReactionNotFound)
     }
 

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -2078,6 +2078,9 @@ impl AppClient {
                 target_message_id,
                 emoji,
             } => {
+                if let Some(emoji) = emoji.as_deref() {
+                    crate::messages::validate_reaction_content(emoji)?;
+                }
                 let reaction_message_ids = self.own_reaction_event_ids(
                     group_id,
                     &sender,
@@ -2318,14 +2321,16 @@ impl AppClient {
             .account_home()
             .account(&self.state.label)?
             .account_id_hex;
-        if let Ok(existing) =
-            self.own_reaction_event_ids(group_id, &sender, target_message_id, Some(emoji))
-        {
-            return Ok(SendSummary {
-                published: 0,
-                message_ids: vec![existing.last().expect("non-empty reaction ids").clone()],
-                maintenance_disposition: cgka_traits::SendMaintenanceDisposition::Ready,
-            });
+        match self.own_reaction_event_ids(group_id, &sender, target_message_id, Some(emoji)) {
+            Ok(existing) => {
+                return Ok(SendSummary {
+                    published: 0,
+                    message_ids: vec![existing.last().expect("non-empty reaction ids").clone()],
+                    maintenance_disposition: cgka_traits::SendMaintenanceDisposition::Ready,
+                });
+            }
+            Err(AppError::ReactionNotFound) => {}
+            Err(error) => return Err(error),
         }
         let (_event, summary) = self
             .send_app_event_with_local_projection(

--- a/crates/marmot-app/src/client/push.rs
+++ b/crates/marmot-app/src/client/push.rs
@@ -561,6 +561,7 @@ pub(crate) fn notification_trigger_for_intent(
         }
         AppMessageIntent::Reaction { .. }
         | AppMessageIntent::Unreact { .. }
+        | AppMessageIntent::DeleteReactions { .. }
         | AppMessageIntent::Edit { .. }
         | AppMessageIntent::Delete { .. }
         | AppMessageIntent::StreamStart { .. }

--- a/crates/marmot-app/src/messages/intents.rs
+++ b/crates/marmot-app/src/messages/intents.rs
@@ -27,6 +27,11 @@ pub(crate) const PUBKEY_REF_TAG: &str = "p";
 /// synchronous Markdown work before send/classification (mdk#654).
 const MAX_MARKDOWN_MENTION_SCAN_BYTES: usize = AGENT_TEXT_STREAM_MAX_PLAINTEXT_FRAME_LEN as usize;
 
+/// Reactions are display metadata that flow into timelines and notification
+/// previews. Keep them compact and free of terminal/control sequences while
+/// still allowing arbitrary multi-scalar emoji clusters.
+const MAX_REACTION_CONTENT_CHARS: usize = 64;
+
 /// Extract the mentioned pubkey hex from a token following a `nostr:` scheme (or
 /// a bare hex/npub), covering NIP-21 `npub` + `nprofile` and a raw hex pubkey.
 /// Event/coordinate references (`note`/`nevent`/`naddr`) are not pubkey mentions.
@@ -255,6 +260,16 @@ pub(crate) fn build_inner_event(
             if emoji.trim().is_empty() {
                 return Err(AppError::InvalidAppMessagePayload(
                     "reaction add requires a non-empty emoji".into(),
+                ));
+            }
+            if emoji.chars().any(char::is_control) {
+                return Err(AppError::InvalidAppMessagePayload(
+                    "reaction content must not contain control characters".into(),
+                ));
+            }
+            if emoji.chars().count() > MAX_REACTION_CONTENT_CHARS {
+                return Err(AppError::InvalidAppMessagePayload(
+                    "reaction content exceeds the maximum length".into(),
                 ));
             }
             Ok(event(

--- a/crates/marmot-app/src/messages/intents.rs
+++ b/crates/marmot-app/src/messages/intents.rs
@@ -557,6 +557,11 @@ pub(crate) fn validate_reaction_content(emoji: &str) -> Result<(), AppError> {
             "reaction add requires a non-empty emoji".into(),
         ));
     }
+    if emoji.trim() != emoji {
+        return Err(AppError::InvalidAppMessagePayload(
+            "reaction content must not have leading or trailing whitespace".into(),
+        ));
+    }
     if emoji.chars().any(char::is_control) {
         return Err(AppError::InvalidAppMessagePayload(
             "reaction content must not contain control characters".into(),

--- a/crates/marmot-app/src/messages/intents.rs
+++ b/crates/marmot-app/src/messages/intents.rs
@@ -171,6 +171,10 @@ pub(crate) enum AppMessageIntent {
     },
     Unreact {
         target_message_id: String,
+        emoji: Option<String>,
+    },
+    DeleteReactions {
+        reaction_message_ids: Vec<String>,
     },
     Reply {
         target_message_id: String,
@@ -230,8 +234,8 @@ pub(crate) enum AppMessageIntent {
 }
 
 /// Build the inner Marmot app event for `intent`, authored by `sender_pubkey_hex`
-/// at `created_at`. `Unreact` must be resolved to a `Delete` of the reaction
-/// event id before this is called.
+/// at `created_at`. `Unreact` must be resolved to `DeleteReactions` before this
+/// is called.
 pub(crate) fn build_inner_event(
     intent: &AppMessageIntent,
     sender_pubkey_hex: &str,
@@ -257,21 +261,7 @@ pub(crate) fn build_inner_event(
             emoji,
         } => {
             validate_message_ref(target_message_id)?;
-            if emoji.trim().is_empty() {
-                return Err(AppError::InvalidAppMessagePayload(
-                    "reaction add requires a non-empty emoji".into(),
-                ));
-            }
-            if emoji.chars().any(char::is_control) {
-                return Err(AppError::InvalidAppMessagePayload(
-                    "reaction content must not contain control characters".into(),
-                ));
-            }
-            if emoji.chars().count() > MAX_REACTION_CONTENT_CHARS {
-                return Err(AppError::InvalidAppMessagePayload(
-                    "reaction content exceeds the maximum length".into(),
-                ));
-            }
+            validate_reaction_content(emoji)?;
             Ok(event(
                 MARMOT_APP_EVENT_KIND_REACTION,
                 vec![event_ref_tag(target_message_id)],
@@ -309,12 +299,7 @@ pub(crate) fn build_inner_event(
             tags.extend(mention_p_tags(content));
             Ok(event(MARMOT_APP_EVENT_KIND_EDIT, tags, content.clone()))
         }
-        AppMessageIntent::Unreact { .. } | AppMessageIntent::Delete { .. } => {
-            let target_message_id = match intent {
-                AppMessageIntent::Delete { target_message_id }
-                | AppMessageIntent::Unreact { target_message_id } => target_message_id,
-                _ => unreachable!(),
-            };
+        AppMessageIntent::Delete { target_message_id } => {
             validate_message_ref(target_message_id)?;
             Ok(event(
                 MARMOT_APP_EVENT_KIND_DELETE,
@@ -322,6 +307,22 @@ pub(crate) fn build_inner_event(
                 String::new(),
             ))
         }
+        AppMessageIntent::DeleteReactions {
+            reaction_message_ids,
+        } => {
+            if reaction_message_ids.is_empty() {
+                return Err(AppError::ReactionNotFound);
+            }
+            let mut tags = Vec::with_capacity(reaction_message_ids.len());
+            for reaction_message_id in reaction_message_ids {
+                validate_message_ref(reaction_message_id)?;
+                tags.push(event_ref_tag(reaction_message_id));
+            }
+            Ok(event(MARMOT_APP_EVENT_KIND_DELETE, tags, String::new()))
+        }
+        AppMessageIntent::Unreact { .. } => Err(AppError::InvalidAppMessagePayload(
+            "unreact must be resolved before event construction".into(),
+        )),
         AppMessageIntent::Media {
             attachments,
             caption,
@@ -548,6 +549,25 @@ pub(crate) fn build_inner_event(
             content.clone(),
         )),
     }
+}
+
+pub(crate) fn validate_reaction_content(emoji: &str) -> Result<(), AppError> {
+    if emoji.trim().is_empty() {
+        return Err(AppError::InvalidAppMessagePayload(
+            "reaction add requires a non-empty emoji".into(),
+        ));
+    }
+    if emoji.chars().any(char::is_control) {
+        return Err(AppError::InvalidAppMessagePayload(
+            "reaction content must not contain control characters".into(),
+        ));
+    }
+    if emoji.chars().count() > MAX_REACTION_CONTENT_CHARS {
+        return Err(AppError::InvalidAppMessagePayload(
+            "reaction content exceeds the maximum length".into(),
+        ));
+    }
+    Ok(())
 }
 
 fn event_ref_tag(target_message_id: &str) -> Vec<String> {

--- a/crates/marmot-app/src/messages/mod.rs
+++ b/crates/marmot-app/src/messages/mod.rs
@@ -2,6 +2,6 @@ mod intents;
 
 pub(crate) use intents::{
     AppMessageIntent, PUBKEY_REF_TAG, STREAM_ROUTE_QUIC, build_inner_event, encode_inner_event,
-    inline_mention_pubkey_hexes, mention_pubkey_hex,
+    inline_mention_pubkey_hexes, mention_pubkey_hex, validate_reaction_content,
 };
 pub use intents::{is_stream_final_event, tag_value, tag_values};

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -2235,17 +2235,39 @@ async fn handle_account_worker_command(
             respond,
         } => {
             let send_started_at = Instant::now();
-            let result = client
-                .send_app_event_with_local_projection(&group_id, intent, |update| {
-                    publish_app_runtime_projection_update(
-                        events,
-                        account_id_hex,
-                        account_label,
-                        update,
-                    );
-                })
-                .await
-                .map(|(_event, summary)| summary);
+            let result = match intent {
+                AppMessageIntent::Reaction {
+                    target_message_id,
+                    emoji,
+                } => {
+                    client
+                        .react_to_message_with_local_projection(
+                            &group_id,
+                            &target_message_id,
+                            &emoji,
+                            |update| {
+                                publish_app_runtime_projection_update(
+                                    events,
+                                    account_id_hex,
+                                    account_label,
+                                    update,
+                                );
+                            },
+                        )
+                        .await
+                }
+                intent => client
+                    .send_app_event_with_local_projection(&group_id, intent, |update| {
+                        publish_app_runtime_projection_update(
+                            events,
+                            account_id_hex,
+                            account_label,
+                            update,
+                        );
+                    })
+                    .await
+                    .map(|(_event, summary)| summary),
+            };
             shared.app_performance_telemetry().record(
                 AppPerformanceOperation::OutboundMessageSend,
                 send_started_at.elapsed(),

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -2013,12 +2013,24 @@ impl MarmotAppRuntime {
         group_id: &GroupId,
         target_message_id: &str,
     ) -> Result<SendSummary, AppError> {
+        self.unreact_from_message_matching(account_ref, group_id, target_message_id, None)
+            .await
+    }
+
+    pub async fn unreact_from_message_matching(
+        &self,
+        account_ref: &str,
+        group_id: &GroupId,
+        target_message_id: &str,
+        emoji: Option<&str>,
+    ) -> Result<SendSummary, AppError> {
         self.accounts
             .send_app_event(
                 account_ref,
                 group_id,
                 AppMessageIntent::Unreact {
                     target_message_id: target_message_id.to_owned(),
+                    emoji: emoji.map(str::to_owned),
                 },
             )
             .await

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -5491,6 +5491,22 @@ fn reaction_intent_rejects_empty_emoji() {
 }
 
 #[test]
+fn reaction_intent_rejects_padded_content() {
+    for emoji in [" 👀", "👀 ", "\t👀"] {
+        let error = build_inner_event(
+            &AppMessageIntent::Reaction {
+                target_message_id: "target-message".to_owned(),
+                emoji: emoji.to_owned(),
+            },
+            SENDER_HEX,
+            1,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("leading or trailing whitespace"));
+    }
+}
+
+#[test]
 fn reaction_intent_rejects_control_characters_and_oversized_content() {
     for emoji in ["👀\nspoof", "👀\u{001b}[31m"] {
         let result = build_inner_event(

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -5491,6 +5491,45 @@ fn reaction_intent_rejects_empty_emoji() {
 }
 
 #[test]
+fn reaction_intent_rejects_control_characters_and_oversized_content() {
+    for emoji in ["👀\nspoof", "👀\u{001b}[31m"] {
+        let result = build_inner_event(
+            &AppMessageIntent::Reaction {
+                target_message_id: "abc123".to_owned(),
+                emoji: emoji.to_owned(),
+            },
+            SENDER_HEX,
+            1,
+        );
+        assert!(matches!(result, Err(AppError::InvalidAppMessagePayload(_))));
+    }
+
+    let result = build_inner_event(
+        &AppMessageIntent::Reaction {
+            target_message_id: "abc123".to_owned(),
+            emoji: "👍".repeat(65),
+        },
+        SENDER_HEX,
+        1,
+    );
+    assert!(matches!(result, Err(AppError::InvalidAppMessagePayload(_))));
+}
+
+#[test]
+fn reaction_intent_accepts_bounded_multi_scalar_emoji() {
+    let event = build_inner_event(
+        &AppMessageIntent::Reaction {
+            target_message_id: "abc123".to_owned(),
+            emoji: "👨‍👩‍👧‍👦".to_owned(),
+        },
+        SENDER_HEX,
+        1,
+    )
+    .unwrap();
+    assert_eq!(event.content, "👨‍👩‍👧‍👦");
+}
+
+#[test]
 fn delete_intent_builds_empty_kind_five_with_e_tag() {
     let event = build(AppMessageIntent::Delete {
         target_message_id: "abc123".to_owned(),

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -5530,6 +5530,21 @@ fn reaction_intent_accepts_bounded_multi_scalar_emoji() {
 }
 
 #[test]
+fn reaction_intent_accepts_exact_maximum_scalar_count() {
+    let emoji = "👍".repeat(64);
+    let event = build_inner_event(
+        &AppMessageIntent::Reaction {
+            target_message_id: "abc123".to_owned(),
+            emoji: emoji.clone(),
+        },
+        SENDER_HEX,
+        1,
+    )
+    .unwrap();
+    assert_eq!(event.content, emoji);
+}
+
+#[test]
 fn delete_intent_builds_empty_kind_five_with_e_tag() {
     let event = build(AppMessageIntent::Delete {
         target_message_id: "abc123".to_owned(),

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -5555,6 +5555,19 @@ fn delete_intent_builds_empty_kind_five_with_e_tag() {
 }
 
 #[test]
+fn delete_reactions_intent_builds_one_kind_five_with_all_e_tags() {
+    let event = build(AppMessageIntent::DeleteReactions {
+        reaction_message_ids: vec!["reaction-one".to_owned(), "reaction-two".to_owned()],
+    });
+    assert_eq!(event.kind, MARMOT_APP_EVENT_KIND_DELETE);
+    assert_eq!(event.content, "");
+    assert_eq!(
+        tag_values(&event.tags, EVENT_REF_TAG),
+        vec!["reaction-one", "reaction-two"]
+    );
+}
+
+#[test]
 fn reply_intent_builds_kind_nine_with_e_and_q_tags() {
     let event = build(AppMessageIntent::Reply {
         target_message_id: "parent".to_owned(),

--- a/crates/marmot-uniffi/src/commands/message.rs
+++ b/crates/marmot-uniffi/src/commands/message.rs
@@ -73,7 +73,7 @@ impl Marmot {
         Ok(summary.into())
     }
 
-    /// Remove this account's reaction from `target_message_id`.
+    /// Remove all of this account's active reactions from `target_message_id`.
     pub async fn unreact_from_message(
         &self,
         account_ref: String,

--- a/integrations/hermes/marmot/README.md
+++ b/integrations/hermes/marmot/README.md
@@ -249,7 +249,10 @@ just hermes-dev-e2e-connector
 
 This test starts a real `wn-agent` process with debug controls enabled, injects
 one inbound message through its local control socket, and verifies the fixed
-Hermes response is sent back through `wn-agent`.
+Hermes response is sent back through `wn-agent`. Its private temporary root
+defaults to the current user's home directory because `wn-agent` rejects shared
+`/tmp` ancestry on macOS; set `MARMOT_CONNECTOR_E2E_TMPDIR` to use another
+private, user-owned parent.
 
 Run the services in foreground terminals:
 

--- a/integrations/hermes/marmot/README.md
+++ b/integrations/hermes/marmot/README.md
@@ -14,7 +14,8 @@ messages using a `(recorded_at, message_id_hex)` cursor. Automatic history
 lookup is best-effort and never drops the current inbound message if it fails.
 
 The adapter also exposes Marmot reaction add/remove primitives to Hermes. They
-target durable message ids and accept arbitrary non-blank reaction content;
+target durable message ids and accept arbitrary non-blank, control-free reaction
+content of at most 64 Unicode scalar values;
 processing-status reaction policy remains a separate host concern.
 
 For live previews, the plugin retries `stream_begin` with one stable v2 request

--- a/integrations/hermes/marmot/README.md
+++ b/integrations/hermes/marmot/README.md
@@ -13,9 +13,11 @@ model-callable `marmot_history` tool can fetch one exact message id or page olde
 messages using a `(recorded_at, message_id_hex)` cursor. Automatic history
 lookup is best-effort and never drops the current inbound message if it fails.
 
-The adapter also exposes Marmot reaction add/remove primitives to Hermes. They
-target durable message ids and accept arbitrary non-blank, control-free reaction
-content of at most 64 Unicode scalar values;
+The model-callable `marmot_reaction` tool and adapter hooks expose Marmot
+reaction add/remove primitives to Hermes. They target an exact durable message
+id or the latest inbound message and accept arbitrary non-blank, control-free
+reaction content of at most 64 Unicode scalar values. Adds are idempotent;
+removal can target exact content or clear all active own reactions atomically;
 processing-status reaction policy remains a separate host concern.
 
 For live previews, the plugin retries `stream_begin` with one stable v2 request

--- a/integrations/hermes/marmot/README.md
+++ b/integrations/hermes/marmot/README.md
@@ -13,6 +13,10 @@ model-callable `marmot_history` tool can fetch one exact message id or page olde
 messages using a `(recorded_at, message_id_hex)` cursor. Automatic history
 lookup is best-effort and never drops the current inbound message if it fails.
 
+The adapter also exposes Marmot reaction add/remove primitives to Hermes. They
+target durable message ids and accept arbitrary non-blank reaction content;
+processing-status reaction policy remains a separate host concern.
+
 For live previews, the plugin retries `stream_begin` with one stable v2 request
 id and retains the returned stream capability in memory for subsequent append,
 status, finalize, and cancel calls. The capability is a bearer secret and must

--- a/integrations/hermes/marmot/adapter.py
+++ b/integrations/hermes/marmot/adapter.py
@@ -1284,6 +1284,42 @@ class MarmotAgentControlClient:
             }
         )
 
+    async def send_reaction(
+        self,
+        account_id_hex: str,
+        group_id_hex: str,
+        target_message_id_hex: str,
+        emoji: str,
+    ) -> Dict[str, Any]:
+        return await self.request(
+            {
+                "type": "send_reaction",
+                "account_id_hex": _normalize_hex(account_id_hex, "account_id_hex"),
+                "group_id_hex": _normalize_hex(group_id_hex, "group_id_hex"),
+                "target_message_id_hex": _normalize_hex(
+                    target_message_id_hex, "target_message_id_hex"
+                ),
+                "emoji": str(emoji),
+            }
+        )
+
+    async def remove_reaction(
+        self,
+        account_id_hex: str,
+        group_id_hex: str,
+        target_message_id_hex: str,
+    ) -> Dict[str, Any]:
+        return await self.request(
+            {
+                "type": "remove_reaction",
+                "account_id_hex": _normalize_hex(account_id_hex, "account_id_hex"),
+                "group_id_hex": _normalize_hex(group_id_hex, "group_id_hex"),
+                "target_message_id_hex": _normalize_hex(
+                    target_message_id_hex, "target_message_id_hex"
+                ),
+            }
+        )
+
     async def group_info(self, account_id_hex: str, group_id_hex: str) -> Dict[str, Any]:
         return await self.request(
             {
@@ -1847,6 +1883,7 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
         )
         self._profile_lookup_gate = ProfileLookupGate()
         self._sent_targets = SentMessageTargetCache()
+        self._last_inbound_message_ids: Dict[str, str] = {}
         self._activation_cache = GroupActivationCache()
         self._listener_task: Optional[asyncio.Task] = None
         self._inbound_queue = KeyedAsyncQueue()
@@ -2712,6 +2749,55 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
             logger.debug("Marmot delete_message failed: %s", exc)
             return False
 
+    async def _add_reaction(self, chat_id: str, message_id: str, emoji: str) -> bool:
+        try:
+            account_id = await self._ensure_account_id()
+            await self.client.send_reaction(account_id, chat_id, message_id, emoji)
+            return True
+        except Exception as exc:
+            logger.debug("Marmot send_reaction failed: %s", exc)
+            return False
+
+    async def add_reaction(
+        self,
+        chat_id: str,
+        emoji: str,
+        message_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Add an explicit agent-requested reaction to a durable message."""
+        target_message_id = message_id or self._last_inbound_message_ids.get(chat_id)
+        if not target_message_id:
+            return {"success": False, "error": "No Marmot message is available to react to"}
+        success = await self._add_reaction(chat_id, target_message_id, emoji)
+        return {"success": success, "emoji": emoji}
+
+    async def _remove_reaction(self, chat_id: str, message_id: str) -> bool:
+        try:
+            account_id = await self._ensure_account_id()
+            await self.client.remove_reaction(account_id, chat_id, message_id)
+            return True
+        except AgentControlError as exc:
+            # A missing own reaction is already the desired state. This occurs
+            # after cancellation or when an earlier acknowledgement failed.
+            if exc.code == "reaction_not_found":
+                return True
+            logger.debug("Marmot remove_reaction failed: %s", exc)
+            return False
+        except Exception as exc:
+            logger.debug("Marmot remove_reaction failed: %s", exc)
+            return False
+
+    async def remove_reaction(
+        self,
+        chat_id: str,
+        message_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Remove this account's reaction from a durable message."""
+        target_message_id = message_id or self._last_inbound_message_ids.get(chat_id)
+        if not target_message_id:
+            return {"success": False, "error": "No Marmot message is available to unreact"}
+        return {"success": await self._remove_reaction(chat_id, target_message_id)}
+
     async def _send_tool_progress_events(
         self,
         chat_id: str,
@@ -3202,6 +3288,7 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
                     tz=timezone.utc,
                 ),
             )
+            self._last_inbound_message_ids[group_id_hex] = message_id_hex
             reply = event.get("reply_to")
             if isinstance(reply, dict):
                 reply_sender = reply.get("sender")

--- a/integrations/hermes/marmot/adapter.py
+++ b/integrations/hermes/marmot/adapter.py
@@ -3260,6 +3260,7 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
             group_id_hex = event["group_id_hex"]
             sender_account_id_hex = event["sender_account_id_hex"]
             message_id_hex = event["message_id_hex"]
+            self._last_inbound_message_ids[group_id_hex] = message_id_hex
             if not await self._should_run_turn(event):
                 logger.debug("Marmot inbound not addressed; skipping turn (groupActivation=mention)")
                 return
@@ -3295,7 +3296,6 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
                     tz=timezone.utc,
                 ),
             )
-            self._last_inbound_message_ids[group_id_hex] = message_id_hex
             reply = event.get("reply_to")
             if isinstance(reply, dict):
                 reply_sender = reply.get("sender")

--- a/integrations/hermes/marmot/adapter.py
+++ b/integrations/hermes/marmot/adapter.py
@@ -3995,14 +3995,6 @@ def _marmot_reaction_tool(args: Dict[str, Any], **_kwargs: Any) -> str:
                 adapter.remove_reaction(group_id_hex, message_id_hex, emoji or None)
             )
         return json.dumps({"ok": bool(result.get("success")), **result})
-    except AgentControlError as exc:
-        return json.dumps(
-            {
-                "ok": False,
-                "error": "Marmot reaction request failed",
-                "code": exc.code or "unknown",
-            }
-        )
     except Exception as exc:
         return json.dumps(
             {

--- a/integrations/hermes/marmot/adapter.py
+++ b/integrations/hermes/marmot/adapter.py
@@ -2752,10 +2752,15 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
     async def _add_reaction(self, chat_id: str, message_id: str, emoji: str) -> bool:
         try:
             account_id = await self._ensure_account_id()
-            await self.client.send_reaction(account_id, chat_id, message_id, emoji)
-            return True
+            response = await self.client.send_reaction(account_id, chat_id, message_id, emoji)
+            return response.get("type") == "app_event_sent" and bool(
+                response.get("message_ids_hex")
+            )
+        except AgentControlError as exc:
+            logger.debug("Marmot send_reaction failed (code=%s)", exc.code or "unknown")
+            return False
         except Exception as exc:
-            logger.debug("Marmot send_reaction failed: %s", exc)
+            logger.debug("Marmot send_reaction failed (%s)", type(exc).__name__)
             return False
 
     async def add_reaction(
@@ -2774,17 +2779,19 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
     async def _remove_reaction(self, chat_id: str, message_id: str) -> bool:
         try:
             account_id = await self._ensure_account_id()
-            await self.client.remove_reaction(account_id, chat_id, message_id)
-            return True
+            response = await self.client.remove_reaction(account_id, chat_id, message_id)
+            return response.get("type") == "app_event_sent" and bool(
+                response.get("message_ids_hex")
+            )
         except AgentControlError as exc:
             # A missing own reaction is already the desired state. This occurs
             # after cancellation or when an earlier acknowledgement failed.
             if exc.code == "reaction_not_found":
                 return True
-            logger.debug("Marmot remove_reaction failed: %s", exc)
+            logger.debug("Marmot remove_reaction failed (code=%s)", exc.code or "unknown")
             return False
         except Exception as exc:
-            logger.debug("Marmot remove_reaction failed: %s", exc)
+            logger.debug("Marmot remove_reaction failed (%s)", type(exc).__name__)
             return False
 
     async def remove_reaction(

--- a/integrations/hermes/marmot/adapter.py
+++ b/integrations/hermes/marmot/adapter.py
@@ -1308,17 +1308,19 @@ class MarmotAgentControlClient:
         account_id_hex: str,
         group_id_hex: str,
         target_message_id_hex: str,
+        emoji: Optional[str] = None,
     ) -> Dict[str, Any]:
-        return await self.request(
-            {
-                "type": "remove_reaction",
-                "account_id_hex": _normalize_hex(account_id_hex, "account_id_hex"),
-                "group_id_hex": _normalize_hex(group_id_hex, "group_id_hex"),
-                "target_message_id_hex": _normalize_hex(
-                    target_message_id_hex, "target_message_id_hex"
-                ),
-            }
-        )
+        payload = {
+            "type": "remove_reaction",
+            "account_id_hex": _normalize_hex(account_id_hex, "account_id_hex"),
+            "group_id_hex": _normalize_hex(group_id_hex, "group_id_hex"),
+            "target_message_id_hex": _normalize_hex(
+                target_message_id_hex, "target_message_id_hex"
+            ),
+        }
+        if emoji is not None:
+            payload["emoji"] = str(emoji)
+        return await self.request(payload)
 
     async def group_info(self, account_id_hex: str, group_id_hex: str) -> Dict[str, Any]:
         return await self.request(
@@ -2779,10 +2781,23 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
             return {"success": False, "error": "Marmot reaction failed"}
         return {"success": True, "message_id": target_message_id}
 
-    async def _remove_reaction(self, chat_id: str, message_id: str) -> bool:
+    async def _remove_reaction(
+        self,
+        chat_id: str,
+        message_id: str,
+        emoji: Optional[str] = None,
+    ) -> bool:
         try:
             account_id = await self._ensure_account_id()
-            response = await self.client.remove_reaction(account_id, chat_id, message_id)
+            if emoji is None:
+                response = await self.client.remove_reaction(account_id, chat_id, message_id)
+            else:
+                response = await self.client.remove_reaction(
+                    account_id,
+                    chat_id,
+                    message_id,
+                    emoji,
+                )
             return response.get("type") == "app_event_sent" and bool(
                 response.get("message_ids_hex")
             )
@@ -2801,12 +2816,13 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         message_id: Optional[str] = None,
+        emoji: Optional[str] = None,
     ) -> Dict[str, Any]:
-        """Remove this account's reaction from a durable message."""
+        """Remove matching or all own reactions from a durable message."""
         target_message_id = message_id or self._last_inbound_message_ids.get(chat_id)
         if not target_message_id:
             return {"success": False, "error": "No Marmot message is available to unreact"}
-        success = await self._remove_reaction(chat_id, target_message_id)
+        success = await self._remove_reaction(chat_id, target_message_id, emoji)
         if not success:
             return {"success": False, "error": "Marmot unreact failed"}
         return {"success": True, "message_id": target_message_id}
@@ -3946,6 +3962,57 @@ def _marmot_history_tool(args: Dict[str, Any], **_kwargs: Any) -> str:
         return json.dumps({"ok": False, "error": str(exc)})
 
 
+def _marmot_reaction_tool(args: Dict[str, Any], **_kwargs: Any) -> str:
+    action = str(args.get("action") or "").strip().lower()
+    group_id_hex = str(args.get("group_id_hex") or "").strip()
+    message_id_hex = str(args.get("message_id_hex") or "").strip() or None
+    emoji = str(args.get("emoji") or "")
+    if action not in {"add", "remove"}:
+        return json.dumps({"ok": False, "error": "action must be add or remove"})
+    if not group_id_hex:
+        return json.dumps({"ok": False, "error": "group_id_hex required"})
+    if action == "add" and not emoji:
+        return json.dumps({"ok": False, "error": "emoji required for add"})
+
+    try:
+        from gateway.config import Platform
+        from gateway.run import _gateway_runner_ref
+        from model_tools import _run_async
+
+        runner = _gateway_runner_ref()
+        adapter = runner.adapters.get(Platform("marmot")) if runner is not None else None
+        if adapter is None:
+            return json.dumps(
+                {
+                    "ok": False,
+                    "error": "marmot_reaction requires a live Marmot adapter",
+                }
+            )
+        if action == "add":
+            result = _run_async(adapter.add_reaction(group_id_hex, emoji, message_id_hex))
+        else:
+            result = _run_async(
+                adapter.remove_reaction(group_id_hex, message_id_hex, emoji or None)
+            )
+        return json.dumps({"ok": bool(result.get("success")), **result})
+    except AgentControlError as exc:
+        return json.dumps(
+            {
+                "ok": False,
+                "error": "Marmot reaction request failed",
+                "code": exc.code or "unknown",
+            }
+        )
+    except Exception as exc:
+        return json.dumps(
+            {
+                "ok": False,
+                "error": "Marmot reaction request failed",
+                "kind": type(exc).__name__,
+            }
+        )
+
+
 def register(ctx):
     """Hermes plugin entry point."""
     ctx.register_platform(
@@ -3965,7 +4032,8 @@ def register(ctx):
             "You are chatting through Marmot, an end-to-end encrypted group "
             "messaging protocol. Chat ids are Marmot group ids and user ids "
             "are Marmot account pubkeys. Use marmot_history with the current "
-            "chat id for exact durable message ids or older transcript pages."
+            "chat id for exact durable message ids or older transcript pages, "
+            "and marmot_reaction to add or remove durable message reactions."
         ),
         emoji="",
     )
@@ -4025,6 +4093,41 @@ def register(ctx):
                 "required": ["group_id_hex"],
             },
             handler=_marmot_history_tool,
+        )
+        register_tool(
+            name="marmot_reaction",
+            toolset="platform",
+            schema={
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["add", "remove"],
+                        "description": "Whether to add or remove a reaction.",
+                    },
+                    "group_id_hex": {
+                        "type": "string",
+                        "description": "Marmot group id hex from the current conversation.",
+                    },
+                    "message_id_hex": {
+                        "type": "string",
+                        "description": (
+                            "Optional durable target message id. Omit to use the latest "
+                            "inbound message in this group."
+                        ),
+                    },
+                    "emoji": {
+                        "type": "string",
+                        "description": (
+                            "Reaction content. Required for add; optional for remove. "
+                            "Omitting it from remove clears all own reactions on the target."
+                        ),
+                    },
+                },
+                "required": ["action", "group_id_hex"],
+            },
+            handler=_marmot_reaction_tool,
         )
 
 

--- a/integrations/hermes/marmot/adapter.py
+++ b/integrations/hermes/marmot/adapter.py
@@ -1968,6 +1968,7 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
         await self._cancel_all_streams("adapter disconnect")
         self._cancel_debounce_tasks()
         self._pending_ambient_context.clear()
+        self._last_inbound_message_ids.clear()
         self._activation_cache.clear()
         self._tool_progress_events.clear()
         self._tool_progress_replies.clear()
@@ -2774,7 +2775,9 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
         if not target_message_id:
             return {"success": False, "error": "No Marmot message is available to react to"}
         success = await self._add_reaction(chat_id, target_message_id, emoji)
-        return {"success": success, "emoji": emoji}
+        if not success:
+            return {"success": False, "error": "Marmot reaction failed"}
+        return {"success": True, "message_id": target_message_id}
 
     async def _remove_reaction(self, chat_id: str, message_id: str) -> bool:
         try:
@@ -2803,7 +2806,10 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
         target_message_id = message_id or self._last_inbound_message_ids.get(chat_id)
         if not target_message_id:
             return {"success": False, "error": "No Marmot message is available to unreact"}
-        return {"success": await self._remove_reaction(chat_id, target_message_id)}
+        success = await self._remove_reaction(chat_id, target_message_id)
+        if not success:
+            return {"success": False, "error": "Marmot unreact failed"}
+        return {"success": True, "message_id": target_message_id}
 
     async def _send_tool_progress_events(
         self,

--- a/integrations/hermes/marmot/tests/e2e_connector.py
+++ b/integrations/hermes/marmot/tests/e2e_connector.py
@@ -124,9 +124,13 @@ async def run() -> None:
 
     from gateway.config import PlatformConfig
 
-    # Keep Unix socket paths short for macOS sockaddr_un limits. Python's
-    # default temp dir can live under a long /var/folders/... path.
-    with tempfile.TemporaryDirectory(prefix="mhce-", dir="/tmp") as tmp:
+    # Keep Unix socket paths short for macOS sockaddr_un limits without using
+    # `/tmp`, whose canonical private-directory posture is intentionally
+    # rejected by fs-private. CI may supply another owner-controlled parent.
+    temp_parent = Path(
+        os.environ.get("MARMOT_CONNECTOR_E2E_TMPDIR") or Path.home()
+    ).expanduser()
+    with tempfile.TemporaryDirectory(prefix="mhce-", dir=temp_parent) as tmp:
         tmp_path = Path(tmp)
         marmot_home = tmp_path / "marmot-home"
         socket_path = tmp_path / "wn-agent.sock"

--- a/integrations/hermes/marmot/tests/test_adapter.py
+++ b/integrations/hermes/marmot/tests/test_adapter.py
@@ -271,6 +271,32 @@ class AgentControlClientTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("idempotency_key", requests[1])
         self.assertNotIn("idempotency_key", requests[2])
 
+    async def test_remove_reaction_includes_optional_emoji_only_when_supplied(self):
+        requests = []
+
+        async def handler(reader, writer):
+            request = await read_json_line(reader)
+            requests.append(request)
+            await write_json_line(
+                writer,
+                {
+                    "marmot_agent_control": "marmot.agent-control.v2",
+                    "id": request["id"],
+                    "type": "app_event_sent",
+                    "message_ids_hex": ["44" * 32],
+                },
+            )
+            writer.close()
+
+        await self.start_server(handler)
+        client = self.adapter.MarmotAgentControlClient(self.socket_path)
+
+        await client.remove_reaction("11" * 32, "22" * 32, "33" * 32)
+        await client.remove_reaction("11" * 32, "22" * 32, "33" * 32, "👀")
+
+        self.assertNotIn("emoji", requests[0])
+        self.assertEqual(requests[1]["emoji"], "👀")
+
     async def test_send_media_includes_idempotency_key_only_when_supplied(self):
         requests = []
 
@@ -5613,7 +5639,7 @@ class PluginRegistrationTests(unittest.TestCase):
     def setUp(self):
         self.adapter_module = load_adapter_module()
 
-    def test_register_exposes_marmot_history_as_a_platform_tool(self):
+    def test_register_exposes_marmot_history_and_reactions_as_platform_tools(self):
         class FakeContext:
             def __init__(self):
                 self.platforms = []
@@ -5633,6 +5659,10 @@ class PluginRegistrationTests(unittest.TestCase):
         self.assertEqual(history["toolset"], "platform")
         self.assertEqual(history["schema"]["required"], ["group_id_hex"])
         self.assertIs(history["handler"], self.adapter_module._marmot_history_tool)
+        reaction = next(tool for tool in ctx.tools if tool["name"] == "marmot_reaction")
+        self.assertEqual(reaction["toolset"], "platform")
+        self.assertEqual(reaction["schema"]["required"], ["action", "group_id_hex"])
+        self.assertIs(reaction["handler"], self.adapter_module._marmot_reaction_tool)
 
     def test_marmot_history_fetches_one_exact_materialized_message(self):
         calls = []
@@ -5683,6 +5713,66 @@ class PluginRegistrationTests(unittest.TestCase):
         self.assertTrue(result["ok"])
         self.assertEqual(result["type"], "timeline_message")
         self.assertEqual(calls, [("11" * 32, "22" * 32, "33" * 32)])
+
+    def test_marmot_reaction_tool_calls_live_adapter_for_add_and_matching_remove(self):
+        calls = []
+
+        class FakeAdapter:
+            async def add_reaction(self, group_id_hex, emoji, message_id_hex):
+                calls.append(("add", group_id_hex, message_id_hex, emoji))
+                return {"success": True, "message_id": message_id_hex}
+
+            async def remove_reaction(self, group_id_hex, message_id_hex, emoji):
+                calls.append(("remove", group_id_hex, message_id_hex, emoji))
+                return {"success": True, "message_id": message_id_hex}
+
+        class AdapterMap:
+            def get(self, _platform):
+                return FakeAdapter()
+
+        gateway_run = types.ModuleType("gateway.run")
+        gateway_run._gateway_runner_ref = lambda: types.SimpleNamespace(
+            adapters=AdapterMap()
+        )
+        model_tools = types.ModuleType("model_tools")
+        model_tools._run_async = asyncio.run
+        sys.modules["gateway.run"] = gateway_run
+        sys.modules["model_tools"] = model_tools
+
+        try:
+            added = json.loads(
+                self.adapter_module._marmot_reaction_tool(
+                    {
+                        "action": "add",
+                        "group_id_hex": "22" * 32,
+                        "message_id_hex": "33" * 32,
+                        "emoji": "👀",
+                    }
+                )
+            )
+            removed = json.loads(
+                self.adapter_module._marmot_reaction_tool(
+                    {
+                        "action": "remove",
+                        "group_id_hex": "22" * 32,
+                        "message_id_hex": "33" * 32,
+                        "emoji": "👀",
+                    }
+                )
+            )
+        finally:
+            sys.modules.pop("gateway.run", None)
+            sys.modules.pop("model_tools", None)
+
+        self.assertTrue(added["ok"])
+        self.assertTrue(removed["ok"])
+        self.assertEqual(
+            calls,
+            [
+                ("add", "22" * 32, "33" * 32, "👀"),
+                ("remove", "22" * 32, "33" * 32, "👀"),
+            ],
+        )
 
 
 class KeyedAsyncQueueDepthTests(unittest.IsolatedAsyncioTestCase):

--- a/integrations/hermes/marmot/tests/test_adapter.py
+++ b/integrations/hermes/marmot/tests/test_adapter.py
@@ -128,6 +128,12 @@ def install_fake_hermes_modules():
             # the keyword even when they ignore it (#836).
             raise NotImplementedError
 
+        async def add_reaction(self, chat_id, emoji, message_id=None):
+            raise NotImplementedError
+
+        async def remove_reaction(self, chat_id, message_id=None):
+            raise NotImplementedError
+
         def build_source(self, **kwargs):
             return SessionSource(platform=self.platform, **kwargs)
 
@@ -5225,11 +5231,11 @@ class ReactionTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(
             await adapter.add_reaction(chat_id, "👀"),
-            {"success": True, "emoji": "👀"},
+            {"success": True, "message_id": latest_id},
         )
         self.assertEqual(
             await adapter.remove_reaction(chat_id, explicit_id),
-            {"success": True},
+            {"success": True, "message_id": explicit_id},
         )
 
         client.send_reaction.assert_awaited_once_with(
@@ -5265,7 +5271,7 @@ class ReactionTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(
             await adapter.add_reaction(chat_id, "👀"),
-            {"success": True, "emoji": "👀"},
+            {"success": True, "message_id": latest_id},
         )
         client.send_reaction.assert_awaited_once_with(
             "11" * 32, chat_id, latest_id, "👀"
@@ -5282,6 +5288,39 @@ class ReactionTests(unittest.IsolatedAsyncioTestCase):
         self.assertFalse((await adapter.remove_reaction("22" * 32))["success"])
         client.send_reaction.assert_not_awaited()
         client.remove_reaction.assert_not_awaited()
+
+    async def test_public_reaction_api_returns_error_for_failed_send(self):
+        client = unittest.mock.AsyncMock()
+        client.send_reaction.return_value = {
+            "type": "app_event_sent",
+            "message_ids_hex": [],
+        }
+        client.remove_reaction.return_value = {
+            "type": "app_event_sent",
+            "message_ids_hex": [],
+        }
+        adapter = self.adapter_module.MarmotPlatformAdapter(
+            self.config_cls(extra={"account_id_hex": "11" * 32}),
+            client=client,
+        )
+
+        added = await adapter.add_reaction("22" * 32, "👀", "33" * 32)
+        removed = await adapter.remove_reaction("22" * 32, "33" * 32)
+        self.assertFalse(added["success"])
+        self.assertIn("error", added)
+        self.assertFalse(removed["success"])
+        self.assertIn("error", removed)
+
+    async def test_disconnect_clears_latest_inbound_reaction_targets(self):
+        adapter = self.adapter_module.MarmotPlatformAdapter(
+            self.config_cls(extra={"account_id_hex": "11" * 32}),
+            client=unittest.mock.AsyncMock(),
+        )
+        adapter._last_inbound_message_ids["22" * 32] = "33" * 32
+
+        await adapter.disconnect()
+
+        self.assertEqual(adapter._last_inbound_message_ids, {})
 
 
 class GroupActivationTests(unittest.IsolatedAsyncioTestCase):

--- a/integrations/hermes/marmot/tests/test_adapter.py
+++ b/integrations/hermes/marmot/tests/test_adapter.py
@@ -5139,6 +5139,14 @@ class ReactionTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_adapter_reaction_primitives_use_inbound_target(self):
         client = unittest.mock.AsyncMock()
+        client.send_reaction.return_value = {
+            "type": "app_event_sent",
+            "message_ids_hex": ["44" * 32],
+        }
+        client.remove_reaction.return_value = {
+            "type": "app_event_sent",
+            "message_ids_hex": ["55" * 32],
+        }
         adapter = self.adapter_module.MarmotPlatformAdapter(
             self.config_cls(extra={"account_id_hex": "11" * 32}),
             client=client,
@@ -5154,6 +5162,36 @@ class ReactionTests(unittest.IsolatedAsyncioTestCase):
             "11" * 32, "22" * 32, "33" * 32
         )
 
+    async def test_reaction_primitives_reject_non_durable_responses(self):
+        client = unittest.mock.AsyncMock()
+        client.send_reaction.return_value = {
+            "type": "app_event_sent",
+            "message_ids_hex": [],
+        }
+        client.remove_reaction.return_value = {
+            "type": "final_sent",
+            "message_ids_hex": ["55" * 32],
+        }
+        adapter = self.adapter_module.MarmotPlatformAdapter(
+            self.config_cls(extra={"account_id_hex": "11" * 32}),
+            client=client,
+        )
+
+        self.assertFalse(await adapter._add_reaction("22" * 32, "33" * 32, "👀"))
+        self.assertFalse(await adapter._remove_reaction("22" * 32, "33" * 32))
+
+    async def test_reaction_failures_do_not_log_exception_text(self):
+        client = unittest.mock.AsyncMock()
+        client.send_reaction.side_effect = RuntimeError("sensitive-local-path")
+        adapter = self.adapter_module.MarmotPlatformAdapter(
+            self.config_cls(extra={"account_id_hex": "11" * 32}),
+            client=client,
+        )
+
+        with self.assertLogs(self.adapter_module.logger, level="DEBUG") as logs:
+            self.assertFalse(await adapter._add_reaction("22" * 32, "33" * 32, "👀"))
+        self.assertNotIn("sensitive-local-path", "\n".join(logs.output))
+
     async def test_missing_reaction_is_idempotent_for_adapter_remove(self):
         client = unittest.mock.AsyncMock()
         client.remove_reaction.side_effect = self.adapter_module.AgentControlError(
@@ -5168,6 +5206,14 @@ class ReactionTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_public_reaction_api_targets_explicit_or_latest_inbound_message(self):
         client = unittest.mock.AsyncMock()
+        client.send_reaction.return_value = {
+            "type": "app_event_sent",
+            "message_ids_hex": ["55" * 32],
+        }
+        client.remove_reaction.return_value = {
+            "type": "app_event_sent",
+            "message_ids_hex": ["66" * 32],
+        }
         adapter = self.adapter_module.MarmotPlatformAdapter(
             self.config_cls(extra={"account_id_hex": "11" * 32}),
             client=client,

--- a/integrations/hermes/marmot/tests/test_adapter.py
+++ b/integrations/hermes/marmot/tests/test_adapter.py
@@ -5239,6 +5239,38 @@ class ReactionTests(unittest.IsolatedAsyncioTestCase):
             "11" * 32, chat_id, explicit_id
         )
 
+    async def test_fallback_reaction_targets_latest_unmentioned_inbound_message(self):
+        client = unittest.mock.AsyncMock()
+        client.send_reaction.return_value = {
+            "type": "app_event_sent",
+            "message_ids_hex": ["55" * 32],
+        }
+        adapter = self.adapter_module.MarmotPlatformAdapter(
+            self.config_cls(extra={"account_id_hex": "11" * 32}),
+            client=client,
+        )
+        adapter._should_run_turn = unittest.mock.AsyncMock(return_value=False)
+        chat_id = "22" * 32
+        latest_id = "33" * 32
+
+        await adapter._dispatch_inbound_message(
+            {
+                "account_id_hex": "11" * 32,
+                "group_id_hex": chat_id,
+                "message_id_hex": latest_id,
+                "sender_account_id_hex": "44" * 32,
+                "text": "not addressed to the agent",
+            }
+        )
+
+        self.assertEqual(
+            await adapter.add_reaction(chat_id, "👀"),
+            {"success": True, "emoji": "👀"},
+        )
+        client.send_reaction.assert_awaited_once_with(
+            "11" * 32, chat_id, latest_id, "👀"
+        )
+
     async def test_public_reaction_api_fails_cleanly_without_a_target_message(self):
         client = unittest.mock.AsyncMock()
         adapter = self.adapter_module.MarmotPlatformAdapter(

--- a/integrations/hermes/marmot/tests/test_adapter.py
+++ b/integrations/hermes/marmot/tests/test_adapter.py
@@ -5132,6 +5132,80 @@ class DeleteMessageTests(unittest.IsolatedAsyncioTestCase):
         )
 
 
+class ReactionTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.adapter_module = load_adapter_module()
+        self.config_cls = sys.modules["gateway.config"].PlatformConfig
+
+    async def test_adapter_reaction_primitives_use_inbound_target(self):
+        client = unittest.mock.AsyncMock()
+        adapter = self.adapter_module.MarmotPlatformAdapter(
+            self.config_cls(extra={"account_id_hex": "11" * 32}),
+            client=client,
+        )
+
+        self.assertTrue(await adapter._add_reaction("22" * 32, "33" * 32, "👀"))
+        self.assertTrue(await adapter._remove_reaction("22" * 32, "33" * 32))
+
+        client.send_reaction.assert_awaited_once_with(
+            "11" * 32, "22" * 32, "33" * 32, "👀"
+        )
+        client.remove_reaction.assert_awaited_once_with(
+            "11" * 32, "22" * 32, "33" * 32
+        )
+
+    async def test_missing_reaction_is_idempotent_for_adapter_remove(self):
+        client = unittest.mock.AsyncMock()
+        client.remove_reaction.side_effect = self.adapter_module.AgentControlError(
+            "no matching reaction", code="reaction_not_found"
+        )
+        adapter = self.adapter_module.MarmotPlatformAdapter(
+            self.config_cls(extra={"account_id_hex": "11" * 32}),
+            client=client,
+        )
+
+        self.assertTrue(await adapter._remove_reaction("22" * 32, "33" * 32))
+
+    async def test_public_reaction_api_targets_explicit_or_latest_inbound_message(self):
+        client = unittest.mock.AsyncMock()
+        adapter = self.adapter_module.MarmotPlatformAdapter(
+            self.config_cls(extra={"account_id_hex": "11" * 32}),
+            client=client,
+        )
+        chat_id = "22" * 32
+        latest_id = "33" * 32
+        explicit_id = "44" * 32
+        adapter._last_inbound_message_ids[chat_id] = latest_id
+
+        self.assertEqual(
+            await adapter.add_reaction(chat_id, "👀"),
+            {"success": True, "emoji": "👀"},
+        )
+        self.assertEqual(
+            await adapter.remove_reaction(chat_id, explicit_id),
+            {"success": True},
+        )
+
+        client.send_reaction.assert_awaited_once_with(
+            "11" * 32, chat_id, latest_id, "👀"
+        )
+        client.remove_reaction.assert_awaited_once_with(
+            "11" * 32, chat_id, explicit_id
+        )
+
+    async def test_public_reaction_api_fails_cleanly_without_a_target_message(self):
+        client = unittest.mock.AsyncMock()
+        adapter = self.adapter_module.MarmotPlatformAdapter(
+            self.config_cls(extra={"account_id_hex": "11" * 32}),
+            client=client,
+        )
+
+        self.assertFalse((await adapter.add_reaction("22" * 32, "👀"))["success"])
+        self.assertFalse((await adapter.remove_reaction("22" * 32))["success"])
+        client.send_reaction.assert_not_awaited()
+        client.remove_reaction.assert_not_awaited()
+
+
 class GroupActivationTests(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
         self.adapter_module = load_adapter_module()

--- a/integrations/hermes/marmot/tests/test_adapter.py
+++ b/integrations/hermes/marmot/tests/test_adapter.py
@@ -5234,6 +5234,10 @@ class ReactionTests(unittest.IsolatedAsyncioTestCase):
             {"success": True, "message_id": latest_id},
         )
         self.assertEqual(
+            await adapter.remove_reaction(chat_id),
+            {"success": True, "message_id": latest_id},
+        )
+        self.assertEqual(
             await adapter.remove_reaction(chat_id, explicit_id),
             {"success": True, "message_id": explicit_id},
         )
@@ -5241,8 +5245,12 @@ class ReactionTests(unittest.IsolatedAsyncioTestCase):
         client.send_reaction.assert_awaited_once_with(
             "11" * 32, chat_id, latest_id, "👀"
         )
-        client.remove_reaction.assert_awaited_once_with(
-            "11" * 32, chat_id, explicit_id
+        self.assertEqual(
+            client.remove_reaction.await_args_list,
+            [
+                unittest.mock.call("11" * 32, chat_id, latest_id),
+                unittest.mock.call("11" * 32, chat_id, explicit_id),
+            ],
         )
 
     async def test_fallback_reaction_targets_latest_unmentioned_inbound_message(self):


### PR DESCRIPTION
## Summary

- expose arbitrary add/remove message reactions through `marmot.agent-control.v2`
- route reaction requests through `agent-connector` to the existing `AppMessageIntent::Reaction` / `Unreact` behavior
- expose Hermes lifecycle and agent-facing reaction APIs, including latest-inbound-message targeting
- document the v1 scope and add wire-shape, connector, and Hermes adapter regression coverage

Closes #862

## Verification

- `just fast-ci`
- `cargo test -p agent-control`
- `cargo test -p agent-connector`
- `python3 -m unittest integrations.hermes.marmot.tests.test_adapter`
- `cargo fmt --all -- --check`
- `git diff --check`

## Review notes

- Independent implementation review found and prompted addition of the public Hermes `add_reaction` / `remove_reaction` API expected by `send_message(action="react"|"unreact")`.
- The required Kimi K3 advisory review was attempted through the shared runner but OpenRouter returned HTTP 402 before producing a verdict; no Kimi approval is claimed.
- `just hermes-dev-script-test` currently reaches an unrelated existing installer assertion failure: `Hermes installer dry-run did not describe active-service upgrade behavior`. This patch does not modify installer scripts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for adding and removing reactions on messages.
  * Reactions can target a specific message or the latest inbound message.
  * Supports removing a specific reaction or all reactions from the caller.
  * Repeated identical reactions are handled idempotently.
* **Bug Fixes**
  * Improved handling of missing or invalid reaction targets.
  * Restricted reactions to non-empty content without control characters and within 64 Unicode characters.
* **Documentation**
  * Documented reaction controls, targeting behavior, removal options, and content limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->