### PR TITLE
Expose message reactions to OpenClaw

### DIFF
--- a/integrations/openclaw/marmot/README.md
+++ b/integrations/openclaw/marmot/README.md
@@ -14,7 +14,9 @@ the Python Hermes plugin in [`../../hermes/marmot/`](../../hermes/marmot).
 The shared `message` tool exposes Marmot reaction add/remove through its
 `react` action. Reactions target durable message ids; omitting `messageId`
 targets the current inbound message, while `remove: true` or an empty `emoji`
-removes the agent account's active reaction. Reaction content follows the
+removes reactions. A non-empty `emoji` with `remove: true` removes that exact
+content; an empty `emoji` removes all of the agent account's active reactions
+on the target. Repeating a removal is idempotent. Reaction content follows the
 agent-control v2 bound: non-blank, control-free, and at most 64 Unicode scalar
 values.
 

--- a/integrations/openclaw/marmot/README.md
+++ b/integrations/openclaw/marmot/README.md
@@ -13,10 +13,11 @@ the Python Hermes plugin in [`../../hermes/marmot/`](../../hermes/marmot).
 
 The shared `message` tool exposes Marmot reaction add/remove through its
 `react` action. Reactions target durable message ids; omitting `messageId`
-targets the current inbound message, while `remove: true` or an empty `emoji`
-removes reactions. A non-empty `emoji` with `remove: true` removes that exact
-content; an empty `emoji` removes all of the agent account's active reactions
-on the target. Repeating a removal is idempotent. Reaction content follows the
+targets the current inbound message. Removal requires explicit `remove: true`:
+a non-empty `emoji` removes that exact content, while an omitted or empty
+`emoji` removes all of the agent account's active reactions on the target.
+Missing, empty, or non-string emoji values never implicitly remove reactions.
+Repeating a removal is idempotent. Reaction content follows the
 agent-control v2 bound: non-blank, control-free, and at most 64 Unicode scalar
 values.
 

--- a/integrations/openclaw/marmot/README.md
+++ b/integrations/openclaw/marmot/README.md
@@ -11,6 +11,13 @@ local Unix socket. It never opens a QUIC connection, encrypts a record, or talks
 to a relay — all of that stays in `wn-agent`. It is the OpenClaw counterpart of
 the Python Hermes plugin in [`../../hermes/marmot/`](../../hermes/marmot).
 
+The shared `message` tool exposes Marmot reaction add/remove through its
+`react` action. Reactions target durable message ids; omitting `messageId`
+targets the current inbound message, while `remove: true` or an empty `emoji`
+removes the agent account's active reaction. Reaction content follows the
+agent-control v2 bound: non-blank, control-free, and at most 64 Unicode scalar
+values.
+
 For each activated inbound turn, the plugin asks `wn-agent` for a bounded recent
 materialized chat window and supplies it to OpenClaw with durable message ids,
 senders, timestamps, reply links, current reaction summaries, and

--- a/integrations/openclaw/marmot/src/channel.ts
+++ b/integrations/openclaw/marmot/src/channel.ts
@@ -30,7 +30,7 @@ import {
 } from "./config.js";
 import { startMarmotGatewayAccount } from "./gateway.js";
 import { AgentControlError } from "./client.js";
-import { createMarmotMessagingAdapter } from "./messaging.js";
+import { createMarmotMessagingAdapter, normalizeMarmotTarget } from "./messaging.js";
 import { createMarmotMessageAdapter } from "./outbound.js";
 import {
   DEFAULT_MARMOT_CHANNEL_ACCOUNT_ID,
@@ -137,13 +137,13 @@ export interface MarmotMessageActionClient {
     groupIdHex: string,
     targetMessageIdHex: string,
   ) => Promise<unknown>;
-  sendReaction?: (
+  sendReaction: (
     accountIdHex: string,
     groupIdHex: string,
     targetMessageIdHex: string,
     emoji: string,
   ) => Promise<unknown>;
-  removeReaction?: (
+  removeReaction: (
     accountIdHex: string,
     groupIdHex: string,
     targetMessageIdHex: string,
@@ -170,11 +170,15 @@ export function createMarmotMessageActionAdapter(
             : typeof ctx.params.message_id === "string"
               ? ctx.params.message_id
             : String(ctx.toolContext?.currentMessageId ?? "");
+        // `deleteByMessageId` mutates immediately and only returns a boolean;
+        // it cannot safely recover a cached group for a reaction. Current
+        // inbound reactions inherit the tool context, while reactions to an
+        // earlier outbound message therefore require an explicit `to`.
         const rawTo =
           typeof ctx.params.to === "string"
             ? ctx.params.to
             : ctx.toolContext?.currentMessagingTarget;
-        const to = rawTo?.startsWith("marmot:") ? rawTo.slice("marmot:".length) : rawTo;
+        const to = normalizeMarmotTarget(rawTo ?? "");
         if (!messageId) {
           return jsonResult({
             ok: false,
@@ -184,26 +188,26 @@ export function createMarmotMessageActionAdapter(
         if (!to) {
           return jsonResult({ ok: false, error: "could not resolve group for this message id" });
         }
+        const remove = ctx.params.remove === true;
+        if (ctx.params.emoji !== undefined && typeof ctx.params.emoji !== "string") {
+          return jsonResult({ ok: false, error: "emoji must be a string" });
+        }
         const emoji = typeof ctx.params.emoji === "string" ? ctx.params.emoji : "";
-        const remove = ctx.params.remove === true || emoji.length === 0;
+        if (!remove && emoji.length === 0) {
+          return jsonResult({ ok: false, error: "emoji required unless remove is true" });
+        }
         try {
           const { client, marmotAccountIdHex } = await deps.resolveTarget(
             ctx.cfg,
             ctx.accountId ?? null,
           );
           if (remove) {
-            if (!client.removeReaction) {
-              return jsonResult({ ok: false, error: "reaction removal unavailable" });
-            }
             if (emoji.length > 0) {
               await client.removeReaction(marmotAccountIdHex, to, messageId, emoji);
             } else {
               await client.removeReaction(marmotAccountIdHex, to, messageId);
             }
             return jsonResult({ ok: true, removed: true });
-          }
-          if (!client.sendReaction) {
-            return jsonResult({ ok: false, error: "reactions unavailable" });
           }
           await client.sendReaction(marmotAccountIdHex, to, messageId, emoji);
           return jsonResult({ ok: true, added: emoji });

--- a/integrations/openclaw/marmot/src/channel.ts
+++ b/integrations/openclaw/marmot/src/channel.ts
@@ -115,8 +115,8 @@ async function probeMarmotAccount(account: ResolvedMarmotAccount): Promise<Marmo
   };
 }
 
-/** Dependencies the channel-owned `delete` action adapter needs. */
-export interface MarmotDeleteActionDeps {
+/** Dependencies the channel-owned message action adapter needs. */
+export interface MarmotMessageActionDeps {
   /** Resolve a sent message id to its group from the send-time cache. */
   deleteByMessageId: (
     targetMessageIdHex: string,
@@ -126,12 +126,23 @@ export interface MarmotDeleteActionDeps {
   resolveTarget: (
     cfg: unknown,
     accountId?: string | null,
-  ) => Promise<{ client: MarmotMessageDeleteClient; marmotAccountIdHex: string }>;
+  ) => Promise<{ client: MarmotMessageActionClient; marmotAccountIdHex: string }>;
 }
 
-/** Narrow view of the control client used by the explicit-group delete fallback. */
-export interface MarmotMessageDeleteClient {
+/** Narrow view of the control client used by message mutations. */
+export interface MarmotMessageActionClient {
   deleteMessage: (
+    accountIdHex: string,
+    groupIdHex: string,
+    targetMessageIdHex: string,
+  ) => Promise<unknown>;
+  sendReaction?: (
+    accountIdHex: string,
+    groupIdHex: string,
+    targetMessageIdHex: string,
+    emoji: string,
+  ) => Promise<unknown>;
+  removeReaction?: (
     accountIdHex: string,
     groupIdHex: string,
     targetMessageIdHex: string,
@@ -143,13 +154,50 @@ export interface MarmotMessageDeleteClient {
  * `message(action:"delete", messageId, to)` reaches `handleAction`. Prefer the
  * send-time cache (no extra round-trip); fall back to an explicit `to` group.
  */
-export function createMarmotDeleteActionAdapter(
-  deps: MarmotDeleteActionDeps,
+export function createMarmotMessageActionAdapter(
+  deps: MarmotMessageActionDeps,
 ): ChannelMessageActionAdapter {
   return {
-    describeMessageTool: () => ({ actions: ["delete"] }),
-    supportsAction: ({ action }) => action === "delete",
+    describeMessageTool: () => ({ actions: ["delete", "react"] }),
+    supportsAction: ({ action }) => action === "delete" || action === "react",
     handleAction: async (ctx: ChannelMessageActionContext) => {
+      if (ctx.action === "react") {
+        const messageId =
+          typeof ctx.params.messageId === "string"
+            ? ctx.params.messageId
+            : String(ctx.toolContext?.currentMessageId ?? "");
+        const to =
+          typeof ctx.params.to === "string"
+            ? ctx.params.to
+            : ctx.toolContext?.currentMessagingTarget;
+        if (!messageId) {
+          return jsonResult({
+            ok: false,
+            error: "messageId required. Provide messageId explicitly or react to the current inbound message.",
+          });
+        }
+        if (!to) {
+          return jsonResult({ ok: false, error: "could not resolve group for this message id" });
+        }
+        const { client, marmotAccountIdHex } = await deps.resolveTarget(
+          ctx.cfg,
+          ctx.accountId ?? null,
+        );
+        const emoji = typeof ctx.params.emoji === "string" ? ctx.params.emoji : "";
+        const remove = ctx.params.remove === true || emoji.length === 0;
+        if (remove) {
+          if (!client.removeReaction) {
+            return jsonResult({ ok: false, error: "reaction removal unavailable" });
+          }
+          await client.removeReaction(marmotAccountIdHex, to, messageId);
+          return jsonResult({ ok: true, removed: true });
+        }
+        if (!client.sendReaction) {
+          return jsonResult({ ok: false, error: "reactions unavailable" });
+        }
+        await client.sendReaction(marmotAccountIdHex, to, messageId, emoji);
+        return jsonResult({ ok: true, added: emoji });
+      }
       if (ctx.action !== "delete") {
         return jsonResult({ ok: false, error: `unsupported action: ${ctx.action}` });
       }
@@ -188,7 +236,7 @@ export function createMarmotChannelPlugin() {
   // can reuse its send-time conversation cache via `deleteByMessageId`.
   const messageAdapter = createMarmotMessageAdapter({ resolveTarget });
 
-  const actions = createMarmotDeleteActionAdapter({
+  const actions = createMarmotMessageActionAdapter({
     deleteByMessageId: messageAdapter.deleteByMessageId,
     resolveTarget,
   });

--- a/integrations/openclaw/marmot/src/channel.ts
+++ b/integrations/openclaw/marmot/src/channel.ts
@@ -29,6 +29,7 @@ import {
   type ResolvedMarmotAccount,
 } from "./config.js";
 import { startMarmotGatewayAccount } from "./gateway.js";
+import { AgentControlError } from "./client.js";
 import { createMarmotMessagingAdapter } from "./messaging.js";
 import { createMarmotMessageAdapter } from "./outbound.js";
 import {
@@ -146,6 +147,7 @@ export interface MarmotMessageActionClient {
     accountIdHex: string,
     groupIdHex: string,
     targetMessageIdHex: string,
+    emoji?: string,
   ) => Promise<unknown>;
 }
 
@@ -193,7 +195,11 @@ export function createMarmotMessageActionAdapter(
             if (!client.removeReaction) {
               return jsonResult({ ok: false, error: "reaction removal unavailable" });
             }
-            await client.removeReaction(marmotAccountIdHex, to, messageId);
+            if (emoji.length > 0) {
+              await client.removeReaction(marmotAccountIdHex, to, messageId, emoji);
+            } else {
+              await client.removeReaction(marmotAccountIdHex, to, messageId);
+            }
             return jsonResult({ ok: true, removed: true });
           }
           if (!client.sendReaction) {
@@ -201,7 +207,14 @@ export function createMarmotMessageActionAdapter(
           }
           await client.sendReaction(marmotAccountIdHex, to, messageId, emoji);
           return jsonResult({ ok: true, added: emoji });
-        } catch {
+        } catch (error) {
+          if (
+            remove &&
+            error instanceof AgentControlError &&
+            error.code === "reaction_not_found"
+          ) {
+            return jsonResult({ ok: true, removed: true });
+          }
           return jsonResult({ ok: false, error: "reaction operation failed" });
         }
       }

--- a/integrations/openclaw/marmot/src/channel.ts
+++ b/integrations/openclaw/marmot/src/channel.ts
@@ -185,18 +185,22 @@ export function createMarmotMessageActionAdapter(
         );
         const emoji = typeof ctx.params.emoji === "string" ? ctx.params.emoji : "";
         const remove = ctx.params.remove === true || emoji.length === 0;
-        if (remove) {
-          if (!client.removeReaction) {
-            return jsonResult({ ok: false, error: "reaction removal unavailable" });
+        try {
+          if (remove) {
+            if (!client.removeReaction) {
+              return jsonResult({ ok: false, error: "reaction removal unavailable" });
+            }
+            await client.removeReaction(marmotAccountIdHex, to, messageId);
+            return jsonResult({ ok: true, removed: true });
           }
-          await client.removeReaction(marmotAccountIdHex, to, messageId);
-          return jsonResult({ ok: true, removed: true });
+          if (!client.sendReaction) {
+            return jsonResult({ ok: false, error: "reactions unavailable" });
+          }
+          await client.sendReaction(marmotAccountIdHex, to, messageId, emoji);
+          return jsonResult({ ok: true, added: emoji });
+        } catch {
+          return jsonResult({ ok: false, error: "reaction operation failed" });
         }
-        if (!client.sendReaction) {
-          return jsonResult({ ok: false, error: "reactions unavailable" });
-        }
-        await client.sendReaction(marmotAccountIdHex, to, messageId, emoji);
-        return jsonResult({ ok: true, added: emoji });
       }
       if (ctx.action !== "delete") {
         return jsonResult({ ok: false, error: `unsupported action: ${ctx.action}` });

--- a/integrations/openclaw/marmot/src/channel.ts
+++ b/integrations/openclaw/marmot/src/channel.ts
@@ -168,10 +168,11 @@ export function createMarmotMessageActionAdapter(
             : typeof ctx.params.message_id === "string"
               ? ctx.params.message_id
             : String(ctx.toolContext?.currentMessageId ?? "");
-        const to =
+        const rawTo =
           typeof ctx.params.to === "string"
             ? ctx.params.to
             : ctx.toolContext?.currentMessagingTarget;
+        const to = rawTo?.startsWith("marmot:") ? rawTo.slice("marmot:".length) : rawTo;
         if (!messageId) {
           return jsonResult({
             ok: false,

--- a/integrations/openclaw/marmot/src/channel.ts
+++ b/integrations/openclaw/marmot/src/channel.ts
@@ -165,6 +165,8 @@ export function createMarmotMessageActionAdapter(
         const messageId =
           typeof ctx.params.messageId === "string"
             ? ctx.params.messageId
+            : typeof ctx.params.message_id === "string"
+              ? ctx.params.message_id
             : String(ctx.toolContext?.currentMessageId ?? "");
         const to =
           typeof ctx.params.to === "string"
@@ -179,13 +181,13 @@ export function createMarmotMessageActionAdapter(
         if (!to) {
           return jsonResult({ ok: false, error: "could not resolve group for this message id" });
         }
-        const { client, marmotAccountIdHex } = await deps.resolveTarget(
-          ctx.cfg,
-          ctx.accountId ?? null,
-        );
         const emoji = typeof ctx.params.emoji === "string" ? ctx.params.emoji : "";
         const remove = ctx.params.remove === true || emoji.length === 0;
         try {
+          const { client, marmotAccountIdHex } = await deps.resolveTarget(
+            ctx.cfg,
+            ctx.accountId ?? null,
+          );
           if (remove) {
             if (!client.removeReaction) {
               return jsonResult({ ok: false, error: "reaction removal unavailable" });

--- a/integrations/openclaw/marmot/src/client.ts
+++ b/integrations/openclaw/marmot/src/client.ts
@@ -65,6 +65,20 @@ export interface AppEventSentResponse {
   message_ids_hex: string[];
 }
 
+function requireAppEventSent(response: Envelope): AppEventSentResponse {
+  if (
+    response.type !== "app_event_sent" ||
+    !Array.isArray(response.message_ids_hex) ||
+    response.message_ids_hex.length === 0 ||
+    response.message_ids_hex.some((value) => typeof value !== "string" || value.length === 0)
+  ) {
+    throw new AgentControlError("wn-agent returned invalid durable reaction response", {
+      code: "invalid_reaction_response",
+    });
+  }
+  return response as unknown as AppEventSentResponse;
+}
+
 export interface StreamBegunResponse {
   type: "stream_begun";
   stream_id_hex: string;
@@ -621,13 +635,14 @@ export class MarmotAgentControlClient {
     targetMessageIdHex: string,
     emoji: string,
   ): Promise<AppEventSentResponse> {
-    return (await this.request({
+    const response = await this.request({
       type: "send_reaction",
       account_id_hex: normalizeHex(accountIdHex, "account_id_hex"),
       group_id_hex: normalizeHex(groupIdHex, "group_id_hex"),
       target_message_id_hex: normalizeHex(targetMessageIdHex, "target_message_id_hex"),
       emoji: String(emoji),
-    })) as unknown as AppEventSentResponse;
+    });
+    return requireAppEventSent(response);
   }
 
   /** Remove this account's active reaction from a durable group message. */
@@ -636,12 +651,13 @@ export class MarmotAgentControlClient {
     groupIdHex: string,
     targetMessageIdHex: string,
   ): Promise<AppEventSentResponse> {
-    return (await this.request({
+    const response = await this.request({
       type: "remove_reaction",
       account_id_hex: normalizeHex(accountIdHex, "account_id_hex"),
       group_id_hex: normalizeHex(groupIdHex, "group_id_hex"),
       target_message_id_hex: normalizeHex(targetMessageIdHex, "target_message_id_hex"),
-    })) as unknown as AppEventSentResponse;
+    });
+    return requireAppEventSent(response);
   }
 
   async streamBegin(

--- a/integrations/openclaw/marmot/src/client.ts
+++ b/integrations/openclaw/marmot/src/client.ts
@@ -652,13 +652,18 @@ export class MarmotAgentControlClient {
     accountIdHex: string,
     groupIdHex: string,
     targetMessageIdHex: string,
+    emoji?: string,
   ): Promise<AppEventSentResponse> {
-    const response = await this.request({
+    const request: Record<string, unknown> = {
       type: "remove_reaction",
       account_id_hex: normalizeHex(accountIdHex, "account_id_hex"),
       group_id_hex: normalizeHex(groupIdHex, "group_id_hex"),
       target_message_id_hex: normalizeHex(targetMessageIdHex, "target_message_id_hex"),
-    });
+    };
+    if (emoji !== undefined) {
+      request.emoji = String(emoji);
+    }
+    const response = await this.request(request);
     return requireAppEventSent(response);
   }
 

--- a/integrations/openclaw/marmot/src/client.ts
+++ b/integrations/openclaw/marmot/src/client.ts
@@ -66,11 +66,13 @@ export interface AppEventSentResponse {
 }
 
 function requireAppEventSent(response: Envelope): AppEventSentResponse {
+  const isMessageId = (value: unknown): value is string =>
+    typeof value === "string" && /^[0-9a-fA-F]{64}$/.test(value);
   if (
     response.type !== "app_event_sent" ||
     !Array.isArray(response.message_ids_hex) ||
     response.message_ids_hex.length === 0 ||
-    response.message_ids_hex.some((value) => typeof value !== "string" || value.length === 0)
+    response.message_ids_hex.some((value) => !isMessageId(value))
   ) {
     throw new AgentControlError("wn-agent returned invalid durable reaction response", {
       code: "invalid_reaction_response",

--- a/integrations/openclaw/marmot/src/client.ts
+++ b/integrations/openclaw/marmot/src/client.ts
@@ -614,6 +614,36 @@ export class MarmotAgentControlClient {
     })) as unknown as FinalSentResponse;
   }
 
+  /** Add arbitrary reaction content to a durable group message. */
+  async sendReaction(
+    accountIdHex: string,
+    groupIdHex: string,
+    targetMessageIdHex: string,
+    emoji: string,
+  ): Promise<AppEventSentResponse> {
+    return (await this.request({
+      type: "send_reaction",
+      account_id_hex: normalizeHex(accountIdHex, "account_id_hex"),
+      group_id_hex: normalizeHex(groupIdHex, "group_id_hex"),
+      target_message_id_hex: normalizeHex(targetMessageIdHex, "target_message_id_hex"),
+      emoji: String(emoji),
+    })) as unknown as AppEventSentResponse;
+  }
+
+  /** Remove this account's active reaction from a durable group message. */
+  async removeReaction(
+    accountIdHex: string,
+    groupIdHex: string,
+    targetMessageIdHex: string,
+  ): Promise<AppEventSentResponse> {
+    return (await this.request({
+      type: "remove_reaction",
+      account_id_hex: normalizeHex(accountIdHex, "account_id_hex"),
+      group_id_hex: normalizeHex(groupIdHex, "group_id_hex"),
+      target_message_id_hex: normalizeHex(targetMessageIdHex, "target_message_id_hex"),
+    })) as unknown as AppEventSentResponse;
+  }
+
   async streamBegin(
     accountIdHex: string,
     groupIdHex: string,

--- a/integrations/openclaw/marmot/test/channel.test.ts
+++ b/integrations/openclaw/marmot/test/channel.test.ts
@@ -258,6 +258,31 @@ describe("createMarmotMessageActionAdapter", () => {
     expect(resultOk(result)).toBe(true);
   });
 
+  it("honors the message_id alias over the current inbound message", async () => {
+    const sendReaction = vi.fn(async () => undefined);
+    const adapter = createMarmotMessageActionAdapter({
+      deleteByMessageId: async () => false,
+      resolveTarget: async () => ({
+        client: { deleteMessage: async () => undefined, sendReaction },
+        marmotAccountIdHex: HEX32("aa"),
+      }),
+    });
+
+    await adapter.handleAction!(
+      reactCtx(
+        { message_id: HEX32("88"), emoji: "👀" },
+        { currentMessageId: HEX32("99"), currentMessagingTarget: HEX32("cc") },
+      ),
+    );
+
+    expect(sendReaction).toHaveBeenCalledWith(
+      HEX32("aa"),
+      HEX32("cc"),
+      HEX32("88"),
+      "👀",
+    );
+  });
+
   it("removes the bot's reaction when emoji is empty", async () => {
     const removeReaction = vi.fn(async () => undefined);
     const adapter = createMarmotMessageActionAdapter({
@@ -307,6 +332,25 @@ describe("createMarmotMessageActionAdapter", () => {
         },
         marmotAccountIdHex: HEX32("aa"),
       }),
+    });
+
+    const result = await adapter.handleAction!(
+      reactCtx(
+        { emoji: "👀" },
+        { currentMessageId: HEX32("99"), currentMessagingTarget: HEX32("cc") },
+      ),
+    );
+    expect(resultOk(result)).toBe(false);
+    expect(resultError(result)).toBe("reaction operation failed");
+    expect(resultError(result)).not.toContain("secret");
+  });
+
+  it("sanitizes failures while resolving a reaction target", async () => {
+    const adapter = createMarmotMessageActionAdapter({
+      deleteByMessageId: async () => false,
+      resolveTarget: async () => {
+        throw new Error("secret socket path");
+      },
     });
 
     const result = await adapter.handleAction!(

--- a/integrations/openclaw/marmot/test/channel.test.ts
+++ b/integrations/openclaw/marmot/test/channel.test.ts
@@ -232,7 +232,7 @@ describe("createMarmotMessageActionAdapter", () => {
     expect(resultError(result)).toMatch(/could not resolve group/);
   });
 
-  it("adds a reaction to the current inbound message", async () => {
+  it("adds a reaction to the current inbound message with a prefixed target", async () => {
     const sendReaction = vi.fn(async () => undefined);
     const adapter = createMarmotMessageActionAdapter({
       deleteByMessageId: async () => false,
@@ -245,7 +245,7 @@ describe("createMarmotMessageActionAdapter", () => {
     const result = await adapter.handleAction!(
       reactCtx(
         { emoji: "👀" },
-        { currentMessageId: HEX32("99"), currentMessagingTarget: HEX32("cc") },
+        { currentMessageId: HEX32("99"), currentMessagingTarget: `marmot:${HEX32("cc")}` },
       ),
     );
 
@@ -283,7 +283,7 @@ describe("createMarmotMessageActionAdapter", () => {
     );
   });
 
-  it("removes the bot's reaction when emoji is empty", async () => {
+  it("removes the bot's reaction from a prefixed target when emoji is empty", async () => {
     const removeReaction = vi.fn(async () => undefined);
     const adapter = createMarmotMessageActionAdapter({
       deleteByMessageId: async () => false,
@@ -294,7 +294,7 @@ describe("createMarmotMessageActionAdapter", () => {
     });
 
     const result = await adapter.handleAction!(
-      reactCtx({ messageId: HEX32("99"), to: HEX32("cc"), emoji: "" }),
+      reactCtx({ messageId: HEX32("99"), to: `marmot:${HEX32("cc")}`, emoji: "" }),
     );
 
     expect(removeReaction).toHaveBeenCalledWith(HEX32("aa"), HEX32("cc"), HEX32("99"));

--- a/integrations/openclaw/marmot/test/channel.test.ts
+++ b/integrations/openclaw/marmot/test/channel.test.ts
@@ -16,6 +16,17 @@ import {
 
 const HEX32 = (b: string) => b.repeat(32);
 
+function messageActionClient(
+  overrides: Partial<MarmotMessageActionClient> = {},
+): MarmotMessageActionClient {
+  return {
+    deleteMessage: async () => undefined,
+    sendReaction: async () => undefined,
+    removeReaction: async () => undefined,
+    ...overrides,
+  };
+}
+
 /** Read the `ok` flag from a `jsonResult`-shaped tool result's details payload. */
 function resultOk(result: { details: unknown }): boolean {
   return (result.details as { ok?: boolean }).ok === true;
@@ -137,7 +148,7 @@ describe("createMarmotMessageActionAdapter", () => {
     const adapter = createMarmotMessageActionAdapter({
       deleteByMessageId: async () => false,
       resolveTarget: async () => ({
-        client: { deleteMessage: async () => undefined },
+        client: messageActionClient(),
         marmotAccountIdHex: HEX32("aa"),
       }),
     });
@@ -151,7 +162,7 @@ describe("createMarmotMessageActionAdapter", () => {
     const adapter = createMarmotMessageActionAdapter({
       deleteByMessageId: async () => false,
       resolveTarget: async () => ({
-        client: { deleteMessage: async () => undefined },
+        client: messageActionClient(),
         marmotAccountIdHex: HEX32("aa"),
       }),
     });
@@ -163,7 +174,7 @@ describe("createMarmotMessageActionAdapter", () => {
   it("deletes via the send-time cache on a cache hit", async () => {
     const deleteByMessageId = vi.fn(async () => true);
     const resolveTarget = vi.fn(async () => ({
-      client: { deleteMessage: vi.fn(async () => undefined) },
+      client: messageActionClient({ deleteMessage: vi.fn(async () => undefined) }),
       marmotAccountIdHex: HEX32("aa"),
     }));
     const adapter = createMarmotMessageActionAdapter({ deleteByMessageId, resolveTarget });
@@ -182,12 +193,12 @@ describe("createMarmotMessageActionAdapter", () => {
 
   it("falls back to the explicit `to` group on a cache miss", async () => {
     const calls: { account: string; group: string; id: string }[] = [];
-    const client: MarmotMessageActionClient = {
+    const client = messageActionClient({
       deleteMessage: async (account, group, id) => {
         calls.push({ account, group, id });
         return undefined;
       },
-    };
+    });
     const adapter = createMarmotMessageActionAdapter({
       deleteByMessageId: async () => false,
       resolveTarget: async () => ({ client, marmotAccountIdHex: HEX32("aa") }),
@@ -207,7 +218,7 @@ describe("createMarmotMessageActionAdapter", () => {
     const adapter = createMarmotMessageActionAdapter({
       deleteByMessageId: async () => false,
       resolveTarget: async () => ({
-        client: { deleteMessage: async () => undefined },
+        client: messageActionClient(),
         marmotAccountIdHex: HEX32("aa"),
       }),
     });
@@ -222,7 +233,7 @@ describe("createMarmotMessageActionAdapter", () => {
     const adapter = createMarmotMessageActionAdapter({
       deleteByMessageId: async () => false,
       resolveTarget: async () => ({
-        client: { deleteMessage },
+        client: messageActionClient({ deleteMessage }),
         marmotAccountIdHex: HEX32("aa"),
       }),
     });
@@ -238,7 +249,7 @@ describe("createMarmotMessageActionAdapter", () => {
     const adapter = createMarmotMessageActionAdapter({
       deleteByMessageId: async () => false,
       resolveTarget: async () => ({
-        client: { deleteMessage: async () => undefined, sendReaction },
+        client: messageActionClient({ sendReaction }),
         marmotAccountIdHex: HEX32("aa"),
       }),
     });
@@ -264,7 +275,7 @@ describe("createMarmotMessageActionAdapter", () => {
     const adapter = createMarmotMessageActionAdapter({
       deleteByMessageId: async () => false,
       resolveTarget: async () => ({
-        client: { deleteMessage: async () => undefined, sendReaction },
+        client: messageActionClient({ sendReaction }),
         marmotAccountIdHex: HEX32("aa"),
       }),
     });
@@ -284,36 +295,81 @@ describe("createMarmotMessageActionAdapter", () => {
     );
   });
 
-  it("removes the bot's reaction from a prefixed target when emoji is empty", async () => {
+  it("removes all reactions only when remove is explicit and emoji is empty", async () => {
     const removeReaction = vi.fn(async () => undefined);
     const adapter = createMarmotMessageActionAdapter({
       deleteByMessageId: async () => false,
       resolveTarget: async () => ({
-        client: { deleteMessage: async () => undefined, removeReaction },
+        client: messageActionClient({ removeReaction }),
         marmotAccountIdHex: HEX32("aa"),
       }),
     });
 
     const result = await adapter.handleAction!(
-      reactCtx({ messageId: HEX32("99"), to: `marmot:${HEX32("cc")}`, emoji: "" }),
+      reactCtx({
+        messageId: HEX32("99"),
+        to: `  MARMOT:0X${"C".repeat(64)}  `,
+        remove: true,
+        emoji: "",
+      }),
     );
 
     expect(removeReaction).toHaveBeenCalledWith(HEX32("aa"), HEX32("cc"), HEX32("99"));
     expect(resultOk(result)).toBe(true);
   });
 
+  it("rejects missing, empty, and non-string emoji without explicit removal", async () => {
+    const resolveTarget = vi.fn(async () => ({
+      client: messageActionClient(),
+      marmotAccountIdHex: HEX32("aa"),
+    }));
+    const adapter = createMarmotMessageActionAdapter({
+      deleteByMessageId: async () => false,
+      resolveTarget,
+    });
+    const toolContext = {
+      currentMessageId: HEX32("99"),
+      currentMessagingTarget: HEX32("cc"),
+    };
+
+    for (const params of [{}, { emoji: "" }, { emoji: 7 }]) {
+      const result = await adapter.handleAction!(reactCtx(params, toolContext));
+      expect(resultOk(result)).toBe(false);
+      expect(resultError(result)).toMatch(/emoji/);
+    }
+    expect(resolveTarget).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid explicit reaction target before resolving a client", async () => {
+    const resolveTarget = vi.fn(async () => ({
+      client: messageActionClient(),
+      marmotAccountIdHex: HEX32("aa"),
+    }));
+    const adapter = createMarmotMessageActionAdapter({
+      deleteByMessageId: async () => false,
+      resolveTarget,
+    });
+
+    const result = await adapter.handleAction!(
+      reactCtx({ messageId: HEX32("99"), to: "marmot:not-hex", emoji: "👀" }),
+    );
+
+    expect(resultOk(result)).toBe(false);
+    expect(resultError(result)).toBe("could not resolve group for this message id");
+    expect(resolveTarget).not.toHaveBeenCalled();
+  });
+
   it("treats an already-absent reaction as an idempotent removal", async () => {
     const adapter = createMarmotMessageActionAdapter({
       deleteByMessageId: async () => false,
       resolveTarget: async () => ({
-        client: {
-          deleteMessage: async () => undefined,
+        client: messageActionClient({
           removeReaction: async () => {
             throw new AgentControlError("reaction was not active", {
               code: "reaction_not_found",
             });
           },
-        },
+        }),
         marmotAccountIdHex: HEX32("aa"),
       }),
     });
@@ -334,7 +390,7 @@ describe("createMarmotMessageActionAdapter", () => {
     const adapter = createMarmotMessageActionAdapter({
       deleteByMessageId: async () => false,
       resolveTarget: async () => ({
-        client: { deleteMessage: async () => undefined, removeReaction },
+        client: messageActionClient({ removeReaction }),
         marmotAccountIdHex: HEX32("aa"),
       }),
     });
@@ -359,10 +415,9 @@ describe("createMarmotMessageActionAdapter", () => {
     const adapter = createMarmotMessageActionAdapter({
       deleteByMessageId: async () => false,
       resolveTarget: async () => ({
-        client: {
-          deleteMessage: async () => undefined,
+        client: messageActionClient({
           sendReaction: async () => { throw new Error("secret socket detail"); },
-        },
+        }),
         marmotAccountIdHex: HEX32("aa"),
       }),
     });
@@ -401,7 +456,7 @@ describe("createMarmotMessageActionAdapter", () => {
     const adapter = createMarmotMessageActionAdapter({
       deleteByMessageId: async () => true,
       resolveTarget: async () => ({
-        client: { deleteMessage: async () => undefined },
+        client: messageActionClient(),
         marmotAccountIdHex: HEX32("aa"),
       }),
     });

--- a/integrations/openclaw/marmot/test/channel.test.ts
+++ b/integrations/openclaw/marmot/test/channel.test.ts
@@ -3,9 +3,9 @@ import type { ChannelMessageActionContext } from "openclaw/plugin-sdk/channel-co
 
 import {
   createMarmotChannelPlugin,
-  createMarmotDeleteActionAdapter,
+  createMarmotMessageActionAdapter,
   resolveMarmotChannelAccount,
-  type MarmotMessageDeleteClient,
+  type MarmotMessageActionClient,
 } from "../src/channel.js";
 import {
   markMarmotInboundReady,
@@ -31,6 +31,19 @@ function deleteCtx(params: Record<string, unknown>): ChannelMessageActionContext
     action: "delete",
     cfg: {},
     params,
+  } as unknown as ChannelMessageActionContext;
+}
+
+function reactCtx(
+  params: Record<string, unknown>,
+  toolContext: { currentMessageId?: string; currentMessagingTarget?: string } = {},
+): ChannelMessageActionContext {
+  return {
+    channel: "marmot",
+    action: "react",
+    cfg: {},
+    params,
+    toolContext,
   } as unknown as ChannelMessageActionContext;
 }
 
@@ -118,9 +131,9 @@ describe("resolveMarmotChannelAccount", () => {
   });
 });
 
-describe("createMarmotDeleteActionAdapter", () => {
-  it("owns only delete so core durable sends can fall through", () => {
-    const adapter = createMarmotDeleteActionAdapter({
+describe("createMarmotMessageActionAdapter", () => {
+  it("owns delete and react so core durable sends can fall through", () => {
+    const adapter = createMarmotMessageActionAdapter({
       deleteByMessageId: async () => false,
       resolveTarget: async () => ({
         client: { deleteMessage: async () => undefined },
@@ -130,18 +143,20 @@ describe("createMarmotDeleteActionAdapter", () => {
 
     expect(adapter.supportsAction?.({ action: "delete" })).toBe(true);
     expect(adapter.supportsAction?.({ action: "send" })).toBe(false);
-    expect(adapter.supportsAction?.({ action: "react" })).toBe(false);
+    expect(adapter.supportsAction?.({ action: "react" })).toBe(true);
   });
 
-  it("declares the delete action through describeMessageTool", () => {
-    const adapter = createMarmotDeleteActionAdapter({
+  it("declares delete and react through describeMessageTool", () => {
+    const adapter = createMarmotMessageActionAdapter({
       deleteByMessageId: async () => false,
       resolveTarget: async () => ({
         client: { deleteMessage: async () => undefined },
         marmotAccountIdHex: HEX32("aa"),
       }),
     });
-    expect(adapter.describeMessageTool({ cfg: {} } as never)).toEqual({ actions: ["delete"] });
+    expect(adapter.describeMessageTool({ cfg: {} } as never)).toEqual({
+      actions: ["delete", "react"],
+    });
   });
 
   it("deletes via the send-time cache on a cache hit", async () => {
@@ -150,7 +165,7 @@ describe("createMarmotDeleteActionAdapter", () => {
       client: { deleteMessage: vi.fn(async () => undefined) },
       marmotAccountIdHex: HEX32("aa"),
     }));
-    const adapter = createMarmotDeleteActionAdapter({ deleteByMessageId, resolveTarget });
+    const adapter = createMarmotMessageActionAdapter({ deleteByMessageId, resolveTarget });
 
     const result = await adapter.handleAction!(deleteCtx({ messageId: HEX32("99") }));
 
@@ -166,13 +181,13 @@ describe("createMarmotDeleteActionAdapter", () => {
 
   it("falls back to the explicit `to` group on a cache miss", async () => {
     const calls: { account: string; group: string; id: string }[] = [];
-    const client: MarmotMessageDeleteClient = {
+    const client: MarmotMessageActionClient = {
       deleteMessage: async (account, group, id) => {
         calls.push({ account, group, id });
         return undefined;
       },
     };
-    const adapter = createMarmotDeleteActionAdapter({
+    const adapter = createMarmotMessageActionAdapter({
       deleteByMessageId: async () => false,
       resolveTarget: async () => ({ client, marmotAccountIdHex: HEX32("aa") }),
     });
@@ -188,7 +203,7 @@ describe("createMarmotDeleteActionAdapter", () => {
   });
 
   it("returns an error when messageId is missing", async () => {
-    const adapter = createMarmotDeleteActionAdapter({
+    const adapter = createMarmotMessageActionAdapter({
       deleteByMessageId: async () => false,
       resolveTarget: async () => ({
         client: { deleteMessage: async () => undefined },
@@ -203,7 +218,7 @@ describe("createMarmotDeleteActionAdapter", () => {
 
   it("errors on a cache miss with no `to` group to fall back to", async () => {
     const deleteMessage = vi.fn(async () => undefined);
-    const adapter = createMarmotDeleteActionAdapter({
+    const adapter = createMarmotMessageActionAdapter({
       deleteByMessageId: async () => false,
       resolveTarget: async () => ({
         client: { deleteMessage },
@@ -217,8 +232,52 @@ describe("createMarmotDeleteActionAdapter", () => {
     expect(resultError(result)).toMatch(/could not resolve group/);
   });
 
+  it("adds a reaction to the current inbound message", async () => {
+    const sendReaction = vi.fn(async () => undefined);
+    const adapter = createMarmotMessageActionAdapter({
+      deleteByMessageId: async () => false,
+      resolveTarget: async () => ({
+        client: { deleteMessage: async () => undefined, sendReaction },
+        marmotAccountIdHex: HEX32("aa"),
+      }),
+    });
+
+    const result = await adapter.handleAction!(
+      reactCtx(
+        { emoji: "👀" },
+        { currentMessageId: HEX32("99"), currentMessagingTarget: HEX32("cc") },
+      ),
+    );
+
+    expect(sendReaction).toHaveBeenCalledWith(
+      HEX32("aa"),
+      HEX32("cc"),
+      HEX32("99"),
+      "👀",
+    );
+    expect(resultOk(result)).toBe(true);
+  });
+
+  it("removes the bot's reaction when emoji is empty", async () => {
+    const removeReaction = vi.fn(async () => undefined);
+    const adapter = createMarmotMessageActionAdapter({
+      deleteByMessageId: async () => false,
+      resolveTarget: async () => ({
+        client: { deleteMessage: async () => undefined, removeReaction },
+        marmotAccountIdHex: HEX32("aa"),
+      }),
+    });
+
+    const result = await adapter.handleAction!(
+      reactCtx({ messageId: HEX32("99"), to: HEX32("cc"), emoji: "" }),
+    );
+
+    expect(removeReaction).toHaveBeenCalledWith(HEX32("aa"), HEX32("cc"), HEX32("99"));
+    expect(resultOk(result)).toBe(true);
+  });
+
   it("rejects an unsupported action", async () => {
-    const adapter = createMarmotDeleteActionAdapter({
+    const adapter = createMarmotMessageActionAdapter({
       deleteByMessageId: async () => true,
       resolveTarget: async () => ({
         client: { deleteMessage: async () => undefined },
@@ -226,7 +285,7 @@ describe("createMarmotDeleteActionAdapter", () => {
       }),
     });
 
-    const ctx = { ...deleteCtx({ messageId: HEX32("99") }), action: "react" } as ChannelMessageActionContext;
+    const ctx = { ...deleteCtx({ messageId: HEX32("99") }), action: "edit" } as ChannelMessageActionContext;
     const result = await adapter.handleAction!(ctx);
     expect(resultOk(result)).toBe(false);
     expect(resultError(result)).toMatch(/unsupported action/);

--- a/integrations/openclaw/marmot/test/channel.test.ts
+++ b/integrations/openclaw/marmot/test/channel.test.ts
@@ -7,6 +7,7 @@ import {
   resolveMarmotChannelAccount,
   type MarmotMessageActionClient,
 } from "../src/channel.js";
+import { AgentControlError } from "../src/client.js";
 import {
   markMarmotInboundReady,
   markMarmotInboundReceived,
@@ -301,6 +302,33 @@ describe("createMarmotMessageActionAdapter", () => {
     expect(resultOk(result)).toBe(true);
   });
 
+  it("treats an already-absent reaction as an idempotent removal", async () => {
+    const adapter = createMarmotMessageActionAdapter({
+      deleteByMessageId: async () => false,
+      resolveTarget: async () => ({
+        client: {
+          deleteMessage: async () => undefined,
+          removeReaction: async () => {
+            throw new AgentControlError("reaction was not active", {
+              code: "reaction_not_found",
+            });
+          },
+        },
+        marmotAccountIdHex: HEX32("aa"),
+      }),
+    });
+
+    const result = await adapter.handleAction!(
+      reactCtx(
+        { remove: true, emoji: "👀" },
+        { currentMessageId: HEX32("99"), currentMessagingTarget: HEX32("cc") },
+      ),
+    );
+
+    expect(resultOk(result)).toBe(true);
+    expect((result.details as { removed?: boolean }).removed).toBe(true);
+  });
+
   it("removes the bot's reaction when remove is true even with an emoji", async () => {
     const removeReaction = vi.fn(async () => undefined);
     const adapter = createMarmotMessageActionAdapter({
@@ -318,7 +346,12 @@ describe("createMarmotMessageActionAdapter", () => {
       ),
     );
 
-    expect(removeReaction).toHaveBeenCalledWith(HEX32("aa"), HEX32("cc"), HEX32("99"));
+    expect(removeReaction).toHaveBeenCalledWith(
+      HEX32("aa"),
+      HEX32("cc"),
+      HEX32("99"),
+      "👀",
+    );
     expect(resultOk(result)).toBe(true);
   });
 

--- a/integrations/openclaw/marmot/test/channel.test.ts
+++ b/integrations/openclaw/marmot/test/channel.test.ts
@@ -276,6 +276,50 @@ describe("createMarmotMessageActionAdapter", () => {
     expect(resultOk(result)).toBe(true);
   });
 
+  it("removes the bot's reaction when remove is true even with an emoji", async () => {
+    const removeReaction = vi.fn(async () => undefined);
+    const adapter = createMarmotMessageActionAdapter({
+      deleteByMessageId: async () => false,
+      resolveTarget: async () => ({
+        client: { deleteMessage: async () => undefined, removeReaction },
+        marmotAccountIdHex: HEX32("aa"),
+      }),
+    });
+
+    const result = await adapter.handleAction!(
+      reactCtx(
+        { remove: true, emoji: "👀" },
+        { currentMessageId: HEX32("99"), currentMessagingTarget: HEX32("cc") },
+      ),
+    );
+
+    expect(removeReaction).toHaveBeenCalledWith(HEX32("aa"), HEX32("cc"), HEX32("99"));
+    expect(resultOk(result)).toBe(true);
+  });
+
+  it("returns a privacy-safe reaction failure", async () => {
+    const adapter = createMarmotMessageActionAdapter({
+      deleteByMessageId: async () => false,
+      resolveTarget: async () => ({
+        client: {
+          deleteMessage: async () => undefined,
+          sendReaction: async () => { throw new Error("secret socket detail"); },
+        },
+        marmotAccountIdHex: HEX32("aa"),
+      }),
+    });
+
+    const result = await adapter.handleAction!(
+      reactCtx(
+        { emoji: "👀" },
+        { currentMessageId: HEX32("99"), currentMessagingTarget: HEX32("cc") },
+      ),
+    );
+    expect(resultOk(result)).toBe(false);
+    expect(resultError(result)).toBe("reaction operation failed");
+    expect(resultError(result)).not.toContain("secret");
+  });
+
   it("rejects an unsupported action", async () => {
     const adapter = createMarmotMessageActionAdapter({
       deleteByMessageId: async () => true,

--- a/integrations/openclaw/marmot/test/client.test.ts
+++ b/integrations/openclaw/marmot/test/client.test.ts
@@ -79,7 +79,24 @@ function handleRequest(socket: Socket, req: Record<string, unknown>): void {
       });
       break;
     case "delete_message":
-      send(socket, id, { type: "final_sent", message_ids_hex: [HEX32("de")] });
+      send(socket, id, {
+        type: "final_sent",
+        message_ids_hex: [HEX32("de")],
+      });
+      break;
+    case "send_reaction":
+      send(socket, id, {
+        type: "app_event_sent",
+        message_ids_hex: [HEX32("e1")],
+        echoed_request: req,
+      });
+      break;
+    case "remove_reaction":
+      send(socket, id, {
+        type: "app_event_sent",
+        message_ids_hex: [HEX32("e2")],
+        echoed_request: req,
+      });
       break;
     case "send_media":
       send(socket, id, { type: "final_sent", message_ids_hex: [HEX32("11")] });
@@ -315,6 +332,31 @@ describe("MarmotAgentControlClient", () => {
   it("deletes a message and returns the deletion event ids", async () => {
     const res = await client.deleteMessage(HEX32("aa"), HEX32("cc"), HEX32("dd"));
     expect(res.message_ids_hex).toEqual([HEX32("de")]);
+  });
+
+  it("adds and removes reactions with the agent-control v2 wire shape", async () => {
+    const added = (await client.sendReaction(
+      HEX32("aa"), HEX32("cc"), HEX32("dd"), "👀",
+    )) as unknown as { message_ids_hex: string[]; echoed_request: Record<string, unknown> };
+    expect(added.message_ids_hex).toEqual([HEX32("e1")]);
+    expect(added.echoed_request).toMatchObject({
+      type: "send_reaction",
+      account_id_hex: HEX32("aa"),
+      group_id_hex: HEX32("cc"),
+      target_message_id_hex: HEX32("dd"),
+      emoji: "👀",
+    });
+
+    const removed = (await client.removeReaction(
+      HEX32("aa"), HEX32("cc"), HEX32("dd"),
+    )) as unknown as { message_ids_hex: string[]; echoed_request: Record<string, unknown> };
+    expect(removed.message_ids_hex).toEqual([HEX32("e2")]);
+    expect(removed.echoed_request).toMatchObject({
+      type: "remove_reaction",
+      account_id_hex: HEX32("aa"),
+      group_id_hex: HEX32("cc"),
+      target_message_id_hex: HEX32("dd"),
+    });
   });
 
   it("uploads media and returns the durable message ids from send_media", async () => {

--- a/integrations/openclaw/marmot/test/client.test.ts
+++ b/integrations/openclaw/marmot/test/client.test.ts
@@ -85,11 +85,17 @@ function handleRequest(socket: Socket, req: Record<string, unknown>): void {
       });
       break;
     case "send_reaction":
-      send(socket, id, {
-        type: "app_event_sent",
-        message_ids_hex: [HEX32("e1")],
-        echoed_request: req,
-      });
+      if (req.emoji === "__wrong_type") {
+        send(socket, id, { type: "final_sent", message_ids_hex: [HEX32("e1")] });
+      } else if (req.emoji === "__empty_ids") {
+        send(socket, id, { type: "app_event_sent", message_ids_hex: [] });
+      } else {
+        send(socket, id, {
+          type: "app_event_sent",
+          message_ids_hex: [HEX32("e1")],
+          echoed_request: req,
+        });
+      }
       break;
     case "remove_reaction":
       send(socket, id, {
@@ -357,6 +363,15 @@ describe("MarmotAgentControlClient", () => {
       group_id_hex: HEX32("cc"),
       target_message_id_hex: HEX32("dd"),
     });
+  });
+
+  it("rejects wrong-type and empty durable reaction responses", async () => {
+    await expect(
+      client.sendReaction(HEX32("aa"), HEX32("cc"), HEX32("dd"), "__wrong_type"),
+    ).rejects.toMatchObject({ code: "invalid_reaction_response" });
+    await expect(
+      client.sendReaction(HEX32("aa"), HEX32("cc"), HEX32("dd"), "__empty_ids"),
+    ).rejects.toMatchObject({ code: "invalid_reaction_response" });
   });
 
   it("uploads media and returns the durable message ids from send_media", async () => {

--- a/integrations/openclaw/marmot/test/client.test.ts
+++ b/integrations/openclaw/marmot/test/client.test.ts
@@ -369,6 +369,19 @@ describe("MarmotAgentControlClient", () => {
       group_id_hex: HEX32("cc"),
       target_message_id_hex: HEX32("dd"),
     });
+    expect(removed.echoed_request).not.toHaveProperty("emoji");
+
+    const removedExact = (await client.removeReaction(
+      HEX32("aa"), HEX32("cc"), HEX32("dd"), "👀",
+    )) as unknown as { message_ids_hex: string[]; echoed_request: Record<string, unknown> };
+    expect(removedExact.message_ids_hex).toEqual([HEX32("e2")]);
+    expect(removedExact.echoed_request).toMatchObject({
+      type: "remove_reaction",
+      account_id_hex: HEX32("aa"),
+      group_id_hex: HEX32("cc"),
+      target_message_id_hex: HEX32("dd"),
+      emoji: "👀",
+    });
   });
 
   it("rejects malformed durable reaction responses", async () => {

--- a/integrations/openclaw/marmot/test/client.test.ts
+++ b/integrations/openclaw/marmot/test/client.test.ts
@@ -89,6 +89,12 @@ function handleRequest(socket: Socket, req: Record<string, unknown>): void {
         send(socket, id, { type: "final_sent", message_ids_hex: [HEX32("e1")] });
       } else if (req.emoji === "__empty_ids") {
         send(socket, id, { type: "app_event_sent", message_ids_hex: [] });
+      } else if (req.emoji === "__non_hex_id") {
+        send(socket, id, { type: "app_event_sent", message_ids_hex: ["z".repeat(64)] });
+      } else if (req.emoji === "__odd_id") {
+        send(socket, id, { type: "app_event_sent", message_ids_hex: ["a".repeat(63)] });
+      } else if (req.emoji === "__wrong_size_id") {
+        send(socket, id, { type: "app_event_sent", message_ids_hex: ["aa"] });
       } else {
         send(socket, id, {
           type: "app_event_sent",
@@ -365,13 +371,18 @@ describe("MarmotAgentControlClient", () => {
     });
   });
 
-  it("rejects wrong-type and empty durable reaction responses", async () => {
+  it("rejects malformed durable reaction responses", async () => {
     await expect(
       client.sendReaction(HEX32("aa"), HEX32("cc"), HEX32("dd"), "__wrong_type"),
     ).rejects.toMatchObject({ code: "invalid_reaction_response" });
     await expect(
       client.sendReaction(HEX32("aa"), HEX32("cc"), HEX32("dd"), "__empty_ids"),
     ).rejects.toMatchObject({ code: "invalid_reaction_response" });
+    for (const emoji of ["__non_hex_id", "__odd_id", "__wrong_size_id"]) {
+      await expect(
+        client.sendReaction(HEX32("aa"), HEX32("cc"), HEX32("dd"), emoji),
+      ).rejects.toMatchObject({ code: "invalid_reaction_response" });
+    }
   });
 
   it("uploads media and returns the durable message ids from send_media", async () => {

--- a/integrations/openclaw/marmot/test/plugin-sdk-surface.test.ts
+++ b/integrations/openclaw/marmot/test/plugin-sdk-surface.test.ts
@@ -36,10 +36,14 @@ const RUNTIME_IMPORTS: ReadonlyArray<readonly [string, readonly string[]]> = [
 
 describe("OpenClaw plugin-sdk runtime surface", () => {
   for (const [subpath, symbols] of RUNTIME_IMPORTS) {
-    it(`${subpath} exports the symbols the plugin imports`, async () => {
-      const mod = (await import(subpath)) as Record<string, unknown>;
-      const missing = symbols.filter((symbol) => mod[symbol] === undefined);
-      expect(missing).toEqual([]);
-    });
+    it(
+      `${subpath} exports the symbols the plugin imports`,
+      async () => {
+        const mod = (await import(subpath)) as Record<string, unknown>;
+        const missing = symbols.filter((symbol) => mod[symbol] === undefined);
+        expect(missing).toEqual([]);
+      },
+      20_000,
+    );
   }
 });

--- a/scripts/openclaw_marmot_connector_e2e.sh
+++ b/scripts/openclaw_marmot_connector_e2e.sh
@@ -43,6 +43,11 @@ fi
 
 source "$dev_root/env.sh"
 
+# Keep the test's socket-startup deadline focused on wn-agent startup rather
+# than including an arbitrarily long first Cargo build in a fresh worktree.
+cd "$MDK_REPO"
+cargo build -q -p agent-connector --bin wn-agent
+
 cd "$OPENCLAW_PLUGIN_SRC"
 pnpm build
 exec env MARMOT_OPENCLAW_CONNECTOR_E2E=1 pnpm exec vitest run test/e2e-connector.test.ts


### PR DESCRIPTION
## Summary

- expose OpenClaw `message(action="react")` support for Marmot conversations
- add and remove durable reactions through the shared `marmot.agent-control.v2` requests introduced by #1399
- allow an omitted `messageId` to target the current inbound message
- document the OpenClaw reaction contract and add client/action-adapter regression coverage
- give cold OpenClaw SDK import canaries enough time under a loaded CI host

## Dependency

This PR is intentionally separate from #1399 and is based on its shared agent-control/connector reaction commits. Merge #1399 first, then this OpenClaw adapter PR. Never enable auto-merge.

## Validation

- `just fast-ci`
- `cargo test -p agent-control` (18 passed)
- `cargo test -p agent-connector` (138 passed)
- `pnpm typecheck`
- `pnpm test` (230 passed, 2 skipped)
- `/tmp/openclaw-marmot-test/e2e-connector.sh` (1 passed against a real debug `wn-agent` process)
- `cargo fmt --all -- --check`
- `git diff --check`

No version or release metadata is changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for adding and removing message reactions in Marmot.
  - Supports explicit reaction targets, emoji validation, and message ID aliases.
  - Reaction removal is safely repeatable when the reaction is already absent.
  - Existing message deletion remains supported.

- **Bug Fixes**
  - Added validation and clearer errors for invalid reaction requests and responses.

- **Documentation**
  - Documented Marmot reaction usage through the shared message tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->