### PR TITLE
Publish macos bindings

### DIFF
--- a/.github/workflows/bindings.yaml
+++ b/.github/workflows/bindings.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       source_sha:
-        description: Full 40-character commit SHA on master to publish as an immutable iOS snapshot
+        description: Full 40-character commit SHA on master to publish as an immutable Apple platform snapshot
         required: true
         type: string
 
@@ -35,6 +35,7 @@ jobs:
       release_id: ${{ steps.identity.outputs.release_id }}
       release_tag: ${{ steps.identity.outputs.release_tag }}
       binary_name: ${{ steps.identity.outputs.binary_name }}
+      macos_binary_name: ${{ steps.identity.outputs.macos_binary_name }}
       swift_name: ${{ steps.identity.outputs.swift_name }}
       is_snapshot: ${{ steps.identity.outputs.is_snapshot }}
 
@@ -98,6 +99,7 @@ jobs:
             echo "release_id=$release_id"
             echo "release_tag=$release_tag"
             echo "binary_name=MarmotKitFFI-$release_id.xcframework.zip"
+            echo "macos_binary_name=MarmotKitFFI-macos-$release_id.xcframework.zip"
             echo "swift_name=MarmotKit-$release_id.swift"
             echo "is_snapshot=$is_snapshot"
           } >> "$GITHUB_OUTPUT"
@@ -181,6 +183,95 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: marmotkit-ios-${{ needs.metadata.outputs.source_sha }}
+          path: dist/*
+          if-no-files-found: error
+
+  macos-bindings:
+    name: Build macOS bindings
+    runs-on: macos-latest
+    needs: metadata
+    timeout-minutes: 60
+    env:
+      # This value is what the job both builds and validates against, so those
+      # two steps cannot disagree. Validating against a lower number fails,
+      # because locally compiled members report exactly this minimum. The
+      # build/package/validate scripts each default to the same 15.0 when run
+      # outside CI; keep those defaults in step with this value.
+      MACOSX_DEPLOYMENT_TARGET: "15.0"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Check out packaged source
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+          ref: ${{ needs.metadata.outputs.source_sha }}
+          path: packaged-source
+
+      - name: Install Rust toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          toolchain="$(sed -n 's/^channel = "\(.*\)"/\1/p' packaged-source/rust-toolchain.toml)"
+          rustup toolchain install "$toolchain" --profile minimal
+          rustup default "$toolchain"
+          rustup target add aarch64-apple-darwin
+          rustc --version
+          cargo --version
+
+      - name: Cache Cargo artifacts
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: packaged-source -> target
+
+      - name: Build MarmotKit macOS XCFramework
+        env:
+          MARMOTKIT_WORKSPACE_DIR: ${{ github.workspace }}/packaged-source
+          MARMOTKIT_CRATE_DIR: ${{ github.workspace }}/packaged-source/crates/marmot-uniffi
+        run: ./crates/marmot-uniffi/xcframework-macos.sh
+
+      - name: Package immutable macOS artifacts
+        shell: bash
+        env:
+          RELEASE_ID: ${{ needs.metadata.outputs.release_id }}
+          RELEASE_TAG: ${{ needs.metadata.outputs.release_tag }}
+          SOURCE_SHA: ${{ needs.metadata.outputs.source_sha }}
+          BUILDER_SHA: ${{ needs.metadata.outputs.builder_sha }}
+          MARMOTKIT_WORKSPACE_DIR: ${{ github.workspace }}/packaged-source
+          MARMOTKIT_CRATE_DIR: ${{ github.workspace }}/packaged-source/crates/marmot-uniffi
+        run: |
+          set -euo pipefail
+          ./crates/marmot-uniffi/package-macos-artifacts.sh \
+            "$RELEASE_ID" "$RELEASE_TAG" "$SOURCE_SHA" dist "$BUILDER_SHA"
+
+      - name: Validate XCFramework slice and SwiftPM archive layout
+        shell: bash
+        env:
+          MACOS_BINARY_NAME: ${{ needs.metadata.outputs.macos_binary_name }}
+        run: |
+          set -euo pipefail
+          ./crates/marmot-uniffi/validate-macos-artifact.sh \
+            "dist/$MACOS_BINARY_NAME" "$MACOSX_DEPLOYMENT_TARGET"
+
+      - name: Compile and link a local SwiftPM consumer
+        shell: bash
+        run: |
+          set -euo pipefail
+          ./crates/marmot-uniffi/validate-swift-package-macos.sh \
+            packaged-source/crates/marmot-uniffi/output/macos/MarmotKit.xcframework \
+            - \
+            packaged-source/crates/marmot-uniffi/output/macos/MarmotKit.swift \
+            "$RUNNER_TEMP/marmotkit-local-macos-consumer"
+
+      - name: Upload macOS bundle
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: marmotkit-macos-${{ needs.metadata.outputs.source_sha }}
           path: dist/*
           if-no-files-found: error
 
@@ -318,11 +409,13 @@ jobs:
     needs:
       - metadata
       - ios-bindings
+      - macos-bindings
       - android-bindings
     if: >-
       always() &&
       needs.metadata.result == 'success' &&
       needs.ios-bindings.result == 'success' &&
+      needs.macos-bindings.result == 'success' &&
       (needs.android-bindings.result == 'success' || needs.android-bindings.result == 'skipped')
     timeout-minutes: 15
     permissions:
@@ -338,9 +431,11 @@ jobs:
           IS_SNAPSHOT: ${{ needs.metadata.outputs.is_snapshot }}
         run: |
           set -euo pipefail
-          mkdir -p dist/ios dist/android
+          mkdir -p dist/ios dist/macos dist/android
           gh run download "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" \
             --name "marmotkit-ios-$SOURCE_SHA" --dir dist/ios
+          gh run download "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" \
+            --name "marmotkit-macos-$SOURCE_SHA" --dir dist/macos
           if [[ "$IS_SNAPSHOT" == "false" ]]; then
             gh run download "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" \
               --name "marmotkit-android-$SOURCE_SHA" --dir dist/android
@@ -356,24 +451,61 @@ jobs:
           BUILDER_SHA: ${{ needs.metadata.outputs.builder_sha }}
           IS_SNAPSHOT: ${{ needs.metadata.outputs.is_snapshot }}
           BINARY_NAME: ${{ needs.metadata.outputs.binary_name }}
+          MACOS_BINARY_NAME: ${{ needs.metadata.outputs.macos_binary_name }}
+          SWIFT_NAME: ${{ needs.metadata.outputs.swift_name }}
         run: |
           set -euo pipefail
           tag="$RELEASE_TAG"
           version="$RELEASE_ID"
           notes="$RUNNER_TEMP/release-notes.md"
           checksum="$(cat "dist/ios/$BINARY_NAME.swiftpm-checksum")"
+          macos_checksum="$(cat "dist/macos/$MACOS_BINARY_NAME.swiftpm-checksum")"
+
+          # The generated Swift binding is platform-independent and published
+          # once, by the iOS job. Both jobs generate it independently from the
+          # same source SHA, so assert they agree: a mismatch means a consumer
+          # could compile that Swift against a mismatched binary ABI.
+          ios_swift_sha="$(jq -r --arg name "$SWIFT_NAME" '.artifacts[$name].sha256' \
+            "dist/ios/marmotkit-ios-$version.manifest.json")"
+          macos_swift_sha="$(jq -r --arg name "$SWIFT_NAME" '.artifacts[$name].sha256' \
+            "dist/macos/marmotkit-macos-$version.manifest.json")"
+          # Check both manifests for a recorded hash before comparing, so a
+          # malformed manifest reports itself instead of masquerading as an
+          # iOS/macOS Swift mismatch.
+          if [[ -z "$ios_swift_sha" || "$ios_swift_sha" == "null" ]]; then
+            echo "error: iOS manifest does not record a SHA-256 for $SWIFT_NAME" >&2
+            exit 1
+          fi
+          if [[ -z "$macos_swift_sha" || "$macos_swift_sha" == "null" ]]; then
+            echo "error: macOS manifest does not record a SHA-256 for $SWIFT_NAME" >&2
+            exit 1
+          fi
+          if [[ "$ios_swift_sha" != "$macos_swift_sha" ]]; then
+            echo "error: iOS and macOS jobs generated different Swift bindings from $SOURCE_SHA" >&2
+            exit 1
+          fi
+
           cat > "$notes" <<EOF
           MarmotKit bindings generated from exact MDK commit \`$SOURCE_SHA\` by workflow commit \`$BUILDER_SHA\`.
 
-          Assets:
+          iOS assets:
           - \`$BINARY_NAME\`: SwiftPM-compatible binary target archive.
-          - \`MarmotKit-$version.swift\`: generated Swift source matching that binary.
           - \`marmotkit-ios-$version.zip\`: complete XCFramework, Swift source, and provenance bundle.
 
-          SwiftPM checksum: \`$checksum\`
+          iOS SwiftPM checksum: \`$checksum\`
 
-          Verify source and artifact provenance with \`marmotkit-ios-$version.manifest.json\`
-          and \`marmotkit-ios-$version.checksums.txt\`. Assets on this release are immutable.
+          macOS assets (arm64):
+          - \`$MACOS_BINARY_NAME\`: SwiftPM-compatible binary target archive.
+          - \`marmotkit-macos-$version.zip\`: complete XCFramework, Swift source, and provenance bundle.
+
+          macOS SwiftPM checksum: \`$macos_checksum\`
+
+          Shared:
+          - \`MarmotKit-$version.swift\`: generated Swift source matching both binaries.
+
+          Verify source and artifact provenance with \`marmotkit-ios-$version.manifest.json\`,
+          \`marmotkit-macos-$version.manifest.json\`, and the matching \`.checksums.txt\` assets.
+          Assets on this release are immutable.
           EOF
 
           if release_state="$(gh release view "$tag" --repo "$GITHUB_REPOSITORY" --json isDraft --jq '.isDraft' 2>/dev/null)"; then
@@ -392,7 +524,7 @@ jobs:
             exit 1
           fi
 
-          assets=(dist/ios/*)
+          assets=(dist/ios/* dist/macos/*)
           if [[ "$IS_SNAPSHOT" == "false" ]]; then
             assets+=(dist/android/*)
             title="v$version - MarmotKit"
@@ -448,7 +580,7 @@ jobs:
           exit 1
 
   validate-published-ios:
-    name: Validate published SwiftPM consumer
+    name: Validate published iOS SwiftPM consumer
     runs-on: macos-latest
     needs:
       - metadata
@@ -491,3 +623,50 @@ jobs:
             "$checksum" \
             "$RUNNER_TEMP/MarmotKit.swift" \
             "$RUNNER_TEMP/marmotkit-remote-consumer"
+
+  validate-published-macos:
+    name: Validate published macOS SwiftPM consumer
+    runs-on: macos-latest
+    needs:
+      - metadata
+      - release
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out packaged source
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Download matching source and checksum
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ needs.metadata.outputs.release_tag }}
+          RELEASE_ID: ${{ needs.metadata.outputs.release_id }}
+          MACOS_BINARY_NAME: ${{ needs.metadata.outputs.macos_binary_name }}
+          # The generated Swift is platform-independent and published once, by
+          # the iOS job. A macOS consumer resolves this exact asset.
+          SWIFT_NAME: ${{ needs.metadata.outputs.swift_name }}
+        run: |
+          set -euo pipefail
+          base_url="https://github.com/$GITHUB_REPOSITORY/releases/download/$RELEASE_TAG"
+          for attempt in 1 2 3 4 5; do
+            if curl -fL --retry 3 --retry-delay 2 \
+              "$base_url/$SWIFT_NAME" -o "$RUNNER_TEMP/MarmotKit.swift" && \
+              curl -fL --retry 3 --retry-delay 2 \
+              "$base_url/$MACOS_BINARY_NAME.swiftpm-checksum" -o "$RUNNER_TEMP/swiftpm-checksum"; then
+              break
+            fi
+            if [[ $attempt -eq 5 ]]; then
+              echo "error: published MarmotKit macOS assets did not become available" >&2
+              exit 1
+            fi
+            sleep 5
+          done
+          checksum="$(tr -d '[:space:]' < "$RUNNER_TEMP/swiftpm-checksum")"
+          ./crates/marmot-uniffi/validate-swift-package-macos.sh \
+            "$base_url/$MACOS_BINARY_NAME" \
+            "$checksum" \
+            "$RUNNER_TEMP/MarmotKit.swift" \
+            "$RUNNER_TEMP/marmotkit-remote-macos-consumer"

--- a/crates/marmot-uniffi/AGENTS.md
+++ b/crates/marmot-uniffi/AGENTS.md
@@ -4,9 +4,11 @@ UniFFI bindings for the Marmot app runtime. Read `README.md` first for build scr
 
 ## Scope
 
-- Own the UniFFI export surface over `marmot-app` for Swift (iOS) and Kotlin (Android) consumers.
-- Own build/packaging scripts: `xcframework.sh` (Swift + XCFramework), `kotlin-bindings.sh` (Android JNI libs +
-  generated Kotlin), `package-ios-artifacts.sh`, `validate-ios-artifact.sh`, and `validate-swift-package.sh`.
+- Own the UniFFI export surface over `marmot-app` for Swift (iOS and macOS) and Kotlin (Android) consumers.
+- Own build/packaging scripts: `xcframework.sh` (Swift + iOS XCFramework), `xcframework-macos.sh` (Swift + macOS
+  XCFramework), `kotlin-bindings.sh` (Android JNI libs + generated Kotlin), `package-ios-artifacts.sh`,
+  `package-macos-artifacts.sh`, `validate-ios-artifact.sh`, `validate-macos-artifact.sh`, `validate-swift-package.sh`,
+  and `validate-swift-package-macos.sh`.
 - Own `marmotkit-release-profile.env`, the canonical Rust release profile for distributable MarmotKit artifacts.
 - Own `marmotkit-endpoints.env` build-time defaults for audit-log tracker and relay-telemetry OTLP route URLs.
 - Keep generated bindings out of git; host apps vendor artifacts from `output/` after running the scripts.
@@ -17,6 +19,15 @@ UniFFI bindings for the Marmot app runtime. Read `README.md` first for build scr
 - Android consumers must call `MarmotAndroid.initialize(context)` before constructing `Marmot` (Keystore JNI via
   `ndk-context`).
 - Endpoint env vars set route URLs only; bearer tokens and runtime secrets stay with the host app.
+- Build and validate an Apple artifact against the same deployment target. Objects compiled under
+  `MACOSX_DEPLOYMENT_TARGET` / `IPHONEOS_DEPLOYMENT_TARGET` report exactly that minimum, and the validators fail on a
+  minimum *newer* than expected, so validating against a lower number fails. macOS publishes at `15.0`.
+- Package Apple static libraries exactly as cargo produced them. Neither `xcframework.sh` nor `xcframework-macos.sh`
+  strips post-link: `marmotkit-release-profile.env` pins `strip=none` and `debug=0`, and the packagers publish that
+  profile as provenance, so a post-link strip would make the manifest describe an artifact that was not shipped.
+- The generated Swift binding is platform-independent, so releases publish `MarmotKit-<id>.swift` exactly once, from
+  the iOS job. `package-macos-artifacts.sh` records its SHA-256 in the macOS manifest but must not emit the file;
+  emitting it would collide with the iOS asset name on the shared release. The release job asserts both hashes match.
 - Host-supplied `group_id_hex` values are variable-length MLS `GroupId` bytes, not Nostr `nostr_group_id` route handles.
   Accept non-empty opaque MLS group ids, including the 16-byte ids OpenMLS generates for MDK today, and do not validate
   them with the 32-byte route-id/pubkey/message-id rule.
@@ -31,6 +42,7 @@ Regenerate and smoke-test bindings after API changes:
 
 ```sh
 ./crates/marmot-uniffi/xcframework.sh
+./crates/marmot-uniffi/xcframework-macos.sh
 ./crates/marmot-uniffi/kotlin-bindings.sh
 cargo test -p marmot-uniffi
 cargo test -p marmot-app
@@ -48,6 +60,14 @@ Release-artifact checks (after `xcframework.sh`):
 ./crates/marmot-uniffi/validate-ios-artifact.sh crates/marmot-uniffi/output/MarmotKit.xcframework 18.0
 ./crates/marmot-uniffi/validate-swift-package.sh \
   crates/marmot-uniffi/output/MarmotKit.xcframework - crates/marmot-uniffi/output/MarmotKit.swift
+```
+
+macOS release-artifact checks (after `xcframework-macos.sh`, which needs `OTLP_EXPORT=1` for packaging):
+
+```sh
+./crates/marmot-uniffi/validate-macos-artifact.sh crates/marmot-uniffi/output/macos/MarmotKit.xcframework 15.0
+./crates/marmot-uniffi/validate-swift-package-macos.sh \
+  crates/marmot-uniffi/output/macos/MarmotKit.xcframework - crates/marmot-uniffi/output/macos/MarmotKit.swift
 ```
 
 See [`README.md`](README.md) for Android NDK prerequisites and initialization requirements.

--- a/crates/marmot-uniffi/DISTRIBUTION.md
+++ b/crates/marmot-uniffi/DISTRIBUTION.md
@@ -1,10 +1,19 @@
-# MarmotKit iOS Binary Distribution
+# MarmotKit Apple Binary Distribution
 
-MarmotKit iOS releases publish the generated Swift API and its matching XCFramework as immutable GitHub Release
+MarmotKit releases publish the generated Swift API and its matching XCFrameworks as immutable GitHub Release
 assets. Consumers keep `MarmotKit.swift` in a Swift source target and declare the XCFramework as a remote binary
 target; neither the expanded XCFramework nor its static libraries need to be committed to the app repository.
 
-## Exact URLs
+Each release carries a separate iOS and macOS XCFramework under distinct asset names, and a single shared
+`MarmotKit-<identifier>.swift`. The generated Swift is platform-independent, so both platforms consume the same file:
+there is no macOS-specific Swift asset to look for.
+
+## iOS
+
+The iOS binary asset carries no platform token in its name, for backward compatibility with URLs consumers already
+pin. macOS assets are explicitly prefixed `-macos-`; an unprefixed `MarmotKitFFI-<identifier>` asset is always iOS.
+
+### Exact URLs
 
 Formal release `marmotkit-v<version>`:
 
@@ -22,7 +31,7 @@ https://github.com/marmot-protocol/mdk/releases/download/marmotkit-snapshot-<sha
 
 These URLs always contain an exact tag or snapshot identifier. Do not use a `latest` URL for SwiftPM artifacts.
 
-## SwiftPM
+### SwiftPM
 
 Download the sibling `.swiftpm-checksum` asset or read the `swiftpm` record in
 `marmotkit-ios-<identifier>.checksums.txt`, then declare:
@@ -49,15 +58,70 @@ toolchain versions, enabled features, iOS targets and deployment target, effecti
 of the binary and generated Swift artifacts. The complete `marmotkit-ios-<identifier>.zip` retains the XCFramework,
 matching Swift source, and the same manifest for consumers that prefer a single provenance bundle.
 
+## macOS
+
+macOS artifacts are Apple Silicon only: the XCFramework carries a single `macos-arm64` slice built for
+`aarch64-apple-darwin`. There is no Intel or universal build.
+
+### Exact URLs
+
+Formal release `marmotkit-v<version>`:
+
+```text
+https://github.com/marmot-protocol/mdk/releases/download/marmotkit-v<version>/MarmotKitFFI-macos-<version>.xcframework.zip
+```
+
+Snapshot for a full 40-character commit SHA `<sha>` reachable from `master`:
+
+```text
+https://github.com/marmot-protocol/mdk/releases/download/marmotkit-snapshot-<sha>/MarmotKitFFI-macos-snapshot-<sha>.xcframework.zip
+```
+
+### SwiftPM
+
+Download the sibling `.swiftpm-checksum` asset or read the `swiftpm` record in
+`marmotkit-macos-<identifier>.checksums.txt`, then declare:
+
+```swift
+.binaryTarget(
+    name: "MarmotKitFFI",
+    url: "<exact URL above>",
+    checksum: "<contents of .swiftpm-checksum>"
+)
+```
+
+The consuming Swift package must declare macOS 15.0 or newer, and the target that wraps the binary links `Security`
+and `SystemConfiguration`.
+
+### Generated Swift is shared with iOS
+
+There is no `MarmotKit-macos-<identifier>.swift` asset, and looking for one is the common mistake. The generated Swift
+binding is platform-independent and published exactly once per release, by the iOS job, as
+`MarmotKit-<identifier>.swift`. Use that same file for a macOS consumer, from the same release identifier as the macOS
+binary. `marmotkit-macos-<identifier>.manifest.json` records its SHA-256 so a macOS consumer can verify it without
+consulting the iOS manifest, and publishing fails if the two jobs ever generate different Swift from one source SHA.
+
+For the same reason, `marmotkit-macos-<identifier>.checksums.txt` carries a `sha256` line for
+`MarmotKit-<identifier>.swift` even though that file is not a macOS release asset — the line lets a macOS consumer
+verify the shared Swift from the macOS checksums file alone. A verifier that walks that file expecting every named
+entry to exist among the macOS assets must skip this one.
+
+For manual verification, compare the ZIP with its `.sha256` asset. The separately published
+`marmotkit-macos-<identifier>.manifest.json` records the full MDK source SHA, workspace version, `Cargo.lock` SHA-256,
+toolchain versions, enabled features, macOS targets and deployment target, effective Rust release profile, and hashes
+of the binary and shared generated Swift artifacts. The complete `marmotkit-macos-<identifier>.zip` retains the
+XCFramework, matching Swift source, and the same manifest for consumers that prefer a single provenance bundle.
+
 ## Publishing
 
-Pushing a formal `marmotkit-v*` tag publishes iOS and Android bindings. To publish an untagged TestFlight snapshot,
-run the `MarmotKit Bindings` workflow with a full SHA on `master`. Its immutable release tag is derived from that SHA.
+Pushing a formal `marmotkit-v*` tag publishes iOS, macOS, and Android bindings. To publish an untagged snapshot, run
+the `MarmotKit Bindings` workflow with a full SHA on `master`. Its immutable release tag is derived from that SHA.
+Snapshots publish the iOS and macOS bindings; Android bindings are published only for formal tags.
 
 Publishing first uploads and verifies every asset on a draft, then publishes it under repository-enforced immutable
 releases. A retry discards only an incomplete draft. Publishing fails if a public release already exists, and snapshot
 publishing also fails if its derived tag already exists. Assets and snapshot tags are never replaced or moved; a
 changed build requires a new formal version or a new source SHA.
 
-The iOS manifest records both the packaged source SHA and the workflow builder SHA. Snapshot dispatches must use the
-workflow from `master`, so an older reachable source commit cannot substitute its own packaging logic.
+The iOS and macOS manifests each record both the packaged source SHA and the workflow builder SHA. Snapshot dispatches
+must use the workflow from `master`, so an older reachable source commit cannot substitute its own packaging logic.

--- a/crates/marmot-uniffi/README.md
+++ b/crates/marmot-uniffi/README.md
@@ -6,8 +6,14 @@ The Rust API in `src/` is the source of truth for both generated Swift and gener
 package that shared surface:
 
 - `./crates/marmot-uniffi/xcframework.sh` builds `output/MarmotKit.xcframework` plus `output/MarmotKit.swift` for iOS.
+- `./crates/marmot-uniffi/xcframework-macos.sh` builds `output/macos/MarmotKit.xcframework` plus
+  `output/macos/MarmotKit.swift` for macOS on Apple Silicon (`aarch64-apple-darwin`). Its output directory is separate
+  from the iOS one so building both in one workspace cannot clobber either artifact.
 - `./crates/marmot-uniffi/kotlin-bindings.sh` builds `output/android/kotlin/.../marmot_uniffi.kt` plus Android
   `jniLibs` shared libraries.
+
+The generated Swift file is platform-independent: `output/MarmotKit.swift` and `output/macos/MarmotKit.swift` are the
+same UniFFI surface, and releases publish it once.
 
 See [`DISTRIBUTION.md`](DISTRIBUTION.md) for immutable SwiftPM binary artifacts, exact release and snapshot URLs,
 checksums, provenance, and the generated Swift synchronization rule.

--- a/crates/marmot-uniffi/package-macos-artifacts.sh
+++ b/crates/marmot-uniffi/package-macos-artifacts.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# Package a built macOS MarmotKit XCFramework as immutable release assets.
+#
+# The generated Swift binding is intentionally not emitted as a dist asset: it
+# is platform-independent and already published once by the iOS job under the
+# name MarmotKit-<release-id>.swift. Emitting it here would collide with that
+# asset name on the shared release. Its SHA-256 is still recorded in this
+# manifest so the release job can assert both jobs generated the same surface.
+
+set -euo pipefail
+
+# Match xcframework-macos.sh: report the rustup-selected toolchain that built
+# the artifact, not an unrelated Homebrew cargo/rustc earlier on PATH.
+export PATH="$HOME/.cargo/bin:$PATH"
+
+usage() {
+  echo "usage: $0 <release-id> <release-tag> <source-sha> <dist-dir> <builder-sha>" >&2
+  exit 2
+}
+
+[[ $# -eq 5 ]] || usage
+
+RELEASE_ID="$1"
+RELEASE_TAG="$2"
+SOURCE_SHA="$3"
+DIST_DIR="$4"
+BUILDER_SHA="$5"
+
+TOOL_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$TOOL_DIR/marmotkit-release-profile.env"
+WORKSPACE_DIR="${MARMOTKIT_WORKSPACE_DIR:-$(cd "$TOOL_DIR/../.." && pwd)}"
+CRATE_DIR="${MARMOTKIT_CRATE_DIR:-$WORKSPACE_DIR/crates/marmot-uniffi}"
+OUTPUT_DIR="$CRATE_DIR/output/macos"
+XCFRAMEWORK="$OUTPUT_DIR/MarmotKit.xcframework"
+SWIFT_BINDING="$OUTPUT_DIR/MarmotKit.swift"
+
+if [[ ! "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "error: source SHA must be a full lowercase 40-character Git commit SHA" >&2
+  exit 1
+fi
+if [[ ! "$BUILDER_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "error: builder SHA must be a full lowercase 40-character Git commit SHA" >&2
+  exit 1
+fi
+if [[ ! -d "$XCFRAMEWORK" || ! -f "$SWIFT_BINDING" ]]; then
+  echo "error: run crates/marmot-uniffi/xcframework-macos.sh before packaging" >&2
+  exit 1
+fi
+
+workspace_version="$(sed -n 's/^version = "\(.*\)"/\1/p' "$WORKSPACE_DIR/Cargo.toml" | head -n 1)"
+lock_sha="$(shasum -a 256 "$WORKSPACE_DIR/Cargo.lock" | awk '{print $1}')"
+rust_version="$(rustc --version)"
+cargo_version="$(cargo --version)"
+deployment_target="${MACOSX_DEPLOYMENT_TARGET:-15.0}"
+if [[ "${OTLP_EXPORT:-}" != "1" && "${OTLP_EXPORT:-}" != "true" ]]; then
+  echo "error: MarmotKit release artifacts require OTLP_EXPORT=1" >&2
+  exit 1
+fi
+
+binary_name="MarmotKitFFI-macos-${RELEASE_ID}.xcframework.zip"
+# Published by the iOS job; referenced here for provenance only.
+swift_name="MarmotKit-${RELEASE_ID}.swift"
+manifest_name="marmotkit-macos-${RELEASE_ID}.manifest.json"
+bundle_name="marmotkit-macos-${RELEASE_ID}.zip"
+checksums_name="marmotkit-macos-${RELEASE_ID}.checksums.txt"
+
+stage_parent="$(mktemp -d)"
+trap 'rm -rf "$stage_parent"' EXIT
+bundle_dir="$stage_parent/marmotkit-macos-$RELEASE_ID"
+
+mkdir -p "$DIST_DIR" "$bundle_dir"
+DIST_DIR="$(cd "$DIST_DIR" && pwd)"
+# Deliberately excludes "$DIST_DIR/$swift_name": that asset belongs to the iOS
+# packager, and this script must never delete it from a shared dist directory.
+rm -f \
+  "$DIST_DIR/$binary_name" \
+  "$DIST_DIR/$binary_name.sha256" \
+  "$DIST_DIR/$binary_name.swiftpm-checksum" \
+  "$DIST_DIR/$manifest_name" \
+  "$DIST_DIR/$bundle_name" \
+  "$DIST_DIR/$bundle_name.sha256" \
+  "$DIST_DIR/$checksums_name"
+
+# A SwiftPM binary-target archive has the XCFramework at the archive root.
+(
+  cd "$OUTPUT_DIR"
+  COPYFILE_DISABLE=1 zip -qry "$DIST_DIR/$binary_name" MarmotKit.xcframework
+)
+
+binary_sha="$(shasum -a 256 "$DIST_DIR/$binary_name" | awk '{print $1}')"
+swiftpm_checksum="$(swift package compute-checksum "$DIST_DIR/$binary_name")"
+swift_sha="$(shasum -a 256 "$SWIFT_BINDING" | awk '{print $1}')"
+plist="$XCFRAMEWORK/Info.plist"
+device_artifact=""
+index=0
+while identifier="$(/usr/libexec/PlistBuddy -c "Print :AvailableLibraries:$index:LibraryIdentifier" "$plist" 2>/dev/null)"; do
+  platform="$(/usr/libexec/PlistBuddy -c "Print :AvailableLibraries:$index:SupportedPlatform" "$plist")"
+  variant="$(/usr/libexec/PlistBuddy -c "Print :AvailableLibraries:$index:SupportedPlatformVariant" "$plist" 2>/dev/null || true)"
+  binary_path="$(/usr/libexec/PlistBuddy -c "Print :AvailableLibraries:$index:BinaryPath" "$plist")"
+  [[ "$platform" == "macos" ]] || { echo "error: unexpected XCFramework platform $platform" >&2; exit 1; }
+  [[ -z "$variant" ]] || { echo "error: unexpected macOS platform variant $variant" >&2; exit 1; }
+  [[ -z "$device_artifact" ]] || { echo "error: duplicate macOS slice" >&2; exit 1; }
+  device_artifact="MarmotKit.xcframework/$identifier/$binary_path"
+  index=$((index + 1))
+done
+[[ $index -eq 1 && -n "$device_artifact" ]] || {
+  echo "error: expected exactly one macOS slice" >&2
+  exit 1
+}
+device_library_sha="$(shasum -a 256 "$XCFRAMEWORK/${device_artifact#MarmotKit.xcframework/}" | awk '{print $1}')"
+
+cat > "$DIST_DIR/$manifest_name" <<EOF
+{
+  "schema_version": 1,
+  "name": "marmotkit-macos",
+  "release_identifier": "$RELEASE_ID",
+  "release_tag": "$RELEASE_TAG",
+  "source_sha": "$SOURCE_SHA",
+  "builder_sha": "$BUILDER_SHA",
+  "workspace_version": "$workspace_version",
+  "cargo_lock_sha256": "$lock_sha",
+  "rustc": "$rust_version",
+  "cargo": "$cargo_version",
+  "features": ["otlp-export"],
+  "macos_targets": ["aarch64-apple-darwin"],
+  "macos_deployment_target": "$deployment_target",
+  "rust_release_profile": {
+    "opt_level": "$CARGO_PROFILE_RELEASE_OPT_LEVEL",
+    "debug": "$CARGO_PROFILE_RELEASE_DEBUG",
+    "debug_assertions": false,
+    "overflow_checks": false,
+    "lto": $CARGO_PROFILE_RELEASE_LTO,
+    "codegen_units": $CARGO_PROFILE_RELEASE_CODEGEN_UNITS,
+    "panic": "$CARGO_PROFILE_RELEASE_PANIC",
+    "strip": "$CARGO_PROFILE_RELEASE_STRIP"
+  },
+  "artifacts": {
+    "$binary_name": {
+      "sha256": "$binary_sha",
+      "swiftpm_checksum": "$swiftpm_checksum"
+    },
+    "$swift_name": {
+      "sha256": "$swift_sha"
+    },
+    "$device_artifact": {
+      "sha256": "$device_library_sha",
+      "architecture": "arm64"
+    }
+  },
+  "contents": ["MarmotKit.xcframework", "MarmotKit.swift", "manifest.json"]
+}
+EOF
+
+cp -R "$XCFRAMEWORK" "$bundle_dir/MarmotKit.xcframework"
+cp "$SWIFT_BINDING" "$bundle_dir/MarmotKit.swift"
+cp "$DIST_DIR/$manifest_name" "$bundle_dir/manifest.json"
+(
+  cd "$stage_parent"
+  COPYFILE_DISABLE=1 zip -qry "$DIST_DIR/$bundle_name" "$(basename "$bundle_dir")"
+)
+
+bundle_sha="$(shasum -a 256 "$DIST_DIR/$bundle_name" | awk '{print $1}')"
+manifest_sha="$(shasum -a 256 "$DIST_DIR/$manifest_name" | awk '{print $1}')"
+
+cat > "$DIST_DIR/$checksums_name" <<EOF
+sha256  $binary_sha  $binary_name
+swiftpm $swiftpm_checksum  $binary_name
+sha256  $swift_sha  $swift_name
+sha256  $manifest_sha  $manifest_name
+sha256  $bundle_sha  $bundle_name
+EOF
+
+printf '%s\n' "$binary_sha  $binary_name" > "$DIST_DIR/$binary_name.sha256"
+printf '%s\n' "$swiftpm_checksum" > "$DIST_DIR/$binary_name.swiftpm-checksum"
+printf '%s\n' "$bundle_sha  $bundle_name" > "$DIST_DIR/$bundle_name.sha256"
+
+echo "Packaged immutable MarmotKit macOS assets in $DIST_DIR"
+echo "  Binary artifact:  $binary_name"
+echo "  SHA-256:          $binary_sha"
+echo "  SwiftPM checksum: $swiftpm_checksum"
+echo "  Swift binding:    published by the iOS job as $swift_name (sha256 $swift_sha)"

--- a/crates/marmot-uniffi/validate-macos-artifact.sh
+++ b/crates/marmot-uniffi/validate-macos-artifact.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Validate macOS XCFramework structure, architecture, deployment target, and ZIP layout.
+#
+# The deployment target passed here must be the same value the artifact was
+# built with. Objects compiled under MACOSX_DEPLOYMENT_TARGET report exactly
+# that minimum, so validating against a lower number fails.
+
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 <xcframework-or-zip> [deployment-target]" >&2
+  exit 2
+}
+
+[[ $# -ge 1 && $# -le 2 ]] || usage
+
+INPUT="$1"
+EXPECTED_DEPLOYMENT_TARGET="${2:-15.0}"
+TEMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+if [[ -f "$INPUT" ]]; then
+  case "$INPUT" in
+    *.zip)
+      root_entries="$(unzip -Z1 "$INPUT" | awk -F/ 'NF {print $1}' | sort -u)"
+      if [[ "$root_entries" != "MarmotKit.xcframework" ]]; then
+        echo "error: SwiftPM ZIP must contain only MarmotKit.xcframework at its root" >&2
+        printf 'found root entries:\n%s\n' "$root_entries" >&2
+        exit 1
+      fi
+      unzip -q "$INPUT" -d "$TEMP_DIR/archive"
+      XCFRAMEWORK="$TEMP_DIR/archive/MarmotKit.xcframework"
+      ;;
+    *)
+      usage
+      ;;
+  esac
+elif [[ -d "$INPUT" ]]; then
+  XCFRAMEWORK="$INPUT"
+else
+  echo "error: artifact does not exist: $INPUT" >&2
+  exit 1
+fi
+
+XCFRAMEWORK="$(cd "$(dirname "$XCFRAMEWORK")" && pwd)/$(basename "$XCFRAMEWORK")"
+
+PLIST="$XCFRAMEWORK/Info.plist"
+[[ -f "$PLIST" ]] || { echo "error: missing XCFramework Info.plist" >&2; exit 1; }
+
+index=0
+while identifier="$(/usr/libexec/PlistBuddy -c "Print :AvailableLibraries:$index:LibraryIdentifier" "$PLIST" 2>/dev/null)"; do
+  platform="$(/usr/libexec/PlistBuddy -c "Print :AvailableLibraries:$index:SupportedPlatform" "$PLIST")"
+  variant="$(/usr/libexec/PlistBuddy -c "Print :AvailableLibraries:$index:SupportedPlatformVariant" "$PLIST" 2>/dev/null || true)"
+  binary_path="$(/usr/libexec/PlistBuddy -c "Print :AvailableLibraries:$index:BinaryPath" "$PLIST")"
+  library="$XCFRAMEWORK/$identifier/$binary_path"
+
+  [[ "$platform" == "macos" ]] || { echo "error: unexpected platform $platform" >&2; exit 1; }
+  [[ -z "$variant" ]] || { echo "error: unexpected macOS platform variant $variant" >&2; exit 1; }
+  [[ -f "$library" ]] || { echo "error: missing library $library" >&2; exit 1; }
+  [[ "$(lipo -archs "$library")" == "arm64" ]] || {
+    echo "error: $identifier is not an arm64-only library" >&2
+    exit 1
+  }
+
+  headers_path="$(/usr/libexec/PlistBuddy -c "Print :AvailableLibraries:$index:HeadersPath" "$PLIST")"
+  [[ -f "$XCFRAMEWORK/$identifier/$headers_path/module.modulemap" ]] || {
+    echo "error: missing module map for $identifier" >&2
+    exit 1
+  }
+  [[ -f "$XCFRAMEWORK/$identifier/$headers_path/marmot_uniffiFFI.h" ]] || {
+    echo "error: missing generated header for $identifier" >&2
+    exit 1
+  }
+
+  # Mach-O LC_BUILD_VERSION platform constant: PLATFORM_MACOS = 1.
+  expected_platform=1
+  expected_platform_name=MACOS
+
+  # otool walks every member of a static archive, including duplicate member
+  # names. Validate every object carrying LC_BUILD_VERSION instead of sampling
+  # a single Rust object. An older minimum is compatible; a newer one would
+  # silently raise the consuming app's deployment requirement. Rust's prebuilt
+  # std objects legitimately report an older minimum than the pinned target.
+  build_info="$(xcrun otool -l "$library")"
+  awk -v identifier="$identifier" \
+      -v expected_platform="$expected_platform" \
+      -v expected_platform_name="$expected_platform_name" \
+      -v expected_minos="$EXPECTED_DEPLOYMENT_TARGET" '
+    function version_gt(left, right, left_parts, right_parts, count, i) {
+      split(left, left_parts, ".")
+      split(right, right_parts, ".")
+      count = 3
+      for (i = 1; i <= count; i++) {
+        if ((left_parts[i] + 0) > (right_parts[i] + 0)) return 1
+        if ((left_parts[i] + 0) < (right_parts[i] + 0)) return 0
+      }
+      return 0
+    }
+    /^Archive : / { member = $0 }
+    /^.*\([^)]*\):$/ { member = $0 }
+    /^[[:space:]]*cmd LC_BUILD_VERSION$/ {
+      in_build_version = 1
+      platform_seen = 0
+      minos_seen = 0
+      count++
+      next
+    }
+    in_build_version && /^[[:space:]]*platform / {
+      platform_seen = 1
+      if (($2 + 0) != expected_platform) {
+        printf "error: %s member %s uses platform %s, expected %s (%s)\n", \
+          identifier, member, $2, expected_platform, expected_platform_name > "/dev/stderr"
+        failed = 1
+      }
+      next
+    }
+    in_build_version && /^[[:space:]]*minos / {
+      minos_seen = 1
+      if (version_gt($2, expected_minos)) {
+        printf "error: %s member %s requires macOS %s, newer than supported %s\n", \
+          identifier, member, $2, expected_minos > "/dev/stderr"
+        failed = 1
+      }
+      in_build_version = 0
+      next
+    }
+    END {
+      if (count == 0) {
+        printf "error: %s contains no LC_BUILD_VERSION commands\n", identifier > "/dev/stderr"
+        failed = 1
+      }
+      if (in_build_version && (!platform_seen || !minos_seen)) {
+        printf "error: incomplete LC_BUILD_VERSION in %s member %s\n", identifier, member > "/dev/stderr"
+        failed = 1
+      }
+      exit failed
+    }
+  ' <<< "$build_info"
+  index=$((index + 1))
+done
+
+[[ $index -eq 1 ]] || {
+  echo "error: expected exactly one arm64 macOS slice" >&2
+  exit 1
+}
+
+echo "Validated every arm64 macOS archive member supports deployment target $EXPECTED_DEPLOYMENT_TARGET"

--- a/crates/marmot-uniffi/validate-swift-package-macos.sh
+++ b/crates/marmot-uniffi/validate-swift-package-macos.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Build a minimal macOS SwiftPM consumer against a local or remote MarmotKit binary target.
+#
+# The generated package mirrors the real macOS consumer: it declares the same
+# system frameworks the app links, so a missing symbol surfaces here rather
+# than in the app repository.
+
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 <xcframework-path-or-https-url> <checksum-or-dash> <MarmotKit.swift> [work-dir]" >&2
+  exit 2
+}
+
+[[ $# -ge 3 && $# -le 4 ]] || usage
+
+ARTIFACT="$1"
+CHECKSUM="$2"
+SWIFT_BINDING="$3"
+if [[ $# -eq 4 ]]; then
+  WORK_DIR="$4"
+  if [[ -e "$WORK_DIR" ]]; then
+    echo "error: validation work directory already exists: $WORK_DIR" >&2
+    exit 1
+  fi
+else
+  WORK_DIR="$(mktemp -d)"
+  trap 'rm -rf "$WORK_DIR"' EXIT
+fi
+
+[[ -f "$SWIFT_BINDING" ]] || { echo "error: missing Swift binding $SWIFT_BINDING" >&2; exit 1; }
+mkdir -p "$WORK_DIR/Sources/MarmotKit" "$WORK_DIR/Sources/MarmotKitConsumer"
+cp "$SWIFT_BINDING" "$WORK_DIR/Sources/MarmotKit/MarmotKit.swift"
+
+if [[ "$ARTIFACT" == https://* ]]; then
+  [[ "$CHECKSUM" =~ ^[0-9a-f]{64}$ ]] || { echo "error: remote artifact requires a SwiftPM checksum" >&2; exit 1; }
+  binary_declaration=".binaryTarget(name: \"MarmotKitFFI\", url: \"$ARTIFACT\", checksum: \"$CHECKSUM\")"
+else
+  [[ -d "$ARTIFACT" ]] || { echo "error: missing local XCFramework $ARTIFACT" >&2; exit 1; }
+  cp -R "$ARTIFACT" "$WORK_DIR/MarmotKit.xcframework"
+  binary_declaration='.binaryTarget(name: "MarmotKitFFI", path: "MarmotKit.xcframework")'
+fi
+
+cat > "$WORK_DIR/Package.swift" <<EOF
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "MarmotKitConsumerValidation",
+    platforms: [.macOS(.v15)],
+    products: [
+        .library(name: "MarmotKit", targets: ["MarmotKit"]),
+        .library(name: "MarmotKitConsumer", type: .dynamic, targets: ["MarmotKitConsumer"]),
+    ],
+    targets: [
+        $binary_declaration,
+        .target(
+            name: "MarmotKit",
+            dependencies: ["MarmotKitFFI"],
+            linkerSettings: [
+                .linkedFramework("Security"),
+                .linkedFramework("SystemConfiguration"),
+            ]
+        ),
+        .target(name: "MarmotKitConsumer", dependencies: ["MarmotKit"]),
+    ]
+)
+EOF
+
+cat > "$WORK_DIR/Sources/MarmotKitConsumer/Consumer.swift" <<'EOF'
+import MarmotKit
+
+// Referencing the generated public object proves the source and binary headers
+// are the matching UniFFI surface. The dynamic product forces a final link.
+public func acceptMarmotForLinkValidation(_ marmot: Marmot) {}
+EOF
+
+(
+  cd "$WORK_DIR"
+  swift package describe >/dev/null
+  # `swift package resolve` performs the remote download and checksum
+  # verification. Xcode then consumes that resolved artifact for macOS builds.
+  swift package resolve
+  xcodebuild \
+    -scheme MarmotKitConsumer \
+    -configuration Release \
+    -destination 'generic/platform=macOS' \
+    -derivedDataPath "$WORK_DIR/DerivedData-macos" \
+    -disableAutomaticPackageResolution \
+    ARCHS=arm64 \
+    ONLY_ACTIVE_ARCH=YES \
+    CODE_SIGNING_ALLOWED=NO \
+    -quiet \
+    build
+)
+
+echo "Validated SwiftPM MarmotKit source compilation and macOS linking"

--- a/crates/marmot-uniffi/xcframework-macos.sh
+++ b/crates/marmot-uniffi/xcframework-macos.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Build the MarmotKit.xcframework for macOS (Apple Silicon).
+#
+# Outputs:
+#   <crate>/output/macos/MarmotKit.xcframework
+#   <crate>/output/macos/MarmotKit.swift   (generated Swift bindings, separate from the xcframework)
+#
+# Targets:
+#   aarch64-apple-darwin    (macOS, arm64)
+#
+# Add x86_64-apple-darwin + lipo if/when an Intel Mac is on the test matrix.
+#
+# The output directory is deliberately distinct from xcframework.sh's so that
+# building both in one workspace cannot clobber the iOS artifact.
+
+set -euo pipefail
+
+# Force rustup's cargo to win over any Homebrew-installed cargo, so that
+# rust-toolchain.toml is honored and Apple targets are visible.
+export PATH="$HOME/.cargo/bin:$PATH"
+
+# Pin the macOS deployment target so the bundled OpenSSL (via rusqlite's
+# SQLCipher feature) is built and linked against the same macOS version.
+# Without this, the build defaults to a very old macOS minimum and the link
+# step fails with missing __chkstk_darwin and friends.
+export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-15.0}"
+export CFLAGS_aarch64_apple_darwin="${CFLAGS_aarch64_apple_darwin:--mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}}"
+export CXXFLAGS_aarch64_apple_darwin="${CXXFLAGS_aarch64_apple_darwin:--mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}}"
+# Target-scoped rather than RUSTFLAGS on purpose. Cargo treats a RUSTFLAGS env
+# var as replacing `[build] rustflags` from .cargo/config.toml rather than
+# merging with it, so a workspace-wide flag added later would be silently
+# dropped for this build alone. Scoping also keeps the flag off the host dylib
+# build below, whose target/release fingerprint is shared with xcframework.sh.
+export CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS="-C link-arg=-mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}"
+
+TOOL_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Keep production release behavior and debug-symbol policy in one source of truth.
+source "$TOOL_DIR/marmotkit-release-profile.env"
+WORKSPACE_DIR="${MARMOTKIT_WORKSPACE_DIR:-$(cd "$TOOL_DIR/../.." && pwd)}"
+CRATE_DIR="${MARMOTKIT_CRATE_DIR:-$WORKSPACE_DIR/crates/marmot-uniffi}"
+TARGET_DIR="$WORKSPACE_DIR/target"
+BUILD_DIR="$CRATE_DIR/build/macos"
+OUT_DIR="$CRATE_DIR/output/macos"
+
+# Set public first-party endpoint defaults for values compiled via option_env!.
+# Tokens remain host-app runtime configuration.
+source "$TOOL_DIR/marmotkit-endpoints.env"
+
+CRATE_NAME="marmot-uniffi"
+LIB_BASENAME="marmot_uniffi"
+FRAMEWORK_NAME="MarmotKit"
+MACOS_TARGET="aarch64-apple-darwin"
+
+FEATURE_ARGS=()
+BINDGEN_FEATURES="cli"
+if [[ "${OTLP_EXPORT:-0}" == "1" || "${OTLP_EXPORT:-}" == "true" ]]; then
+  FEATURE_ARGS=(--features otlp-export)
+  BINDGEN_FEATURES="cli,otlp-export"
+fi
+
+# Run from the workspace root so cargo resolves the right Cargo.toml no
+# matter where this script was invoked from (e.g. the macOS repo's
+# sync-bindings.sh).
+cd "$WORKSPACE_DIR"
+
+echo "==> Cleaning previous build artifacts"
+rm -rf "$BUILD_DIR" "$OUT_DIR/$FRAMEWORK_NAME.xcframework" "$OUT_DIR/$FRAMEWORK_NAME.swift"
+mkdir -p "$BUILD_DIR/headers" "$OUT_DIR"
+
+echo "==> Ensuring $MACOS_TARGET is installed"
+rustup target add "$MACOS_TARGET"
+
+echo "==> Building host dylib (used for binding generation)"
+cargo build --release -p "$CRATE_NAME" ${FEATURE_ARGS[@]+"${FEATURE_ARGS[@]}"}
+
+# On an Apple Silicon host this is nominally the same triple as the host build,
+# but passing --target keeps it in its own target dir and makes the
+# deployment-target flags apply, so keep it explicit.
+echo "==> Building macOS target ($MACOS_TARGET)"
+cargo build --release -p "$CRATE_NAME" --target "$MACOS_TARGET" ${FEATURE_ARGS[@]+"${FEATURE_ARGS[@]}"}
+
+echo "==> Generating Swift bindings"
+cargo run --release -p "$CRATE_NAME" --features "$BINDGEN_FEATURES" --bin uniffi-bindgen -- \
+  generate \
+  --library "$TARGET_DIR/release/lib${LIB_BASENAME}.dylib" \
+  --language swift \
+  --out-dir "$BUILD_DIR/swift"
+
+echo "==> Staging headers + modulemap for XCFramework"
+cp "$BUILD_DIR/swift/${LIB_BASENAME}FFI.h" "$BUILD_DIR/headers/"
+# XCFramework expects the modulemap to be named module.modulemap
+cp "$BUILD_DIR/swift/${LIB_BASENAME}FFI.modulemap" "$BUILD_DIR/headers/module.modulemap"
+
+# The static library is packaged exactly as cargo produced it, matching
+# xcframework.sh. Do not strip it here: marmotkit-release-profile.env pins
+# strip=none and debug=0, and package-macos-artifacts.sh publishes that profile
+# as provenance, so a post-link strip would make the manifest describe an
+# artifact that is not the one shipped.
+echo "==> Creating $FRAMEWORK_NAME.xcframework"
+xcodebuild -create-xcframework \
+  -library "$TARGET_DIR/$MACOS_TARGET/release/lib${LIB_BASENAME}.a" \
+  -headers "$BUILD_DIR/headers" \
+  -output "$OUT_DIR/$FRAMEWORK_NAME.xcframework"
+
+echo "==> Copying generated Swift binding to output dir"
+cp "$BUILD_DIR/swift/${LIB_BASENAME}.swift" "$OUT_DIR/${FRAMEWORK_NAME}.swift"
+
+echo ""
+echo "Done."
+echo "  XCFramework:       $OUT_DIR/$FRAMEWORK_NAME.xcframework"
+echo "  Swift binding:     $OUT_DIR/$FRAMEWORK_NAME.swift"
+echo "  Deployment target: $MACOSX_DEPLOYMENT_TARGET"

--- a/crates/marmot-uniffi/xcframework.sh
+++ b/crates/marmot-uniffi/xcframework.sh
@@ -29,7 +29,9 @@ source "$TOOL_DIR/marmotkit-release-profile.env"
 WORKSPACE_DIR="${MARMOTKIT_WORKSPACE_DIR:-$(cd "$TOOL_DIR/../.." && pwd)}"
 CRATE_DIR="${MARMOTKIT_CRATE_DIR:-$WORKSPACE_DIR/crates/marmot-uniffi}"
 TARGET_DIR="$WORKSPACE_DIR/target"
-BUILD_DIR="$CRATE_DIR/build"
+# Scoped to build/ios, not build/, so cleaning this script's scratch space
+# cannot take xcframework-macos.sh's build/macos with it.
+BUILD_DIR="$CRATE_DIR/build/ios"
 OUT_DIR="$CRATE_DIR/output"
 
 # Set public first-party endpoint defaults for values compiled via option_env!.
@@ -55,6 +57,9 @@ cd "$WORKSPACE_DIR"
 echo "==> Cleaning previous build artifacts"
 rm -rf "$BUILD_DIR" "$OUT_DIR/$FRAMEWORK_NAME.xcframework" "$OUT_DIR/$FRAMEWORK_NAME.swift"
 mkdir -p "$BUILD_DIR/headers" "$OUT_DIR"
+
+echo "==> Ensuring iOS targets are installed"
+rustup target add aarch64-apple-ios aarch64-apple-ios-sim
 
 echo "==> Building host dylib (used for binding generation)"
 cargo build --release -p "$CRATE_NAME" ${FEATURE_ARGS[@]+"${FEATURE_ARGS[@]}"}

--- a/release.md
+++ b/release.md
@@ -306,8 +306,9 @@ The workflow lives at:
 ```
 
 It runs when a tag matching `marmotkit-v*` is pushed. The workflow validates version-like tags such as
-`marmotkit-v0.9.0`, builds both binding bundles, and creates the matching immutable GitHub Release. It can also be
-dispatched with a full commit SHA reachable from `master` to create an immutable iOS-only TestFlight snapshot.
+`marmotkit-v0.9.0`, builds the iOS, macOS, and Android binding bundles, and creates the matching immutable GitHub
+Release. It can also be dispatched with a full commit SHA reachable from `master` to create an immutable iOS + macOS
+snapshot; Android bindings are published only for formal tags.
 
 Create the tag:
 
@@ -321,22 +322,39 @@ For releases that should include the matching MDK source and WN Agent tracks, pr
 
 The release job creates these assets:
 
-- `MarmotKitFFI-<version>.xcframework.zip`
+- `MarmotKitFFI-<version>.xcframework.zip` (iOS)
 - `MarmotKitFFI-<version>.xcframework.zip.sha256`
 - `MarmotKitFFI-<version>.xcframework.zip.swiftpm-checksum`
-- `MarmotKit-<version>.swift`
 - `marmotkit-ios-<version>.manifest.json`
 - `marmotkit-ios-<version>.checksums.txt`
 - `marmotkit-ios-<version>.zip`
 - `marmotkit-ios-<version>.zip.sha256`
+- `MarmotKitFFI-macos-<version>.xcframework.zip` (macOS, Apple Silicon)
+- `MarmotKitFFI-macos-<version>.xcframework.zip.sha256`
+- `MarmotKitFFI-macos-<version>.xcframework.zip.swiftpm-checksum`
+- `marmotkit-macos-<version>.manifest.json`
+- `marmotkit-macos-<version>.checksums.txt`
+- `marmotkit-macos-<version>.zip`
+- `marmotkit-macos-<version>.zip.sha256`
+- `MarmotKit-<version>.swift` (shared by iOS and macOS)
 - `marmotkit-android-<version>.zip`
 - `marmotkit-android-<version>.zip.sha256`
+
+The generated Swift binding is platform-independent, so it is published exactly once, by the iOS job. There is no
+`MarmotKit-macos-<version>.swift`; macOS consumers use the same `MarmotKit-<version>.swift` from the same release.
+Publishing fails if the iOS and macOS jobs ever generate different Swift from one source SHA.
 
 Snapshot assets use `snapshot-<full-sha>` in place of `<version>` and are published under the exact
 `marmotkit-snapshot-<full-sha>` release tag. The binary-only ZIP contains `MarmotKit.xcframework` at its archive root
 for SwiftPM. See `crates/marmot-uniffi/DISTRIBUTION.md` for URL and consumer examples.
 
 The iOS zip contains:
+
+- `MarmotKit.xcframework`
+- `MarmotKit.swift`
+- `manifest.json`
+
+The macOS zip contains:
 
 - `MarmotKit.xcframework`
 - `MarmotKit.swift`


### PR DESCRIPTION
To be able to replace the bindings in the mac repo, we need to publish them for mac here. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Apple Silicon macOS support for MarmotKit bindings and XCFramework distribution.
  - macOS releases now include checksums, manifests, provenance information, and Swift Package Manager support.
  - iOS and macOS share the same platform-independent Swift API.

- **Documentation**
  - Updated build, distribution, release, and snapshot documentation for iOS, macOS, and Android assets.

- **Bug Fixes**
  - Improved platform-specific build isolation and iOS target setup to prevent cross-platform build conflicts.

- **Tests**
  - Added automated validation for macOS artifacts, packages, checksums, and Swift Package Manager integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->