### PR TITLE
fix(cgka-engine): schedule the drain when an outbound intent is queued

### DIFF
--- a/crates/cgka-engine/src/conformance_snapshot.rs
+++ b/crates/cgka-engine/src/conformance_snapshot.rs
@@ -714,6 +714,21 @@ pub(crate) fn capture_structural_progress_snapshot<S: StorageProvider>(
     if engine.pending_convergence_groups.contains(group_id) && !future_scheduled_work {
         runnable_work = runnable_work.saturating_add(1);
     }
+    // The schedule above is an edge a host consumes once; a durable intent is
+    // level state that outlives an unproductive drain. It stays runnable until
+    // the drain regenerates it and hands it to the app, which then owes the
+    // confirm or the retry. `Stable` is the drain's own precondition, and a
+    // pass inside its window reports the cutoff as the next wake instead.
+    let unreleased_outbound_intents = pending_work
+        .queued_outbound_intents
+        .saturating_sub(pending_work.regenerated_standalone_publishes)
+        .saturating_sub(pending_work.regenerated_pending_publishes);
+    if unreleased_outbound_intents > 0
+        && lifecycle == GroupLifecycleState::Stable
+        && !future_scheduled_work
+    {
+        runnable_work = runnable_work.saturating_add(1);
+    }
     if pass.is_none() && pending_work.unresolved_convergence_inputs > 0 {
         runnable_work = runnable_work.saturating_add(1);
     }

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -412,9 +412,7 @@ impl<S: StorageProvider> Engine<S> {
                 },
             ));
         }
-        let queued = self.queue_outbound_intent(group_id.clone(), intent)?;
-        self.schedule_pending_convergence_group(&group_id);
-        Ok(queued)
+        self.queue_outbound_intent(group_id, intent)
     }
 
     fn validate_send_acceptance(&mut self, intent: &SendIntent) -> Result<GroupId, EngineError> {
@@ -1662,6 +1660,19 @@ impl<S: StorageProvider> Engine<S> {
                 intent,
                 created_at_ms,
             })?;
+        // The drain is what releases this row, so writing it and arming the
+        // drain are one step — see `has_queued_outbound_intents`. `Stable` is
+        // the drain's own precondition: a group held by a publish or a halt
+        // gets its arm from the seam that ends the hold
+        // (`schedule_drain_for_retained_outbound_intents`), and arming into the
+        // hold would only spend the schedule on a drain that returns early.
+        if self
+            .epoch_manager
+            .state(&group_id)
+            .is_some_and(EpochState::is_stable)
+        {
+            self.schedule_pending_convergence_group(&group_id);
+        }
         Ok(SendResult::Queued {
             group_id,
             intent_id,

--- a/crates/cgka-engine/src/publish.rs
+++ b/crates/cgka-engine/src/publish.rs
@@ -506,17 +506,24 @@ impl<S: StorageProvider> Engine<S> {
     /// outbound intents.
     ///
     /// Retained application payloads are released by the next convergence drain
-    /// (`converge_and_drain_queued_outbound_intents`), and in this process only
-    /// the seam that returns the group to `Stable` arranges that. While the
-    /// group is held — `PendingPublish`, or halted `Unrecoverable` — the caller
-    /// gates keep it still: ingest buffers rather than advances the state, and
-    /// the drain and send paths both return early on non-`Stable`. So every
-    /// such seam must schedule on its way out: a publish outcome and a verified
-    /// repair Welcome through this helper, quarantine recovery
-    /// (`retry_hydrate_quarantined_group`) unconditionally because it has
-    /// already read the group. (Across a restart, session-open hydration re-arms
-    /// the drain from the same durable queue whatever state the group landed
-    /// in.)
+    /// (`converge_and_drain_queued_outbound_intents`). `queue_outbound_intent`
+    /// arms that drain as it writes the row, but only for a `Stable` group, and
+    /// only as an edge a host consumes once.
+    ///
+    /// Three conditions hold a queue past that arm. `PendingPublish` and halted
+    /// `Unrecoverable` hold it through the caller gates — ingest buffers rather
+    /// than advances the state, and the drain and send paths both return early
+    /// on non-`Stable` — so arming into them would spend a schedule on a drain
+    /// that returns early, and the seam that ends each re-arms on its way out
+    /// instead: a publish outcome and a verified repair Welcome through this
+    /// helper, quarantine recovery (`retry_hydrate_quarantined_group`)
+    /// unconditionally because it has already read the group. `Stable` with an
+    /// unsettled convergence pass holds it too and has no such seam: it is
+    /// carried by the level signal, staying visible as runnable work until it
+    /// releases (`has_queued_outbound_intents`), which is what a scheduler
+    /// re-reads once it has consumed the edge. (Across a restart, session-open
+    /// hydration re-arms the drain from the same durable queue whatever state
+    /// the group landed in.)
     ///
     /// Best-effort by construction: this runs after the outcome is durable, so
     /// a transient backend lock here must not fail already-committed work.

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -4466,6 +4466,175 @@ async fn a_verified_repair_schedules_the_drain_for_retained_intents_without_a_re
     );
 }
 
+#[cfg(feature = "test-conformance-snapshot")]
+#[tokio::test]
+async fn a_settled_convergence_pass_leaves_no_unscheduled_retained_intent() {
+    // Retention across a halt is the dramatic case; this is the ordinary one.
+    // A `Stable` observer inside an open convergence pass also retains an app
+    // message, and the same promise applies: something must bring the drain
+    // back, and the engine's own progress projection must say so.
+    //
+    // Two signals carry that, and a host needs both. The schedule edge tells a
+    // running host to drain now; the structural-progress projection is the
+    // level state a scheduler re-reads after it has consumed that edge. A drain
+    // that consumes the edge without releasing the intent — because the pass
+    // had not settled yet — must not leave the projection claiming the group is
+    // idle while a user's message is still durable and unsent.
+    let (mut alice, _alice_storage) = build_client(b"alice");
+    let carol_storage = SqliteAccountStorage::in_memory().unwrap();
+    let clock = ManualConvergenceClock::new(1_000, 10_000);
+    let mut carol =
+        build_client_with_storage_and_clock(b"carol", carol_storage.clone(), clock.clone());
+    let mut david = build_client(b"david").0;
+
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "queued-intent-scheduling".into(),
+            description: "".into(),
+            members: vec![carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    carol
+        .join_welcome(welcome_for(&welcomes, b"carol"))
+        .await
+        .unwrap();
+
+    let invite = alice
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![david.fresh_key_package().await.unwrap()],
+        })
+        .await
+        .unwrap();
+    let (commit, invite_pending) = evolution(invite);
+    alice.confirm_published(invite_pending).await.unwrap();
+    assert!(matches!(
+        carol.ingest(route(commit, &group_id)).await.unwrap(),
+        IngestOutcome::Buffered { .. }
+    ));
+    assert_eq!(
+        carol_storage
+            .convergence_pass(&group_id)
+            .unwrap()
+            .expect("the buffered commit opens a pass")
+            .cutoff_monotonic_ms(),
+        2_000
+    );
+
+    // A running host has already taken everything the ingest produced, so what
+    // the assertions below observe is what the send itself left behind.
+    carol.drain_events();
+    let scheduled_before_send = carol.drain_pending_convergence_groups();
+
+    let queued = carol
+        .send(SendIntent::AppMessage {
+            group_id: group_id.clone(),
+            payload: app_payload_for(&carol, b"typed inside the pass window"),
+        })
+        .await
+        .unwrap();
+    let intent_id = match queued {
+        SendResult::Queued { intent_id, .. } => intent_id,
+        other => panic!("an unsettled pass retains the send, got {other:?}"),
+    };
+    assert!(
+        carol.drain_pending_convergence_groups().contains(&group_id),
+        "queueing a durable outbound intent must schedule the drain that releases \
+         it; scheduled before the send: {scheduled_before_send:?}"
+    );
+
+    // The pass is still inside its quiescence window, so the intent's exit is
+    // the cutoff, not a drain that can run now.
+    let waiting = carol
+        .conformance_structural_progress_snapshot(&group_id)
+        .expect("read-only conformance progress");
+    assert_eq!(waiting.pending_work.queued_outbound_intents, 1);
+    assert_eq!(waiting.earliest_next_wake_monotonic_ms, Some(2_000));
+    assert_eq!(
+        waiting.runnable_work, 0,
+        "an intent waiting on an open pass rides the cutoff wake and must not \
+         report work a drain would refuse: {waiting:?}"
+    );
+
+    // The host wakes at the cutoff and settles the pass — the ordinary prepass a
+    // runtime runs before it drains. That settles convergence without releasing
+    // the intent, and the schedule edge above has already been consumed.
+    clock.advance_ms(1_500);
+    assert!(
+        carol
+            .advance_convergence_inputs_until_settled(&group_id, 2_500)
+            .await
+            .unwrap(),
+        "the cutoff has passed, so the pass settles"
+    );
+    carol.drain_events();
+
+    let settled = carol
+        .conformance_structural_progress_snapshot(&group_id)
+        .expect("read-only conformance progress");
+    assert_eq!(settled.pending_work.queued_outbound_intents, 1);
+    assert!(
+        settled.runnable_work > 0 || settled.earliest_next_wake_monotonic_ms.is_some(),
+        "a durable intent nobody has published yet must keep the group armed, \
+         not report an idle group: {settled:?}"
+    );
+
+    // And that is a message, not bookkeeping: the drain publishes it under the
+    // post-settlement epoch and Alice reads it.
+    let mut drained = carol
+        .advance_convergence(&group_id)
+        .await
+        .expect("the armed drain releases the retained intent");
+    assert_eq!(
+        drained.len(),
+        1,
+        "expected exactly the retained message, got {drained:?}"
+    );
+    let SendResult::ApplicationMessage {
+        msg, source_epoch, ..
+    } = drained.remove(0)
+    else {
+        panic!("a retained app-message intent drains as an application message")
+    };
+    assert_eq!(source_epoch, carol.epoch(&group_id).unwrap());
+    assert!(matches!(
+        alice.ingest(route(msg, &group_id)).await.unwrap(),
+        IngestOutcome::Processed
+    ));
+    let received = alice
+        .drain_events()
+        .into_iter()
+        .find_map(|event| match event {
+            GroupEvent::MessageReceived {
+                sender, payload, ..
+            } => Some((sender, payload)),
+            _ => None,
+        })
+        .expect("alice observes the retained message");
+    assert_eq!(received.0, carol.self_id());
+    assert_eq!(app_content(&received.1), b"typed inside the pass window");
+
+    carol
+        .confirm_queued_outbound_intent(&intent_id)
+        .expect("the drained intent is the one the pass window retained");
+    assert!(
+        carol_storage
+            .list_queued_outbound_intents(&group_id)
+            .unwrap()
+            .is_empty()
+    );
+}
+
 #[tokio::test]
 async fn engine_prunes_retained_anchor_snapshots_to_rewind_horizon() {
     let (mut alice, _alice_storage) = build_client(b"alice");


### PR DESCRIPTION
An application send accepted while a group is `Stable` but with an unsettled convergence pass is queued durably and then left unarmed. Nothing tells the host to come back, and the engine's own progress projection reports the group as idle while it still holds the payload — which contradicts `has_queued_outbound_intents`, whose rustdoc says "Runtime schedulers must keep a wakeup armed while any remain".

Two siblings write the same durable queue and disagreed about it. `do_queue_app_message` called `schedule_pending_convergence_group` after `queue_outbound_intent`; the `send` path called `queue_outbound_intent` alone. Move the schedule into `queue_outbound_intent` so the durable write and the arm are one step, and both callers inherit it.

The arm is gated on `Stable`, which is the drain's own precondition. A group held by a publish or a halt already gets its arm from the seam that ends the hold, and arming into the hold would only spend the schedule on a drain that returns early — the invariant `resolving_a_publish_schedules_the_drain_for_retained_app_messages` pins. `schedule_drain_for_retained_outbound_intents`'s rustdoc claimed `PendingPublish` and `Unrecoverable` were the only holding states; the third, `Stable` with an unsettled pass, is now named there too.

runnable_work vs future_scheduled_work
--------------------------------------
The schedule is an edge a host consumes once. A drain that consumes it before the pass settles releases nothing and takes the edge with it, so the durable row also needs a level signal. `runnable_work` now counts an unreleased intent, under two guards that keep it honest:

  - Subtract the regenerated counts. Once the drain has handed an intent to the app, the app owes the confirm or the retry, not the engine. Counting those would report work no drain can advance, and would double-count what the simulator already tracks as `outbound_awaiting_acknowledgement`.
  - Reuse `future_scheduled_work`, exactly as the adjacent `pending_convergence_groups` term does. An intent queued while a pass is still inside its quiescence window must yield `next_wake = cutoff`, not a hot `runnable_work` spin: a drain run before the cutoff provably returns empty. Once the cutoff passes, the pass contributes the runnable edge itself, so this term never double-counts.

RED evidence
------------
`a_settled_convergence_pass_leaves_no_unscheduled_retained_intent`, no fork required. Two members, observer `Stable`, a delivered commit opens a `Collecting` pass, and a send inside the window returns `Queued`.

First failure, the missing arm:

    queueing a durable outbound intent must schedule the drain that
    releases it; scheduled before the send: []

With the arm in place but the projection unchanged, the second failure — the host has consumed the edge and settled the pass, and the engine now claims an idle group while holding the payload:

    a durable intent nobody has published yet must keep the group armed,
    not report an idle group: ConformanceStructuralProgressSnapshot {
    ... lifecycle: Stable, pending_work: { ... queued_outbound_intents: 1,
    ... regenerated_standalone_publishes: 0, regenerated_pending_publishes: 0 },
    pass_phase: Some(Completed), earliest_next_wake_monotonic_ms: None,
    runnable_work: 0, terminal_unrecoverable: false }

That is the conformance driver's `blocked_observation` state: not quiescent, nothing runnable, no wake to advance to.

Pre-existing, not a regression of any open PR: both files were byte-identical to master before this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved delivery of outgoing messages queued while group updates are still in progress.
  - Queued messages now reliably resume processing once the group reaches a stable state.
  - Prevented queued messages from being overlooked during recovery or application restart.
  - Improved progress tracking so pending messages remain visible until successfully delivered and confirmed.

- **Documentation**
  - Clarified message-processing behavior across stable, updating, and recovery states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->