### PR TITLE
perf(cgka-engine): answer send gates with indexed state probes

### DIFF
--- a/crates/cgka-engine/src/convergence_input.rs
+++ b/crates/cgka-engine/src/convergence_input.rs
@@ -52,9 +52,17 @@ impl ClassifiedConvergenceInput {
     }
 
     fn can_gate_outbound(self) -> bool {
-        matches!(self.state, MessageState::Created | MessageState::Retryable)
+        OUTBOUND_GATING_STATES.contains(&self.state)
     }
 }
+
+/// The stored message states in which a retained input can gate outbound
+/// sends. `Engine::has_unresolved_convergence_inputs` passes this list to an
+/// indexed storage existence probe before paying a full list-and-decode scan;
+/// defining [`ClassifiedConvergenceInput::can_gate_outbound`] in terms of the
+/// same constant keeps the fast path and the classifier in lockstep.
+pub(crate) const OUTBOUND_GATING_STATES: [MessageState; 2] =
+    [MessageState::Created, MessageState::Retryable];
 
 #[derive(Default)]
 pub(crate) struct ConvergenceInputContext {
@@ -181,6 +189,31 @@ mod tests {
             source_epoch,
             state,
             digest: [digest_byte; 32],
+        }
+    }
+
+    #[test]
+    fn outbound_gating_states_stay_in_lockstep_with_the_classifier() {
+        // The indexed send-gate fast path prunes on `OUTBOUND_GATING_STATES`
+        // before the full scan runs `can_gate_outbound`; a state that gates in
+        // the classifier but is missing from the constant would make the fast
+        // path silently unblock sends.
+        for state in [
+            MessageState::Sent,
+            MessageState::Created,
+            MessageState::Processed,
+            MessageState::Failed,
+            MessageState::Retryable,
+            MessageState::EpochInvalidated,
+            MessageState::PeelDeferred,
+            MessageState::ConvergenceDeferred,
+        ] {
+            let classified = input(ConvergencePassMemberRole::CommitEdge, 1, state, 1);
+            assert_eq!(
+                classified.can_gate_outbound(),
+                OUTBOUND_GATING_STATES.contains(&state),
+                "{state:?} disagrees between can_gate_outbound and OUTBOUND_GATING_STATES"
+            );
         }
     }
 

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -909,6 +909,19 @@ impl<S: StorageProvider> Engine<S> {
             Err(e) => return Err(EngineError::Storage(e)),
         };
         let (anchor, ceiling) = self.convergence_gate_horizon(group_id, &group)?;
+        // Indexed fast path: `any_gating_convergence_input` can only report a
+        // gate when some retained row is in an outbound-gating state
+        // (`ClassifiedConvergenceInput::can_gate_outbound`). This runs on
+        // every send, so answer the common no-gating-work case with one
+        // existence probe instead of listing and decoding the group's whole
+        // retained window.
+        if !self.storage.has_messages_in_states(
+            group_id,
+            &crate::convergence_input::OUTBOUND_GATING_STATES,
+            EpochId(anchor),
+        )? {
+            return Ok(false);
+        }
         let records = self.storage.list_messages(group_id, EpochId(anchor))?;
         Ok(self.any_gating_convergence_input(anchor, ceiling, &records))
     }
@@ -1108,12 +1121,14 @@ impl<S: StorageProvider> Engine<S> {
         }
 
         let now = self.convergence_now();
-        let mut deferred: Vec<_> = self
-            .storage
-            .list_messages(group_id, EpochId(0))?
-            .into_iter()
-            .filter(|record| record.state == MessageState::PeelDeferred)
-            .collect();
+        // State-filtered listing: this sweep runs on every drain and the
+        // backlog is usually empty, so let the backend's index find the
+        // `PeelDeferred` rows instead of decoding the whole retained window.
+        let mut deferred = self.storage.list_messages_in_states(
+            group_id,
+            &[MessageState::PeelDeferred],
+            EpochId(0),
+        )?;
         if self.normalize_deferred_peel_lifecycles(&mut deferred, now)? {
             // Legacy initialization and restart rebasing are durable writes,
             // so migrate them in the same bounded slices as peel attempts.

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -88,6 +88,8 @@ mod migration_0043_transport_group_routes;
 mod migration_0044_local_group_deletion_frontiers;
 #[path = "migrations/0045_timeline_canonical_order.rs"]
 mod migration_0045_timeline_canonical_order;
+#[path = "migrations/0046_message_group_state_epoch_index.rs"]
+mod migration_0046_message_group_state_epoch_index;
 
 use crate::SqliteResultExt;
 use cgka_traits::storage::{StorageError, StorageResult};
@@ -324,6 +326,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 45,
         name: "0045_timeline_canonical_order",
         apply: migration_0045_timeline_canonical_order::apply,
+    },
+    Migration {
+        version: 46,
+        name: "0046_message_group_state_epoch_index",
+        apply: migration_0046_message_group_state_epoch_index::apply,
     },
 ];
 

--- a/crates/storage-sqlite/src/migrations/0046_message_group_state_epoch_index.rs
+++ b/crates/storage-sqlite/src/migrations/0046_message_group_state_epoch_index.rs
@@ -1,0 +1,17 @@
+use crate::SqliteResultExt;
+use cgka_traits::storage::StorageResult;
+use rusqlite::Transaction;
+
+/// Index state-filtered message lookups. The engine's outbound send gate and
+/// deferred-peel sweep ask "does this group hold any row in state X at or
+/// after epoch Y" on every send; without a state-leading index those probes
+/// scan and decode the group's whole retained history.
+pub(crate) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
+    tx.execute_batch(
+        r#"
+CREATE INDEX IF NOT EXISTS idx_cgka_messages_group_state_epoch
+    ON cgka_messages (group_id, state, epoch);
+"#,
+    )
+    .storage()
+}

--- a/crates/storage-sqlite/src/storage/messages.rs
+++ b/crates/storage-sqlite/src/storage/messages.rs
@@ -127,6 +127,63 @@ impl MessageStorage for SqliteAccountStorage {
         records.iter().map(|record| deserialize(record)).collect()
     }
 
+    fn has_messages_in_states(
+        &self,
+        group_id: &GroupId,
+        states: &[MessageState],
+        at_or_after_epoch: EpochId,
+    ) -> StorageResult<bool> {
+        if states.is_empty() {
+            return Ok(false);
+        }
+        let sql = format!(
+            "SELECT EXISTS(
+                SELECT 1 FROM cgka_messages
+                WHERE group_id = ?1 AND epoch >= ?2 AND state IN ({})
+             )",
+            state_placeholders(states)
+        );
+        let conn = self.lock()?;
+        conn.query_row(
+            &sql,
+            rusqlite::params_from_iter(state_query_params(group_id, at_or_after_epoch, states)?),
+            |row| row.get(0),
+        )
+        .storage()
+    }
+
+    fn list_messages_in_states(
+        &self,
+        group_id: &GroupId,
+        states: &[MessageState],
+        at_or_after_epoch: EpochId,
+    ) -> StorageResult<Vec<MessageRecord>> {
+        if states.is_empty() {
+            return Ok(Vec::new());
+        }
+        let sql = format!(
+            "SELECT record FROM cgka_messages
+             WHERE group_id = ?1 AND epoch >= ?2 AND state IN ({})
+             ORDER BY insert_order",
+            state_placeholders(states)
+        );
+        let conn = self.lock()?;
+        let mut stmt = conn.prepare(&sql).storage()?;
+        let records = stmt
+            .query_map(
+                rusqlite::params_from_iter(state_query_params(
+                    group_id,
+                    at_or_after_epoch,
+                    states,
+                )?),
+                |row| row.get::<_, Vec<u8>>(0),
+            )
+            .storage()?
+            .collect::<Result<Vec<_>, _>>()
+            .storage()?;
+        records.iter().map(|record| deserialize(record)).collect()
+    }
+
     fn put_pending_application_event(&self, event: &GroupEvent) -> StorageResult<()> {
         let (group_id, message_id) = match event {
             GroupEvent::MessageReceived {
@@ -302,6 +359,35 @@ impl MessageStorage for SqliteAccountStorage {
     fn release_group_snapshot(&self, group_id: &GroupId, name: &str) -> StorageResult<()> {
         snapshots::release(self, group_id, name)
     }
+}
+
+/// `?N` placeholder list for a state `IN (...)` clause, numbered after the
+/// fixed `?1` group-id and `?2` epoch parameters.
+fn state_placeholders(states: &[MessageState]) -> String {
+    (0..states.len())
+        .map(|index| format!("?{}", index + 3))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Positional parameters matching [`state_placeholders`]: group id, epoch
+/// floor, then one integer per requested state.
+fn state_query_params(
+    group_id: &GroupId,
+    at_or_after_epoch: EpochId,
+    states: &[MessageState],
+) -> StorageResult<Vec<rusqlite::types::Value>> {
+    let mut params = Vec::with_capacity(states.len() + 2);
+    params.push(rusqlite::types::Value::Blob(group_id.as_slice().to_vec()));
+    params.push(rusqlite::types::Value::Integer(epoch_to_i64(
+        at_or_after_epoch,
+    )?));
+    params.extend(
+        states
+            .iter()
+            .map(|state| rusqlite::types::Value::Integer(message_state_to_i64(*state))),
+    );
+    Ok(params)
 }
 
 /// Read-modify-write the stored state of a single message on an already-locked
@@ -599,6 +685,94 @@ mod tests {
             .delete_pending_application_events(&[committed.id])
             .unwrap();
         assert!(store.list_pending_application_events().unwrap().is_empty());
+    }
+
+    #[test]
+    fn state_filtered_queries_match_the_full_listing() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        store.put_group(&sample_group(gid(1), 0, 0)).unwrap();
+        store.put_group(&sample_group(gid(2), 0, 0)).unwrap();
+
+        let with_state = |id, group, epoch, state| {
+            let mut message = sample_message(id, group, epoch);
+            message.state = state;
+            store.put_message(&message).unwrap();
+        };
+        with_state(mid(1), gid(1), 0, MessageState::Created);
+        with_state(mid(2), gid(1), 5, MessageState::PeelDeferred);
+        with_state(mid(3), gid(1), 2, MessageState::Retryable);
+        with_state(mid(4), gid(1), 7, MessageState::Processed);
+        with_state(mid(5), gid(2), 0, MessageState::PeelDeferred);
+
+        let ids = |states: &[MessageState], epoch: u64| {
+            store
+                .list_messages_in_states(&gid(1), states, EpochId(epoch))
+                .unwrap()
+                .into_iter()
+                .map(|m| m.id)
+                .collect::<Vec<_>>()
+        };
+
+        assert_eq!(ids(&[MessageState::PeelDeferred], 0), vec![mid(2)]);
+        assert_eq!(
+            ids(&[MessageState::Created, MessageState::Retryable], 0),
+            vec![mid(1), mid(3)],
+            "insert order must be preserved",
+        );
+        assert_eq!(
+            ids(&[MessageState::Created, MessageState::Retryable], 1),
+            vec![mid(3)],
+            "epoch floor must apply",
+        );
+        assert_eq!(ids(&[], 0), Vec::<cgka_traits::MessageId>::new());
+
+        assert!(
+            store
+                .has_messages_in_states(&gid(1), &[MessageState::PeelDeferred], EpochId(0))
+                .unwrap()
+        );
+        assert!(
+            !store
+                .has_messages_in_states(&gid(1), &[MessageState::PeelDeferred], EpochId(6))
+                .unwrap(),
+            "epoch floor must apply to the existence probe",
+        );
+        assert!(
+            !store
+                .has_messages_in_states(&gid(1), &[MessageState::Failed], EpochId(0))
+                .unwrap()
+        );
+        assert!(
+            !store
+                .has_messages_in_states(&gid(1), &[], EpochId(0))
+                .unwrap()
+        );
+
+        // Parity with the trait's default (list + filter) semantics.
+        for states in [
+            &[MessageState::PeelDeferred][..],
+            &[MessageState::Created, MessageState::Retryable][..],
+            &[MessageState::Processed][..],
+        ] {
+            let expected: Vec<_> = store
+                .list_messages(&gid(1), EpochId(0))
+                .unwrap()
+                .into_iter()
+                .filter(|record| states.contains(&record.state))
+                .collect();
+            assert_eq!(
+                store
+                    .list_messages_in_states(&gid(1), states, EpochId(0))
+                    .unwrap(),
+                expected
+            );
+            assert_eq!(
+                store
+                    .has_messages_in_states(&gid(1), states, EpochId(0))
+                    .unwrap(),
+                !expected.is_empty()
+            );
+        }
     }
 
     #[test]

--- a/crates/traits/src/storage.rs
+++ b/crates/traits/src/storage.rs
@@ -208,6 +208,42 @@ pub trait MessageStorage {
         at_or_after_epoch: EpochId,
     ) -> StorageResult<Vec<MessageRecord>>;
 
+    /// Whether any retained row for `group_id` at or after `at_or_after_epoch`
+    /// is in one of `states`. Hot-path gates (outbound send checks, sweep
+    /// short-circuits) call this before deciding whether a full
+    /// [`Self::list_messages`] scan is worth paying, so backends should answer
+    /// it with an indexed existence probe instead of materializing and
+    /// decoding rows. An empty `states` slice answers `false`.
+    fn has_messages_in_states(
+        &self,
+        group_id: &GroupId,
+        states: &[MessageState],
+        at_or_after_epoch: EpochId,
+    ) -> StorageResult<bool> {
+        Ok(self
+            .list_messages(group_id, at_or_after_epoch)?
+            .iter()
+            .any(|record| states.contains(&record.state)))
+    }
+
+    /// [`Self::list_messages`] restricted to rows whose state is in `states`,
+    /// in the same deterministic replay order. Backends should push the state
+    /// filter into the query so callers interested in a rare state (for
+    /// example `PeelDeferred`) do not pay to materialize and decode every
+    /// retained row. An empty `states` slice returns no rows.
+    fn list_messages_in_states(
+        &self,
+        group_id: &GroupId,
+        states: &[MessageState],
+        at_or_after_epoch: EpochId,
+    ) -> StorageResult<Vec<MessageRecord>> {
+        Ok(self
+            .list_messages(group_id, at_or_after_epoch)?
+            .into_iter()
+            .filter(|record| states.contains(&record.state))
+            .collect())
+    }
+
     /// Persist authenticated app-visible output until its app projection has
     /// committed. Implementations accept `MessageReceived` and `GroupJoined`,
     /// keyed by their source message or Welcome id, and reject other events.


### PR DESCRIPTION
Every outbound send paid two full scans of the group's retained message window:

- `has_unresolved_convergence_inputs` listed and JSON-decoded every row at or after the anchor epoch, then classified each one, even though only rows in `Created` or `Retryable` state can gate a send.
- `retry_deferred_peels` listed every row from epoch 0 to find `PeelDeferred` rows, which are almost always absent.

This PR answers both gates with indexed queries:

- New `MessageStorage::has_messages_in_states` and `list_messages_in_states`, with default implementations on top of `list_messages`, so existing backends keep working unchanged.
- storage-sqlite overrides both with SQL state filters, served by a new `(group_id, state, epoch)` index (migration 0046).
- The send gate returns early on one `EXISTS` probe when the group holds no row in a gating state. The deferred-peel sweep decodes only `PeelDeferred` rows.

`OUTBOUND_GATING_STATES` keeps the fast path and `ClassifiedConvergenceInput::can_gate_outbound` in lockstep: the classifier is defined in terms of the constant, and an exhaustive test covers every `MessageState` variant.

No behavior change: the fast path skips work only when the full scan would have found nothing, and the sweep sees the same rows it saw before. Marmot colonies with long chat histories feel this on every send.

Verified with `just fast-ci`, `cargo test -p storage-sqlite`, `cargo test -p cgka-traits`, and `cargo test -p cgka-engine --features test-policy-overrides,test-crash-hooks`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved message processing by efficiently locating deferred and outbound-gating messages.
  * Added optimized filtering by message state and epoch for faster retained-message queries.

* **Reliability**
  * Clarified which message states qualify for outbound gating.
  * Added coverage for state classification, filtering behavior, ordering, and epoch boundaries.

* **Storage**
  * Added a database index to accelerate message lookups by group, state, and epoch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->