### PR TITLE
perf(storage-sqlite): scope retained-anchor snapshots to group state

### DIFF
--- a/crates/cgka-engine/src/convergence_input.rs
+++ b/crates/cgka-engine/src/convergence_input.rs
@@ -52,9 +52,17 @@ impl ClassifiedConvergenceInput {
     }
 
     fn can_gate_outbound(self) -> bool {
-        matches!(self.state, MessageState::Created | MessageState::Retryable)
+        OUTBOUND_GATING_STATES.contains(&self.state)
     }
 }
+
+/// The stored message states in which a retained input can gate outbound
+/// sends. `Engine::has_unresolved_convergence_inputs` passes this list to an
+/// indexed storage existence probe before paying a full list-and-decode scan;
+/// defining [`ClassifiedConvergenceInput::can_gate_outbound`] in terms of the
+/// same constant keeps the fast path and the classifier in lockstep.
+pub(crate) const OUTBOUND_GATING_STATES: [MessageState; 2] =
+    [MessageState::Created, MessageState::Retryable];
 
 #[derive(Default)]
 pub(crate) struct ConvergenceInputContext {
@@ -181,6 +189,31 @@ mod tests {
             source_epoch,
             state,
             digest: [digest_byte; 32],
+        }
+    }
+
+    #[test]
+    fn outbound_gating_states_stay_in_lockstep_with_the_classifier() {
+        // The indexed send-gate fast path prunes on `OUTBOUND_GATING_STATES`
+        // before the full scan runs `can_gate_outbound`; a state that gates in
+        // the classifier but is missing from the constant would make the fast
+        // path silently unblock sends.
+        for state in [
+            MessageState::Sent,
+            MessageState::Created,
+            MessageState::Processed,
+            MessageState::Failed,
+            MessageState::Retryable,
+            MessageState::EpochInvalidated,
+            MessageState::PeelDeferred,
+            MessageState::ConvergenceDeferred,
+        ] {
+            let classified = input(ConvergencePassMemberRole::CommitEdge, 1, state, 1);
+            assert_eq!(
+                classified.can_gate_outbound(),
+                OUTBOUND_GATING_STATES.contains(&state),
+                "{state:?} disagrees between can_gate_outbound and OUTBOUND_GATING_STATES"
+            );
         }
     }
 

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -909,6 +909,19 @@ impl<S: StorageProvider> Engine<S> {
             Err(e) => return Err(EngineError::Storage(e)),
         };
         let (anchor, ceiling) = self.convergence_gate_horizon(group_id, &group)?;
+        // Indexed fast path: `any_gating_convergence_input` can only report a
+        // gate when some retained row is in an outbound-gating state
+        // (`ClassifiedConvergenceInput::can_gate_outbound`). This runs on
+        // every send, so answer the common no-gating-work case with one
+        // existence probe instead of listing and decoding the group's whole
+        // retained window.
+        if !self.storage.has_messages_in_states(
+            group_id,
+            &crate::convergence_input::OUTBOUND_GATING_STATES,
+            EpochId(anchor),
+        )? {
+            return Ok(false);
+        }
         let records = self.storage.list_messages(group_id, EpochId(anchor))?;
         Ok(self.any_gating_convergence_input(anchor, ceiling, &records))
     }
@@ -1108,12 +1121,14 @@ impl<S: StorageProvider> Engine<S> {
         }
 
         let now = self.convergence_now();
-        let mut deferred: Vec<_> = self
-            .storage
-            .list_messages(group_id, EpochId(0))?
-            .into_iter()
-            .filter(|record| record.state == MessageState::PeelDeferred)
-            .collect();
+        // State-filtered listing: this sweep runs on every drain and the
+        // backlog is usually empty, so let the backend's index find the
+        // `PeelDeferred` rows instead of decoding the whole retained window.
+        let mut deferred = self.storage.list_messages_in_states(
+            group_id,
+            &[MessageState::PeelDeferred],
+            EpochId(0),
+        )?;
         if self.normalize_deferred_peel_lifecycles(&mut deferred, now)? {
             // Legacy initialization and restart rebasing are durable writes,
             // so migrate them in the same bounded slices as peel attempts.

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -2666,8 +2666,15 @@ pub(crate) fn retain_current_group_epoch_snapshot<S: StorageProvider>(
         .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?
         .epoch
         .0;
+    // State-scoped: this runs on every canonical advance, and the anchor is
+    // only ever consumed as an OpenMLS/group-state rewind base. The message
+    // ledger is deliberately not captured — the convergence probe works from
+    // pre-seeded inputs (`seed_stored_openmls_graph_inputs` runs before the
+    // rewind), and the historical apply restores the live message/queue sets
+    // over the rollback anyway (`restore_live_message_and_queue_records`).
+    // Capturing them would make every applied commit O(retained bytes).
     storage
-        .create_group_snapshot(group_id, &retained_anchor_snapshot_name(epoch))
+        .create_group_state_snapshot(group_id, &retained_anchor_snapshot_name(epoch))
         .map_err(|e| OpenMlsProjectionError::Snapshot(format!("{e:?}")))?;
     prune_retained_anchor_snapshots(storage, group_id, epoch, max_retained_anchor_rewind)?;
     prune_group_state_checkpoints(storage, group_id, epoch, max_retained_anchor_rewind)

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -88,6 +88,8 @@ mod migration_0043_transport_group_routes;
 mod migration_0044_local_group_deletion_frontiers;
 #[path = "migrations/0045_timeline_canonical_order.rs"]
 mod migration_0045_timeline_canonical_order;
+#[path = "migrations/0046_message_group_state_epoch_index.rs"]
+mod migration_0046_message_group_state_epoch_index;
 
 use crate::SqliteResultExt;
 use cgka_traits::storage::{StorageError, StorageResult};
@@ -324,6 +326,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 45,
         name: "0045_timeline_canonical_order",
         apply: migration_0045_timeline_canonical_order::apply,
+    },
+    Migration {
+        version: 46,
+        name: "0046_message_group_state_epoch_index",
+        apply: migration_0046_message_group_state_epoch_index::apply,
     },
 ];
 

--- a/crates/storage-sqlite/src/migrations/0046_message_group_state_epoch_index.rs
+++ b/crates/storage-sqlite/src/migrations/0046_message_group_state_epoch_index.rs
@@ -1,0 +1,17 @@
+use crate::SqliteResultExt;
+use cgka_traits::storage::StorageResult;
+use rusqlite::Transaction;
+
+/// Index state-filtered message lookups. The engine's outbound send gate and
+/// deferred-peel sweep ask "does this group hold any row in state X at or
+/// after epoch Y" on every send; without a state-leading index those probes
+/// scan and decode the group's whole retained history.
+pub(crate) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
+    tx.execute_batch(
+        r#"
+CREATE INDEX IF NOT EXISTS idx_cgka_messages_group_state_epoch
+    ON cgka_messages (group_id, state, epoch);
+"#,
+    )
+    .storage()
+}

--- a/crates/storage-sqlite/src/storage/messages.rs
+++ b/crates/storage-sqlite/src/storage/messages.rs
@@ -127,6 +127,63 @@ impl MessageStorage for SqliteAccountStorage {
         records.iter().map(|record| deserialize(record)).collect()
     }
 
+    fn has_messages_in_states(
+        &self,
+        group_id: &GroupId,
+        states: &[MessageState],
+        at_or_after_epoch: EpochId,
+    ) -> StorageResult<bool> {
+        if states.is_empty() {
+            return Ok(false);
+        }
+        let sql = format!(
+            "SELECT EXISTS(
+                SELECT 1 FROM cgka_messages
+                WHERE group_id = ?1 AND epoch >= ?2 AND state IN ({})
+             )",
+            state_placeholders(states)
+        );
+        let conn = self.lock()?;
+        conn.query_row(
+            &sql,
+            rusqlite::params_from_iter(state_query_params(group_id, at_or_after_epoch, states)?),
+            |row| row.get(0),
+        )
+        .storage()
+    }
+
+    fn list_messages_in_states(
+        &self,
+        group_id: &GroupId,
+        states: &[MessageState],
+        at_or_after_epoch: EpochId,
+    ) -> StorageResult<Vec<MessageRecord>> {
+        if states.is_empty() {
+            return Ok(Vec::new());
+        }
+        let sql = format!(
+            "SELECT record FROM cgka_messages
+             WHERE group_id = ?1 AND epoch >= ?2 AND state IN ({})
+             ORDER BY insert_order",
+            state_placeholders(states)
+        );
+        let conn = self.lock()?;
+        let mut stmt = conn.prepare(&sql).storage()?;
+        let records = stmt
+            .query_map(
+                rusqlite::params_from_iter(state_query_params(
+                    group_id,
+                    at_or_after_epoch,
+                    states,
+                )?),
+                |row| row.get::<_, Vec<u8>>(0),
+            )
+            .storage()?
+            .collect::<Result<Vec<_>, _>>()
+            .storage()?;
+        records.iter().map(|record| deserialize(record)).collect()
+    }
+
     fn put_pending_application_event(&self, event: &GroupEvent) -> StorageResult<()> {
         let (group_id, message_id) = match event {
             GroupEvent::MessageReceived {
@@ -302,6 +359,35 @@ impl MessageStorage for SqliteAccountStorage {
     fn release_group_snapshot(&self, group_id: &GroupId, name: &str) -> StorageResult<()> {
         snapshots::release(self, group_id, name)
     }
+}
+
+/// `?N` placeholder list for a state `IN (...)` clause, numbered after the
+/// fixed `?1` group-id and `?2` epoch parameters.
+fn state_placeholders(states: &[MessageState]) -> String {
+    (0..states.len())
+        .map(|index| format!("?{}", index + 3))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Positional parameters matching [`state_placeholders`]: group id, epoch
+/// floor, then one integer per requested state.
+fn state_query_params(
+    group_id: &GroupId,
+    at_or_after_epoch: EpochId,
+    states: &[MessageState],
+) -> StorageResult<Vec<rusqlite::types::Value>> {
+    let mut params = Vec::with_capacity(states.len() + 2);
+    params.push(rusqlite::types::Value::Blob(group_id.as_slice().to_vec()));
+    params.push(rusqlite::types::Value::Integer(epoch_to_i64(
+        at_or_after_epoch,
+    )?));
+    params.extend(
+        states
+            .iter()
+            .map(|state| rusqlite::types::Value::Integer(message_state_to_i64(*state))),
+    );
+    Ok(params)
 }
 
 /// Read-modify-write the stored state of a single message on an already-locked
@@ -599,6 +685,94 @@ mod tests {
             .delete_pending_application_events(&[committed.id])
             .unwrap();
         assert!(store.list_pending_application_events().unwrap().is_empty());
+    }
+
+    #[test]
+    fn state_filtered_queries_match_the_full_listing() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        store.put_group(&sample_group(gid(1), 0, 0)).unwrap();
+        store.put_group(&sample_group(gid(2), 0, 0)).unwrap();
+
+        let with_state = |id, group, epoch, state| {
+            let mut message = sample_message(id, group, epoch);
+            message.state = state;
+            store.put_message(&message).unwrap();
+        };
+        with_state(mid(1), gid(1), 0, MessageState::Created);
+        with_state(mid(2), gid(1), 5, MessageState::PeelDeferred);
+        with_state(mid(3), gid(1), 2, MessageState::Retryable);
+        with_state(mid(4), gid(1), 7, MessageState::Processed);
+        with_state(mid(5), gid(2), 0, MessageState::PeelDeferred);
+
+        let ids = |states: &[MessageState], epoch: u64| {
+            store
+                .list_messages_in_states(&gid(1), states, EpochId(epoch))
+                .unwrap()
+                .into_iter()
+                .map(|m| m.id)
+                .collect::<Vec<_>>()
+        };
+
+        assert_eq!(ids(&[MessageState::PeelDeferred], 0), vec![mid(2)]);
+        assert_eq!(
+            ids(&[MessageState::Created, MessageState::Retryable], 0),
+            vec![mid(1), mid(3)],
+            "insert order must be preserved",
+        );
+        assert_eq!(
+            ids(&[MessageState::Created, MessageState::Retryable], 1),
+            vec![mid(3)],
+            "epoch floor must apply",
+        );
+        assert_eq!(ids(&[], 0), Vec::<cgka_traits::MessageId>::new());
+
+        assert!(
+            store
+                .has_messages_in_states(&gid(1), &[MessageState::PeelDeferred], EpochId(0))
+                .unwrap()
+        );
+        assert!(
+            !store
+                .has_messages_in_states(&gid(1), &[MessageState::PeelDeferred], EpochId(6))
+                .unwrap(),
+            "epoch floor must apply to the existence probe",
+        );
+        assert!(
+            !store
+                .has_messages_in_states(&gid(1), &[MessageState::Failed], EpochId(0))
+                .unwrap()
+        );
+        assert!(
+            !store
+                .has_messages_in_states(&gid(1), &[], EpochId(0))
+                .unwrap()
+        );
+
+        // Parity with the trait's default (list + filter) semantics.
+        for states in [
+            &[MessageState::PeelDeferred][..],
+            &[MessageState::Created, MessageState::Retryable][..],
+            &[MessageState::Processed][..],
+        ] {
+            let expected: Vec<_> = store
+                .list_messages(&gid(1), EpochId(0))
+                .unwrap()
+                .into_iter()
+                .filter(|record| states.contains(&record.state))
+                .collect();
+            assert_eq!(
+                store
+                    .list_messages_in_states(&gid(1), states, EpochId(0))
+                    .unwrap(),
+                expected
+            );
+            assert_eq!(
+                store
+                    .has_messages_in_states(&gid(1), states, EpochId(0))
+                    .unwrap(),
+                !expected.is_empty()
+            );
+        }
     }
 
     #[test]

--- a/crates/storage-sqlite/src/storage/messages.rs
+++ b/crates/storage-sqlite/src/storage/messages.rs
@@ -348,6 +348,10 @@ impl MessageStorage for SqliteAccountStorage {
         snapshots::create(self, group_id, name)
     }
 
+    fn create_group_state_snapshot(&self, group_id: &GroupId, name: &str) -> StorageResult<()> {
+        snapshots::create_state_scoped(self, group_id, name)
+    }
+
     fn list_group_snapshots(&self, group_id: &GroupId) -> StorageResult<Vec<String>> {
         snapshots::list(self, group_id)
     }

--- a/crates/storage-sqlite/src/storage/snapshots.rs
+++ b/crates/storage-sqlite/src/storage/snapshots.rs
@@ -238,6 +238,71 @@ mod tests {
     }
 
     #[test]
+    fn legacy_full_snapshot_blob_with_plain_array_fields_still_restores() {
+        // Blobs written before state-scoped snapshots serialized `messages`
+        // and `queued_outbound` as plain JSON arrays (the fields were `Vec`,
+        // not `Option<Vec>`). Serde decodes those arrays as `Some(..)`, so a
+        // pre-change anchor keeps its capture-time restore semantics. This
+        // builds such a blob from scratch — no `Option` involved — and locks
+        // that compatibility in.
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let anchor_group = sample_group(gid(1), 0, 1);
+        let anchor_message = sample_message(mid(1), anchor_group.id.clone(), 0);
+        store.put_group(&anchor_group).unwrap();
+
+        let legacy_blob = serde_json::to_vec(&serde_json::json!({
+            "group": serde_json::to_value(&anchor_group).unwrap(),
+            "messages": [{
+                "insert_order": 1,
+                "record": serde_json::to_value(&anchor_message).unwrap(),
+            }],
+            "queued_outbound": [],
+            "member_caps": [],
+            "convergence_policy": null,
+            "validated_tree_marker": null,
+            "openmls_values": [],
+        }))
+        .unwrap();
+        store
+            .lock()
+            .unwrap()
+            .execute(
+                "INSERT INTO cgka_group_snapshots (group_id, name, snapshot)
+                 VALUES (?1, ?2, ?3)",
+                rusqlite::params![
+                    anchor_group.id.as_slice(),
+                    "legacy-full",
+                    legacy_blob.as_slice()
+                ],
+            )
+            .unwrap();
+
+        let live_group = sample_group(gid(1), 1, 2);
+        store.put_group(&live_group).unwrap();
+        store
+            .put_message(&sample_message(mid(2), live_group.id.clone(), 1))
+            .unwrap();
+
+        store
+            .rollback_group_to_snapshot(&live_group.id, "legacy-full")
+            .unwrap();
+
+        // Full-image semantics preserved: the legacy blob's ledger replaces
+        // the live rows, exactly as before the Option change.
+        assert_eq!(store.get_group(&anchor_group.id).unwrap(), anchor_group);
+        assert_eq!(
+            store.list_messages(&anchor_group.id, EpochId(0)).unwrap(),
+            vec![anchor_message]
+        );
+        assert!(
+            store
+                .list_queued_outbound_intents(&anchor_group.id)
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
     fn group_state_checkpoint_restores_canonical_state_without_rewinding_live_work() {
         let store = SqliteAccountStorage::in_memory().unwrap();
         let g1 = sample_group(gid(1), 1, 1);

--- a/crates/storage-sqlite/src/storage/snapshots.rs
+++ b/crates/storage-sqlite/src/storage/snapshots.rs
@@ -13,7 +13,15 @@ pub(super) fn create(
     group_id: &GroupId,
     name: &str,
 ) -> StorageResult<()> {
-    capture::create(store, group_id, name)
+    capture::create(store, group_id, name, capture::SnapshotScope::Full)
+}
+
+pub(super) fn create_state_scoped(
+    store: &SqliteAccountStorage,
+    group_id: &GroupId,
+    name: &str,
+) -> StorageResult<()> {
+    capture::create(store, group_id, name, capture::SnapshotScope::GroupState)
 }
 
 pub(super) fn list(store: &SqliteAccountStorage, group_id: &GroupId) -> StorageResult<Vec<String>> {
@@ -171,6 +179,62 @@ mod tests {
         );
         let state: Option<TestGroupState> = store.mls_storage().group_state(&mls_group_id).unwrap();
         assert_eq!(state, Some(TestGroupState(b"epoch-0".to_vec())));
+    }
+
+    #[test]
+    fn state_scoped_snapshot_rolls_back_group_state_without_touching_messages_or_queue() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let g0 = sample_group(gid(1), 0, 1);
+        store.put_group(&g0).unwrap();
+        store
+            .put_message(&sample_message(mid(1), g0.id.clone(), 0))
+            .unwrap();
+        store
+            .put_queued_outbound_intent(&sample_queued_intent(mid(10), g0.id.clone()))
+            .unwrap();
+        let mls_group_id = openmls::group::GroupId::from_slice(g0.id.as_slice());
+        store
+            .mls_storage()
+            .write_group_state(&mls_group_id, &TestGroupState(b"epoch-0".to_vec()))
+            .unwrap();
+
+        store
+            .create_group_state_snapshot(&g0.id, "retained-anchor")
+            .unwrap();
+
+        let g1 = sample_group(gid(1), 1, 2);
+        store.put_group(&g1).unwrap();
+        store
+            .put_message(&sample_message(mid(2), g0.id.clone(), 1))
+            .unwrap();
+        store.delete_queued_outbound_intent(&mid(10)).unwrap();
+        let live_queued = sample_queued_intent(mid(11), g0.id.clone());
+        store.put_queued_outbound_intent(&live_queued).unwrap();
+        store
+            .mls_storage()
+            .write_group_state(&mls_group_id, &TestGroupState(b"epoch-1".to_vec()))
+            .unwrap();
+
+        store
+            .rollback_group_to_snapshot(&g0.id, "retained-anchor")
+            .unwrap();
+
+        // Canonical state rewinds to capture time...
+        assert_eq!(store.get_group(&g0.id).unwrap(), g0);
+        let state: Option<TestGroupState> = store.mls_storage().group_state(&mls_group_id).unwrap();
+        assert_eq!(state, Some(TestGroupState(b"epoch-0".to_vec())));
+        // ...while the live message ledger and outbound queue are untouched.
+        let ids: Vec<_> = store
+            .list_messages(&g0.id, EpochId(0))
+            .unwrap()
+            .into_iter()
+            .map(|m| m.id)
+            .collect();
+        assert_eq!(ids, vec![mid(1), mid(2)]);
+        assert_eq!(
+            store.list_queued_outbound_intents(&g0.id).unwrap(),
+            vec![live_queued]
+        );
     }
 
     #[test]

--- a/crates/storage-sqlite/src/storage/snapshots/capture.rs
+++ b/crates/storage-sqlite/src/storage/snapshots/capture.rs
@@ -17,14 +17,27 @@ use cgka_traits::storage::{StorageError, StorageResult};
 use cgka_traits::types::{GroupId, MemberId};
 use rusqlite::{OptionalExtension, TransactionBehavior, params};
 
+/// What a snapshot captures — and therefore what its rollback later rewrites.
+#[derive(Clone, Copy)]
+pub(super) enum SnapshotScope {
+    /// Everything: group record, message ledger, outbound queue, member
+    /// capabilities, convergence policy, validation marker, OpenMLS values.
+    Full,
+    /// Canonical group state only. The message ledger and outbound queue are
+    /// not captured, and rolling back to such a snapshot leaves the live
+    /// `cgka_messages` / `cgka_queued_outbound` rows untouched.
+    GroupState,
+}
+
 pub(super) fn create(
     store: &SqliteAccountStorage,
     group_id: &GroupId,
     name: &str,
+    scope: SnapshotScope,
 ) -> StorageResult<()> {
     if store.connection.is_current_thread_transaction_owner() {
         let conn = store.lock()?;
-        return create_on_connection(&conn, group_id, name);
+        return create_on_connection(&conn, group_id, name, scope);
     }
 
     retry_on_busy(|| {
@@ -32,7 +45,7 @@ pub(super) fn create(
         let tx = conn
             .transaction_with_behavior(TransactionBehavior::Immediate)
             .storage()?;
-        create_on_connection(&tx, group_id, name)?;
+        create_on_connection(&tx, group_id, name, scope)?;
         tx.commit().storage()?;
         Ok(())
     })
@@ -42,8 +55,9 @@ fn create_on_connection(
     conn: &rusqlite::Connection,
     group_id: &GroupId,
     name: &str,
+    scope: SnapshotScope,
 ) -> StorageResult<()> {
-    let snapshot = capture_snapshot(conn, group_id)?;
+    let snapshot = capture_snapshot(conn, group_id, scope)?;
     let snapshot_blob = serialize_sensitive(&snapshot)?;
     conn.execute(
         "INSERT OR REPLACE INTO cgka_group_snapshots (group_id, name, snapshot)
@@ -54,7 +68,11 @@ fn create_on_connection(
     Ok(())
 }
 
-fn capture_snapshot(conn: &rusqlite::Connection, group_id: &GroupId) -> StorageResult<Snapshot> {
+fn capture_snapshot(
+    conn: &rusqlite::Connection,
+    group_id: &GroupId,
+    scope: SnapshotScope,
+) -> StorageResult<Snapshot> {
     let mls_group_key = mls_group_key(group_id)?;
     let group_blob: Vec<u8> = conn
         .query_row(
@@ -66,8 +84,13 @@ fn capture_snapshot(conn: &rusqlite::Connection, group_id: &GroupId) -> StorageR
         .storage()?
         .ok_or(StorageError::NotFound)?;
     let group = deserialize(&group_blob)?;
-    let messages = messages(conn, group_id)?;
-    let queued_outbound = queued_outbound(conn, group_id)?;
+    let (messages, queued_outbound) = match scope {
+        SnapshotScope::Full => (
+            Some(messages(conn, group_id)?),
+            Some(queued_outbound(conn, group_id)?),
+        ),
+        SnapshotScope::GroupState => (None, None),
+    };
     let member_caps = member_capabilities(conn, group_id)?;
     let convergence_policy = convergence_policy(conn, group_id)?;
     let validated_tree_marker = validated_tree_marker(conn, group_id)?;
@@ -122,7 +145,7 @@ pub(super) fn export(store: &SqliteAccountStorage, group_id: &GroupId) -> Storag
         .transpose()?;
     serialize(&ReplaySnapshot {
         version: REPLAY_SNAPSHOT_VERSION,
-        group: capture_snapshot(&conn, group_id)?,
+        group: capture_snapshot(&conn, group_id, SnapshotScope::Full)?,
         convergence_pass,
     })
 }

--- a/crates/storage-sqlite/src/storage/snapshots/restore.rs
+++ b/crates/storage-sqlite/src/storage/snapshots/restore.rs
@@ -125,8 +125,15 @@ fn restore_snapshot(
     mls_group_key: &[u8],
 ) -> StorageResult<()> {
     group(conn, group_id, &snapshot.group)?;
-    messages(conn, group_id, &snapshot.messages)?;
-    queued_outbound(conn, group_id, &snapshot.queued_outbound)?;
+    // A state-scoped snapshot (`None`) never captured the message ledger or
+    // outbound queue, so rollback must leave the live rows alone rather than
+    // restore an empty image.
+    if let Some(snapshot_messages) = &snapshot.messages {
+        messages(conn, group_id, snapshot_messages)?;
+    }
+    if let Some(snapshot_queued) = &snapshot.queued_outbound {
+        queued_outbound(conn, group_id, snapshot_queued)?;
+    }
     member_capabilities(conn, group_id, &snapshot.member_caps)?;
     convergence_policy(conn, group_id, snapshot.convergence_policy.as_deref())?;
     validated_tree_marker(conn, group_id, snapshot.validated_tree_marker.as_deref())?;

--- a/crates/storage-sqlite/src/storage/snapshots/rows.rs
+++ b/crates/storage-sqlite/src/storage/snapshots/rows.rs
@@ -11,8 +11,14 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize)]
 pub(super) struct Snapshot {
     pub(super) group: Group,
-    pub(super) messages: Vec<OrderedMessage>,
-    pub(super) queued_outbound: Vec<OrderedQueuedOutbound>,
+    /// `None` marks a state-scoped snapshot: the message ledger was not
+    /// captured, and rollback leaves the live `cgka_messages` rows (and their
+    /// pending application events) untouched. Full snapshots — including
+    /// every blob written before state-scoped capture existed — carry `Some`
+    /// and keep their capture-time restore semantics.
+    pub(super) messages: Option<Vec<OrderedMessage>>,
+    /// Same contract as `messages`, for `cgka_queued_outbound`.
+    pub(super) queued_outbound: Option<Vec<OrderedQueuedOutbound>>,
     pub(super) member_caps: Vec<MemberCapabilitiesSnapshot>,
     pub(super) convergence_policy: Option<Vec<u8>>,
     pub(super) validated_tree_marker: Option<Vec<u8>>,

--- a/crates/traits/src/storage.rs
+++ b/crates/traits/src/storage.rs
@@ -208,6 +208,42 @@ pub trait MessageStorage {
         at_or_after_epoch: EpochId,
     ) -> StorageResult<Vec<MessageRecord>>;
 
+    /// Whether any retained row for `group_id` at or after `at_or_after_epoch`
+    /// is in one of `states`. Hot-path gates (outbound send checks, sweep
+    /// short-circuits) call this before deciding whether a full
+    /// [`Self::list_messages`] scan is worth paying, so backends should answer
+    /// it with an indexed existence probe instead of materializing and
+    /// decoding rows. An empty `states` slice answers `false`.
+    fn has_messages_in_states(
+        &self,
+        group_id: &GroupId,
+        states: &[MessageState],
+        at_or_after_epoch: EpochId,
+    ) -> StorageResult<bool> {
+        Ok(self
+            .list_messages(group_id, at_or_after_epoch)?
+            .iter()
+            .any(|record| states.contains(&record.state)))
+    }
+
+    /// [`Self::list_messages`] restricted to rows whose state is in `states`,
+    /// in the same deterministic replay order. Backends should push the state
+    /// filter into the query so callers interested in a rare state (for
+    /// example `PeelDeferred`) do not pay to materialize and decode every
+    /// retained row. An empty `states` slice returns no rows.
+    fn list_messages_in_states(
+        &self,
+        group_id: &GroupId,
+        states: &[MessageState],
+        at_or_after_epoch: EpochId,
+    ) -> StorageResult<Vec<MessageRecord>> {
+        Ok(self
+            .list_messages(group_id, at_or_after_epoch)?
+            .into_iter()
+            .filter(|record| states.contains(&record.state))
+            .collect())
+    }
+
     /// Persist authenticated app-visible output until its app projection has
     /// committed. Implementations accept `MessageReceived` and `GroupJoined`,
     /// keyed by their source message or Welcome id, and reject other events.

--- a/crates/traits/src/storage.rs
+++ b/crates/traits/src/storage.rs
@@ -267,6 +267,24 @@ pub trait MessageStorage {
     fn has_ingress_dedup_marker(&self, id: &MessageId) -> StorageResult<bool>;
 
     fn create_group_snapshot(&self, group_id: &GroupId, name: &str) -> StorageResult<()>;
+
+    /// [`Self::create_group_snapshot`] scoped to canonical group state: the
+    /// group record, member capabilities, convergence policy, validation
+    /// marker, and group-scoped OpenMLS values — the message ledger and
+    /// outbound queue are not captured, and rolling back to such a snapshot
+    /// leaves those tables untouched. Use this for snapshots taken on every
+    /// canonical advance (retained anchors), where capturing the whole
+    /// retained message history would make each applied commit O(stored
+    /// bytes).
+    ///
+    /// Callers must not depend on the narrower scope for correctness: the
+    /// default implementation captures a full snapshot, whose rollback also
+    /// restores messages and queued outbound work (a superset image is always
+    /// an acceptable substitute).
+    fn create_group_state_snapshot(&self, group_id: &GroupId, name: &str) -> StorageResult<()> {
+        self.create_group_snapshot(group_id, name)
+    }
+
     fn list_group_snapshots(&self, group_id: &GroupId) -> StorageResult<Vec<String>>;
     fn rollback_group_to_snapshot(&self, group_id: &GroupId, name: &str) -> StorageResult<()>;
     fn release_group_snapshot(&self, group_id: &GroupId, name: &str) -> StorageResult<()>;


### PR DESCRIPTION
Stacked on #1405.

`retain_current_group_epoch_snapshot` runs on every applied commit and captured a full group snapshot: the group record, OpenMLS values, and a copy of every retained message row and queued outbound intent, serialized into one blob inside the write transaction. Commit cost grew with the size of the retained history, and the message copies were dead weight:

- The convergence probe rewinds to an anchor and replays from inputs seeded before the rewind (`seed_stored_openmls_graph_inputs`). It never reads message rows after the rollback.
- The historical apply lists the live message and queue sets before the rewind and writes them back over whatever the rollback restored (`restore_live_message_and_queue_records`). The anchor's copies were deleted and replaced every time.

This PR scopes retained-anchor snapshots to canonical group state:

- New `MessageStorage::create_group_state_snapshot` captures the group record, member capabilities, convergence policy, validation marker, and group-scoped OpenMLS values. The default implementation falls back to a full snapshot, so other backends keep working unchanged.
- In storage-sqlite, the snapshot blob's `messages` and `queued_outbound` fields are now `Option`. `None` means the ledger was not captured, and rollback leaves the live `cgka_messages` and `cgka_queued_outbound` rows alone. Blobs written before this change carry `Some` and keep their old restore semantics, so existing databases need no migration.
- `retain_current_group_epoch_snapshot` uses the scoped capture. Probe snapshots, apply snapshots, and the conformance replay export stay full.

One deliberate semantic edge: rolling back to a legacy full anchor restored the anchor-time message image before the live rows were written back, which could resurrect rows deleted between the anchor and the apply. Scoped anchors never touch the ledger, so deleted rows stay deleted.

Every marmot burrow now stores one winter cache per epoch instead of dragging the whole meadow into it.

Verified with `just fast-ci`, `cargo test -p storage-sqlite`, `cargo test -p cgka-engine --features test-policy-overrides,test-crash-hooks`, and `cargo test -p cgka-conformance-simulator`.
