### PR TITLE
perf(marmot-uniffi): reuse timeline row conversions across window snapshots

### DIFF
--- a/crates/marmot-uniffi/src/markdown.rs
+++ b/crates/marmot-uniffi/src/markdown.rs
@@ -218,33 +218,25 @@ fn markdown_input_within_ffi_limit(text: &str) -> LimitedMarkdownInput<'_> {
     }
 }
 
-impl From<&MdDocument> for MarkdownDocumentFfi {
-    fn from(value: &MdDocument) -> Self {
+/// Owned conversions throughout: the parse in [`parse_markdown_document`] is
+/// the only producer of these ASTs, and it hands the document over for good,
+/// so every string moves into the FFI value instead of being cloned. This
+/// halves the allocation cost of converting a parsed message.
+impl From<MdDocument> for MarkdownDocumentFfi {
+    fn from(value: MdDocument) -> Self {
         Self {
             blocks: value
                 .blocks
-                .iter()
+                .into_iter()
                 .map(|block| markdown_block_from_md(block, 0))
                 .collect(),
             truncated: false,
-            blank_lines_before: value.blank_lines_before.clone(),
+            blank_lines_before: value.blank_lines_before,
         }
     }
 }
 
-impl From<MdDocument> for MarkdownDocumentFfi {
-    fn from(value: MdDocument) -> Self {
-        (&value).into()
-    }
-}
-
-impl From<&MdBlock> for MarkdownBlockFfi {
-    fn from(value: &MdBlock) -> Self {
-        markdown_block_from_md(value, 0)
-    }
-}
-
-fn markdown_block_from_md(value: &MdBlock, depth: usize) -> MarkdownBlockFfi {
+fn markdown_block_from_md(value: MdBlock, depth: usize) -> MarkdownBlockFfi {
     if depth >= MAX_FFI_MARKDOWN_DEPTH {
         return MarkdownBlockFfi::Paragraph {
             inlines: Vec::new(),
@@ -255,7 +247,7 @@ fn markdown_block_from_md(value: &MdBlock, depth: usize) -> MarkdownBlockFfi {
             inlines: markdown_inlines_from_md(inlines, 0),
         },
         MdBlock::Heading { level, inlines } => MarkdownBlockFfi::Heading {
-            level: *level,
+            level,
             inlines: markdown_inlines_from_md(inlines, 0),
         },
         MdBlock::ThematicBreak => MarkdownBlockFfi::ThematicBreak,
@@ -264,25 +256,25 @@ fn markdown_block_from_md(value: &MdBlock, depth: usize) -> MarkdownBlockFfi {
             info,
             content,
         } => MarkdownBlockFfi::CodeBlock {
-            kind: (*kind).into(),
-            info: info.clone(),
-            content: content.clone(),
+            kind: kind.into(),
+            info,
+            content,
         },
         MdBlock::BlockQuote {
             blocks,
             blank_lines_before,
         } => MarkdownBlockFfi::BlockQuote {
             blocks: blocks
-                .iter()
+                .into_iter()
                 .map(|block| markdown_block_from_md(block, depth + 1))
                 .collect(),
-            blank_lines_before: blank_lines_before.clone(),
+            blank_lines_before,
         },
         MdBlock::List { kind, tight, items } => MarkdownBlockFfi::ListBlock {
             kind: kind.into(),
-            tight: *tight,
+            tight,
             items: items
-                .iter()
+                .into_iter()
                 .map(|item| markdown_list_item_from_md(item, depth + 1))
                 .collect(),
         },
@@ -291,19 +283,17 @@ fn markdown_block_from_md(value: &MdBlock, depth: usize) -> MarkdownBlockFfi {
             header,
             rows,
         } => MarkdownBlockFfi::Table {
-            alignments: alignments
-                .iter()
-                .map(|alignment| (*alignment).into())
+            alignments: alignments.into_iter().map(Into::into).collect(),
+            header: header
+                .into_iter()
+                .map(markdown_table_cell_from_md)
                 .collect(),
-            header: header.iter().map(markdown_table_cell_from_md).collect(),
             rows: rows
-                .iter()
-                .map(|row| row.iter().map(markdown_table_cell_from_md).collect())
+                .into_iter()
+                .map(|row| row.into_iter().map(markdown_table_cell_from_md).collect())
                 .collect(),
         },
-        MdBlock::MathBlock { content } => MarkdownBlockFfi::MathBlock {
-            content: content.clone(),
-        },
+        MdBlock::MathBlock { content } => MarkdownBlockFfi::MathBlock { content },
     }
 }
 
@@ -316,9 +306,9 @@ impl From<MdCodeBlockKind> for MarkdownCodeBlockKindFfi {
     }
 }
 
-impl From<&MdListKind> for MarkdownListKindFfi {
-    fn from(value: &MdListKind) -> Self {
-        match *value {
+impl From<MdListKind> for MarkdownListKindFfi {
+    fn from(value: MdListKind) -> Self {
+        match value {
             MdListKind::Bullet { marker } => Self::Bullet {
                 marker: (marker as char).to_string(),
             },
@@ -330,21 +320,15 @@ impl From<&MdListKind> for MarkdownListKindFfi {
     }
 }
 
-impl From<&MdListItem> for MarkdownListItemFfi {
-    fn from(value: &MdListItem) -> Self {
-        markdown_list_item_from_md(value, 0)
-    }
-}
-
-fn markdown_list_item_from_md(value: &MdListItem, depth: usize) -> MarkdownListItemFfi {
+fn markdown_list_item_from_md(value: MdListItem, depth: usize) -> MarkdownListItemFfi {
     MarkdownListItemFfi {
         blocks: value
             .blocks
-            .iter()
+            .into_iter()
             .map(|block| markdown_block_from_md(block, depth))
             .collect(),
         checked: value.checked,
-        blank_lines_before: value.blank_lines_before.clone(),
+        blank_lines_before: value.blank_lines_before,
     }
 }
 
@@ -359,46 +343,30 @@ impl From<MdAlignment> for MarkdownAlignmentFfi {
     }
 }
 
-impl From<&MdTableCell> for MarkdownTableCellFfi {
-    fn from(value: &MdTableCell) -> Self {
-        markdown_table_cell_from_md(value)
-    }
-}
-
-fn markdown_table_cell_from_md(value: &MdTableCell) -> MarkdownTableCellFfi {
+fn markdown_table_cell_from_md(value: MdTableCell) -> MarkdownTableCellFfi {
     MarkdownTableCellFfi {
-        inlines: markdown_inlines_from_md(&value.inlines, 0),
+        inlines: markdown_inlines_from_md(value.inlines, 0),
     }
 }
 
-impl From<&MdInline> for MarkdownInlineFfi {
-    fn from(value: &MdInline) -> Self {
-        markdown_inline_from_md(value, 0)
-    }
-}
-
-fn markdown_inlines_from_md(values: &[MdInline], depth: usize) -> Vec<MarkdownInlineFfi> {
+fn markdown_inlines_from_md(values: Vec<MdInline>, depth: usize) -> Vec<MarkdownInlineFfi> {
     values
-        .iter()
+        .into_iter()
         .map(|value| markdown_inline_from_md(value, depth))
         .collect()
 }
 
-fn markdown_inline_from_md(value: &MdInline, depth: usize) -> MarkdownInlineFfi {
+fn markdown_inline_from_md(value: MdInline, depth: usize) -> MarkdownInlineFfi {
     if depth >= MAX_FFI_MARKDOWN_DEPTH {
         return MarkdownInlineFfi::Text {
             content: String::new(),
         };
     }
     match value {
-        MdInline::Text(content) => MarkdownInlineFfi::Text {
-            content: content.clone(),
-        },
+        MdInline::Text(content) => MarkdownInlineFfi::Text { content },
         MdInline::SoftBreak => MarkdownInlineFfi::SoftBreak,
         MdInline::HardBreak => MarkdownInlineFfi::HardBreak,
-        MdInline::Code(content) => MarkdownInlineFfi::Code {
-            content: content.clone(),
-        },
+        MdInline::Code(content) => MarkdownInlineFfi::Code { content },
         MdInline::Emph(children) => MarkdownInlineFfi::Emph {
             children: markdown_inlines_from_md(children, depth + 1),
         },
@@ -414,10 +382,10 @@ fn markdown_inline_from_md(value: &MdInline, depth: usize) -> MarkdownInlineFfi 
             children,
             classification,
         } => MarkdownInlineFfi::Link {
-            dest: dest.clone(),
-            title: title.clone(),
+            dest,
+            title,
             children: markdown_inlines_from_md(children, depth + 1),
-            classification: (*classification).into(),
+            classification: classification.into(),
         },
         MdInline::Image {
             dest,
@@ -425,23 +393,21 @@ fn markdown_inline_from_md(value: &MdInline, depth: usize) -> MarkdownInlineFfi 
             alt,
             classification,
         } => MarkdownInlineFfi::Image {
-            dest: dest.clone(),
-            title: title.clone(),
+            dest,
+            title,
             alt: markdown_inlines_from_md(alt, depth + 1),
-            classification: (*classification).into(),
+            classification: classification.into(),
         },
         MdInline::Autolink {
             url,
             kind,
             classification,
         } => MarkdownInlineFfi::Autolink {
-            url: url.clone(),
-            kind: (*kind).into(),
-            classification: (*classification).into(),
+            url,
+            kind: kind.into(),
+            classification: classification.into(),
         },
-        MdInline::Math(content) => MarkdownInlineFfi::Math {
-            content: content.clone(),
-        },
+        MdInline::Math(content) => MarkdownInlineFfi::Math { content },
         MdInline::NostrMention(entity) => MarkdownInlineFfi::NostrMention {
             entity: entity.into(),
         },
@@ -476,11 +442,11 @@ impl From<MdLinkDestinationKind> for MarkdownLinkDestinationKindFfi {
     }
 }
 
-impl From<&MdNostrEntity> for MarkdownNostrEntityFfi {
-    fn from(value: &MdNostrEntity) -> Self {
+impl From<MdNostrEntity> for MarkdownNostrEntityFfi {
+    fn from(value: MdNostrEntity) -> Self {
         Self {
             hrp: value.hrp.into(),
-            bech32: value.bech32.clone(),
+            bech32: value.bech32,
         }
     }
 }

--- a/crates/marmot-uniffi/src/subscriptions.rs
+++ b/crates/marmot-uniffi/src/subscriptions.rs
@@ -13,15 +13,16 @@
 //! All inner state lives behind a `tokio::sync::Mutex` because UniFFI passes
 //! these objects via `Arc<Self>` and `recv()` requires `&mut`.
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
+use std::sync::PoisonError;
 
 use marmot_app::{
     RuntimeAgentStreamWatch, RuntimeChatListSubscription, RuntimeChatsSubscription,
     RuntimeEventsSubscription, RuntimeGroupStateSubscription, RuntimeMessagesSubscription,
-    RuntimeNotificationsSubscription, RuntimeTimelineMessagesSubscription, TimelineWindowHandle,
-    UserSearchSubscription as AppUserSearchSubscription,
+    RuntimeNotificationsSubscription, RuntimeTimelineMessagesSubscription, TimelineMessageRecord,
+    TimelinePage, TimelineWindowHandle, UserSearchSubscription as AppUserSearchSubscription,
 };
 use tokio::sync::Mutex;
 
@@ -29,7 +30,7 @@ use crate::MarmotKitError;
 use crate::conversions::{
     AgentStreamUpdateFfi, AppGroupRecordFfi, AppMessageRecordFfi, ChatListRowFfi,
     ChatListSubscriptionUpdateFfi, MarmotEventFfi, MessageUpdateFfi, NotificationUpdateFfi,
-    TimelinePageFfi, TimelineSubscriptionUpdateFfi, UserSearchUpdateFfi,
+    TimelineMessageRecordFfi, TimelinePageFfi, TimelineSubscriptionUpdateFfi, UserSearchUpdateFfi,
 };
 
 #[derive(uniffi::Object)]
@@ -180,6 +181,53 @@ pub struct TimelineMessagesSubscription {
     snapshot: StdMutex<Option<TimelinePageFfi>>,
     window: TimelineWindowHandle,
     receiver: Mutex<RuntimeTimelineMessagesSubscription>,
+    /// Converted rows from the most recent window snapshot, keyed by
+    /// `message_id_hex`. Converting a row is expensive (Markdown parse,
+    /// imeta media resolution, reaction re-sort), and a live update usually
+    /// changes one row in a window of hundreds, so `next()` and the paginate
+    /// calls reuse the previous conversion for every row whose source record
+    /// is unchanged.
+    conversion_cache: StdMutex<HashMap<String, CachedTimelineRow>>,
+}
+
+struct CachedTimelineRow {
+    source: TimelineMessageRecord,
+    converted: TimelineMessageRecordFfi,
+}
+
+/// Convert a window snapshot to its FFI page, reusing cached conversions for
+/// rows whose source record equals the one that produced them. The cache is
+/// replaced with exactly the rows of this page, so rows that scrolled out of
+/// the window are dropped and the cache never outgrows the window cap.
+fn convert_timeline_page_cached(
+    cache: &StdMutex<HashMap<String, CachedTimelineRow>>,
+    page: TimelinePage,
+) -> TimelinePageFfi {
+    let mut cache = cache.lock().unwrap_or_else(PoisonError::into_inner);
+    let mut retained = HashMap::with_capacity(page.messages.len());
+    let messages = page
+        .messages
+        .into_iter()
+        .map(|record| {
+            let key = record.message_id_hex.clone();
+            let row = match cache.remove(&key) {
+                Some(cached) if cached.source == record => cached,
+                _ => CachedTimelineRow {
+                    source: record.clone(),
+                    converted: record.into(),
+                },
+            };
+            let converted = row.converted.clone();
+            retained.insert(key, row);
+            converted
+        })
+        .collect();
+    *cache = retained;
+    TimelinePageFfi {
+        messages,
+        has_more_before: page.has_more_before,
+        has_more_after: page.has_more_after,
+    }
 }
 
 impl TimelineMessagesSubscription {
@@ -191,11 +239,13 @@ impl TimelineMessagesSubscription {
         )
         .entered();
         let window = inner.window_handle();
-        let snapshot: TimelinePageFfi = inner.take_snapshot().into();
+        let conversion_cache = StdMutex::new(HashMap::new());
+        let snapshot = convert_timeline_page_cached(&conversion_cache, inner.take_snapshot());
         Arc::new(Self {
             snapshot: StdMutex::new(Some(snapshot)),
             window,
             receiver: Mutex::new(inner),
+            conversion_cache,
         })
     }
 }
@@ -214,7 +264,10 @@ impl TimelineMessagesSubscription {
     pub async fn next(&self) -> Option<TimelinePageFfi> {
         let mut receiver = self.receiver.lock().await;
         receiver.recv().await?;
-        Some(self.window.snapshot().into())
+        Some(convert_timeline_page_cached(
+            &self.conversion_cache,
+            self.window.snapshot(),
+        ))
     }
 
     pub async fn next_update(&self) -> Option<TimelineSubscriptionUpdateFfi> {
@@ -231,7 +284,8 @@ impl TimelineMessagesSubscription {
     /// task can paginate without blocking (and this never blocks the UI thread,
     /// unlike the synchronous `Marmot::timeline_messages`).
     pub async fn paginate_backwards(&self, count: u32) -> Result<TimelinePageFfi, MarmotKitError> {
-        Ok(self.window.paginate_backwards(count as usize).await?.into())
+        let page = self.window.paginate_backwards(count as usize).await?;
+        Ok(convert_timeline_page_cached(&self.conversion_cache, page))
     }
 
     /// Extend the materialized window toward the live head by up to `count`
@@ -239,7 +293,8 @@ impl TimelineMessagesSubscription {
     /// window (`has_more_after` becomes false). Same windowing/threading
     /// guarantees as [`paginate_backwards`](Self::paginate_backwards).
     pub async fn paginate_forwards(&self, count: u32) -> Result<TimelinePageFfi, MarmotKitError> {
-        Ok(self.window.paginate_forwards(count as usize).await?.into())
+        let page = self.window.paginate_forwards(count as usize).await?;
+        Ok(convert_timeline_page_cached(&self.conversion_cache, page))
     }
 }
 
@@ -356,6 +411,80 @@ mod tests {
 
         assert_eq!(take_snapshot(&snapshot), Some("initial"));
         assert_eq!(take_snapshot(&snapshot), None);
+    }
+
+    #[test]
+    fn cached_conversion_reuses_unchanged_rows_and_never_serves_stale_content() {
+        use cgka_traits::app_event::MARMOT_APP_EVENT_KIND_CHAT;
+        use marmot_app::TimelineReactionSummary;
+
+        fn record(id: &str, plaintext: &str) -> TimelineMessageRecord {
+            TimelineMessageRecord {
+                message_id_hex: id.to_string(),
+                source_message_id_hex: None,
+                source_epoch: None,
+                retention_seconds: None,
+                retention_expires_at: None,
+                direction: "received".to_string(),
+                group_id_hex: "aa".to_string(),
+                sender: "bb".to_string(),
+                plaintext: plaintext.to_string(),
+                kind: MARMOT_APP_EVENT_KIND_CHAT,
+                tags: Vec::new(),
+                timeline_at: 1,
+                received_at: 1,
+                reply_to_message_id_hex: None,
+                reply_preview: None,
+                media: None,
+                agent_text_stream: None,
+                reactions: TimelineReactionSummary::default(),
+                deleted: false,
+                deleted_by_message_id_hex: None,
+                invalidation_status: None,
+            }
+        }
+
+        fn page(messages: Vec<TimelineMessageRecord>) -> TimelinePage {
+            TimelinePage {
+                messages,
+                has_more_before: false,
+                has_more_after: false,
+            }
+        }
+
+        let cache = StdMutex::new(HashMap::new());
+
+        let first = convert_timeline_page_cached(
+            &cache,
+            page(vec![record("m1", "hello"), record("m2", "world")]),
+        );
+        assert_eq!(first.messages.len(), 2);
+        assert_eq!(cache.lock().unwrap().len(), 2);
+
+        // Unchanged rows come back identical from the cache.
+        let second = convert_timeline_page_cached(
+            &cache,
+            page(vec![record("m1", "hello"), record("m2", "world")]),
+        );
+        assert_eq!(second.messages[0].plaintext, "hello");
+        assert_eq!(second.messages[1].plaintext, "world");
+
+        // A changed row is re-converted, never served stale: the new markdown
+        // shows up in the tokens, not just the plaintext.
+        let third = convert_timeline_page_cached(
+            &cache,
+            page(vec![record("m1", "edited **bold**"), record("m2", "world")]),
+        );
+        assert_eq!(third.messages[0].plaintext, "edited **bold**");
+        assert!(!third.messages[0].content_tokens.blocks.is_empty());
+
+        // Rows that leave the window are pruned so the cache tracks the
+        // window cap, not history.
+        let fourth = convert_timeline_page_cached(&cache, page(vec![record("m2", "world")]));
+        assert_eq!(fourth.messages.len(), 1);
+        let cache = cache.lock().unwrap();
+        assert_eq!(cache.len(), 1);
+        assert!(cache.contains_key("m2"));
     }
 
     // The timeline window's projection/cap/anchoring contract now lives and is


### PR DESCRIPTION
Every live update on a timeline subscription reconverted the whole window: `TimelineMessagesSubscription::next()` (and both paginate calls) ran `window.snapshot().into()`, which re-parsed Markdown, re-walked `imeta` media, and re-sorted reactions for every row. One inbound message in a 100-row window cost about 100 markdown parses on the host's render path.

Two changes:

- `TimelineMessagesSubscription` keeps a conversion cache keyed by `message_id_hex`, storing each converted FFI row beside the source record that produced it. A snapshot conversion reuses the cached row whenever the source `TimelineMessageRecord` compares equal (it is `PartialEq`) and re-converts only changed rows, so reactions, edits, deletes, and delivery-state flips still invalidate exactly the rows they touch. The cache is replaced with the current page's rows on every conversion, so it is bounded by the window cap and rows that scroll out are dropped.
- The markdown AST to FFI converters now move strings instead of cloning them. `parse_markdown_document` is the only producer of these ASTs and hands the document over for good, yet the owned `From<MdDocument>` delegated to the borrowing converter and re-cloned every string in the tree. The unused borrowing impls are removed.

A new unit test pins the cache contract: unchanged rows come back identical, a changed row is re-converted (asserted through the parsed tokens, not just the plaintext), and rows that leave the window are pruned.

Marmots scrolling a busy burrow chat now pay for one new message, not the whole wall.

Verified with `just fast-ci`, `cargo test -p marmot-uniffi` (103 lib + 28 smoke tests), and `cargo test -p marmot-markdown`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved timeline loading and updates by reusing unchanged content, making navigation and pagination more efficient.
  - Reduced unnecessary processing when viewing timeline pages.

- **Bug Fixes**
  - Ensured modified timeline items display their latest content instead of stale data.
  - Improved cleanup of outdated timeline entries as the visible window changes.
  - Preserved Markdown formatting, links, metadata, and embedded entities during conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->