### PR TITLE
perf(agent-stream-compose): stop echoing the full transcript per command

### DIFF
--- a/crates/agent-stream-compose/src/lib.rs
+++ b/crates/agent-stream-compose/src/lib.rs
@@ -45,6 +45,43 @@ pub struct StreamComposeReport {
     pub error: Option<String>,
 }
 
+/// Per-command acknowledgement for `Append`/`Status`/`Progress`.
+///
+/// [`StreamComposeReport`] minus the accumulated `text`. The session still
+/// appends every chunk to its full transcript internally (`Finish` returns
+/// and validates it), but responding with the report cloned the entire
+/// transcript so far on every command — O(n²) bytes copied over a stream's
+/// life, for a value both the connector and the daemon discard. Callers that
+/// need the final text get it from `Finish`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct StreamComposeAck {
+    pub account: Option<String>,
+    pub group_id: String,
+    pub stream_id: String,
+    pub start_message_id: String,
+    pub candidate: String,
+    pub status: String,
+    pub transcript_hash: Option<String>,
+    pub chunk_count: u64,
+    pub error: Option<String>,
+}
+
+impl StreamComposeAck {
+    fn from_report(report: &StreamComposeReport) -> Self {
+        Self {
+            account: report.account.clone(),
+            group_id: report.group_id.clone(),
+            stream_id: report.stream_id.clone(),
+            start_message_id: report.start_message_id.clone(),
+            candidate: report.candidate.clone(),
+            status: report.status.clone(),
+            transcript_hash: report.transcript_hash.clone(),
+            chunk_count: report.chunk_count,
+            error: report.error.clone(),
+        }
+    }
+}
+
 /// Caller-supplied final-transcript expectation, validated atomically inside
 /// the compose task before any teardown. On mismatch the session responds
 /// `Err` and keeps running, so finalize is retryable.
@@ -59,15 +96,15 @@ pub struct StreamFinishExpectation {
 pub enum StreamComposeCommand {
     Append {
         text: String,
-        respond: oneshot::Sender<Result<StreamComposeReport, String>>,
+        respond: oneshot::Sender<Result<StreamComposeAck, String>>,
     },
     Status {
         status: String,
-        respond: oneshot::Sender<Result<StreamComposeReport, String>>,
+        respond: oneshot::Sender<Result<StreamComposeAck, String>>,
     },
     Progress {
         text: String,
-        respond: oneshot::Sender<Result<StreamComposeReport, String>>,
+        respond: oneshot::Sender<Result<StreamComposeAck, String>>,
     },
     Finish {
         /// Optional final-transcript expectation. When set, it is validated
@@ -531,7 +568,7 @@ async fn append_stream_compose_text<P: LiveBrokerPublisher>(
     mut live: ComposeLiveSink<'_, P>,
     text: String,
     chunk_bytes: usize,
-) -> Result<StreamComposeReport, String> {
+) -> Result<StreamComposeAck, String> {
     transcript.append_text(&text, chunk_bytes)?;
     report.text.push_str(&text);
     report.chunk_count = transcript.chunk_count();
@@ -548,7 +585,7 @@ async fn append_stream_compose_text<P: LiveBrokerPublisher>(
         report.error = Some(format!("live stream failed: {err}"));
     }
 
-    Ok(report.clone())
+    Ok(StreamComposeAck::from_report(report))
 }
 
 async fn append_stream_compose_status<P: LiveBrokerPublisher>(
@@ -557,7 +594,7 @@ async fn append_stream_compose_status<P: LiveBrokerPublisher>(
     live: ComposeLiveSink<'_, P>,
     status: String,
     chunk_bytes: usize,
-) -> Result<StreamComposeReport, String> {
+) -> Result<StreamComposeAck, String> {
     report.status.clone_from(&status);
     append_stream_compose_non_text_record(
         report,
@@ -576,7 +613,7 @@ async fn append_stream_compose_progress<P: LiveBrokerPublisher>(
     live: ComposeLiveSink<'_, P>,
     text: String,
     chunk_bytes: usize,
-) -> Result<StreamComposeReport, String> {
+) -> Result<StreamComposeAck, String> {
     append_stream_compose_non_text_record(
         report,
         transcript,
@@ -602,7 +639,7 @@ async fn append_stream_compose_non_text_record<P: LiveBrokerPublisher>(
     record_type: u8,
     text: String,
     chunk_bytes: usize,
-) -> Result<StreamComposeReport, String> {
+) -> Result<StreamComposeAck, String> {
     transcript.append_record_text(record_type, &text, chunk_bytes)?;
     report.chunk_count = transcript.chunk_count();
     report.transcript_hash = Some(transcript.transcript_hash());
@@ -612,7 +649,7 @@ async fn append_stream_compose_non_text_record<P: LiveBrokerPublisher>(
         report.error = Some(format!("live stream failed: {err}"));
     }
 
-    Ok(report.clone())
+    Ok(StreamComposeAck::from_report(report))
 }
 
 async fn append_live_record<P: LiveBrokerPublisher>(

--- a/crates/agent-stream-compose/src/tests.rs
+++ b/crates/agent-stream-compose/src/tests.rs
@@ -180,7 +180,6 @@ async fn compose_session_finalizes_local_transcript_when_broker_connect_is_pendi
         .expect("append should not wait for broker connect")
         .unwrap()
         .unwrap();
-    assert_eq!(appended.text, "hello ");
     assert_eq!(appended.chunk_count, 1);
 
     let (finish_tx, finish_rx) = oneshot::channel();
@@ -373,7 +372,6 @@ async fn compose_session_status_updates_transcript_without_changing_text() {
         16,
     );
     assert_eq!(status_report.status, "thinking");
-    assert_eq!(status_report.text, "hello");
     assert_eq!(status_report.chunk_count, 2);
     assert_eq!(
         status_report.transcript_hash.as_deref(),
@@ -449,7 +447,6 @@ async fn compose_session_progress_updates_transcript_without_changing_text() {
         ],
         16,
     );
-    assert_eq!(progress_report.text, "answer");
     assert_eq!(progress_report.chunk_count, 2);
     assert_eq!(
         progress_report.transcript_hash.as_deref(),
@@ -876,7 +873,6 @@ async fn compose_session_times_out_stalled_live_flush_and_still_finishes() {
         .expect("append should use local transcript while broker connect is pending")
         .unwrap()
         .unwrap();
-    assert_eq!(appended.text, "hello");
     assert_eq!(appended.chunk_count, 1);
     assert_eq!(appended.error, None);
 
@@ -959,7 +955,6 @@ async fn compose_session_times_out_pending_broker_connect_and_disables_live_prev
         .expect("append should use local transcript while broker connect is pending")
         .unwrap()
         .unwrap();
-    assert_eq!(first.text, "buffered");
     assert_eq!(first.error, None);
 
     tokio::time::sleep(Duration::from_millis(50)).await;
@@ -976,7 +971,6 @@ async fn compose_session_times_out_pending_broker_connect_and_disables_live_prev
         .expect("append should complete after broker connect timeout")
         .unwrap()
         .unwrap();
-    assert_eq!(second.text, "buffered after timeout");
     assert!(
         second
             .error
@@ -1317,7 +1311,6 @@ async fn finish_with_mismatched_expectation_keeps_session_alive_and_retryable() 
         .expect("append after mismatched finish should complete")
         .unwrap()
         .unwrap();
-    assert_eq!(appended.text, "hello world");
     assert_eq!(appended.chunk_count, 2);
 
     // A corrected finish over the full transcript succeeds.

--- a/crates/cli/src/daemon/tests.rs
+++ b/crates/cli/src/daemon/tests.rs
@@ -457,7 +457,6 @@ async fn stream_compose_returns_local_transcript_when_broker_connect_is_pending(
         .expect("append should not wait for broker connect")
         .unwrap()
         .unwrap();
-    assert_eq!(appended.text, "hello ");
     assert_eq!(appended.chunk_count, 1);
 
     let (finish_tx, finish_rx) = oneshot::channel();

--- a/crates/cli/src/tui/client.rs
+++ b/crates/cli/src/tui/client.rs
@@ -731,6 +731,7 @@ impl TuiApp {
             group_id: preview_group_id.clone(),
             pending_text: String::new(),
             last_flush: Instant::now(),
+            flushed_bytes: 0,
         });
         self.input.clear();
         self.refresh_messages()?;
@@ -827,16 +828,15 @@ impl TuiApp {
                 return Err(err);
             }
         };
+        let _ = result;
+        let mut bytes = text.len();
         if let Some(streaming) = self.streaming.as_mut()
             && streaming.stream_id == stream_id
         {
             streaming.last_flush = Instant::now();
+            streaming.flushed_bytes += text.len();
+            bytes = streaming.flushed_bytes;
         }
-        let bytes = result
-            .get("text")
-            .and_then(Value::as_str)
-            .map(str::len)
-            .unwrap_or_default();
         self.status = format!("streaming {} bytes on {}", bytes, shorten(&stream_id, 18));
         Ok(())
     }

--- a/crates/cli/src/tui/model.rs
+++ b/crates/cli/src/tui/model.rs
@@ -2581,6 +2581,10 @@ pub(crate) struct StreamComposer {
     pub(crate) group_id: String,
     pub(crate) pending_text: String,
     pub(crate) last_flush: Instant,
+    /// Total bytes flushed to the compose session so far. Tracked locally
+    /// because the per-append ack no longer echoes the accumulated
+    /// transcript back.
+    pub(crate) flushed_bytes: usize,
 }
 
 pub(crate) fn subscription_event_from_json(envelope: Value) -> SubscriptionEvent {

--- a/crates/cli/src/tui/tests.rs
+++ b/crates/cli/src/tui/tests.rs
@@ -1572,6 +1572,7 @@ fn active_stream_preview_pins_to_open_time_group_after_selection_shift() {
         group_id: stream_group.to_owned(),
         pending_text: String::new(),
         last_flush: Instant::now(),
+        flushed_bytes: 0,
     });
     app.input.set_value("hello");
 
@@ -2606,6 +2607,7 @@ fn failed_due_stream_append_updates_last_flush_to_back_off_tick_retry() {
         group_id: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_owned(),
         pending_text: "queued".to_owned(),
         last_flush: stale_flush,
+        flushed_bytes: 0,
     });
 
     let first = app.flush_stream_append_if_due(first_due);
@@ -2641,6 +2643,7 @@ fn streaming_keys_capture_input_before_screen_dispatch() {
         group_id: "bb".repeat(32),
         pending_text: String::new(),
         last_flush: Instant::now(),
+        flushed_bytes: 0,
     });
 
     // Main view: a character queues on the stream composer.
@@ -2681,6 +2684,7 @@ fn streaming_enter_failure_is_caught_into_status_and_keeps_tui_running() {
         group_id: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_owned(),
         pending_text: String::new(),
         last_flush: Instant::now(),
+        flushed_bytes: 0,
     });
     app.input.set_value("hello");
 
@@ -2726,6 +2730,7 @@ fn streaming_enter_failure_before_finish_preserves_composer() {
         group_id: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_owned(),
         pending_text: "queued".to_owned(),
         last_flush: Instant::now(),
+        flushed_bytes: 0,
     });
     app.input.set_value("queued");
 
@@ -9699,6 +9704,7 @@ fn handle_paste_while_streaming_appends_to_pending_text_and_updates_status() {
         group_id: "bb".repeat(32),
         pending_text: "typed".to_owned(),
         last_flush: Instant::now(),
+        flushed_bytes: 0,
     });
 
     app.handle_paste("PASTED".to_owned());

--- a/crates/marmot-uniffi/src/markdown.rs
+++ b/crates/marmot-uniffi/src/markdown.rs
@@ -218,33 +218,25 @@ fn markdown_input_within_ffi_limit(text: &str) -> LimitedMarkdownInput<'_> {
     }
 }
 
-impl From<&MdDocument> for MarkdownDocumentFfi {
-    fn from(value: &MdDocument) -> Self {
+/// Owned conversions throughout: the parse in [`parse_markdown_document`] is
+/// the only producer of these ASTs, and it hands the document over for good,
+/// so every string moves into the FFI value instead of being cloned. This
+/// halves the allocation cost of converting a parsed message.
+impl From<MdDocument> for MarkdownDocumentFfi {
+    fn from(value: MdDocument) -> Self {
         Self {
             blocks: value
                 .blocks
-                .iter()
+                .into_iter()
                 .map(|block| markdown_block_from_md(block, 0))
                 .collect(),
             truncated: false,
-            blank_lines_before: value.blank_lines_before.clone(),
+            blank_lines_before: value.blank_lines_before,
         }
     }
 }
 
-impl From<MdDocument> for MarkdownDocumentFfi {
-    fn from(value: MdDocument) -> Self {
-        (&value).into()
-    }
-}
-
-impl From<&MdBlock> for MarkdownBlockFfi {
-    fn from(value: &MdBlock) -> Self {
-        markdown_block_from_md(value, 0)
-    }
-}
-
-fn markdown_block_from_md(value: &MdBlock, depth: usize) -> MarkdownBlockFfi {
+fn markdown_block_from_md(value: MdBlock, depth: usize) -> MarkdownBlockFfi {
     if depth >= MAX_FFI_MARKDOWN_DEPTH {
         return MarkdownBlockFfi::Paragraph {
             inlines: Vec::new(),
@@ -255,7 +247,7 @@ fn markdown_block_from_md(value: &MdBlock, depth: usize) -> MarkdownBlockFfi {
             inlines: markdown_inlines_from_md(inlines, 0),
         },
         MdBlock::Heading { level, inlines } => MarkdownBlockFfi::Heading {
-            level: *level,
+            level,
             inlines: markdown_inlines_from_md(inlines, 0),
         },
         MdBlock::ThematicBreak => MarkdownBlockFfi::ThematicBreak,
@@ -264,25 +256,25 @@ fn markdown_block_from_md(value: &MdBlock, depth: usize) -> MarkdownBlockFfi {
             info,
             content,
         } => MarkdownBlockFfi::CodeBlock {
-            kind: (*kind).into(),
-            info: info.clone(),
-            content: content.clone(),
+            kind: kind.into(),
+            info,
+            content,
         },
         MdBlock::BlockQuote {
             blocks,
             blank_lines_before,
         } => MarkdownBlockFfi::BlockQuote {
             blocks: blocks
-                .iter()
+                .into_iter()
                 .map(|block| markdown_block_from_md(block, depth + 1))
                 .collect(),
-            blank_lines_before: blank_lines_before.clone(),
+            blank_lines_before,
         },
         MdBlock::List { kind, tight, items } => MarkdownBlockFfi::ListBlock {
             kind: kind.into(),
-            tight: *tight,
+            tight,
             items: items
-                .iter()
+                .into_iter()
                 .map(|item| markdown_list_item_from_md(item, depth + 1))
                 .collect(),
         },
@@ -291,19 +283,17 @@ fn markdown_block_from_md(value: &MdBlock, depth: usize) -> MarkdownBlockFfi {
             header,
             rows,
         } => MarkdownBlockFfi::Table {
-            alignments: alignments
-                .iter()
-                .map(|alignment| (*alignment).into())
+            alignments: alignments.into_iter().map(Into::into).collect(),
+            header: header
+                .into_iter()
+                .map(markdown_table_cell_from_md)
                 .collect(),
-            header: header.iter().map(markdown_table_cell_from_md).collect(),
             rows: rows
-                .iter()
-                .map(|row| row.iter().map(markdown_table_cell_from_md).collect())
+                .into_iter()
+                .map(|row| row.into_iter().map(markdown_table_cell_from_md).collect())
                 .collect(),
         },
-        MdBlock::MathBlock { content } => MarkdownBlockFfi::MathBlock {
-            content: content.clone(),
-        },
+        MdBlock::MathBlock { content } => MarkdownBlockFfi::MathBlock { content },
     }
 }
 
@@ -316,9 +306,9 @@ impl From<MdCodeBlockKind> for MarkdownCodeBlockKindFfi {
     }
 }
 
-impl From<&MdListKind> for MarkdownListKindFfi {
-    fn from(value: &MdListKind) -> Self {
-        match *value {
+impl From<MdListKind> for MarkdownListKindFfi {
+    fn from(value: MdListKind) -> Self {
+        match value {
             MdListKind::Bullet { marker } => Self::Bullet {
                 marker: (marker as char).to_string(),
             },
@@ -330,21 +320,15 @@ impl From<&MdListKind> for MarkdownListKindFfi {
     }
 }
 
-impl From<&MdListItem> for MarkdownListItemFfi {
-    fn from(value: &MdListItem) -> Self {
-        markdown_list_item_from_md(value, 0)
-    }
-}
-
-fn markdown_list_item_from_md(value: &MdListItem, depth: usize) -> MarkdownListItemFfi {
+fn markdown_list_item_from_md(value: MdListItem, depth: usize) -> MarkdownListItemFfi {
     MarkdownListItemFfi {
         blocks: value
             .blocks
-            .iter()
+            .into_iter()
             .map(|block| markdown_block_from_md(block, depth))
             .collect(),
         checked: value.checked,
-        blank_lines_before: value.blank_lines_before.clone(),
+        blank_lines_before: value.blank_lines_before,
     }
 }
 
@@ -359,46 +343,30 @@ impl From<MdAlignment> for MarkdownAlignmentFfi {
     }
 }
 
-impl From<&MdTableCell> for MarkdownTableCellFfi {
-    fn from(value: &MdTableCell) -> Self {
-        markdown_table_cell_from_md(value)
-    }
-}
-
-fn markdown_table_cell_from_md(value: &MdTableCell) -> MarkdownTableCellFfi {
+fn markdown_table_cell_from_md(value: MdTableCell) -> MarkdownTableCellFfi {
     MarkdownTableCellFfi {
-        inlines: markdown_inlines_from_md(&value.inlines, 0),
+        inlines: markdown_inlines_from_md(value.inlines, 0),
     }
 }
 
-impl From<&MdInline> for MarkdownInlineFfi {
-    fn from(value: &MdInline) -> Self {
-        markdown_inline_from_md(value, 0)
-    }
-}
-
-fn markdown_inlines_from_md(values: &[MdInline], depth: usize) -> Vec<MarkdownInlineFfi> {
+fn markdown_inlines_from_md(values: Vec<MdInline>, depth: usize) -> Vec<MarkdownInlineFfi> {
     values
-        .iter()
+        .into_iter()
         .map(|value| markdown_inline_from_md(value, depth))
         .collect()
 }
 
-fn markdown_inline_from_md(value: &MdInline, depth: usize) -> MarkdownInlineFfi {
+fn markdown_inline_from_md(value: MdInline, depth: usize) -> MarkdownInlineFfi {
     if depth >= MAX_FFI_MARKDOWN_DEPTH {
         return MarkdownInlineFfi::Text {
             content: String::new(),
         };
     }
     match value {
-        MdInline::Text(content) => MarkdownInlineFfi::Text {
-            content: content.clone(),
-        },
+        MdInline::Text(content) => MarkdownInlineFfi::Text { content },
         MdInline::SoftBreak => MarkdownInlineFfi::SoftBreak,
         MdInline::HardBreak => MarkdownInlineFfi::HardBreak,
-        MdInline::Code(content) => MarkdownInlineFfi::Code {
-            content: content.clone(),
-        },
+        MdInline::Code(content) => MarkdownInlineFfi::Code { content },
         MdInline::Emph(children) => MarkdownInlineFfi::Emph {
             children: markdown_inlines_from_md(children, depth + 1),
         },
@@ -414,10 +382,10 @@ fn markdown_inline_from_md(value: &MdInline, depth: usize) -> MarkdownInlineFfi 
             children,
             classification,
         } => MarkdownInlineFfi::Link {
-            dest: dest.clone(),
-            title: title.clone(),
+            dest,
+            title,
             children: markdown_inlines_from_md(children, depth + 1),
-            classification: (*classification).into(),
+            classification: classification.into(),
         },
         MdInline::Image {
             dest,
@@ -425,23 +393,21 @@ fn markdown_inline_from_md(value: &MdInline, depth: usize) -> MarkdownInlineFfi 
             alt,
             classification,
         } => MarkdownInlineFfi::Image {
-            dest: dest.clone(),
-            title: title.clone(),
+            dest,
+            title,
             alt: markdown_inlines_from_md(alt, depth + 1),
-            classification: (*classification).into(),
+            classification: classification.into(),
         },
         MdInline::Autolink {
             url,
             kind,
             classification,
         } => MarkdownInlineFfi::Autolink {
-            url: url.clone(),
-            kind: (*kind).into(),
-            classification: (*classification).into(),
+            url,
+            kind: kind.into(),
+            classification: classification.into(),
         },
-        MdInline::Math(content) => MarkdownInlineFfi::Math {
-            content: content.clone(),
-        },
+        MdInline::Math(content) => MarkdownInlineFfi::Math { content },
         MdInline::NostrMention(entity) => MarkdownInlineFfi::NostrMention {
             entity: entity.into(),
         },
@@ -476,11 +442,11 @@ impl From<MdLinkDestinationKind> for MarkdownLinkDestinationKindFfi {
     }
 }
 
-impl From<&MdNostrEntity> for MarkdownNostrEntityFfi {
-    fn from(value: &MdNostrEntity) -> Self {
+impl From<MdNostrEntity> for MarkdownNostrEntityFfi {
+    fn from(value: MdNostrEntity) -> Self {
         Self {
             hrp: value.hrp.into(),
-            bech32: value.bech32.clone(),
+            bech32: value.bech32,
         }
     }
 }

--- a/crates/marmot-uniffi/src/subscriptions.rs
+++ b/crates/marmot-uniffi/src/subscriptions.rs
@@ -13,15 +13,16 @@
 //! All inner state lives behind a `tokio::sync::Mutex` because UniFFI passes
 //! these objects via `Arc<Self>` and `recv()` requires `&mut`.
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
+use std::sync::PoisonError;
 
 use marmot_app::{
     RuntimeAgentStreamWatch, RuntimeChatListSubscription, RuntimeChatsSubscription,
     RuntimeEventsSubscription, RuntimeGroupStateSubscription, RuntimeMessagesSubscription,
-    RuntimeNotificationsSubscription, RuntimeTimelineMessagesSubscription, TimelineWindowHandle,
-    UserSearchSubscription as AppUserSearchSubscription,
+    RuntimeNotificationsSubscription, RuntimeTimelineMessagesSubscription, TimelineMessageRecord,
+    TimelinePage, TimelineWindowHandle, UserSearchSubscription as AppUserSearchSubscription,
 };
 use tokio::sync::Mutex;
 
@@ -29,7 +30,7 @@ use crate::MarmotKitError;
 use crate::conversions::{
     AgentStreamUpdateFfi, AppGroupRecordFfi, AppMessageRecordFfi, ChatListRowFfi,
     ChatListSubscriptionUpdateFfi, MarmotEventFfi, MessageUpdateFfi, NotificationUpdateFfi,
-    TimelinePageFfi, TimelineSubscriptionUpdateFfi, UserSearchUpdateFfi,
+    TimelineMessageRecordFfi, TimelinePageFfi, TimelineSubscriptionUpdateFfi, UserSearchUpdateFfi,
 };
 
 #[derive(uniffi::Object)]
@@ -180,6 +181,53 @@ pub struct TimelineMessagesSubscription {
     snapshot: StdMutex<Option<TimelinePageFfi>>,
     window: TimelineWindowHandle,
     receiver: Mutex<RuntimeTimelineMessagesSubscription>,
+    /// Converted rows from the most recent window snapshot, keyed by
+    /// `message_id_hex`. Converting a row is expensive (Markdown parse,
+    /// imeta media resolution, reaction re-sort), and a live update usually
+    /// changes one row in a window of hundreds, so `next()` and the paginate
+    /// calls reuse the previous conversion for every row whose source record
+    /// is unchanged.
+    conversion_cache: StdMutex<HashMap<String, CachedTimelineRow>>,
+}
+
+struct CachedTimelineRow {
+    source: TimelineMessageRecord,
+    converted: TimelineMessageRecordFfi,
+}
+
+/// Convert a window snapshot to its FFI page, reusing cached conversions for
+/// rows whose source record equals the one that produced them. The cache is
+/// replaced with exactly the rows of this page, so rows that scrolled out of
+/// the window are dropped and the cache never outgrows the window cap.
+fn convert_timeline_page_cached(
+    cache: &StdMutex<HashMap<String, CachedTimelineRow>>,
+    page: TimelinePage,
+) -> TimelinePageFfi {
+    let mut cache = cache.lock().unwrap_or_else(PoisonError::into_inner);
+    let mut retained = HashMap::with_capacity(page.messages.len());
+    let messages = page
+        .messages
+        .into_iter()
+        .map(|record| {
+            let key = record.message_id_hex.clone();
+            let row = match cache.remove(&key) {
+                Some(cached) if cached.source == record => cached,
+                _ => CachedTimelineRow {
+                    source: record.clone(),
+                    converted: record.into(),
+                },
+            };
+            let converted = row.converted.clone();
+            retained.insert(key, row);
+            converted
+        })
+        .collect();
+    *cache = retained;
+    TimelinePageFfi {
+        messages,
+        has_more_before: page.has_more_before,
+        has_more_after: page.has_more_after,
+    }
 }
 
 impl TimelineMessagesSubscription {
@@ -191,11 +239,13 @@ impl TimelineMessagesSubscription {
         )
         .entered();
         let window = inner.window_handle();
-        let snapshot: TimelinePageFfi = inner.take_snapshot().into();
+        let conversion_cache = StdMutex::new(HashMap::new());
+        let snapshot = convert_timeline_page_cached(&conversion_cache, inner.take_snapshot());
         Arc::new(Self {
             snapshot: StdMutex::new(Some(snapshot)),
             window,
             receiver: Mutex::new(inner),
+            conversion_cache,
         })
     }
 }
@@ -214,7 +264,10 @@ impl TimelineMessagesSubscription {
     pub async fn next(&self) -> Option<TimelinePageFfi> {
         let mut receiver = self.receiver.lock().await;
         receiver.recv().await?;
-        Some(self.window.snapshot().into())
+        Some(convert_timeline_page_cached(
+            &self.conversion_cache,
+            self.window.snapshot(),
+        ))
     }
 
     pub async fn next_update(&self) -> Option<TimelineSubscriptionUpdateFfi> {
@@ -231,7 +284,8 @@ impl TimelineMessagesSubscription {
     /// task can paginate without blocking (and this never blocks the UI thread,
     /// unlike the synchronous `Marmot::timeline_messages`).
     pub async fn paginate_backwards(&self, count: u32) -> Result<TimelinePageFfi, MarmotKitError> {
-        Ok(self.window.paginate_backwards(count as usize).await?.into())
+        let page = self.window.paginate_backwards(count as usize).await?;
+        Ok(convert_timeline_page_cached(&self.conversion_cache, page))
     }
 
     /// Extend the materialized window toward the live head by up to `count`
@@ -239,7 +293,8 @@ impl TimelineMessagesSubscription {
     /// window (`has_more_after` becomes false). Same windowing/threading
     /// guarantees as [`paginate_backwards`](Self::paginate_backwards).
     pub async fn paginate_forwards(&self, count: u32) -> Result<TimelinePageFfi, MarmotKitError> {
-        Ok(self.window.paginate_forwards(count as usize).await?.into())
+        let page = self.window.paginate_forwards(count as usize).await?;
+        Ok(convert_timeline_page_cached(&self.conversion_cache, page))
     }
 }
 
@@ -356,6 +411,80 @@ mod tests {
 
         assert_eq!(take_snapshot(&snapshot), Some("initial"));
         assert_eq!(take_snapshot(&snapshot), None);
+    }
+
+    #[test]
+    fn cached_conversion_reuses_unchanged_rows_and_never_serves_stale_content() {
+        use cgka_traits::app_event::MARMOT_APP_EVENT_KIND_CHAT;
+        use marmot_app::TimelineReactionSummary;
+
+        fn record(id: &str, plaintext: &str) -> TimelineMessageRecord {
+            TimelineMessageRecord {
+                message_id_hex: id.to_string(),
+                source_message_id_hex: None,
+                source_epoch: None,
+                retention_seconds: None,
+                retention_expires_at: None,
+                direction: "received".to_string(),
+                group_id_hex: "aa".to_string(),
+                sender: "bb".to_string(),
+                plaintext: plaintext.to_string(),
+                kind: MARMOT_APP_EVENT_KIND_CHAT,
+                tags: Vec::new(),
+                timeline_at: 1,
+                received_at: 1,
+                reply_to_message_id_hex: None,
+                reply_preview: None,
+                media: None,
+                agent_text_stream: None,
+                reactions: TimelineReactionSummary::default(),
+                deleted: false,
+                deleted_by_message_id_hex: None,
+                invalidation_status: None,
+            }
+        }
+
+        fn page(messages: Vec<TimelineMessageRecord>) -> TimelinePage {
+            TimelinePage {
+                messages,
+                has_more_before: false,
+                has_more_after: false,
+            }
+        }
+
+        let cache = StdMutex::new(HashMap::new());
+
+        let first = convert_timeline_page_cached(
+            &cache,
+            page(vec![record("m1", "hello"), record("m2", "world")]),
+        );
+        assert_eq!(first.messages.len(), 2);
+        assert_eq!(cache.lock().unwrap().len(), 2);
+
+        // Unchanged rows come back identical from the cache.
+        let second = convert_timeline_page_cached(
+            &cache,
+            page(vec![record("m1", "hello"), record("m2", "world")]),
+        );
+        assert_eq!(second.messages[0].plaintext, "hello");
+        assert_eq!(second.messages[1].plaintext, "world");
+
+        // A changed row is re-converted, never served stale: the new markdown
+        // shows up in the tokens, not just the plaintext.
+        let third = convert_timeline_page_cached(
+            &cache,
+            page(vec![record("m1", "edited **bold**"), record("m2", "world")]),
+        );
+        assert_eq!(third.messages[0].plaintext, "edited **bold**");
+        assert!(!third.messages[0].content_tokens.blocks.is_empty());
+
+        // Rows that leave the window are pruned so the cache tracks the
+        // window cap, not history.
+        let fourth = convert_timeline_page_cached(&cache, page(vec![record("m2", "world")]));
+        assert_eq!(fourth.messages.len(), 1);
+        let cache = cache.lock().unwrap();
+        assert_eq!(cache.len(), 1);
+        assert!(cache.contains_key("m2"));
     }
 
     // The timeline window's projection/cap/anchoring contract now lives and is


### PR DESCRIPTION
Stacked on the `uniffi-window-cache` PR.

Every `Append`/`Status`/`Progress` command on a compose session responded with a clone of `StreamComposeReport`, whose `text` field holds the entire accumulated transcript. That is O(n^2) bytes copied over a stream's life: a 1 MB transcript appended in 1 KB chunks copies about 500 MB. The `wn-agent` connector discards everything but the ack, and the daemon only printed the response.

These commands now respond with `StreamComposeAck`: the report minus `text` (stream/group ids, status, transcript hash, chunk count, live error). The session still accumulates the full transcript internally, and `Finish` keeps returning and validating the complete report, so the final-transcript expectation contract is unchanged.

One visible change, called out deliberately: the daemon's `compose-append` JSON output no longer contains a `text` key. Its only consumer was the TUI's "streaming N bytes" counter, which read its own text back off the daemon. The TUI now tracks flushed bytes locally (`StreamComposer::flushed_bytes`) and shows the cumulative streamed total, where it previously showed only the last ack's size.

The marmot relay line now passes along a receipt, not a copy of every acorn hauled so far.

Verified with `just fast-ci`, `cargo test -p agent-stream-compose`, `cargo test -p agent-connector`, and the wn-cli stream and TUI suites (34 + 433 tests) with `test-policy-overrides`.
