### PR TITLE
perf(cgka-engine): measured join/create lifecycle speedups + criterion bench harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,6 +802,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -894,6 +906,7 @@ dependencies = [
  "async-trait",
  "cgka-traits",
  "chacha20poly1305",
+ "criterion",
  "hex",
  "insta",
  "k256",
@@ -1012,6 +1025,33 @@ name = "chunked_transfer"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "cipher"
@@ -1246,6 +1286,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "futures",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "tokio",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1318,6 +1396,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -2127,6 +2211,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2715,10 +2810,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -3711,6 +3826,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4174,6 +4295,34 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "png"
@@ -5841,6 +5990,16 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ proptest = "1"
 insta = { version = "1", features = ["json"] }
 stateright = "0.31.0"
 test-log = { version = "0.2", features = ["trace"] }
+criterion = { version = "0.5", features = ["async_tokio"] }
 
 # workspace-internal
 fs-private = { path = "crates/fs-private" }

--- a/crates/cgka-engine/Cargo.toml
+++ b/crates/cgka-engine/Cargo.toml
@@ -57,3 +57,8 @@ sha2.workspace = true
 # `tests/support/epoch_sealed_peeler.rs`) with the same AEAD the Nostr kind-445
 # binding uses, so engine visibility in tests matches production.
 chacha20poly1305.workspace = true
+criterion.workspace = true
+
+[[bench]]
+name = "group_lifecycle"
+harness = false

--- a/crates/cgka-engine/benches/group_lifecycle.rs
+++ b/crates/cgka-engine/benches/group_lifecycle.rs
@@ -1,0 +1,309 @@
+//! Criterion benchmarks for the group creation and welcome-join flows.
+//!
+//! These benches drive the real OpenMLS-backed engine over in-memory SQLite
+//! storage with the same pass-through peeler style the Tier-2 tests use, so
+//! the measured work is the engine's own CPU + storage cost: KeyPackage
+//! parsing/validation, commit/welcome production, per-invitee wrapping, and
+//! the join transaction. Transport crypto is deliberately excluded.
+//!
+//! Run:
+//!
+//! ```sh
+//! cargo bench -p cgka-engine --bench group_lifecycle
+//! ```
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use cgka_engine::account_identity_proof::{
+    AccountIdentityProofRequest, AccountIdentityProofSigner,
+};
+use cgka_engine::{Engine, EngineBuilder};
+use cgka_traits::engine::{CgkaEngine, CreateGroupRequest, KeyPackage, SendResult};
+use cgka_traits::error::PeelerError;
+use cgka_traits::group::ProtocolProfile;
+use cgka_traits::group_context::GroupContextSnapshot;
+use cgka_traits::ingest::{PeeledContent, PeeledMessage};
+use cgka_traits::peeler::TransportPeeler;
+use cgka_traits::transport::{
+    EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
+};
+use cgka_traits::types::{MemberId, MessageId};
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
+use k256::schnorr::{SigningKey, signature::hazmat::PrehashSigner};
+use sha2::{Digest, Sha256};
+use storage_sqlite::SqliteAccountStorage;
+
+// ── Deterministic identities (mirrors tests/support) ────────────────────────
+
+fn proof_signer(seed: &[u8]) -> Arc<dyn AccountIdentityProofSigner> {
+    Arc::new(TestAccountIdentityProofSigner(signing_key(seed)))
+}
+
+fn signing_key(seed: &[u8]) -> SigningKey {
+    let mut counter = 0u64;
+    loop {
+        let mut material = [0u8; 32];
+        let mut hasher = Sha256::new();
+        hasher.update(b"cgka-engine-test-identity-v1");
+        hasher.update(seed);
+        hasher.update(counter.to_be_bytes());
+        material.copy_from_slice(&hasher.finalize());
+        if let Ok(sk) = SigningKey::from_bytes(&material) {
+            return sk;
+        }
+        counter += 1;
+    }
+}
+
+struct TestAccountIdentityProofSigner(SigningKey);
+
+impl AccountIdentityProofSigner for TestAccountIdentityProofSigner {
+    fn sign_account_identity_proof(
+        &self,
+        request: &AccountIdentityProofRequest,
+    ) -> Result<[u8; 64], String> {
+        if self.0.verifying_key().to_bytes().as_slice() != request.account_identity.as_slice() {
+            return Err("request account identity does not match test key".into());
+        }
+        let signature = self
+            .0
+            .sign_prehash(&request.proof_event_id()?)
+            .map_err(|e| e.to_string())?;
+        Ok(signature.to_bytes())
+    }
+}
+
+fn pad32(name: &[u8]) -> Vec<u8> {
+    signing_key(name).verifying_key().to_bytes().to_vec()
+}
+
+// ── Pass-through peeler (no transport crypto) ───────────────────────────────
+
+fn hash_id(bytes: &[u8]) -> MessageId {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut h = DefaultHasher::new();
+    bytes.hash(&mut h);
+    MessageId::new(h.finish().to_be_bytes().to_vec())
+}
+
+struct BenchPeeler;
+
+#[async_trait]
+impl TransportPeeler for BenchPeeler {
+    async fn peel_group_message(
+        &self,
+        msg: &TransportMessage,
+        _ctx: &GroupContextSnapshot,
+    ) -> Result<PeeledMessage, PeelerError> {
+        Ok(PeeledMessage {
+            id: msg.id.clone(),
+            group_id: None,
+            sender: None,
+            content: PeeledContent::MlsMessage {
+                bytes: msg.payload.clone(),
+            },
+            origin: msg.clone(),
+        })
+    }
+
+    async fn peel_welcome(&self, msg: &TransportMessage) -> Result<PeeledMessage, PeelerError> {
+        Ok(PeeledMessage {
+            id: msg.id.clone(),
+            group_id: None,
+            sender: None,
+            content: PeeledContent::Welcome {
+                bytes: msg.payload.clone(),
+            },
+            origin: msg.clone(),
+        })
+    }
+
+    async fn wrap_group_message(
+        &self,
+        payload: &EncryptedPayload,
+        ctx: &GroupContextSnapshot,
+    ) -> Result<TransportMessage, PeelerError> {
+        Ok(TransportMessage {
+            id: hash_id(&payload.ciphertext),
+            payload: payload.ciphertext.clone(),
+            timestamp: Timestamp(0),
+            causal_deps: vec![],
+            source: TransportSource("bench".into()),
+            envelope: TransportEnvelope::GroupMessage {
+                transport_group_id: ctx.transport_group_id().unwrap_or_default().to_vec(),
+            },
+        })
+    }
+
+    async fn wrap_welcome(
+        &self,
+        payload: &EncryptedPayload,
+        recipient: &MemberId,
+    ) -> Result<TransportMessage, PeelerError> {
+        let mut id_material = payload.ciphertext.clone();
+        id_material.extend_from_slice(recipient.as_slice());
+        Ok(TransportMessage {
+            id: hash_id(&id_material),
+            payload: payload.ciphertext.clone(),
+            timestamp: Timestamp(0),
+            causal_deps: vec![],
+            source: TransportSource("bench".into()),
+            envelope: TransportEnvelope::Welcome {
+                recipient: recipient.clone(),
+            },
+        })
+    }
+}
+
+// ── Engine construction ─────────────────────────────────────────────────────
+
+fn build_client(identity: &[u8]) -> Engine<SqliteAccountStorage> {
+    EngineBuilder::new(SqliteAccountStorage::in_memory().unwrap())
+        .identity(pad32(identity))
+        .account_identity_proof_signer(proof_signer(identity))
+        .protocol_profile(ProtocolProfile::Current)
+        .peeler(Box::new(BenchPeeler))
+        .build()
+        .expect("build bench engine")
+}
+
+/// Mint one fresh KeyPackage per invitee identity. Each identity gets its own
+/// throwaway engine because a KeyPackage binds the identity's MLS signer.
+fn invitee_key_packages(count: usize) -> Vec<KeyPackage> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("bench runtime");
+    let mut out = Vec::with_capacity(count);
+    for index in 0..count {
+        let identity = format!("bench-invitee-{index}");
+        let mut engine = build_client(identity.as_bytes());
+        out.push(
+            rt.block_on(engine.fresh_key_package())
+                .expect("mint invitee key package"),
+        );
+    }
+    out
+}
+
+fn create_request(members: Vec<KeyPackage>) -> CreateGroupRequest {
+    CreateGroupRequest {
+        name: "bench".into(),
+        description: "bench".into(),
+        members,
+        required_features: vec![],
+        app_components: vec![],
+        initial_admins: vec![],
+    }
+}
+
+// ── create_group ────────────────────────────────────────────────────────────
+
+fn bench_create_group(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("bench runtime");
+    let mut group = c.benchmark_group("create_group");
+    for invitees in [1_usize, 8, 32] {
+        let key_packages = invitee_key_packages(invitees);
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("{invitees} invitees")),
+            &key_packages,
+            |b, key_packages| {
+                let alice = std::sync::Arc::new(tokio::sync::Mutex::new(build_client(
+                    b"bench-alice-create",
+                )));
+                b.to_async(&rt).iter(|| {
+                    let alice = alice.clone();
+                    async move {
+                        let request = create_request(key_packages.clone());
+                        let (group_id, result) = alice
+                            .lock()
+                            .await
+                            .create_group(request)
+                            .await
+                            .expect("create_group succeeds");
+                        // Sanity: founding creation returns one Welcome per invitee.
+                        debug_assert!(matches!(
+                            result,
+                            SendResult::FoundingGroupCreated { .. }
+                        ));
+                        group_id
+                    }
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+// ── join_welcome ────────────────────────────────────────────────────────────
+
+fn bench_join_welcome(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("bench runtime");
+    let mut group = c.benchmark_group("join_welcome");
+    // A join consumes its Welcome, so every iteration needs a fresh one.
+    // Warm-up and measurement both draw from the same pre-generated pool;
+    // keep the pool comfortably larger than the iteration count, and keep
+    // the iteration count bounded so the joining engine does not accumulate
+    // an unrealistic number of groups.
+    group.warm_up_time(std::time::Duration::from_millis(200));
+    group.measurement_time(std::time::Duration::from_millis(300));
+    group.sample_size(10);
+    const PREGENERATED_WELCOMES: usize = 800;
+    for stored_key_packages in [1_usize, 8, 32] {
+        let mut bob = build_client(b"bench-bob-join");
+        // Persist `stored_key_packages` last-resort bundles for bob; the join
+        // path must locate the one a Welcome references among them. Keep the
+        // final one as the invite target.
+        let mut bob_kp = None;
+        for _ in 0..stored_key_packages {
+            bob_kp = Some(
+                rt.block_on(bob.fresh_key_package())
+                    .expect("mint bob key package"),
+            );
+        }
+        let bob_kp = bob_kp.expect("at least one key package");
+        let mut alice = build_client(b"bench-alice-join");
+        // Untimed setup: alice founds a fresh group inviting bob per Welcome.
+        let mut welcomes = Vec::with_capacity(PREGENERATED_WELCOMES);
+        for _ in 0..PREGENERATED_WELCOMES {
+            let (_group_id, result) = rt
+                .block_on(alice.create_group(create_request(vec![bob_kp.clone()])))
+                .expect("create_group succeeds");
+            match result {
+                SendResult::FoundingGroupCreated { welcomes: mut wrapped } => {
+                    welcomes.push(wrapped.remove(0));
+                }
+                other => panic!("expected FoundingGroupCreated, got {other:?}"),
+            }
+        }
+        let bob = std::sync::Arc::new(tokio::sync::Mutex::new(bob));
+        group.bench_function(
+            BenchmarkId::from_parameter(format!("{stored_key_packages} stored key packages")),
+            |b| {
+                b.to_async(&rt).iter_batched(
+                    || welcomes.pop().expect("pre-generated welcome pool"),
+                    |welcome| {
+                        let bob = bob.clone();
+                        async move {
+                            bob.lock()
+                                .await
+                                .join_welcome(welcome)
+                                .await
+                                .expect("join succeeds")
+                        }
+                    },
+                    BatchSize::PerIteration,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_create_group, bench_join_welcome);
+criterion_main!(benches);

--- a/crates/cgka-engine/benches/group_lifecycle.rs
+++ b/crates/cgka-engine/benches/group_lifecycle.rs
@@ -217,18 +217,13 @@ fn bench_create_group(c: &mut Criterion) {
                 b.to_async(&rt).iter(|| {
                     let alice = alice.clone();
                     async move {
-                        let __tc = std::time::Instant::now(); // TEMP-PROBE
                         let request = create_request(key_packages.clone());
-                        eprintln!("TEMP-PROBE closure clone: {:?}", __tc.elapsed()); // TEMP-PROBE
-                        let __tl = std::time::Instant::now(); // TEMP-PROBE
-                        let mut guard = alice.lock().await; // TEMP-PROBE
-                        eprintln!("TEMP-PROBE closure lock: {:?}", __tl.elapsed()); // TEMP-PROBE
-                        let __tg = std::time::Instant::now(); // TEMP-PROBE
-                        let (group_id, result) = guard
+                        let (group_id, result) = alice
+                            .lock()
+                            .await
                             .create_group(request)
                             .await
                             .expect("create_group succeeds");
-                        eprintln!("TEMP-PROBE closure create_group: {:?}", __tg.elapsed()); // TEMP-PROBE
                         // Sanity: founding creation returns one Welcome per invitee.
                         debug_assert!(matches!(result, SendResult::FoundingGroupCreated { .. }));
                         group_id

--- a/crates/cgka-engine/benches/group_lifecycle.rs
+++ b/crates/cgka-engine/benches/group_lifecycle.rs
@@ -217,13 +217,18 @@ fn bench_create_group(c: &mut Criterion) {
                 b.to_async(&rt).iter(|| {
                     let alice = alice.clone();
                     async move {
+                        let __tc = std::time::Instant::now(); // TEMP-PROBE
                         let request = create_request(key_packages.clone());
-                        let (group_id, result) = alice
-                            .lock()
-                            .await
+                        eprintln!("TEMP-PROBE closure clone: {:?}", __tc.elapsed()); // TEMP-PROBE
+                        let __tl = std::time::Instant::now(); // TEMP-PROBE
+                        let mut guard = alice.lock().await; // TEMP-PROBE
+                        eprintln!("TEMP-PROBE closure lock: {:?}", __tl.elapsed()); // TEMP-PROBE
+                        let __tg = std::time::Instant::now(); // TEMP-PROBE
+                        let (group_id, result) = guard
                             .create_group(request)
                             .await
                             .expect("create_group succeeds");
+                        eprintln!("TEMP-PROBE closure create_group: {:?}", __tg.elapsed()); // TEMP-PROBE
                         // Sanity: founding creation returns one Welcome per invitee.
                         debug_assert!(matches!(
                             result,
@@ -305,5 +310,65 @@ fn bench_join_welcome(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_create_group, bench_join_welcome);
+/// Joining a larger group: every join ends with a buffered-message replay
+/// scan over the group's stored messages. The just-persisted Welcome record
+/// alone is ~180KB of JSON at this size; a re-join additionally carries the
+/// group's whole prior history.
+fn bench_join_welcome_large_group(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("bench runtime");
+    let mut group = c.benchmark_group("join_welcome_large_group");
+    group.warm_up_time(std::time::Duration::from_millis(200));
+    group.measurement_time(std::time::Duration::from_millis(300));
+    group.sample_size(10);
+    const PREGENERATED_WELCOMES: usize = 400;
+    const OTHER_MEMBERS: usize = 31;
+    let mut bob = build_client(b"bench-bob-join-large");
+    let bob_kp = rt
+        .block_on(bob.fresh_key_package())
+        .expect("mint bob key package");
+    let other_key_packages = invitee_key_packages(OTHER_MEMBERS);
+    let mut alice = build_client(b"bench-alice-join-large");
+    let mut welcomes = Vec::with_capacity(PREGENERATED_WELCOMES);
+    for _ in 0..PREGENERATED_WELCOMES {
+        let mut members = other_key_packages.clone();
+        members.push(bob_kp.clone());
+        let (_group_id, result) = rt
+            .block_on(alice.create_group(create_request(members)))
+            .expect("create_group succeeds");
+        match result {
+            SendResult::FoundingGroupCreated { welcomes: mut wrapped } => {
+                // bob's KeyPackage was last, so his Welcome is last.
+                welcomes.push(wrapped.remove(wrapped.len() - 1));
+            }
+            other => panic!("expected FoundingGroupCreated, got {other:?}"),
+        }
+    }
+    let bob = std::sync::Arc::new(tokio::sync::Mutex::new(bob));
+    group.bench_function("32 members", |b| {
+        b.to_async(&rt).iter_batched(
+            || welcomes.pop().expect("pre-generated welcome pool"),
+            |welcome| {
+                let bob = bob.clone();
+                async move {
+                    bob.lock()
+                        .await
+                        .join_welcome(welcome)
+                        .await
+                        .expect("join succeeds")
+                }
+            },
+            BatchSize::PerIteration,
+        );
+    });
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_create_group,
+    bench_join_welcome,
+    bench_join_welcome_large_group
+);
 criterion_main!(benches);

--- a/crates/cgka-engine/benches/group_lifecycle.rs
+++ b/crates/cgka-engine/benches/group_lifecycle.rs
@@ -230,10 +230,7 @@ fn bench_create_group(c: &mut Criterion) {
                             .expect("create_group succeeds");
                         eprintln!("TEMP-PROBE closure create_group: {:?}", __tg.elapsed()); // TEMP-PROBE
                         // Sanity: founding creation returns one Welcome per invitee.
-                        debug_assert!(matches!(
-                            result,
-                            SendResult::FoundingGroupCreated { .. }
-                        ));
+                        debug_assert!(matches!(result, SendResult::FoundingGroupCreated { .. }));
                         group_id
                     }
                 });
@@ -280,7 +277,9 @@ fn bench_join_welcome(c: &mut Criterion) {
                 .block_on(alice.create_group(create_request(vec![bob_kp.clone()])))
                 .expect("create_group succeeds");
             match result {
-                SendResult::FoundingGroupCreated { welcomes: mut wrapped } => {
+                SendResult::FoundingGroupCreated {
+                    welcomes: mut wrapped,
+                } => {
                     welcomes.push(wrapped.remove(0));
                 }
                 other => panic!("expected FoundingGroupCreated, got {other:?}"),
@@ -338,7 +337,9 @@ fn bench_join_welcome_large_group(c: &mut Criterion) {
             .block_on(alice.create_group(create_request(members)))
             .expect("create_group succeeds");
         match result {
-            SendResult::FoundingGroupCreated { welcomes: mut wrapped } => {
+            SendResult::FoundingGroupCreated {
+                welcomes: mut wrapped,
+            } => {
                 // bob's KeyPackage was last, so his Welcome is last.
                 welcomes.push(wrapped.remove(wrapped.len() - 1));
             }

--- a/crates/cgka-engine/src/group_lifecycle.rs
+++ b/crates/cgka-engine/src/group_lifecycle.rs
@@ -42,6 +42,7 @@ use openmls::prelude::{
 };
 use openmls::treesync::Node;
 use openmls_traits::OpenMlsProvider as _;
+use openmls_traits::storage::StorageProvider as OpenMlsStorageProvider;
 use openmls_traits::types::Ciphersuite;
 use sha2::{Digest, Sha256};
 use tls_codec::{Deserialize as _, Serialize as _};
@@ -963,30 +964,25 @@ impl<S: StorageProvider> Engine<S> {
                 // Match in the same order OpenMLS uses: the first Welcome
                 // KeyPackageRef for which this account-device has a private
                 // bundle. Transport tags are deliberately outside this
-                // selection.
-                let local_bundle_keys = storage
-                    .stored_key_package_bundles()?
-                    .into_iter()
-                    .map(|stored| {
-                        let bundle = serde_json::from_slice::<KeyPackageBundle>(&stored.value)
-                            .map_err(|error| EngineError::Serialize(error.to_string()))?;
-                        let reference =
-                            bundle
-                                .key_package()
-                                .hash_ref(provider.crypto())
-                                .map_err(|error| {
-                                    EngineError::Backend(format!("key_package ref: {error:?}"))
-                                })?;
-                        Ok::<_, EngineError>(reference.as_slice().to_vec())
-                    })
-                    .collect::<Result<BTreeSet<_>, _>>()?;
-                let consumed_key_package_ref = welcome
-                    .secrets()
-                    .iter()
-                    .map(|secret| secret.new_member())
-                    .find(|reference| local_bundle_keys.contains(reference.as_slice()))
-                    .map(|reference| reference.as_slice().to_vec())
-                    .ok_or(EngineError::InvalidWelcome)?;
+                // selection. Point-query per candidate ref — the same lookup
+                // `ProcessedWelcome::new_from_welcome` performs internally —
+                // rather than enumerating, JSON-decoding, and re-hashing
+                // every stored bundle on each join.
+                let mut consumed_key_package_ref = None;
+                for secret in welcome.secrets() {
+                    let reference = secret.new_member();
+                    let bundle: Option<KeyPackageBundle> =
+                        OpenMlsStorageProvider::key_package(provider.storage(), &reference)
+                            .map_err(|error| {
+                                EngineError::Backend(format!("key_package lookup: {error:?}"))
+                            })?;
+                    if bundle.is_some() {
+                        consumed_key_package_ref = Some(reference.as_slice().to_vec());
+                        break;
+                    }
+                }
+                let consumed_key_package_ref =
+                    consumed_key_package_ref.ok_or(EngineError::InvalidWelcome)?;
                 let processed = openmls::group::ProcessedWelcome::new_from_welcome(
                     &provider,
                     &join_config,

--- a/crates/cgka-engine/src/group_lifecycle.rs
+++ b/crates/cgka-engine/src/group_lifecycle.rs
@@ -566,11 +566,6 @@ impl<S: StorageProvider> Engine<S> {
         // Every other member lands in the group via `welcomes`, which carry
         // the post-commit state directly. Dropping the commit avoids a
         // welcome-before-commit `AlreadyAtEpoch` bounce.
-        //
-        // The context snapshot is built off the still-staged group; for
-        // welcomes, only the recipient pubkey matters at wrap time, so the
-        // pre-merge group context is sufficient.
-        let ctx = build_group_context_snapshot(&mls_group, &provider)?;
         let welcome_relays = welcome_relays_for_group(&mls_group)?;
 
         let mut welcomes = Vec::with_capacity(parsed_kps.len());
@@ -797,8 +792,6 @@ impl<S: StorageProvider> Engine<S> {
         if let Some(guard) = pending_commit_guard {
             guard.disarm();
         }
-
-        let _ = ctx;
 
         Ok((
             group_id,

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -1732,7 +1732,18 @@ impl<S: StorageProvider> Engine<S> {
         &mut self,
         group_id: &GroupId,
     ) -> Result<(), EngineError> {
-        let records = self.storage.list_messages(group_id, EpochId(0))?;
+        // Only states the loop below can act on; the storage backend skips
+        // fetching and decoding terminal/record-only rows entirely, which
+        // keeps a re-join from re-parsing the group's whole message history.
+        let records = self.storage.list_messages_in_states(
+            group_id,
+            &[
+                MessageState::Created,
+                MessageState::Retryable,
+                MessageState::PeelDeferred,
+            ],
+            EpochId(0),
+        )?;
         for record in records {
             if !matches!(
                 record.state,

--- a/crates/cgka-engine/tests/AGENTS.md
+++ b/crates/cgka-engine/tests/AGENTS.md
@@ -116,6 +116,23 @@ epoch-scoped readability; `MockPeeler` stays right for everything else.
 cargo test -p cgka-engine
 ```
 
+Note: the default build pins the v1 convergence policy; suites that install custom policies need
+`cargo test -p cgka-engine --features test-policy-overrides` (CI runs the workspace with
+`wn-cli/test-policy-overrides,cgka-engine/test-crash-hooks`, see `justfile`).
+
+## Benchmarks
+
+`benches/group_lifecycle.rs` (criterion) times the group-creation and welcome-join flows over
+in-memory SQLite with a pass-through peeler: `create_group` at 1/8/32 invitees, `join_welcome` at
+1/8/32 stored key packages, and `join_welcome_large_group` for 32-member joins. Run:
+
+```sh
+cargo bench -p cgka-engine --bench group_lifecycle
+```
+
+These benches are the measurement rail for engine-lifecycle performance work; extend them when a
+change claims a lifecycle speedup.
+
 ## Tier 3 — Harness scenarios + proptest
 
 **Where:** `crates/cgka-conformance-simulator/tests/`. Multi-client convergence under a deterministic in-memory bus.


### PR DESCRIPTION
## Summary

Benchmark-driven performance pass over the group-creation and welcome-join flows, plus a criterion harness to keep them measured. Each commit is bisectable and was verified against the benches (and the full engine suite) individually; no behavior changes.

Rebased onto master after **#1405** merged: this PR no longer carries any state-filter infrastructure (trait method / SQLite override / parity tests) — it reuses `MessageStorage::list_messages_in_states` from #1405, whose `(group_id, state, epoch)` index (migration 0046) also serves the replay filter here.

**Headline numbers** (release profile, in-memory SQLite, pass-through peeler):

| Benchmark | Before | After | Change |
| --- | --- | --- | --- |
| `join_welcome` / 1 stored key package | 2.29ms | 1.27ms | **−44%** |
| `join_welcome` / 8 stored key packages | 2.22ms | 1.28ms | **−42%** |
| `join_welcome` / 32 stored key packages | 2.40ms | 1.28ms | **−47%** |
| `join_welcome_large_group` / 32 members | 5.01ms | 4.43ms | **−12%** (replay filter on the #1405 index) |
| `create_group` / 32 invitees | 65.3ms | 64.8ms | ~flat (see "what was not done") |

## Commits

1. **`8ae514f8` test: criterion benchmarks** — `crates/cgka-engine/benches/group_lifecycle.rs`: `create_group` at 1/8/32 invitees, `join_welcome` at 1/8/32 stored key packages, 32-member group joins. Measurement rail the perf commits cite.
2. **`a5dac290` perf: point-query welcome key-package matching** — `do_join_peeled_welcome` previously enumerated every stored KeyPackage bundle through an **unindexed** `label` filter on `openmls_values` (scanning the account's whole MLS state table), then JSON-decoded and re-hashed each bundle. Now it does the same indexed primary-key point lookup OpenMLS's `keys_for_welcome` does, in the same first-match order, inside the same join transaction. Matching semantics unchanged.
3. **`0bb92a7e` perf: state-filtered replay scan** — `replay_buffered_messages` now calls #1405's `list_messages_in_states` so the end-of-join replay no longer JSON-parses the just-written ~180KB welcome record — or the whole group history on re-join — only to skip those rows. The replay loop keeps its state guard; behavior unchanged on every backend.
4. **`eeebb2eb` refactor: drop dead group-context snapshot** — `do_create_group` built a `GroupContextSnapshot` (an `export_secret` KDF + app-dict parse) and discarded it unread on both profile paths; also removes a spurious failure mode. Behavior unchanged; measured effect below bench noise, but it ran on every create.
5. **`d9464291` style**, **`47c332c9` docs**, **`d766ebd4` test cleanup** — fmt, bench documentation in `tests/AGENTS.md`, and removal of profiling probes that had leaked into the create bench closure (CodeRabbit catch).

## What was evaluated and deliberately not done

- **Welcome-payload clone hoist** in the create/invite wrap loops: measured ~0.02% — 50× below bench noise. Reverted rather than merged as a theoretical win.
- **Per-invitee member-id re-derivation dedup**: <0.6% of create. Dropped.
- **Staged-commit account-proof re-validation**: deliberate seam-hardening duplication (repo invariant). Kept.
- **The real create bottleneck — JSON storage double-expansion** (16.7KB welcome → 60KB → 180KB stored row) and the **~6MB founding snapshot blob** (~39ms of create): that's the established storage format, i.e. a migration, not a perf tweak. Filed as tracking issue **#1415** with child issues #1410–#1414 (versioning infra, payload BLOB column, snapshot blob v2, bench gates, ops runbook).

## Test plan

- [x] `cargo test -p cgka-engine --features test-policy-overrides,test-crash-hooks` — all green (25 binaries)
- [x] `cargo test -p storage-sqlite` — green
- [x] `cargo test -p cgka-traits` — green
- [x] `just fast-ci` — fmt/check/clippy workspace-wide green
- [x] Benches re-run after each commit and again after the #1405 rebase; numbers above are reproducible via `cargo bench -p cgka-engine --bench group_lifecycle`

Note: `tests/deferred_peel_lifecycle.rs` requires the `test-policy-overrides` feature and fails without it on plain `master` too (pre-existing; CI runs with the feature set above).

## Follow-up

Storage-format v2 migration is tracked in #1415 (children #1410–#1414) — versioning infrastructure, `cgka_messages` payload BLOB column, snapshot blob v2, bench acceptance gates, and the migration ops runbook.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved group creation and membership handling for more efficient lifecycle operations.
  * Reduced unnecessary message processing during replay, helping deferred and retryable messages be handled more efficiently.

* **Testing**
  * Added benchmarks covering group creation, invitations, and joins across different group sizes.

* **Documentation**
  * Added guidance for running convergence-policy tests and maintaining the group lifecycle benchmarks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->