### PR TITLE
perf(marmot-app): keep an O(1) seen-events index on the client

### DIFF
--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -84,6 +84,20 @@ where
     results.into_iter().map(|(_, result)| result).collect()
 }
 
+/// Outcome of one [`AppClient::refresh_group_routes`] pass, separating the
+/// in-memory routing-table delta from durable-state mutation: only the latter
+/// obligates a state save, only the former obligates a relay-subscription
+/// refresh.
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct GroupRouteRefresh {
+    /// The in-memory routing table changed; relay subscriptions need a
+    /// `sync_runtime_groups` refresh.
+    pub(crate) routing_changed: bool,
+    /// `prune_prior_nostr_routes` removed retired prior routes from persisted
+    /// group state; a save is required for the retirement to stick.
+    pub(crate) state_pruned: bool,
+}
+
 pub struct AppClient {
     pub(crate) app: MarmotApp,
     pub(crate) runtime: AppRuntime,
@@ -3163,8 +3177,8 @@ impl AppClient {
 
     /// Reconcile every group's current and still-live prior transport
     /// subscriptions, returning whether any installed route changed.
-    pub(crate) fn refresh_group_routes(&mut self) -> Result<bool, AppError> {
-        let mut changed = false;
+    pub(crate) fn refresh_group_routes(&mut self) -> Result<GroupRouteRefresh, AppError> {
+        let mut refresh = GroupRouteRefresh::default();
         for group in &mut self.state.groups {
             let Ok(group_id_bytes) = hex::decode(&group.group_id_hex) else {
                 tracing::warn!(
@@ -3182,7 +3196,7 @@ impl AppClient {
                 .is_ok_and(|group| group.disbanded.is_some())
             {
                 if self.routing.replace_group_routes(&group_id, Vec::new()) {
-                    changed = true;
+                    refresh.routing_changed = true;
                 }
                 continue;
             }
@@ -3196,7 +3210,7 @@ impl AppClient {
                 .unwrap_or(true)
                 && let Ok(group_record) = self.runtime.group_record(&group_id)
             {
-                group.prune_prior_nostr_routes(group_record.epoch.0);
+                refresh.state_pruned |= group.prune_prior_nostr_routes(group_record.epoch.0);
             }
             let Ok(subscriptions) = group.transport_subscriptions(&group_id) else {
                 tracing::warn!(
@@ -3208,10 +3222,10 @@ impl AppClient {
                 continue;
             };
             if self.routing.replace_group_routes(&group_id, subscriptions) {
-                changed = true;
+                refresh.routing_changed = true;
             }
         }
-        Ok(changed)
+        Ok(refresh)
     }
 
     fn refresh_routing(&mut self) -> Result<(), AppError> {

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -95,6 +95,12 @@ pub struct AppClient {
     pub(crate) relay_plane: MarmotRelayPlane,
     pub(crate) transport_signer: Arc<dyn nostr::NostrSigner>,
     pub(crate) state: AccountState,
+    /// O(1) membership index over `state.seen_events`, kept in lockstep by
+    /// `remember_seen_event` (which removes pruned ring entries from it).
+    /// Derived state: rebuilt from the ordered ring at construction and never
+    /// persisted. Before this index existed, every inbound delivery and every
+    /// publish-report batch rebuilt a `HashSet` from the full 16k-entry ring.
+    pub(crate) seen_events_index: HashSet<String>,
     /// Group-system timeline rows synthesized during the most recent publish
     /// path. The runtime account worker drains this after each command and
     /// broadcasts `ProjectionUpdated` so live timeline subscriptions refresh.
@@ -3221,13 +3227,9 @@ impl AppClient {
         if effects.reports.is_empty() {
             return;
         }
-        // The publish path holds no parallel lookup set (unlike the inbound
-        // `next_event`/`sync_sdk_relay` hot path), so build one once for this
-        // small report batch and reuse the shared O(1) recorder for each id.
-        let mut seen: HashSet<String> = self.state.seen_events.iter().cloned().collect();
         for report in &effects.reports {
             let event_id = hex::encode(report.message_id.as_slice());
-            remember_seen_event(&mut seen, &mut self.state, event_id);
+            remember_seen_event(&mut self.seen_events_index, &mut self.state, event_id);
         }
     }
 

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -289,7 +289,8 @@ impl AppClient {
         // Reconcile epoch-bounded prior routes before issuing the first relay
         // subscriptions. This makes retirement deterministic even for a quiet
         // group that has no new inbound events after restart.
-        if self.refresh_group_routes().map_err(SyncFailure::from)? {
+        let refresh = self.refresh_group_routes().map_err(SyncFailure::from)?;
+        if refresh.routing_changed || refresh.state_pruned {
             self.save_state_with_pending_local_group_deletion_frontier_clears()
                 .map_err(SyncFailure::from)?;
         }
@@ -465,7 +466,7 @@ impl AppClient {
         // Reconcile transport routes once after the batch drains instead of per
         // membership-changing event. This installs a join's current route and
         // retains any still-live address displaced by a routing rotation.
-        let routes_changed = self.refresh_group_routes()?;
+        let routes_changed = self.refresh_group_routes()?.routing_changed;
         if (routes_dirty || routes_changed)
             && let Err(error) = self.sync_runtime_groups().await
         {
@@ -520,7 +521,7 @@ impl AppClient {
                 None,
             )
             .await?;
-        let routes_changed = self.refresh_group_routes()?;
+        let routes_changed = self.refresh_group_routes()?.routing_changed;
         if routes_dirty || routes_changed {
             self.sync_runtime_groups().await?;
         }
@@ -650,9 +651,16 @@ impl AppClient {
         if routes_dirty {
             self.save_state_with_pending_local_group_deletion_frontier_clears()?;
         }
-        let routes_changed = self.refresh_group_routes()?;
-        self.save_state_with_pending_local_group_deletion_frontier_clears()?;
-        if routes_dirty || routes_changed {
+        let refresh = self.refresh_group_routes()?;
+        // The routes-dirty save above already persisted this delivery's app
+        // projection; save again only when that first save did not run, or
+        // when route retirement just mutated persisted group state. The
+        // routing-table delta lives in memory and obligates a subscription
+        // refresh, not a second identical state write.
+        if !routes_dirty || refresh.state_pruned {
+            self.save_state_with_pending_local_group_deletion_frontier_clears()?;
+        }
+        if routes_dirty || refresh.routing_changed {
             self.sync_runtime_groups().await?;
         }
         self.drain_epoch_stall_escalations(&mut summary);
@@ -820,7 +828,8 @@ impl AppClient {
     ) -> Result<(), SyncCheckpointError> {
         let routes_changed = self
             .refresh_group_routes()
-            .map_err(SyncCheckpointError::BeforePersistence)?;
+            .map_err(SyncCheckpointError::BeforePersistence)?
+            .routing_changed;
         let checkpoint = if cfg!(feature = "test-policy-overrides")
             && self
                 .app
@@ -1401,7 +1410,8 @@ impl AppClient {
     /// detection). Unlike the automatic detector path, this is a caller-owned
     /// operation and therefore does not mutate the detector's debounce state.
     pub(crate) async fn repair_full_history(&mut self) -> Result<SyncSummary, SyncFailure> {
-        if self.refresh_group_routes().map_err(SyncFailure::from)? {
+        let refresh = self.refresh_group_routes().map_err(SyncFailure::from)?;
+        if refresh.routing_changed || refresh.state_pruned {
             self.save_state_with_pending_local_group_deletion_frontier_clears()
                 .map_err(SyncFailure::from)?;
         }
@@ -1490,7 +1500,7 @@ impl AppClient {
                 None,
             )
             .await?;
-        let routes_changed = self.refresh_group_routes()?;
+        let routes_changed = self.refresh_group_routes()?.routing_changed;
         if routes_dirty || routes_changed {
             self.sync_runtime_groups().await?;
         }

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -616,12 +616,6 @@ impl AppClient {
             .account_home()
             .account(&self.state.label)?
             .account_id_hex;
-        let mut seen = self
-            .state
-            .seen_events
-            .iter()
-            .cloned()
-            .collect::<HashSet<_>>();
 
         loop {
             let delivery = self
@@ -630,13 +624,13 @@ impl AppClient {
                 .await?
                 .ok_or(AppError::TransportClosed)?;
             let event_id = hex::encode(delivery.message.id.as_slice());
-            if is_own_relay_echo(&delivery, &local_account_id_hex, &seen) {
+            if is_own_relay_echo(&delivery, &local_account_id_hex, &self.seen_events_index) {
                 continue;
             }
-            if seen.contains(&event_id) {
+            if self.seen_events_index.contains(&event_id) {
                 continue;
             }
-            remember_seen_event(&mut seen, &mut self.state, event_id);
+            remember_seen_event(&mut self.seen_events_index, &mut self.state, event_id);
             return Ok(delivery);
         }
     }
@@ -674,12 +668,6 @@ impl AppClient {
             .map_err(|source| SyncFailure::from(AppError::from(source)))?
             .account_id_hex;
         let mut summary = SyncSummary::default();
-        let mut seen = self
-            .state
-            .seen_events
-            .iter()
-            .cloned()
-            .collect::<HashSet<_>>();
         let mut first_wait = true;
         // Forensic drain accounting: wall-clock span, count of deliveries
         // actually ingested (echoes and already-seen duplicates are skipped and
@@ -715,10 +703,10 @@ impl AppClient {
                 Err(_) => break,
             };
             let event_id = hex::encode(delivery.message.id.as_slice());
-            if is_own_relay_echo(&delivery, &local_account_id_hex, &seen) {
+            if is_own_relay_echo(&delivery, &local_account_id_hex, &self.seen_events_index) {
                 continue;
             }
-            if seen.contains(&event_id) {
+            if self.seen_events_index.contains(&event_id) {
                 continue;
             }
             if cfg!(feature = "test-policy-overrides")
@@ -758,7 +746,7 @@ impl AppClient {
                         .await);
                 }
             };
-            remember_seen_event(&mut seen, &mut self.state, event_id);
+            remember_seen_event(&mut self.seen_events_index, &mut self.state, event_id);
             *deliveries = (*deliveries).saturating_add(1);
             summary.merge(delivery_summary);
             routes_dirty |= delivery_routes_dirty;

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -290,7 +290,10 @@ impl AppClient {
         // subscriptions. This makes retirement deterministic even for a quiet
         // group that has no new inbound events after restart.
         let refresh = self.refresh_group_routes().map_err(SyncFailure::from)?;
-        if refresh.routing_changed || refresh.state_pruned {
+        // A routing-table delta lives in memory and obligates the subscription
+        // refresh below, not a state write; only route retirement mutates
+        // persisted group state.
+        if refresh.state_pruned {
             self.save_state_with_pending_local_group_deletion_frontier_clears()
                 .map_err(SyncFailure::from)?;
         }
@@ -631,7 +634,6 @@ impl AppClient {
             if self.seen_events_index.contains(&event_id) {
                 continue;
             }
-            remember_seen_event(&mut self.seen_events_index, &mut self.state, event_id);
             return Ok(delivery);
         }
     }
@@ -642,9 +644,15 @@ impl AppClient {
     ) -> Result<SyncSummary, AppError> {
         let display_names = self.app.display_names_by_id()?;
         let mut summary = SyncSummary::default();
+        let event_id = hex::encode(delivery.message.id.as_slice());
         let routes_dirty = self
             .ingest_delivery(delivery, &display_names, &mut summary)
             .await?;
+        // Mark the delivery seen only after durable ingest succeeds, matching
+        // the catch-up drain below. Marking at receive time would let a failed
+        // ingest poison the index, so a reused client would silently skip the
+        // redelivered event.
+        remember_seen_event(&mut self.seen_events_index, &mut self.state, event_id);
         // A membership-changing ingest is already durable. Persist its app
         // projection before route reconciliation or subscription refresh can
         // fail, matching the catch-up checkpoint below.
@@ -1411,7 +1419,9 @@ impl AppClient {
     /// operation and therefore does not mutate the detector's debounce state.
     pub(crate) async fn repair_full_history(&mut self) -> Result<SyncSummary, SyncFailure> {
         let refresh = self.refresh_group_routes().map_err(SyncFailure::from)?;
-        if refresh.routing_changed || refresh.state_pruned {
+        // As in `sync_inner`: save only for persisted-state pruning, not for
+        // in-memory routing-table deltas.
+        if refresh.state_pruned {
             self.save_state_with_pending_local_group_deletion_frontier_clears()
                 .map_err(SyncFailure::from)?;
         }

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -1440,6 +1440,12 @@ impl MarmotApp {
         if let Some(lifecycle) = &lifecycle {
             lifecycle.ensure_running()?;
         }
+        let seen_events_index = open
+            .state
+            .seen_events
+            .iter()
+            .cloned()
+            .collect::<std::collections::HashSet<_>>();
         let mut client = AppClient {
             app: self.clone(),
             runtime: open.runtime,
@@ -1449,6 +1455,7 @@ impl MarmotApp {
             relay_plane: relay_plane.clone(),
             transport_signer: open.signer,
             state: open.state,
+            seen_events_index,
             pending_projection_updates: Vec::new(),
             pending_applied_sync_summary: SyncSummary::default(),
             pending_failed_sync_summary: SyncSummary::default(),

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -7115,6 +7115,139 @@ async fn an_escalation_recorded_during_a_received_delivery_rides_that_seam() {
     );
 }
 
+/// A delivery whose ingest fails must stay retryable on the same reused
+/// client.
+///
+/// `receive_next_delivery` must not mark the id seen before
+/// `ingest_received_delivery` commits it: a pre-ingest mark would poison the
+/// seen-events index on failure, so the reused client would silently skip the
+/// event when the relay redelivers it.
+#[cfg(feature = "test-policy-overrides")]
+#[tokio::test]
+async fn a_failed_ingest_leaves_the_delivery_retryable_on_the_reused_client() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(dir.path());
+    home.create_account("alice").unwrap();
+    let bob = home.create_account("bob").unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+        .with_test_relay_client(relay.clone());
+    // One shared plane for both clients, so a publish fans out locally into
+    // the other account's registered routes (`deliver_local_publish`).
+    let plane = MarmotRelayPlane::new(None, relay.clone());
+
+    let mut alice = app
+        .client_with_relay_plane("alice", &plane, None)
+        .await
+        .unwrap();
+    let mut bob_client = app
+        .client_with_relay_plane("bob", &plane, None)
+        .await
+        .unwrap();
+    // Register bob's inbox route before the welcome publishes.
+    bob_client.sync().await.unwrap();
+    let group_id = alice
+        .create_group("retryable failed ingest", &[bob.account_id_hex.as_str()])
+        .await
+        .unwrap();
+    let inject = |event: NostrTransportEvent| {
+        let plane = plane.clone();
+        async move {
+            plane
+                .handle_relay_event_for_test(NostrRelayEvent {
+                    endpoint: TransportEndpoint("wss://relay.example".to_owned()),
+                    subscription_id: None,
+                    event,
+                })
+                .await
+        }
+    };
+    assert!(
+        bob_client
+            .sync()
+            .await
+            .unwrap()
+            .joined_groups
+            .contains(&group_id),
+        "bob must join before the failing application message",
+    );
+
+    let published_before_send = relay.published_events.lock().unwrap().len();
+    alice
+        .send(&group_id, b"must survive a failed ingest")
+        .await
+        .unwrap();
+    let relay_event = relay
+        .published_events
+        .lock()
+        .unwrap()
+        .iter()
+        .skip(published_before_send)
+        .find(|event| event.kind == transport_nostr_peeler::KIND_MARMOT_GROUP_MESSAGE)
+        .cloned()
+        .expect("published group message backing the send");
+    bob_client
+        .app
+        .config
+        .dev_fail_ingest_after_application_event_ack = true;
+    let delivery = tokio::time::timeout(Duration::from_secs(5), bob_client.receive_next_delivery())
+        .await
+        .expect("locally fanned-out application message")
+        .unwrap();
+    let event_id = hex::encode(delivery.message.id.as_slice());
+    assert_eq!(event_id, relay_event.id);
+    bob_client
+        .ingest_received_delivery(delivery)
+        .await
+        .expect_err("the injected post-ack failure must surface");
+    assert!(
+        !bob_client.seen_events_index.contains(&event_id),
+        "a failed ingest must not mark the delivery seen",
+    );
+
+    // The relay redelivers (for example on resubscribe); the reused client
+    // must return the delivery again instead of skipping it as already seen.
+    bob_client
+        .app
+        .config
+        .dev_fail_ingest_after_application_event_ack = false;
+    assert!(
+        inject(relay_event).await.expect("route the redelivery") >= 1,
+        "the group route must accept the redelivery",
+    );
+    let redelivery =
+        tokio::time::timeout(Duration::from_secs(5), bob_client.receive_next_delivery())
+            .await
+            .expect("redelivered application message")
+            .unwrap();
+    assert_eq!(hex::encode(redelivery.message.id.as_slice()), event_id);
+    let summary = bob_client
+        .ingest_received_delivery(redelivery)
+        .await
+        .expect("the retry must ingest the redelivered event");
+    assert!(
+        bob_client.seen_events_index.contains(&event_id),
+        "a successful ingest must mark the delivery seen",
+    );
+    // The first attempt durably projected the message before its injected
+    // post-ack failure, so the retried duplicate must not project it again.
+    // (Live-summary replay after a post-ack failure is pinned separately in
+    // `tests/partial_sync_summary.rs`.)
+    assert!(
+        summary.messages.is_empty(),
+        "the retried duplicate must not re-project the already-applied message",
+    );
+    assert_eq!(
+        app.messages("bob")
+            .unwrap()
+            .iter()
+            .map(|message| message.plaintext.as_str())
+            .collect::<Vec<_>>(),
+        vec!["must survive a failed ingest"],
+        "the failed delivery's message must be durably projected exactly once",
+    );
+}
+
 /// Every SQLite database this app can open, plus the root runtime lease, must
 /// be released by one `close_storage` call — that is the whole contract iOS
 /// depends on before it suspends the process (`0xdead10cc` is raised for *any*


### PR DESCRIPTION
Every inbound delivery (`receive_next_delivery`), every catch-up drain (`sync_sdk_relay`), and every publish-report batch (`remember_published_reports`) rebuilt a `HashSet` from the full `state.seen_events` ring: up to 16,384 string clones per message on the hottest app-layer path.

The odd part is that `remember_seen_event` already maintains a caller-held set incrementally, inserting new ids and removing pruned ring entries. The waste was that every caller built that set from scratch and threw it away. This PR holds it as `AppClient::seen_events_index`: built once at client construction, used directly by all three call sites.

The index is derived state over the ordered ring. It is never persisted, the ring's serialization is untouched, the ring is never mutated outside `remember_seen_event`, and the client's state is never replaced after construction, so the two cannot drift. The existing `remember_seen_event` tests pin the lockstep contract.

One marmot checks the burrow ledger; it does not recopy the ledger to check it.

Verified with `just fast-ci` and `cargo nextest run -p marmot-app --lib` (631 tests).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved event synchronization performance, especially when processing large histories.
  - Enhanced duplicate-event filtering to help prevent repeated deliveries during synchronization.
  - Improved route synchronization and recovery, reducing unnecessary state updates while preserving required changes.
  - Increased reliability when refreshing routes, repairing state, and reaching synchronization convergence.

- **Bug Fixes**
  - Fixed event delivery retries after a failed ingestion, ensuring events can be processed successfully without creating duplicate durable results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->