### PR TITLE
perf(marmot-app): save once per delivery unless route retirement changed state

### DIFF
--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -84,6 +84,20 @@ where
     results.into_iter().map(|(_, result)| result).collect()
 }
 
+/// Outcome of one [`AppClient::refresh_group_routes`] pass, separating the
+/// in-memory routing-table delta from durable-state mutation: only the latter
+/// obligates a state save, only the former obligates a relay-subscription
+/// refresh.
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct GroupRouteRefresh {
+    /// The in-memory routing table changed; relay subscriptions need a
+    /// `sync_runtime_groups` refresh.
+    pub(crate) routing_changed: bool,
+    /// `prune_prior_nostr_routes` removed retired prior routes from persisted
+    /// group state; a save is required for the retirement to stick.
+    pub(crate) state_pruned: bool,
+}
+
 pub struct AppClient {
     pub(crate) app: MarmotApp,
     pub(crate) runtime: AppRuntime,
@@ -3163,8 +3177,8 @@ impl AppClient {
 
     /// Reconcile every group's current and still-live prior transport
     /// subscriptions, returning whether any installed route changed.
-    pub(crate) fn refresh_group_routes(&mut self) -> Result<bool, AppError> {
-        let mut changed = false;
+    pub(crate) fn refresh_group_routes(&mut self) -> Result<GroupRouteRefresh, AppError> {
+        let mut refresh = GroupRouteRefresh::default();
         for group in &mut self.state.groups {
             let Ok(group_id_bytes) = hex::decode(&group.group_id_hex) else {
                 tracing::warn!(
@@ -3182,7 +3196,7 @@ impl AppClient {
                 .is_ok_and(|group| group.disbanded.is_some())
             {
                 if self.routing.replace_group_routes(&group_id, Vec::new()) {
-                    changed = true;
+                    refresh.routing_changed = true;
                 }
                 continue;
             }
@@ -3196,7 +3210,7 @@ impl AppClient {
                 .unwrap_or(true)
                 && let Ok(group_record) = self.runtime.group_record(&group_id)
             {
-                group.prune_prior_nostr_routes(group_record.epoch.0);
+                refresh.state_pruned |= group.prune_prior_nostr_routes(group_record.epoch.0);
             }
             let Ok(subscriptions) = group.transport_subscriptions(&group_id) else {
                 tracing::warn!(
@@ -3208,10 +3222,10 @@ impl AppClient {
                 continue;
             };
             if self.routing.replace_group_routes(&group_id, subscriptions) {
-                changed = true;
+                refresh.routing_changed = true;
             }
         }
-        Ok(changed)
+        Ok(refresh)
     }
 
     fn refresh_routing(&mut self) -> Result<(), AppError> {

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -289,7 +289,8 @@ impl AppClient {
         // Reconcile epoch-bounded prior routes before issuing the first relay
         // subscriptions. This makes retirement deterministic even for a quiet
         // group that has no new inbound events after restart.
-        if self.refresh_group_routes().map_err(SyncFailure::from)? {
+        let refresh = self.refresh_group_routes().map_err(SyncFailure::from)?;
+        if refresh.routing_changed || refresh.state_pruned {
             self.save_state_with_pending_local_group_deletion_frontier_clears()
                 .map_err(SyncFailure::from)?;
         }
@@ -465,7 +466,7 @@ impl AppClient {
         // Reconcile transport routes once after the batch drains instead of per
         // membership-changing event. This installs a join's current route and
         // retains any still-live address displaced by a routing rotation.
-        let routes_changed = self.refresh_group_routes()?;
+        let routes_changed = self.refresh_group_routes()?.routing_changed;
         if (routes_dirty || routes_changed)
             && let Err(error) = self.sync_runtime_groups().await
         {
@@ -520,7 +521,7 @@ impl AppClient {
                 None,
             )
             .await?;
-        let routes_changed = self.refresh_group_routes()?;
+        let routes_changed = self.refresh_group_routes()?.routing_changed;
         if routes_dirty || routes_changed {
             self.sync_runtime_groups().await?;
         }
@@ -650,9 +651,16 @@ impl AppClient {
         if routes_dirty {
             self.save_state_with_pending_local_group_deletion_frontier_clears()?;
         }
-        let routes_changed = self.refresh_group_routes()?;
-        self.save_state_with_pending_local_group_deletion_frontier_clears()?;
-        if routes_dirty || routes_changed {
+        let refresh = self.refresh_group_routes()?;
+        // The routes-dirty save above already persisted this delivery's app
+        // projection; save again only when that first save did not run, or
+        // when route retirement just mutated persisted group state. The
+        // routing-table delta lives in memory and obligates a subscription
+        // refresh, not a second identical state write.
+        if !routes_dirty || refresh.state_pruned {
+            self.save_state_with_pending_local_group_deletion_frontier_clears()?;
+        }
+        if routes_dirty || refresh.routing_changed {
             self.sync_runtime_groups().await?;
         }
         self.drain_epoch_stall_escalations(&mut summary);
@@ -820,7 +828,8 @@ impl AppClient {
     ) -> Result<(), SyncCheckpointError> {
         let routes_changed = self
             .refresh_group_routes()
-            .map_err(SyncCheckpointError::BeforePersistence)?;
+            .map_err(SyncCheckpointError::BeforePersistence)?
+            .routing_changed;
         let checkpoint = if cfg!(feature = "test-policy-overrides")
             && self
                 .app
@@ -1401,7 +1410,8 @@ impl AppClient {
     /// detection). Unlike the automatic detector path, this is a caller-owned
     /// operation and therefore does not mutate the detector's debounce state.
     pub(crate) async fn repair_full_history(&mut self) -> Result<SyncSummary, SyncFailure> {
-        if self.refresh_group_routes().map_err(SyncFailure::from)? {
+        let refresh = self.refresh_group_routes().map_err(SyncFailure::from)?;
+        if refresh.routing_changed || refresh.state_pruned {
             self.save_state_with_pending_local_group_deletion_frontier_clears()
                 .map_err(SyncFailure::from)?;
         }
@@ -1490,7 +1500,7 @@ impl AppClient {
                 None,
             )
             .await?;
-        let routes_changed = self.refresh_group_routes()?;
+        let routes_changed = self.refresh_group_routes()?.routing_changed;
         if routes_dirty || routes_changed {
             self.sync_runtime_groups().await?;
         }


### PR DESCRIPTION
Stacked on the `seen-events-index` PR.

`ingest_received_delivery` persisted the full account state twice for every membership-changing delivery: once behind the `routes_dirty` checkpoint, then unconditionally again after `refresh_group_routes`. Each save snapshots every group plus the 16k-entry seen-events ring, so the double write was pure duplication whenever route reconciliation left persisted state untouched.

The root cause is that `refresh_group_routes` conflated two different outcomes in one bool: the in-memory routing-table delta (which obligates a relay-subscription refresh, not a save) and prior-route retirement via `prune_prior_nostr_routes` (which mutates persisted group state and does obligate a save; its return value was silently dropped). This PR splits them into `GroupRouteRefresh { routing_changed, state_pruned }`.

- The delivery path saves a second time only when the first save did not run or pruning actually mutated state.
- The `sync_inner` and catch-up route-reconciliation sites gain the `state_pruned` trigger. That fixes a latent miss: retirement previously went unpersisted unless the routing table happened to change in the same pass.
- Checkpoint paths whose unconditional boundary save already covers pruning keep their behavior unchanged.

The marmot stamps the winter ledger once per delivery, not twice for the same acorns.

Verified with `just fast-ci` and `cargo nextest run -p marmot-app` (743 passing; the 5 relay_runtime failures are this machine's known environment failures and reproduce on clean master).
