### PR TITLE
Fix nightly app-witness oracle and retain failure evidence

### DIFF
--- a/.github/workflows/simulator-nightly.yml
+++ b/.github/workflows/simulator-nightly.yml
@@ -51,7 +51,32 @@ jobs:
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Run nightly convergence lane
-        run: just convergence-nightly-lane
+        id: convergence_lane
+        continue-on-error: true
+        run: |
+          # SQLCipher deliberately locks sensitive allocations. Give the test
+          # process enough memlock headroom so the runner does not amplify one
+          # warning per allocation when its inherited limit is exhausted.
+          sudo prlimit --pid "$$" --memlock=unlimited:unlimited
+          just convergence-nightly-lane
+
+      - name: Capture failed adversarial scenarios
+        if: steps.convergence_lane.outcome == 'failure'
+        continue-on-error: true
+        run: |
+          sudo prlimit --pid "$$" --memlock=unlimited:unlimited
+          cargo run -p cgka-conformance-simulator \
+            --bin cgka-conformance-simulator-report --locked -- \
+            --family adversarial-reliability/v1 \
+            --seed 7 \
+            --cases 12 \
+            --out target/cgka-conformance-simulator-nightly-reports \
+            --storage file \
+            --strict-oracle
+
+      - name: Propagate nightly convergence failure
+        if: steps.convergence_lane.outcome == 'failure'
+        run: exit 1
 
       - name: Run simulator doctests
         run: cargo test -p cgka-conformance-simulator --doc --locked

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -741,11 +741,14 @@ regression, covers a new semantic edge, or is the smallest readable example of a
 
 ### Adversarial Reliability Catalog
 
-`adversarial-reliability/v1` (generator version `3`) rotates through twelve deterministic workload shapes: retained-history offline floods;
+`adversarial-reliability/v1` (generator version `4`) rotates through twelve deterministic workload shapes: retained-history offline floods;
 sustained app/proposal/commit traffic; self-update versus admin progress; a named unrecoverable losing-branch invite;
 unequal relay reconciliation; restart boundaries plus the engine's real SIGKILL durable-phase matrix; multi-group noisy
 neighbors; replay-budget exhaustion; shared-account multi-device witnesses; full-engine app-witness A/B selection;
 mixed-binary compatibility with mixed-policy preflight rejection; and clock, scheduler, timestamp, and cursor attacks.
+The app-witness case pins the exact payload multiplicity for each candidate branch but deliberately does not claim an
+order between messages from different senders; scenarios that inject a transport reorder continue to pin ordered
+`received_payloads` explicitly.
 
 The normal test target runs small headline regressions. The multi-round sustained case is ignored by default and is
 invoked explicitly; the report CLI runs any number of seeded cases with either in-memory or encrypted file-backed

--- a/crates/cgka-conformance-simulator/src/family.rs
+++ b/crates/cgka-conformance-simulator/src/family.rs
@@ -335,7 +335,7 @@ pub fn generate_adversarial_reliability_case(seed: u64, case_index: u64) -> Gene
     add_strict_reliability_oracle(&mut scenario, &mut expected_outcomes);
     GeneratedScenarioCase {
         family_name,
-        generator_version: "3".into(),
+        generator_version: "4".into(),
         seed,
         case_index,
         subject,
@@ -1785,12 +1785,16 @@ fn admin_policy_step(client: &str, admins: Vec<String>, pending: &str) -> Scenar
 }
 
 fn payload_absent_assert(client: &str, payload: &str) -> ScenarioStep {
+    payload_count_assert(client, payload, 0)
+}
+
+fn payload_count_assert(client: &str, payload: &str, count: usize) -> ScenarioStep {
     ScenarioStep::Assert {
         assertion: crate::ScenarioAssertionV2::Exactly {
             predicate: crate::ScenarioPredicateV2::PayloadCount {
                 client: client.into(),
                 payload: payload.into(),
-                count: 0,
+                count,
             },
         },
     }
@@ -2960,6 +2964,11 @@ fn adversarial_reliability_app_witness_value(
                 delta_ms: 30 * 24 * 60 * 60 * 1_000 + 1,
             },
             tick(["alice", "bob", "carol", "david", "eve", "frank"]),
+            // MLS does not define an order between different senders. Pin the
+            // exact payload multiset without inventing a cross-sender order.
+            payload_count_assert("carol", &format!("eve-witness-{case_index}"), 1),
+            payload_count_assert("carol", &format!("frank-witness-{case_index}"), 1),
+            payload_count_assert("carol", &format!("david-witness-{case_index}"), 0),
         ],
     };
     (
@@ -2971,15 +2980,14 @@ fn adversarial_reliability_app_witness_value(
             // Bob's branch carries two app witnesses against alice's one, so
             // witness-decided selection deterministically keeps eve's and
             // frank's payloads and never emits david's on carol.
-            client_state(
-                "carol",
-                2,
-                5,
-                vec![
-                    format!("eve-witness-{case_index}"),
-                    format!("frank-witness-{case_index}"),
-                ],
-            ),
+            TraceExpectation::ClientState {
+                client: "carol".into(),
+                epoch: 2,
+                member_count: 5,
+                received_payloads: None,
+                added_members: None,
+                removed_members: None,
+            },
         ],
     )
 }

--- a/crates/cgka-conformance-simulator/tests/adversarial_reliability_campaigns.rs
+++ b/crates/cgka-conformance-simulator/tests/adversarial_reliability_campaigns.rs
@@ -32,7 +32,7 @@ fn generator_versions_track_the_renamed_output_contract() {
     assert!(
         generate_adversarial_reliability_family(7, 12)
             .iter()
-            .all(|case| case.generator_version == "3")
+            .all(|case| case.generator_version == "4")
     );
     for case in [
         generate_adversarial_reliability_offline_regression(7),
@@ -41,6 +41,57 @@ fn generator_versions_track_the_renamed_output_contract() {
     ] {
         assert_eq!(case.generator_version, "3-regression");
     }
+}
+
+#[test]
+fn app_witness_case_pins_payload_multiplicity_without_cross_sender_order() {
+    let case = generate_adversarial_reliability_case(7, 9);
+    let carol_payload_order = case.expected_outcomes.iter().find_map(|expectation| {
+        if let cgka_conformance_simulator::TraceExpectation::ClientState {
+            client,
+            received_payloads,
+            ..
+        } = expectation
+            && client == "carol"
+        {
+            return Some(received_payloads);
+        }
+        None
+    });
+    assert_eq!(carol_payload_order, Some(&None));
+
+    let payload_counts = case
+        .scenario
+        .steps
+        .iter()
+        .filter_map(|step| {
+            if let cgka_conformance_simulator::ScenarioStep::Assert {
+                assertion:
+                    cgka_conformance_simulator::ScenarioAssertionV2::Exactly {
+                        predicate:
+                            cgka_conformance_simulator::ScenarioPredicateV2::PayloadCount {
+                                client,
+                                payload,
+                                count,
+                            },
+                    },
+            } = step
+                && client == "carol"
+                && payload.ends_with("-witness-9")
+            {
+                return Some((payload.as_str(), *count));
+            }
+            None
+        })
+        .collect::<std::collections::BTreeMap<_, _>>();
+    assert_eq!(
+        payload_counts,
+        std::collections::BTreeMap::from([
+            ("david-witness-9", 0),
+            ("eve-witness-9", 1),
+            ("frank-witness-9", 1),
+        ])
+    );
 }
 
 async fn assert_generated_case(case_index: usize) -> cgka_conformance_simulator::ScenarioReport {

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "Convergence Reliability And Simulation Plan"
 created: 2026-07-30
-updated: 2026-08-12
+updated: 2026-08-13
 tags: [marmot, cgka, convergence, simulation, verification, reliability]
 status: working-plan
 ---
@@ -998,10 +998,14 @@ through app-runtime, process, retained-history, or distributed execution. Milest
 equivalence and cryptographic interoperability as first-class campaign properties rather than assuming that either the
 engine repair or scaling the existing corpus is sufficient.
 
-Status update (2026-08, option C route unification): the pairwise fork-recovery route has since been deleted — every
-member adjudicates a same-epoch rival through distributed convergence, so the specific committer-versus-observer
-asymmetry above no longer exists structurally. The 6.1 items below remain the assurance program for the routes that
-still exist (ordinary ingest, stored convergence, retained-history replay, crash/restart recovery).
+Status update (2026-08, option C route unification):
+[MDK #1293](https://github.com/marmot-protocol/mdk/pull/1293) deleted the pairwise fork-recovery route — every member
+now adjudicates a same-epoch rival through distributed convergence, so the specific committer-versus-observer
+asymmetry above no longer exists structurally. [MDK #1403](https://github.com/marmot-protocol/mdk/pull/1403) then
+closed the queued-outbound scheduling defect exposed by that unification. The 6.1 items below remain the assurance
+program for the routes that still exist (ordinary ingest, stored convergence, retained-history replay, and
+crash/restart recovery). The pre-unification app-runtime counterexample remains valuable historical evidence, but it
+must be rerun on the unified route before it can describe current `master`.
 
 ### 6.1 Decision-route assurance closure
 
@@ -1053,11 +1057,13 @@ reliably. Preserve and minimize that counterexample before changing production c
 dependency-closed input contract into process/container/VM execution and the remaining durable-transition
 permutations.
 
-[MDK #1329](https://github.com/marmot-protocol/mdk/pull/1329) has now merged the fail-closed missing-anchor behavior and
-Welcome-repair retirement. Its formerly stacked [MDK #1293](https://github.com/marmot-protocol/mdk/pull/1293) remains
-open and is not part of the oracle. The route inventory, assurance claims, and campaign inputs remain independently
-reviewable and runnable against current `master`; a production PR may change the implementation under test, but not
-silently redefine the expected result.
+[MDK #1329](https://github.com/marmot-protocol/mdk/pull/1329) merged the fail-closed missing-anchor behavior and
+Welcome-repair retirement. Its formerly stacked [MDK #1293](https://github.com/marmot-protocol/mdk/pull/1293) has now
+merged the single distributed same-epoch route, and [MDK #1403](https://github.com/marmot-protocol/mdk/pull/1403)
+repairs the durable queued-send scheduling edge it exposed. The route inventory, assurance claims, and campaign inputs
+remain independently reviewable and runnable against current `master`; a production PR may change the implementation
+under test, but not silently redefine the expected result. Revalidate the app-runtime counterexample after those
+production changes before deciding whether it is still a live defect or only pre-unification evidence.
 
 ### 6.2 Container and VM execution
 
@@ -1253,9 +1259,11 @@ residual gap.
    reference passes exact state, dispositions, pending-work, and decryptability checks. A focused
    hide/repair/restore/repair regression fixes and protects the original destructive event-id tombstone bug, but
    repeated corrected-input app runs still produce both complete equivalence and a two-branch protocol/probe split.
-   Route equivalence, active decryptability, and complete application disposition therefore remain open alongside
-   process/container/VM execution and durable-transition permutations. The decision-route inventory is machine
-   checked; keep the remaining assurance artifacts independent of #1293.
+   Those repeated executions predate the merged route unification and queued-send scheduling repair. Re-run the exact
+   corrected-input app-runtime scenario on current `master` before carrying its outcome into process/container/VM
+   execution. Route equivalence, active decryptability, complete application disposition, distributed execution, and
+   durable-transition permutations remain open. The decision-route inventory is machine checked against the unified
+   route.
 6. [x] Land and execute a focused current-`master` regression gate for the production convergence changes that landed
    after the reviewed 1,170-case snapshot. Cover #1329 missing-anchor halt and authenticated Welcome repair, #1360
    atomic self-removal persistence across injected write failures and restart, #1365 armed full-history backfill after
@@ -1430,6 +1438,9 @@ incorrect result.
 | 2026-08-11 | 6.1 app-runtime cross-route falsification | Added action-addressed event staging to the app-runtime harness's real retained Nostr relay so offline recipients cannot race the intended four-party branch topology. The strict retained-engine reference still reaches exact state, durable commit dispositions, no pending work, and twelve active decryptability edges; repeated app-runtime executions have three exact counterexample surfaces: Zeta one epoch behind, public agreement with Alpha's probe missing at Zeta, or an Alpha/Observer versus Yankee/Zeta protocol-and-probe split. A fourth shape or complete equivalence now fails the characterization. This is retained counterexample evidence, not passing route-equivalence evidence; no production convergence behavior changed. | `cross-route-app-runtime-recovery/v1`; `four_party_cross_route_recovery_records_app_runtime_equivalence_falsification`; route-assurance claims reopened |
 | 2026-08-11 | 6.1 pairwise route retirement | Retired the `pairwise_fork_recovery` decision-route claim after the option C unification deleted the route: the inventory entry, enum variant, and matrix row were removed rather than re-pointed at distributed convergence, which already holds its own route claim and would have double-counted the same seam. The two surviving properties are cited under `stored_convergence` as the renamed engine regressions, and the abstract route-lifecycle mutant survives route-agnostically | [MDK #1293](https://github.com/marmot-protocol/mdk/pull/1293); `route_assurance`; `provisional_winner_terminalization`; [`CONVERGENCE_ROUTE_MATRIX.md`](../../crates/cgka-conformance-simulator/CONVERGENCE_ROUTE_MATRIX.md) retired-routes record |
 | 2026-08-12 | 6.1 app-runtime cross-route corrected-input evidence | Replaced destructive event deletion with a reversible relay query-visibility layer and added a focused offline hide/repair/restore/repair regression. Repeated validation disproved the proposed positive-equivalence rewrite: corrected-input executions can reach full equivalence or retain a two-branch public/probe split even though the strict retained-engine reference reaches exact canonical state, accepted/invalidated/accepted commit dispositions, no pending work, and twelve decryptability edges. The corrected-input characterization passed 20/20 consecutive executions on commit `2461b874`, while the equivalence-only contract failed during its repetition sequence. The app-runtime route-equivalence, active-decryptability, and complete-application-disposition claims remain open; no production behavior changed. | `retained_relay_control_restores_hidden_history_for_offline_repair`; `four_party_cross_route_recovery_characterizes_corrected_app_runtime_outcomes`; corrected simulator input contract plus retained falsification |
+| 2026-08-12 | 6.1 unified same-epoch route and queued-send repair | Merged option C: removed the pairwise committer-only fork route so every participant uses distributed convergence, added branch-relative peel contexts and route-equivalence evidence, then repaired the durable queued-outbound scheduling edge and runnable-work level signal exposed by the longer unified convergence window. The corrected-input app-runtime result above predates both changes and is retained as historical falsification evidence, not a characterization of current `master`; repeat it before assigning the next production defect. | [MDK #1293](https://github.com/marmot-protocol/mdk/pull/1293); [MDK #1403](https://github.com/marmot-protocol/mdk/pull/1403); unified-route engine and simulator regressions |
+| 2026-08-13 | Post-unification campaign performance baseline | Replaced full retained-message scans with indexed state probes, scoped retained-anchor snapshots to canonical group state while keeping legacy full-snapshot rollback compatibility, and point-queried Welcome key packages plus buffered replay states during join/create lifecycle work. These changes reduce the cost of long-history and participant-growth campaigns but do not close any route-equivalence or distributed evidence item by themselves. | [MDK #1405](https://github.com/marmot-protocol/mdk/pull/1405); [MDK #1406](https://github.com/marmot-protocol/mdk/pull/1406); [MDK #1416](https://github.com/marmot-protocol/mdk/pull/1416); storage and engine suites plus lifecycle benchmarks |
+| 2026-08-13 | Nightly cross-sender oracle correction | Diagnosed the scheduled lane failure as an invalid ordering claim in `adversarial-reliability/app-witness-value/v1`: both runs agreed on the selected branch, epoch, roster, and exact payload multiplicities, but MLS does not define a total order across independent senders. The scenario now asserts one Eve witness, one Frank witness, and no David witness without weakening scenarios that intentionally test ordered delivery. A failed nightly lane also emits the exact seed-7 adversarial reports and capsules before propagating failure, and the runner raises its memlock limit instead of flooding logs when SQLCipher locks sensitive allocations. | [MDK #1409](https://github.com/marmot-protocol/mdk/issues/1409); scheduled run `31669097875`; focused adversarial reliability tests; nightly artifact path |
 
 ## Capability Naming Cleanup
 


### PR DESCRIPTION
## Summary

- reconcile the convergence reliability plan with merged route unification, queued-send scheduling, and campaign-performance work
- fix the seed-7 app-witness oracle by asserting exact payload multiplicities without inventing an MLS cross-sender delivery order
- bump the adversarial catalog generator contract to v4 and pin the new order-neutral contract structurally
- make a failed nightly lane reproduce the exact adversarial catalog into durable reports/capsules before propagating failure
- raise the hosted runner's memlock limit for the nightly processes so SQLCipher memory locking does not amplify one warning per allocation

## Root cause

The nightly run in #1409 reached the same canonical branch, epoch, roster, and payload set in both failing tests. It failed only because Carol observed Frank's and Eve's messages in the opposite order from the `ClientState.received_payloads` expectation. MLS does not define a total order between independent senders.

The fix deliberately preserves the ordered `received_payloads` contract used by transport-reorder scenarios. Only `adversarial-reliability/app-witness-value/v1` switches to exact `PayloadCount` assertions: one Eve witness, one Frank witness, and zero David witnesses.

## Scope

Simulator scenario/oracle data, its tests/docs, the tracking plan, and the scheduled workflow only. No production convergence, app-runtime, storage, or protocol behavior changes.

## Verification

- `cargo nextest run -p cgka-conformance-simulator --features test-policy-overrides --test adversarial_reliability_campaigns --locked` (12 passed, 3 ignored)
- `just fast-ci`
- `actionlint .github/workflows/simulator-nightly.yml`
- docs stale-language scan from `docs/AGENTS.md`

Closes #1409.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nightly reliability validation with clearer failure handling and diagnostic reports.
  * Corrected adversarial scenario checks to validate per-sender payload counts without requiring unsupported cross-sender ordering.
  * Updated reliability test coverage for app-witness scenarios.

* **Documentation**
  * Updated reliability scenarios and architecture progress notes, including current milestone status and validation guidance.
  * Documented expanded workload shapes and clarified payload-ordering expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->