### PR TITLE
Implement versioned storage format v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,6 +957,7 @@ name = "cgka-traits"
 version = "0.9.11"
 dependencies = [
  "async-trait",
+ "criterion",
  "hex",
  "insta",
  "openmls_traits",

--- a/crates/cgka-engine/benches/group_lifecycle.rs
+++ b/crates/cgka-engine/benches/group_lifecycle.rs
@@ -25,6 +25,7 @@ use cgka_traits::group::ProtocolProfile;
 use cgka_traits::group_context::GroupContextSnapshot;
 use cgka_traits::ingest::{PeeledContent, PeeledMessage};
 use cgka_traits::peeler::TransportPeeler;
+use cgka_traits::storage::MessageStorage;
 use cgka_traits::transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
 };
@@ -160,13 +161,62 @@ impl TransportPeeler for BenchPeeler {
 // ── Engine construction ─────────────────────────────────────────────────────
 
 fn build_client(identity: &[u8]) -> Engine<SqliteAccountStorage> {
-    EngineBuilder::new(SqliteAccountStorage::in_memory().unwrap())
+    build_client_with_storage(identity, SqliteAccountStorage::in_memory().unwrap())
+}
+
+fn build_client_with_storage(
+    identity: &[u8],
+    storage: SqliteAccountStorage,
+) -> Engine<SqliteAccountStorage> {
+    EngineBuilder::new(storage)
         .identity(pad32(identity))
         .account_identity_proof_signer(proof_signer(identity))
         .protocol_profile(ProtocolProfile::Current)
         .peeler(Box::new(BenchPeeler))
         .build()
         .expect("build bench engine")
+}
+
+// ── retained-anchor snapshot capture ───────────────────────────────────────
+
+fn bench_retained_anchor_snapshot(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("bench runtime");
+    let mut group = c.benchmark_group("retained_anchor_snapshot");
+    for invitees in [0_usize, 32] {
+        let storage = SqliteAccountStorage::in_memory().unwrap();
+        let mut alice = build_client_with_storage(
+            format!("bench-alice-snapshot-{invitees}").as_bytes(),
+            storage.clone(),
+        );
+        let key_packages = invitee_key_packages(invitees);
+        let (group_id, _) = rt
+            .block_on(alice.create_group(create_request(key_packages)))
+            .expect("create_group succeeds");
+
+        group.bench_function(
+            BenchmarkId::from_parameter(format!("{invitees} invitees")),
+            |b| {
+                b.iter(|| {
+                    storage
+                        .create_group_state_snapshot(&group_id, "bench-retained-anchor")
+                        .expect("snapshot capture succeeds")
+                });
+            },
+        );
+        group.bench_function(
+            BenchmarkId::from_parameter(format!("{invitees} invitees, full rollback")),
+            |b| {
+                b.iter(|| {
+                    storage
+                        .create_group_snapshot(&group_id, "bench-full-rollback")
+                        .expect("full snapshot capture succeeds")
+                });
+            },
+        );
+    }
+    group.finish();
 }
 
 /// Mint one fresh KeyPackage per invitee identity. Each identity gets its own
@@ -364,6 +414,7 @@ fn bench_join_welcome_large_group(c: &mut Criterion) {
 criterion_group!(
     benches,
     bench_create_group,
+    bench_retained_anchor_snapshot,
     bench_join_welcome,
     bench_join_welcome_large_group
 );

--- a/crates/storage-sqlite/AGENTS.md
+++ b/crates/storage-sqlite/AGENTS.md
@@ -35,6 +35,11 @@ not "fix" it into the per-account database.
   `docs/marmot-architecture/overview/local-artifact-safety.md`.
 - Retained-anchor policy is engine/group policy. SQLite stores snapshots and policy bytes; the engine decides when to
   prune.
+- Follow `docs/marmot-architecture/storage-format-v2.md`: numbered schema migrations gate database compatibility;
+  independently decoded blobs carry artifact-local versions; new `cgka_messages` writes use normalized format 2;
+  legacy format-1 rows remain readable and promote atomically on mutation.
+- Never make `record` and normalized message columns competing authorities. In format 2, scalar columns, `payload`,
+  and `deferred_peel` are authoritative and `record` is `NULL`.
 - Migration file names use padded numeric prefixes, for example `0001_initial_schema.rs`.
 
 ## Verification

--- a/crates/storage-sqlite/src/codec.rs
+++ b/crates/storage-sqlite/src/codec.rs
@@ -27,7 +27,7 @@ impl SensitiveBytes {
         Self(Zeroizing::new(bytes))
     }
 
-    fn with_capacity(capacity: usize) -> Self {
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
         Self(Zeroizing::new(Vec::with_capacity(capacity)))
     }
 
@@ -51,6 +51,24 @@ impl SensitiveBytes {
             drop(previous);
         }
         self.0.push(byte);
+    }
+
+    pub(crate) fn extend_exact(&mut self, bytes: &[u8]) -> StorageResult<()> {
+        if bytes.len() > self.0.capacity().saturating_sub(self.0.len()) {
+            return Err(StorageError::Serialization(
+                "sensitive binary encoding exceeded its exact allocation".to_owned(),
+            ));
+        }
+        self.0.extend_from_slice(bytes);
+        Ok(())
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub(crate) fn capacity(&self) -> usize {
+        self.0.capacity()
     }
 }
 
@@ -229,6 +247,22 @@ pub(crate) fn message_state_to_i64(state: MessageState) -> i64 {
         MessageState::EpochInvalidated => 5,
         MessageState::PeelDeferred => 6,
         MessageState::ConvergenceDeferred => 7,
+    }
+}
+
+pub(crate) fn message_state_from_i64(state: i64) -> StorageResult<MessageState> {
+    match state {
+        0 => Ok(MessageState::Sent),
+        1 => Ok(MessageState::Created),
+        2 => Ok(MessageState::Processed),
+        3 => Ok(MessageState::Failed),
+        4 => Ok(MessageState::Retryable),
+        5 => Ok(MessageState::EpochInvalidated),
+        6 => Ok(MessageState::PeelDeferred),
+        7 => Ok(MessageState::ConvergenceDeferred),
+        _ => Err(StorageError::Serialization(format!(
+            "unknown stored message state {state}"
+        ))),
     }
 }
 

--- a/crates/storage-sqlite/src/lib.rs
+++ b/crates/storage-sqlite/src/lib.rs
@@ -47,6 +47,7 @@ pub use shared::{
     PublicDirectoryUserRecord, SqliteSharedStorage, StoredAuditLogSettings,
     StoredRelayTelemetrySettings,
 };
+pub use storage::messages::MessageFormatPromotionProgress;
 pub use timeline::{
     MAX_TIMELINE_LIMIT, SecurePruneAppEventsResult, StoredAppEvent, TimelineMessageChange,
     TimelineMessageQuery, TimelineMessageRecord, TimelineMessageTarget, TimelinePage,
@@ -60,6 +61,7 @@ pub use agent_stream_sequences::{
 };
 pub(crate) use codec::{
     SQLITE_BIND_PARAMETER_CHUNK, SqliteResultExt, bool_i64, created_at_to_i64, deserialize,
-    epoch_to_i64, i64_to_u64, i64_to_usize, message_state_to_i64, optional_u64_to_i64, serialize,
-    tags_from_json, u64_to_i64, unix_now_ms, unix_now_seconds, unix_now_seconds_i64, usize_to_i64,
+    epoch_to_i64, i64_to_u64, i64_to_usize, message_state_from_i64, message_state_to_i64,
+    optional_u64_to_i64, serialize, tags_from_json, u64_to_i64, unix_now_ms, unix_now_seconds,
+    unix_now_seconds_i64, usize_to_i64,
 };

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -519,17 +519,18 @@ fn apply_migration(connection: &mut Connection, migration: &Migration) -> Storag
 
 #[cfg(test)]
 fn migration_crash_pause(version: i64) {
-    use std::io::Write;
-
     let expected = version.to_string();
     if std::env::var("MDK_STORAGE_TEST_MIGRATION_CRASH_VERSION").as_deref() != Ok(expected.as_str())
     {
         return;
     }
-    println!("MDK_STORAGE_TEST_CRASH_READY:migration-{version}");
-    std::io::stdout()
-        .flush()
-        .expect("flush migration crash point");
+    let ready = std::env::var_os("MDK_STORAGE_TEST_CRASH_READY_FILE")
+        .expect("migration crash ready-file path");
+    std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(ready)
+        .expect("create migration crash ready file");
     loop {
         std::thread::park();
     }
@@ -545,16 +546,16 @@ mod tests {
     };
     use cgka_traits::message::MessageRecord;
     use cgka_traits::storage::{GroupStorage, MessageStorage};
-    use std::io::{BufRead, BufReader, Read};
+    use std::io::Read;
     use std::path::Path;
     use std::process::{Command, Stdio};
-    use std::sync::mpsc;
+    use std::thread;
     use std::time::Duration;
 
     const CRASH_CHILD_ENV: &str = "MDK_STORAGE_TEST_CRASH_CHILD";
     const CRASH_DATABASE_ENV: &str = "MDK_STORAGE_TEST_CRASH_DATABASE";
+    const CRASH_READY_FILE_ENV: &str = "MDK_STORAGE_TEST_CRASH_READY_FILE";
     const TEST_DATABASE_KEY: &str = "storage format migration crash key";
-    const READY_PREFIX: &str = "MDK_STORAGE_TEST_CRASH_READY:";
 
     fn applied_migrations(store: &SqliteAccountStorage) -> Vec<(i64, String)> {
         let conn = store.lock().unwrap();
@@ -634,47 +635,27 @@ mod tests {
         database: &Path,
         ready_suffix: &str,
     ) {
+        let ready_file = database.with_extension(format!("{ready_suffix}.ready"));
         let mut child = Command::new(std::env::current_exe().unwrap())
             .args(["--ignored", "--exact", test_name, "--nocapture"])
             .env(CRASH_CHILD_ENV, child_mode)
             .env(CRASH_DATABASE_ENV, database)
+            .env(CRASH_READY_FILE_ENV, &ready_file)
             .env(crash_env, crash_value)
-            .stdout(Stdio::piped())
+            .stdout(Stdio::null())
             .stderr(Stdio::piped())
             .spawn()
             .unwrap();
-        let stdout = child.stdout.take().unwrap();
-        let (line_tx, line_rx) = mpsc::channel();
-        let reader = std::thread::spawn(move || {
-            for line in BufReader::new(stdout).lines() {
-                if line_tx.send(line).is_err() {
-                    return;
-                }
+        let deadline = std::time::Instant::now() + Duration::from_secs(30);
+        while !ready_file.exists() && std::time::Instant::now() < deadline {
+            if child.try_wait().unwrap().is_some() {
+                break;
             }
-        });
-        let expected = format!("{READY_PREFIX}{ready_suffix}");
-        let mut output = Vec::new();
-        let ready = loop {
-            match line_rx.recv_timeout(Duration::from_secs(30)) {
-                Ok(Ok(line)) => {
-                    let matches = line == expected;
-                    output.push(line);
-                    if matches {
-                        break true;
-                    }
-                }
-                Ok(Err(error)) => {
-                    output.push(format!("stdout error: {error}"));
-                    break false;
-                }
-                Err(_) => break false,
-            }
-        };
-        if !ready {
+            thread::sleep(Duration::from_millis(10));
+        }
+        if !ready_file.exists() {
             let _ = child.kill();
             let _ = child.wait();
-            drop(line_rx);
-            let _ = reader.join();
             let mut stderr = String::new();
             child
                 .stderr
@@ -682,15 +663,10 @@ mod tests {
                 .unwrap()
                 .read_to_string(&mut stderr)
                 .unwrap();
-            panic!(
-                "child did not reach {ready_suffix}; stdout:\n{}\nstderr:\n{stderr}",
-                output.join("\n")
-            );
+            panic!("child did not reach {ready_suffix}; stderr:\n{stderr}");
         }
         child.kill().unwrap();
         assert!(!child.wait().unwrap().success());
-        drop(line_rx);
-        reader.join().unwrap();
     }
 
     #[test]

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -512,13 +512,49 @@ fn apply_migration(connection: &mut Connection, migration: &Migration) -> Storag
         params![migration.version, migration.name],
     )
     .storage()?;
+    #[cfg(test)]
+    migration_crash_pause(migration.version);
     tx.commit().storage()
+}
+
+#[cfg(test)]
+fn migration_crash_pause(version: i64) {
+    use std::io::Write;
+
+    let expected = version.to_string();
+    if std::env::var("MDK_STORAGE_TEST_MIGRATION_CRASH_VERSION").as_deref() != Ok(expected.as_str())
+    {
+        return;
+    }
+    println!("MDK_STORAGE_TEST_CRASH_READY:migration-{version}");
+    std::io::stdout()
+        .flush()
+        .expect("flush migration crash point");
+    loop {
+        std::thread::park();
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{SqlCipherKey, SqliteAccountStorage};
+    use crate::storage::test_support::{gid, mid, sample_group, sample_message};
+    use crate::{
+        SqlCipherHardening, SqlCipherKey, SqliteAccountStorage, epoch_to_i64, message_state_to_i64,
+        open_hardened_sqlcipher, serialize,
+    };
+    use cgka_traits::message::MessageRecord;
+    use cgka_traits::storage::{GroupStorage, MessageStorage};
+    use std::io::{BufRead, BufReader, Read};
+    use std::path::Path;
+    use std::process::{Command, Stdio};
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    const CRASH_CHILD_ENV: &str = "MDK_STORAGE_TEST_CRASH_CHILD";
+    const CRASH_DATABASE_ENV: &str = "MDK_STORAGE_TEST_CRASH_DATABASE";
+    const TEST_DATABASE_KEY: &str = "storage format migration crash key";
+    const READY_PREFIX: &str = "MDK_STORAGE_TEST_CRASH_READY:";
 
     fn applied_migrations(store: &SqliteAccountStorage) -> Vec<(i64, String)> {
         let conn = store.lock().unwrap();
@@ -536,6 +572,150 @@ mod tests {
             .iter()
             .map(|migration| (migration.version, migration.name.to_string()))
             .collect()
+    }
+
+    fn keyed_connection(path: &Path) -> rusqlite::Connection {
+        let connection = rusqlite::Connection::open(path).unwrap();
+        let key = SqlCipherKey::new(TEST_DATABASE_KEY).unwrap();
+        open_hardened_sqlcipher(&connection, &key, SqlCipherHardening::live_cache()).unwrap();
+        connection.busy_timeout(Duration::from_secs(1)).unwrap();
+        connection
+            .pragma_update(None, "foreign_keys", true)
+            .unwrap();
+        let _: String = connection
+            .query_row("PRAGMA journal_mode = WAL", [], |row| row.get(0))
+            .unwrap();
+        connection
+    }
+
+    fn seed_file_backed_v1_database(path: &Path, message_count: u8) -> Vec<MessageRecord> {
+        let mut connection = keyed_connection(path);
+        run(&mut connection, &MIGRATIONS[..46]).unwrap();
+        let group = sample_group(gid(1), 0, 0);
+        connection
+            .execute(
+                "INSERT INTO cgka_groups (id, epoch, record) VALUES (?1, ?2, ?3)",
+                params![
+                    group.id.as_slice(),
+                    epoch_to_i64(group.epoch).unwrap(),
+                    serialize(&group).unwrap()
+                ],
+            )
+            .unwrap();
+        let messages = (1..=message_count)
+            .map(|id| {
+                let mut message = sample_message(mid(id), group.id.clone(), 0);
+                message.payload = vec![id; 16_727];
+                connection
+                    .execute(
+                        "INSERT INTO cgka_messages (id, group_id, epoch, state, record)
+                         VALUES (?1, ?2, ?3, ?4, ?5)",
+                        params![
+                            message.id.as_slice(),
+                            message.group_id.as_slice(),
+                            epoch_to_i64(message.epoch).unwrap(),
+                            message_state_to_i64(message.state),
+                            serialize(&message).unwrap(),
+                        ],
+                    )
+                    .unwrap();
+                message
+            })
+            .collect();
+        drop(connection);
+        messages
+    }
+
+    fn kill_child_at(
+        test_name: &str,
+        child_mode: &str,
+        crash_env: &str,
+        crash_value: &str,
+        database: &Path,
+        ready_suffix: &str,
+    ) {
+        let mut child = Command::new(std::env::current_exe().unwrap())
+            .args(["--ignored", "--exact", test_name, "--nocapture"])
+            .env(CRASH_CHILD_ENV, child_mode)
+            .env(CRASH_DATABASE_ENV, database)
+            .env(crash_env, crash_value)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+        let stdout = child.stdout.take().unwrap();
+        let (line_tx, line_rx) = mpsc::channel();
+        let reader = std::thread::spawn(move || {
+            for line in BufReader::new(stdout).lines() {
+                if line_tx.send(line).is_err() {
+                    return;
+                }
+            }
+        });
+        let expected = format!("{READY_PREFIX}{ready_suffix}");
+        let mut output = Vec::new();
+        let ready = loop {
+            match line_rx.recv_timeout(Duration::from_secs(30)) {
+                Ok(Ok(line)) => {
+                    let matches = line == expected;
+                    output.push(line);
+                    if matches {
+                        break true;
+                    }
+                }
+                Ok(Err(error)) => {
+                    output.push(format!("stdout error: {error}"));
+                    break false;
+                }
+                Err(_) => break false,
+            }
+        };
+        if !ready {
+            let _ = child.kill();
+            let _ = child.wait();
+            drop(line_rx);
+            let _ = reader.join();
+            let mut stderr = String::new();
+            child
+                .stderr
+                .take()
+                .unwrap()
+                .read_to_string(&mut stderr)
+                .unwrap();
+            panic!(
+                "child did not reach {ready_suffix}; stdout:\n{}\nstderr:\n{stderr}",
+                output.join("\n")
+            );
+        }
+        child.kill().unwrap();
+        assert!(!child.wait().unwrap().success());
+        drop(line_rx);
+        reader.join().unwrap();
+    }
+
+    #[test]
+    #[ignore = "spawned by file-backed migration crash test"]
+    fn storage_format_migration_crash_child() {
+        if std::env::var(CRASH_CHILD_ENV).as_deref() != Ok("migration") {
+            return;
+        }
+        let path = std::env::var_os(CRASH_DATABASE_ENV).unwrap();
+        let mut connection = keyed_connection(Path::new(&path));
+        run(&mut connection, MIGRATIONS).unwrap();
+        panic!("migration crash point was not reached");
+    }
+
+    #[test]
+    #[ignore = "spawned by file-backed promotion crash test"]
+    fn storage_format_promotion_crash_child() {
+        if std::env::var(CRASH_CHILD_ENV).as_deref() != Ok("promotion") {
+            return;
+        }
+        let path = std::env::var_os(CRASH_DATABASE_ENV).unwrap();
+        let key = SqlCipherKey::new(TEST_DATABASE_KEY).unwrap();
+        let store = SqliteAccountStorage::open_encrypted(Path::new(&path), &key).unwrap();
+        store.promote_legacy_message_rows(3).unwrap();
+        panic!("promotion crash point was not reached");
     }
 
     fn semantic_chat_list_timestamps(store: &SqliteAccountStorage) -> Vec<(String, u64, u64)> {
@@ -565,6 +745,129 @@ mod tests {
     fn initial_schema_migration_is_recorded() {
         let store = SqliteAccountStorage::in_memory().unwrap();
         assert_eq!(applied_migrations(&store), expected_migrations());
+    }
+
+    #[test]
+    fn file_backed_v1_database_upgrades_once_and_refuses_downgrade() {
+        let directory = tempfile::tempdir().unwrap();
+        let database = directory.path().join("v1-upgrade.sqlite3");
+        let expected = seed_file_backed_v1_database(&database, 1);
+        let key = SqlCipherKey::new(TEST_DATABASE_KEY).unwrap();
+
+        let store = SqliteAccountStorage::open_encrypted(&database, &key).unwrap();
+        assert_eq!(
+            store.get_group(&gid(1)).unwrap(),
+            sample_group(gid(1), 0, 0)
+        );
+        assert_eq!(store.get_message(&mid(1)).unwrap(), expected[0]);
+        assert_eq!(applied_migrations(&store), expected_migrations());
+        store.close().unwrap();
+
+        let mut older_connection = keyed_connection(&database);
+        let before: i64 = older_connection
+            .query_row("SELECT count(*) FROM cgka_messages", [], |row| row.get(0))
+            .unwrap();
+        let error = run(&mut older_connection, &MIGRATIONS[..46]).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("database was migrated by a newer storage-sqlite version: 47")
+        );
+        let after: i64 = older_connection
+            .query_row("SELECT count(*) FROM cgka_messages", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(
+            after, before,
+            "downgrade refusal must not touch account rows"
+        );
+    }
+
+    #[test]
+    fn process_kill_mid_migration_reopens_and_upgrades_once() {
+        let directory = tempfile::tempdir().unwrap();
+        let database = directory.path().join("migration-kill.sqlite3");
+        let expected = seed_file_backed_v1_database(&database, 2);
+
+        kill_child_at(
+            "migrations::tests::storage_format_migration_crash_child",
+            "migration",
+            "MDK_STORAGE_TEST_MIGRATION_CRASH_VERSION",
+            "47",
+            &database,
+            "migration-47",
+        );
+
+        let connection = keyed_connection(&database);
+        assert_eq!(applied_name(&connection, 47).unwrap(), None);
+        let storage_format_columns: i64 = connection
+            .query_row(
+                "SELECT count(*) FROM pragma_table_info('cgka_messages') WHERE name = 'storage_format'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(storage_format_columns, 0);
+        let count: i64 = connection
+            .query_row("SELECT count(*) FROM cgka_messages", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 2, "killed migration must retain every v1 row");
+        drop(connection);
+
+        let key = SqlCipherKey::new(TEST_DATABASE_KEY).unwrap();
+        let store = SqliteAccountStorage::open_encrypted(&database, &key).unwrap();
+        assert_eq!(store.get_message(&mid(1)).unwrap(), expected[0]);
+        assert_eq!(store.get_message(&mid(2)).unwrap(), expected[1]);
+        assert_eq!(applied_migrations(&store), expected_migrations());
+    }
+
+    #[test]
+    fn process_kill_mid_promotion_rolls_back_and_retry_converges() {
+        let directory = tempfile::tempdir().unwrap();
+        let database = directory.path().join("promotion-kill.sqlite3");
+        let expected = seed_file_backed_v1_database(&database, 3);
+        let key = SqlCipherKey::new(TEST_DATABASE_KEY).unwrap();
+        SqliteAccountStorage::open_encrypted(&database, &key)
+            .unwrap()
+            .close()
+            .unwrap();
+
+        kill_child_at(
+            "migrations::tests::storage_format_promotion_crash_child",
+            "promotion",
+            "MDK_STORAGE_TEST_PROMOTION_CRASH_AFTER",
+            "1",
+            &database,
+            "promotion-1",
+        );
+
+        let connection = keyed_connection(&database);
+        let legacy: i64 = connection
+            .query_row(
+                "SELECT count(*) FROM cgka_messages WHERE storage_format = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(legacy, 3, "killed promotion batch must roll back every row");
+        drop(connection);
+
+        let store = SqliteAccountStorage::open_encrypted(&database, &key).unwrap();
+        let progress = store.promote_legacy_message_rows(3).unwrap();
+        assert_eq!(progress.promoted, 3);
+        assert!(!progress.has_more);
+        for (index, message) in expected.iter().enumerate() {
+            assert_eq!(&store.get_message(&mid(index as u8 + 1)).unwrap(), message);
+        }
+        let normalized: i64 = store
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT count(*) FROM cgka_messages WHERE storage_format = 2",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(normalized, 3);
     }
 
     #[test]

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -90,6 +90,8 @@ mod migration_0044_local_group_deletion_frontiers;
 mod migration_0045_timeline_canonical_order;
 #[path = "migrations/0046_message_group_state_epoch_index.rs"]
 mod migration_0046_message_group_state_epoch_index;
+#[path = "migrations/0047_normalized_message_records.rs"]
+mod migration_0047_normalized_message_records;
 
 use crate::SqliteResultExt;
 use cgka_traits::storage::{StorageError, StorageResult};
@@ -332,6 +334,11 @@ const MIGRATIONS: &[Migration] = &[
         name: "0046_message_group_state_epoch_index",
         apply: migration_0046_message_group_state_epoch_index::apply,
     },
+    Migration {
+        version: 47,
+        name: "0047_normalized_message_records",
+        apply: migration_0047_normalized_message_records::apply,
+    },
 ];
 
 pub(crate) fn run_all(connection: &mut Connection) -> StorageResult<()> {
@@ -558,6 +565,114 @@ mod tests {
     fn initial_schema_migration_is_recorded() {
         let store = SqliteAccountStorage::in_memory().unwrap();
         assert_eq!(applied_migrations(&store), expected_migrations());
+    }
+
+    #[test]
+    fn normalized_message_migration_preserves_legacy_rows_without_backfill() {
+        let mut connection = rusqlite::Connection::open_in_memory().unwrap();
+        connection
+            .pragma_update(None, "foreign_keys", true)
+            .unwrap();
+        run(&mut connection, &MIGRATIONS[..46]).unwrap();
+        connection
+            .execute(
+                "INSERT INTO cgka_groups (id, epoch, record) VALUES (?1, 0, ?2)",
+                params![&[0xaa_u8], b"group"],
+            )
+            .unwrap();
+        let legacy = br#"{"payload":[1,2,3]}"#;
+        connection
+            .execute(
+                "INSERT INTO cgka_messages (id, group_id, epoch, state, record)
+                 VALUES (?1, ?2, 3, 4, ?3)",
+                params![&[0x01_u8], &[0xaa_u8], legacy],
+            )
+            .unwrap();
+
+        run(&mut connection, MIGRATIONS).unwrap();
+
+        let migrated = connection
+            .query_row(
+                "SELECT storage_format, record, payload, deferred_peel
+                 FROM cgka_messages WHERE id = ?1",
+                params![&[0x01_u8]],
+                |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, Vec<u8>>(1)?,
+                        row.get::<_, Option<Vec<u8>>>(2)?,
+                        row.get::<_, Option<Vec<u8>>>(3)?,
+                    ))
+                },
+            )
+            .unwrap();
+        assert_eq!(migrated, (1, legacy.to_vec(), None, None));
+    }
+
+    #[test]
+    fn normalized_message_migration_is_atomic_before_commit() {
+        let mut connection = rusqlite::Connection::open_in_memory().unwrap();
+        connection
+            .pragma_update(None, "foreign_keys", true)
+            .unwrap();
+        run(&mut connection, &MIGRATIONS[..46]).unwrap();
+        connection
+            .execute(
+                "INSERT INTO cgka_groups (id, epoch, record) VALUES (?1, 0, ?2)",
+                params![&[0xaa_u8], b"group"],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO cgka_messages (id, group_id, epoch, state, record)
+                 VALUES (?1, ?2, 3, 4, ?3)",
+                params![&[0x01_u8], &[0xaa_u8], b"legacy-record"],
+            )
+            .unwrap();
+
+        let tx = connection.transaction().unwrap();
+        migration_0047_normalized_message_records::apply(&tx).unwrap();
+        // Models termination after the schema/data rewrite but before the
+        // migration runner can commit its transaction.
+        tx.rollback().unwrap();
+
+        let columns = connection
+            .prepare("PRAGMA table_info(cgka_messages)")
+            .unwrap()
+            .query_map([], |row| row.get::<_, String>(1))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert!(!columns.iter().any(|column| column == "storage_format"));
+        let record: Vec<u8> = connection
+            .query_row(
+                "SELECT record FROM cgka_messages WHERE id = ?1",
+                params![&[0x01_u8]],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(record, b"legacy-record");
+
+        run(&mut connection, MIGRATIONS).unwrap();
+    }
+
+    #[test]
+    fn pre_format_v2_binary_refuses_migration_47_database() {
+        let mut connection = rusqlite::Connection::open_in_memory().unwrap();
+        run(&mut connection, MIGRATIONS).unwrap();
+
+        let error = run(&mut connection, &MIGRATIONS[..46]).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("database was migrated by a newer storage-sqlite version: 47"),
+            "unexpected downgrade error: {error}"
+        );
+        assert_eq!(
+            applied_migrations_from_connection(&connection),
+            expected_migrations(),
+            "downgrade refusal must not mutate migration state"
+        );
     }
 
     #[test]

--- a/crates/storage-sqlite/src/migrations/0047_normalized_message_records.rs
+++ b/crates/storage-sqlite/src/migrations/0047_normalized_message_records.rs
@@ -1,0 +1,45 @@
+use crate::SqliteResultExt;
+use cgka_traits::storage::StorageResult;
+use rusqlite::Transaction;
+
+/// Introduce the normalized message-row format without rewriting account
+/// history during session open.
+///
+/// Existing rows remain format 1 and retain their complete JSON `record`.
+/// Current writers use format 2, where indexed scalar columns are authoritative
+/// and the byte-heavy payload plus optional deferred-peel metadata are stored
+/// separately. Reading or updating a format-1 row can promote it atomically.
+pub(crate) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
+    tx.execute_batch(
+        r#"
+CREATE TABLE cgka_messages_new (
+    insert_order INTEGER PRIMARY KEY AUTOINCREMENT,
+    id BLOB NOT NULL UNIQUE,
+    group_id BLOB NOT NULL REFERENCES cgka_groups(id) ON DELETE CASCADE,
+    epoch INTEGER NOT NULL,
+    state INTEGER NOT NULL,
+    storage_format INTEGER NOT NULL DEFAULT 1,
+    record BLOB,
+    payload BLOB,
+    deferred_peel BLOB,
+    CHECK (
+        (storage_format = 1 AND record IS NOT NULL AND payload IS NULL)
+        OR
+        (storage_format = 2 AND record IS NULL AND payload IS NOT NULL)
+    )
+);
+INSERT INTO cgka_messages_new (
+    insert_order, id, group_id, epoch, state, storage_format, record, payload, deferred_peel
+)
+SELECT insert_order, id, group_id, epoch, state, 1, record, NULL, NULL
+FROM cgka_messages;
+DROP TABLE cgka_messages;
+ALTER TABLE cgka_messages_new RENAME TO cgka_messages;
+CREATE INDEX idx_cgka_messages_group_epoch
+    ON cgka_messages (group_id, epoch, insert_order);
+CREATE INDEX idx_cgka_messages_group_state_epoch
+    ON cgka_messages (group_id, state, epoch);
+"#,
+    )
+    .storage()
+}

--- a/crates/storage-sqlite/src/storage/messages.rs
+++ b/crates/storage-sqlite/src/storage/messages.rs
@@ -102,16 +102,17 @@ impl SqliteAccountStorage {
 
 #[cfg(test)]
 fn promotion_crash_pause(promoted: usize) {
-    use std::io::Write;
-
     let expected = promoted.to_string();
     if std::env::var("MDK_STORAGE_TEST_PROMOTION_CRASH_AFTER").as_deref() != Ok(expected.as_str()) {
         return;
     }
-    println!("MDK_STORAGE_TEST_CRASH_READY:promotion-{promoted}");
-    std::io::stdout()
-        .flush()
-        .expect("flush promotion crash point");
+    let ready = std::env::var_os("MDK_STORAGE_TEST_CRASH_READY_FILE")
+        .expect("promotion crash ready-file path");
+    std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(ready)
+        .expect("create promotion crash ready file");
     loop {
         std::thread::park();
     }

--- a/crates/storage-sqlite/src/storage/messages.rs
+++ b/crates/storage-sqlite/src/storage/messages.rs
@@ -1,41 +1,103 @@
 use super::snapshots;
 use crate::connection::retry_on_busy;
 use crate::{
-    SqliteAccountStorage, SqliteResultExt, deserialize, epoch_to_i64, message_state_to_i64,
-    serialize,
+    SqliteAccountStorage, SqliteResultExt, deserialize, epoch_to_i64, i64_to_u64,
+    message_state_from_i64, message_state_to_i64, serialize,
 };
 use cgka_traits::engine::GroupEvent;
-use cgka_traits::message::{MessageRecord, MessageState};
+use cgka_traits::message::{DeferredPeelLifecycle, MessageRecord, MessageState};
 use cgka_traits::storage::{GroupStateCheckpointRef, MessageStorage, StorageError, StorageResult};
 use cgka_traits::types::{EpochId, GroupId, MessageId};
 use rusqlite::{OptionalExtension, TransactionBehavior, params};
 
 const INGRESS_DEDUP_MARKER_CAPACITY: i64 = 4_096;
+const NORMALIZED_MESSAGE_STORAGE_FORMAT: i64 = 2;
+const MESSAGE_FORMAT_PROMOTION_BATCH_MAX: usize = 256;
+
+const MESSAGE_COLUMNS: &str =
+    "id, group_id, epoch, state, storage_format, record, payload, deferred_peel";
+
+type MessageColumns = (
+    Vec<u8>,
+    Vec<u8>,
+    i64,
+    i64,
+    i64,
+    Option<Vec<u8>>,
+    Option<Vec<u8>>,
+    Option<Vec<u8>>,
+);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct MessageFormatPromotionProgress {
+    pub promoted: usize,
+    pub has_more: bool,
+}
+
+impl SqliteAccountStorage {
+    /// Promote at most `limit` legacy message rows to normalized format 2.
+    ///
+    /// The bounded batch is atomic and idempotent. A malformed row rolls the
+    /// whole batch back, so a caller never observes a skipped or half-promoted
+    /// prefix. Hosts may schedule repeated batches away from session-open
+    /// latency; this method emits no identifiers or payload data.
+    pub fn promote_legacy_message_rows(
+        &self,
+        limit: usize,
+    ) -> StorageResult<MessageFormatPromotionProgress> {
+        if limit == 0 || limit > MESSAGE_FORMAT_PROMOTION_BATCH_MAX {
+            return Err(StorageError::Backend(format!(
+                "message format promotion batch must be between 1 and {MESSAGE_FORMAT_PROMOTION_BATCH_MAX}"
+            )));
+        }
+        retry_on_busy(|| {
+            let mut conn = self.lock()?;
+            let tx = conn
+                .transaction_with_behavior(TransactionBehavior::Immediate)
+                .storage()?;
+            let rows = {
+                let mut statement = tx
+                    .prepare(&format!(
+                        "SELECT {MESSAGE_COLUMNS} FROM cgka_messages
+                         WHERE storage_format = 1
+                         ORDER BY insert_order
+                         LIMIT ?1"
+                    ))
+                    .storage()?;
+                statement
+                    .query_map(
+                        params![i64::try_from(limit).unwrap_or(i64::MAX)],
+                        message_columns,
+                    )
+                    .storage()?
+                    .collect::<Result<Vec<_>, _>>()
+                    .storage()?
+            };
+            let promoted = rows.len();
+            for columns in rows {
+                let record = decode_message_columns(columns)?;
+                put_message_on_connection(&tx, None, &record)?;
+            }
+            let has_more = tx
+                .query_row(
+                    "SELECT EXISTS(
+                        SELECT 1 FROM cgka_messages WHERE storage_format = 1
+                     )",
+                    [],
+                    |row| row.get(0),
+                )
+                .storage()?;
+            tx.commit().storage()?;
+            Ok(MessageFormatPromotionProgress { promoted, has_more })
+        })
+    }
+}
 
 impl MessageStorage for SqliteAccountStorage {
     fn put_message(&self, record: &MessageRecord) -> StorageResult<()> {
-        let serialized = serialize(record)?;
-        let epoch = epoch_to_i64(record.epoch)?;
         let write = || {
             let conn = self.lock()?;
-            conn.execute(
-                "INSERT INTO cgka_messages (id, group_id, epoch, state, record)
-                 VALUES (?1, ?2, ?3, ?4, ?5)
-                 ON CONFLICT(id) DO UPDATE SET
-                    group_id = excluded.group_id,
-                    epoch = excluded.epoch,
-                    state = excluded.state,
-                    record = excluded.record",
-                params![
-                    record.id.as_slice(),
-                    record.group_id.as_slice(),
-                    epoch,
-                    message_state_to_i64(record.state),
-                    serialized,
-                ],
-            )
-            .storage()?;
-            Ok(())
+            put_message_on_connection(&conn, None, record)
         };
         if self.connection.is_current_thread_transaction_owner() {
             write()
@@ -47,17 +109,17 @@ impl MessageStorage for SqliteAccountStorage {
     }
 
     fn get_message(&self, id: &MessageId) -> StorageResult<MessageRecord> {
-        let record: Vec<u8> = self
+        let columns = self
             .lock()?
             .query_row(
-                "SELECT record FROM cgka_messages WHERE id = ?1",
+                &format!("SELECT {MESSAGE_COLUMNS} FROM cgka_messages WHERE id = ?1"),
                 params![id.as_slice()],
-                |row| row.get(0),
+                message_columns,
             )
             .optional()
             .storage()?
             .ok_or(StorageError::NotFound)?;
-        deserialize(&record)
+        decode_message_columns(columns)
     }
 
     fn delete_message(&self, id: &MessageId) -> StorageResult<()> {
@@ -109,22 +171,7 @@ impl MessageStorage for SqliteAccountStorage {
         at_or_after_epoch: EpochId,
     ) -> StorageResult<Vec<MessageRecord>> {
         let conn = self.lock()?;
-        let mut stmt = conn
-            .prepare(
-                "SELECT record FROM cgka_messages
-                 WHERE group_id = ?1 AND epoch >= ?2
-                 ORDER BY insert_order",
-            )
-            .storage()?;
-        let records = stmt
-            .query_map(
-                params![group_id.as_slice(), epoch_to_i64(at_or_after_epoch)?],
-                |row| row.get::<_, Vec<u8>>(0),
-            )
-            .storage()?
-            .collect::<Result<Vec<_>, _>>()
-            .storage()?;
-        records.iter().map(|record| deserialize(record)).collect()
+        list_messages_on_connection(&conn, group_id, at_or_after_epoch, None)
     }
 
     fn has_messages_in_states(
@@ -162,7 +209,7 @@ impl MessageStorage for SqliteAccountStorage {
             return Ok(Vec::new());
         }
         let sql = format!(
-            "SELECT record FROM cgka_messages
+            "SELECT {MESSAGE_COLUMNS} FROM cgka_messages
              WHERE group_id = ?1 AND epoch >= ?2 AND state IN ({})
              ORDER BY insert_order",
             state_placeholders(states)
@@ -176,12 +223,12 @@ impl MessageStorage for SqliteAccountStorage {
                     at_or_after_epoch,
                     states,
                 )?),
-                |row| row.get::<_, Vec<u8>>(0),
+                message_columns,
             )
             .storage()?
             .collect::<Result<Vec<_>, _>>()
             .storage()?;
-        records.iter().map(|record| deserialize(record)).collect()
+        records.into_iter().map(decode_message_columns).collect()
     }
 
     fn put_pending_application_event(&self, event: &GroupEvent) -> StorageResult<()> {
@@ -365,6 +412,150 @@ impl MessageStorage for SqliteAccountStorage {
     }
 }
 
+fn message_columns(row: &rusqlite::Row<'_>) -> rusqlite::Result<MessageColumns> {
+    Ok((
+        row.get(0)?,
+        row.get(1)?,
+        row.get(2)?,
+        row.get(3)?,
+        row.get(4)?,
+        row.get(5)?,
+        row.get(6)?,
+        row.get(7)?,
+    ))
+}
+
+fn decode_message_columns(columns: MessageColumns) -> StorageResult<MessageRecord> {
+    let (id, group_id, epoch, state, storage_format, record, payload, deferred_peel) = columns;
+    match storage_format {
+        1 => deserialize(record.as_deref().ok_or_else(|| {
+            StorageError::Serialization("legacy message row is missing its record blob".to_owned())
+        })?),
+        NORMALIZED_MESSAGE_STORAGE_FORMAT => Ok(MessageRecord {
+            id: MessageId::new(id),
+            group_id: GroupId::new(group_id),
+            epoch: EpochId(i64_to_u64(epoch)?),
+            state: message_state_from_i64(state)?,
+            payload: payload.ok_or_else(|| {
+                StorageError::Serialization(
+                    "normalized message row is missing its payload blob".to_owned(),
+                )
+            })?,
+            deferred_peel: deferred_peel
+                .as_deref()
+                .map(deserialize::<DeferredPeelLifecycle>)
+                .transpose()?,
+        }),
+        version => Err(StorageError::Serialization(format!(
+            "unsupported message storage format {version}"
+        ))),
+    }
+}
+
+fn list_messages_on_connection(
+    conn: &rusqlite::Connection,
+    group_id: &GroupId,
+    at_or_after_epoch: EpochId,
+    include_insert_order: Option<&mut Vec<i64>>,
+) -> StorageResult<Vec<MessageRecord>> {
+    let mut statement = conn
+        .prepare(&format!(
+            "SELECT insert_order, {MESSAGE_COLUMNS} FROM cgka_messages
+             WHERE group_id = ?1 AND epoch >= ?2
+             ORDER BY insert_order"
+        ))
+        .storage()?;
+    let rows = statement
+        .query_map(
+            params![group_id.as_slice(), epoch_to_i64(at_or_after_epoch)?],
+            |row| Ok((row.get::<_, i64>(0)?, message_columns_at(row, 1)?)),
+        )
+        .storage()?
+        .collect::<Result<Vec<_>, _>>()
+        .storage()?;
+    let mut orders = include_insert_order;
+    rows.into_iter()
+        .map(|(insert_order, columns)| {
+            if let Some(orders) = orders.as_deref_mut() {
+                orders.push(insert_order);
+            }
+            decode_message_columns(columns)
+        })
+        .collect()
+}
+
+fn message_columns_at(row: &rusqlite::Row<'_>, offset: usize) -> rusqlite::Result<MessageColumns> {
+    Ok((
+        row.get(offset)?,
+        row.get(offset + 1)?,
+        row.get(offset + 2)?,
+        row.get(offset + 3)?,
+        row.get(offset + 4)?,
+        row.get(offset + 5)?,
+        row.get(offset + 6)?,
+        row.get(offset + 7)?,
+    ))
+}
+
+pub(super) fn ordered_messages_on_connection(
+    conn: &rusqlite::Connection,
+    group_id: &GroupId,
+) -> StorageResult<Vec<(i64, MessageRecord)>> {
+    let mut orders = Vec::new();
+    let records = list_messages_on_connection(conn, group_id, EpochId(0), Some(&mut orders))?;
+    Ok(orders.into_iter().zip(records).collect())
+}
+
+pub(super) fn put_message_on_connection(
+    conn: &rusqlite::Connection,
+    insert_order: Option<i64>,
+    record: &MessageRecord,
+) -> StorageResult<()> {
+    let deferred_peel = record.deferred_peel.as_ref().map(serialize).transpose()?;
+    match insert_order {
+        None => conn.execute(
+            "INSERT INTO cgka_messages (
+                 id, group_id, epoch, state, storage_format, record, payload, deferred_peel
+             ) VALUES (?1, ?2, ?3, ?4, ?5, NULL, ?6, ?7)
+             ON CONFLICT(id) DO UPDATE SET
+                group_id = excluded.group_id,
+                epoch = excluded.epoch,
+                state = excluded.state,
+                storage_format = excluded.storage_format,
+                record = NULL,
+                payload = excluded.payload,
+                deferred_peel = excluded.deferred_peel",
+            params![
+                record.id.as_slice(),
+                record.group_id.as_slice(),
+                epoch_to_i64(record.epoch)?,
+                message_state_to_i64(record.state),
+                NORMALIZED_MESSAGE_STORAGE_FORMAT,
+                &record.payload,
+                deferred_peel,
+            ],
+        ),
+        Some(insert_order) => conn.execute(
+            "INSERT INTO cgka_messages (
+                 insert_order, id, group_id, epoch, state, storage_format,
+                 record, payload, deferred_peel
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, NULL, ?7, ?8)",
+            params![
+                insert_order,
+                record.id.as_slice(),
+                record.group_id.as_slice(),
+                epoch_to_i64(record.epoch)?,
+                message_state_to_i64(record.state),
+                NORMALIZED_MESSAGE_STORAGE_FORMAT,
+                &record.payload,
+                deferred_peel,
+            ],
+        ),
+    }
+    .storage()?;
+    Ok(())
+}
+
 /// `?N` placeholder list for a state `IN (...)` clause, numbered after the
 /// fixed `?1` group-id and `?2` epoch parameters.
 fn state_placeholders(states: &[MessageState]) -> String {
@@ -394,39 +585,56 @@ fn state_query_params(
     Ok(params)
 }
 
-/// Read-modify-write the stored state of a single message on an already-locked
-/// connection (which may be a bare `Connection` or a `Transaction` — both deref
-/// to `Connection`). Factored out so `update_message_state` can run it either
-/// inside the caller's open engine transaction or inside a fresh local one.
+/// Update normalized rows without reading or rewriting their payload. A legacy
+/// row is decoded once and promoted atomically so subsequent state flips use
+/// the scalar fast path.
 fn update_message_state_on_connection(
     conn: &rusqlite::Connection,
     id: &MessageId,
     new_state: MessageState,
 ) -> StorageResult<()> {
-    let record_bytes: Vec<u8> = conn
+    let storage_format: i64 = conn
         .query_row(
-            "SELECT record FROM cgka_messages WHERE id = ?1",
+            "SELECT storage_format FROM cgka_messages WHERE id = ?1",
             params![id.as_slice()],
             |row| row.get(0),
         )
         .optional()
         .storage()?
         .ok_or(StorageError::NotFound)?;
-    let mut record: MessageRecord = deserialize(&record_bytes)?;
-    record.state = new_state;
-    if new_state != MessageState::PeelDeferred {
-        record.deferred_peel = None;
-    }
-    let changed = conn
-        .execute(
-            "UPDATE cgka_messages SET state = ?1, record = ?2 WHERE id = ?3",
+    let changed = if storage_format == NORMALIZED_MESSAGE_STORAGE_FORMAT {
+        conn.execute(
+            "UPDATE cgka_messages
+             SET state = ?1,
+                 deferred_peel = CASE WHEN ?1 = ?2 THEN deferred_peel ELSE NULL END
+             WHERE id = ?3",
             params![
                 message_state_to_i64(new_state),
-                serialize(&record)?,
-                id.as_slice()
+                message_state_to_i64(MessageState::PeelDeferred),
+                id.as_slice(),
             ],
         )
-        .storage()?;
+        .storage()?
+    } else if storage_format == 1 {
+        let columns = conn
+            .query_row(
+                &format!("SELECT {MESSAGE_COLUMNS} FROM cgka_messages WHERE id = ?1"),
+                params![id.as_slice()],
+                message_columns,
+            )
+            .storage()?;
+        let mut record = decode_message_columns(columns)?;
+        record.state = new_state;
+        if new_state != MessageState::PeelDeferred {
+            record.deferred_peel = None;
+        }
+        put_message_on_connection(conn, None, &record)?;
+        1
+    } else {
+        return Err(StorageError::Serialization(format!(
+            "unsupported message storage format {storage_format}"
+        )));
+    };
     if changed == 0 {
         return Err(StorageError::NotFound);
     }
@@ -451,8 +659,8 @@ fn delete_message_on_connection(conn: &rusqlite::Connection, id: &MessageId) -> 
 
 #[cfg(test)]
 mod tests {
-    use crate::SqliteAccountStorage;
     use crate::storage::test_support::{gid, mid, sample_group, sample_message};
+    use crate::{SqliteAccountStorage, serialize};
     use cgka_traits::engine::GroupEvent;
     use cgka_traits::message::{DeferredPeelLifecycle, MessageState};
     use cgka_traits::storage::{GroupStorage, MessageStorage, StorageError};
@@ -495,6 +703,157 @@ mod tests {
             store.get_message(&message.id).unwrap().state,
             MessageState::PeelDeferred
         );
+    }
+
+    #[test]
+    fn normalized_row_keeps_payload_out_of_state_updates() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        store.put_group(&sample_group(gid(1), 0, 0)).unwrap();
+        let message = sample_message(mid(1), gid(1), 0);
+        store.put_message(&message).unwrap();
+
+        let before: (i64, bool, Vec<u8>) = store
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT storage_format, record IS NULL, payload
+                 FROM cgka_messages WHERE id = ?1",
+                rusqlite::params![message.id.as_slice()],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(before, (2, true, message.payload.clone()));
+
+        store
+            .update_message_state(&message.id, MessageState::Processed)
+            .unwrap();
+        let after: (i64, bool, Vec<u8>) = store
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT storage_format, record IS NULL, payload
+                 FROM cgka_messages WHERE id = ?1",
+                rusqlite::params![message.id.as_slice()],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(after, before, "state update must not rewrite payload bytes");
+    }
+
+    #[test]
+    fn legacy_row_reads_and_promotes_on_state_update() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        store.put_group(&sample_group(gid(1), 0, 0)).unwrap();
+        let message = sample_message(mid(1), gid(1), 0);
+        store
+            .lock()
+            .unwrap()
+            .execute(
+                "INSERT INTO cgka_messages (id, group_id, epoch, state, record)
+                 VALUES (?1, ?2, 0, 1, ?3)",
+                rusqlite::params![
+                    message.id.as_slice(),
+                    message.group_id.as_slice(),
+                    serialize(&message).unwrap(),
+                ],
+            )
+            .unwrap();
+        assert_eq!(store.get_message(&message.id).unwrap(), message);
+
+        store
+            .update_message_state(&message.id, MessageState::Processed)
+            .unwrap();
+        let promoted = store.get_message(&message.id).unwrap();
+        assert_eq!(promoted.state, MessageState::Processed);
+        assert_eq!(promoted.payload, message.payload);
+        let format: (i64, bool, bool) = store
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT storage_format, record IS NULL, payload IS NOT NULL
+                 FROM cgka_messages WHERE id = ?1",
+                rusqlite::params![message.id.as_slice()],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(format, (2, true, true));
+    }
+
+    #[test]
+    fn bounded_legacy_promotion_converges_in_atomic_batches() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        store.put_group(&sample_group(gid(1), 0, 0)).unwrap();
+        for index in 1..=3 {
+            let message = sample_message(mid(index), gid(1), 0);
+            store
+                .lock()
+                .unwrap()
+                .execute(
+                    "INSERT INTO cgka_messages (id, group_id, epoch, state, record)
+                     VALUES (?1, ?2, 0, 1, ?3)",
+                    rusqlite::params![
+                        message.id.as_slice(),
+                        message.group_id.as_slice(),
+                        serialize(&message).unwrap(),
+                    ],
+                )
+                .unwrap();
+        }
+
+        assert_eq!(
+            store.promote_legacy_message_rows(2).unwrap(),
+            super::MessageFormatPromotionProgress {
+                promoted: 2,
+                has_more: true,
+            }
+        );
+        assert_eq!(
+            store.promote_legacy_message_rows(2).unwrap(),
+            super::MessageFormatPromotionProgress {
+                promoted: 1,
+                has_more: false,
+            }
+        );
+        assert_eq!(
+            store.promote_legacy_message_rows(2).unwrap(),
+            super::MessageFormatPromotionProgress {
+                promoted: 0,
+                has_more: false,
+            }
+        );
+    }
+
+    #[test]
+    fn malformed_legacy_promotion_rolls_back_the_whole_batch() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        store.put_group(&sample_group(gid(1), 0, 0)).unwrap();
+        let valid = sample_message(mid(1), gid(1), 0);
+        for (id, record) in [
+            (mid(1), serialize(&valid).unwrap()),
+            (mid(2), b"not-json".to_vec()),
+        ] {
+            store
+                .lock()
+                .unwrap()
+                .execute(
+                    "INSERT INTO cgka_messages (id, group_id, epoch, state, record)
+                     VALUES (?1, ?2, 0, 1, ?3)",
+                    rusqlite::params![id.as_slice(), gid(1).as_slice(), record],
+                )
+                .unwrap();
+        }
+
+        assert!(store.promote_legacy_message_rows(2).is_err());
+        let legacy_count: i64 = store
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT count(*) FROM cgka_messages WHERE storage_format = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(legacy_count, 2);
     }
 
     #[test]

--- a/crates/storage-sqlite/src/storage/messages.rs
+++ b/crates/storage-sqlite/src/storage/messages.rs
@@ -74,9 +74,16 @@ impl SqliteAccountStorage {
                     .storage()?
             };
             let promoted = rows.len();
+            #[cfg(test)]
+            let mut promoted_so_far = 0;
             for columns in rows {
                 let record = decode_message_columns(columns)?;
                 put_message_on_connection(&tx, None, &record)?;
+                #[cfg(test)]
+                {
+                    promoted_so_far += 1;
+                    promotion_crash_pause(promoted_so_far);
+                }
             }
             let has_more = tx
                 .query_row(
@@ -90,6 +97,23 @@ impl SqliteAccountStorage {
             tx.commit().storage()?;
             Ok(MessageFormatPromotionProgress { promoted, has_more })
         })
+    }
+}
+
+#[cfg(test)]
+fn promotion_crash_pause(promoted: usize) {
+    use std::io::Write;
+
+    let expected = promoted.to_string();
+    if std::env::var("MDK_STORAGE_TEST_PROMOTION_CRASH_AFTER").as_deref() != Ok(expected.as_str()) {
+        return;
+    }
+    println!("MDK_STORAGE_TEST_CRASH_READY:promotion-{promoted}");
+    std::io::stdout()
+        .flush()
+        .expect("flush promotion crash point");
+    loop {
+        std::thread::park();
     }
 }
 

--- a/crates/storage-sqlite/src/storage/mod.rs
+++ b/crates/storage-sqlite/src/storage/mod.rs
@@ -11,7 +11,7 @@ mod groups;
 pub(crate) mod leave_requests;
 mod maintenance;
 mod member_validation_cache;
-mod messages;
+pub(crate) mod messages;
 mod outbound;
 pub(crate) mod snapshots;
 mod transport_routes;

--- a/crates/storage-sqlite/src/storage/snapshots.rs
+++ b/crates/storage-sqlite/src/storage/snapshots.rs
@@ -498,6 +498,40 @@ mod tests {
     }
 
     #[test]
+    fn identical_legacy_json_group_state_checkpoint_retry_is_idempotent() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let anchor = sample_group(gid(1), 1, 1);
+        store.put_group(&anchor).unwrap();
+        let legacy = crate::serialize(&super::rows::GroupStateCheckpoint {
+            group: anchor.clone(),
+            member_caps: Vec::new(),
+            validated_tree_marker: None,
+            openmls_values: Vec::new(),
+        })
+        .unwrap();
+        store
+            .lock()
+            .unwrap()
+            .execute(
+                "INSERT INTO cgka_group_state_checkpoints
+                    (group_id, checkpoint_id, resulting_epoch, checkpoint)
+                 VALUES (?1, 'legacy-json', 1, ?2)",
+                rusqlite::params![anchor.id.as_slice(), legacy],
+            )
+            .unwrap();
+
+        store
+            .create_group_state_checkpoint(
+                &anchor.id,
+                &GroupStateCheckpointRef {
+                    id: "legacy-json".into(),
+                    resulting_epoch: EpochId(1),
+                },
+            )
+            .expect("logical equality must be format-independent");
+    }
+
+    #[test]
     fn releasing_missing_group_state_checkpoint_reports_snapshot_missing() {
         let store = SqliteAccountStorage::in_memory().unwrap();
         let group = sample_group(gid(1), 1, 1);

--- a/crates/storage-sqlite/src/storage/snapshots.rs
+++ b/crates/storage-sqlite/src/storage/snapshots.rs
@@ -1,5 +1,6 @@
 mod capture;
 mod checkpoints;
+mod format;
 mod lifecycle;
 mod restore;
 mod rows;
@@ -182,6 +183,55 @@ mod tests {
     }
 
     #[test]
+    fn new_snapshots_are_versioned_binary_and_unknown_versions_fail_closed() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let group = sample_group(gid(1), 0, 1);
+        store.put_group(&group).unwrap();
+        let mut message = sample_message(mid(1), group.id.clone(), 0);
+        message.payload = vec![0xA5; 16_727];
+        store.put_message(&message).unwrap();
+        store.create_group_snapshot(&group.id, "v2").unwrap();
+
+        let mut blob: Vec<u8> = store
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT snapshot FROM cgka_group_snapshots
+                 WHERE group_id = ?1 AND name = 'v2'",
+                rusqlite::params![group.id.as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(blob.starts_with(b"MDKS\0\x02"));
+        assert!(
+            blob.len() < 20_000,
+            "raw message bytes must not expand back into a JSON number array: {}",
+            blob.len()
+        );
+
+        blob[4..6].copy_from_slice(&3_u16.to_be_bytes());
+        store
+            .lock()
+            .unwrap()
+            .execute(
+                "UPDATE cgka_group_snapshots SET snapshot = ?1
+                 WHERE group_id = ?2 AND name = 'v2'",
+                rusqlite::params![blob, group.id.as_slice()],
+            )
+            .unwrap();
+        let error = store
+            .rollback_group_to_snapshot(&group.id, "v2")
+            .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("unsupported group snapshot version 3")
+        );
+        assert_eq!(store.get_group(&group.id).unwrap(), group);
+        assert_eq!(store.get_message(&message.id).unwrap(), message);
+    }
+
+    #[test]
     fn state_scoped_snapshot_rolls_back_group_state_without_touching_messages_or_queue() {
         let store = SqliteAccountStorage::in_memory().unwrap();
         let g0 = sample_group(gid(1), 0, 1);
@@ -327,6 +377,17 @@ mod tests {
         store
             .create_group_state_checkpoint(&g1.id, &checkpoint)
             .unwrap();
+        let checkpoint_blob: Vec<u8> = store
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT checkpoint FROM cgka_group_state_checkpoints
+                 WHERE group_id = ?1 AND checkpoint_id = ?2",
+                rusqlite::params![g1.id.as_slice(), checkpoint.id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(checkpoint_blob.starts_with(b"MDKS\0\x02"));
         // Exact retry is idempotent.
         store
             .create_group_state_checkpoint(&g1.id, &checkpoint)
@@ -401,6 +462,39 @@ mod tests {
             store.list_group_state_checkpoints(&g2.id).unwrap(),
             vec![checkpoint]
         );
+    }
+
+    #[test]
+    fn legacy_json_group_state_checkpoint_remains_restorable() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let anchor = sample_group(gid(1), 1, 1);
+        store.put_group(&anchor).unwrap();
+        let legacy = crate::serialize(&super::rows::GroupStateCheckpoint {
+            group: anchor.clone(),
+            member_caps: Vec::new(),
+            validated_tree_marker: None,
+            openmls_values: Vec::new(),
+        })
+        .unwrap();
+        store
+            .lock()
+            .unwrap()
+            .execute(
+                "INSERT INTO cgka_group_state_checkpoints
+                    (group_id, checkpoint_id, resulting_epoch, checkpoint)
+                 VALUES (?1, 'legacy-json', 1, ?2)",
+                rusqlite::params![anchor.id.as_slice(), legacy],
+            )
+            .unwrap();
+
+        store
+            .put_group(&sample_group(anchor.id.clone(), 2, 2))
+            .unwrap();
+        store
+            .restore_group_state_checkpoint(&anchor.id, "legacy-json")
+            .unwrap();
+
+        assert_eq!(store.get_group(&anchor.id).unwrap(), anchor);
     }
 
     #[test]

--- a/crates/storage-sqlite/src/storage/snapshots/AGENTS.md
+++ b/crates/storage-sqlite/src/storage/snapshots/AGENTS.md
@@ -10,6 +10,7 @@ Map for SQLite group snapshots.
 | `restore.rs` | Restores a serialized snapshot into live tables. |
 | `lifecycle.rs` | Snapshot listing and release. |
 | `rows.rs` | Snapshot serialization rows. |
+| `format.rs` | Versioned binary snapshot/checkpoint envelope and legacy JSON decoding. |
 
 ## Rules
 
@@ -17,3 +18,5 @@ Map for SQLite group snapshots.
   policy, and group-scoped OpenMLS rows.
 - Rollback should restore the captured state and leave unrelated groups alone.
 - Snapshot release is idempotent only where the caller explicitly handles `SnapshotMissing`.
+- New rollback snapshots and group-state checkpoints use the `MDKS` v2 envelope; untagged legacy JSON remains
+  readable, while tagged unknown versions fail closed.

--- a/crates/storage-sqlite/src/storage/snapshots/capture.rs
+++ b/crates/storage-sqlite/src/storage/snapshots/capture.rs
@@ -1,3 +1,4 @@
+use super::format as snapshot_format;
 use super::rows::{
     GroupStateCheckpoint, MemberCapabilitiesSnapshot, OpenMlsValueSnapshot, OrderedMessage,
     OrderedQueuedOutbound, Snapshot,
@@ -7,10 +8,9 @@ use super::rows::{REPLAY_SNAPSHOT_VERSION, ReplaySnapshot};
 use crate::openmls_storage::mls_group_key;
 #[cfg(feature = "test-conformance-replay")]
 use crate::serialize;
+use crate::storage::messages::ordered_messages_on_connection;
 use crate::{
-    SqliteAccountStorage, SqliteResultExt,
-    codec::{SensitiveBytes, serialize_sensitive},
-    connection::retry_on_busy,
+    SqliteAccountStorage, SqliteResultExt, codec::SensitiveBytes, connection::retry_on_busy,
     deserialize,
 };
 use cgka_traits::storage::{StorageError, StorageResult};
@@ -58,7 +58,7 @@ fn create_on_connection(
     scope: SnapshotScope,
 ) -> StorageResult<()> {
     let snapshot = capture_snapshot(conn, group_id, scope)?;
-    let snapshot_blob = serialize_sensitive(&snapshot)?;
+    let snapshot_blob = snapshot_format::encode(&snapshot)?;
     conn.execute(
         "INSERT OR REPLACE INTO cgka_group_snapshots (group_id, name, snapshot)
              VALUES (?1, ?2, ?3)",
@@ -151,28 +151,15 @@ pub(super) fn export(store: &SqliteAccountStorage, group_id: &GroupId) -> Storag
 }
 
 fn messages(tx: &rusqlite::Connection, group_id: &GroupId) -> StorageResult<Vec<OrderedMessage>> {
-    let mut stmt = tx
-        .prepare(
-            "SELECT insert_order, record FROM cgka_messages
-             WHERE group_id = ?1
-             ORDER BY insert_order",
-        )
-        .storage()?;
-    let rows = stmt
-        .query_map(params![group_id.as_slice()], |row| {
-            Ok((row.get::<_, i64>(0)?, row.get::<_, Vec<u8>>(1)?))
-        })
-        .storage()?
-        .collect::<Result<Vec<_>, _>>()
-        .storage()?;
-    rows.into_iter()
-        .map(|(insert_order, record)| {
-            Ok(OrderedMessage {
+    ordered_messages_on_connection(tx, group_id).map(|messages| {
+        messages
+            .into_iter()
+            .map(|(insert_order, record)| OrderedMessage {
                 insert_order,
-                record: deserialize(&record)?,
+                record,
             })
-        })
-        .collect()
+            .collect()
+    })
 }
 
 fn queued_outbound(

--- a/crates/storage-sqlite/src/storage/snapshots/checkpoints.rs
+++ b/crates/storage-sqlite/src/storage/snapshots/checkpoints.rs
@@ -1,9 +1,7 @@
-use super::{capture, restore, rows::GroupStateCheckpoint};
+use super::{capture, format as snapshot_format, restore};
 use crate::{
-    SqliteAccountStorage, SqliteResultExt,
-    codec::{SensitiveBytes, serialize_sensitive},
-    connection::retry_on_busy,
-    deserialize, epoch_to_i64,
+    SqliteAccountStorage, SqliteResultExt, codec::SensitiveBytes, connection::retry_on_busy,
+    epoch_to_i64,
 };
 use cgka_traits::storage::{GroupStateCheckpointRef, StorageError, StorageResult};
 use cgka_traits::types::{EpochId, GroupId};
@@ -34,7 +32,7 @@ fn create_on_connection(
     checkpoint: &GroupStateCheckpointRef,
 ) -> StorageResult<()> {
     let state = capture::capture_group_state(conn, group_id)?;
-    let blob = serialize_sensitive(&state)?;
+    let blob = snapshot_format::encode_checkpoint(&state)?;
     let existing = conn
         .query_row(
             "SELECT resulting_epoch, checkpoint
@@ -103,7 +101,7 @@ fn restore_on_connection(
         .storage()?
         .ok_or_else(|| StorageError::SnapshotMissing(checkpoint_id.to_owned()))?,
     );
-    let checkpoint: GroupStateCheckpoint = deserialize(blob.as_slice())?;
+    let checkpoint = snapshot_format::decode_checkpoint(blob.as_slice())?;
     restore::restore_group_state(conn, group_id, &checkpoint)
 }
 

--- a/crates/storage-sqlite/src/storage/snapshots/checkpoints.rs
+++ b/crates/storage-sqlite/src/storage/snapshots/checkpoints.rs
@@ -44,10 +44,15 @@ fn create_on_connection(
         .optional()
         .storage()?;
     if let Some((resulting_epoch, existing_blob)) = existing {
-        if resulting_epoch == epoch_to_i64(checkpoint.resulting_epoch)?
-            && existing_blob == blob.as_slice()
-        {
-            return Ok(());
+        if resulting_epoch == epoch_to_i64(checkpoint.resulting_epoch)? {
+            // Existing checkpoints can remain as untagged legacy JSON after
+            // upgrade. Canonicalize their decoded state before comparing so
+            // an exact retry stays idempotent across storage formats.
+            let existing_state = snapshot_format::decode_checkpoint(&existing_blob)?;
+            let existing_blob = snapshot_format::encode_checkpoint(&existing_state)?;
+            if existing_blob.as_slice() == blob.as_slice() {
+                return Ok(());
+            }
         }
         return Err(StorageError::AlreadyExists);
     }

--- a/crates/storage-sqlite/src/storage/snapshots/format.rs
+++ b/crates/storage-sqlite/src/storage/snapshots/format.rs
@@ -1,0 +1,552 @@
+use super::rows::{
+    GroupStateCheckpoint, MemberCapabilitiesSnapshot, OpenMlsValueSnapshot, OrderedMessage,
+    OrderedQueuedOutbound, Snapshot,
+};
+use crate::codec::{SensitiveBytes, serialize_sensitive};
+use crate::{deserialize, i64_to_u64, message_state_from_i64, message_state_to_i64, serialize};
+use cgka_traits::message::MessageRecord;
+use cgka_traits::storage::{StorageError, StorageResult};
+use cgka_traits::types::{EpochId, GroupId, MemberId, MessageId};
+use serde::de::DeserializeOwned;
+
+const SNAPSHOT_MAGIC: &[u8; 4] = b"MDKS";
+const SNAPSHOT_VERSION: u16 = 2;
+const MAX_FIELD_LEN: usize = 1 << 30;
+const MAX_LIST_ITEMS: usize = 1 << 20;
+
+pub(super) fn encode(snapshot: &Snapshot) -> StorageResult<SensitiveBytes> {
+    let prepared = PreparedSnapshot::new(snapshot)?;
+    let encoded_len = snapshot_encoded_len(snapshot, &prepared)?;
+    let mut encoder = Encoder::new(encoded_len);
+    encoder.bytes(SNAPSHOT_MAGIC)?;
+    encoder.u16(SNAPSHOT_VERSION)?;
+    encoder.var(&prepared.group)?;
+    encoder.option_list(snapshot.messages.as_deref(), |message, index, encoder| {
+        encoder.u64(i64_to_u64(message.insert_order)?)?;
+        encode_message(
+            &message.record,
+            prepared.message_deferred[index].as_deref(),
+            encoder,
+        )
+    })?;
+    encoder.option_list(
+        snapshot.queued_outbound.as_deref(),
+        |queued, index, encoder| {
+            encoder.u64(i64_to_u64(queued.insert_order)?)?;
+            encoder.var(prepared.queued[index].as_slice())
+        },
+    )?;
+    encoder.list(&snapshot.member_caps, |caps, index, encoder| {
+        encoder.var(caps.member_id.as_slice())?;
+        encoder.var(&prepared.member_caps[index])
+    })?;
+    encoder.option_bytes(snapshot.convergence_policy.as_deref())?;
+    encoder.option_bytes(snapshot.validated_tree_marker.as_deref())?;
+    encoder.list(&snapshot.openmls_values, |value, _, encoder| {
+        encoder.var(&value.label)?;
+        encoder.var(&value.storage_key)?;
+        encoder.var(&value.group_key)?;
+        encoder.var(value.value.as_slice())
+    })?;
+    encoder.finish()
+}
+
+pub(super) fn decode(bytes: &[u8]) -> StorageResult<Snapshot> {
+    if !bytes.starts_with(SNAPSHOT_MAGIC) {
+        return deserialize(bytes);
+    }
+    let mut decoder = Decoder::new(bytes);
+    decoder.expect(SNAPSHOT_MAGIC, "snapshot magic")?;
+    let version = decoder.u16("snapshot version")?;
+    if version != SNAPSHOT_VERSION {
+        return Err(serialization(format!(
+            "unsupported group snapshot version {version}"
+        )));
+    }
+    let group = decoder.json("group")?;
+    let messages = decoder.option_list("messages", |decoder| {
+        let insert_order = decoder.i64_from_u64("message insert order")?;
+        let id = MessageId::new(decoder.var("message id")?.to_vec());
+        let group_id = GroupId::new(decoder.var("message group id")?.to_vec());
+        let epoch = EpochId(decoder.u64("message epoch")?);
+        let state = message_state_from_i64(i64::from(decoder.u8("message state")?))?;
+        let payload = decoder.var("message payload")?.to_vec();
+        let deferred_peel = decoder.option_json("deferred peel")?;
+        Ok(OrderedMessage {
+            insert_order,
+            record: MessageRecord {
+                id,
+                group_id,
+                epoch,
+                state,
+                payload,
+                deferred_peel,
+            },
+        })
+    })?;
+    let queued_outbound = decoder.option_list("queued outbound", |decoder| {
+        Ok(OrderedQueuedOutbound {
+            insert_order: decoder.i64_from_u64("queued insert order")?,
+            record: decoder.json("queued outbound record")?,
+        })
+    })?;
+    let member_caps = decoder.list("member capabilities", |decoder| {
+        Ok(MemberCapabilitiesSnapshot {
+            member_id: MemberId::new(decoder.var("member id")?.to_vec()),
+            capabilities: decoder.json("member capabilities")?,
+        })
+    })?;
+    let convergence_policy = decoder.option_bytes("convergence policy")?;
+    let validated_tree_marker = decoder.option_bytes("validated tree marker")?;
+    let openmls_values = decoder.list("OpenMLS values", |decoder| {
+        Ok(OpenMlsValueSnapshot {
+            label: decoder.var("OpenMLS label")?.to_vec(),
+            storage_key: decoder.var("OpenMLS storage key")?.to_vec(),
+            group_key: decoder.var("OpenMLS group key")?.to_vec(),
+            value: SensitiveBytes::new(decoder.var("OpenMLS value")?.to_vec()),
+        })
+    })?;
+    decoder.finish("group snapshot")?;
+    Ok(Snapshot {
+        group,
+        messages,
+        queued_outbound,
+        member_caps,
+        convergence_policy,
+        validated_tree_marker,
+        openmls_values,
+    })
+}
+
+pub(super) fn encode_checkpoint(
+    checkpoint: &GroupStateCheckpoint,
+) -> StorageResult<SensitiveBytes> {
+    encode(&Snapshot {
+        group: checkpoint.group.clone(),
+        messages: None,
+        queued_outbound: None,
+        member_caps: checkpoint
+            .member_caps
+            .iter()
+            .map(|caps| MemberCapabilitiesSnapshot {
+                member_id: caps.member_id.clone(),
+                capabilities: caps.capabilities.clone(),
+            })
+            .collect(),
+        convergence_policy: None,
+        validated_tree_marker: checkpoint.validated_tree_marker.clone(),
+        openmls_values: checkpoint
+            .openmls_values
+            .iter()
+            .map(|value| OpenMlsValueSnapshot {
+                label: value.label.clone(),
+                storage_key: value.storage_key.clone(),
+                group_key: value.group_key.clone(),
+                value: SensitiveBytes::new(value.value.as_slice().to_vec()),
+            })
+            .collect(),
+    })
+}
+
+pub(super) fn decode_checkpoint(bytes: &[u8]) -> StorageResult<GroupStateCheckpoint> {
+    if !bytes.starts_with(SNAPSHOT_MAGIC) {
+        return deserialize(bytes);
+    }
+    let snapshot = decode(bytes)?;
+    if snapshot.messages.is_some()
+        || snapshot.queued_outbound.is_some()
+        || snapshot.convergence_policy.is_some()
+    {
+        return Err(serialization(
+            "group-state checkpoint contains rollback-only fields",
+        ));
+    }
+    Ok(GroupStateCheckpoint {
+        group: snapshot.group,
+        member_caps: snapshot.member_caps,
+        validated_tree_marker: snapshot.validated_tree_marker,
+        openmls_values: snapshot.openmls_values,
+    })
+}
+
+struct PreparedSnapshot {
+    group: Vec<u8>,
+    message_deferred: Vec<Option<Vec<u8>>>,
+    queued: Vec<SensitiveBytes>,
+    member_caps: Vec<Vec<u8>>,
+}
+
+impl PreparedSnapshot {
+    fn new(snapshot: &Snapshot) -> StorageResult<Self> {
+        Ok(Self {
+            group: serialize(&snapshot.group)?,
+            message_deferred: snapshot
+                .messages
+                .as_deref()
+                .unwrap_or_default()
+                .iter()
+                .map(|message| {
+                    message
+                        .record
+                        .deferred_peel
+                        .as_ref()
+                        .map(serialize)
+                        .transpose()
+                })
+                .collect::<StorageResult<Vec<_>>>()?,
+            queued: snapshot
+                .queued_outbound
+                .as_deref()
+                .unwrap_or_default()
+                .iter()
+                .map(|queued| serialize_sensitive(&queued.record))
+                .collect::<StorageResult<Vec<_>>>()?,
+            member_caps: snapshot
+                .member_caps
+                .iter()
+                .map(|caps| serialize(&caps.capabilities))
+                .collect::<StorageResult<Vec<_>>>()?,
+        })
+    }
+}
+
+fn encode_message(
+    message: &MessageRecord,
+    deferred: Option<&[u8]>,
+    encoder: &mut Encoder,
+) -> StorageResult<()> {
+    encoder.var(message.id.as_slice())?;
+    encoder.var(message.group_id.as_slice())?;
+    encoder.u64(message.epoch.0)?;
+    encoder.u8(u8::try_from(message_state_to_i64(message.state))
+        .map_err(|_| serialization("message state does not fit the snapshot encoding"))?)?;
+    encoder.var(&message.payload)?;
+    encoder.option_bytes(deferred)
+}
+
+// Compute the complete length without materializing secret-bearing output.
+fn snapshot_encoded_len(snapshot: &Snapshot, prepared: &PreparedSnapshot) -> StorageResult<usize> {
+    let mut len = SNAPSHOT_MAGIC.len() + 2 + var_len(prepared.group.len())?;
+    len = checked_add(len, 1)?;
+    if let Some(messages) = &snapshot.messages {
+        let mut body = 0;
+        for (index, message) in messages.iter().enumerate() {
+            body = checked_add(body, 8)?;
+            body = checked_add(
+                body,
+                message_encoded_len(&message.record, prepared.message_deferred[index].as_deref())?,
+            )?;
+        }
+        len = checked_add(len, var_len(body)?)?;
+    }
+    len = checked_add(len, 1)?;
+    if let Some(queued) = &snapshot.queued_outbound {
+        let mut body = 0;
+        for (index, _) in queued.iter().enumerate() {
+            body = checked_add(body, 8)?;
+            body = checked_add(body, var_len(prepared.queued[index].len())?)?;
+        }
+        len = checked_add(len, var_len(body)?)?;
+    }
+    let mut caps_body = 0;
+    for (index, caps) in snapshot.member_caps.iter().enumerate() {
+        caps_body = checked_add(caps_body, var_len(caps.member_id.as_slice().len())?)?;
+        caps_body = checked_add(caps_body, var_len(prepared.member_caps[index].len())?)?;
+    }
+    len = checked_add(len, var_len(caps_body)?)?;
+    len = checked_add(len, option_len(snapshot.convergence_policy.as_deref())?)?;
+    len = checked_add(len, option_len(snapshot.validated_tree_marker.as_deref())?)?;
+    let mut openmls_body = 0;
+    for value in &snapshot.openmls_values {
+        for field_len in [
+            value.label.len(),
+            value.storage_key.len(),
+            value.group_key.len(),
+            value.value.as_slice().len(),
+        ] {
+            openmls_body = checked_add(openmls_body, var_len(field_len)?)?;
+        }
+    }
+    checked_add(len, var_len(openmls_body)?)
+}
+
+fn message_encoded_len(message: &MessageRecord, deferred: Option<&[u8]>) -> StorageResult<usize> {
+    let mut len = var_len(message.id.as_slice().len())?;
+    len = checked_add(len, var_len(message.group_id.as_slice().len())?)?;
+    len = checked_add(len, 8 + 1)?;
+    len = checked_add(len, var_len(message.payload.len())?)?;
+    checked_add(len, option_len(deferred)?)
+}
+
+fn option_len(value: Option<&[u8]>) -> StorageResult<usize> {
+    match value {
+        None => Ok(1),
+        Some(value) => checked_add(1, var_len(value.len())?),
+    }
+}
+
+fn var_len(len: usize) -> StorageResult<usize> {
+    if len > MAX_FIELD_LEN {
+        return Err(serialization("snapshot field exceeds format limit"));
+    }
+    checked_add(quic_len(len)?, len)
+}
+
+fn quic_len(value: usize) -> StorageResult<usize> {
+    match value {
+        0..=63 => Ok(1),
+        64..=16_383 => Ok(2),
+        16_384..=1_073_741_823 => Ok(4),
+        _ if value <= MAX_FIELD_LEN => Ok(8),
+        _ => Err(serialization("snapshot length exceeds format limit")),
+    }
+}
+
+fn checked_add(left: usize, right: usize) -> StorageResult<usize> {
+    left.checked_add(right)
+        .ok_or_else(|| serialization("snapshot encoded length overflow"))
+}
+
+struct Encoder {
+    out: SensitiveBytes,
+    expected_len: usize,
+}
+
+impl Encoder {
+    fn new(expected_len: usize) -> Self {
+        Self {
+            out: SensitiveBytes::with_capacity(expected_len),
+            expected_len,
+        }
+    }
+
+    fn bytes(&mut self, bytes: &[u8]) -> StorageResult<()> {
+        self.out.extend_exact(bytes)
+    }
+
+    fn u8(&mut self, value: u8) -> StorageResult<()> {
+        self.bytes(&[value])
+    }
+
+    fn u16(&mut self, value: u16) -> StorageResult<()> {
+        self.bytes(&value.to_be_bytes())
+    }
+
+    fn u64(&mut self, value: u64) -> StorageResult<()> {
+        self.bytes(&value.to_be_bytes())
+    }
+
+    fn var(&mut self, bytes: &[u8]) -> StorageResult<()> {
+        if bytes.len() > MAX_FIELD_LEN {
+            return Err(serialization("snapshot field exceeds format limit"));
+        }
+        let mut prefix = Vec::with_capacity(8);
+        cgka_traits::app_components::encode_quic_varint(bytes.len() as u64, &mut prefix);
+        self.bytes(&prefix)?;
+        self.bytes(bytes)
+    }
+
+    fn option_bytes(&mut self, bytes: Option<&[u8]>) -> StorageResult<()> {
+        match bytes {
+            None => self.u8(0),
+            Some(bytes) => {
+                self.u8(1)?;
+                self.var(bytes)
+            }
+        }
+    }
+
+    fn list<T>(
+        &mut self,
+        values: &[T],
+        mut encode: impl FnMut(&T, usize, &mut Encoder) -> StorageResult<()>,
+    ) -> StorageResult<()> {
+        if values.len() > MAX_LIST_ITEMS {
+            return Err(serialization("snapshot list exceeds item limit"));
+        }
+        let start = self.out.len();
+        // Reserve the prefix by first measuring the list body independently.
+        let mut body = Encoder::new(self.expected_len.saturating_sub(start));
+        for (index, value) in values.iter().enumerate() {
+            encode(value, index, &mut body)?;
+        }
+        let body = body.finish_unchecked()?;
+        self.var(body.as_slice())
+    }
+
+    fn option_list<T>(
+        &mut self,
+        values: Option<&[T]>,
+        encode: impl FnMut(&T, usize, &mut Encoder) -> StorageResult<()>,
+    ) -> StorageResult<()> {
+        match values {
+            None => self.u8(0),
+            Some(values) => {
+                self.u8(1)?;
+                self.list(values, encode)
+            }
+        }
+    }
+
+    fn finish_unchecked(self) -> StorageResult<SensitiveBytes> {
+        Ok(self.out)
+    }
+
+    fn finish(self) -> StorageResult<SensitiveBytes> {
+        if self.out.len() != self.expected_len || self.out.capacity() != self.expected_len {
+            return Err(serialization(format!(
+                "snapshot length mismatch: expected {}, wrote {}",
+                self.expected_len,
+                self.out.len()
+            )));
+        }
+        Ok(self.out)
+    }
+}
+
+struct Decoder<'a> {
+    remaining: &'a [u8],
+}
+
+impl<'a> Decoder<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { remaining: bytes }
+    }
+
+    fn expect(&mut self, expected: &[u8], label: &str) -> StorageResult<()> {
+        if !self.remaining.starts_with(expected) {
+            return Err(serialization(format!("invalid {label}")));
+        }
+        self.remaining = &self.remaining[expected.len()..];
+        Ok(())
+    }
+
+    fn take(&mut self, len: usize, label: &str) -> StorageResult<&'a [u8]> {
+        if self.remaining.len() < len {
+            return Err(serialization(format!("truncated {label}")));
+        }
+        let value = &self.remaining[..len];
+        self.remaining = &self.remaining[len..];
+        Ok(value)
+    }
+
+    fn u8(&mut self, label: &str) -> StorageResult<u8> {
+        Ok(self.take(1, label)?[0])
+    }
+
+    fn u16(&mut self, label: &str) -> StorageResult<u16> {
+        let bytes = self.take(2, label)?;
+        Ok(u16::from_be_bytes([bytes[0], bytes[1]]))
+    }
+
+    fn u64(&mut self, label: &str) -> StorageResult<u64> {
+        let bytes = self.take(8, label)?;
+        let mut value = [0_u8; 8];
+        value.copy_from_slice(bytes);
+        Ok(u64::from_be_bytes(value))
+    }
+
+    fn i64_from_u64(&mut self, label: &str) -> StorageResult<i64> {
+        i64::try_from(self.u64(label)?)
+            .map_err(|_| serialization(format!("{label} exceeds SQLite integer range")))
+    }
+
+    fn var(&mut self, label: &str) -> StorageResult<&'a [u8]> {
+        let (len, prefix_len) = cgka_traits::app_components::decode_quic_varint(self.remaining)
+            .map_err(|error| serialization(format!("{label} length: {error}")))?;
+        let len = usize::try_from(len).map_err(|_| serialization(format!("{label} too large")))?;
+        if len > MAX_FIELD_LEN {
+            return Err(serialization(format!("{label} exceeds format limit")));
+        }
+        self.take(prefix_len, label)?;
+        self.take(len, label)
+    }
+
+    fn json<T: DeserializeOwned>(&mut self, label: &str) -> StorageResult<T> {
+        deserialize(self.var(label)?)
+    }
+
+    fn option_bytes(&mut self, label: &str) -> StorageResult<Option<Vec<u8>>> {
+        match self.u8("option discriminant")? {
+            0 => Ok(None),
+            1 => Ok(Some(self.var(label)?.to_vec())),
+            value => Err(serialization(format!(
+                "invalid option discriminant {value}"
+            ))),
+        }
+    }
+
+    fn option_json<T: DeserializeOwned>(&mut self, label: &str) -> StorageResult<Option<T>> {
+        self.option_bytes(label)?
+            .as_deref()
+            .map(deserialize)
+            .transpose()
+    }
+
+    fn list<T>(
+        &mut self,
+        label: &str,
+        mut decode: impl FnMut(&mut Decoder<'_>) -> StorageResult<T>,
+    ) -> StorageResult<Vec<T>> {
+        let body = self.var(label)?;
+        let mut decoder = Decoder::new(body);
+        let mut values = Vec::new();
+        while !decoder.remaining.is_empty() {
+            if values.len() == MAX_LIST_ITEMS {
+                return Err(serialization(format!("{label} exceeds item limit")));
+            }
+            values.push(decode(&mut decoder)?);
+        }
+        Ok(values)
+    }
+
+    fn option_list<T>(
+        &mut self,
+        label: &str,
+        decode: impl FnMut(&mut Decoder<'_>) -> StorageResult<T>,
+    ) -> StorageResult<Option<Vec<T>>> {
+        match self.u8("option discriminant")? {
+            0 => Ok(None),
+            1 => self.list(label, decode).map(Some),
+            value => Err(serialization(format!(
+                "invalid option discriminant {value}"
+            ))),
+        }
+    }
+
+    fn finish(self, label: &str) -> StorageResult<()> {
+        if self.remaining.is_empty() {
+            Ok(())
+        } else {
+            Err(serialization(format!("{label} has trailing bytes")))
+        }
+    }
+}
+
+fn serialization(message: impl Into<String>) -> StorageError {
+    StorageError::Serialization(message.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::test_support::{gid, sample_group};
+
+    #[test]
+    fn state_scoped_v2_has_stable_golden_bytes() {
+        let snapshot = Snapshot {
+            group: sample_group(gid(1), 0, 0),
+            messages: None,
+            queued_outbound: None,
+            member_caps: Vec::new(),
+            convergence_policy: None,
+            validated_tree_marker: None,
+            openmls_values: Vec::new(),
+        };
+        let encoded = encode(&snapshot).unwrap();
+        assert_eq!(
+            hex::encode(encoded.as_slice()),
+            "4d444b53000240f27b226964223a5b312c312c312c315d2c226e616d65223a2273616d706c65222c226465736372697074696f6e223a2264657363222c2265706f6368223a302c226d656d62657273223a5b5d2c2272657175697265645f6361706162696c6974696573223a7b2270726f706f73616c73223a5b5d2c22657874656e73696f6e73223a5b5d2c226170705f636f6d706f6e656e7473223a7b22696473223a5b5d7d7d2c2270726f746f636f6c5f70726f66696c65223a226c6567616379222c2272656d6f766564223a66616c73652c22756e7265636f76657261626c65223a66616c73652c226a6f696e5f65706f6368223a307d000000000000"
+        );
+    }
+}

--- a/crates/storage-sqlite/src/storage/snapshots/restore.rs
+++ b/crates/storage-sqlite/src/storage/snapshots/restore.rs
@@ -1,13 +1,17 @@
+use super::format as snapshot_format;
 use super::rows::{
     GroupStateCheckpoint, MemberCapabilitiesSnapshot, OpenMlsValueSnapshot, OrderedMessage,
     OrderedQueuedOutbound, Snapshot,
 };
 #[cfg(feature = "test-conformance-replay")]
 use super::rows::{REPLAY_SNAPSHOT_VERSION, ReplaySnapshot};
+#[cfg(feature = "test-conformance-replay")]
+use crate::deserialize;
 use crate::openmls_storage::mls_group_key;
+use crate::storage::messages::put_message_on_connection;
 use crate::{
     SqliteAccountStorage, SqliteResultExt, codec::SensitiveBytes, connection::retry_on_busy,
-    created_at_to_i64, deserialize, epoch_to_i64, message_state_to_i64, serialize,
+    created_at_to_i64, epoch_to_i64, serialize,
 };
 use cgka_traits::group::Group;
 use cgka_traits::storage::{StorageError, StorageResult};
@@ -62,7 +66,7 @@ fn rollback_snapshot(
         .storage()?
         .ok_or_else(|| StorageError::SnapshotMissing(name.to_string()))?,
     );
-    let snapshot: Snapshot = deserialize(snapshot_blob.as_slice())?;
+    let snapshot = snapshot_format::decode(snapshot_blob.as_slice())?;
     restore_snapshot(conn, group_id, &snapshot, mls_group_key)
 }
 
@@ -180,20 +184,7 @@ fn messages(
     )
     .storage()?;
     for message in messages {
-        conn.execute(
-            "INSERT INTO cgka_messages
-                (insert_order, id, group_id, epoch, state, record)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-            params![
-                message.insert_order,
-                message.record.id.as_slice(),
-                message.record.group_id.as_slice(),
-                epoch_to_i64(message.record.epoch)?,
-                message_state_to_i64(message.record.state),
-                serialize(&message.record)?
-            ],
-        )
-        .storage()?;
+        put_message_on_connection(conn, Some(message.insert_order), &message.record)?;
     }
     // A full snapshot replaces this group's protocol messages. Preserve
     // pending application deliveries whose source messages were restored, but

--- a/crates/traits/Cargo.toml
+++ b/crates/traits/Cargo.toml
@@ -19,4 +19,9 @@ sha2.workspace = true
 zeroize.workspace = true
 
 [dev-dependencies]
+criterion.workspace = true
 insta.workspace = true
+
+[[bench]]
+name = "stored_message_codec"
+harness = false

--- a/crates/traits/benches/stored_message_codec.rs
+++ b/crates/traits/benches/stored_message_codec.rs
@@ -1,0 +1,47 @@
+use cgka_traits::message::StoredMessagePayload;
+use cgka_traits::transport::{Timestamp, TransportEnvelope, TransportMessage, TransportSource};
+use cgka_traits::types::{MemberId, MessageId};
+use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
+
+fn representative_welcome() -> StoredMessagePayload {
+    StoredMessagePayload::outbound_welcome(TransportMessage {
+        id: MessageId::new(vec![0x11; 32]),
+        payload: vec![0xA5; 16_727],
+        timestamp: Timestamp(1_723_456_789),
+        causal_deps: Vec::new(),
+        source: TransportSource("nostr".to_owned()),
+        envelope: TransportEnvelope::Welcome {
+            recipient: MemberId::new(vec![0x22; 32]),
+        },
+    })
+}
+
+fn codecs(c: &mut Criterion) {
+    let value = representative_welcome();
+    let json = serde_json::to_vec(&value).unwrap();
+    let mdk = value.encode().unwrap();
+    eprintln!(
+        "stored_message_codec sizes raw_payload=16727 json={} mdk_v2={}",
+        json.len(),
+        mdk.len()
+    );
+
+    let mut group = c.benchmark_group("stored_message_codec");
+    group.throughput(Throughput::Bytes(16_727));
+    group.bench_function("encode/json", |b| {
+        b.iter(|| serde_json::to_vec(black_box(&value)).unwrap())
+    });
+    group.bench_function("encode/mdk_v2", |b| {
+        b.iter(|| black_box(&value).encode().unwrap())
+    });
+    group.bench_function("decode/json", |b| {
+        b.iter(|| serde_json::from_slice::<StoredMessagePayload>(black_box(&json)).unwrap())
+    });
+    group.bench_function("decode/mdk_v2", |b| {
+        b.iter(|| StoredMessagePayload::decode(black_box(&mdk)).unwrap())
+    });
+    group.finish();
+}
+
+criterion_group!(benches, codecs);
+criterion_main!(benches);

--- a/crates/traits/src/message.rs
+++ b/crates/traits/src/message.rs
@@ -7,8 +7,15 @@
 
 use crate::engine::CommitOrderingPriority;
 use crate::transport::TransportMessage;
+use crate::transport::{Timestamp, TransportEnvelope, TransportSource};
 use crate::types::{EpochId, GroupId, MemberId, MessageId};
 use serde::{Deserialize, Serialize};
+use std::fmt;
+
+const STORED_MESSAGE_PAYLOAD_MAGIC: &[u8; 5] = b"MDKMP";
+const STORED_MESSAGE_PAYLOAD_VERSION: u16 = 2;
+const MAX_STORED_MESSAGE_FIELD_LEN: usize = 1 << 30;
+const MAX_STORED_MESSAGE_LIST_ITEMS: usize = 1 << 20;
 
 /// Convergence-relevant ordering metadata for a commit this device published
 /// and confirmed, captured at confirm time (while the staged commit is still
@@ -142,16 +149,26 @@ impl StoredMessagePayload {
         Self::OwnCommitWire { message, stamp }
     }
 
-    pub fn encode(&self) -> Result<Vec<u8>, serde_json::Error> {
-        serde_json::to_vec(self)
+    /// Encode the MDK-local storage payload format.
+    ///
+    /// Version 2 deliberately follows Marmot's binary grammar (fixed-width
+    /// network-order integers and canonical QUIC-varint length prefixes), but
+    /// it is an implementation storage format rather than a Marmot wire type.
+    pub fn encode(&self) -> Result<Vec<u8>, StoredMessagePayloadCodecError> {
+        encode_stored_message_payload_v2(self)
     }
 
-    pub fn decode(bytes: &[u8]) -> Result<Self, serde_json::Error> {
+    /// Decode the current binary format, the previous tagged JSON envelope,
+    /// or the oldest bare-`TransportMessage` JSON representation.
+    pub fn decode(bytes: &[u8]) -> Result<Self, StoredMessagePayloadCodecError> {
+        if bytes.starts_with(STORED_MESSAGE_PAYLOAD_MAGIC) {
+            return decode_stored_message_payload_v2(bytes);
+        }
         match serde_json::from_slice(bytes) {
             Ok(payload) => Ok(payload),
             Err(envelope_error) => match serde_json::from_slice(bytes) {
                 Ok(legacy) => Ok(Self::OpenMlsWire(legacy)),
-                Err(_) => Err(envelope_error),
+                Err(_) => Err(StoredMessagePayloadCodecError::LegacyJson(envelope_error)),
             },
         }
     }
@@ -230,6 +247,390 @@ impl StoredMessagePayload {
             } => openmls_message,
         }
     }
+}
+
+/// Failure to decode an MDK-local stored-message payload.
+#[derive(Debug)]
+pub enum StoredMessagePayloadCodecError {
+    Invalid(String),
+    LegacyJson(serde_json::Error),
+}
+
+impl fmt::Display for StoredMessagePayloadCodecError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Invalid(message) => formatter.write_str(message),
+            Self::LegacyJson(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for StoredMessagePayloadCodecError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Invalid(_) => None,
+            Self::LegacyJson(error) => Some(error),
+        }
+    }
+}
+
+fn encode_stored_message_payload_v2(
+    payload: &StoredMessagePayload,
+) -> Result<Vec<u8>, StoredMessagePayloadCodecError> {
+    let mut out = Vec::new();
+    out.extend_from_slice(STORED_MESSAGE_PAYLOAD_MAGIC);
+    out.extend_from_slice(&STORED_MESSAGE_PAYLOAD_VERSION.to_be_bytes());
+    match payload {
+        StoredMessagePayload::RawTransport(message) => {
+            out.push(0);
+            encode_transport_message(message, &mut out)?;
+        }
+        StoredMessagePayload::OutboundWelcome(message) => {
+            out.push(1);
+            encode_transport_message(message, &mut out)?;
+        }
+        StoredMessagePayload::OpenMlsWire(message) => {
+            out.push(2);
+            encode_transport_message(message, &mut out)?;
+        }
+        StoredMessagePayload::SignedOpenMlsWire {
+            exact_message,
+            openmls_message,
+            stamp,
+            own_application_stamp,
+        } => {
+            out.push(3);
+            encode_transport_message(exact_message, &mut out)?;
+            encode_transport_message(openmls_message, &mut out)?;
+            encode_option(stamp.as_ref(), &mut out, encode_own_commit_stamp)?;
+            encode_option(
+                own_application_stamp.as_deref(),
+                &mut out,
+                encode_own_application_stamp,
+            )?;
+        }
+        StoredMessagePayload::OwnCommitWire { message, stamp } => {
+            out.push(4);
+            encode_transport_message(message, &mut out)?;
+            encode_own_commit_stamp(stamp, &mut out)?;
+        }
+    }
+    Ok(out)
+}
+
+fn decode_stored_message_payload_v2(
+    bytes: &[u8],
+) -> Result<StoredMessagePayload, StoredMessagePayloadCodecError> {
+    let mut decoder = Decoder::new(bytes);
+    decoder.expect(STORED_MESSAGE_PAYLOAD_MAGIC, "stored-message payload magic")?;
+    let version = decoder.u16("stored-message payload version")?;
+    if version != STORED_MESSAGE_PAYLOAD_VERSION {
+        return Err(invalid(format!(
+            "unsupported stored-message payload version {version}"
+        )));
+    }
+    let payload = match decoder.u8("stored-message payload variant")? {
+        0 => StoredMessagePayload::RawTransport(decoder.transport_message()?),
+        1 => StoredMessagePayload::OutboundWelcome(decoder.transport_message()?),
+        2 => StoredMessagePayload::OpenMlsWire(decoder.transport_message()?),
+        3 => StoredMessagePayload::SignedOpenMlsWire {
+            exact_message: decoder.transport_message()?,
+            openmls_message: decoder.transport_message()?,
+            stamp: decoder.option(|decoder| decoder.own_commit_stamp())?,
+            own_application_stamp: decoder
+                .option(|decoder| decoder.own_application_stamp())?
+                .map(Box::new),
+        },
+        4 => StoredMessagePayload::OwnCommitWire {
+            message: decoder.transport_message()?,
+            stamp: decoder.own_commit_stamp()?,
+        },
+        variant => {
+            return Err(invalid(format!(
+                "unknown stored-message payload variant {variant}"
+            )));
+        }
+    };
+    decoder.finish("stored-message payload")?;
+    Ok(payload)
+}
+
+fn encode_transport_message(
+    message: &TransportMessage,
+    out: &mut Vec<u8>,
+) -> Result<(), StoredMessagePayloadCodecError> {
+    encode_var_bytes(message.id.as_slice(), out, "message id")?;
+    encode_var_bytes(&message.payload, out, "transport payload")?;
+    out.extend_from_slice(&message.timestamp.0.to_be_bytes());
+    encode_list(&message.causal_deps, out, |dependency, body| {
+        encode_var_bytes(dependency.as_slice(), body, "causal dependency")
+    })?;
+    encode_var_bytes(message.source.0.as_bytes(), out, "transport source")?;
+    match &message.envelope {
+        TransportEnvelope::GroupMessage { transport_group_id } => {
+            out.push(0);
+            encode_var_bytes(transport_group_id, out, "transport group id")?;
+        }
+        TransportEnvelope::Welcome { recipient } => {
+            out.push(1);
+            encode_var_bytes(recipient.as_slice(), out, "welcome recipient")?;
+        }
+    }
+    Ok(())
+}
+
+fn encode_own_commit_stamp(
+    stamp: &OwnCommitConvergenceStamp,
+    out: &mut Vec<u8>,
+) -> Result<(), StoredMessagePayloadCodecError> {
+    encode_var_bytes(stamp.committer.as_slice(), out, "commit stamp committer")?;
+    out.push(match stamp.priority {
+        CommitOrderingPriority::Privileged => 0,
+        CommitOrderingPriority::Ordinary => 1,
+    });
+    encode_list(&stamp.consumed_proposal_refs, out, |proposal_ref, body| {
+        encode_var_bytes(proposal_ref.as_bytes(), body, "consumed proposal reference")
+    })?;
+    encode_option(stamp.checkpoint_id.as_ref(), out, |value, body| {
+        encode_var_bytes(value.as_bytes(), body, "checkpoint id")
+    })?;
+    encode_option(
+        stamp.resulting_epoch_authenticator.as_ref(),
+        out,
+        |value, body| encode_var_bytes(value.as_bytes(), body, "epoch authenticator"),
+    )
+}
+
+fn encode_own_application_stamp(
+    stamp: &OwnApplicationConvergenceStamp,
+    out: &mut Vec<u8>,
+) -> Result<(), StoredMessagePayloadCodecError> {
+    encode_var_bytes(stamp.sender.as_slice(), out, "application stamp sender")?;
+    encode_var_bytes(
+        stamp.source_epoch_authenticator.as_bytes(),
+        out,
+        "source epoch authenticator",
+    )
+}
+
+fn encode_option<T>(
+    value: Option<&T>,
+    out: &mut Vec<u8>,
+    encode: impl FnOnce(&T, &mut Vec<u8>) -> Result<(), StoredMessagePayloadCodecError>,
+) -> Result<(), StoredMessagePayloadCodecError> {
+    match value {
+        None => out.push(0),
+        Some(value) => {
+            out.push(1);
+            encode(value, out)?;
+        }
+    }
+    Ok(())
+}
+
+fn encode_list<T>(
+    values: &[T],
+    out: &mut Vec<u8>,
+    mut encode: impl FnMut(&T, &mut Vec<u8>) -> Result<(), StoredMessagePayloadCodecError>,
+) -> Result<(), StoredMessagePayloadCodecError> {
+    if values.len() > MAX_STORED_MESSAGE_LIST_ITEMS {
+        return Err(invalid("stored-message list exceeds item limit"));
+    }
+    let mut body = Vec::new();
+    for value in values {
+        encode(value, &mut body)?;
+    }
+    encode_var_bytes(&body, out, "stored-message list")
+}
+
+fn encode_var_bytes(
+    bytes: &[u8],
+    out: &mut Vec<u8>,
+    label: &str,
+) -> Result<(), StoredMessagePayloadCodecError> {
+    if bytes.len() > MAX_STORED_MESSAGE_FIELD_LEN {
+        return Err(invalid(format!("{label} exceeds storage format limit")));
+    }
+    crate::app_components::encode_quic_varint(bytes.len() as u64, out);
+    out.extend_from_slice(bytes);
+    Ok(())
+}
+
+struct Decoder<'a> {
+    remaining: &'a [u8],
+}
+
+impl<'a> Decoder<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { remaining: bytes }
+    }
+
+    fn expect(
+        &mut self,
+        expected: &[u8],
+        label: &str,
+    ) -> Result<(), StoredMessagePayloadCodecError> {
+        if !self.remaining.starts_with(expected) {
+            return Err(invalid(format!("invalid {label}")));
+        }
+        self.remaining = &self.remaining[expected.len()..];
+        Ok(())
+    }
+
+    fn u8(&mut self, label: &str) -> Result<u8, StoredMessagePayloadCodecError> {
+        let value = *self
+            .remaining
+            .first()
+            .ok_or_else(|| invalid(format!("truncated {label}")))?;
+        self.remaining = &self.remaining[1..];
+        Ok(value)
+    }
+
+    fn u16(&mut self, label: &str) -> Result<u16, StoredMessagePayloadCodecError> {
+        if self.remaining.len() < 2 {
+            return Err(invalid(format!("truncated {label}")));
+        }
+        let value = u16::from_be_bytes([self.remaining[0], self.remaining[1]]);
+        self.remaining = &self.remaining[2..];
+        Ok(value)
+    }
+
+    fn u64(&mut self, label: &str) -> Result<u64, StoredMessagePayloadCodecError> {
+        if self.remaining.len() < 8 {
+            return Err(invalid(format!("truncated {label}")));
+        }
+        let mut bytes = [0_u8; 8];
+        bytes.copy_from_slice(&self.remaining[..8]);
+        self.remaining = &self.remaining[8..];
+        Ok(u64::from_be_bytes(bytes))
+    }
+
+    fn var_bytes(&mut self, label: &str) -> Result<Vec<u8>, StoredMessagePayloadCodecError> {
+        let (len, prefix_len) = crate::app_components::decode_quic_varint(self.remaining)
+            .map_err(|error| invalid(format!("{label} length: {error}")))?;
+        let len = usize::try_from(len).map_err(|_| invalid(format!("{label} is too large")))?;
+        if len > MAX_STORED_MESSAGE_FIELD_LEN {
+            return Err(invalid(format!("{label} exceeds storage format limit")));
+        }
+        let end = prefix_len
+            .checked_add(len)
+            .ok_or_else(|| invalid(format!("{label} length overflow")))?;
+        if self.remaining.len() < end {
+            return Err(invalid(format!("truncated {label}")));
+        }
+        let value = self.remaining[prefix_len..end].to_vec();
+        self.remaining = &self.remaining[end..];
+        Ok(value)
+    }
+
+    fn string(&mut self, label: &str) -> Result<String, StoredMessagePayloadCodecError> {
+        String::from_utf8(self.var_bytes(label)?)
+            .map_err(|_| invalid(format!("{label} is not UTF-8")))
+    }
+
+    fn list<T>(
+        &mut self,
+        label: &str,
+        mut decode: impl FnMut(&mut Decoder<'_>) -> Result<T, StoredMessagePayloadCodecError>,
+    ) -> Result<Vec<T>, StoredMessagePayloadCodecError> {
+        let body = self.var_bytes(label)?;
+        let mut decoder = Decoder::new(&body);
+        let mut values = Vec::new();
+        while !decoder.remaining.is_empty() {
+            if values.len() == MAX_STORED_MESSAGE_LIST_ITEMS {
+                return Err(invalid(format!("{label} exceeds item limit")));
+            }
+            values.push(decode(&mut decoder)?);
+        }
+        Ok(values)
+    }
+
+    fn option<T>(
+        &mut self,
+        decode: impl FnOnce(&mut Decoder<'_>) -> Result<T, StoredMessagePayloadCodecError>,
+    ) -> Result<Option<T>, StoredMessagePayloadCodecError> {
+        match self.u8("option discriminant")? {
+            0 => Ok(None),
+            1 => decode(self).map(Some),
+            value => Err(invalid(format!("invalid option discriminant {value}"))),
+        }
+    }
+
+    fn transport_message(&mut self) -> Result<TransportMessage, StoredMessagePayloadCodecError> {
+        let id = MessageId::new(self.var_bytes("message id")?);
+        let payload = self.var_bytes("transport payload")?;
+        let timestamp = Timestamp(self.u64("transport timestamp")?);
+        let causal_deps = self.list("causal dependencies", |decoder| {
+            decoder.var_bytes("causal dependency").map(MessageId::new)
+        })?;
+        let source = TransportSource(self.string("transport source")?);
+        let envelope = match self.u8("transport envelope variant")? {
+            0 => TransportEnvelope::GroupMessage {
+                transport_group_id: self.var_bytes("transport group id")?,
+            },
+            1 => TransportEnvelope::Welcome {
+                recipient: MemberId::new(self.var_bytes("welcome recipient")?),
+            },
+            value => {
+                return Err(invalid(format!(
+                    "unknown transport envelope variant {value}"
+                )));
+            }
+        };
+        Ok(TransportMessage {
+            id,
+            payload,
+            timestamp,
+            causal_deps,
+            source,
+            envelope,
+        })
+    }
+
+    fn own_commit_stamp(
+        &mut self,
+    ) -> Result<OwnCommitConvergenceStamp, StoredMessagePayloadCodecError> {
+        let committer = MemberId::new(self.var_bytes("commit stamp committer")?);
+        let priority = match self.u8("commit ordering priority")? {
+            0 => CommitOrderingPriority::Privileged,
+            1 => CommitOrderingPriority::Ordinary,
+            value => return Err(invalid(format!("unknown commit ordering priority {value}"))),
+        };
+        let consumed_proposal_refs = self.list("consumed proposal references", |decoder| {
+            decoder.string("consumed proposal reference")
+        })?;
+        let checkpoint_id = self.option(|decoder| decoder.string("checkpoint id"))?;
+        let resulting_epoch_authenticator =
+            self.option(|decoder| decoder.string("epoch authenticator"))?;
+        Ok(OwnCommitConvergenceStamp {
+            committer,
+            priority,
+            consumed_proposal_refs,
+            checkpoint_id,
+            resulting_epoch_authenticator,
+        })
+    }
+
+    fn own_application_stamp(
+        &mut self,
+    ) -> Result<OwnApplicationConvergenceStamp, StoredMessagePayloadCodecError> {
+        Ok(OwnApplicationConvergenceStamp {
+            sender: MemberId::new(self.var_bytes("application stamp sender")?),
+            source_epoch_authenticator: self.string("source epoch authenticator")?,
+        })
+    }
+
+    fn finish(self, label: &str) -> Result<(), StoredMessagePayloadCodecError> {
+        if self.remaining.is_empty() {
+            Ok(())
+        } else {
+            Err(invalid(format!("{label} has trailing bytes")))
+        }
+    }
+}
+
+fn invalid(message: impl Into<String>) -> StoredMessagePayloadCodecError {
+    StoredMessagePayloadCodecError::Invalid(message.into())
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -311,4 +712,117 @@ pub enum MessageState {
     /// The epoch this message targets has been superseded by a fork recovery
     /// transition; the message will never apply. Kept for audit.
     EpochInvalidated,
+}
+
+#[cfg(test)]
+mod stored_payload_codec_tests {
+    use super::*;
+
+    fn transport(envelope: TransportEnvelope) -> TransportMessage {
+        TransportMessage {
+            id: MessageId::new([0xaa]),
+            payload: vec![0xbb, 0xcc],
+            timestamp: Timestamp(7),
+            causal_deps: vec![MessageId::new([0x11]), MessageId::new([0x22, 0x23])],
+            source: TransportSource("nostr".to_owned()),
+            envelope,
+        }
+    }
+
+    #[test]
+    fn v2_round_trips_every_payload_variant() {
+        let group_message = transport(TransportEnvelope::GroupMessage {
+            transport_group_id: vec![0xdd; 32],
+        });
+        let welcome = transport(TransportEnvelope::Welcome {
+            recipient: MemberId::new(vec![0xee; 32]),
+        });
+        let commit_stamp = OwnCommitConvergenceStamp {
+            committer: MemberId::new(vec![0x33; 32]),
+            priority: CommitOrderingPriority::Privileged,
+            consumed_proposal_refs: vec!["01".to_owned(), "0203".to_owned()],
+            checkpoint_id: Some("checkpoint".to_owned()),
+            resulting_epoch_authenticator: Some("authenticator".to_owned()),
+        };
+        let app_stamp = OwnApplicationConvergenceStamp {
+            sender: MemberId::new(vec![0x44; 32]),
+            source_epoch_authenticator: "source-authenticator".to_owned(),
+        };
+        let values = [
+            StoredMessagePayload::RawTransport(group_message.clone()),
+            StoredMessagePayload::OutboundWelcome(welcome),
+            StoredMessagePayload::OpenMlsWire(group_message.clone()),
+            StoredMessagePayload::SignedOpenMlsWire {
+                exact_message: group_message.clone(),
+                openmls_message: group_message.clone(),
+                stamp: Some(commit_stamp.clone()),
+                own_application_stamp: Some(Box::new(app_stamp)),
+            },
+            StoredMessagePayload::OwnCommitWire {
+                message: group_message,
+                stamp: commit_stamp,
+            },
+        ];
+
+        for value in values {
+            let encoded = value.encode().unwrap();
+            assert!(encoded.starts_with(b"MDKMP\0\x02"));
+            assert_eq!(StoredMessagePayload::decode(&encoded).unwrap(), value);
+        }
+    }
+
+    #[test]
+    fn v2_simple_payload_has_stable_golden_bytes() {
+        let value = StoredMessagePayload::OpenMlsWire(TransportMessage {
+            id: MessageId::new([0xaa]),
+            payload: vec![0xbb, 0xcc],
+            timestamp: Timestamp(7),
+            causal_deps: Vec::new(),
+            source: TransportSource("x".to_owned()),
+            envelope: TransportEnvelope::GroupMessage {
+                transport_group_id: vec![0xdd],
+            },
+        });
+        assert_eq!(
+            hex::encode(value.encode().unwrap()),
+            "4d444b4d5000020201aa02bbcc00000000000000070001780001dd"
+        );
+    }
+
+    #[test]
+    fn decode_accepts_both_legacy_json_shapes() {
+        let message = transport(TransportEnvelope::GroupMessage {
+            transport_group_id: vec![0xdd; 32],
+        });
+        let envelope = StoredMessagePayload::RawTransport(message.clone());
+        assert_eq!(
+            StoredMessagePayload::decode(&serde_json::to_vec(&envelope).unwrap()).unwrap(),
+            envelope
+        );
+        assert_eq!(
+            StoredMessagePayload::decode(&serde_json::to_vec(&message).unwrap()).unwrap(),
+            StoredMessagePayload::OpenMlsWire(message)
+        );
+    }
+
+    #[test]
+    fn v2_decode_rejects_trailing_and_noncanonical_bytes() {
+        let value = StoredMessagePayload::OpenMlsWire(TransportMessage {
+            id: MessageId::new([0xaa]),
+            payload: Vec::new(),
+            timestamp: Timestamp(0),
+            causal_deps: Vec::new(),
+            source: TransportSource(String::new()),
+            envelope: TransportEnvelope::GroupMessage {
+                transport_group_id: Vec::new(),
+            },
+        });
+        let mut trailing = value.encode().unwrap();
+        trailing.push(0);
+        assert!(StoredMessagePayload::decode(&trailing).is_err());
+
+        let mut noncanonical = value.encode().unwrap();
+        noncanonical.splice(8..9, [0x40, 0x01]);
+        assert!(StoredMessagePayload::decode(&noncanonical).is_err());
+    }
 }

--- a/docs/marmot-architecture/index.md
+++ b/docs/marmot-architecture/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Marmot Architecture — Index"
 created: 2026-04-15
-updated: 2026-07-30
+updated: 2026-08-13
 tags: [marmot, architecture, index]
 ---
 
@@ -146,6 +146,10 @@ These are longer working documents. Go here when you need depth, not orientation
   - **What it covers:** Inventory of long-lived daemon/broker runtime structures (maps, counters, handle sets, temp
     artifacts) with their bounds and eviction/reclamation rules, plus the tracked-resource discipline for adding new
     ones.
+
+- **Doc:** [`storage-format-v2.md`](./storage-format-v2.md)
+  - **What it covers:** MDK-local storage versioning, normalized protocol-message rows, the explicit stored-message
+    binary envelope, legacy compatibility, snapshot-v2 decision gate, and upgrade/downgrade operations.
 
 - **Doc:** [marmot-protocol/marmot](https://github.com/marmot-protocol/marmot)
   - **What it covers:** Marmot v2 protocol draft by stable protocol surface and app component.

--- a/docs/marmot-architecture/storage-format-v2.md
+++ b/docs/marmot-architecture/storage-format-v2.md
@@ -1,0 +1,190 @@
+---
+title: "Storage Format v2"
+created: 2026-08-13
+updated: 2026-08-13
+tags: [marmot, storage, sqlite, migration, encoding]
+status: current
+---
+
+# Storage Format v2
+
+This document owns MDK's local SQLCipher storage-format contract. It is not a
+Marmot wire format and does not constrain other Marmot implementations. The
+canonical protocol specifies which state must be reproducible; this document
+specifies how `storage-sqlite` currently persists that state.
+
+## Versioning model
+
+There is no database-wide `format_version` independent of schema migrations.
+That value would be ambiguous while rows and opaque artifacts intentionally
+coexist at different versions.
+
+- `cgka_schema_migrations` is the database compatibility gate. Every writer
+  change that an older binary cannot safely read lands with a numbered
+  migration. `reject_unknown_future_migrations` makes an older binary refuse
+  the database before it reads or writes application tables.
+- Every independently decoded opaque artifact has its own version. A binary
+  envelope starts with an artifact-specific magic value and a fixed-width
+  network-order version. Untagged legacy JSON is recognized only at the
+  artifact's documented v1 fallback boundary.
+- Readers accept supported old versions. Writers emit only the newest version.
+  Unsupported or malformed versions fail closed; readers never guess from a
+  partially decoded value.
+- Golden byte fixtures pin each binary artifact. Schema migration tests pin
+  old-row reads and downgrade refusal.
+
+## Binary grammar
+
+MDK-local binary artifacts reuse the Marmot binary grammar for consistency:
+
+- fields appear in the documented order;
+- fixed-width integers use network byte order;
+- variable byte strings use the shortest canonical QUIC-varint byte-length
+  prefix;
+- list fields are one QUIC-length-prefixed byte vector containing concatenated
+  item encodings;
+- option fields use a one-byte discriminator (`0` absent, `1` present);
+- decoders reject non-minimal length prefixes, unknown discriminants, truncated
+  values, invalid UTF-8 for string fields, and trailing bytes.
+
+Using the same grammar is an MDK implementation convention. It does not make
+these storage artifacts Marmot protocol values.
+
+## `cgka_messages` authority model
+
+Migration `0047_normalized_message_records` supports two row formats:
+
+| Column | Format 1 | Format 2 |
+| --- | --- | --- |
+| `id`, `group_id`, `epoch`, `state` | indexed copy; legacy `record` remains the decoded authority | authoritative |
+| `storage_format` | `1` | `2` |
+| `record` | complete JSON `MessageRecord` | `NULL` |
+| `payload` | `NULL` | exact `MessageRecord.payload` bytes |
+| `deferred_peel` | `NULL`; represented inside `record` | optional JSON `DeferredPeelLifecycle` metadata |
+
+Existing rows remain format 1 at migration time so opening a large account does
+not perform an unbounded history rewrite. Current writes are format 2. Updating
+a legacy row promotes it atomically; updating a format-2 state changes only the
+scalar `state` and, when leaving `PeelDeferred`, clears `deferred_peel`. It does
+not read, decode, copy, or rewrite `payload`.
+
+The retained legacy `record` column is a compatibility read path, not an
+ongoing second authority. `promote_legacy_message_rows` promotes at most 256
+rows in one atomic, idempotent batch and reports only aggregate progress so a
+host can schedule it away from account-open latency. Removing format-1 reads
+requires a later migration and release decision.
+Reclaiming freed SQLCipher pages is an explicit maintenance operation; opening
+an account never runs `VACUUM` implicitly.
+
+## `StoredMessagePayload` v2
+
+New `MessageRecord.payload` values use this envelope:
+
+```text
+opaque magic[5] = "MDKMP";
+uint16 version = 2;
+uint8 variant;
+PayloadVariant body;
+```
+
+Variant values are stable:
+
+| Value | Body |
+| --- | --- |
+| `0` | one `TransportMessage`, `RawTransport` |
+| `1` | one `TransportMessage`, `OutboundWelcome` |
+| `2` | one `TransportMessage`, `OpenMlsWire` |
+| `3` | exact `TransportMessage`, OpenMLS `TransportMessage`, optional own-commit stamp, optional own-application stamp |
+| `4` | one `TransportMessage`, required own-commit stamp |
+
+A stored `TransportMessage` contains, in order:
+
+```text
+opaque id<V>;
+opaque payload<V>;
+uint64 timestamp;
+MessageId causal_dependencies<V>;
+opaque source_utf8<V>;
+uint8 envelope_variant; // 0 group message, 1 welcome
+opaque envelope_id<V>;  // transport group id or recipient id
+```
+
+Each `MessageId` inside `causal_dependencies` is itself a length-prefixed opaque
+value. An own-commit stamp contains the length-prefixed committer id, a one-byte
+priority (`0` privileged, `1` ordinary), a vector of length-prefixed UTF-8
+proposal references, optional checkpoint id, and optional resulting epoch
+authenticator. An own-application stamp contains the sender id and source epoch
+authenticator.
+
+Each field is limited to at most `2^30` bytes and each decoded list to at most
+`2^20` items. These are defensive local resource bounds, not protocol limits.
+
+The decoder falls back from a missing `MDKMP` magic to the previous tagged JSON
+envelope and then the oldest bare-`TransportMessage` JSON shape. A value that
+starts with `MDKMP` never falls back after a binary decoding failure.
+
+## Snapshot v2
+
+Retained-anchor snapshots no longer copy the message ledger or queued outbound
+work. Their 32-invitee capture cost measured roughly 1.23 ms. Full rollback
+snapshots still include the live message ledger and measured roughly 11.0 ms,
+so that path justified a binary format.
+
+Snapshot and group-state checkpoint v2 start with `MDKS`, network-order `uint16` version `2`, and then
+length-delimited group JSON, optional normalized message rows, optional queued
+outbound rows, member capabilities, optional convergence-policy and validation
+bytes, and raw OpenMLS key/value rows. Message ids, group ids, payloads, and
+OpenMLS fields remain raw bytes rather than JSON number arrays. The exact
+encoded length is computed before allocating the zeroizing output buffer; the
+encoder cannot grow it. Temporary list bodies that can contain secret material
+also use zeroizing ownership.
+
+A blob without `MDKS` is decoded as the corresponding unversioned JSON v1
+snapshot or checkpoint. A blob with `MDKS` never falls back following a v2
+error. Full snapshots, state-scoped snapshots, and branch-addressed checkpoints
+use the envelope. State-scoped snapshots and checkpoints encode the message and
+queue options as absent; checkpoints additionally reject rollback-only message,
+queue, or convergence-policy fields during decoding.
+
+## Decision evidence
+
+Measured on 2026-08-13 in the release profile on the same local machine and
+Criterion harness used to identify the original regression:
+
+| Measurement | Current result |
+| --- | --- |
+| `create_group/32 invitees` | 15.62–15.73 ms; the pre-v2 current-head baseline was about 28.09 ms |
+| retained-anchor capture, empty group | 177–185 us |
+| retained-anchor capture, 32 invitees | 1.23–1.29 ms |
+| full rollback snapshot, 32 invitees, JSON | 10.95–11.03 ms |
+| full rollback snapshot, 32 invitees, v2 | 3.62–4.40 ms |
+| representative 16,727-byte Welcome, JSON payload envelope | 67,254 bytes |
+| representative 16,727-byte Welcome, explicit MDK v2 envelope | 16,821 bytes |
+| MDK v2 encode / decode | about 686 ns / 335 ns |
+| JSON encode / decode | about 40.4 us / 114.4 us |
+
+A Postcard 1.1.3 spike produced 16,810 bytes and encoded in about 6.42 us, but
+could not deserialize the existing internally tagged `StoredMessagePayload`
+Serde shape (`WontImplement`). Supporting it would therefore require a second
+Postcard-specific DTO/schema in addition to the explicit compatibility
+contract. The explicit MDK format is smaller than JSON, faster than both tested
+encoders, already decodes the production type, and has stable golden bytes, so
+Postcard is not adopted.
+
+The group-state-only retained-anchor capture is roughly 1.25 ms at the
+32-invitee fixture and the headline create benchmark is below the 20 ms target.
+Snapshot v2 is justified by the separately measured full rollback path, not by
+the obsolete pre-#1406 claim that retained anchors still contain messages.
+
+## Operational policy
+
+- Upgrade is automatic through numbered transactional migrations.
+- Downgrade across migration 47 is unsupported: an older binary refuses the
+  newer migration before reading account data.
+- Migration 47 changes table shape atomically but does not backfill history, so
+  session-open time is bounded independently of message-history size.
+- The promotion sweep uses batches of at most 256 rows, aggregate privacy-safe
+  progress, and an idempotent transaction; malformed input rolls back the
+  whole batch.
+- `VACUUM` is opt-in maintenance on an already keyed connection and is never
+  part of automatic session open.

--- a/docs/marmot-architecture/storage-format-v2.md
+++ b/docs/marmot-architecture/storage-format-v2.md
@@ -62,11 +62,14 @@ Migration `0047_normalized_message_records` supports two row formats:
 | `payload` | `NULL` | exact `MessageRecord.payload` bytes |
 | `deferred_peel` | `NULL`; represented inside `record` | optional JSON `DeferredPeelLifecycle` metadata |
 
-Existing rows remain format 1 at migration time so opening a large account does
-not perform an unbounded history rewrite. Current writes are format 2. Updating
-a legacy row promotes it atomically; updating a format-2 state changes only the
-scalar `state` and, when leaving `PeelDeferred`, clears `deferred_peel`. It does
-not read, decode, copy, or rewrite `payload`.
+Migration 47 preserves existing rows as format 1, so account open does not
+decode or promote each legacy payload. It does, however, rebuild
+`cgka_messages` with a one-time physical row copy inside the migration
+transaction. That I/O, exclusive-write duration, WAL growth, and temporary
+free-space requirement scale with message history. Current writes are format
+2. Updating a legacy row promotes it atomically; updating a format-2 state
+changes only the scalar `state` and, when leaving `PeelDeferred`, clears
+`deferred_peel`. It does not read, decode, copy, or rewrite `payload`.
 
 The retained legacy `record` column is a compatibility read path, not an
 ongoing second authority. `promote_legacy_message_rows` promotes at most 256
@@ -130,21 +133,25 @@ work. Their 32-invitee capture cost measured roughly 1.23 ms. Full rollback
 snapshots still include the live message ledger and measured roughly 11.0 ms,
 so that path justified a binary format.
 
-Snapshot and group-state checkpoint v2 start with `MDKS`, network-order `uint16` version `2`, and then
-length-delimited group JSON, optional normalized message rows, optional queued
-outbound rows, member capabilities, optional convergence-policy and validation
-bytes, and raw OpenMLS key/value rows. Message ids, group ids, payloads, and
-OpenMLS fields remain raw bytes rather than JSON number arrays. The exact
-encoded length is computed before allocating the zeroizing output buffer; the
-encoder cannot grow it. Temporary list bodies that can contain secret material
-also use zeroizing ownership.
+Snapshot and group-state checkpoint v2 start with `MDKS` and network-order
+`uint16` version `2`. A full rollback snapshot then contains length-delimited
+group JSON, normalized message rows, queued outbound rows, member capabilities,
+optional convergence-policy and validation bytes, and raw OpenMLS key/value
+rows. A state-scoped snapshot intentionally marks the message and queue fields
+absent, so restoring it leaves the live message ledger, pending application
+events, and outbound queue untouched. A branch-addressed checkpoint is also
+canonical-state-only and additionally omits convergence policy. Message ids,
+group ids, payloads, and OpenMLS fields remain raw bytes rather than JSON number
+arrays. The exact encoded length is computed before allocating the zeroizing
+output buffer; the encoder cannot grow it. Temporary list bodies that can
+contain secret material also use zeroizing ownership.
 
 A blob without `MDKS` is decoded as the corresponding unversioned JSON v1
 snapshot or checkpoint. A blob with `MDKS` never falls back following a v2
 error. Full snapshots, state-scoped snapshots, and branch-addressed checkpoints
-use the envelope. State-scoped snapshots and checkpoints encode the message and
-queue options as absent; checkpoints additionally reject rollback-only message,
-queue, or convergence-policy fields during decoding.
+use the envelope. Decoders preserve the scope distinction: checkpoints reject
+rollback-only message, queue, or convergence-policy fields rather than silently
+accepting a full snapshot as canonical-state-only.
 
 ## Decision evidence
 
@@ -181,8 +188,11 @@ the obsolete pre-#1406 claim that retained anchors still contain messages.
 - Upgrade is automatic through numbered transactional migrations.
 - Downgrade across migration 47 is unsupported: an older binary refuses the
   newer migration before reading account data.
-- Migration 47 changes table shape atomically but does not backfill history, so
-  session-open time is bounded independently of message-history size.
+- Migration 47 changes table shape atomically through a one-time physical copy
+  proportional to message-history size. It performs no per-row payload decode
+  or format-2 promotion, but the first upgrade still needs history-scaled lock
+  time, WAL growth, and temporary free space. Large-account duration and disk
+  requirements must be measured before the release cohort is promoted.
 - The promotion sweep uses batches of at most 256 rows, aggregate privacy-safe
   progress, and an idempotent transaction; malformed input rolls back the
   whole batch.

--- a/release.md
+++ b/release.md
@@ -153,6 +153,33 @@ not compiled into MarmotKit; apps supply them at runtime.
 
 The GitHub workflow repeats the release builds on clean runners. Local builds catch drift earlier.
 
+## Storage-Format Changes
+
+For a release that adds a `storage-sqlite` migration or changes an opaque
+storage artifact:
+
+1. Link the format definition and compatibility evidence from
+   `docs/marmot-architecture/storage-format-v2.md` in the release notes.
+2. Verify an older fixture opens and upgrades once, a current fixture reopens
+   without rewriting, and the prior binary refuses the new migration before
+   reading or writing account tables.
+3. Run crash/failure-injection tests at every multi-row transformation or
+   artifact replacement boundary. Schema migrations are transactional;
+   background promotion work must additionally be row-idempotent and bounded.
+4. State explicitly that downgrade across the migration is unsupported. The
+   remedies are to re-upgrade or restore a pre-upgrade account database/export;
+   never advise manually removing migration rows.
+5. Recommend a pre-upgrade backup/export in the cohort release notes when the
+   release rewrites existing durable data. Migration 47 only changes table
+   shape and retains legacy message rows, so it does not perform a history-size
+   open-time rewrite.
+6. Do not run `VACUUM` during automatic account open. If page reclamation is
+   useful, expose it as explicit keyed-connection maintenance and report its
+   expected duration and temporary free-space requirement.
+
+Storage migrations do not require a workspace version bump during feature
+development. The eventual release version remains a manual release operation.
+
 ## Whole-Workspace Release
 
 Use this for a versioned MDK source/library release.

--- a/release.md
+++ b/release.md
@@ -169,16 +169,20 @@ storage artifact:
 4. State explicitly that downgrade across the migration is unsupported. The
    remedies are to re-upgrade or restore a pre-upgrade account database/export;
    never advise manually removing migration rows.
-5. Recommend a pre-upgrade backup/export in the cohort release notes when the
-   release rewrites existing durable data. Migration 47 only changes table
-   shape and retains legacy message rows, so it does not perform a history-size
-   open-time rewrite.
+5. Recommend a pre-upgrade backup/export for the migration-47 cohort. Although
+   it preserves legacy row bytes and defers per-row format promotion, its
+   transactional table rebuild physically copies the complete message history.
+   Validate upgrade duration, WAL growth, and temporary free-space requirements
+   on a representative large account before release.
 6. Do not run `VACUUM` during automatic account open. If page reclamation is
    useful, expose it as explicit keyed-connection maintenance and report its
    expected duration and temporary free-space requirement.
 
 Storage migrations do not require a workspace version bump during feature
 development. The eventual release version remains a manual release operation.
+
+Before pushing, run `just fast-ci`. Let GitHub CI run the full `just ci` test
+matrix.
 
 ## Whole-Workspace Release
 


### PR DESCRIPTION
## Summary

- normalize `cgka_messages` so indexed state and metadata are authoritative scalar columns while opaque payload and deferred-peel data live in dedicated BLOBs
- add explicit, versioned `MDKMP` v2 message-payload and `MDKS` v2 snapshot/checkpoint codecs with legacy JSON reads and fail-closed tagged decoding
- preserve existing rows during migration 47 and expose bounded, atomic, resumable lazy promotion instead of rewriting account history at session open
- preserve zeroizing snapshot output, state-scoped retained anchors, full rollback semantics, and conformance-replay behavior
- document the compatibility model, downgrade refusal, backfill/VACUUM posture, release sequencing, and measured format decision

## Why

JSON encoded byte fields as decimal arrays twice: a representative 16,727-byte Welcome became a roughly 180 KB message row. State changes then read and double-parsed that complete record merely to flip one enum. Full rollback snapshots repeated the same expansion in a versionless blob.

This change keeps the storage boundary local to one account-device database. It does not change Marmot or MLS wire bytes. Migration 47 remains the database downgrade gate, while each opaque artifact carries its own version so mixed legacy/current rows and snapshots remain readable without a redundant global format flag.

## Measured impact

The stacked measurement rail in #1425 reports:

- `create_group/32`: approximately 65 ms at the tracker baseline, 28.09 ms immediately before v2, and 15.22 ms after v2
- representative normalized 32-member Welcome value: 16,821 bytes, down from the 180,002-byte tracker anchor
- largest 32-member founding snapshot: approximately 82.6 KB, down from roughly 6 MB
- payload encode/decode: approximately 40.4 us / 114.4 us JSON to 686 ns / 335 ns v2
- retained-anchor capture at 32 invitees: approximately 1.23–1.29 ms
- full rollback snapshot at 32 invitees: approximately 10.95–11.03 ms JSON to 3.62–4.40 ms v2
- `join_welcome/1 stored KP`: 1.30 ms; `join_welcome/32 stored KPs`: 1.33 ms; 32-member join: 3.94 ms

These satisfy the size and `create_group/32` targets in #1413. The stacked PR also adds the missing send, ingest, real rejoin-with-history, canonical-advance, and database-footprint rails.

## Compatibility and recovery

- new binaries read legacy message rows, payload JSON, snapshot JSON, and checkpoint JSON
- new writes use normalized rows and tagged v2 artifacts
- old binaries refuse migration 47 through the existing future-migration gate before account-table access
- bounded promotion batches are atomic and idempotent; malformed input rolls back the whole batch
- tagged unknown artifact versions fail closed and never retry as legacy JSON
- an encrypted file-backed schema-v46 database upgrades once while preserving group/message bytes and then refuses downgrade without touching account rows
- process-kill tests stop after migration-47 mutation but before commit, and after the first row of a promotion batch; reopen proves the transaction rolled back and retry converges without data loss

## Validation

- `just fast-ci` after rebase onto current `origin/master`
- `cargo test -p cgka-traits`
- `cargo test -p storage-sqlite --features test-conformance-replay` (368 passed, 2 child-process entry points ignored)
- focused file-backed upgrade, migration-kill, and promotion-kill tests
- `cargo test -p cgka-engine --features test-policy-overrides,test-crash-hooks --test group_creation` (50 passed)
- `cargo test -p cgka-engine --features test-policy-overrides,test-crash-hooks --test crash_recovery_sqlite` (3 passed, 1 child ignored)
- `cargo test -p cgka-engine --features test-policy-overrides,test-crash-hooks --test publish_lifecycle` (18 passed)
- latest GitHub run is green across format/check/clippy, all four Rust test shards, simulator/vectors, relay runtime, CLI E2E, and Tamarin

A local full-feature `just ci` run previously exposed `cold_reopen_recovers_quiet_offline_history_without_a_live_trigger`; the same feature-set failure reproduced on unmodified `origin/master`. The latest GitHub matrix for this exact PR head is green.

## PR sequence

1. Review and merge this storage implementation into `master`.
2. Review #1425 as the single stacked measurement commit, then retarget it to `master` after this PR merges.
3. Keep large-history upgrade timing, progress reporting, optional compaction, and cohort release evidence in #1414.

The durability/spec contract is being handled independently in [marmot#416](https://github.com/marmot-protocol/marmot/pull/416); this PR remains an implementation-local storage change.

Closes #1410
Closes #1411
Closes #1412

Related: #1413, #1414, #1415