### PR TITLE
chore(release): prepare 0.9.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agent-connector"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "agent-control",
  "agent-stream-compose",
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "agent-control"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "serde",
  "serde_json",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "agent-stream-compose"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "cgka-traits",
  "hex",
@@ -864,7 +864,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cgka-conformance-simulator"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-engine"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-session"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-traits"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "async-trait",
  "hex",
@@ -1191,7 +1191,7 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "convergence-campaign-runner"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "async-trait",
  "cgka-conformance-simulator",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "fs-private"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "libc",
  "tempfile",
@@ -2723,7 +2723,7 @@ dependencies = [
 
 [[package]]
 name = "incident-replay"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "cgka-conformance-simulator",
  "fs-private",
@@ -3320,7 +3320,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-account"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-app"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3397,7 +3397,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-forensics"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "fs-private",
  "serde",
@@ -3407,7 +3407,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-markdown"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "serde",
  "serde_json",
@@ -3415,7 +3415,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-terminal-harness"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "agent-control",
  "async-trait",
@@ -3430,7 +3430,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-uniffi"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "cgka-engine",
  "cgka-traits",
@@ -5650,7 +5650,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-sqlite"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "cgka-traits",
  "fs-private",
@@ -6266,7 +6266,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-adapter"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -6286,7 +6286,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-peeler"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -6303,7 +6303,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-broker"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "cgka-traits",
  "clap",
@@ -6322,7 +6322,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-stream"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "cgka-traits",
  "chacha20poly1305",
@@ -7389,7 +7389,7 @@ dependencies = [
 
 [[package]]
 name = "wn-cli"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "agent-stream-compose",
  "cgka-session",
@@ -7423,7 +7423,7 @@ dependencies = [
 
 [[package]]
 name = "wn-opencode"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "async-trait",
  "clap",
@@ -7438,7 +7438,7 @@ dependencies = [
 
 [[package]]
 name = "wn-pi"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "async-trait",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "0.9.11"
+version = "0.9.12"
 license = "MIT"
 publish = false
 

--- a/crates/cgka-conformance-simulator/vectors/admin-handover.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/admin-handover.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "admin-handover/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.11",
+  "conformance_version": "0.9.12",
   "seed": null,
   "scenario": {
     "name": "admin-handover/v1",

--- a/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "admin-policy-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.11",
+  "conformance_version": "0.9.12",
   "seed": null,
   "scenario": {
     "name": "admin-policy-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "concurrent-invite-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.11",
+  "conformance_version": "0.9.12",
   "seed": null,
   "scenario": {
     "name": "concurrent-invite-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-committer-selected/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.11",
+  "conformance_version": "0.9.12",
   "seed": null,
   "scenario": {
     "name": "convergence-committer-selected/v1",

--- a/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-witness-selected/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.11",
+  "conformance_version": "0.9.12",
   "seed": null,
   "scenario": {
     "name": "convergence-witness-selected/v1",

--- a/crates/cgka-conformance-simulator/vectors/conversation.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/conversation.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "conversation/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.11",
+  "conformance_version": "0.9.12",
   "seed": null,
   "scenario": {
     "name": "conversation/v1",

--- a/crates/cgka-conformance-simulator/vectors/cross-route-own-commit-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/cross-route-own-commit-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "cross-route-own-commit-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.11",
+  "conformance_version": "0.9.12",
   "seed": null,
   "scenario": {
     "name": "cross-route-own-commit-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/current-profile-required-set.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/current-profile-required-set.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "current-profile-required-set/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.11",
+  "conformance_version": "0.9.12",
   "seed": null,
   "application_profile": {
     "name": "current",

--- a/crates/cgka-conformance-simulator/vectors/deferred-tick-catchup.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/deferred-tick-catchup.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "deferred-tick-catchup/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.11",
+  "conformance_version": "0.9.12",
   "seed": null,
   "scenario": {
     "name": "deferred-tick-catchup/v1",

--- a/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "delayed-past-epoch-app-message/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.11",
+  "conformance_version": "0.9.12",
   "seed": null,
   "scenario": {
     "name": "delayed-past-epoch-app-message/v1",

--- a/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "drop-queued/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.11",
+  "conformance_version": "0.9.12",
   "seed": null,
   "scenario": {
     "name": "drop-queued/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.11",
+  "conformance_version": "0.9.12",
   "seed": null,
   "scenario": {
     "name": "group-data-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.11",
+  "conformance_version": "0.9.12",
   "seed": null,
   "scenario": {
     "name": "group-data-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-profile-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-profile-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-profile-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.11",
+  "conformance_version": "0.9.12",
   "seed": null,
   "scenario": {
     "name": "group-profile-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.11",
+  "conformance_version": "0.9.12",
   "seed": null,
   "scenario": {
     "name": "convergence-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "fork-recovery-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.11",
+  "conformance_version": "0.9.12",
   "seed": null,
   "scenario": {
     "name": "fork-recovery-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "membership-fork-recovery-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.11",
+  "conformance_version": "0.9.12",
   "seed": null,
   "scenario": {
     "name": "membership-fork-recovery-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incremental-growth.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incremental-growth.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "incremental-growth/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.11",
+  "conformance_version": "0.9.12",
   "seed": null,
   "scenario": {
     "name": "incremental-growth/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-member/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.11",
+  "conformance_version": "0.9.12",
   "seed": null,
   "scenario": {
     "name": "invite-member/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.11",
+  "conformance_version": "0.9.12",
   "seed": null,
   "scenario": {
     "name": "invite-publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/late-welcome-backfill.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/late-welcome-backfill.v1.json
@@ -1,7 +1,7 @@
 {
  "scenario_name": "late-welcome-backfill/v1",
  "vector_version": "1",
- "conformance_version": "0.9.11",
+ "conformance_version": "0.9.12",
  "seed": null,
  "scenario": {
   "name": "late-welcome-backfill/v1",

--- a/crates/cgka-conformance-simulator/vectors/latecomer-forward-secrecy.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/latecomer-forward-secrecy.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "latecomer-forward-secrecy/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.11",
+  "conformance_version": "0.9.12",
   "seed": null,
   "scenario": {
     "name": "latecomer-forward-secrecy/v1",

--- a/crates/cgka-conformance-simulator/vectors/leaver-removal-secrecy.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/leaver-removal-secrecy.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "leaver-removal-secrecy/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.11",
+  "conformance_version": "0.9.12",
   "seed": null,
   "scenario": {
     "name": "leaver-removal-secrecy/v1",

--- a/crates/cgka-conformance-simulator/vectors/multigroup-isolation.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/multigroup-isolation.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "multigroup-isolation/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.11",
+  "conformance_version": "0.9.12",
   "seed": null,
   "scenario": {
     "name": "multigroup-isolation/v1",

--- a/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "partition-clear-leave/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.11",
+  "conformance_version": "0.9.12",
   "seed": null,
   "scenario": {
     "name": "partition-clear-leave/v1",

--- a/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.11",
+  "conformance_version": "0.9.12",
   "seed": null,
   "scenario": {
     "name": "publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "queue-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.11",
+  "conformance_version": "0.9.12",
   "seed": null,
   "scenario": {
     "name": "queue-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/readd-after-eviction.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/readd-after-eviction.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "readd-after-eviction/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.11",
+  "conformance_version": "0.9.12",
   "seed": null,
   "scenario": {
     "name": "readd-after-eviction/v1",

--- a/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "restart-delivery-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.11",
+  "conformance_version": "0.9.12",
   "seed": null,
   "scenario": {
     "name": "restart-delivery-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/route-equivalence.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/route-equivalence.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "route-equivalence/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.11",
+  "conformance_version": "0.9.12",
   "seed": null,
   "scenario": {
     "name": "route-equivalence/v1",

--- a/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "three-client-message-exchange/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.11",
+  "conformance_version": "0.9.12",
   "seed": null,
   "scenario": {
     "name": "three-client-message-exchange/v1",

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -9,7 +9,25 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ## [Unreleased]
 
+## [0.9.12] - 2026-08-13
+
 ### Added
+
+- WN Agent's `marmot.agent-control.v2` protocol now supports adding and
+  removing durable message reactions. Hermes exposes the operations through
+  its Marmot tools, and OpenClaw exposes them through
+  `message(action="react")`, including current-message targeting, bounded
+  reaction content, exact or all-reaction removal, and idempotent missing
+  removal handling.
+  ([#1399](https://github.com/marmot-protocol/mdk/pull/1399),
+  [#1401](https://github.com/marmot-protocol/mdk/pull/1401))
+
+- MarmotKit releases now publish immutable SwiftPM-compatible XCFramework
+  archives, generated Swift source, checksums, and complete provenance
+  manifests. Exact-master snapshot releases use source-SHA identities so
+  pre-release app builds can pin bindings without replacing a versioned
+  artifact.
+  ([#1378](https://github.com/marmot-protocol/mdk/pull/1378))
 
 - `wn tui` group detail now has a lowercase `a` that searches for a member to
   add, for when you do not have the pubkey to hand (`A` remains the paste-a-pubkey
@@ -18,6 +36,40 @@ versioning through the workspace version in the root `Cargo.toml`.
   detail, and a completed add reopens and reloads it.
 
 ### Changed
+
+- Agent stream-compose append, status, and progress acknowledgements no longer
+  echo the accumulated transcript on every command. This removes quadratic
+  copying for long streams; `compose-append` JSON no longer contains `text`,
+  while finish responses still carry and validate the complete transcript and
+  the TUI tracks flushed bytes locally.
+  ([#1408](https://github.com/marmot-protocol/mdk/pull/1408))
+
+- Hot paths now avoid history-sized repeated work: outbound send gates use
+  indexed message-state probes, retained convergence anchors omit unused
+  message-ledger copies, Welcome joins use point lookups and filtered replay,
+  MarmotKit timeline windows reconvert only changed rows, and app clients keep
+  an incremental seen-event index. Existing databases remain compatible.
+  ([#1405](https://github.com/marmot-protocol/mdk/pull/1405),
+  [#1406](https://github.com/marmot-protocol/mdk/pull/1406),
+  [#1407](https://github.com/marmot-protocol/mdk/pull/1407),
+  [#1416](https://github.com/marmot-protocol/mdk/pull/1416),
+  [#1417](https://github.com/marmot-protocol/mdk/pull/1417))
+
+- Same-epoch fork resolution now uses one rule for every member: the
+  committer's pairwise fast-path is removed, and a committer adjudicates a
+  rival commit through the same distributed-convergence pass as an observer,
+  with its own commit materialized from the commit-addressed checkpoints
+  introduced in #1285. When the in-horizon recovery material (the retained
+  source-epoch anchor) is missing, the group fails closed loudly — durable
+  `Unrecoverable` halt plus a `GroupUnrecoverable` event — instead of
+  silently keeping a possibly losing branch. A committer's rival resolution
+  now waits for the convergence pass's quiescence window (~1 s); sends queue
+  during it. The `ForkRecovered` group event and its MarmotKit FFI variant
+  are removed (the convergence-path `CommitRolledBack` +
+  `GroupStateInvalidated` pair is the rollback signal); forensic audit logs
+  keep parsing the historical `fork_resolution` and `snapshot_created` rows,
+  which current engines no longer emit.
+  ([#1293](https://github.com/marmot-protocol/mdk/pull/1293))
 
 - Encrypted media and Hermes/WN Agent file delivery now accept blobs up to
   512 MiB (including the 16-byte authentication tag), enabling APKs and other
@@ -45,6 +97,23 @@ versioning through the workspace version in the root `Cargo.toml`.
   ([#1396](https://github.com/marmot-protocol/mdk/pull/1396))
 
 ### Fixed
+
+- Outbound application messages queued during an unsettled convergence pass
+  now durably arm their drain and remain visible as runnable or scheduled work,
+  preventing accepted sends from being stranded while the group appears idle.
+  ([#1403](https://github.com/marmot-protocol/mdk/pull/1403))
+
+- Removed members can rejoin through a fresh Welcome without evicted-era
+  snapshots aborting the past-epoch peel probe, and deliveries dropped before
+  a delayed Welcome are no longer remembered as seen so relay redelivery can
+  catch the new member up.
+  ([#1367](https://github.com/marmot-protocol/mdk/pull/1367),
+  [#1379](https://github.com/marmot-protocol/mdk/pull/1379))
+
+- Incident replay now recognizes manifest-less NDJSON stream remnants by their
+  type discriminator and fails closed instead of accepting a truncated error
+  stream as an empty healthy export.
+  ([#1140](https://github.com/marmot-protocol/mdk/pull/1140))
 
 - OpenClaw Marmot inbound turns now resolve agent-scoped session stores with the
   routed agent id, and beta message sends bypass the delete-only action adapter
@@ -391,21 +460,6 @@ versioning through the workspace version in the root `Cargo.toml`.
   `Sendable`/`Error` conformances; the dependency refresh also removes the
   audited `bincode`, `paste`, and `proc-macro-error2` paths and incorporates the
   `nostr` fix for RUSTSEC-2026-0219.
-
-- Same-epoch fork resolution now uses one rule for every member: the
-  committer's pairwise fast-path is removed, and a committer adjudicates a
-  rival commit through the same distributed-convergence pass as an observer,
-  with its own commit materialized from the commit-addressed checkpoints
-  introduced in #1285. When the in-horizon recovery material (the retained
-  source-epoch anchor) is missing, the group fails closed loudly — durable
-  `Unrecoverable` halt plus a `GroupUnrecoverable` event — instead of
-  silently keeping a possibly losing branch. A committer's rival resolution
-  now waits for the convergence pass's quiescence window (~1 s); sends queue
-  during it. The `ForkRecovered` group event and its MarmotKit FFI variant
-  are removed (the convergence-path `CommitRolledBack` +
-  `GroupStateInvalidated` pair is the rollback signal); forensic audit logs
-  keep parsing the historical `fork_resolution` and `snapshot_created` rows,
-  which current engines no longer emit.
 
 - The bundled SQLCipher stack now uses rusqlite 0.40.1/libsqlite3-sys 0.38.1,
   providing SQLCipher 4.14.0 and SQLite 3.51.3 with SQLite's WAL-reset
@@ -1458,7 +1512,8 @@ Initial release of the `dm` command-line app, the `dmd` background daemon, and t
 - Local installation docs for `cargo install --path crates/cli --locked --bins`.
 - Homebrew release checklist and namespaced tap packaging path for `marmot-protocol/tap/darkmatter`.
 
-[Unreleased]: https://github.com/marmot-protocol/mdk/compare/v0.9.11...HEAD
+[Unreleased]: https://github.com/marmot-protocol/mdk/compare/v0.9.12...HEAD
+[0.9.12]: https://github.com/marmot-protocol/mdk/compare/v0.9.11...v0.9.12
 [0.9.11]: https://github.com/marmot-protocol/mdk/compare/v0.9.10...v0.9.11
 [0.9.10]: https://github.com/marmot-protocol/mdk/compare/v0.9.9...v0.9.10
 [0.9.9]: https://github.com/marmot-protocol/mdk/compare/v0.9.8...v0.9.9


### PR DESCRIPTION
## Summary

- bump the MDK workspace compatibility cohort from 0.9.11 to 0.9.12
- update all workspace package entries in Cargo.lock and all 31 conformance fixture versions
- cut the accumulated CLI, WN Agent, and MarmotKit notes into a dated 0.9.12 changelog section
- add missing notes for agent/OpenClaw reactions, immutable SwiftPM MarmotKit artifacts, performance work, queued-send recovery, rejoin/backfill, and incident replay
- move the post-0.9.11 fork-resolution note out of the already-released 0.9.11 section
- advance changelog comparison links for the new cohort

This PR prepares release metadata only. It does not create tags, releases, or artifacts. After merge, the full cohort can be released from the merged origin/master commit with `just release-all 0.9.12` (or the draft coordinator).

## Impact

The merged commit will be the shared source snapshot for MDK, WN Agent, and MarmotKit 0.9.12. The changelog calls out the compatibility-relevant changes, including the removed MarmotKit `ForkRecovered` event variant and the stream-compose acknowledgement JSON change.

## Validation

- `just fast-ci`
- `cargo test -p marmot-uniffi` (103 unit, 2 media-fixture, 28 smoke tests)
- `cargo test -p cgka-conformance-simulator canonical_vector_fixtures_match_generated_traces` (31 fixtures)
- `cargo check --workspace --all-targets`
- `git diff --check`
- `just release-all-dry-run 0.9.12`
