### PR TITLE
Process convergence applications at source epoch

### DIFF
--- a/crates/cgka-engine/src/canonicalization.rs
+++ b/crates/cgka-engine/src/canonicalization.rs
@@ -797,9 +797,9 @@ fn attach_app_witnesses(
                 // Witness counting evaluates the retained app-payload window with
                 // the CANDIDATE's tip_epoch as the reference tip, not the global
                 // canonical tip (retained-history.md "App-payload retention" and
-                // convergence.md "App-payload witnesses"). Using current_tip_epoch
-                // here would count a different witness set than a spec-faithful
-                // client and select a different branch -> fork.
+                // convergence.md "App-payload witnesses"). Active convergence
+                // retains the ability to authenticate the frozen input at its
+                // source epoch; it does not make an expired witness eligible.
                 if app_message_expired(candidate.tip_epoch, policy, *epoch) {
                     continue;
                 }

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -2802,16 +2802,6 @@ fn replay_messages_for_canonicalization_result<S: StorageProvider>(
         let record = storage
             .get_message(&message_id)
             .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
-        // An accepted proposal below the apply-start epoch was consumed by a
-        // commit in the skipped already-applied prefix: its effect is inside
-        // the live state, and MLS proposals are epoch-scoped, so replaying it
-        // against the post-prefix state would be rejected (WrongEpoch) and
-        // fail the whole apply. Skip the replay; its `Processed` disposition
-        // still persists so it leaves the convergence input set.
-        if result.accepted_proposals.contains(hex_message_id) && record.epoch.0 < apply_start_epoch
-        {
-            continue;
-        }
         let Some(message) = openmls_wire_message_from_record(&record)? else {
             return Err(OpenMlsProjectionError::Decode(format!(
                 "accepted message {} is not a stored OpenMLS wire payload",
@@ -2819,6 +2809,22 @@ fn replay_messages_for_canonicalization_result<S: StorageProvider>(
             )));
         };
         let projection = project_mls_message(&message.payload)?;
+        let source_epoch =
+            projection
+                .source_epoch
+                .ok_or(OpenMlsProjectionError::UnsupportedMessageKind(
+                    projection.kind,
+                ))?;
+        // An accepted proposal below the apply-start epoch was consumed by a
+        // commit in the skipped already-applied prefix: its effect is inside
+        // the live state, and MLS proposals are epoch-scoped, so replaying it
+        // against the post-prefix state would be rejected (WrongEpoch) and
+        // fail the whole apply. Use the authenticated wire epoch rather than
+        // mutable row metadata. Skip the replay; its `Processed` disposition
+        // still persists so it leaves the convergence input set.
+        if result.accepted_proposals.contains(hex_message_id) && source_epoch < apply_start_epoch {
+            continue;
+        }
         let kind_order = match projection.kind {
             // Proposals and applications from epoch E must be processed while
             // the group is still at E. The commit advancing E -> E+1 comes
@@ -2829,7 +2835,7 @@ fn replay_messages_for_canonicalization_result<S: StorageProvider>(
             OpenMlsContentKind::Commit => 2,
             OpenMlsContentKind::Welcome | OpenMlsContentKind::Other => 3,
         };
-        replay_messages.push((record.epoch.0, kind_order, input_order, message));
+        replay_messages.push((source_epoch, kind_order, input_order, message));
     }
     replay_messages.sort_by_key(|message| (message.0, message.1, message.2));
     Ok(replay_messages
@@ -3043,6 +3049,9 @@ fn candidate_paths_with_pending_replay_messages(
     for proposals in proposals_by_epoch.values_mut() {
         proposals.sort_by(|a, b| a.id.as_slice().cmp(b.id.as_slice()));
     }
+    for applications in applications_by_epoch.values_mut() {
+        applications.sort_by(|a, b| a.id.as_slice().cmp(b.id.as_slice()));
+    }
 
     candidate_paths
         .iter()
@@ -3051,16 +3060,20 @@ fn candidate_paths_with_pending_replay_messages(
                 let mut seen = BTreeSet::new();
                 let mut messages = Vec::new();
                 let mut final_epoch = None;
-                let mut first_commit_epoch = None;
-                for message in &path.messages {
-                    let projection = project_mls_message(&message.payload)?;
-                    if projection.kind == OpenMlsContentKind::Commit {
-                        first_commit_epoch = Some(projection.source_epoch.ok_or(
+                let projected_messages = path
+                    .messages
+                    .iter()
+                    .map(|message| Ok((message, project_mls_message(&message.payload)?)))
+                    .collect::<Result<Vec<_>, OpenMlsProjectionError>>()?;
+                let first_commit_epoch = projected_messages
+                    .iter()
+                    .find(|(_, projection)| projection.kind == OpenMlsContentKind::Commit)
+                    .map(|(_, projection)| {
+                        projection.source_epoch.ok_or(
                             OpenMlsProjectionError::UnsupportedMessageKind(projection.kind),
-                        )?);
-                        break;
-                    }
-                }
+                        )
+                    })
+                    .transpose()?;
                 // A late application from common pre-fork history can be
                 // older than every commit in the candidate path. Probe it
                 // against the retained base state, before the first commit;
@@ -3079,8 +3092,7 @@ fn candidate_paths_with_pending_replay_messages(
                         }
                     }
                 }
-                for message in &path.messages {
-                    let projection = project_mls_message(&message.payload)?;
+                for (message, projection) in projected_messages {
                     if projection.kind == OpenMlsContentKind::Commit {
                         let source_epoch = projection.source_epoch.ok_or(
                             OpenMlsProjectionError::UnsupportedMessageKind(projection.kind),

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -3051,6 +3051,34 @@ fn candidate_paths_with_pending_replay_messages(
                 let mut seen = BTreeSet::new();
                 let mut messages = Vec::new();
                 let mut final_epoch = None;
+                let mut first_commit_epoch = None;
+                for message in &path.messages {
+                    let projection = project_mls_message(&message.payload)?;
+                    if projection.kind == OpenMlsContentKind::Commit {
+                        first_commit_epoch = Some(projection.source_epoch.ok_or(
+                            OpenMlsProjectionError::UnsupportedMessageKind(projection.kind),
+                        )?);
+                        break;
+                    }
+                }
+                // A late application from common pre-fork history can be
+                // older than every commit in the candidate path. Probe it
+                // against the retained base state, before the first commit;
+                // that state owns the widest past-epoch decryption window.
+                // The observation is shared by every candidate and therefore
+                // cannot bias selection toward either fork.
+                if let Some(first_commit_epoch) = first_commit_epoch {
+                    for applications in applications_by_epoch
+                        .range(..first_commit_epoch)
+                        .map(|(_, applications)| applications)
+                    {
+                        for application in applications {
+                            if seen.insert(hex::encode(application.id.as_slice())) {
+                                messages.push(application.clone());
+                            }
+                        }
+                    }
+                }
                 for message in &path.messages {
                     let projection = project_mls_message(&message.payload)?;
                     if projection.kind == OpenMlsContentKind::Commit {

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -2783,7 +2783,7 @@ fn replay_messages_for_canonicalization_result<S: StorageProvider>(
 ) -> Result<Vec<TransportMessage>, OpenMlsProjectionError> {
     let mut replay_messages = Vec::new();
     let mut seen = BTreeSet::new();
-    for hex_message_id in result
+    for (input_order, hex_message_id) in result
         .accepted_proposals
         .iter()
         .chain(
@@ -2793,6 +2793,7 @@ fn replay_messages_for_canonicalization_result<S: StorageProvider>(
                 .filter(|commit_id| !applied_prefix.contains(*commit_id)),
         )
         .chain(&result.accepted_app_messages)
+        .enumerate()
     {
         if !seen.insert(hex_message_id.clone()) {
             continue;
@@ -2817,9 +2818,24 @@ fn replay_messages_for_canonicalization_result<S: StorageProvider>(
                 hex_message_id
             )));
         };
-        replay_messages.push(message);
+        let projection = project_mls_message(&message.payload)?;
+        let kind_order = match projection.kind {
+            // Proposals and applications from epoch E must be processed while
+            // the group is still at E. The commit advancing E -> E+1 comes
+            // last so OpenMLS cannot prune source-epoch application material
+            // before the accepted application is authenticated (mdk#1171).
+            OpenMlsContentKind::Proposal => 0,
+            OpenMlsContentKind::Application => 1,
+            OpenMlsContentKind::Commit => 2,
+            OpenMlsContentKind::Welcome | OpenMlsContentKind::Other => 3,
+        };
+        replay_messages.push((record.epoch.0, kind_order, input_order, message));
     }
-    Ok(replay_messages)
+    replay_messages.sort_by_key(|message| (message.0, message.1, message.2));
+    Ok(replay_messages
+        .into_iter()
+        .map(|(_, _, _, message)| message)
+        .collect())
 }
 
 fn update_group_record_from_replay<S: StorageProvider>(
@@ -2997,7 +3013,7 @@ fn candidate_paths_with_pending_replay_messages(
     pending_messages: &[TransportMessage],
 ) -> Result<Vec<OpenMlsCandidatePath>, OpenMlsProjectionError> {
     let mut proposals_by_epoch: BTreeMap<u64, Vec<TransportMessage>> = BTreeMap::new();
-    let mut applications = Vec::new();
+    let mut applications_by_epoch: BTreeMap<u64, Vec<TransportMessage>> = BTreeMap::new();
     for message in pending_messages {
         let projection = project_mls_message(&message.payload)?;
         match projection.kind {
@@ -3010,7 +3026,15 @@ fn candidate_paths_with_pending_replay_messages(
                     .or_default()
                     .push(message.clone());
             }
-            OpenMlsContentKind::Application => applications.push(message.clone()),
+            OpenMlsContentKind::Application => {
+                let source_epoch = projection.source_epoch.ok_or(
+                    OpenMlsProjectionError::UnsupportedMessageKind(projection.kind),
+                )?;
+                applications_by_epoch
+                    .entry(source_epoch)
+                    .or_default()
+                    .push(message.clone());
+            }
             OpenMlsContentKind::Commit
             | OpenMlsContentKind::Welcome
             | OpenMlsContentKind::Other => {}
@@ -3040,6 +3064,18 @@ fn candidate_paths_with_pending_replay_messages(
                                 }
                             }
                         }
+                        // Authenticate applications while the candidate still
+                        // owns their source-epoch state. Their branch-specific
+                        // observations are retained for witness scoring and the
+                        // eventual post-selection disposition; delivery itself
+                        // still happens only during canonical apply.
+                        if let Some(applications) = applications_by_epoch.get(&source_epoch) {
+                            for application in applications {
+                                if seen.insert(hex::encode(application.id.as_slice())) {
+                                    messages.push(application.clone());
+                                }
+                            }
+                        }
                         final_epoch = Some(source_epoch.saturating_add(1));
                     }
                     if seen.insert(hex::encode(message.id.as_slice())) {
@@ -3059,9 +3095,13 @@ fn candidate_paths_with_pending_replay_messages(
                         }
                     }
                 }
-                for message in &applications {
-                    if seen.insert(hex::encode(message.id.as_slice())) {
-                        messages.push(message.clone());
+                if let Some(final_epoch) = final_epoch
+                    && let Some(applications) = applications_by_epoch.get(&final_epoch)
+                {
+                    for application in applications {
+                        if seen.insert(hex::encode(application.id.as_slice())) {
+                            messages.push(application.clone());
+                        }
                     }
                 }
                 Ok(OpenMlsCandidatePath {

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -2392,6 +2392,129 @@ async fn engine_materializes_multi_commit_path_from_stored_commits() {
     );
 }
 
+/// Application observations and the accepted-message result are canonical
+/// even when peers admit the same source-epoch applications in opposite
+/// transport order. Exercise the retained base, each commit edge, and the
+/// selected tip so every application replay bucket uses the same ordering.
+#[tokio::test]
+async fn application_replay_is_invariant_to_opposite_arrival_order() {
+    let (mut alice, _alice_storage) = build_client(b"alice");
+    let (mut forward, _forward_storage) = build_client(b"forward");
+    let (mut reverse, _reverse_storage) = build_client(b"reverse");
+
+    let forward_kp = forward.fresh_key_package().await.unwrap();
+    let reverse_kp = reverse.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "canonical-application-arrival-order".into(),
+            description: "".into(),
+            members: vec![forward_kp, reverse_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    forward
+        .join_welcome(welcome_for(&welcomes, b"forward"))
+        .await
+        .unwrap();
+    reverse
+        .join_welcome(welcome_for(&welcomes, b"reverse"))
+        .await
+        .unwrap();
+    forward.drain_events();
+    reverse.drain_events();
+
+    let base_apps = [
+        send_app(&mut alice, &group_id, b"base-a".to_vec()).await,
+        send_app(&mut alice, &group_id, b"base-b".to_vec()).await,
+    ];
+    let (mut david, _david_storage) = build_client(b"arrival-order-david");
+    let invite_david = alice
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![david.fresh_key_package().await.unwrap()],
+        })
+        .await
+        .unwrap();
+    let (commit_david, pending) = evolution(invite_david);
+    alice.confirm_published(pending).await.unwrap();
+    let edge_apps = [
+        send_app(&mut alice, &group_id, b"edge-a".to_vec()).await,
+        send_app(&mut alice, &group_id, b"edge-b".to_vec()).await,
+    ];
+    let (mut eve, _eve_storage) = build_client(b"arrival-order-eve");
+    let invite_eve = alice
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![eve.fresh_key_package().await.unwrap()],
+        })
+        .await
+        .unwrap();
+    let (commit_eve, pending) = evolution(invite_eve);
+    alice.confirm_published(pending).await.unwrap();
+    let tip_apps = [
+        send_app(&mut alice, &group_id, b"tip-a".to_vec()).await,
+        send_app(&mut alice, &group_id, b"tip-b".to_vec()).await,
+    ];
+    let commit_david = route(commit_david, &group_id);
+    let commit_eve = route(commit_eve, &group_id);
+
+    for apps in [&base_apps, &edge_apps, &tip_apps] {
+        for app in apps {
+            forward
+                .buffer_openmls_convergence_message_at(&group_id, app.clone(), 1_000)
+                .unwrap();
+        }
+    }
+    for commit in [&commit_david, &commit_eve] {
+        forward
+            .buffer_openmls_convergence_message_at(&group_id, commit.clone(), 1_000)
+            .unwrap();
+        reverse
+            .buffer_openmls_convergence_message_at(&group_id, commit.clone(), 1_000)
+            .unwrap();
+    }
+    for apps in [&tip_apps, &edge_apps, &base_apps] {
+        for app in apps.iter().rev() {
+            reverse
+                .buffer_openmls_convergence_message_at(&group_id, app.clone(), 1_000)
+                .unwrap();
+        }
+    }
+
+    let forward_result = forward
+        .converge_stored_openmls_messages_at(&group_id, 1_000_000)
+        .unwrap();
+    let reverse_result = reverse
+        .converge_stored_openmls_messages_at(&group_id, 1_000_000)
+        .unwrap();
+
+    assert_eq!(
+        forward_result.accepted_app_messages,
+        reverse_result.accepted_app_messages
+    );
+    let received_payloads = |events: Vec<GroupEvent>| {
+        events
+            .into_iter()
+            .filter_map(|event| match event {
+                GroupEvent::MessageReceived { payload, .. } => Some(app_content(&payload).to_vec()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(
+        received_payloads(forward.drain_events()),
+        received_payloads(reverse.drain_events())
+    );
+}
+
 /// A frozen convergence pass already owns a bounded retained-anchor snapshot.
 /// Application inputs admitted while they are inside the app window must use
 /// that source-epoch state before later commits in the same pass advance far

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -858,6 +858,145 @@ async fn engine_converges_stored_openmls_messages_to_selected_branch() {
     );
 }
 
+/// A late application from common history can enter convergence while a newer
+/// epoch is contested. Every candidate path starts at the fork epoch, so the
+/// application predates the first commit in every path. It must still be
+/// authenticated against the retained base state and delivered after branch
+/// selection rather than being invalidated without a decryption attempt.
+#[tokio::test]
+async fn contested_fork_delivers_late_pre_fork_application() {
+    let (mut alice, _alice_storage) = build_client(b"alice");
+    let (mut bob, _bob_storage) = build_client(b"bob");
+    let (mut carol, carol_storage) = build_client(b"carol");
+    let (mut common_invitee, _common_invitee_storage) = build_client(b"common-invitee");
+    let (mut alice_invitee, _alice_invitee_storage) = build_client(b"alice-invitee");
+    let (mut bob_invitee, _bob_invitee_storage) = build_client(b"bob-invitee");
+
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "late-pre-fork-application".into(),
+            description: "".into(),
+            members: vec![
+                bob.fresh_key_package().await.unwrap(),
+                carol.fresh_key_package().await.unwrap(),
+            ],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![bob.self_id()],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    bob.join_welcome(welcome_for(&welcomes, b"bob"))
+        .await
+        .unwrap();
+    carol
+        .join_welcome(welcome_for(&welcomes, b"carol"))
+        .await
+        .unwrap();
+    carol.drain_events();
+
+    // Hold this epoch-1 application until after the shared group has advanced
+    // and epoch 2 has forked.
+    let late_app = send_app(
+        &mut alice,
+        &group_id,
+        b"late shared-history application".to_vec(),
+    )
+    .await;
+
+    let common_invite = alice
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![common_invitee.fresh_key_package().await.unwrap()],
+        })
+        .await
+        .unwrap();
+    let (common_commit, common_pending) = evolution(common_invite);
+    alice.confirm_published(common_pending).await.unwrap();
+    let common_commit = route(common_commit, &group_id);
+    assert!(matches!(
+        bob.ingest(common_commit.clone()).await.unwrap(),
+        IngestOutcome::Buffered { .. }
+    ));
+    bob.converge_stored_openmls_messages_at(&group_id, 1_000_000)
+        .expect("Bob applies the shared commit");
+    assert!(matches!(
+        carol.ingest(common_commit).await.unwrap(),
+        IngestOutcome::Buffered { .. }
+    ));
+    carol
+        .converge_stored_openmls_messages_at(&group_id, 1_000_000)
+        .expect("Carol applies the shared commit");
+    assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(2));
+    carol.drain_events();
+
+    let alice_fork = alice
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![alice_invitee.fresh_key_package().await.unwrap()],
+        })
+        .await
+        .unwrap();
+    let bob_fork = bob
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![bob_invitee.fresh_key_package().await.unwrap()],
+        })
+        .await
+        .unwrap();
+    let (alice_commit, _alice_pending) = evolution(alice_fork);
+    let (bob_commit, _bob_pending) = evolution(bob_fork);
+    for message in [
+        route(alice_commit, &group_id),
+        route(bob_commit, &group_id),
+        late_app.clone(),
+    ] {
+        carol
+            .buffer_openmls_convergence_message_at(&group_id, message, 1_000)
+            .unwrap();
+    }
+
+    let result = carol
+        .converge_stored_openmls_messages_at(&group_id, 1_000_000)
+        .expect("contested fork converges with late shared-history evidence");
+    let late_app_id = content_hex(&late_app);
+
+    assert_eq!(result.convergence_status, ConvergenceStatus::Settled);
+    assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(3));
+    assert_eq!(result.accepted_app_messages, vec![late_app_id.clone()]);
+    assert!(
+        result
+            .invalidated_app_messages
+            .iter()
+            .all(|invalidated| invalidated.message_id != late_app_id)
+    );
+    assert_message_state(&carol_storage, &late_app, MessageState::Processed);
+
+    let events = carol.drain_events();
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| matches!(
+                event,
+                GroupEvent::MessageReceived { payload, .. }
+                    if app_content(payload) == b"late shared-history application"
+            ))
+            .count(),
+        1,
+        "late shared-history application must be delivered exactly once: {events:?}"
+    );
+    assert!(!events.iter().any(|event| matches!(
+        event,
+        GroupEvent::AppMessageInvalidated { message_id, .. }
+            if *message_id == content_id(&late_app)
+    )));
+}
+
 /// Regression for the Android-visible "This message is no longer valid"
 /// banner on a device's own sent message. OpenMLS cannot decrypt an own
 /// private-message ciphertext during candidate replay, so convergence must use

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -2253,6 +2253,139 @@ async fn engine_materializes_multi_commit_path_from_stored_commits() {
     );
 }
 
+/// A frozen convergence pass already owns a bounded retained-anchor snapshot.
+/// Application inputs admitted while they are inside the app window must use
+/// that source-epoch state before later commits in the same pass advance far
+/// enough to prune it. Dividing the same retained input across passes must not
+/// decide whether the application is delivered (mdk#1171).
+#[tokio::test]
+async fn retained_application_delivery_is_invariant_to_convergence_pass_partition() {
+    let (mut alice, _alice_storage) = build_client(b"alice");
+    let (mut one_pass, one_pass_storage) = build_client(b"one-pass");
+    let (mut split_pass, split_pass_storage) = build_client(b"split-pass");
+
+    let one_pass_kp = one_pass.fresh_key_package().await.unwrap();
+    let split_pass_kp = split_pass.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "retained-app-pass-partition".into(),
+            description: "".into(),
+            members: vec![one_pass_kp, split_pass_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    one_pass
+        .join_welcome(welcome_for(&welcomes, b"one-pass"))
+        .await
+        .unwrap();
+    split_pass
+        .join_welcome(welcome_for(&welcomes, b"split-pass"))
+        .await
+        .unwrap();
+    one_pass.drain_events();
+    split_pass.drain_events();
+
+    let app = send_app(
+        &mut alice,
+        &group_id,
+        b"retained across active convergence".to_vec(),
+    )
+    .await;
+    let mut commits = Vec::new();
+    for index in 0..6 {
+        let identity = format!("partition-invitee-{index}");
+        let (mut invitee, _invitee_storage) = build_client(identity.as_bytes());
+        let invite = alice
+            .send(SendIntent::Invite {
+                group_id: group_id.clone(),
+                key_packages: vec![invitee.fresh_key_package().await.unwrap()],
+            })
+            .await
+            .unwrap();
+        let (commit, pending) = evolution(invite);
+        alice.confirm_published(pending).await.unwrap();
+        commits.push(route(commit, &group_id));
+    }
+
+    for message in commits.iter().chain([&app]) {
+        one_pass
+            .buffer_openmls_convergence_message_at(&group_id, message.clone(), 1_000)
+            .unwrap();
+    }
+    let one_pass_result = one_pass
+        .converge_stored_openmls_messages_at(&group_id, 1_000_000)
+        .unwrap();
+
+    for message in commits[..5].iter().chain([&app]) {
+        split_pass
+            .buffer_openmls_convergence_message_at(&group_id, message.clone(), 1_000)
+            .unwrap();
+    }
+    let split_first_result = split_pass
+        .converge_stored_openmls_messages_at(&group_id, 1_000_000)
+        .unwrap();
+    split_pass
+        .buffer_openmls_convergence_message_at(&group_id, commits[5].clone(), 2_000_000)
+        .unwrap();
+    split_pass
+        .converge_stored_openmls_messages_at(&group_id, 3_000_000)
+        .unwrap();
+
+    assert_eq!(one_pass.epoch(&group_id).unwrap(), EpochId(7));
+    assert_eq!(split_pass.epoch(&group_id).unwrap(), EpochId(7));
+    assert_eq!(one_pass_result.accepted_commits.len(), 6);
+    assert_eq!(
+        one_pass_result.accepted_app_messages,
+        vec![content_hex(&app)]
+    );
+    assert_eq!(
+        split_first_result.accepted_app_messages,
+        vec![content_hex(&app)]
+    );
+    assert_eq!(
+        one_pass_storage
+            .get_message(&content_id(&app))
+            .unwrap()
+            .state,
+        MessageState::Processed
+    );
+    assert_eq!(
+        split_pass_storage
+            .get_message(&content_id(&app))
+            .unwrap()
+            .state,
+        MessageState::Processed
+    );
+
+    for events in [one_pass.drain_events(), split_pass.drain_events()] {
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(
+                    event,
+                    GroupEvent::MessageReceived { payload, .. }
+                        if app_content(payload) == b"retained across active convergence"
+                ))
+                .count(),
+            1,
+            "the admitted application must be delivered exactly once: {events:?}"
+        );
+        assert!(!events.iter().any(|event| matches!(
+            event,
+            GroupEvent::AppMessageInvalidated { message_id, .. }
+                if *message_id == content_id(&app)
+        )));
+    }
+}
+
 /// Reuse-path sibling of `engine_materializes_multi_commit_path_from_stored_commits`: the same
 /// multi-commit chain but with NO pending application message buffered, so canonicalization takes
 /// the #635 reuse branch (BFS-materialized candidates are reused instead of re-materialized). The

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -2438,8 +2438,13 @@ async fn retained_application_delivery_is_invariant_to_convergence_pass_partitio
         b"retained across active convergence".to_vec(),
     )
     .await;
+    let retention_limit =
+        usize::try_from(CanonicalizationPolicy::default().app_message_past_epoch_limit)
+            .expect("pinned application-retention limit fits usize");
+    let commit_count = retention_limit + 1;
+    let expected_tip = EpochId(1 + commit_count as u64);
     let mut commits = Vec::new();
-    for index in 0..6 {
+    for index in 0..commit_count {
         let identity = format!("partition-invitee-{index}");
         let (mut invitee, _invitee_storage) = build_client(identity.as_bytes());
         let invite = alice
@@ -2459,11 +2464,17 @@ async fn retained_application_delivery_is_invariant_to_convergence_pass_partitio
             .buffer_openmls_convergence_message_at(&group_id, message.clone(), 1_000)
             .unwrap();
     }
+    // Inbound contested-pass handoff can retain a past-epoch wire message in
+    // a row stamped with the receiver's newer current epoch. Final apply must
+    // order by the authenticated wire source epoch, not this row metadata.
+    let mut one_pass_app_record = one_pass_storage.get_message(&content_id(&app)).unwrap();
+    one_pass_app_record.epoch = expected_tip;
+    one_pass_storage.put_message(&one_pass_app_record).unwrap();
     let one_pass_result = one_pass
         .converge_stored_openmls_messages_at(&group_id, 1_000_000)
         .unwrap();
 
-    for message in commits[..5].iter().chain([&app]) {
+    for message in commits[..retention_limit].iter().chain([&app]) {
         split_pass
             .buffer_openmls_convergence_message_at(&group_id, message.clone(), 1_000)
             .unwrap();
@@ -2472,15 +2483,19 @@ async fn retained_application_delivery_is_invariant_to_convergence_pass_partitio
         .converge_stored_openmls_messages_at(&group_id, 1_000_000)
         .unwrap();
     split_pass
-        .buffer_openmls_convergence_message_at(&group_id, commits[5].clone(), 2_000_000)
+        .buffer_openmls_convergence_message_at(
+            &group_id,
+            commits[retention_limit].clone(),
+            2_000_000,
+        )
         .unwrap();
     split_pass
         .converge_stored_openmls_messages_at(&group_id, 3_000_000)
         .unwrap();
 
-    assert_eq!(one_pass.epoch(&group_id).unwrap(), EpochId(7));
-    assert_eq!(split_pass.epoch(&group_id).unwrap(), EpochId(7));
-    assert_eq!(one_pass_result.accepted_commits.len(), 6);
+    assert_eq!(one_pass.epoch(&group_id).unwrap(), expected_tip);
+    assert_eq!(split_pass.epoch(&group_id).unwrap(), expected_tip);
+    assert_eq!(one_pass_result.accepted_commits.len(), commit_count);
     assert_eq!(
         one_pass_result.accepted_app_messages,
         vec![content_hex(&app)]

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -2496,10 +2496,15 @@ async fn application_replay_is_invariant_to_opposite_arrival_order() {
         .converge_stored_openmls_messages_at(&group_id, 1_000_000)
         .unwrap();
 
-    assert_eq!(
-        forward_result.accepted_app_messages,
-        reverse_result.accepted_app_messages
-    );
+    let expected_app_messages = [&base_apps, &edge_apps, &tip_apps]
+        .into_iter()
+        .flatten()
+        .map(content_hex)
+        .collect::<Vec<_>>();
+    let mut expected_app_messages = expected_app_messages;
+    expected_app_messages.sort();
+    assert_eq!(forward_result.accepted_app_messages, expected_app_messages);
+    assert_eq!(reverse_result.accepted_app_messages, expected_app_messages);
     let received_payloads = |events: Vec<GroupEvent>| {
         events
             .into_iter()
@@ -2509,10 +2514,25 @@ async fn application_replay_is_invariant_to_opposite_arrival_order() {
             })
             .collect::<Vec<_>>()
     };
-    assert_eq!(
-        received_payloads(forward.drain_events()),
-        received_payloads(reverse.drain_events())
-    );
+    let canonical_payloads = |apps: &[TransportMessage; 2], payloads: [&[u8]; 2]| {
+        let mut keyed_payloads = apps
+            .iter()
+            .zip(payloads)
+            .map(|(app, payload)| (content_hex(app), payload.to_vec()))
+            .collect::<Vec<_>>();
+        keyed_payloads.sort_by(|left, right| left.0.cmp(&right.0));
+        keyed_payloads
+            .into_iter()
+            .map(|(_, payload)| payload)
+            .collect::<Vec<_>>()
+    };
+    let expected_payloads = canonical_payloads(&base_apps, [b"base-a", b"base-b"])
+        .into_iter()
+        .chain(canonical_payloads(&edge_apps, [b"edge-a", b"edge-b"]))
+        .chain(canonical_payloads(&tip_apps, [b"tip-a", b"tip-b"]))
+        .collect::<Vec<_>>();
+    assert_eq!(received_payloads(forward.drain_events()), expected_payloads);
+    assert_eq!(received_payloads(reverse.drain_events()), expected_payloads);
 }
 
 /// A frozen convergence pass already owns a bounded retained-anchor snapshot.

--- a/docs/marmot-architecture/cgka-engine-canonicalization-contract.md
+++ b/docs/marmot-architecture/cgka-engine-canonicalization-contract.md
@@ -172,9 +172,12 @@ The OpenMLS replay bridge MUST translate consumed `ProposalRef` values back to t
 before reporting proposal dispositions. When replay processes an application message on a candidate branch, that
 observation supplies the app message's decrypting branch set, sender, epoch, and stored payload reference for witness
 scoring and invalidation reporting. Candidate paths SHOULD be commit paths. The replay bridge is responsible for probing
-pending proposals before those commits and probing pending application messages after the candidate state is
-materialized. An application message that does not decrypt on a candidate branch is ignored for that branch, not treated
-as a branch materialization failure.
+pending proposals and application messages at their source epoch before the commit that advances that candidate to the
+next epoch. The frozen pass's retained anchor keeps that source-epoch state available as bounded active convergence work;
+branch-specific authentication observations survive until selection, but application delivery remains deferred until the
+selected branch is applied. Witness eligibility still uses the candidate tip and pinned app-payload window from the
+adopted protocol. An application message that does not decrypt on a candidate branch is ignored for that branch, not
+treated as a branch materialization failure.
 
 `outbound_intents` contains local work the application wants to publish:
 

--- a/docs/marmot-architecture/cgka-engine-canonicalization-contract.md
+++ b/docs/marmot-architecture/cgka-engine-canonicalization-contract.md
@@ -175,7 +175,9 @@ scoring and invalidation reporting. Candidate paths SHOULD be commit paths. The 
 pending proposals and application messages at their source epoch before the commit that advances that candidate to the
 next epoch. The frozen pass's retained anchor keeps that source-epoch state available as bounded active convergence work;
 branch-specific authentication observations survive until selection, but application delivery remains deferred until the
-selected branch is applied. Witness eligibility still uses the candidate tip and pinned app-payload window from the
+selected branch is applied. A retained application from common pre-fork history that predates the first commit in every
+candidate path is probed against the retained base state before that first commit and contributes the same observation to
+every decrypting candidate. Witness eligibility still uses the candidate tip and pinned app-payload window from the
 adopted protocol. An application message that does not decrypt on a candidate branch is ignored for that branch, not
 treated as a branch materialization failure.
 

--- a/docs/marmot-architecture/distributed-convergence.md
+++ b/docs/marmot-architecture/distributed-convergence.md
@@ -298,8 +298,10 @@ Engine integration and OpenMLS conformance tests also cover:
 - stale commits older than the retained anchor invalidated,
 - retained-anchor replay and stale invalidation after engine rebuild,
 - source-epoch application authentication before each advancing commit, including one-pass versus split-pass delivery
-  equivalence at the six-advance app-retention boundary,
-- contested-fork delivery of late applications from retained common pre-fork history,
+  equivalence at the six-advance app-retention boundary
+  (`retained_application_delivery_is_invariant_to_convergence_pass_partition`),
+- contested-fork delivery of late applications from retained common pre-fork history
+  (`contested_fork_delivers_late_pre_fork_application`),
 - delayed past-epoch application messages peeled from retained epoch contexts,
 - peeler-ingest to `GroupEvent` output across multiple in-memory clients using the real Nostr peeler over an in-memory
   bus. This proves selected branch epoch/member events plus branch-aware retry for future-epoch raw transport messages:

--- a/docs/marmot-architecture/distributed-convergence.md
+++ b/docs/marmot-architecture/distributed-convergence.md
@@ -299,6 +299,7 @@ Engine integration and OpenMLS conformance tests also cover:
 - retained-anchor replay and stale invalidation after engine rebuild,
 - source-epoch application authentication before each advancing commit, including one-pass versus split-pass delivery
   equivalence at the six-advance app-retention boundary,
+- contested-fork delivery of late applications from retained common pre-fork history,
 - delayed past-epoch application messages peeled from retained epoch contexts,
 - peeler-ingest to `GroupEvent` output across multiple in-memory clients using the real Nostr peeler over an in-memory
   bus. This proves selected branch epoch/member events plus branch-aware retry for future-epoch raw transport messages:

--- a/docs/marmot-architecture/distributed-convergence.md
+++ b/docs/marmot-architecture/distributed-convergence.md
@@ -297,6 +297,8 @@ Engine integration and OpenMLS conformance tests also cover:
 - retained anchor pruning by `max_rewind_commits`,
 - stale commits older than the retained anchor invalidated,
 - retained-anchor replay and stale invalidation after engine rebuild,
+- source-epoch application authentication before each advancing commit, including one-pass versus split-pass delivery
+  equivalence at the six-advance app-retention boundary,
 - delayed past-epoch application messages peeled from retained epoch contexts,
 - peeler-ingest to `GroupEvent` output across multiple in-memory clients using the real Nostr peeler over an in-memory
   bus. This proves selected branch epoch/member events plus branch-aware retry for future-epoch raw transport messages:


### PR DESCRIPTION
## Summary

- process pending proposals and application messages at their source epoch before replaying the commit that advances the candidate
- order the selected branch's final replay by epoch and content kind so accepted applications are authenticated before source-epoch material is pruned
- use the frozen convergence pass's retained anchor as bounded active-work retention without introducing another long-lived secret store
- document that active retention preserves authentication ability but does not make an expired application witness eligible

## Root cause

Candidate materialization previously replayed the full commit path before probing pending application messages. Final canonical apply similarly replayed accepted proposals and commits before accepted applications. A sufficiently large retained commit burst could therefore advance OpenMLS beyond the application's source epoch and prune the cryptographic material needed to authenticate or deliver that application.

This made delivery depend on convergence-pass partitioning: processing five commits and the application in one pass followed by another commit could succeed, while processing the same six commits and application in one frozen pass could lose the application.

## Behavior

For each candidate epoch E, replay now processes:

1. proposals at E
2. applications at E
3. the commit advancing E to E+1

Branch-specific application observations remain available for witness scoring, while application delivery still occurs only when the selected canonical branch is applied. Witness eligibility continues to use the adopted candidate-tip application window, preserving the existing forward-secrecy policy boundary.

Fixes #1171.

## Validation

- `cargo test -p cgka-engine --features test-policy-overrides --test distributed_convergence` — 85 passed
- focused six-advance one-pass versus split-pass regression
- canonical-branch application delivery and branch-witness tests
- `cargo test -p cgka-conformance-simulator`
- `just fast-ci`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved replay consistency across competing branches and message arrival orders.
  - Correctly authenticates applications using their source epoch.
  - Handles late and pre-branch application messages, including retained history.
  - Ensures applications are delivered once on the selected branch.
  - Ignores undecryptable applications without blocking branch processing.
  - Clarified witness eligibility at branch-specific epochs.

- **Documentation**
  - Added details on replay behavior and convergence scenarios.

- **Tests**
  - Added regression coverage for split, one-pass, and contested-branch delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->