### PR TITLE
test(simulator): assure cross-route process convergence

### DIFF
--- a/crates/cgka-conformance-simulator/CONVERGENCE_ROUTE_MATRIX.md
+++ b/crates/cgka-conformance-simulator/CONVERGENCE_ROUTE_MATRIX.md
@@ -13,12 +13,12 @@ below is deliberately not treated as passing evidence.
 
 | Route id | Production owner | Independent model | Mutation sentinel | Current campaign evidence | Current limitation |
 | --- | --- | --- | --- | --- | --- |
-| `ordinary_ingest` | `message_processor/ingest.rs` | partial: `reference_convergence::evaluate` | covered: cutoff admission and output invalidation | observer vectors, both strict cross-route regressions, the shared engine/app/process restart journey, and the app-runtime cross-route characterization | Corrected reversible relay input can still leave a two-branch public/probe split; process/distributed execution and exact app-runtime state remain open. |
-| `stored_convergence` | `distributed_convergence.rs` | partial: selector plus lifecycle models | covered: comparator and frozen membership | both strict cross-route regressions, app-runtime cross-route characterization, restart properties, convergence chaos, and the two reconsideration regressions inherited from the retired pairwise route | Route choice is not represented in the models, and app-runtime/process/distributed equivalence remains open. |
-| `candidate_materialization` | `openmls_projection.rs` | partial: dependency/disposition model | covered: retention and frozen membership | engine and retained-history cross-route recovery plus OpenMLS replay | Exact cryptographic and durable-disposition evidence remains limited to engine-capable subjects; app-runtime/process/distributed equivalence remains open. |
-| `retained_history_replay` | `message_processor/ingest.rs`, `openmls_projection.rs` | partial: unequal-history lifecycle | covered: retention and witness deduplication | `cross-route-retained-history-recovery/v1`, `cross-route-app-runtime-recovery/v1`, retained-relay equality, offline journeys, and shared app/process offline full-history recovery | Reversible relay-wide app-runtime history removes the tombstone artifact but does not reliably produce public or active-chat equivalence; process, multi-relay, retention-boundary, and distributed evidence remain open. |
-| `crash_restart_recovery` | `engine.rs`, `distributed_convergence.rs` | covered: crash/restart lifecycle | covered: frozen membership and scheduler re-arm | both strict cross-route encrypted-SQLite regressions, the app-runtime cross-route restart, durable-phase kill properties, and the shared engine/app/process restart journey | The adversarial app-runtime topology covers one post-displacement restart; every durable transition plus process/distributed adapters remain open. |
-| `application_disposition` | `message_processor/ingest.rs`, `openmls_projection.rs` | covered: reference dispositions | covered: output invalidation | scenario-input ledgers and bidirectional decryptability probes in both strict cross-route regressions; app-runtime corrected-input characterization | Corrected-input runs can split the known chat inputs by branch; exact durable dispositions on external adapters and the existing sender-visible branch-replacement gap remain open. |
+| `ordinary_ingest` | `message_processor/ingest.rs` | partial: `reference_convergence::evaluate` | covered: cutoff admission and output invalidation | observer vectors, both strict cross-route regressions, the shared engine/app/process restart journey, and positive app-runtime plus isolated-process cross-route runs | App/process evidence is limited to public projections; container/VM execution and exact external-adapter state remain open. |
+| `stored_convergence` | `distributed_convergence.rs` | partial: selector plus lifecycle models | covered: comparator and frozen membership | both strict cross-route regressions, positive app-runtime and isolated-process cross-route runs, restart properties, convergence chaos, and the two reconsideration regressions inherited from the retired pairwise route | Route choice is not represented in the models; exact external-adapter and distributed container/VM evidence remains open. |
+| `candidate_materialization` | `openmls_projection.rs` | partial: dependency/disposition model | covered: retention and frozen membership | engine and retained-history cross-route recovery plus OpenMLS replay | Exact cryptographic and durable-disposition evidence remains limited to engine-capable subjects; app-runtime/process/container/VM evidence is public-projection only. |
+| `retained_history_replay` | `message_processor/ingest.rs`, `openmls_projection.rs` | partial: unequal-history lifecycle | covered: retention and witness deduplication | `cross-route-retained-history-recovery/v1`, `cross-route-app-runtime-recovery/v1`, retained-relay equality, offline journeys, shared app/process offline full-history recovery, and the controlled four-process route | Runner-owned reversible retained history now produces public equivalence through app-runtime and isolated-process adapters; multi-relay, retention-boundary, external-relay, container, and VM evidence remain open. |
+| `crash_restart_recovery` | `engine.rs`, `distributed_convergence.rs` | covered: crash/restart lifecycle | covered: frozen membership and scheduler re-arm | both strict cross-route encrypted-SQLite regressions, app-runtime and isolated-process cross-route restart, durable-phase kill properties, and the shared engine/app/process restart journey | The adversarial production-shaped adapters cover one post-displacement restart; every durable transition plus container/VM adapters remain open. |
+| `application_disposition` | `message_processor/ingest.rs`, `openmls_projection.rs` | covered: reference dispositions | covered: output invalidation | scenario-input ledgers and bidirectional decryptability probes in both strict cross-route regressions; complete duplicate-free public app projections in app-runtime and process cross-route runs | Exact durable dispositions on external adapters and the existing sender-visible branch-replacement gap remain open. |
 
 ## Assurance claims
 
@@ -36,14 +36,18 @@ mutation, or replay counterexample reopens it. Later green runs are retained as
 evidence but cannot silently clear a known falsification; the falsification
 must be resolved by explicit reviewed evidence.
 
-`cross-route-app-runtime-recovery/v1` keeps `route_equivalence`,
-`active_bidirectional_decryptability`, and `complete_application_disposition`
-open. The original simulator did contain a real input-contract bug: destructive
+`cross-route-app-runtime-recovery/v1` now supplies positive public
+`route_equivalence` evidence through both the in-process app runtime and four
+isolated app processes. It does not close `exact_cryptographic_agreement`,
+`active_bidirectional_decryptability`, or `complete_application_disposition`
+for those black-box adapters because their public observation schema does not
+expose the required engine-private evidence. The original simulator did contain a real input-contract bug: destructive
 database deletion permanently tombstoned temporarily hidden event ids. After a
-reversible query-visibility layer removed that artifact, repeated executions
-still produced both complete equivalence and a two-branch protocol/probe split.
-The corrected-input characterization accepts only reviewed terminal surfaces;
-it is counterexample evidence, not passing assurance evidence.
+reversible query-visibility layer removed that artifact, historical
+pre-unification executions still produced both complete equivalence and a
+two-branch protocol/probe split. Those runs remain counterexample evidence for
+their tested snapshots; the post-unification positive app-runtime and process
+oracles reject every such terminal split.
 
 Its losing-branch surface is stated as a rule rather than an enumeration of
 observed shapes, because which participants transiently hold the losing branch
@@ -76,8 +80,7 @@ in the mutation catalog.
 
 ## Active production work
 
-MDK #1329 has merged the fail-closed missing-anchor behavior and Welcome-repair
-retirement. Its formerly stacked #1293 remains open. This inventory describes
-current `master` and does not encode #1293's proposed result as an oracle. If a
+MDK #1329 and the formerly stacked #1293 have both merged. This inventory
+describes current `master`, including #1293's unified same-epoch route. If a
 route is removed or its source marker changes, the source audit fails and the
 inventory must be reviewed before evidence is carried forward.

--- a/crates/cgka-conformance-simulator/PROPERTY_TESTS.md
+++ b/crates/cgka-conformance-simulator/PROPERTY_TESTS.md
@@ -173,11 +173,25 @@ helpers. Shared harness generators live in `src/proptest_support.rs`.
   `four_party_cross_route_recovery_app_runtime_equivalence_soak` repeats the complete retained-control/app-runtime
   trial twenty times for reviewed evidence without adding that runtime to normal CI; the post-change PR run reached
   full public equivalence in all twenty trials.
-- Boundary: process, container, and VM adapters do not yet expose equivalent controlled retained-event staging. They
-  must not claim this topology from targeted catch-up alone because a live relay can deliver the competing root first.
-  The app adapter exposes public protocol and application projections, not exact MLS-state commitments, the strict
+- Boundary: the app adapter exposes public protocol and application projections, not exact MLS-state commitments, the strict
   subject's durable input ledger, or active decryptability probes; those stronger retained-engine checks remain a
   control rather than an app-runtime claim.
+
+### `four_party_cross_route_recovery_processes_match_unified_route`
+
+- Runs: the exact same `cross-route-app-runtime-recovery/v1` Scenario IR and digest through four child processes, each
+  owning one full `MarmotAppRuntime` and an isolated encrypted SQLite root. The parent owns the same reversible local
+  retained-relay control used by the in-process app harness. Offline actions checkpoint the public observation and
+  stop the child/runtime, so open subscriptions cannot buffer events across the intended transport disconnection;
+  reconnect reopens the same durable participant root.
+- Checks: exact expanded schedule and input digest, four complete public checkpoints, the controlled two-branch
+  intermediate state, final epoch/roster/admin/profile agreement, the complete duplicate-free five-message set, no
+  pending confirmation, participant-local losing-branch withdrawal rules, one public commitment, and a real durable
+  Zeta reopen. An ignored twenty-trial soak repeats the full process route outside normal CI.
+- Boundary: runner-owned local relays declare `retained_relay_control`; externally supplied relay URLs fail capability
+  preflight rather than pretending the runner can hide or restore their events. The process protocol still does not
+  expose exact MLS commitments, durable input dispositions, or active decryptability probes. Container and VM
+  execution of this Scenario IR remains open.
 
 ## Shared Generators
 

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -139,11 +139,12 @@ These are the scenarios another implementation should be able to load from JSON 
 
 ### `cross-route-app-runtime-recovery/v1`
 
-- File: constructed by `four_party_cross_route_recovery_app_runtime_matches_unified_route`; promotion to a portable
+- File: constructed by `four_party_cross_route_recovery_app_runtime_matches_unified_route` and executed unchanged by
+  `four_party_cross_route_recovery_processes_match_unified_route`; promotion to a portable
   saved input still requires an adapter-neutral representation of reversible retained-event staging.
 - Subject: the strict half uses retained-engine exact observations; the black-box half uses the public
-  `MarmotAppRuntime` commands and projections with separate encrypted SQLite roots per participant and a real local
-  Nostr relay.
+  `MarmotAppRuntime` commands and projections either in-process or in four isolated child processes. Every participant
+  has a separate encrypted SQLite root and uses a real runner-owned local Nostr relay.
 - Pressure: Alpha and Observer are offline while Zeta's root is retained; Yankee ingests that root, then goes offline.
   The harness reversibly hides Zeta's root from whole-relay queries before Alpha reconnects and authors its competing
   root, hides Alpha's root before Yankee reconnects and extends Zeta's branch, restarts Zeta, restores both retained
@@ -153,9 +154,10 @@ These are the scenarios another implementation should be able to load from JSON 
   scheduling repair, the app-runtime oracle now requires the same public epoch, roster, administration, depth-two
   profile, and complete duplicate-free probe set at every participant. The prior lag, missing-probe, and two-branch
   surfaces are historical pre-unification counterexamples and now fail the test; the reviewed post-change soak reached
-  full public equivalence in all twenty trials. Exact app-runtime cryptographic commitment, active-decryptability,
-  complete application disposition, process/container/VM execution, and per-durable-transition permutations remain
-  open.
+  full public equivalence in all twenty trials. The process adapter now enforces the same public oracle after real
+  child-runtime disconnect/reopen boundaries; its twenty-trial soak remains opt-in. Exact external-adapter
+  cryptographic commitment, active-decryptability, complete application disposition, container/VM execution, and
+  per-durable-transition permutations remain open.
 
 ### `convergence-committer-selected/v1`
 

--- a/crates/cgka-conformance-simulator/src/app_runtime.rs
+++ b/crates/cgka-conformance-simulator/src/app_runtime.rs
@@ -193,6 +193,43 @@ impl AppRuntimeHarness {
         self.relay_control.publication_cursor().await
     }
 
+    async fn set_all_maintenance_paused(&self, paused: bool) -> Result<(), SubjectError> {
+        let labels = self
+            .participants
+            .iter()
+            .filter(|(_, participant)| participant.online && participant.runtime.is_some())
+            .map(|(label, _)| label.clone())
+            .collect::<Vec<_>>();
+        let mut changed = Vec::new();
+        let mut first_resume_error = None;
+        for label in labels {
+            let participant = self.participant(&label)?;
+            let runtime = participant.runtime()?;
+            let result = if paused {
+                runtime.pause_maintenance(&participant.account_id).await
+            } else {
+                runtime.resume_maintenance(&participant.account_id).await
+            };
+            match result {
+                Ok(()) => changed.push(label),
+                Err(error) if paused => {
+                    for changed_label in changed.iter().rev() {
+                        let changed_participant = self.participant(changed_label)?;
+                        let _ = changed_participant
+                            .runtime()?
+                            .resume_maintenance(&changed_participant.account_id)
+                            .await;
+                    }
+                    return Err(app_error(error));
+                }
+                Err(error) => {
+                    first_resume_error.get_or_insert_with(|| app_error(error));
+                }
+            }
+        }
+        first_resume_error.map_or(Ok(()), Err)
+    }
+
     async fn record_relay_action_events(
         &mut self,
         action_id: &str,
@@ -748,31 +785,40 @@ impl ConvergenceSubject for AppRuntimeHarness {
                 "app-runtime adapter does not synthesize feature-gated key packages",
             ));
         }
-        let before = self.relay_publication_cursor().await;
-        let invitees = self.account_ids(action.invitees)?;
-        let participant = self.participant(action.creator)?;
-        let group_id = participant
-            .runtime()?
-            .create_group(&participant.account_id, action.name, &invitees, None)
+        self.set_all_maintenance_paused(true).await?;
+        let result = async {
+            let before = self.relay_publication_cursor().await;
+            let invitees = self.account_ids(action.invitees)?;
+            let participant = self.participant(action.creator)?;
+            let group_id = participant
+                .runtime()?
+                .create_group(&participant.account_id, action.name, &invitees, None)
+                .await
+                .map_err(app_error)?;
+            let group_label = self
+                .active_scenario_group
+                .clone()
+                .unwrap_or_else(|| "default".into());
+            self.scenario_groups.insert(group_label, group_id.clone());
+            let message_ids = self
+                .apply_admin_set(action.creator, &group_id, action.initial_admins)
+                .await?;
+            self.record_relay_action_events(
+                action.action_id,
+                action.creator,
+                before,
+                true,
+                action.invitees.len() + message_ids.len(),
+                &message_ids,
+            )
             .await
-            .map_err(app_error)?;
-        let group_label = self
-            .active_scenario_group
-            .clone()
-            .unwrap_or_else(|| "default".into());
-        self.scenario_groups.insert(group_label, group_id.clone());
-        let message_ids = self
-            .apply_admin_set(action.creator, &group_id, action.initial_admins)
-            .await?;
-        self.record_relay_action_events(
-            action.action_id,
-            action.creator,
-            before,
-            true,
-            action.invitees.len() + message_ids.len(),
-            &message_ids,
-        )
-        .await?;
+        }
+        .await;
+        let resume = self.set_all_maintenance_paused(false).await;
+        match (result, resume) {
+            (Err(error), _) | (Ok(()), Err(error)) => return Err(error),
+            (Ok(()), Ok(())) => {}
+        }
         self.record_accepted_publication(action.creator, action.pending);
         Ok(())
     }
@@ -939,28 +985,36 @@ impl ConvergenceSubject for AppRuntimeHarness {
         &mut self,
         action: SubjectSendApplication<'_>,
     ) -> Result<(), SubjectError> {
-        let before = self.relay_publication_cursor().await;
-        let group_id = self.active_group()?;
-        let participant = self.participant(action.sender)?;
-        let summary = participant
-            .runtime()?
-            .send_message(
-                &participant.account_id,
-                &group_id,
-                action.payload.as_bytes().to_vec(),
+        self.set_all_maintenance_paused(true).await?;
+        let result = async {
+            let before = self.relay_publication_cursor().await;
+            let group_id = self.active_group()?;
+            let participant = self.participant(action.sender)?;
+            let summary = participant
+                .runtime()?
+                .send_message(
+                    &participant.account_id,
+                    &group_id,
+                    action.payload.as_bytes().to_vec(),
+                )
+                .await
+                .map_err(app_error)?;
+            self.record_relay_action_events(
+                action.action_id,
+                action.sender,
+                before,
+                false,
+                summary.published,
+                &[],
             )
             .await
-            .map_err(app_error)?;
-        self.record_relay_action_events(
-            action.action_id,
-            action.sender,
-            before,
-            false,
-            summary.published,
-            &[],
-        )
-        .await?;
-        Ok(())
+        }
+        .await;
+        let resume = self.set_all_maintenance_paused(false).await;
+        match (result, resume) {
+            (Err(error), _) | (Ok(()), Err(error)) => Err(error),
+            (Ok(()), Ok(())) => Ok(()),
+        }
     }
 
     async fn leave(&mut self, action_id: &str, client: &str) -> Result<(), SubjectError> {
@@ -1396,11 +1450,15 @@ fn environment_error(error: impl std::fmt::Display) -> SubjectError {
 }
 
 fn relay_control_error(error: RelayControlError) -> SubjectError {
-    SubjectError::classified(
-        SubjectFailureCategory::ExpectedRefusal,
-        error.code,
-        error.message,
-    )
+    let category = match error.code {
+        "relay_publication_cursor_invalid"
+        | "relay_action_publication_timeout"
+        | "relay_action_publication_count_mismatch"
+        | "relay_action_publication_identity_mismatch"
+        | "relay_action_publication_identity_count_mismatch" => SubjectFailureCategory::Environment,
+        _ => SubjectFailureCategory::ExpectedRefusal,
+    };
+    SubjectError::classified(category, error.code, error.message)
 }
 
 fn block_on_subject<F>(future: F) -> Result<(), SubjectError>
@@ -1470,5 +1528,32 @@ mod tests {
 
         let resource = app_error(AppError::RuntimeBusy);
         assert_eq!(resource.category, SubjectFailureCategory::Resource);
+    }
+
+    #[test]
+    fn relay_publication_correlation_failures_are_environment_errors() {
+        for code in [
+            "relay_publication_cursor_invalid",
+            "relay_action_publication_timeout",
+            "relay_action_publication_count_mismatch",
+            "relay_action_publication_identity_mismatch",
+            "relay_action_publication_identity_count_mismatch",
+        ] {
+            let error = relay_control_error(RelayControlError {
+                code,
+                message: "normalized relay-control failure",
+            });
+            assert_eq!(error.code, code);
+            assert_eq!(error.category, SubjectFailureCategory::Environment);
+        }
+
+        let expected_refusal = relay_control_error(RelayControlError {
+            code: "unsupported_relay_selector",
+            message: "normalized relay-control refusal",
+        });
+        assert_eq!(
+            expected_refusal.category,
+            SubjectFailureCategory::ExpectedRefusal
+        );
     }
 }

--- a/crates/cgka-conformance-simulator/src/app_runtime.rs
+++ b/crates/cgka-conformance-simulator/src/app_runtime.rs
@@ -22,7 +22,8 @@ use tempfile::TempDir;
 use tokio::sync::broadcast;
 
 use crate::relay_control::{
-    RelayActionEvents, RelayActionExpectation, RelayControl, RelayControlError,
+    RELAY_ACTION_PUBLICATION_TIMEOUT, RelayActionEvents, RelayActionExpectation, RelayControl,
+    RelayControlError,
 };
 use crate::{
     ClientEventCounts, ClientObservation, ConvergenceSubject, ScenarioAdminPolicyObservation,
@@ -254,7 +255,7 @@ impl AppRuntimeHarness {
                     include_welcomes,
                     expected_publications,
                     expected_event_ids,
-                    timeout: Duration::from_secs(5),
+                    timeout: RELAY_ACTION_PUBLICATION_TIMEOUT,
                 },
             )
             .await

--- a/crates/cgka-conformance-simulator/src/app_runtime.rs
+++ b/crates/cgka-conformance-simulator/src/app_runtime.rs
@@ -21,7 +21,9 @@ use sha2::{Digest, Sha256};
 use tempfile::TempDir;
 use tokio::sync::broadcast;
 
-use crate::relay_control::{RelayActionEvents, RelayControl, RelayControlError};
+use crate::relay_control::{
+    RelayActionEvents, RelayActionExpectation, RelayControl, RelayControlError,
+};
 use crate::{
     ClientEventCounts, ClientObservation, ConvergenceSubject, ScenarioAdminPolicyObservation,
     ScenarioInputLedgerEntry, SubjectCapability, SubjectCreateGroup, SubjectDescriptor,
@@ -197,22 +199,28 @@ impl AppRuntimeHarness {
         actor: &str,
         before: usize,
         include_welcomes: bool,
+        expected_publications: usize,
+        expected_event_ids: &[String],
     ) -> Result<(), SubjectError> {
         self.participant(actor)?;
-        // Scenario commands execute serially. Kind-445 outer authors are
-        // intentionally ephemeral, so the successful command boundary—not
-        // event.pubkey—is the actor attribution available at this layer.
-        // Filtering to group messages and action-local Welcome gift wraps
-        // excludes unrelated runtime projections.
+        // Scenario commands execute serially. Where the public app API exposes
+        // transport message ids, validate those exact relay events; chat sends
+        // expose only application-event ids, so they retain the bounded count
+        // fallback at this command boundary. Kind-445 outer authors are
+        // intentionally ephemeral and cannot identify the actor.
         self.relay_control
-            .record_action_events(
+            .wait_for_action_events(
                 &mut self.relay_action_events,
                 action_id,
                 before,
-                include_welcomes,
+                RelayActionExpectation {
+                    include_welcomes,
+                    expected_publications,
+                    expected_event_ids,
+                    timeout: Duration::from_secs(5),
+                },
             )
             .await
-            .map(|_| ())
             .map_err(relay_control_error)
     }
 
@@ -753,10 +761,18 @@ impl ConvergenceSubject for AppRuntimeHarness {
             .clone()
             .unwrap_or_else(|| "default".into());
         self.scenario_groups.insert(group_label, group_id.clone());
-        self.apply_admin_set(action.creator, &group_id, action.initial_admins)
+        let message_ids = self
+            .apply_admin_set(action.creator, &group_id, action.initial_admins)
             .await?;
-        self.record_relay_action_events(action.action_id, action.creator, before, true)
-            .await?;
+        self.record_relay_action_events(
+            action.action_id,
+            action.creator,
+            before,
+            true,
+            action.invitees.len() + message_ids.len(),
+            &message_ids,
+        )
+        .await?;
         self.record_accepted_publication(action.creator, action.pending);
         Ok(())
     }
@@ -769,13 +785,20 @@ impl ConvergenceSubject for AppRuntimeHarness {
         let group_id = self.active_group()?;
         let invitees = self.account_ids(action.invitees)?;
         let participant = self.participant(action.inviter)?;
-        participant
+        let summary = participant
             .runtime()?
             .invite_members(&participant.account_id, &group_id, &invitees)
             .await
             .map_err(app_error)?;
-        self.record_relay_action_events(action.action_id, action.inviter, before, true)
-            .await?;
+        self.record_relay_action_events(
+            action.action_id,
+            action.inviter,
+            before,
+            true,
+            summary.published,
+            &summary.message_ids,
+        )
+        .await?;
         self.record_accepted_publication(action.inviter, action.pending);
         Ok(())
     }
@@ -787,7 +810,7 @@ impl ConvergenceSubject for AppRuntimeHarness {
         let before = self.relay_publication_cursor().await;
         let group_id = self.active_group()?;
         let participant = self.participant(action.client)?;
-        participant
+        let summary = participant
             .runtime()?
             .update_group_profile(
                 &participant.account_id,
@@ -797,8 +820,15 @@ impl ConvergenceSubject for AppRuntimeHarness {
             )
             .await
             .map_err(app_error)?;
-        self.record_relay_action_events(action.action_id, action.client, before, false)
-            .await?;
+        self.record_relay_action_events(
+            action.action_id,
+            action.client,
+            before,
+            false,
+            summary.published,
+            &summary.message_ids,
+        )
+        .await?;
         self.record_accepted_publication(action.client, action.pending);
         Ok(())
     }
@@ -811,19 +841,25 @@ impl ConvergenceSubject for AppRuntimeHarness {
         let group_id = self.active_group()?;
         let members = self.account_ids(action.members)?;
         let participant = self.participant(action.remover)?;
-        participant
+        let summary = participant
             .runtime()?
             .remove_members(&participant.account_id, &group_id, &members)
             .await
             .map_err(app_error)?;
-        self.record_relay_action_events(action.action_id, action.remover, before, false)
-            .await?;
+        self.record_relay_action_events(
+            action.action_id,
+            action.remover,
+            before,
+            false,
+            summary.published,
+            &summary.message_ids,
+        )
+        .await?;
         self.record_accepted_publication(action.remover, action.pending);
         Ok(())
     }
 
     async fn self_update(&mut self, action: SubjectSelfUpdate<'_>) -> Result<(), SubjectError> {
-        let before = self.relay_publication_cursor().await;
         let group_id = self.active_group()?;
         let participant = self.participant(action.client)?;
         participant
@@ -831,8 +867,6 @@ impl ConvergenceSubject for AppRuntimeHarness {
             .schedule_manual_self_update(&participant.account_id, &group_id)
             .await
             .map_err(app_error)?;
-        self.record_relay_action_events(action.action_id, action.client, before, false)
-            .await?;
         self.record_accepted_publication(action.client, action.pending);
         Ok(())
     }
@@ -843,11 +877,19 @@ impl ConvergenceSubject for AppRuntimeHarness {
     ) -> Result<(), SubjectError> {
         let before = self.relay_publication_cursor().await;
         let group_id = self.active_group()?;
-        self.apply_admin_set(action.client, &group_id, action.admins)
+        let message_ids = self
+            .apply_admin_set(action.client, &group_id, action.admins)
             .await?;
         if let Some(action_id) = action.action_id {
-            self.record_relay_action_events(action_id, action.client, before, false)
-                .await?;
+            self.record_relay_action_events(
+                action_id,
+                action.client,
+                before,
+                false,
+                message_ids.len(),
+                &message_ids,
+            )
+            .await?;
         }
         if let Some(pending) = action.pending {
             self.record_accepted_publication(action.client, pending);
@@ -900,7 +942,7 @@ impl ConvergenceSubject for AppRuntimeHarness {
         let before = self.relay_publication_cursor().await;
         let group_id = self.active_group()?;
         let participant = self.participant(action.sender)?;
-        participant
+        let summary = participant
             .runtime()?
             .send_message(
                 &participant.account_id,
@@ -909,8 +951,15 @@ impl ConvergenceSubject for AppRuntimeHarness {
             )
             .await
             .map_err(app_error)?;
-        self.record_relay_action_events(action.action_id, action.sender, before, false)
-            .await?;
+        self.record_relay_action_events(
+            action.action_id,
+            action.sender,
+            before,
+            false,
+            summary.published,
+            &[],
+        )
+        .await?;
         Ok(())
     }
 
@@ -918,13 +967,20 @@ impl ConvergenceSubject for AppRuntimeHarness {
         let before = self.relay_publication_cursor().await;
         let group_id = self.active_group()?;
         let participant = self.participant(client)?;
-        participant
+        let summary = participant
             .runtime()?
             .leave_group(&participant.account_id, &group_id)
             .await
             .map_err(app_error)?;
-        self.record_relay_action_events(action_id, client, before, false)
-            .await?;
+        self.record_relay_action_events(
+            action_id,
+            client,
+            before,
+            false,
+            summary.published,
+            &summary.message_ids,
+        )
+        .await?;
         Ok(())
     }
 
@@ -1034,7 +1090,7 @@ impl AppRuntimeHarness {
         actor: &str,
         group_id: &GroupId,
         target_labels: &[String],
-    ) -> Result<(), SubjectError> {
+    ) -> Result<Vec<String>, SubjectError> {
         let actor_participant = self.participant(actor)?;
         let group_id_hex = hex::encode(group_id.as_slice());
         let group = actor_participant
@@ -1067,45 +1123,72 @@ impl AppRuntimeHarness {
             .into_iter()
             .collect::<BTreeSet<_>>();
         let mut applied = Vec::new();
+        let mut message_ids = Vec::new();
         for account_id in targets.difference(&current) {
-            if let Err(error) = actor_participant
+            let summary = match actor_participant
                 .runtime()?
                 .promote_admin(&actor_participant.account_id, group_id, account_id)
                 .await
             {
-                return Err(
-                    compensate_admin_changes(actor_participant, group_id, &applied, error).await,
-                );
-            }
+                Ok(summary) => summary,
+                Err(error) => {
+                    return Err(compensate_admin_changes(
+                        actor_participant,
+                        group_id,
+                        &applied,
+                        error,
+                    )
+                    .await);
+                }
+            };
+            message_ids.extend(summary.message_ids);
             applied.push(AdminChange::Promoted(account_id.clone()));
         }
         for account_id in current
             .difference(&targets)
             .filter(|account_id| *account_id != &actor_participant.account_id)
         {
-            if let Err(error) = actor_participant
+            let summary = match actor_participant
                 .runtime()?
                 .demote_admin(&actor_participant.account_id, group_id, account_id)
                 .await
             {
-                return Err(
-                    compensate_admin_changes(actor_participant, group_id, &applied, error).await,
-                );
-            }
+                Ok(summary) => summary,
+                Err(error) => {
+                    return Err(compensate_admin_changes(
+                        actor_participant,
+                        group_id,
+                        &applied,
+                        error,
+                    )
+                    .await);
+                }
+            };
+            message_ids.extend(summary.message_ids);
             applied.push(AdminChange::Demoted(account_id.clone()));
         }
         if current.contains(&actor_participant.account_id)
             && !targets.contains(&actor_participant.account_id)
-            && let Err(error) = actor_participant
+        {
+            let summary = match actor_participant
                 .runtime()?
                 .self_demote_admin(&actor_participant.account_id, group_id)
                 .await
-        {
-            return Err(
-                compensate_admin_changes(actor_participant, group_id, &applied, error).await,
-            );
+            {
+                Ok(summary) => summary,
+                Err(error) => {
+                    return Err(compensate_admin_changes(
+                        actor_participant,
+                        group_id,
+                        &applied,
+                        error,
+                    )
+                    .await);
+                }
+            };
+            message_ids.extend(summary.message_ids);
         }
-        Ok(())
+        Ok(message_ids)
     }
 }
 

--- a/crates/cgka-conformance-simulator/src/app_runtime.rs
+++ b/crates/cgka-conformance-simulator/src/app_runtime.rs
@@ -7,7 +7,6 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -17,15 +16,12 @@ use marmot_app::{
     MarmotAppRuntime,
 };
 use nostr_relay_builder::LocalRelay;
-use nostr_relay_builder::prelude::{
-    Backend, BoxedFuture, DatabaseError, DatabaseEventStatus, Event, EventId, Events, Filter, Kind,
-    MemoryDatabase, MemoryDatabaseOptions, NostrDatabase, RelayBuilder, SaveEventStatus,
-};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tempfile::TempDir;
-use tokio::sync::{Mutex, broadcast};
+use tokio::sync::broadcast;
 
+use crate::relay_control::{RelayActionEvents, RelayControl, RelayControlError};
 use crate::{
     ClientEventCounts, ClientObservation, ConvergenceSubject, ScenarioAdminPolicyObservation,
     ScenarioInputLedgerEntry, SubjectCapability, SubjectCreateGroup, SubjectDescriptor,
@@ -102,93 +98,6 @@ struct Participant {
     offline_observation: Option<AppRuntimeObservationV1>,
 }
 
-#[derive(Clone, Debug)]
-struct RecordingRelayDatabase {
-    inner: MemoryDatabase,
-    publication_log: Arc<Mutex<Vec<Event>>>,
-    hidden_event_ids: Arc<Mutex<BTreeSet<EventId>>>,
-}
-
-impl NostrDatabase for RecordingRelayDatabase {
-    fn backend(&self) -> Backend {
-        self.inner.backend()
-    }
-
-    fn save_event<'a>(
-        &'a self,
-        event: &'a Event,
-    ) -> BoxedFuture<'a, Result<SaveEventStatus, DatabaseError>> {
-        Box::pin(async move {
-            let status = self.inner.save_event(event).await?;
-            if status.is_success() {
-                self.publication_log.lock().await.push(event.clone());
-            }
-            Ok(status)
-        })
-    }
-
-    fn check_id<'a>(
-        &'a self,
-        event_id: &'a EventId,
-    ) -> BoxedFuture<'a, Result<DatabaseEventStatus, DatabaseError>> {
-        Box::pin(async move {
-            if self.hidden_event_ids.lock().await.contains(event_id) {
-                return Ok(DatabaseEventStatus::NotExistent);
-            }
-            self.inner.check_id(event_id).await
-        })
-    }
-
-    fn event_by_id<'a>(
-        &'a self,
-        event_id: &'a EventId,
-    ) -> BoxedFuture<'a, Result<Option<Event>, DatabaseError>> {
-        Box::pin(async move {
-            if self.hidden_event_ids.lock().await.contains(event_id) {
-                return Ok(None);
-            }
-            self.inner.event_by_id(event_id).await
-        })
-    }
-
-    fn count(&self, filter: Filter) -> BoxedFuture<'_, Result<usize, DatabaseError>> {
-        Box::pin(async move { Ok(self.query(filter).await?.len()) })
-    }
-
-    fn query(&self, filter: Filter) -> BoxedFuture<'_, Result<Events, DatabaseError>> {
-        Box::pin(async move {
-            // Apply the requested limit only after hidden events are removed;
-            // otherwise one hidden newest event would incorrectly reduce the
-            // visible result below the relay client's requested page size.
-            let mut database_filter = filter.clone();
-            database_filter.limit = None;
-            let events = self.inner.query(database_filter).await?;
-            let hidden_event_ids = self.hidden_event_ids.lock().await;
-            let mut visible = Events::new(&filter);
-            visible.extend(
-                events
-                    .into_iter()
-                    .filter(|event| !hidden_event_ids.contains(&event.id)),
-            );
-            Ok(visible)
-        })
-    }
-
-    fn delete(&self, filter: Filter) -> BoxedFuture<'_, Result<(), DatabaseError>> {
-        self.inner.delete(filter)
-    }
-
-    fn wipe(&self) -> BoxedFuture<'_, Result<(), DatabaseError>> {
-        self.inner.wipe()
-    }
-}
-
-#[derive(Clone, Debug)]
-struct SequencedRelayEvent {
-    publication_sequence: usize,
-    event: Event,
-}
-
 impl Participant {
     fn root(&self) -> &Path {
         self.root.path()
@@ -208,31 +117,19 @@ impl Participant {
 /// In-process application harness backed by one real local Nostr relay.
 pub struct AppRuntimeHarness {
     _relay: LocalRelay,
+    relay_control: RelayControl,
     relay_url: String,
     participants: BTreeMap<String, Participant>,
     scenario_groups: BTreeMap<String, GroupId>,
     active_scenario_group: Option<String>,
     accepted_publications: BTreeMap<String, BTreeSet<String>>,
-    relay_publication_log: Arc<Mutex<Vec<Event>>>,
-    relay_action_events: BTreeMap<String, Vec<SequencedRelayEvent>>,
-    hidden_relay_event_ids: Arc<Mutex<BTreeSet<EventId>>>,
+    relay_action_events: RelayActionEvents,
 }
 
 impl AppRuntimeHarness {
     pub async fn new(clients: &[String]) -> Result<Self, SubjectError> {
-        // These are RelayBuilder's prior in-memory defaults. Keeping them
-        // explicit preserves MockRelay behavior while exposing the database.
-        let relay_database = MemoryDatabase::with_opts(MemoryDatabaseOptions {
-            events: true,
-            max_events: Some(75_000),
-        });
-        let relay_publication_log = Arc::new(Mutex::new(Vec::new()));
-        let hidden_relay_event_ids = Arc::new(Mutex::new(BTreeSet::new()));
-        let relay = LocalRelay::new(RelayBuilder::default().database(RecordingRelayDatabase {
-            inner: relay_database.clone(),
-            publication_log: Arc::clone(&relay_publication_log),
-            hidden_event_ids: Arc::clone(&hidden_relay_event_ids),
-        }));
+        let relay_control = RelayControl::new();
+        let relay = LocalRelay::new(relay_control.relay_builder());
         relay.run().await.map_err(environment_error)?;
         let relay_url = relay.url().await.to_string();
         let endpoint = TransportEndpoint::from(relay_url.clone());
@@ -280,19 +177,18 @@ impl AppRuntimeHarness {
         }
         Ok(Self {
             _relay: relay,
+            relay_control,
             relay_url,
             participants,
             scenario_groups: BTreeMap::new(),
             active_scenario_group: None,
             accepted_publications: BTreeMap::new(),
-            relay_publication_log,
             relay_action_events: BTreeMap::new(),
-            hidden_relay_event_ids,
         })
     }
 
     async fn relay_publication_cursor(&self) -> usize {
-        self.relay_publication_log.lock().await.len()
+        self.relay_control.publication_cursor().await
     }
 
     async fn record_relay_action_events(
@@ -303,34 +199,21 @@ impl AppRuntimeHarness {
         include_welcomes: bool,
     ) -> Result<(), SubjectError> {
         self.participant(actor)?;
-        let publication_log = self.relay_publication_log.lock().await;
-        if before > publication_log.len() {
-            return Err(SubjectError::new(
-                "relay_publication_cursor_invalid",
-                "the retained relay publication cursor moved backwards",
-            ));
-        }
         // Scenario commands execute serially. Kind-445 outer authors are
         // intentionally ephemeral, so the successful command boundary—not
         // event.pubkey—is the actor attribution available at this layer.
         // Filtering to group messages and action-local Welcome gift wraps
         // excludes unrelated runtime projections.
-        let mut events = publication_log[before..]
-            .iter()
-            .enumerate()
-            .filter(|(_, event)| {
-                event.kind == Kind::MlsGroupMessage
-                    || (include_welcomes && event.kind == Kind::GiftWrap)
-            })
-            .map(|(offset, event)| SequencedRelayEvent {
-                publication_sequence: before + offset,
-                event: event.clone(),
-            })
-            .collect::<Vec<_>>();
-        events.sort_by_key(|event| event.publication_sequence);
-        self.relay_action_events
-            .insert(action_id.to_owned(), events);
-        Ok(())
+        self.relay_control
+            .record_action_events(
+                &mut self.relay_action_events,
+                action_id,
+                before,
+                include_welcomes,
+            )
+            .await
+            .map(|_| ())
+            .map_err(relay_control_error)
     }
 
     async fn set_shared_relay_event_presence(
@@ -347,50 +230,6 @@ impl AppRuntimeHarness {
                 "the app-runtime adapter owns only relay:shared",
             ));
         }
-        if selector.publication.is_some() || selector.sender.is_some() || selector.class.is_some() {
-            return Err(SubjectError::classified(
-                SubjectFailureCategory::ExpectedRefusal,
-                "unsupported_relay_selector",
-                "the app-runtime relay gate requires an action_id-only selector",
-            ));
-        }
-        let action_id = selector.action_id.as_deref().ok_or_else(|| {
-            SubjectError::classified(
-                SubjectFailureCategory::ExpectedRefusal,
-                "missing_relay_action_id",
-                "the app-runtime relay gate requires an action id",
-            )
-        })?;
-        let event = self
-            .relay_action_events
-            .get(action_id)
-            .and_then(|events| events.get(selector.occurrence))
-            .map(|event| event.event.clone())
-            .ok_or_else(|| {
-                SubjectError::classified(
-                    SubjectFailureCategory::ExpectedRefusal,
-                    "relay_event_not_found",
-                    "no immediately published group-message or Welcome relay event matched the scenario action; deferred publications are not action-addressable on this adapter",
-                )
-            })?;
-        if visible {
-            let removed = self.hidden_relay_event_ids.lock().await.remove(&event.id);
-            if !removed {
-                return Err(SubjectError::classified(
-                    SubjectFailureCategory::ExpectedRefusal,
-                    "relay_event_not_removed",
-                    "the selected event is not currently hidden from the shared relay",
-                ));
-            }
-            return Ok(());
-        }
-        if self.hidden_relay_event_ids.lock().await.contains(&event.id) {
-            return Err(SubjectError::classified(
-                SubjectFailureCategory::ExpectedRefusal,
-                "relay_event_already_removed",
-                "the selected event is already hidden from the shared relay",
-            ));
-        }
         if clients
             .iter()
             .any(|client| !self.participants.contains_key(client))
@@ -401,10 +240,11 @@ impl AppRuntimeHarness {
                 "every named relay-removal client must belong to the harness",
             ));
         }
-        if self
-            .participants
-            .values()
-            .any(|participant| participant.online)
+        if !visible
+            && self
+                .participants
+                .values()
+                .any(|participant| participant.online)
         {
             return Err(SubjectError::classified(
                 SubjectFailureCategory::ExpectedRefusal,
@@ -412,8 +252,10 @@ impl AppRuntimeHarness {
                 "an event can be hidden from the shared relay only while every harness participant is offline",
             ));
         }
-        self.hidden_relay_event_ids.lock().await.insert(event.id);
-        Ok(())
+        self.relay_control
+            .set_action_event_visibility(&self.relay_action_events, selector, visible)
+            .await
+            .map_err(relay_control_error)
     }
 
     pub fn participant_roots(&self) -> BTreeMap<String, PathBuf> {
@@ -1470,6 +1312,14 @@ fn environment_error(error: impl std::fmt::Display) -> SubjectError {
     SubjectError::new("app_runtime_environment", error.to_string())
 }
 
+fn relay_control_error(error: RelayControlError) -> SubjectError {
+    SubjectError::classified(
+        SubjectFailureCategory::ExpectedRefusal,
+        error.code,
+        error.message,
+    )
+}
+
 fn block_on_subject<F>(future: F) -> Result<(), SubjectError>
 where
     F: std::future::Future<Output = Result<(), SubjectError>>,
@@ -1510,70 +1360,6 @@ fn walk_file_bytes(root: &Path) -> Vec<u64> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[tokio::test]
-    async fn recording_database_preserves_successful_relay_admission_order() {
-        let publication_log = Arc::new(Mutex::new(Vec::new()));
-        let hidden_event_ids = Arc::new(Mutex::new(BTreeSet::new()));
-        let database = RecordingRelayDatabase {
-            inner: MemoryDatabase::with_opts(MemoryDatabaseOptions {
-                events: true,
-                max_events: None,
-            }),
-            publication_log: Arc::clone(&publication_log),
-            hidden_event_ids: Arc::clone(&hidden_event_ids),
-        };
-        let keys = nostr::Keys::generate();
-        let first = nostr::EventBuilder::new(Kind::MlsGroupMessage, "first admitted")
-            .custom_created_at(nostr::Timestamp::from_secs(200))
-            .sign_with_keys(&keys)
-            .unwrap();
-        let second = nostr::EventBuilder::new(Kind::MlsGroupMessage, "second admitted")
-            .custom_created_at(nostr::Timestamp::from_secs(100))
-            .sign_with_keys(&keys)
-            .unwrap();
-
-        assert!(database.save_event(&first).await.unwrap().is_success());
-        assert!(database.save_event(&second).await.unwrap().is_success());
-        assert!(!database.save_event(&first).await.unwrap().is_success());
-
-        let recorded = publication_log.lock().await;
-        assert_eq!(recorded.len(), 2);
-        assert_eq!(recorded[0].id, first.id);
-        assert_eq!(recorded[1].id, second.id);
-        drop(recorded);
-
-        hidden_event_ids.lock().await.insert(first.id);
-        assert_eq!(
-            database.check_id(&first.id).await.unwrap(),
-            DatabaseEventStatus::NotExistent
-        );
-        assert!(database.event_by_id(&first.id).await.unwrap().is_none());
-        let one_group_event = Filter::new().kind(Kind::MlsGroupMessage).limit(1);
-        assert_eq!(database.count(one_group_event.clone()).await.unwrap(), 1);
-        assert_eq!(
-            database
-                .query(one_group_event.clone())
-                .await
-                .unwrap()
-                .first()
-                .map(|event| event.id),
-            Some(second.id),
-            "the query limit must be applied after hidden events are filtered"
-        );
-
-        assert!(hidden_event_ids.lock().await.remove(&first.id));
-        assert_eq!(
-            database
-                .query(one_group_event)
-                .await
-                .unwrap()
-                .first()
-                .map(|event| event.id),
-            Some(first.id),
-            "restoring visibility must expose the original retained event"
-        );
-    }
 
     #[test]
     fn public_commitment_preserves_a_reported_zero_member_count() {

--- a/crates/cgka-conformance-simulator/src/lib.rs
+++ b/crates/cgka-conformance-simulator/src/lib.rs
@@ -42,6 +42,7 @@ pub mod proptest_support;
 mod quiescence;
 pub mod reference_convergence;
 mod reference_subject;
+mod relay_control;
 pub mod report;
 mod retained_relay;
 pub mod route_assurance;

--- a/crates/cgka-conformance-simulator/src/node_protocol.rs
+++ b/crates/cgka-conformance-simulator/src/node_protocol.rs
@@ -13,6 +13,7 @@ use cgka_traits::{GroupId, TransportEndpoint};
 use marmot_account::AccountHome;
 use marmot_app::{
     AccountSetupRequest, AppError, AppMessageQuery, MarmotApp, MarmotAppConfig, MarmotAppRuntime,
+    SendSummary,
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -137,6 +138,8 @@ pub enum NodeResponseBodyV1 {
     Ack {
         action_id: String,
         published: usize,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        message_ids: Vec<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         group_id_hex: Option<String>,
     },
@@ -449,8 +452,12 @@ impl NodeServer {
                     .map_err(app_node_error)?;
                 state.groups.insert(group.clone(), group_id.clone());
                 state.active_group = Some(group);
-                set_admins(state, &group_id, &initial_admin_accounts).await?;
-                Ok(ack(action_id, 1, Some(hex::encode(group_id.as_slice()))))
+                let message_ids = set_admins(state, &group_id, &initial_admin_accounts).await?;
+                Ok(ack_with_message_ids(
+                    action_id,
+                    message_ids,
+                    Some(hex::encode(group_id.as_slice())),
+                ))
             }
             NodeCommandV1::InviteMembers {
                 action_id,
@@ -462,7 +469,7 @@ impl NodeServer {
                     .invite_members(&state.account_id, &group_id, &member_accounts)
                     .await
                     .map_err(app_node_error)?;
-                Ok(ack(action_id, summary.published, None))
+                Ok(ack_from_summary(action_id, summary, None))
             }
             NodeCommandV1::RemoveMembers {
                 action_id,
@@ -474,7 +481,7 @@ impl NodeServer {
                     .remove_members(&state.account_id, &group_id, &member_accounts)
                     .await
                     .map_err(app_node_error)?;
-                Ok(ack(action_id, summary.published, None))
+                Ok(ack_from_summary(action_id, summary, None))
             }
             NodeCommandV1::UpdateGroupData { action_id, name } => {
                 let group_id = active_group(state)?;
@@ -483,7 +490,7 @@ impl NodeServer {
                     .update_group_profile(&state.account_id, &group_id, Some(name), None)
                     .await
                     .map_err(app_node_error)?;
-                Ok(ack(action_id, summary.published, None))
+                Ok(ack_from_summary(action_id, summary, None))
             }
             NodeCommandV1::UpdateGroupProfile {
                 action_id,
@@ -496,15 +503,15 @@ impl NodeServer {
                     .update_group_profile(&state.account_id, &group_id, name, description)
                     .await
                     .map_err(app_node_error)?;
-                Ok(ack(action_id, summary.published, None))
+                Ok(ack_from_summary(action_id, summary, None))
             }
             NodeCommandV1::UpdateAdminPolicy {
                 action_id,
                 admin_accounts,
             } => {
                 let group_id = active_group(state)?;
-                set_admins(state, &group_id, &admin_accounts).await?;
-                Ok(ack(action_id, 1, None))
+                let message_ids = set_admins(state, &group_id, &admin_accounts).await?;
+                Ok(ack_with_message_ids(action_id, message_ids, None))
             }
             NodeCommandV1::SelfUpdate { action_id } => {
                 let group_id = active_group(state)?;
@@ -522,6 +529,10 @@ impl NodeServer {
                     .send_message(&state.account_id, &group_id, payload.into_bytes())
                     .await
                     .map_err(app_node_error)?;
+                // The public app API reports the canonical application-event
+                // id here, not the outer transport event id recorded by the
+                // relay. Preserve the publication count without pretending
+                // that the two identity domains are interchangeable.
                 Ok(ack(action_id, summary.published, None))
             }
             NodeCommandV1::Leave { action_id } => {
@@ -531,7 +542,7 @@ impl NodeServer {
                     .leave_group(&state.account_id, &group_id)
                     .await
                     .map_err(app_node_error)?;
-                Ok(ack(action_id, summary.published, None))
+                Ok(ack_from_summary(action_id, summary, None))
             }
             NodeCommandV1::CatchUp {
                 action_id,
@@ -805,7 +816,7 @@ async fn set_admins(
     state: &NodeRuntimeState,
     group_id: &GroupId,
     targets: &[String],
-) -> Result<(), NodeErrorV1> {
+) -> Result<Vec<String>, NodeErrorV1> {
     let group = state
         .app
         .group(&state.account_id, &hex::encode(group_id.as_slice()))
@@ -832,39 +843,51 @@ async fn set_admins(
         .into_iter()
         .collect::<BTreeSet<_>>();
     let mut applied = Vec::new();
+    let mut message_ids = Vec::new();
     for account in targets.difference(&current) {
-        if let Err(error) = state
+        let summary = match state
             .runtime
             .promote_admin(&state.account_id, group_id, account)
             .await
         {
-            return Err(compensate_node_admin_changes(state, group_id, &applied, error).await);
-        }
+            Ok(summary) => summary,
+            Err(error) => {
+                return Err(compensate_node_admin_changes(state, group_id, &applied, error).await);
+            }
+        };
+        message_ids.extend(summary.message_ids);
         applied.push(NodeAdminChange::Promoted(account.clone()));
     }
     for account in current
         .difference(&targets)
         .filter(|account| *account != &state.account_id)
     {
-        if let Err(error) = state
+        let summary = match state
             .runtime
             .demote_admin(&state.account_id, group_id, account)
             .await
         {
-            return Err(compensate_node_admin_changes(state, group_id, &applied, error).await);
-        }
+            Ok(summary) => summary,
+            Err(error) => {
+                return Err(compensate_node_admin_changes(state, group_id, &applied, error).await);
+            }
+        };
+        message_ids.extend(summary.message_ids);
         applied.push(NodeAdminChange::Demoted(account.clone()));
     }
-    if current.contains(&state.account_id)
-        && !targets.contains(&state.account_id)
-        && let Err(error) = state
+    if current.contains(&state.account_id) && !targets.contains(&state.account_id) {
+        match state
             .runtime
             .self_demote_admin(&state.account_id, group_id)
             .await
-    {
-        return Err(compensate_node_admin_changes(state, group_id, &applied, error).await);
+        {
+            Ok(summary) => message_ids.extend(summary.message_ids),
+            Err(error) => {
+                return Err(compensate_node_admin_changes(state, group_id, &applied, error).await);
+            }
+        }
     }
-    Ok(())
+    Ok(message_ids)
 }
 
 enum NodeAdminChange {
@@ -947,6 +970,33 @@ fn ack(
     NodeResponseBodyV1::Ack {
         action_id: action_id.into(),
         published,
+        message_ids: Vec::new(),
+        group_id_hex,
+    }
+}
+
+fn ack_from_summary(
+    action_id: impl Into<String>,
+    summary: SendSummary,
+    group_id_hex: Option<String>,
+) -> NodeResponseBodyV1 {
+    NodeResponseBodyV1::Ack {
+        action_id: action_id.into(),
+        published: summary.published,
+        message_ids: summary.message_ids,
+        group_id_hex,
+    }
+}
+
+fn ack_with_message_ids(
+    action_id: impl Into<String>,
+    message_ids: Vec<String>,
+    group_id_hex: Option<String>,
+) -> NodeResponseBodyV1 {
+    NodeResponseBodyV1::Ack {
+        action_id: action_id.into(),
+        published: message_ids.len(),
+        message_ids,
         group_id_hex,
     }
 }

--- a/crates/cgka-conformance-simulator/src/node_protocol.rs
+++ b/crates/cgka-conformance-simulator/src/node_protocol.rs
@@ -112,6 +112,12 @@ pub enum NodeCommandV1 {
     ClearEvents {
         action_id: String,
     },
+    PauseMaintenance {
+        action_id: String,
+    },
+    ResumeMaintenance {
+        action_id: String,
+    },
     Barrier {
         action_id: String,
         barrier: String,
@@ -579,6 +585,22 @@ impl NodeServer {
                 state.runtime_events_observed = 0;
                 state.previous_checkpoint = None;
                 state.stable_checkpoint_observations = 0;
+                Ok(ack(action_id, 0, None))
+            }
+            NodeCommandV1::PauseMaintenance { action_id } => {
+                state
+                    .runtime
+                    .pause_maintenance(&state.account_id)
+                    .await
+                    .map_err(app_node_error)?;
+                Ok(ack(action_id, 0, None))
+            }
+            NodeCommandV1::ResumeMaintenance { action_id } => {
+                state
+                    .runtime
+                    .resume_maintenance(&state.account_id)
+                    .await
+                    .map_err(app_node_error)?;
                 Ok(ack(action_id, 0, None))
             }
             NodeCommandV1::Barrier { action_id, barrier } => {

--- a/crates/cgka-conformance-simulator/src/process_orchestrator.rs
+++ b/crates/cgka-conformance-simulator/src/process_orchestrator.rs
@@ -491,6 +491,7 @@ impl ProcessOrchestrator {
         action_id: &str,
         cursors: BTreeMap<String, usize>,
         include_welcomes: bool,
+        expected_publications: usize,
     ) -> Result<(), ProcessOrchestratorError> {
         for (relay, before) in cursors {
             let control = self.relay_controls.get(&relay).ok_or_else(|| {
@@ -501,31 +502,20 @@ impl ProcessOrchestrator {
             })?;
             // A node acknowledges its command after the durable app-runtime
             // mutation, while the Nostr transport may still be admitting the
-            // resulting event on the relay task. Wait for that immediate
-            // publication so a later action-id selector cannot race an empty
-            // correlation entry.
-            let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
-            loop {
-                let recorded = control
-                    .record_action_events(
-                        self.relay_action_events.entry(relay.clone()).or_default(),
-                        action_id,
-                        before,
-                        include_welcomes,
-                    )
-                    .await
-                    .map_err(process_relay_control_error)?;
-                if recorded > 0 {
-                    break;
-                }
-                if tokio::time::Instant::now() >= deadline {
-                    return Err(ProcessOrchestratorError::new(
-                        "relay_action_publication_timeout",
-                        "the process action completed without an immediate retained relay publication",
-                    ));
-                }
-                tokio::time::sleep(Duration::from_millis(10)).await;
-            }
+            // resulting events on the relay task. Wait for the action's known
+            // publication count so a delayed Welcome cannot be omitted from
+            // this action or admitted after the next action's cursor.
+            control
+                .wait_for_action_events(
+                    self.relay_action_events.entry(relay.clone()).or_default(),
+                    action_id,
+                    before,
+                    include_welcomes,
+                    expected_publications,
+                    Duration::from_secs(5),
+                )
+                .await
+                .map_err(process_relay_control_error)?;
         }
         Ok(())
     }
@@ -629,7 +619,7 @@ impl ProcessOrchestrator {
                     } => group_id,
                     body => return Err((Some(creator.clone()), unexpected_response(body))),
                 };
-                self.record_relay_action_events(action_id, relay_cursors, true)
+                self.record_relay_action_events(action_id, relay_cursors, true, invitees.len())
                     .await
                     .map_err(orchestrator_failure)?;
                 self.groups.insert(group.clone(), group_id.clone());
@@ -666,7 +656,7 @@ impl ProcessOrchestrator {
                     },
                 )
                 .await?;
-                self.record_relay_action_events(action_id, relay_cursors, true)
+                self.record_relay_action_events(action_id, relay_cursors, true, invitees.len() + 1)
                     .await
                     .map_err(orchestrator_failure)?;
                 self.record_accepted_publication(inviter, pending);
@@ -691,7 +681,7 @@ impl ProcessOrchestrator {
                     },
                 )
                 .await?;
-                self.record_relay_action_events(action_id, relay_cursors, false)
+                self.record_relay_action_events(action_id, relay_cursors, false, 1)
                     .await
                     .map_err(orchestrator_failure)?;
                 self.record_accepted_publication(remover, pending);
@@ -710,7 +700,7 @@ impl ProcessOrchestrator {
                     },
                 )
                 .await?;
-                self.record_relay_action_events(action_id, relay_cursors, false)
+                self.record_relay_action_events(action_id, relay_cursors, false, 1)
                     .await
                     .map_err(orchestrator_failure)?;
                 self.record_accepted_publication(client, pending);
@@ -734,7 +724,7 @@ impl ProcessOrchestrator {
                     },
                 )
                 .await?;
-                self.record_relay_action_events(action_id, relay_cursors, false)
+                self.record_relay_action_events(action_id, relay_cursors, false, 1)
                     .await
                     .map_err(orchestrator_failure)?;
                 self.record_accepted_publication(client, pending);
@@ -760,7 +750,7 @@ impl ProcessOrchestrator {
                     },
                 )
                 .await?;
-                self.record_relay_action_events(action_id, relay_cursors, false)
+                self.record_relay_action_events(action_id, relay_cursors, false, 1)
                     .await
                     .map_err(orchestrator_failure)?;
                 self.record_accepted_publication(client, pending);
@@ -785,7 +775,7 @@ impl ProcessOrchestrator {
                     },
                 )
                 .await?;
-                self.record_relay_action_events(action_id, relay_cursors, false)
+                self.record_relay_action_events(action_id, relay_cursors, false, 1)
                     .await
                     .map_err(orchestrator_failure)?;
                 self.record_accepted_publication(client, pending);
@@ -805,7 +795,7 @@ impl ProcessOrchestrator {
                     },
                 )
                 .await?;
-                self.record_relay_action_events(action_id, relay_cursors, false)
+                self.record_relay_action_events(action_id, relay_cursors, false, 1)
                     .await
                     .map_err(orchestrator_failure)?;
                 Ok((vec![sender.clone()], ProcessActionStatusV1::Completed))
@@ -823,7 +813,7 @@ impl ProcessOrchestrator {
                     },
                 )
                 .await?;
-                self.record_relay_action_events(action_id, relay_cursors, false)
+                self.record_relay_action_events(action_id, relay_cursors, false, 1)
                     .await
                     .map_err(orchestrator_failure)?;
                 Ok((vec![client.clone()], ProcessActionStatusV1::Completed))

--- a/crates/cgka-conformance-simulator/src/process_orchestrator.rs
+++ b/crates/cgka-conformance-simulator/src/process_orchestrator.rs
@@ -602,40 +602,50 @@ impl ProcessOrchestrator {
                 let admins = self
                     .account_ids(admin_labels)
                     .map_err(orchestrator_failure)?;
-                let relay_cursors = self
-                    .relay_publication_cursors(creator)
+                self.set_all_maintenance_paused(action_id, true).await?;
+                let result = async {
+                    let relay_cursors = self
+                        .relay_publication_cursors(creator)
+                        .await
+                        .map_err(orchestrator_failure)?;
+                    let response = self
+                        .send(
+                            creator,
+                            NodeCommandV1::CreateGroup {
+                                action_id: action_id.into(),
+                                group: group.clone(),
+                                name: name.clone(),
+                                member_accounts: members,
+                                initial_admin_accounts: admins,
+                            },
+                        )
+                        .await?;
+                    let (group_id, admin_publications, message_ids) = match response {
+                        NodeResponseBodyV1::Ack {
+                            published,
+                            message_ids,
+                            group_id_hex: Some(group_id),
+                            ..
+                        } if published == message_ids.len() => (group_id, published, message_ids),
+                        body => return Err((Some(creator.clone()), unexpected_response(body))),
+                    };
+                    self.record_relay_action_events(
+                        action_id,
+                        relay_cursors,
+                        true,
+                        invitees.len() + admin_publications,
+                        &message_ids,
+                    )
                     .await
                     .map_err(orchestrator_failure)?;
-                let response = self
-                    .send(
-                        creator,
-                        NodeCommandV1::CreateGroup {
-                            action_id: action_id.into(),
-                            group: group.clone(),
-                            name: name.clone(),
-                            member_accounts: members,
-                            initial_admin_accounts: admins,
-                        },
-                    )
-                    .await?;
-                let (group_id, admin_publications, message_ids) = match response {
-                    NodeResponseBodyV1::Ack {
-                        published,
-                        message_ids,
-                        group_id_hex: Some(group_id),
-                        ..
-                    } if published == message_ids.len() => (group_id, published, message_ids),
-                    body => return Err((Some(creator.clone()), unexpected_response(body))),
+                    Ok(group_id)
                 };
-                self.record_relay_action_events(
-                    action_id,
-                    relay_cursors,
-                    true,
-                    invitees.len() + admin_publications,
-                    &message_ids,
-                )
-                .await
-                .map_err(orchestrator_failure)?;
+                let result = result.await;
+                let resume = self.set_all_maintenance_paused(action_id, false).await;
+                let group_id = match (result, resume) {
+                    (Err(error), _) | (Ok(_), Err(error)) => return Err(error),
+                    (Ok(group_id), Ok(())) => group_id,
+                };
                 self.groups.insert(group.clone(), group_id.clone());
                 let labels = self.running_labels();
                 for client in &labels {
@@ -825,28 +835,37 @@ impl ProcessOrchestrator {
             }
             ScenarioStep::SendAppMessage { sender, payload } => {
                 self.select_group(sender, &group).await?;
-                let relay_cursors = self
-                    .relay_publication_cursors(sender)
-                    .await
-                    .map_err(orchestrator_failure)?;
-                let (published, message_ids) = self
-                    .expect_counted_publish_ack(
-                        sender,
-                        NodeCommandV1::SendApplication {
-                            action_id: action_id.into(),
-                            payload: payload.clone(),
-                        },
+                self.set_all_maintenance_paused(action_id, true).await?;
+                let result = async {
+                    let relay_cursors = self
+                        .relay_publication_cursors(sender)
+                        .await
+                        .map_err(orchestrator_failure)?;
+                    let (published, message_ids) = self
+                        .expect_counted_publish_ack(
+                            sender,
+                            NodeCommandV1::SendApplication {
+                                action_id: action_id.into(),
+                                payload: payload.clone(),
+                            },
+                        )
+                        .await?;
+                    self.record_relay_action_events(
+                        action_id,
+                        relay_cursors,
+                        false,
+                        published,
+                        &message_ids,
                     )
-                    .await?;
-                self.record_relay_action_events(
-                    action_id,
-                    relay_cursors,
-                    false,
-                    published,
-                    &message_ids,
-                )
-                .await
-                .map_err(orchestrator_failure)?;
+                    .await
+                    .map_err(orchestrator_failure)
+                }
+                .await;
+                let resume = self.set_all_maintenance_paused(action_id, false).await;
+                match (result, resume) {
+                    (Err(error), _) | (Ok(()), Err(error)) => return Err(error),
+                    (Ok(()), Ok(())) => {}
+                }
                 Ok((vec![sender.clone()], ProcessActionStatusV1::Completed))
             }
             ScenarioStep::Leave { client } => {
@@ -1251,6 +1270,47 @@ impl ProcessOrchestrator {
             NodeResponseBodyV1::Ack { .. } => Ok(()),
             body => Err((Some(client.into()), unexpected_response(body))),
         }
+    }
+
+    async fn set_all_maintenance_paused(
+        &mut self,
+        action_id: &str,
+        paused: bool,
+    ) -> Result<(), (Option<String>, NodeErrorV1)> {
+        let labels = self.running_labels();
+        let mut changed = Vec::new();
+        let mut first_resume_error = None;
+        for label in labels {
+            let command = if paused {
+                NodeCommandV1::PauseMaintenance {
+                    action_id: action_id.into(),
+                }
+            } else {
+                NodeCommandV1::ResumeMaintenance {
+                    action_id: action_id.into(),
+                }
+            };
+            match self.expect_ack(&label, command).await {
+                Ok(()) => changed.push(label),
+                Err(error) if paused => {
+                    for changed_label in changed.iter().rev() {
+                        let _ = self
+                            .expect_ack(
+                                changed_label,
+                                NodeCommandV1::ResumeMaintenance {
+                                    action_id: action_id.into(),
+                                },
+                            )
+                            .await;
+                    }
+                    return Err(error);
+                }
+                Err(error) => {
+                    first_resume_error.get_or_insert(error);
+                }
+            }
+        }
+        first_resume_error.map_or(Ok(()), Err)
     }
 
     async fn expect_publish_ack(

--- a/crates/cgka-conformance-simulator/src/process_orchestrator.rs
+++ b/crates/cgka-conformance-simulator/src/process_orchestrator.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::Duration;
 
-use nostr_relay_builder::MockRelay;
+use nostr_relay_builder::LocalRelay;
 use serde::{Deserialize, Serialize};
 use sha2::Digest;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -17,6 +17,7 @@ use crate::node_protocol::{
     NODE_OBSERVATION_SCHEMA_VERSION, NODE_PROTOCOL_VERSION, NodeCommandV1, NodeErrorV1,
     NodeFailureCapsuleV1, NodeObservationV1, NodeRequestV1, NodeResponseBodyV1, NodeResponseV1,
 };
+use crate::relay_control::{RelayActionEvents, RelayControl, RelayControlError};
 use crate::{
     CompiledScenarioV2, ResolvedScenarioInputV1, ScenarioActionScheduleV2,
     ScenarioInputProvenanceV1, ScenarioRelaySyncModeV2, ScenarioSpec, ScenarioStep,
@@ -179,13 +180,16 @@ pub struct ProcessOrchestrator {
     run_root: tempfile::TempDir,
     artifact_directory: PathBuf,
     compiled: CompiledScenarioV2,
-    _relays: BTreeMap<String, MockRelay>,
+    _relays: BTreeMap<String, LocalRelay>,
+    relay_controls: BTreeMap<String, RelayControl>,
+    relay_action_events: BTreeMap<String, RelayActionEvents>,
     relay_urls: BTreeMap<String, String>,
     nodes: BTreeMap<String, NodeProcess>,
     account_ids: BTreeMap<String, String>,
     processes: BTreeMap<String, String>,
     process_relays: BTreeMap<String, Vec<String>>,
     groups: BTreeMap<String, String>,
+    offline_observations: BTreeMap<String, NodeObservationV1>,
     lifecycle: Vec<ProcessLifecycleEventV1>,
     input_provenance: Option<ScenarioInputProvenanceV1>,
     executed_scenario_ir_sha256: String,
@@ -200,7 +204,6 @@ struct NodeProcess {
     stdin: ChildStdin,
     stdout: BufReader<ChildStdout>,
     next_request: u64,
-    paused: bool,
 }
 
 impl ProcessOrchestrator {
@@ -245,11 +248,14 @@ impl ProcessOrchestrator {
         let compiled = compile_scenario(scenario).map_err(|error| {
             ProcessOrchestratorError::new("scenario_compile", error.to_string())
         })?;
-        preflight_process_compiled_scenario(&compiled, &process_subject_descriptor()).map_err(
-            |error| {
-                ProcessOrchestratorError::new("process_capability_preflight", error.to_string())
-            },
-        )?;
+        let owns_relay_control = external_relay_urls.is_none();
+        preflight_process_compiled_scenario(
+            &compiled,
+            &process_subject_descriptor(owns_relay_control),
+        )
+        .map_err(|error| {
+            ProcessOrchestratorError::new("process_capability_preflight", error.to_string())
+        })?;
         let artifact_directory = artifact_directory.as_ref().to_path_buf();
         fs_private::create_dir_all_private(&artifact_directory).map_err(environment_error)?;
         let run_root = tempfile::Builder::new()
@@ -269,6 +275,7 @@ impl ProcessOrchestrator {
                 .collect()
         };
         let mut relays = BTreeMap::new();
+        let mut relay_controls = BTreeMap::new();
         let relay_urls = if let Some(relay_urls) = external_relay_urls {
             let expected = relay_labels
                 .iter()
@@ -288,9 +295,12 @@ impl ProcessOrchestrator {
         } else {
             let mut relay_urls = BTreeMap::new();
             for label in relay_labels {
-                let relay = MockRelay::run().await.map_err(environment_error)?;
+                let relay_control = RelayControl::new();
+                let relay = LocalRelay::new(relay_control.relay_builder());
+                relay.run().await.map_err(environment_error)?;
                 relay_urls.insert(label.clone(), relay.url().await.to_string());
-                relays.insert(label, relay);
+                relays.insert(label.clone(), relay);
+                relay_controls.insert(label, relay_control);
             }
             relay_urls
         };
@@ -321,12 +331,15 @@ impl ProcessOrchestrator {
             artifact_directory,
             compiled,
             _relays: relays,
+            relay_controls,
+            relay_action_events: BTreeMap::new(),
             relay_urls,
             nodes: BTreeMap::new(),
             account_ids: BTreeMap::new(),
             processes,
             process_relays,
             groups: BTreeMap::new(),
+            offline_observations: BTreeMap::new(),
             lifecycle: Vec::new(),
             input_provenance: None,
             executed_scenario_ir_sha256,
@@ -446,9 +459,6 @@ impl ProcessOrchestrator {
         let labels = self.nodes.keys().cloned().collect::<Vec<_>>();
         for label in labels {
             if let Some(mut node) = self.nodes.remove(&label) {
-                if node.paused {
-                    let _ = resume_pid(node.child.id());
-                }
                 let _ = node.send(NodeCommandV1::Shutdown).await;
                 let _ = timeout(Duration::from_secs(5), node.child.wait()).await;
                 let _ = kill_process_group(&mut node.child).await;
@@ -461,6 +471,107 @@ impl ProcessOrchestrator {
             .entry(client.to_owned())
             .or_default()
             .insert(publication.to_owned());
+    }
+
+    async fn relay_publication_cursors(
+        &self,
+        client: &str,
+    ) -> Result<BTreeMap<String, usize>, ProcessOrchestratorError> {
+        let mut cursors = BTreeMap::new();
+        for label in self.relay_labels_for_client(client)? {
+            if let Some(control) = self.relay_controls.get(&label) {
+                cursors.insert(label, control.publication_cursor().await);
+            }
+        }
+        Ok(cursors)
+    }
+
+    async fn record_relay_action_events(
+        &mut self,
+        action_id: &str,
+        cursors: BTreeMap<String, usize>,
+        include_welcomes: bool,
+    ) -> Result<(), ProcessOrchestratorError> {
+        for (relay, before) in cursors {
+            let control = self.relay_controls.get(&relay).ok_or_else(|| {
+                ProcessOrchestratorError::new(
+                    "relay_control_unavailable",
+                    "the process adapter does not own the selected relay control",
+                )
+            })?;
+            // A node acknowledges its command after the durable app-runtime
+            // mutation, while the Nostr transport may still be admitting the
+            // resulting event on the relay task. Wait for that immediate
+            // publication so a later action-id selector cannot race an empty
+            // correlation entry.
+            let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+            loop {
+                let recorded = control
+                    .record_action_events(
+                        self.relay_action_events.entry(relay.clone()).or_default(),
+                        action_id,
+                        before,
+                        include_welcomes,
+                    )
+                    .await
+                    .map_err(process_relay_control_error)?;
+                if recorded > 0 {
+                    break;
+                }
+                if tokio::time::Instant::now() >= deadline {
+                    return Err(ProcessOrchestratorError::new(
+                        "relay_action_publication_timeout",
+                        "the process action completed without an immediate retained relay publication",
+                    ));
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        }
+        Ok(())
+    }
+
+    async fn set_relay_event_visibility(
+        &mut self,
+        relay: &str,
+        selector: &crate::ScenarioMessageSelectorV2,
+        clients: &[String],
+        visible: bool,
+    ) -> Result<(), ProcessOrchestratorError> {
+        if clients
+            .iter()
+            .any(|client| !self.compiled.clients.contains(client))
+        {
+            return Err(ProcessOrchestratorError::new(
+                "unknown_relay_removal_client",
+                "every named relay-removal client must belong to the process harness",
+            ));
+        }
+        if !visible
+            && self.compiled.clients.iter().any(|client| {
+                self.nodes.contains_key(client) || !self.offline_observations.contains_key(client)
+            })
+        {
+            return Err(ProcessOrchestratorError::new(
+                "relay_removal_requires_all_participants_offline",
+                "an event can be hidden from the relay only while every process participant is offline",
+            ));
+        }
+        let control = self.relay_controls.get(relay).ok_or_else(|| {
+            ProcessOrchestratorError::new(
+                "relay_control_unavailable",
+                "the process adapter does not own the selected relay control",
+            )
+        })?;
+        let action_events = self.relay_action_events.get(relay).ok_or_else(|| {
+            ProcessOrchestratorError::new(
+                "relay_event_not_found",
+                "the selected relay has no action-addressed publications",
+            )
+        })?;
+        control
+            .set_action_event_visibility(action_events, selector, visible)
+            .await
+            .map_err(process_relay_control_error)
     }
 
     async fn execute_action(
@@ -495,6 +606,10 @@ impl ProcessOrchestrator {
                 let admins = self
                     .account_ids(admin_labels)
                     .map_err(orchestrator_failure)?;
+                let relay_cursors = self
+                    .relay_publication_cursors(creator)
+                    .await
+                    .map_err(orchestrator_failure)?;
                 let response = self
                     .send(
                         creator,
@@ -514,6 +629,9 @@ impl ProcessOrchestrator {
                     } => group_id,
                     body => return Err((Some(creator.clone()), unexpected_response(body))),
                 };
+                self.record_relay_action_events(action_id, relay_cursors, true)
+                    .await
+                    .map_err(orchestrator_failure)?;
                 self.groups.insert(group.clone(), group_id.clone());
                 let labels = self.running_labels();
                 for client in &labels {
@@ -536,6 +654,10 @@ impl ProcessOrchestrator {
             } => {
                 self.select_group(inviter, &group).await?;
                 let member_accounts = self.account_ids(invitees).map_err(orchestrator_failure)?;
+                let relay_cursors = self
+                    .relay_publication_cursors(inviter)
+                    .await
+                    .map_err(orchestrator_failure)?;
                 self.expect_ack(
                     inviter,
                     NodeCommandV1::InviteMembers {
@@ -544,6 +666,9 @@ impl ProcessOrchestrator {
                     },
                 )
                 .await?;
+                self.record_relay_action_events(action_id, relay_cursors, true)
+                    .await
+                    .map_err(orchestrator_failure)?;
                 self.record_accepted_publication(inviter, pending);
                 Ok((vec![inviter.clone()], ProcessActionStatusV1::Completed))
             }
@@ -554,6 +679,10 @@ impl ProcessOrchestrator {
             } => {
                 self.select_group(remover, &group).await?;
                 let member_accounts = self.account_ids(members).map_err(orchestrator_failure)?;
+                let relay_cursors = self
+                    .relay_publication_cursors(remover)
+                    .await
+                    .map_err(orchestrator_failure)?;
                 self.expect_ack(
                     remover,
                     NodeCommandV1::RemoveMembers {
@@ -562,11 +691,18 @@ impl ProcessOrchestrator {
                     },
                 )
                 .await?;
+                self.record_relay_action_events(action_id, relay_cursors, false)
+                    .await
+                    .map_err(orchestrator_failure)?;
                 self.record_accepted_publication(remover, pending);
                 Ok((vec![remover.clone()], ProcessActionStatusV1::Completed))
             }
             ScenarioStep::SelfUpdate { client, pending } => {
                 self.select_group(client, &group).await?;
+                let relay_cursors = self
+                    .relay_publication_cursors(client)
+                    .await
+                    .map_err(orchestrator_failure)?;
                 self.expect_ack(
                     client,
                     NodeCommandV1::SelfUpdate {
@@ -574,6 +710,9 @@ impl ProcessOrchestrator {
                     },
                 )
                 .await?;
+                self.record_relay_action_events(action_id, relay_cursors, false)
+                    .await
+                    .map_err(orchestrator_failure)?;
                 self.record_accepted_publication(client, pending);
                 Ok((vec![client.clone()], ProcessActionStatusV1::Completed))
             }
@@ -583,6 +722,10 @@ impl ProcessOrchestrator {
                 pending,
             } => {
                 self.select_group(client, &group).await?;
+                let relay_cursors = self
+                    .relay_publication_cursors(client)
+                    .await
+                    .map_err(orchestrator_failure)?;
                 self.expect_ack(
                     client,
                     NodeCommandV1::UpdateGroupData {
@@ -591,6 +734,9 @@ impl ProcessOrchestrator {
                     },
                 )
                 .await?;
+                self.record_relay_action_events(action_id, relay_cursors, false)
+                    .await
+                    .map_err(orchestrator_failure)?;
                 self.record_accepted_publication(client, pending);
                 Ok((vec![client.clone()], ProcessActionStatusV1::Completed))
             }
@@ -601,6 +747,10 @@ impl ProcessOrchestrator {
                 pending,
             } => {
                 self.select_group(client, &group).await?;
+                let relay_cursors = self
+                    .relay_publication_cursors(client)
+                    .await
+                    .map_err(orchestrator_failure)?;
                 self.expect_ack(
                     client,
                     NodeCommandV1::UpdateGroupProfile {
@@ -610,6 +760,9 @@ impl ProcessOrchestrator {
                     },
                 )
                 .await?;
+                self.record_relay_action_events(action_id, relay_cursors, false)
+                    .await
+                    .map_err(orchestrator_failure)?;
                 self.record_accepted_publication(client, pending);
                 Ok((vec![client.clone()], ProcessActionStatusV1::Completed))
             }
@@ -620,6 +773,10 @@ impl ProcessOrchestrator {
             } => {
                 self.select_group(client, &group).await?;
                 let admin_accounts = self.account_ids(admins).map_err(orchestrator_failure)?;
+                let relay_cursors = self
+                    .relay_publication_cursors(client)
+                    .await
+                    .map_err(orchestrator_failure)?;
                 self.expect_ack(
                     client,
                     NodeCommandV1::UpdateAdminPolicy {
@@ -628,11 +785,18 @@ impl ProcessOrchestrator {
                     },
                 )
                 .await?;
+                self.record_relay_action_events(action_id, relay_cursors, false)
+                    .await
+                    .map_err(orchestrator_failure)?;
                 self.record_accepted_publication(client, pending);
                 Ok((vec![client.clone()], ProcessActionStatusV1::Completed))
             }
             ScenarioStep::SendAppMessage { sender, payload } => {
                 self.select_group(sender, &group).await?;
+                let relay_cursors = self
+                    .relay_publication_cursors(sender)
+                    .await
+                    .map_err(orchestrator_failure)?;
                 self.expect_ack(
                     sender,
                     NodeCommandV1::SendApplication {
@@ -641,10 +805,17 @@ impl ProcessOrchestrator {
                     },
                 )
                 .await?;
+                self.record_relay_action_events(action_id, relay_cursors, false)
+                    .await
+                    .map_err(orchestrator_failure)?;
                 Ok((vec![sender.clone()], ProcessActionStatusV1::Completed))
             }
             ScenarioStep::Leave { client } => {
                 self.select_group(client, &group).await?;
+                let relay_cursors = self
+                    .relay_publication_cursors(client)
+                    .await
+                    .map_err(orchestrator_failure)?;
                 self.expect_ack(
                     client,
                     NodeCommandV1::Leave {
@@ -652,6 +823,9 @@ impl ProcessOrchestrator {
                     },
                 )
                 .await?;
+                self.record_relay_action_events(action_id, relay_cursors, false)
+                    .await
+                    .map_err(orchestrator_failure)?;
                 Ok((vec![client.clone()], ProcessActionStatusV1::Completed))
             }
             ScenarioStep::DeliverAll => {
@@ -662,7 +836,7 @@ impl ProcessOrchestrator {
             ScenarioStep::Tick { clients } => {
                 let labels = clients
                     .iter()
-                    .filter(|client| self.nodes.get(*client).is_some_and(|node| !node.paused))
+                    .filter(|client| self.nodes.contains_key(*client))
                     .cloned()
                     .collect::<Vec<_>>();
                 self.catch_up(&labels, action_id, false).await?;
@@ -671,7 +845,7 @@ impl ProcessOrchestrator {
             ScenarioStep::SyncRelayHistory { clients, sync } => {
                 let clients = clients
                     .iter()
-                    .filter(|client| self.nodes.get(*client).is_some_and(|node| !node.paused))
+                    .filter(|client| self.nodes.contains_key(*client))
                     .cloned()
                     .collect::<Vec<_>>();
                 let full_history = matches!(
@@ -731,11 +905,11 @@ impl ProcessOrchestrator {
                 Ok((vec![client.clone()], ProcessActionStatusV1::Completed))
             }
             ScenarioStep::SetClientOffline { client } => {
-                self.pause_participant(client, action_id)?;
+                self.disconnect_participant(client, action_id).await?;
                 Ok((vec![client.clone()], ProcessActionStatusV1::Completed))
             }
             ScenarioStep::ReconnectClient { client } => {
-                self.resume_participant(client, action_id)?;
+                self.reconnect_participant(client, action_id).await?;
                 self.catch_up(std::slice::from_ref(client), action_id, false)
                     .await?;
                 Ok((vec![client.clone()], ProcessActionStatusV1::Completed))
@@ -768,6 +942,17 @@ impl ProcessOrchestrator {
                     )
                     .await?;
                 }
+                Ok((clients.clone(), ProcessActionStatusV1::Completed))
+            }
+            ScenarioStep::SetRelayEventVisibility {
+                relay,
+                selector,
+                clients,
+                visible,
+            } => {
+                self.set_relay_event_visibility(relay, selector, clients, *visible)
+                    .await
+                    .map_err(orchestrator_failure)?;
                 Ok((clients.clone(), ProcessActionStatusV1::Completed))
             }
             unsupported => Err((
@@ -848,7 +1033,6 @@ impl ProcessOrchestrator {
             stdin,
             stdout: BufReader::new(stdout),
             next_request: 0,
-            paused: false,
         };
         let relay_urls = self.relay_urls_for_client(client)?;
         let response = node
@@ -909,7 +1093,10 @@ impl ProcessOrchestrator {
         Ok(())
     }
 
-    fn relay_urls_for_client(&self, client: &str) -> Result<Vec<String>, ProcessOrchestratorError> {
+    fn relay_labels_for_client(
+        &self,
+        client: &str,
+    ) -> Result<Vec<String>, ProcessOrchestratorError> {
         let process = self.processes.get(client).ok_or_else(|| {
             ProcessOrchestratorError::new("topology", "participant has no process mapping")
         })?;
@@ -919,16 +1106,31 @@ impl ProcessOrchestrator {
             .cloned()
             .unwrap_or_default();
         if labels.is_empty() {
-            return Ok(self.relay_urls.values().cloned().collect());
+            return Ok(self.relay_urls.keys().cloned().collect());
         }
-        labels
+        if labels
+            .iter()
+            .any(|label| !self.relay_urls.contains_key(label))
+        {
+            return Err(ProcessOrchestratorError::new(
+                "topology",
+                "process references unknown relay",
+            ));
+        }
+        Ok(labels)
+    }
+
+    fn relay_urls_for_client(&self, client: &str) -> Result<Vec<String>, ProcessOrchestratorError> {
+        Ok(self
+            .relay_labels_for_client(client)?
             .into_iter()
             .map(|label| {
-                self.relay_urls.get(&label).cloned().ok_or_else(|| {
-                    ProcessOrchestratorError::new("topology", "process references unknown relay")
-                })
+                self.relay_urls
+                    .get(&label)
+                    .cloned()
+                    .expect("validated label")
             })
-            .collect()
+            .collect())
     }
 
     fn account_ids(&self, labels: &[String]) -> Result<Vec<String>, ProcessOrchestratorError> {
@@ -979,17 +1181,6 @@ impl ProcessOrchestrator {
                 },
             )
         })?;
-        if node.paused {
-            return Err((
-                Some(client.into()),
-                NodeErrorV1 {
-                    code: "participant_paused".into(),
-                    category: SubjectFailureCategory::ExpectedRefusal,
-                    retryable: true,
-                    message: "participant process is paused".into(),
-                },
-            ));
-        }
         match node.send(command).await {
             Ok(NodeResponseBodyV1::Error(error)) => Err((Some(client.into()), error)),
             Ok(body) => Ok(body),
@@ -1042,6 +1233,23 @@ impl ProcessOrchestrator {
     ) -> Result<Vec<NodeObservationV1>, (Option<String>, NodeErrorV1)> {
         let mut observations = Vec::with_capacity(clients.len());
         for client in clients {
+            if !self.nodes.contains_key(client) {
+                let observation = self.offline_observations.get(client).ok_or_else(|| {
+                    (
+                        Some(client.clone()),
+                        NodeErrorV1 {
+                            code: "offline_observation_unavailable".into(),
+                            category: SubjectFailureCategory::Environment,
+                            retryable: false,
+                            message:
+                                "the process went offline without a public observation checkpoint"
+                                    .into(),
+                        },
+                    )
+                })?;
+                observations.push(observation.clone());
+                continue;
+            }
             match self
                 .send(
                     client,
@@ -1120,61 +1328,89 @@ impl ProcessOrchestrator {
     }
 
     fn running_labels(&self) -> Vec<String> {
-        self.nodes
-            .iter()
-            .filter(|(_, node)| !node.paused)
-            .map(|(label, _)| label.clone())
-            .collect()
+        self.nodes.keys().cloned().collect()
     }
 
-    fn pause_participant(
+    async fn disconnect_participant(
         &mut self,
         client: &str,
         action_id: &str,
     ) -> Result<(), (Option<String>, NodeErrorV1)> {
-        let node = self.nodes.get_mut(client).ok_or_else(|| {
+        let observation = match self
+            .send(
+                client,
+                NodeCommandV1::Observe {
+                    action_id: action_id.into(),
+                },
+            )
+            .await?
+        {
+            NodeResponseBodyV1::Observation { observation, .. } => *observation,
+            body => return Err((Some(client.into()), unexpected_response(body))),
+        };
+        let mut node = self.nodes.remove(client).ok_or_else(|| {
             orchestrator_failure(ProcessOrchestratorError::new(
                 "participant_not_running",
-                "cannot pause a stopped participant",
+                "cannot disconnect a stopped participant",
             ))
         })?;
-        pause_pid(node.child.id()).map_err(|error| {
-            orchestrator_failure(ProcessOrchestratorError::new(
-                "pause_failed",
-                error.to_string(),
-            ))
-        })?;
-        node.paused = true;
+        match node.send(NodeCommandV1::Shutdown).await {
+            Ok(NodeResponseBodyV1::Shutdown) => {}
+            Ok(body) => return Err((Some(client.into()), unexpected_response(body))),
+            Err(error) => return Err(orchestrator_failure(error)),
+        }
+        let _ = timeout(Duration::from_secs(5), node.child.wait()).await;
+        kill_process_group(&mut node.child)
+            .await
+            .map_err(|error| orchestrator_failure(environment_error(error)))?;
+        self.offline_observations.insert(client.into(), observation);
         self.lifecycle.push(ProcessLifecycleEventV1 {
             action_id: action_id.into(),
             participant: client.into(),
-            event: "paused".into(),
+            event: "disconnected".into(),
         });
         Ok(())
     }
 
-    fn resume_participant(
+    async fn reconnect_participant(
         &mut self,
         client: &str,
         action_id: &str,
     ) -> Result<(), (Option<String>, NodeErrorV1)> {
-        let node = self.nodes.get_mut(client).ok_or_else(|| {
-            orchestrator_failure(ProcessOrchestratorError::new(
-                "participant_not_running",
-                "cannot resume a stopped participant",
-            ))
-        })?;
-        resume_pid(node.child.id()).map_err(|error| {
-            orchestrator_failure(ProcessOrchestratorError::new(
-                "resume_failed",
-                error.to_string(),
-            ))
-        })?;
-        node.paused = false;
+        if self.nodes.contains_key(client) && !self.offline_observations.contains_key(client) {
+            self.lifecycle.push(ProcessLifecycleEventV1 {
+                action_id: action_id.into(),
+                participant: client.into(),
+                event: "already_connected".into(),
+            });
+            return Ok(());
+        }
+        if !self.offline_observations.contains_key(client) || self.nodes.contains_key(client) {
+            return Err(orchestrator_failure(ProcessOrchestratorError::new(
+                "participant_connectivity_inconsistent",
+                "participant process and offline checkpoint disagree",
+            )));
+        }
+        self.launch_participant(client, action_id)
+            .await
+            .map_err(orchestrator_failure)?;
+        self.configure_peers().await.map_err(orchestrator_failure)?;
+        let groups = self.groups.clone();
+        for (group, group_id_hex) in groups {
+            self.expect_ack(
+                client,
+                NodeCommandV1::SelectGroup {
+                    group,
+                    group_id_hex,
+                },
+            )
+            .await?;
+        }
+        self.offline_observations.remove(client);
         self.lifecycle.push(ProcessLifecycleEventV1 {
             action_id: action_id.into(),
             participant: client.into(),
-            event: "resumed".into(),
+            event: "reconnected".into(),
         });
         Ok(())
     }
@@ -1190,9 +1426,7 @@ impl ProcessOrchestrator {
                 "cannot crash a stopped participant",
             ))
         })?;
-        if node.paused {
-            let _ = resume_pid(node.child.id());
-        }
+        self.offline_observations.remove(client);
         kill_process_group(&mut node.child).await.map_err(|error| {
             orchestrator_failure(ProcessOrchestratorError::new(
                 "kill_failed",
@@ -1230,6 +1464,7 @@ impl ProcessOrchestrator {
             )
             .await?;
         }
+        self.offline_observations.remove(client);
         self.lifecycle.push(ProcessLifecycleEventV1 {
             action_id: action_id.into(),
             participant: client.into(),
@@ -1340,25 +1575,29 @@ fn decode_node_response(
     Ok(response)
 }
 
-fn process_subject_descriptor() -> SubjectDescriptor {
+fn process_subject_descriptor(owns_relay_control: bool) -> SubjectDescriptor {
+    let mut capabilities = BTreeSet::from([
+        SubjectCapability::GroupMutation,
+        SubjectCapability::ApplicationMessaging,
+        SubjectCapability::TransportDelivery,
+        SubjectCapability::EventObservation,
+        SubjectCapability::AdminPolicyObservation,
+        SubjectCapability::CrashReopen,
+        SubjectCapability::OutboundPublication,
+        SubjectCapability::StructuralProgress,
+        SubjectCapability::ParticipantConnectivity,
+        SubjectCapability::ProcessLifecycle,
+        SubjectCapability::MultiGroup,
+        SubjectCapability::RetainedRelayHistory,
+    ]);
+    if owns_relay_control {
+        capabilities.insert(SubjectCapability::RetainedRelayControl);
+    }
     SubjectDescriptor {
         adapter: "marmot_app_process".into(),
         adapter_version: "1".into(),
         storage_backend: "sqlcipher_per_process".into(),
-        capabilities: BTreeSet::from([
-            SubjectCapability::GroupMutation,
-            SubjectCapability::ApplicationMessaging,
-            SubjectCapability::TransportDelivery,
-            SubjectCapability::EventObservation,
-            SubjectCapability::AdminPolicyObservation,
-            SubjectCapability::CrashReopen,
-            SubjectCapability::OutboundPublication,
-            SubjectCapability::StructuralProgress,
-            SubjectCapability::ParticipantConnectivity,
-            SubjectCapability::ProcessLifecycle,
-            SubjectCapability::MultiGroup,
-            SubjectCapability::RetainedRelayHistory,
-        ]),
+        capabilities,
     }
 }
 
@@ -1406,6 +1645,10 @@ fn orchestrator_failure(error: ProcessOrchestratorError) -> (Option<String>, Nod
 
 fn environment_error(error: impl fmt::Display) -> ProcessOrchestratorError {
     ProcessOrchestratorError::new("process_environment", error.to_string())
+}
+
+fn process_relay_control_error(error: RelayControlError) -> ProcessOrchestratorError {
+    ProcessOrchestratorError::new(error.code, error.message)
 }
 
 fn action_participant(step: &ScenarioStep) -> Option<String> {
@@ -1456,44 +1699,6 @@ fn process_action_error(error: (Option<String>, NodeErrorV1)) -> ProcessOrchestr
 pub fn process_participant_token(label: &str) -> String {
     let digest = hex::encode(sha2::Sha256::digest(label.as_bytes()));
     format!("participant-{}", &digest[..16])
-}
-
-#[cfg(unix)]
-fn pause_pid(pid: Option<u32>) -> std::io::Result<()> {
-    signal_pid(pid, libc::SIGSTOP)
-}
-
-#[cfg(not(unix))]
-fn pause_pid(_pid: Option<u32>) -> std::io::Result<()> {
-    Err(std::io::Error::new(
-        std::io::ErrorKind::Unsupported,
-        "process pause is unavailable on this platform",
-    ))
-}
-
-#[cfg(unix)]
-fn resume_pid(pid: Option<u32>) -> std::io::Result<()> {
-    signal_pid(pid, libc::SIGCONT)
-}
-
-#[cfg(not(unix))]
-fn resume_pid(_pid: Option<u32>) -> std::io::Result<()> {
-    Err(std::io::Error::new(
-        std::io::ErrorKind::Unsupported,
-        "process resume is unavailable on this platform",
-    ))
-}
-
-#[cfg(unix)]
-fn signal_pid(pid: Option<u32>, signal: libc::c_int) -> std::io::Result<()> {
-    let pid = pid.ok_or_else(|| std::io::Error::other("child has no pid"))?;
-    let pid = i32::try_from(pid).map_err(std::io::Error::other)?;
-    // SAFETY: the pid belongs to a live direct child owned by this orchestrator.
-    if unsafe { libc::kill(pid, signal) } == 0 {
-        Ok(())
-    } else {
-        Err(std::io::Error::last_os_error())
-    }
 }
 
 async fn kill_process_group(child: &mut Child) -> std::io::Result<()> {
@@ -1622,8 +1827,10 @@ mod tests {
 
     #[test]
     fn process_preflight_supports_observed_quiescence_without_claiming_virtual_time() {
-        let descriptor = process_subject_descriptor();
+        let descriptor = process_subject_descriptor(false);
         assert!(!descriptor.supports(SubjectCapability::VirtualTime));
+        assert!(!descriptor.supports(SubjectCapability::RetainedRelayControl));
+        assert!(process_subject_descriptor(true).supports(SubjectCapability::RetainedRelayControl));
 
         let await_spec = ScenarioSpec {
             name: "process-observed-quiescence".into(),

--- a/crates/cgka-conformance-simulator/src/process_orchestrator.rs
+++ b/crates/cgka-conformance-simulator/src/process_orchestrator.rs
@@ -18,7 +18,8 @@ use crate::node_protocol::{
     NodeFailureCapsuleV1, NodeObservationV1, NodeRequestV1, NodeResponseBodyV1, NodeResponseV1,
 };
 use crate::relay_control::{
-    RelayActionEvents, RelayActionExpectation, RelayControl, RelayControlError,
+    RELAY_ACTION_PUBLICATION_TIMEOUT, RelayActionEvents, RelayActionExpectation, RelayControl,
+    RelayControlError,
 };
 use crate::{
     CompiledScenarioV2, ResolvedScenarioInputV1, ScenarioActionScheduleV2,
@@ -517,7 +518,7 @@ impl ProcessOrchestrator {
                         include_welcomes,
                         expected_publications,
                         expected_event_ids,
-                        timeout: Duration::from_secs(5),
+                        timeout: RELAY_ACTION_PUBLICATION_TIMEOUT,
                     },
                 )
                 .await

--- a/crates/cgka-conformance-simulator/src/process_orchestrator.rs
+++ b/crates/cgka-conformance-simulator/src/process_orchestrator.rs
@@ -17,7 +17,9 @@ use crate::node_protocol::{
     NODE_OBSERVATION_SCHEMA_VERSION, NODE_PROTOCOL_VERSION, NodeCommandV1, NodeErrorV1,
     NodeFailureCapsuleV1, NodeObservationV1, NodeRequestV1, NodeResponseBodyV1, NodeResponseV1,
 };
-use crate::relay_control::{RelayActionEvents, RelayControl, RelayControlError};
+use crate::relay_control::{
+    RelayActionEvents, RelayActionExpectation, RelayControl, RelayControlError,
+};
 use crate::{
     CompiledScenarioV2, ResolvedScenarioInputV1, ScenarioActionScheduleV2,
     ScenarioInputProvenanceV1, ScenarioRelaySyncModeV2, ScenarioSpec, ScenarioStep,
@@ -492,6 +494,7 @@ impl ProcessOrchestrator {
         cursors: BTreeMap<String, usize>,
         include_welcomes: bool,
         expected_publications: usize,
+        expected_event_ids: &[String],
     ) -> Result<(), ProcessOrchestratorError> {
         for (relay, before) in cursors {
             let control = self.relay_controls.get(&relay).ok_or_else(|| {
@@ -510,9 +513,12 @@ impl ProcessOrchestrator {
                     self.relay_action_events.entry(relay.clone()).or_default(),
                     action_id,
                     before,
-                    include_welcomes,
-                    expected_publications,
-                    Duration::from_secs(5),
+                    RelayActionExpectation {
+                        include_welcomes,
+                        expected_publications,
+                        expected_event_ids,
+                        timeout: Duration::from_secs(5),
+                    },
                 )
                 .await
                 .map_err(process_relay_control_error)?;
@@ -612,16 +618,24 @@ impl ProcessOrchestrator {
                         },
                     )
                     .await?;
-                let group_id = match response {
+                let (group_id, admin_publications, message_ids) = match response {
                     NodeResponseBodyV1::Ack {
+                        published,
+                        message_ids,
                         group_id_hex: Some(group_id),
                         ..
-                    } => group_id,
+                    } if published == message_ids.len() => (group_id, published, message_ids),
                     body => return Err((Some(creator.clone()), unexpected_response(body))),
                 };
-                self.record_relay_action_events(action_id, relay_cursors, true, invitees.len())
-                    .await
-                    .map_err(orchestrator_failure)?;
+                self.record_relay_action_events(
+                    action_id,
+                    relay_cursors,
+                    true,
+                    invitees.len() + admin_publications,
+                    &message_ids,
+                )
+                .await
+                .map_err(orchestrator_failure)?;
                 self.groups.insert(group.clone(), group_id.clone());
                 let labels = self.running_labels();
                 for client in &labels {
@@ -648,17 +662,24 @@ impl ProcessOrchestrator {
                     .relay_publication_cursors(inviter)
                     .await
                     .map_err(orchestrator_failure)?;
-                self.expect_ack(
-                    inviter,
-                    NodeCommandV1::InviteMembers {
-                        action_id: action_id.into(),
-                        member_accounts,
-                    },
+                let message_ids = self
+                    .expect_publish_ack(
+                        inviter,
+                        NodeCommandV1::InviteMembers {
+                            action_id: action_id.into(),
+                            member_accounts,
+                        },
+                    )
+                    .await?;
+                self.record_relay_action_events(
+                    action_id,
+                    relay_cursors,
+                    true,
+                    message_ids.len(),
+                    &message_ids,
                 )
-                .await?;
-                self.record_relay_action_events(action_id, relay_cursors, true, invitees.len() + 1)
-                    .await
-                    .map_err(orchestrator_failure)?;
+                .await
+                .map_err(orchestrator_failure)?;
                 self.record_accepted_publication(inviter, pending);
                 Ok((vec![inviter.clone()], ProcessActionStatusV1::Completed))
             }
@@ -673,26 +694,29 @@ impl ProcessOrchestrator {
                     .relay_publication_cursors(remover)
                     .await
                     .map_err(orchestrator_failure)?;
-                self.expect_ack(
-                    remover,
-                    NodeCommandV1::RemoveMembers {
-                        action_id: action_id.into(),
-                        member_accounts,
-                    },
+                let message_ids = self
+                    .expect_publish_ack(
+                        remover,
+                        NodeCommandV1::RemoveMembers {
+                            action_id: action_id.into(),
+                            member_accounts,
+                        },
+                    )
+                    .await?;
+                self.record_relay_action_events(
+                    action_id,
+                    relay_cursors,
+                    false,
+                    message_ids.len(),
+                    &message_ids,
                 )
-                .await?;
-                self.record_relay_action_events(action_id, relay_cursors, false, 1)
-                    .await
-                    .map_err(orchestrator_failure)?;
+                .await
+                .map_err(orchestrator_failure)?;
                 self.record_accepted_publication(remover, pending);
                 Ok((vec![remover.clone()], ProcessActionStatusV1::Completed))
             }
             ScenarioStep::SelfUpdate { client, pending } => {
                 self.select_group(client, &group).await?;
-                let relay_cursors = self
-                    .relay_publication_cursors(client)
-                    .await
-                    .map_err(orchestrator_failure)?;
                 self.expect_ack(
                     client,
                     NodeCommandV1::SelfUpdate {
@@ -700,9 +724,6 @@ impl ProcessOrchestrator {
                     },
                 )
                 .await?;
-                self.record_relay_action_events(action_id, relay_cursors, false, 1)
-                    .await
-                    .map_err(orchestrator_failure)?;
                 self.record_accepted_publication(client, pending);
                 Ok((vec![client.clone()], ProcessActionStatusV1::Completed))
             }
@@ -716,17 +737,24 @@ impl ProcessOrchestrator {
                     .relay_publication_cursors(client)
                     .await
                     .map_err(orchestrator_failure)?;
-                self.expect_ack(
-                    client,
-                    NodeCommandV1::UpdateGroupData {
-                        action_id: action_id.into(),
-                        name: name.clone(),
-                    },
+                let message_ids = self
+                    .expect_publish_ack(
+                        client,
+                        NodeCommandV1::UpdateGroupData {
+                            action_id: action_id.into(),
+                            name: name.clone(),
+                        },
+                    )
+                    .await?;
+                self.record_relay_action_events(
+                    action_id,
+                    relay_cursors,
+                    false,
+                    message_ids.len(),
+                    &message_ids,
                 )
-                .await?;
-                self.record_relay_action_events(action_id, relay_cursors, false, 1)
-                    .await
-                    .map_err(orchestrator_failure)?;
+                .await
+                .map_err(orchestrator_failure)?;
                 self.record_accepted_publication(client, pending);
                 Ok((vec![client.clone()], ProcessActionStatusV1::Completed))
             }
@@ -741,18 +769,25 @@ impl ProcessOrchestrator {
                     .relay_publication_cursors(client)
                     .await
                     .map_err(orchestrator_failure)?;
-                self.expect_ack(
-                    client,
-                    NodeCommandV1::UpdateGroupProfile {
-                        action_id: action_id.into(),
-                        name: name.clone(),
-                        description: description.clone(),
-                    },
+                let message_ids = self
+                    .expect_publish_ack(
+                        client,
+                        NodeCommandV1::UpdateGroupProfile {
+                            action_id: action_id.into(),
+                            name: name.clone(),
+                            description: description.clone(),
+                        },
+                    )
+                    .await?;
+                self.record_relay_action_events(
+                    action_id,
+                    relay_cursors,
+                    false,
+                    message_ids.len(),
+                    &message_ids,
                 )
-                .await?;
-                self.record_relay_action_events(action_id, relay_cursors, false, 1)
-                    .await
-                    .map_err(orchestrator_failure)?;
+                .await
+                .map_err(orchestrator_failure)?;
                 self.record_accepted_publication(client, pending);
                 Ok((vec![client.clone()], ProcessActionStatusV1::Completed))
             }
@@ -767,17 +802,24 @@ impl ProcessOrchestrator {
                     .relay_publication_cursors(client)
                     .await
                     .map_err(orchestrator_failure)?;
-                self.expect_ack(
-                    client,
-                    NodeCommandV1::UpdateAdminPolicy {
-                        action_id: action_id.into(),
-                        admin_accounts,
-                    },
+                let message_ids = self
+                    .expect_publish_ack(
+                        client,
+                        NodeCommandV1::UpdateAdminPolicy {
+                            action_id: action_id.into(),
+                            admin_accounts,
+                        },
+                    )
+                    .await?;
+                self.record_relay_action_events(
+                    action_id,
+                    relay_cursors,
+                    false,
+                    message_ids.len(),
+                    &message_ids,
                 )
-                .await?;
-                self.record_relay_action_events(action_id, relay_cursors, false, 1)
-                    .await
-                    .map_err(orchestrator_failure)?;
+                .await
+                .map_err(orchestrator_failure)?;
                 self.record_accepted_publication(client, pending);
                 Ok((vec![client.clone()], ProcessActionStatusV1::Completed))
             }
@@ -787,17 +829,24 @@ impl ProcessOrchestrator {
                     .relay_publication_cursors(sender)
                     .await
                     .map_err(orchestrator_failure)?;
-                self.expect_ack(
-                    sender,
-                    NodeCommandV1::SendApplication {
-                        action_id: action_id.into(),
-                        payload: payload.clone(),
-                    },
+                let (published, message_ids) = self
+                    .expect_counted_publish_ack(
+                        sender,
+                        NodeCommandV1::SendApplication {
+                            action_id: action_id.into(),
+                            payload: payload.clone(),
+                        },
+                    )
+                    .await?;
+                self.record_relay_action_events(
+                    action_id,
+                    relay_cursors,
+                    false,
+                    published,
+                    &message_ids,
                 )
-                .await?;
-                self.record_relay_action_events(action_id, relay_cursors, false, 1)
-                    .await
-                    .map_err(orchestrator_failure)?;
+                .await
+                .map_err(orchestrator_failure)?;
                 Ok((vec![sender.clone()], ProcessActionStatusV1::Completed))
             }
             ScenarioStep::Leave { client } => {
@@ -806,16 +855,23 @@ impl ProcessOrchestrator {
                     .relay_publication_cursors(client)
                     .await
                     .map_err(orchestrator_failure)?;
-                self.expect_ack(
-                    client,
-                    NodeCommandV1::Leave {
-                        action_id: action_id.into(),
-                    },
+                let message_ids = self
+                    .expect_publish_ack(
+                        client,
+                        NodeCommandV1::Leave {
+                            action_id: action_id.into(),
+                        },
+                    )
+                    .await?;
+                self.record_relay_action_events(
+                    action_id,
+                    relay_cursors,
+                    false,
+                    message_ids.len(),
+                    &message_ids,
                 )
-                .await?;
-                self.record_relay_action_events(action_id, relay_cursors, false, 1)
-                    .await
-                    .map_err(orchestrator_failure)?;
+                .await
+                .map_err(orchestrator_failure)?;
                 Ok((vec![client.clone()], ProcessActionStatusV1::Completed))
             }
             ScenarioStep::DeliverAll => {
@@ -1197,6 +1253,36 @@ impl ProcessOrchestrator {
         }
     }
 
+    async fn expect_publish_ack(
+        &mut self,
+        client: &str,
+        command: NodeCommandV1,
+    ) -> Result<Vec<String>, (Option<String>, NodeErrorV1)> {
+        match self.send(client, command).await? {
+            NodeResponseBodyV1::Ack {
+                published,
+                message_ids,
+                ..
+            } if published == message_ids.len() => Ok(message_ids),
+            body => Err((Some(client.into()), unexpected_response(body))),
+        }
+    }
+
+    async fn expect_counted_publish_ack(
+        &mut self,
+        client: &str,
+        command: NodeCommandV1,
+    ) -> Result<(usize, Vec<String>), (Option<String>, NodeErrorV1)> {
+        match self.send(client, command).await? {
+            NodeResponseBodyV1::Ack {
+                published,
+                message_ids,
+                ..
+            } if message_ids.len() <= published => Ok((published, message_ids)),
+            body => Err((Some(client.into()), unexpected_response(body))),
+        }
+    }
+
     async fn catch_up(
         &mut self,
         clients: &[String],
@@ -1338,17 +1424,26 @@ impl ProcessOrchestrator {
             NodeResponseBodyV1::Observation { observation, .. } => *observation,
             body => return Err((Some(client.into()), unexpected_response(body))),
         };
-        let mut node = self.nodes.remove(client).ok_or_else(|| {
-            orchestrator_failure(ProcessOrchestratorError::new(
-                "participant_not_running",
-                "cannot disconnect a stopped participant",
-            ))
-        })?;
-        match node.send(NodeCommandV1::Shutdown).await {
+        let shutdown = self
+            .nodes
+            .get_mut(client)
+            .ok_or_else(|| {
+                orchestrator_failure(ProcessOrchestratorError::new(
+                    "participant_not_running",
+                    "cannot disconnect a stopped participant",
+                ))
+            })?
+            .send(NodeCommandV1::Shutdown)
+            .await;
+        match shutdown {
             Ok(NodeResponseBodyV1::Shutdown) => {}
             Ok(body) => return Err((Some(client.into()), unexpected_response(body))),
             Err(error) => return Err(orchestrator_failure(error)),
         }
+        let mut node = self
+            .nodes
+            .remove(client)
+            .expect("shutdown node remains tracked");
         let _ = timeout(Duration::from_secs(5), node.child.wait()).await;
         kill_process_group(&mut node.child)
             .await

--- a/crates/cgka-conformance-simulator/src/relay_control.rs
+++ b/crates/cgka-conformance-simulator/src/relay_control.rs
@@ -17,7 +17,7 @@ use tokio::time::{Duration, Instant, sleep};
 
 use crate::ScenarioMessageSelectorV2;
 
-pub(crate) const RELAY_ACTION_PUBLICATION_TIMEOUT: Duration = Duration::from_secs(15);
+pub(crate) const RELAY_ACTION_PUBLICATION_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Clone, Debug)]
 struct RecordingRelayDatabase {

--- a/crates/cgka-conformance-simulator/src/relay_control.rs
+++ b/crates/cgka-conformance-simulator/src/relay_control.rs
@@ -112,6 +112,13 @@ pub(crate) struct RelayControlError {
     pub message: &'static str,
 }
 
+pub(crate) struct RelayActionExpectation<'a> {
+    pub include_welcomes: bool,
+    pub expected_publications: usize,
+    pub expected_event_ids: &'a [String],
+    pub timeout: Duration,
+}
+
 #[derive(Clone, Debug)]
 pub(crate) struct RelayControl {
     publication_log: Arc<Mutex<Vec<Event>>>,
@@ -178,16 +185,45 @@ impl RelayControl {
         action_events: &mut RelayActionEvents,
         action_id: &str,
         before: usize,
-        include_welcomes: bool,
-        expected_publications: usize,
-        timeout: Duration,
+        expectation: RelayActionExpectation<'_>,
     ) -> Result<(), RelayControlError> {
+        let RelayActionExpectation {
+            include_welcomes,
+            expected_publications,
+            expected_event_ids,
+            timeout,
+        } = expectation;
+        if expected_event_ids.len() > expected_publications {
+            return Err(RelayControlError {
+                code: "relay_action_publication_identity_count_mismatch",
+                message: "the action's expected relay event ids do not match its publication count",
+            });
+        }
+        let expected_event_ids = expected_event_ids.iter().cloned().collect::<BTreeSet<_>>();
         let deadline = Instant::now() + timeout;
         loop {
             let recorded = self
                 .record_action_events(action_events, action_id, before, include_welcomes)
                 .await?;
-            if recorded == expected_publications {
+            let observed_event_ids = action_events
+                .get(action_id)
+                .into_iter()
+                .flatten()
+                .map(|event| event.event.id.to_hex())
+                .collect::<BTreeSet<_>>();
+            if expected_event_ids.len() == expected_publications
+                && observed_event_ids
+                    .iter()
+                    .any(|event_id| !expected_event_ids.contains(event_id))
+            {
+                return Err(RelayControlError {
+                    code: "relay_action_publication_identity_mismatch",
+                    message: "a retained relay event admitted after the action cursor was not published by that action",
+                });
+            }
+            if recorded == expected_publications
+                && expected_event_ids.is_subset(&observed_event_ids)
+            {
                 return Ok(());
             }
             if recorded > expected_publications {
@@ -199,7 +235,7 @@ impl RelayControl {
             if Instant::now() >= deadline {
                 return Err(RelayControlError {
                     code: "relay_action_publication_timeout",
-                    message: "the process action did not publish its expected retained relay events before the deadline",
+                    message: "the action's expected retained relay publications were not admitted before the deadline",
                 });
             }
             sleep(Duration::from_millis(10)).await;
@@ -366,9 +402,12 @@ mod tests {
                 &mut action_events,
                 "invite",
                 0,
-                true,
-                2,
-                Duration::from_secs(1),
+                RelayActionExpectation {
+                    include_welcomes: true,
+                    expected_publications: 2,
+                    expected_event_ids: &[],
+                    timeout: Duration::from_secs(1),
+                },
             )
             .await
             .unwrap();
@@ -396,5 +435,49 @@ mod tests {
             .await
             .unwrap();
         assert!(database.event_by_id(&welcome.id).await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn action_identity_rejects_a_delayed_publication_from_an_earlier_action() {
+        let control = RelayControl::new();
+        let database = RecordingRelayDatabase {
+            inner: MemoryDatabase::with_opts(MemoryDatabaseOptions {
+                events: true,
+                max_events: None,
+            }),
+            publication_log: Arc::clone(&control.publication_log),
+            hidden_event_ids: Arc::clone(&control.hidden_event_ids),
+        };
+        let keys = nostr::Keys::generate();
+        let delayed_prior = nostr::EventBuilder::new(Kind::MlsGroupMessage, "prior action")
+            .sign_with_keys(&keys)
+            .unwrap();
+        let current = nostr::EventBuilder::new(Kind::MlsGroupMessage, "current action")
+            .sign_with_keys(&keys)
+            .unwrap();
+        assert!(
+            database
+                .save_event(&delayed_prior)
+                .await
+                .unwrap()
+                .is_success()
+        );
+
+        let error = control
+            .wait_for_action_events(
+                &mut RelayActionEvents::new(),
+                "current",
+                0,
+                RelayActionExpectation {
+                    include_welcomes: false,
+                    expected_publications: 1,
+                    expected_event_ids: &[current.id.to_hex()],
+                    timeout: Duration::from_secs(1),
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.code, "relay_action_publication_identity_mismatch");
     }
 }

--- a/crates/cgka-conformance-simulator/src/relay_control.rs
+++ b/crates/cgka-conformance-simulator/src/relay_control.rs
@@ -1,0 +1,283 @@
+//! Simulator-owned retained-relay recording and reversible query visibility.
+//!
+//! The control is deliberately outside production transport code. Scenario
+//! adapters use successful relay admission order to associate immediate MLS
+//! publications with stable action ids, then temporarily remove selected
+//! events from retained queries without tombstoning the underlying event.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+
+use nostr_relay_builder::prelude::{
+    Backend, BoxedFuture, DatabaseError, DatabaseEventStatus, Event, EventId, Events, Filter, Kind,
+    MemoryDatabase, MemoryDatabaseOptions, NostrDatabase, RelayBuilder, SaveEventStatus,
+};
+use tokio::sync::Mutex;
+
+use crate::ScenarioMessageSelectorV2;
+
+#[derive(Clone, Debug)]
+struct RecordingRelayDatabase {
+    inner: MemoryDatabase,
+    publication_log: Arc<Mutex<Vec<Event>>>,
+    hidden_event_ids: Arc<Mutex<BTreeSet<EventId>>>,
+}
+
+impl NostrDatabase for RecordingRelayDatabase {
+    fn backend(&self) -> Backend {
+        self.inner.backend()
+    }
+
+    fn save_event<'a>(
+        &'a self,
+        event: &'a Event,
+    ) -> BoxedFuture<'a, Result<SaveEventStatus, DatabaseError>> {
+        Box::pin(async move {
+            let status = self.inner.save_event(event).await?;
+            if status.is_success() {
+                self.publication_log.lock().await.push(event.clone());
+            }
+            Ok(status)
+        })
+    }
+
+    fn check_id<'a>(
+        &'a self,
+        event_id: &'a EventId,
+    ) -> BoxedFuture<'a, Result<DatabaseEventStatus, DatabaseError>> {
+        Box::pin(async move {
+            if self.hidden_event_ids.lock().await.contains(event_id) {
+                return Ok(DatabaseEventStatus::NotExistent);
+            }
+            self.inner.check_id(event_id).await
+        })
+    }
+
+    fn event_by_id<'a>(
+        &'a self,
+        event_id: &'a EventId,
+    ) -> BoxedFuture<'a, Result<Option<Event>, DatabaseError>> {
+        Box::pin(async move {
+            if self.hidden_event_ids.lock().await.contains(event_id) {
+                return Ok(None);
+            }
+            self.inner.event_by_id(event_id).await
+        })
+    }
+
+    fn count(&self, filter: Filter) -> BoxedFuture<'_, Result<usize, DatabaseError>> {
+        Box::pin(async move { Ok(self.query(filter).await?.len()) })
+    }
+
+    fn query(&self, filter: Filter) -> BoxedFuture<'_, Result<Events, DatabaseError>> {
+        Box::pin(async move {
+            // Apply the requested limit only after hidden events are removed;
+            // otherwise one hidden newest event would incorrectly reduce the
+            // visible result below the relay client's requested page size.
+            let mut database_filter = filter.clone();
+            database_filter.limit = None;
+            let events = self.inner.query(database_filter).await?;
+            let hidden_event_ids = self.hidden_event_ids.lock().await;
+            let mut visible = Events::new(&filter);
+            visible.extend(
+                events
+                    .into_iter()
+                    .filter(|event| !hidden_event_ids.contains(&event.id)),
+            );
+            Ok(visible)
+        })
+    }
+
+    fn delete(&self, filter: Filter) -> BoxedFuture<'_, Result<(), DatabaseError>> {
+        self.inner.delete(filter)
+    }
+
+    fn wipe(&self) -> BoxedFuture<'_, Result<(), DatabaseError>> {
+        self.inner.wipe()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct SequencedRelayEvent {
+    publication_sequence: usize,
+    event: Event,
+}
+
+pub(crate) type RelayActionEvents = BTreeMap<String, Vec<SequencedRelayEvent>>;
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct RelayControlError {
+    pub code: &'static str,
+    pub message: &'static str,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct RelayControl {
+    publication_log: Arc<Mutex<Vec<Event>>>,
+    hidden_event_ids: Arc<Mutex<BTreeSet<EventId>>>,
+}
+
+impl RelayControl {
+    pub fn new() -> Self {
+        Self {
+            publication_log: Arc::new(Mutex::new(Vec::new())),
+            hidden_event_ids: Arc::new(Mutex::new(BTreeSet::new())),
+        }
+    }
+
+    pub fn relay_builder(&self) -> RelayBuilder {
+        RelayBuilder::default().database(RecordingRelayDatabase {
+            inner: MemoryDatabase::with_opts(MemoryDatabaseOptions {
+                events: true,
+                max_events: Some(75_000),
+            }),
+            publication_log: Arc::clone(&self.publication_log),
+            hidden_event_ids: Arc::clone(&self.hidden_event_ids),
+        })
+    }
+
+    pub async fn publication_cursor(&self) -> usize {
+        self.publication_log.lock().await.len()
+    }
+
+    pub async fn record_action_events(
+        &self,
+        action_events: &mut RelayActionEvents,
+        action_id: &str,
+        before: usize,
+        include_welcomes: bool,
+    ) -> Result<usize, RelayControlError> {
+        let publication_log = self.publication_log.lock().await;
+        if before > publication_log.len() {
+            return Err(RelayControlError {
+                code: "relay_publication_cursor_invalid",
+                message: "the retained relay publication cursor moved backwards",
+            });
+        }
+        let mut events = publication_log[before..]
+            .iter()
+            .enumerate()
+            .filter(|(_, event)| {
+                event.kind == Kind::MlsGroupMessage
+                    || (include_welcomes && event.kind == Kind::GiftWrap)
+            })
+            .map(|(offset, event)| SequencedRelayEvent {
+                publication_sequence: before + offset,
+                event: event.clone(),
+            })
+            .collect::<Vec<_>>();
+        events.sort_by_key(|event| event.publication_sequence);
+        let recorded = events.len();
+        action_events.insert(action_id.to_owned(), events);
+        Ok(recorded)
+    }
+
+    pub async fn set_action_event_visibility(
+        &self,
+        action_events: &RelayActionEvents,
+        selector: &ScenarioMessageSelectorV2,
+        visible: bool,
+    ) -> Result<(), RelayControlError> {
+        if selector.publication.is_some() || selector.sender.is_some() || selector.class.is_some() {
+            return Err(RelayControlError {
+                code: "unsupported_relay_selector",
+                message: "the retained relay gate requires an action_id-only selector",
+            });
+        }
+        let action_id = selector.action_id.as_deref().ok_or(RelayControlError {
+            code: "missing_relay_action_id",
+            message: "the retained relay gate requires an action id",
+        })?;
+        let event_id = action_events
+            .get(action_id)
+            .and_then(|events| events.get(selector.occurrence))
+            .map(|event| event.event.id)
+            .ok_or(RelayControlError {
+                code: "relay_event_not_found",
+                message: "no immediately published group-message or Welcome relay event matched the scenario action; deferred publications are not action-addressable on this adapter",
+            })?;
+        let mut hidden_event_ids = self.hidden_event_ids.lock().await;
+        if visible {
+            if !hidden_event_ids.remove(&event_id) {
+                return Err(RelayControlError {
+                    code: "relay_event_not_removed",
+                    message: "the selected event is not currently hidden from the relay",
+                });
+            }
+        } else if !hidden_event_ids.insert(event_id) {
+            return Err(RelayControlError {
+                code: "relay_event_already_removed",
+                message: "the selected event is already hidden from the relay",
+            });
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn recording_database_preserves_successful_relay_admission_order() {
+        let control = RelayControl::new();
+        let database = RecordingRelayDatabase {
+            inner: MemoryDatabase::with_opts(MemoryDatabaseOptions {
+                events: true,
+                max_events: None,
+            }),
+            publication_log: Arc::clone(&control.publication_log),
+            hidden_event_ids: Arc::clone(&control.hidden_event_ids),
+        };
+        let keys = nostr::Keys::generate();
+        let first = nostr::EventBuilder::new(Kind::MlsGroupMessage, "first admitted")
+            .custom_created_at(nostr::Timestamp::from_secs(200))
+            .sign_with_keys(&keys)
+            .unwrap();
+        let second = nostr::EventBuilder::new(Kind::MlsGroupMessage, "second admitted")
+            .custom_created_at(nostr::Timestamp::from_secs(100))
+            .sign_with_keys(&keys)
+            .unwrap();
+
+        assert!(database.save_event(&first).await.unwrap().is_success());
+        assert!(database.save_event(&second).await.unwrap().is_success());
+        assert!(!database.save_event(&first).await.unwrap().is_success());
+
+        let recorded = control.publication_log.lock().await;
+        assert_eq!(recorded.len(), 2);
+        assert_eq!(recorded[0].id, first.id);
+        assert_eq!(recorded[1].id, second.id);
+        drop(recorded);
+
+        control.hidden_event_ids.lock().await.insert(first.id);
+        assert_eq!(
+            database.check_id(&first.id).await.unwrap(),
+            DatabaseEventStatus::NotExistent
+        );
+        assert!(database.event_by_id(&first.id).await.unwrap().is_none());
+        let one_group_event = Filter::new().kind(Kind::MlsGroupMessage).limit(1);
+        assert_eq!(database.count(one_group_event.clone()).await.unwrap(), 1);
+        assert_eq!(
+            database
+                .query(one_group_event.clone())
+                .await
+                .unwrap()
+                .first()
+                .map(|event| event.id),
+            Some(second.id),
+            "the query limit must be applied after hidden events are filtered"
+        );
+
+        assert!(control.hidden_event_ids.lock().await.remove(&first.id));
+        assert_eq!(
+            database
+                .query(one_group_event)
+                .await
+                .unwrap()
+                .first()
+                .map(|event| event.id),
+            Some(first.id),
+            "restoring visibility must expose the original retained event"
+        );
+    }
+}

--- a/crates/cgka-conformance-simulator/src/relay_control.rs
+++ b/crates/cgka-conformance-simulator/src/relay_control.rs
@@ -17,6 +17,8 @@ use tokio::time::{Duration, Instant, sleep};
 
 use crate::ScenarioMessageSelectorV2;
 
+pub(crate) const RELAY_ACTION_PUBLICATION_TIMEOUT: Duration = Duration::from_secs(15);
+
 #[derive(Clone, Debug)]
 struct RecordingRelayDatabase {
     inner: MemoryDatabase,

--- a/crates/cgka-conformance-simulator/src/relay_control.rs
+++ b/crates/cgka-conformance-simulator/src/relay_control.rs
@@ -13,6 +13,7 @@ use nostr_relay_builder::prelude::{
     MemoryDatabase, MemoryDatabaseOptions, NostrDatabase, RelayBuilder, SaveEventStatus,
 };
 use tokio::sync::Mutex;
+use tokio::time::{Duration, Instant, sleep};
 
 use crate::ScenarioMessageSelectorV2;
 
@@ -172,6 +173,39 @@ impl RelayControl {
         Ok(recorded)
     }
 
+    pub async fn wait_for_action_events(
+        &self,
+        action_events: &mut RelayActionEvents,
+        action_id: &str,
+        before: usize,
+        include_welcomes: bool,
+        expected_publications: usize,
+        timeout: Duration,
+    ) -> Result<(), RelayControlError> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            let recorded = self
+                .record_action_events(action_events, action_id, before, include_welcomes)
+                .await?;
+            if recorded == expected_publications {
+                return Ok(());
+            }
+            if recorded > expected_publications {
+                return Err(RelayControlError {
+                    code: "relay_action_publication_count_mismatch",
+                    message: "the process action published more retained relay events than expected",
+                });
+            }
+            if Instant::now() >= deadline {
+                return Err(RelayControlError {
+                    code: "relay_action_publication_timeout",
+                    message: "the process action did not publish its expected retained relay events before the deadline",
+                });
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+    }
+
     pub async fn set_action_event_visibility(
         &self,
         action_events: &RelayActionEvents,
@@ -279,5 +313,88 @@ mod tests {
             Some(first.id),
             "restoring visibility must expose the original retained event"
         );
+    }
+
+    #[tokio::test]
+    async fn delayed_welcome_remains_addressable_as_its_actions_explicit_occurrence() {
+        let control = RelayControl::new();
+        let database = RecordingRelayDatabase {
+            inner: MemoryDatabase::with_opts(MemoryDatabaseOptions {
+                events: true,
+                max_events: None,
+            }),
+            publication_log: Arc::clone(&control.publication_log),
+            hidden_event_ids: Arc::clone(&control.hidden_event_ids),
+        };
+        let keys = nostr::Keys::generate();
+        let group_message = nostr::EventBuilder::new(Kind::MlsGroupMessage, "commit")
+            .sign_with_keys(&keys)
+            .unwrap();
+        let welcome = nostr::EventBuilder::new(Kind::GiftWrap, "welcome")
+            .sign_with_keys(&keys)
+            .unwrap();
+        assert!(
+            database
+                .save_event(&group_message)
+                .await
+                .unwrap()
+                .is_success()
+        );
+
+        let mut action_events = RelayActionEvents::new();
+        assert_eq!(
+            control
+                .record_action_events(&mut action_events, "invite", 0, true)
+                .await
+                .unwrap(),
+            1
+        );
+        let delayed_database = database.clone();
+        let delayed_welcome = welcome.clone();
+        let delayed_admission = tokio::spawn(async move {
+            sleep(Duration::from_millis(25)).await;
+            assert!(
+                delayed_database
+                    .save_event(&delayed_welcome)
+                    .await
+                    .unwrap()
+                    .is_success()
+            );
+        });
+        control
+            .wait_for_action_events(
+                &mut action_events,
+                "invite",
+                0,
+                true,
+                2,
+                Duration::from_secs(1),
+            )
+            .await
+            .unwrap();
+        delayed_admission.await.unwrap();
+
+        let selector = ScenarioMessageSelectorV2 {
+            action_id: Some("invite".into()),
+            occurrence: 1,
+            ..Default::default()
+        };
+        control
+            .set_action_event_visibility(&action_events, &selector, false)
+            .await
+            .unwrap();
+        assert!(database.event_by_id(&welcome.id).await.unwrap().is_none());
+        assert!(
+            database
+                .event_by_id(&group_message.id)
+                .await
+                .unwrap()
+                .is_some()
+        );
+        control
+            .set_action_event_visibility(&action_events, &selector, true)
+            .await
+            .unwrap();
+        assert!(database.event_by_id(&welcome.id).await.unwrap().is_some());
     }
 }

--- a/crates/cgka-conformance-simulator/tests/node_protocol.rs
+++ b/crates/cgka-conformance-simulator/tests/node_protocol.rs
@@ -60,6 +60,17 @@ async fn node_wraps_one_runtime_and_defines_observable_quiescence() {
     assert!(matches!(
         request(
             &mut server,
+            "pause-maintenance",
+            NodeCommandV1::PauseMaintenance {
+                action_id: "step-0:create_group@main".into(),
+            },
+        )
+        .await,
+        NodeResponseBodyV1::Ack { .. }
+    ));
+    assert!(matches!(
+        request(
+            &mut server,
             "create",
             NodeCommandV1::CreateGroup {
                 action_id: "step-0:create_group@main".into(),
@@ -74,6 +85,17 @@ async fn node_wraps_one_runtime_and_defines_observable_quiescence() {
             group_id_hex: Some(_),
             ..
         }
+    ));
+    assert!(matches!(
+        request(
+            &mut server,
+            "resume-maintenance",
+            NodeCommandV1::ResumeMaintenance {
+                action_id: "step-0:create_group@main".into(),
+            },
+        )
+        .await,
+        NodeResponseBodyV1::Ack { .. }
     ));
     assert!(matches!(
         request(

--- a/crates/cgka-conformance-simulator/tests/process_orchestrator.rs
+++ b/crates/cgka-conformance-simulator/tests/process_orchestrator.rs
@@ -2,14 +2,17 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use cgka_conformance_simulator::process_orchestrator::{ProcessNodeLaunchV1, ProcessOrchestrator};
+use cgka_conformance_simulator::process_orchestrator::{
+    ProcessActionStatusV1, ProcessNodeLaunchV1, ProcessOrchestrator, ProcessScenarioReportV1,
+};
 use cgka_conformance_simulator::{
     AppRuntimeHarness, AppRuntimeObservationV1, GeneratedScenarioCase, GeneratedScenarioInputV1,
     GeneratedSubjectKind, HarnessStorageMode, RetainedRelaySubject, ScenarioAccountV2,
     ScenarioDeviceV2, ScenarioInputDisposition, ScenarioMessageSelectorV2, ScenarioProcessV2,
     ScenarioRelaySyncModeV2, ScenarioRelayV2, ScenarioSpec, ScenarioStep, ScenarioTopologyV2,
-    TraceExpectation, compile_scenario, node_protocol::NodeObservationV1,
-    resolve_scenario_input_bytes, run_scenario_report, run_scenario_report_with_subject,
+    TraceExpectation, canonical_scenario_ir_sha256, compile_scenario,
+    node_protocol::NodeObservationV1, resolve_scenario_input_bytes, run_scenario_report,
+    run_scenario_report_with_subject,
 };
 use cgka_traits::group::ProtocolProfile;
 
@@ -1300,6 +1303,193 @@ async fn four_party_cross_route_recovery_app_runtime_equivalence_soak() {
     );
 }
 
+const PROCESS_ROUTE_EQUIVALENCE_SOAK_TRIALS: usize = 20;
+
+fn validate_four_party_cross_route_process_report(
+    spec: &ScenarioSpec,
+    report: &ProcessScenarioReportV1,
+) -> Result<(), String> {
+    if !report.completed || !report.failure_capsules.is_empty() {
+        return Err(format!(
+            "process execution did not complete cleanly; last action={:?}, lifecycle tail={:?}, failure capsules={:?}",
+            report.actions.last(),
+            report.lifecycle.iter().rev().take(6).collect::<Vec<_>>(),
+            report.failure_capsules,
+        ));
+    }
+    let schedule = compile_scenario(spec).map_err(|error| error.to_string())?;
+    if report.canonical_schedule != schedule.expanded_schedule()
+        || report.actions.len() != report.canonical_schedule.len()
+        || report
+            .actions
+            .iter()
+            .any(|action| action.status == ProcessActionStatusV1::Failed)
+    {
+        return Err(format!(
+            "process execution did not preserve the canonical schedule: {report:#?}"
+        ));
+    }
+    let expected_digest = canonical_scenario_ir_sha256(spec).map_err(|error| error.to_string())?;
+    if report.executed_scenario_ir_sha256.as_deref() != Some(expected_digest.as_str()) {
+        return Err(format!(
+            "process execution reported the wrong Scenario IR digest: {report:#?}"
+        ));
+    }
+    if report.observations.len() != spec.clients.len() * 4 {
+        return Err(format!(
+            "expected four complete process checkpoints: {report:#?}"
+        ));
+    }
+    let checkpoints = report
+        .observations
+        .chunks_exact(spec.clients.len())
+        .map(|observations| {
+            observations
+                .iter()
+                .map(|observation| (observation.participant.as_str(), observation))
+                .collect::<BTreeMap<_, _>>()
+        })
+        .collect::<Vec<_>>();
+    let baseline = &checkpoints[0];
+    let routed = &checkpoints[1];
+    let settled = &checkpoints[3];
+    if routed["zeta"].protocol.epoch != 4
+        || routed["alpha"].protocol.epoch != 4
+        || routed["yankee"].protocol.epoch != 4
+        || routed["observer"].protocol.epoch != 3
+    {
+        return Err(format!(
+            "process route did not reach the controlled intermediate split: {routed:#?}"
+        ));
+    }
+
+    let expected_payloads = BTreeSet::from([
+        "probe-from-alpha".to_owned(),
+        "probe-from-observer".to_owned(),
+        "probe-from-yankee".to_owned(),
+        "probe-from-zeta".to_owned(),
+        "zeta-branch-witness".to_owned(),
+    ]);
+    let mut public_commitments = BTreeSet::new();
+    for client in &spec.clients {
+        let observation = settled[client.as_str()];
+        if observation.protocol.epoch != 5
+            || observation.protocol.member_count != 4
+            || observation.protocol.member_identities != ["alpha", "observer", "yankee", "zeta"]
+            || observation.protocol.admin_identities != ["alpha", "yankee", "zeta"]
+            || observation.protocol.group_name != "zeta-branch-depth-two"
+            || !observation.protocol.group_description.is_empty()
+        {
+            return Err(format!(
+                "{client} did not reach the selected public protocol state: {settled:#?}"
+            ));
+        }
+        public_commitments.insert(observation.protocol.state_commitment_sha256.as_str());
+        let payloads = observation
+            .application
+            .visible_plaintexts
+            .iter()
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        if payloads != expected_payloads
+            || observation.application.visible_plaintexts.len() != payloads.len()
+            || observation.application.pending_confirmation
+        {
+            return Err(format!(
+                "{client} did not reach the complete duplicate-free application projection: {settled:#?}"
+            ));
+        }
+        let invalidated = observation.application.invalidated_message_ids.len();
+        let left_losing_branch = observation.protocol.group_name != "alpha-root"
+            && observation.protocol.epoch > baseline[client.as_str()].protocol.epoch;
+        if invalidated > 1
+            || (invalidated != 0 && !left_losing_branch)
+            || (client == "alpha" && invalidated != usize::from(left_losing_branch))
+            || ((client == "yankee" || client == "zeta") && invalidated != 0)
+        {
+            return Err(format!(
+                "{client} violated the losing-branch withdrawal rule: {settled:#?}"
+            ));
+        }
+        let visible_ids = observation
+            .application
+            .visible_message_ids
+            .iter()
+            .collect::<BTreeSet<_>>();
+        if observation
+            .application
+            .invalidated_message_ids
+            .iter()
+            .any(|id| visible_ids.contains(id))
+        {
+            return Err(format!(
+                "{client} projected an invalidated row as visible: {settled:#?}"
+            ));
+        }
+    }
+    if public_commitments.len() != 1 {
+        return Err(format!(
+            "process participants disagree on their public state commitment: {settled:#?}"
+        ));
+    }
+    let zeta_launches = report
+        .lifecycle
+        .iter()
+        .filter(|event| event.participant == "zeta" && event.event == "launched")
+        .count();
+    if zeta_launches < 2 {
+        return Err(format!(
+            "zeta did not reopen through the process lifecycle: {:#?}",
+            report.lifecycle
+        ));
+    }
+    Ok(())
+}
+
+async fn run_four_party_cross_route_process_trial() -> Result<(), String> {
+    let spec = cross_route_app_runtime_scenario(false);
+    let artifacts = tempfile::tempdir().map_err(|error| error.to_string())?;
+    let mut process = ProcessOrchestrator::launch(
+        env!("CARGO_BIN_EXE_cgka-conformance-node"),
+        &spec,
+        artifacts.path(),
+    )
+    .await
+    .map_err(|error| error.to_string())?;
+    let roots = process.participant_roots();
+    if roots.len() != spec.clients.len()
+        || roots.values().collect::<BTreeSet<_>>().len() != spec.clients.len()
+    {
+        process.shutdown().await;
+        return Err(format!("process roots were not isolated: {roots:#?}"));
+    }
+    let report = process.run().await.map_err(|error| error.to_string());
+    process.shutdown().await;
+    validate_four_party_cross_route_process_report(&spec, &report?)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn four_party_cross_route_recovery_processes_match_unified_route() {
+    if let Err(error) = run_four_party_cross_route_process_trial().await {
+        panic!("four-process cross-route recovery failed: {error}");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "manual twenty-trial process route-equivalence soak"]
+async fn four_party_cross_route_recovery_process_equivalence_soak() {
+    let mut failures = Vec::new();
+    for trial in 1..=PROCESS_ROUTE_EQUIVALENCE_SOAK_TRIALS {
+        if let Err(error) = run_four_party_cross_route_process_trial().await {
+            failures.push((trial, error));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "the unified route produced non-equivalent process outcomes: {failures:#?}"
+    );
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn process_adapter_executes_the_ir_embedded_in_a_saved_generated_input() {
     let spec = cross_adapter_restart_scenario();
@@ -1346,7 +1536,7 @@ async fn process_adapter_executes_the_ir_embedded_in_a_saved_generated_input() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn process_kill_pause_resume_and_restart_agree_with_uninterrupted_execution() {
+async fn process_kill_disconnect_reconnect_and_restart_agree_with_uninterrupted_execution() {
     let uninterrupted_spec = process_scenario("uninterrupted-app-process", false);
     let uninterrupted_artifacts = tempfile::tempdir().unwrap();
     let mut uninterrupted = ProcessOrchestrator::launch(
@@ -1397,13 +1587,13 @@ async fn process_kill_pause_resume_and_restart_agree_with_uninterrupted_executio
         recovered_report
             .lifecycle
             .iter()
-            .any(|event| event.event == "paused")
+            .any(|event| event.event == "disconnected")
     );
     assert!(
         recovered_report
             .lifecycle
             .iter()
-            .any(|event| event.event == "resumed")
+            .any(|event| event.event == "reconnected")
     );
     assert!(
         recovered_report
@@ -1529,6 +1719,35 @@ async fn external_relay_map_must_exactly_match_topology() {
         Err(error) => error,
     };
     assert_eq!(error.code, "missing_external_relay");
+}
+
+#[tokio::test]
+async fn external_relays_do_not_claim_runner_owned_visibility_control() {
+    let spec = cross_route_app_runtime_scenario(false);
+    let artifacts = tempfile::tempdir().unwrap();
+    let error = match ProcessOrchestrator::launch_with(
+        ProcessNodeLaunchV1::executable(env!("CARGO_BIN_EXE_cgka-conformance-node")),
+        Some(BTreeMap::from([(
+            "relay:shared".into(),
+            "ws://127.0.0.1:1".into(),
+        )])),
+        &spec,
+        artifacts.path(),
+    )
+    .await
+    {
+        Ok(mut orchestrator) => {
+            orchestrator.shutdown().await;
+            panic!("an uncontrolled external relay passed retained-control preflight")
+        }
+        Err(error) => error,
+    };
+    assert_eq!(error.code, "process_capability_preflight");
+    assert!(
+        error.message.contains("retained_relay_control"),
+        "{}",
+        error.message
+    );
 }
 
 #[test]

--- a/crates/cgka-conformance-simulator/tests/process_orchestrator.rs
+++ b/crates/cgka-conformance-simulator/tests/process_orchestrator.rs
@@ -1352,6 +1352,7 @@ fn validate_four_party_cross_route_process_report(
         .collect::<Vec<_>>();
     let baseline = &checkpoints[0];
     let routed = &checkpoints[1];
+    let first_settled = &checkpoints[2];
     let settled = &checkpoints[3];
     if routed["zeta"].protocol.epoch != 4
         || routed["alpha"].protocol.epoch != 4
@@ -1373,6 +1374,31 @@ fn validate_four_party_cross_route_process_report(
     let mut public_commitments = BTreeSet::new();
     for client in &spec.clients {
         let observation = settled[client.as_str()];
+        let prior = first_settled[client.as_str()];
+        if prior.protocol != observation.protocol
+            || prior.application != observation.application
+            || prior.progress.projection_checkpoint_sha256
+                != observation.progress.projection_checkpoint_sha256
+            || prior.progress.relay_inbound_events_seen
+                != observation.progress.relay_inbound_events_seen
+            || prior.progress.relay_inbound_events_delivered
+                != observation.progress.relay_inbound_events_delivered
+            || prior.progress.relay_publish_attempts != observation.progress.relay_publish_attempts
+            || prior.progress.relay_publish_failures != observation.progress.relay_publish_failures
+            || prior.progress.relay_directory_inflight_fetches != 0
+            || observation.progress.relay_directory_inflight_fetches != 0
+            || prior.progress.relay_directory_completed_fetches
+                != observation.progress.relay_directory_completed_fetches
+            || prior.progress.retry_timer_armed
+            || observation.progress.retry_timer_armed
+            || observation.progress.stable_checkpoint_observations
+                < prior.progress.stable_checkpoint_observations
+            || observation.progress.stable_checkpoint_observations < 2
+        {
+            return Err(format!(
+                "{client} did not preserve a stable final process checkpoint: {first_settled:#?} {settled:#?}"
+            ));
+        }
         if observation.protocol.epoch != 5
             || observation.protocol.member_count != 4
             || observation.protocol.member_identities != ["alpha", "observer", "yankee", "zeta"]

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -933,7 +933,7 @@ the process contract.
 
 - [x] Allocate one isolated root per participant.
 - [x] Launch and barrier N participant processes.
-- [x] Kill, pause, resume, and restart individual participants.
+- [x] Kill, disconnect, durably reconnect, and restart individual participants.
 - [x] Connect all participants to controlled local relay topologies.
 - [x] Preserve the canonical Scenario IR action schedule and observation schema.
 
@@ -941,8 +941,9 @@ the process contract.
 and launches one `cgka-conformance-node` process for each account-device participant. Participant labels are hashed
 before they become filesystem components; each process gets a private root, private stderr file, and a stable durable
 identity across restart. On Unix each child is its own process-group leader, so crash actions kill and reap the entire
-owned group while offline/reconnect actions use real process suspension and resumption. The parent re-establishes peer
-aliases and scenario-group selections after a restart before continuing the canonical schedule.
+owned group. Offline actions first record the public checkpoint, then gracefully stop the runtime and child so an open
+relay subscription cannot buffer delivery across the declared disconnect; reconnect reopens the same durable root and
+re-establishes peer aliases plus scenario-group selections before continuing the canonical schedule.
 
 The process report retains the compiler's expanded action schedule, records an outcome for every executed action, and
 uses the node's versioned layered observation schema. Explicit topology relay labels become parent-owned local relay
@@ -960,8 +961,8 @@ It does not query engine queues or child databases.
 Milestone 5 is complete. `process_orchestrator` drives one canonical scenario through the engine,
 `MarmotAppRuntime`, and a real child process and compares epoch, roster size, signed group profile, and the normalized
 public app/process commitment. A two-participant, two-relay scenario proves stable convergence and visible-message
-projection with no invalidated output. Its lifecycle variant performs real pause, resume, process-group kill, durable
-restart, full-history repair, and settlement, then compares the final protocol and application projections with the
+projection with no invalidated output. Its lifecycle variant performs real disconnect, durable reconnect,
+process-group kill, restart, full-history repair, and settlement, then compares the final protocol and application projections with the
 uninterrupted run. The failure path writes an owner-only shareable capsule containing the scenario participant label,
 stable action id, `app_process` layer, normalized error classification, and replay instructions; a controlled marker
 test proves producer error text is not copied into it.
@@ -1006,7 +1007,7 @@ closed the queued-outbound scheduling defect exposed by that unification. The 6.
 program for the routes that still exist (ordinary ingest, stored convergence, retained-history replay, and
 crash/restart recovery). The pre-unification app-runtime counterexample remains valuable historical evidence. Its
 post-unification rerun now owns a positive public-equivalence oracle on current `master`; the stronger evidence that
-the app adapter cannot expose and the process/container/VM routes remain open below.
+the app/process adapters cannot expose and the container/VM routes remain open below.
 
 ### 6.1 Decision-route assurance closure
 
@@ -1038,8 +1039,10 @@ the app adapter cannot expose and the process/container/VM routes remain open be
     execution now exists as `cross-route-app-runtime-recovery/v1`. A reversible relay query layer fixes the original
     destructive event-id tombstone artifact. Revalidation after #1293 route unification and #1403 queued-send repair
     now requires complete public protocol/probe equivalence and rejects every pre-unification lag, missing-probe, and
-    branch-split surface. Keep this item open for process/container/VM execution, per-durable-transition restart
-    permutations, and exact evidence on adapters that can expose it.
+    branch-split surface. The exact same IR and digest now pass that public oracle in four isolated app processes using
+    runner-owned reversible relay control, a real disconnect/reopen boundary, and one post-displacement restart. Keep
+    this item open for container/VM execution, per-durable-transition restart permutations, and exact evidence on
+    adapters that can expose it.
 - [x] Add a bounded abstract route-choice lifecycle and mutation sentinel for reconsiderable versus terminal loser
   disposition, volatile routing history, and restart; record that exhaustive shared-model and production-route
   comparison remains part of the open route-equivalence work above.
@@ -1054,10 +1057,10 @@ the app adapter cannot expose and the process/container/VM routes remain open be
 
 The remaining 6.1 work is assurance closure, not another speculative engine rewrite. #1285 is the implementation now
 on `master`; after #1293 and #1403, the retained-engine reference settles and the corrected-input app-runtime route is
-held to the same public terminal protocol/profile/probe result. Carry the same authenticated dependency-closed input
-contract into process/container/VM execution and the remaining durable-transition permutations. Do not project the
-app adapter's public evidence into exact cryptographic, durable-disposition, or active-decryptability claims that the
-adapter cannot expose.
+held to the same public terminal protocol/profile/probe result. The isolated-process adapter now carries that same
+input contract and public oracle. Carry it next into container/VM execution and the remaining durable-transition
+permutations. Do not project app/process public evidence into exact cryptographic, durable-disposition, or
+active-decryptability claims that those adapters cannot expose.
 
 [MDK #1329](https://github.com/marmot-protocol/mdk/pull/1329) merged the fail-closed missing-anchor behavior and
 Welcome-repair retirement. Its formerly stacked [MDK #1293](https://github.com/marmot-protocol/mdk/pull/1293) has now
@@ -1249,7 +1252,8 @@ residual gap.
 5. [ ] Complete the #1285 cross-route regression across every capable adapter. The `CgkaEngine` checkpoint is now permanent
    as `cross-route-own-commit-recovery/v1` and pins exact cryptographic, decryptability, commit-disposition, pending-work,
    and projection agreement after restart. `cross-route-retained-history-recovery/v1` now establishes the same contract
-   through retained relay histories; full app-runtime, process, container, and VM evidence remains.
+   through retained relay histories; app-runtime and isolated-process public-projection evidence is now complete, while
+   container/VM execution and engine-private evidence unavailable through those public adapters remain open.
    [MDK #1372](https://github.com/marmot-protocol/mdk/pull/1372) completed the first capability-overlap slice: one
    profile/message/restart journey runs unchanged through the `CgkaEngine` harness and the full
    app-runtime/separate-process adapters, crossing the production-shaped `CgkaEngine`, `TransportPeeler`, and
@@ -1263,10 +1267,12 @@ residual gap.
    the earlier corrected-input app runs produced both complete equivalence and a two-branch protocol/probe split, but
    those executions predated the merged route unification and queued-send scheduling repair. The current-master
    app-runtime oracle now rejects every historical non-equivalent surface and requires complete public equivalence;
-   its explicit ignored soak repeats the full retained-control/app-runtime trial twenty times. Process/container/VM
-   execution, exact cryptographic and active-decryptability evidence on capable adapters, complete application
-   disposition, and durable-transition permutations remain open. The decision-route inventory is machine checked
-   against the unified route.
+   its explicit ignored soak repeats the full retained-control/app-runtime trial twenty times. The same IR and digest
+   now run through four isolated app processes with separate SQLCipher roots, runner-owned reversible relay control,
+   real transport disconnect/reopen, one post-displacement restart, strict public state/application assertions, and a
+   separate ignored twenty-trial soak. Container/VM execution, exact cryptographic and active-decryptability evidence
+   on capable adapters, complete application disposition, and durable-transition permutations remain open. The
+   decision-route inventory is machine checked against the unified route.
 6. [x] Land and execute a focused current-`master` regression gate for the production convergence changes that landed
    after the reviewed 1,170-case snapshot. Cover #1329 missing-anchor halt and authenticated Welcome repair, #1360
    atomic self-removal persistence across injected write failures and restart, #1365 armed full-history backfill after
@@ -1444,6 +1450,7 @@ incorrect result.
 | 2026-08-12 | 6.1 unified same-epoch route and queued-send repair | Merged option C: removed the pairwise committer-only fork route so every participant uses distributed convergence, added branch-relative peel contexts and route-equivalence evidence, then repaired the durable queued-outbound scheduling edge and runnable-work level signal exposed by the longer unified convergence window. The corrected-input app-runtime result above predates both changes and is retained as historical falsification evidence, not a characterization of current `master`; repeat it before assigning the next production defect. | [MDK #1293](https://github.com/marmot-protocol/mdk/pull/1293); [MDK #1403](https://github.com/marmot-protocol/mdk/pull/1403); unified-route engine and simulator regressions |
 | 2026-08-13 | 6.1 post-unification app-runtime route assurance | Re-ran the exact corrected-input four-party topology after #1293 and #1403, then replaced the permissive historical terminal-surface classifier with a positive public-equivalence oracle. The strict retained-engine control still owns exact canonical state, accepted/invalidated/accepted commit dispositions, no pending work, and twelve decryptability edges; the full `MarmotAppRuntime` path must now match its epoch, roster, administration, and depth-two profile with the complete duplicate-free probe set and no pending confirmation. Five consecutive pre-change current-master trials reached that result, followed by a 20/20 post-change run of the explicit ignored soak. Process/container/VM execution and evidence unavailable through the app projection remain open; no production code changed. | `four_party_cross_route_recovery_app_runtime_matches_unified_route`; `four_party_cross_route_recovery_app_runtime_equivalence_soak`; simulator/app-runtime assurance only |
 | 2026-08-13 | Post-unification campaign performance baseline | Replaced full retained-message scans with indexed state probes, scoped retained-anchor snapshots to canonical group state while keeping legacy full-snapshot rollback compatibility, and point-queried Welcome key packages plus buffered replay states during join/create lifecycle work. These changes reduce the cost of long-history and participant-growth campaigns but do not close any route-equivalence or distributed evidence item by themselves. | [MDK #1405](https://github.com/marmot-protocol/mdk/pull/1405); [MDK #1406](https://github.com/marmot-protocol/mdk/pull/1406); [MDK #1416](https://github.com/marmot-protocol/mdk/pull/1416); storage and engine suites plus lifecycle benchmarks |
+| 2026-08-13 | 6.1 isolated-process cross-route assurance | Extracted runner-owned reversible retained-relay control for reuse by app and process adapters, then executed the exact app-runtime four-party IR and digest through four child runtimes with separate encrypted roots. Replaced SIGSTOP offline simulation with public checkpoint plus graceful runtime/transport disconnect and durable reopen, preventing open subscriptions from buffering withheld events across the declared offline boundary. The strict process oracle pins the controlled split, canonical schedule, public terminal protocol/profile, complete duplicate-free application set, losing-branch withdrawal rule, no pending confirmation, and real Zeta reopen. Exact MLS state, durable input dispositions, and active decryptability remain unavailable through the public node protocol; container/VM and every-transition permutations remain open. No production engine or app behavior changed. | `four_party_cross_route_recovery_processes_match_unified_route`; `four_party_cross_route_recovery_process_equivalence_soak`; process-adapter capability preflight and focused simulator tests |
 | 2026-08-13 | Nightly cross-sender oracle correction | Diagnosed the scheduled lane failure as an invalid ordering claim in `adversarial-reliability/app-witness-value/v1`: both runs agreed on the selected branch, epoch, roster, and exact payload multiplicities, but MLS does not define a total order across independent senders. The scenario now asserts one Eve witness, one Frank witness, and no David witness without weakening scenarios that intentionally test ordered delivery. A failed nightly lane also emits the exact seed-7 adversarial reports and capsules before propagating failure, and the runner raises its memlock limit instead of flooding logs when SQLCipher locks sensitive allocations. | [MDK #1409](https://github.com/marmot-protocol/mdk/issues/1409); scheduled run `31669097875`; focused adversarial reliability tests; nightly artifact path |
 
 ## Capability Naming Cleanup


### PR DESCRIPTION
## Summary

- extract runner-owned reversible retained-relay control for reuse by the app-runtime and process adapters
- run the canonical four-party cross-route scenario unchanged through four isolated app processes with separate encrypted roots
- replace SIGSTOP-based offline simulation with a real runtime/transport disconnect and durable reopen
- enforce strict public schedule, state, application, invalidation, quiescence, and restart assertions
- update the convergence route matrix and Milestone 6 tracking plan with the new evidence and remaining boundaries

## Why

The app-runtime adapter already had positive post-unification route-equivalence evidence, but the process adapter could not select the same action-addressed retained history. Its SIGSTOP offline model also left relay subscriptions open, allowing events to buffer while a participant was nominally offline and invalidating controlled-route assumptions.

The process orchestrator now checkpoints the public observation and gracefully stops the child/runtime for offline actions. Reconnect reopens the same durable SQLCipher root. Runner-owned relays advertise reversible visibility control; externally supplied relays fail capability preflight instead of claiming control the runner does not own.

This PR changes simulator/process infrastructure and assurance documentation only. It does not change production convergence-engine or app behavior.

## Assurance boundary

The process oracle covers the canonical schedule and IR digest, intermediate branch split, final epoch/roster/admin/profile agreement, the complete duplicate-free application-message set, losing-branch withdrawal behavior, pending-confirmation state, public commitment equality, and a real durable restart.

The public node protocol still does not expose exact MLS-state commitments, durable convergence-input dispositions, or active decryptability probes. Those claims remain owned by engine-capable subjects. Container/VM execution and every-durable-transition permutations remain open.

## Verification

- `cargo test -p cgka-conformance-simulator --test process_orchestrator --locked` — 13 passed, 2 ignored manual soaks
- `cargo test -p cgka-conformance-simulator --test app_runtime_adapter --locked` — 9 passed
- `cargo test -p cgka-conformance-simulator --test route_assurance --locked` — 8 passed
- `cargo test -p cgka-conformance-simulator --test process_orchestrator four_party_cross_route_recovery_process_equivalence_soak --locked -- --ignored --exact --nocapture` — 20/20 trials passed in 1,133 seconds
- final focused four-process route and disconnect/reconnect lifecycle regressions passed after the last audit adjustment
- `just fast-ci`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added graceful disconnect, reconnect, and durable restart flows for multi-process scenarios.
  * Added controlled recovery testing for retained messages and event visibility across application and process routes.
  * Operation acknowledgements now include published message identifiers where applicable.

* **Bug Fixes**
  * Improved relay event visibility and publication tracking during recovery.
  * Participants must be offline before retained events can be temporarily hidden.

* **Documentation**
  * Expanded convergence and reliability coverage, including current limitations and supported execution environments.
  * Added evidence for cross-route equivalence, recovery checkpoints, and restart behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->