### PR TITLE
Add storage format measurement rail

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -47,9 +47,10 @@ test-default:
 test-otlp:
     cargo nextest run --workspace --features {{otlp-features}},{{test-features}}
 
-# Startup scaling benchmarks (mdk#1161): builds stores with 0/10/100/1000
-# groups and 8/64-member rosters, cold-reopens each, and prints stable
-# `MDK_BENCH ...` lines separating chat-projection readiness from full
+# Startup scaling benchmarks (mdk#1161, mdk#1413): builds stores with
+# 0/10/100/1000 groups, 8/64-member rosters, and a message-heavy case;
+# reports the SQLCipher database footprint, cold-reopens each, and prints
+# stable `MDK_BENCH ...` lines separating chat-projection readiness from full
 # account-command readiness. Release profile so timings reflect shipped code.
 bench-startup:
     cargo test --release -p marmot-app --test startup_scaling -- --ignored --nocapture --test-threads=1

--- a/crates/cgka-engine/Cargo.toml
+++ b/crates/cgka-engine/Cargo.toml
@@ -44,7 +44,7 @@ sha2.workspace = true
 k256 = { version = "0.13", default-features = false, features = ["schnorr"] }
 
 [dev-dependencies]
-storage-sqlite.workspace = true
+storage-sqlite = { workspace = true, features = ["storage-format-benchmarks"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 test-log.workspace = true
 insta.workspace = true

--- a/crates/cgka-engine/benches/group_lifecycle.rs
+++ b/crates/cgka-engine/benches/group_lifecycle.rs
@@ -1,4 +1,5 @@
-//! Criterion benchmarks for the group creation and welcome-join flows.
+//! Criterion benchmarks for group creation, Welcome joins, and canonical
+//! state advances.
 //!
 //! These benches drive the real OpenMLS-backed engine over in-memory SQLite
 //! storage with the same pass-through peeler style the Tier-2 tests use, so
@@ -19,7 +20,8 @@ use cgka_engine::account_identity_proof::{
     AccountIdentityProofRequest, AccountIdentityProofSigner,
 };
 use cgka_engine::{Engine, EngineBuilder};
-use cgka_traits::engine::{CgkaEngine, CreateGroupRequest, KeyPackage, SendResult};
+use cgka_traits::app_event::{MARMOT_APP_EVENT_KIND_CHAT, MarmotAppEvent};
+use cgka_traits::engine::{CgkaEngine, CreateGroupRequest, KeyPackage, SendIntent, SendResult};
 use cgka_traits::error::PeelerError;
 use cgka_traits::group::ProtocolProfile;
 use cgka_traits::group_context::GroupContextSnapshot;
@@ -29,7 +31,7 @@ use cgka_traits::storage::MessageStorage;
 use cgka_traits::transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
 };
-use cgka_traits::types::{MemberId, MessageId};
+use cgka_traits::types::{EpochId, GroupId, MemberId, MessageId};
 use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
 use k256::schnorr::{SigningKey, signature::hazmat::PrehashSigner};
 use sha2::{Digest, Sha256};
@@ -248,6 +250,74 @@ fn create_request(members: Vec<KeyPackage>) -> CreateGroupRequest {
     }
 }
 
+/// Emit stable logical-size anchors alongside Criterion's timing output. The
+/// Welcome value counts the byte-bearing normalized row columns; SQLite page
+/// overhead is captured separately by the startup-scaling database footprint.
+fn report_storage_format_sizes(_: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("bench runtime");
+    let storage = SqliteAccountStorage::in_memory().unwrap();
+    let mut alice = build_client_with_storage(b"bench-alice-format-sizes", storage.clone());
+    let (group_id, result) = rt
+        .block_on(alice.create_group(create_request(invitee_key_packages(32))))
+        .expect("create_group succeeds");
+    let SendResult::FoundingGroupCreated { welcomes } = result else {
+        panic!("expected FoundingGroupCreated");
+    };
+    let welcome = welcomes.first().expect("32-member group has Welcomes");
+    let sizes = storage
+        .storage_format_bench_sizes(&group_id, &welcome.id)
+        .expect("read storage-format size anchors");
+    let welcome_record_bytes = sizes.message_value_bytes;
+    let founding_snapshot_bytes = sizes.largest_snapshot_bytes;
+    println!(
+        "MDK_BENCH storage_format_sizes members=32 welcome_record_bytes={welcome_record_bytes} \
+         founding_snapshot_bytes={founding_snapshot_bytes}"
+    );
+}
+
+fn confirm_group_evolution(
+    rt: &tokio::runtime::Runtime,
+    engine: &mut Engine<SqliteAccountStorage>,
+    result: SendResult,
+) -> TransportMessage {
+    let SendResult::GroupEvolution { msg, pending, .. } = result else {
+        panic!("expected GroupEvolution");
+    };
+    rt.block_on(engine.confirm_published(pending))
+        .expect("confirm_published succeeds");
+    msg
+}
+
+fn update_group_data(
+    rt: &tokio::runtime::Runtime,
+    engine: &mut Engine<SqliteAccountStorage>,
+    group_id: &GroupId,
+    sequence: usize,
+) -> TransportMessage {
+    let result = rt
+        .block_on(engine.send(SendIntent::UpdateGroupData {
+            group_id: group_id.clone(),
+            name: Some(format!("bench-{sequence}")),
+            description: None,
+        }))
+        .expect("UpdateGroupData succeeds");
+    confirm_group_evolution(rt, engine, result)
+}
+
+fn app_payload_for(engine: &Engine<SqliteAccountStorage>) -> Vec<u8> {
+    MarmotAppEvent::new(
+        hex::encode(engine.self_id().as_slice()),
+        1_700_000_000,
+        MARMOT_APP_EVENT_KIND_CHAT,
+        vec![],
+        "storage-format benchmark",
+    )
+    .encode()
+    .expect("benchmark app event encodes")
+}
+
 // ── create_group ────────────────────────────────────────────────────────────
 
 fn bench_create_group(c: &mut Criterion) {
@@ -355,9 +425,7 @@ fn bench_join_welcome(c: &mut Criterion) {
 }
 
 /// Joining a larger group: every join ends with a buffered-message replay
-/// scan over the group's stored messages. The just-persisted Welcome record
-/// alone is ~180KB of JSON at this size; a re-join additionally carries the
-/// group's whole prior history.
+/// scan over the group's stored messages.
 fn bench_join_welcome_large_group(c: &mut Criterion) {
     let rt = tokio::runtime::Builder::new_current_thread()
         .build()
@@ -411,11 +479,253 @@ fn bench_join_welcome_large_group(c: &mut Criterion) {
     group.finish();
 }
 
+fn prepare_app_send(
+    rt: &tokio::runtime::Runtime,
+) -> (Engine<SqliteAccountStorage>, GroupId, Vec<u8>) {
+    let mut alice = build_client(b"bench-alice-app-send");
+    let (group_id, create) = rt
+        .block_on(alice.create_group(create_request(vec![])))
+        .expect("create_group succeeds");
+    assert!(matches!(create, SendResult::FoundingGroupCreated { .. }));
+    let payload = app_payload_for(&alice);
+    (alice, group_id, payload)
+}
+
+/// Pure application-message encryption and normalized-row persistence.
+fn bench_app_message_send(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("bench runtime");
+    let mut group = c.benchmark_group("send_app_message");
+    group.warm_up_time(std::time::Duration::from_millis(200));
+    group.measurement_time(std::time::Duration::from_millis(300));
+    group.sample_size(10);
+    group.bench_function("current profile", |b| {
+        b.iter_batched(
+            || prepare_app_send(&rt),
+            |(mut alice, group_id, payload)| {
+                let result = rt
+                    .block_on(alice.send(SendIntent::AppMessage { group_id, payload }))
+                    .expect("app send succeeds");
+                assert!(matches!(result, SendResult::ApplicationMessage { .. }));
+            },
+            BatchSize::PerIteration,
+        );
+    });
+    group.finish();
+}
+
+fn prepare_app_ingest(
+    rt: &tokio::runtime::Runtime,
+) -> (Engine<SqliteAccountStorage>, TransportMessage) {
+    let mut alice = build_client(b"bench-alice-app-ingest");
+    let mut bob = build_client(b"bench-bob-app-ingest");
+    let bob_kp = rt
+        .block_on(bob.fresh_key_package())
+        .expect("mint bob key package");
+    let (group_id, create) = rt
+        .block_on(alice.create_group(create_request(vec![bob_kp])))
+        .expect("create_group succeeds");
+    let SendResult::FoundingGroupCreated { mut welcomes } = create else {
+        panic!("expected FoundingGroupCreated");
+    };
+    rt.block_on(bob.join_welcome(welcomes.remove(0)))
+        .expect("bob joins");
+    let result = rt
+        .block_on(alice.send(SendIntent::AppMessage {
+            group_id,
+            payload: app_payload_for(&alice),
+        }))
+        .expect("app send succeeds");
+    let SendResult::ApplicationMessage { msg, .. } = result else {
+        panic!("expected ApplicationMessage");
+    };
+    (bob, msg)
+}
+
+/// Peeling, MLS decryption, validation, and normalized-row persistence for an
+/// inbound application message.
+fn bench_app_message_ingest(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("bench runtime");
+    let mut group = c.benchmark_group("ingest_app_message");
+    group.warm_up_time(std::time::Duration::from_millis(200));
+    group.measurement_time(std::time::Duration::from_millis(300));
+    group.sample_size(10);
+    group.bench_function("current profile", |b| {
+        b.iter_batched(
+            || prepare_app_ingest(&rt),
+            |(mut bob, message)| rt.block_on(bob.ingest(message)).expect("ingest succeeds"),
+            BatchSize::PerIteration,
+        );
+    });
+    group.finish();
+}
+
+fn prepare_rejoin_with_history(
+    rt: &tokio::runtime::Runtime,
+    retained_commits: usize,
+) -> (Engine<SqliteAccountStorage>, TransportMessage) {
+    let mut alice = build_client(b"bench-alice-rejoin");
+    let bob_storage = SqliteAccountStorage::in_memory().unwrap();
+    let mut bob = build_client_with_storage(b"bench-bob-rejoin", bob_storage.clone());
+    let bob_id = bob.self_id().clone();
+    let bob_kp = rt
+        .block_on(bob.fresh_key_package())
+        .expect("mint initial bob key package");
+    let (group_id, create) = rt
+        .block_on(alice.create_group(create_request(vec![bob_kp])))
+        .expect("create_group succeeds");
+    let SendResult::FoundingGroupCreated { mut welcomes } = create else {
+        panic!("expected FoundingGroupCreated");
+    };
+    rt.block_on(bob.join_welcome(welcomes.remove(0)))
+        .expect("initial join succeeds");
+
+    // Build real canonical history on both peers. These commits become the
+    // rows and retained checkpoints that the rejoin path must reconcile.
+    for sequence in 0..retained_commits {
+        let commit = update_group_data(rt, &mut alice, &group_id, sequence);
+        rt.block_on(bob.ingest(commit))
+            .expect("bob ingests retained commit");
+        bob.converge_stored_openmls_messages_at(&group_id, 1_000_000)
+            .expect("retained commit converges");
+    }
+    assert!(
+        bob_storage
+            .list_messages(&group_id, EpochId(0))
+            .expect("list retained rejoin history")
+            .len()
+            >= retained_commits,
+        "fixture must retain the requested canonical history"
+    );
+
+    let removal = rt
+        .block_on(alice.send(SendIntent::RemoveMembers {
+            group_id: group_id.clone(),
+            members: vec![bob_id],
+        }))
+        .expect("remove succeeds");
+    let removal_commit = confirm_group_evolution(rt, &mut alice, removal);
+    rt.block_on(bob.ingest(removal_commit))
+        .expect("bob ingests removal");
+    bob.converge_stored_openmls_messages_at(&group_id, 1_000_000)
+        .expect("removal converges");
+
+    let rejoin_kp = rt
+        .block_on(bob.fresh_key_package())
+        .expect("mint rejoin key package");
+    let rejoin = rt
+        .block_on(alice.send(SendIntent::Invite {
+            group_id,
+            key_packages: vec![rejoin_kp],
+        }))
+        .expect("re-invite succeeds");
+    let SendResult::GroupEvolution {
+        mut welcomes,
+        pending,
+        ..
+    } = rejoin
+    else {
+        panic!("expected GroupEvolution");
+    };
+    rt.block_on(alice.confirm_published(pending))
+        .expect("confirm re-invite succeeds");
+    (bob, welcomes.remove(0))
+}
+
+/// Same-group rejoin after removal, scaled by the canonical commit history
+/// retained by the joining device. Fixture construction is excluded from the
+/// timed interval; only the second `join_welcome` call is measured.
+fn bench_rejoin_welcome_with_history(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("bench runtime");
+    let mut group = c.benchmark_group("rejoin_welcome_with_history");
+    group.warm_up_time(std::time::Duration::from_millis(200));
+    group.measurement_time(std::time::Duration::from_millis(300));
+    group.sample_size(10);
+    for retained_commits in [0_usize, 8, 32] {
+        group.bench_function(
+            BenchmarkId::from_parameter(format!("{retained_commits} retained commits")),
+            |b| {
+                b.iter_batched(
+                    || prepare_rejoin_with_history(&rt, retained_commits),
+                    |(mut bob, welcome)| {
+                        rt.block_on(bob.join_welcome(welcome))
+                            .expect("rejoin succeeds")
+                    },
+                    BatchSize::PerIteration,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+fn prepare_canonical_advance(
+    rt: &tokio::runtime::Runtime,
+    retained_commits: usize,
+) -> (Engine<SqliteAccountStorage>, GroupId, usize) {
+    let storage = SqliteAccountStorage::in_memory().unwrap();
+    let mut alice = build_client_with_storage(b"bench-alice-canonical-advance", storage.clone());
+    let (group_id, create) = rt
+        .block_on(alice.create_group(create_request(vec![])))
+        .expect("create_group succeeds");
+    assert!(matches!(create, SendResult::FoundingGroupCreated { .. }));
+    for sequence in 0..retained_commits {
+        update_group_data(rt, &mut alice, &group_id, sequence);
+    }
+    assert!(
+        storage
+            .list_messages(&group_id, EpochId(0))
+            .expect("list retained canonical history")
+            .len()
+            >= retained_commits,
+        "fixture must retain the requested canonical history"
+    );
+    (alice, group_id, retained_commits)
+}
+
+/// One canonical commit preparation + confirmation at fixed retained-history
+/// depths. The setup commits are real state advances but are excluded from the
+/// timed interval.
+fn bench_canonical_advance_with_history(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("bench runtime");
+    let mut group = c.benchmark_group("canonical_advance_with_history");
+    group.warm_up_time(std::time::Duration::from_millis(200));
+    group.measurement_time(std::time::Duration::from_millis(300));
+    group.sample_size(10);
+    for retained_commits in [0_usize, 8, 32] {
+        group.bench_function(
+            BenchmarkId::from_parameter(format!("{retained_commits} retained commits")),
+            |b| {
+                b.iter_batched(
+                    || prepare_canonical_advance(&rt, retained_commits),
+                    |(mut alice, group_id, sequence)| {
+                        update_group_data(&rt, &mut alice, &group_id, sequence)
+                    },
+                    BatchSize::PerIteration,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
 criterion_group!(
     benches,
+    report_storage_format_sizes,
     bench_create_group,
     bench_retained_anchor_snapshot,
     bench_join_welcome,
-    bench_join_welcome_large_group
+    bench_join_welcome_large_group,
+    bench_app_message_send,
+    bench_app_message_ingest,
+    bench_rejoin_welcome_with_history,
+    bench_canonical_advance_with_history
 );
 criterion_main!(benches);

--- a/crates/marmot-app/tests/startup_scaling.rs
+++ b/crates/marmot-app/tests/startup_scaling.rs
@@ -1,8 +1,9 @@
 //! Startup scaling benchmarks for the account-open critical path (mdk#1161).
 //!
-//! Each case builds an on-disk store with N groups (and M invited members per
-//! group), tears everything down, then measures a cold reopen the way a host
-//! app boots:
+//! Each case builds an on-disk store with N groups, M invited members per
+//! group, and P application messages per group. It records the resulting
+//! SQLCipher database footprint, tears everything down, then measures a cold
+//! reopen the way a host app boots:
 //!
 //! 1. `MarmotApp::chat_list` on a fresh app instance, **before** any runtime
 //!    exists — the persisted chat-projection read a host renders first.
@@ -34,6 +35,7 @@
 //! cached key package each to the mock relay and are referenced by account id
 //! when the bench account creates groups.
 
+use std::path::Path;
 use std::time::{Duration, Instant};
 
 use marmot_account::AccountHome;
@@ -53,6 +55,11 @@ fn open_store(dir: &tempfile::TempDir, relay_url: &str) -> MarmotApp {
 struct BenchReport {
     groups: usize,
     roster: usize,
+    messages_per_group: usize,
+    /// Main SQLCipher database file after fixture connections close.
+    database_bytes: u64,
+    /// Main database plus any SQLite WAL and shared-memory sidecars.
+    database_footprint_bytes: u64,
     /// Cold `MarmotApp::chat_list` read on a fresh app, before any runtime.
     chat_list: Duration,
     /// `MarmotAppRuntime::start()` wall clock on the same cold store.
@@ -73,12 +80,16 @@ struct BenchReport {
 impl BenchReport {
     fn print(&self, case: &str) {
         println!(
-            "MDK_BENCH startup_scaling case={case} groups={} roster={} \
-             chat_list_ms={} ready_ms={} group_read_ms={} account_open_wait_ms={} \
+            "MDK_BENCH startup_scaling case={case} groups={} roster={} messages_per_group={} \
+             database_bytes={} database_footprint_bytes={} chat_list_ms={} ready_ms={} \
+             group_read_ms={} account_open_wait_ms={} \
              session_open_ms={} group_hydration_ms={} profile_load_ms={} \
              read_snapshot_ms={}",
             self.groups,
             self.roster,
+            self.messages_per_group,
+            self.database_bytes,
+            self.database_footprint_bytes,
             self.chat_list.as_millis(),
             self.start_ready.as_millis(),
             self.group_read.as_millis(),
@@ -91,8 +102,23 @@ impl BenchReport {
     }
 }
 
+fn file_bytes(path: &Path) -> u64 {
+    std::fs::metadata(path).map_or(0, |metadata| metadata.len())
+}
+
+fn database_footprint(path: &Path) -> (u64, u64) {
+    let database_bytes = file_bytes(path);
+    let mut wal_path = path.as_os_str().to_owned();
+    wal_path.push("-wal");
+    let mut shm_path = path.as_os_str().to_owned();
+    shm_path.push("-shm");
+    let footprint =
+        database_bytes + file_bytes(Path::new(&wal_path)) + file_bytes(Path::new(&shm_path));
+    (database_bytes, footprint)
+}
+
 /// Build the fixture store, then cold-reopen it and measure. See module docs.
-async fn run_case(groups: usize, roster: usize) -> BenchReport {
+async fn run_case(groups: usize, roster: usize, messages_per_group: usize) -> BenchReport {
     let relay = MockRelay::run().await.unwrap();
     let url = relay.url().await.to_string();
 
@@ -119,14 +145,28 @@ async fn run_case(groups: usize, roster: usize) -> BenchReport {
         let mut client = app_fixture.client(BENCH_ACCOUNT).await.unwrap();
         let member_refs: Vec<&str> = member_ids.iter().map(String::as_str).collect();
         for group in 0..groups {
-            group_ids.push(
+            let group_id = client
+                .create_group(&format!("bench group {group}"), &member_refs)
+                .await
+                .unwrap();
+            for message in 0..messages_per_group {
                 client
-                    .create_group(&format!("bench group {group}"), &member_refs)
+                    .send(
+                        &group_id,
+                        format!("bench group {group} message {message}").as_bytes(),
+                    )
                     .await
-                    .unwrap(),
-            );
+                    .unwrap();
+            }
+            group_ids.push(group_id);
         }
     }
+    let database_path = home_bench.account_dir(BENCH_ACCOUNT).join("session.sqlite");
+    let (database_bytes, database_footprint_bytes) = database_footprint(&database_path);
+    assert!(
+        database_bytes > 0,
+        "fixture database must exist and be non-empty"
+    );
 
     // --- cold reopen: durable chat projection first, then full readiness ---
     let app = open_store(&dir_bench, &url);
@@ -166,6 +206,9 @@ async fn run_case(groups: usize, roster: usize) -> BenchReport {
     let report = BenchReport {
         groups,
         roster,
+        messages_per_group,
+        database_bytes,
+        database_footprint_bytes,
         chat_list,
         start_ready,
         group_read,
@@ -182,7 +225,7 @@ async fn run_case(groups: usize, roster: usize) -> BenchReport {
 /// Bench bodies compose many app boots and MLS commits; debug builds need
 /// more than libtest's default 2 MiB stack (same shape as
 /// `cursor_persistence.rs`).
-fn run_bench(name: &'static str, groups: usize, roster: usize) {
+fn run_bench(name: &'static str, groups: usize, roster: usize, messages_per_group: usize) {
     let thread = std::thread::Builder::new()
         .name(name.to_owned())
         .stack_size(8 * 1024 * 1024)
@@ -191,7 +234,7 @@ fn run_bench(name: &'static str, groups: usize, roster: usize) {
                 .enable_all()
                 .build()
                 .unwrap();
-            let report = test_runtime.block_on(run_case(groups, roster));
+            let report = test_runtime.block_on(run_case(groups, roster, messages_per_group));
             report.print(name);
         })
         .unwrap();
@@ -202,41 +245,47 @@ fn run_bench(name: &'static str, groups: usize, roster: usize) {
 /// working in every CI run without the full matrix's cost.
 #[test]
 fn startup_scaling_smoke() {
-    run_bench("smoke", 3, 1);
+    run_bench("smoke", 3, 1, 0);
 }
 
 #[test]
 #[ignore = "startup scaling benchmark; run via `just bench-startup`"]
 fn startup_scaling_groups_0() {
-    run_bench("groups_0", 0, 0);
+    run_bench("groups_0", 0, 0, 0);
 }
 
 #[test]
 #[ignore = "startup scaling benchmark; run via `just bench-startup`"]
 fn startup_scaling_groups_10() {
-    run_bench("groups_10", 10, 1);
+    run_bench("groups_10", 10, 1, 0);
 }
 
 #[test]
 #[ignore = "startup scaling benchmark; run via `just bench-startup`"]
 fn startup_scaling_groups_100() {
-    run_bench("groups_100", 100, 1);
+    run_bench("groups_100", 100, 1, 0);
 }
 
 #[test]
 #[ignore = "startup scaling benchmark; run via `just bench-startup`"]
 fn startup_scaling_groups_1000() {
-    run_bench("groups_1000", 1000, 1);
+    run_bench("groups_1000", 1000, 1, 0);
 }
 
 #[test]
 #[ignore = "startup scaling benchmark; run via `just bench-startup`"]
 fn startup_scaling_roster_8() {
-    run_bench("roster_8", 10, 8);
+    run_bench("roster_8", 10, 8, 0);
 }
 
 #[test]
 #[ignore = "startup scaling benchmark; run via `just bench-startup`"]
 fn startup_scaling_roster_64() {
-    run_bench("roster_64", 10, 64);
+    run_bench("roster_64", 10, 64, 0);
+}
+
+#[test]
+#[ignore = "startup scaling benchmark; run via `just bench-startup`"]
+fn startup_scaling_messages_32() {
+    run_bench("messages_32", 10, 1, 32);
 }

--- a/crates/storage-sqlite/Cargo.toml
+++ b/crates/storage-sqlite/Cargo.toml
@@ -24,4 +24,5 @@ tempfile.workspace = true
 
 [features]
 extensions-draft = ["openmls_traits/extensions-draft"]
+storage-format-benchmarks = []
 test-conformance-replay = []

--- a/crates/storage-sqlite/src/lib.rs
+++ b/crates/storage-sqlite/src/lib.rs
@@ -48,6 +48,8 @@ pub use shared::{
     StoredRelayTelemetrySettings,
 };
 pub use storage::messages::MessageFormatPromotionProgress;
+#[cfg(feature = "storage-format-benchmarks")]
+pub use storage::messages::StorageFormatBenchSizes;
 pub use timeline::{
     MAX_TIMELINE_LIMIT, SecurePruneAppEventsResult, StoredAppEvent, TimelineMessageChange,
     TimelineMessageQuery, TimelineMessageRecord, TimelineMessageTarget, TimelinePage,

--- a/crates/storage-sqlite/src/storage/messages.rs
+++ b/crates/storage-sqlite/src/storage/messages.rs
@@ -34,7 +34,55 @@ pub struct MessageFormatPromotionProgress {
     pub has_more: bool,
 }
 
+/// Logical blob/value sizes used by the storage-format benchmark rail.
+///
+/// This excludes SQLite page overhead; the startup-scaling harness reports
+/// the complete database-file footprint separately.
+#[cfg(feature = "storage-format-benchmarks")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct StorageFormatBenchSizes {
+    pub message_value_bytes: u64,
+    pub largest_snapshot_bytes: u64,
+}
+
 impl SqliteAccountStorage {
+    /// Read aggregate value sizes without returning any stored content.
+    #[cfg(feature = "storage-format-benchmarks")]
+    pub fn storage_format_bench_sizes(
+        &self,
+        group_id: &GroupId,
+        message_id: &MessageId,
+    ) -> StorageResult<StorageFormatBenchSizes> {
+        let conn = self.lock()?;
+        let message_value_bytes = conn
+            .query_row(
+                "SELECT length(id) + length(group_id) + coalesce(length(payload), 0) +
+                        coalesce(length(record), 0) + coalesce(length(deferred_peel), 0)
+                 FROM cgka_messages WHERE id = ?1",
+                params![message_id.as_slice()],
+                |row| row.get::<_, i64>(0),
+            )
+            .optional()
+            .storage()?
+            .ok_or(StorageError::NotFound)?;
+        let largest_snapshot_bytes = conn
+            .query_row(
+                "SELECT max(length(snapshot)) FROM cgka_group_snapshots WHERE group_id = ?1",
+                params![group_id.as_slice()],
+                |row| row.get::<_, Option<i64>>(0),
+            )
+            .storage()?
+            .ok_or_else(|| StorageError::SnapshotMissing("benchmark-size-anchor".into()))?;
+        Ok(StorageFormatBenchSizes {
+            message_value_bytes: u64::try_from(message_value_bytes).map_err(|error| {
+                StorageError::Backend(format!("invalid message benchmark size: {error}"))
+            })?,
+            largest_snapshot_bytes: u64::try_from(largest_snapshot_bytes).map_err(|error| {
+                StorageError::Backend(format!("invalid snapshot benchmark size: {error}"))
+            })?,
+        })
+    }
+
     /// Promote at most `limit` legacy message rows to normalized format 2.
     ///
     /// The bounded batch is atomic and idempotent. A malformed row rolls the
@@ -728,6 +776,38 @@ mod tests {
             store.get_message(&message.id).unwrap().state,
             MessageState::PeelDeferred
         );
+    }
+
+    #[cfg(feature = "storage-format-benchmarks")]
+    #[test]
+    fn storage_format_bench_sizes_accepts_legacy_message_rows() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let group = sample_group(gid(1), 0, 0);
+        let message = sample_message(mid(1), group.id.clone(), 0);
+        let record = serialize(&message).unwrap();
+        store.put_group(&group).unwrap();
+        store
+            .lock()
+            .unwrap()
+            .execute(
+                "INSERT INTO cgka_messages (id, group_id, epoch, state, record)
+                 VALUES (?1, ?2, 0, 0, ?3)",
+                rusqlite::params![message.id.as_slice(), group.id.as_slice(), record],
+            )
+            .unwrap();
+        store
+            .create_group_snapshot(&group.id, "legacy-size")
+            .unwrap();
+
+        let sizes = store
+            .storage_format_bench_sizes(&group.id, &message.id)
+            .expect("legacy row size is defined");
+        assert_eq!(
+            sizes.message_value_bytes,
+            u64::try_from(message.id.as_slice().len() + group.id.as_slice().len() + record.len())
+                .unwrap()
+        );
+        assert!(sizes.largest_snapshot_bytes > 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add real same-group rejoin and canonical-advance Criterion cases scaled across 0, 8, and 32 retained commits
- add application-message send and ingest Criterion anchors so future storage changes can enforce the tracker non-regression guard
- emit stable logical Welcome-row and founding-snapshot byte metrics from a feature-gated aggregate storage probe
- extend `just bench-startup` with database footprint reporting and a 10-group, 320-message fixture

This is intentionally stacked on #1421 so the storage implementation and its measurement/reporting rail remain independently reviewable. Review this PR as the single commit above `codex/storage-format-v2`.

## Post-v2 measurements

Release profile on an Apple Silicon development machine:

| Metric | Result |
| --- | ---: |
| `create_group/32 invitees` | 15.22 ms |
| normalized 32-member Welcome value | 16,821 bytes |
| largest 32-member founding snapshot | 82.6 KB |
| `join_welcome/1 stored KP` | 1.30 ms |
| `join_welcome/32 stored KPs` | 1.33 ms |
| `join_welcome_large_group/32 members` | 3.94 ms |
| app-message send | 1.11 ms |
| app-message ingest | 1.06 ms |
| rejoin after 32 retained commits | 2.19 ms |
| canonical advance after 32 retained commits | 3.12 ms |

The tracker anchors were 180,002 bytes per Welcome row, roughly 6 MB for the founding snapshot, and roughly 65 ms for `create_group/32`. The post-v2 values are below all three stated targets. The new send/ingest cases establish stable same-harness baselines for subsequent changes; the repository did not previously contain those benches.

The focused release startup fixture reported:

```text
MDK_BENCH startup_scaling case=messages_32 groups=10 roster=1 messages_per_group=32 database_bytes=3039232 database_footprint_bytes=3039232 chat_list_ms=199 ready_ms=108 group_read_ms=4 account_open_wait_ms=107 session_open_ms=50 group_hydration_ms=0 profile_load_ms=0 read_snapshot_ms=0
```

## Validation

- `just fast-ci`
- `cargo test -p storage-sqlite --features storage-format-benchmarks` (367 passed, 2 subprocess entry points ignored)
- `cargo test -p marmot-app --test startup_scaling` (smoke passed, 7 benchmark cases ignored)
- `cargo test -p cgka-engine --features test-policy-overrides`
- focused release Criterion runs for all metrics above
- focused release startup message-heavy fixture

A featureless `cargo test -p cgka-engine` is independently red because `deferred_peel_lifecycle` deliberately installs non-default policies but does not enable `test-policy-overrides`; the feature-correct engine suite is green.

Tracks #1413
Related: #1415