### PR TITLE
Refactor/incident replay outcome display single source

### DIFF
--- a/crates/incident-replay/AGENTS.md
+++ b/crates/incident-replay/AGENTS.md
@@ -155,18 +155,20 @@ Precedence, highest first:
 5. **Quarantine `unrecoverable_halt`** — an engine recorded halting
    unrecoverably, so its group stays blocked until a verified repair clears the
    marker. Two audit surfaces arm it, and the reason string from whichever fired
-   is reported per engine — **causes first-class, re-assertions only when there is
-   no cause**. `already_unrecoverable` (emitted on every convergence attempt
-   against an already-halted group) and `hydrate_unrecoverable_group` (every
-   session open over one) *arm* the gate like any other reason, because a window
-   of nothing but re-assertions is still a live halt, but they never say why the
-   engine stopped: beside a real cause they are noise in the line an operator
-   reads first, and `BTreeSet` order puts `already_unrecoverable` ahead of the
-   diagnosis. Once the cause is known they add nothing — that a halt is durable
-   and still being retried is what rule 5 *means*. When re-assertions are all the
-   export has (the real 26a9f546 shape: the halt predates the window) they are
-   reported, because the engine still has to be named and "the halt stands, cause
-   not in this window" is the honest reading. The two surfaces are
+   is reported per engine — **causes first-class, non-causes only when there is
+   no cause**. Three strings name no cause. `already_unrecoverable` (emitted on
+   every convergence attempt against an already-halted group) and
+   `hydrate_unrecoverable_group` (every session open over one) *arm* the gate
+   like any other reason, because a window of nothing but re-assertions is still
+   a live halt, but they never say why the engine stopped: beside a real cause
+   they are noise in the line an operator reads first, and `BTreeSet` order puts
+   `already_unrecoverable` ahead of the diagnosis. Once the cause is known they
+   add nothing — that a halt is durable and still being retried is what rule 5
+   *means*. `unspecified` — the stand-in for a halt row that carried no reason at
+   all — names even less and ranks with them. When non-causes are all the export
+   has (the real 26a9f546 shape: the halt predates the window) they are reported,
+   because the engine still has to be named and "the halt stands, cause not in
+   this window" is the honest reading. The two surfaces are
    `convergence_run_state` with `phase: unrecoverable`
    (mdk#1110 — reason `frozen_pass_integrity_failure` from `error_kind:
    frozen_member_integrity`, and the reason-less `error_kind:

--- a/crates/incident-replay/AGENTS.md
+++ b/crates/incident-replay/AGENTS.md
@@ -112,16 +112,14 @@ incident becomes a vector only if the simulator reproduces the recorded outcome
     only *after* a failure — and one rule keeps it honest: a lower route may
     override a higher route's quarantine only by producing an accepted vector. A
     second quarantine never displaces the higher-precedence one; it becomes an
-    `advisory (fallback route):` instead. When the fall-through *does* produce an
-    accepted vector, the superseded finding is also written into that artifact's
-    `unavailable_fields` as `contested_convergence_replay`, with the same sentence
-    the advisory carries: the advisory is stdout, the artifact is what gets
-    persisted and read later as evidence, and an envelope showing a clean accepted
-    archetype with no trace of the higher-precedence incident that shared the
-    export fails the standard `archetype` already enforces on itself. The
-    `fallback route` finding has no such home by construction — both routes failed
-    closed, so there is no accepted artifact — and the advisory line is its only
-    surface. Vector names live here too: they are pipeline facts, not CLI ones.
+    `advisory (fallback route):` instead. When the fall-through *does* produce
+    an accepted vector, the superseded finding is also written into that
+    artifact's `unavailable_fields` as `contested_convergence_replay`, with the
+    same sentence the advisory carries (`fall_through_to_fork` carries the
+    argument for why the persisted envelope needs it too). The `fallback route`
+    finding has no such home by construction — both routes failed closed, so
+    there is no accepted artifact — and the advisory line is its only surface.
+    Vector names live here too: they are pipeline facts, not CLI ones.
 - **Module:** `src/main.rs`
   - **Role:** CLI — read one export file, detect its format, print the `Routing`.
     Reading and formatting only; route policy is `src/route.rs`. Exits 0 for any
@@ -206,14 +204,12 @@ Precedence, highest first:
    comparison are contract, not incident: a repair sharing the halt's
    millisecond does **not** clear it (a tie orders nothing, and the two orders
    mean opposite things), and **one untimed halt row makes the whole halt side
-   unorderable** — not just that row. The untimed row may be the newest halt
-   evidence there is, so the newest *timed* halt is only a lower bound on the
-   halt's position and a repair after that bound proves nothing; taking it as
-   the halt's position is the fail-open direction, clearing a live halt on
-   partially instrumented input. It therefore outranks rule 6, which it usually
-   explains: on the real 26a9f546 export the halted engine is exactly the one
-   rule 6 labelled `went dark`, and reporting the inference over the diagnosis
-   would send the operator to re-pull for a confirmation they already have.
+   unorderable** — not just that row (`HaltLifecycle::halt_position_ms` carries
+   the argument for why the newest *timed* halt is only a lower bound). Rule 5
+   outranks rule 6, which it usually explains: on the real 26a9f546 export the
+   halted engine is exactly the one rule 6 labelled `went dark`, and reporting
+   the inference over the diagnosis would send the operator to re-pull for a
+   confirmation they already have.
    A halt is a client failure, not a branch contest, so there is still nothing
    to replay. `halt_advisory` exposes the same computation verdict-independently,
    as `liveness_advisory` does for rule 6.

--- a/crates/incident-replay/AGENTS.md
+++ b/crates/incident-replay/AGENTS.md
@@ -196,21 +196,21 @@ Precedence, highest first:
    below). Clearing is decided per **`(engine_id, group_ref)`** — `Unrecoverable`
    is per-group state, so a repair in one group must not clear another group's
    halt — by **repair strictly after the newest halt**, with surviving halts
-   folded back
-   per engine so an engine halted in two groups is still one halted engine with
-   the union of its reasons. Newest-wins needs no global event ordering because a
-   live halt is continuously re-asserted (every session open re-emits
-   `hydrate_unrecoverable_group`; every convergence attempt emits
-   `already_unrecoverable`), so a halt that outlived its repair leaves rows after
-   it. Both rows come from one engine — one clock, one recorder file — so rule 6's
-   cross-device grace does not apply here. Two boundaries of that comparison are
-   contract, not incident: a repair sharing the halt's millisecond does **not**
-   clear it (a tie orders nothing, and the two orders mean opposite things), and
-   **one untimed halt row makes the whole halt side unorderable** — not just that
-   row. The untimed row may be the newest halt evidence there is, so the newest
-   *timed* halt is only a lower bound on the halt's position and a repair after
-   that bound proves nothing; taking it as the halt's position is the fail-open
-   direction, clearing a live halt on partially instrumented input. It therefore outranks rule 6, which it usually
+   folded back per engine so an engine halted in two groups is still one halted
+   engine with the union of its reasons. Newest-wins needs no global event
+   ordering because a live halt is continuously re-asserted (every session open
+   re-emits `hydrate_unrecoverable_group`; every convergence attempt emits
+   `already_unrecoverable`), so a halt that outlived its repair leaves rows
+   after it. Both rows come from one engine — one clock, one recorder file — so
+   rule 6's cross-device grace does not apply here. Two boundaries of that
+   comparison are contract, not incident: a repair sharing the halt's
+   millisecond does **not** clear it (a tie orders nothing, and the two orders
+   mean opposite things), and **one untimed halt row makes the whole halt side
+   unorderable** — not just that row. The untimed row may be the newest halt
+   evidence there is, so the newest *timed* halt is only a lower bound on the
+   halt's position and a repair after that bound proves nothing; taking it as
+   the halt's position is the fail-open direction, clearing a live halt on
+   partially instrumented input. It therefore outranks rule 6, which it usually
    explains: on the real 26a9f546 export the halted engine is exactly the one
    rule 6 labelled `went dark`, and reporting the inference over the diagnosis
    would send the operator to re-pull for a confirmation they already have.

--- a/crates/incident-replay/src/classify.rs
+++ b/crates/incident-replay/src/classify.rs
@@ -417,21 +417,21 @@ fn unrecoverable_halt(export: &AgentStateExport) -> Option<QuarantineReason> {
     (!engines.is_empty()).then_some(QuarantineReason::UnrecoverableHalt { engines })
 }
 
-/// One engine's halt reasons as the operator should read them: its causes, or its
-/// re-assertions when it recorded no cause.
+/// One engine's halt reasons as the operator should read them: its causes, or
+/// everything it recorded when it recorded no cause.
 ///
-/// A re-assertion never names why the engine stopped (see
-/// [`export::is_halt_re_assertion`]), so beside a real cause it is noise in the
-/// line an operator reads first. It is not dropped unconditionally, because a
-/// halt that predates the export window leaves nothing *but* re-assertions and
-/// that engine still has to be named — which is also the honest report for it:
-/// this export shows the halt standing, not what caused it.
+/// A non-cause never names why the engine stopped (see
+/// [`export::is_halt_cause`]), so beside a real cause it is noise in the line an
+/// operator reads first. Non-causes are not dropped unconditionally, because a
+/// halt that predates the export window leaves nothing *but* non-causes and that
+/// engine still has to be named — which is also the honest report for it: this
+/// export shows the halt standing, not what caused it.
 ///
-/// [`export::is_halt_re_assertion`]: crate::export::is_halt_re_assertion
+/// [`export::is_halt_cause`]: crate::export::is_halt_cause
 fn reported_halt_reasons(reasons: &BTreeSet<&str>) -> Vec<String> {
     let causes: Vec<String> = reasons
         .iter()
-        .filter(|reason| !crate::export::is_halt_re_assertion(reason))
+        .filter(|reason| crate::export::is_halt_cause(reason))
         .map(|reason| (*reason).to_owned())
         .collect();
     if causes.is_empty() {

--- a/crates/incident-replay/src/classify.rs
+++ b/crates/incident-replay/src/classify.rs
@@ -329,11 +329,11 @@ impl HaltLifecycle<'_> {
     /// durable halt survives. See `docs/marmot-architecture/audit-logging.md`.)
     ///
     /// Absence fails closed in both directions: an unrepaired halt keeps its
-    /// quarantine, and so does a halt whose evidence cannot be ordered. Untimed
-    /// rows never clear anything — arming rule 5 needs no timestamps, but
-    /// *clearing* it does, and guessing here would turn a real halt into a
-    /// healthy verdict. This is also why untimed fixtures and
-    /// pre-instrumentation exports classify exactly as before.
+    /// quarantine, and so does a halt whose evidence cannot be ordered — arming
+    /// rule 5 needs no timestamps, but *clearing* it does. See
+    /// [`Self::halt_position_ms`] for when the halt's position is unknowable and
+    /// why guessing it is the one fail-open direction. This is also why untimed
+    /// fixtures and pre-instrumentation exports classify exactly as before.
     fn still_halted(&self) -> bool {
         if self.reasons.is_empty() {
             return false;
@@ -352,7 +352,8 @@ impl HaltLifecycle<'_> {
     /// newest timed row is a lower bound on the halt's position rather than the
     /// position itself, and a repair after that bound proves nothing. Reading the
     /// newest timed row as the answer is the one direction [`Self::still_halted`]
-    /// must not take — it clears a halt whose position is unknown.
+    /// must not take — on partially instrumented input it clears a live halt
+    /// whose position is unknown.
     fn halt_position_ms(&self) -> Option<u64> {
         if self.untimed_halt {
             return None;

--- a/crates/incident-replay/src/export.rs
+++ b/crates/incident-replay/src/export.rs
@@ -41,30 +41,41 @@ const VERIFIED_REPAIR_REASON: &str = "join_welcome_repair";
 
 /// Stand-in reason for a halt whose row carried none. Every emitting surface
 /// populates a reason today; this keeps the lenient model from dropping a halt
-/// on the floor should one ever not.
+/// on the floor should one ever not. It names no cause, so it is reported only
+/// when nothing better is available — see [`HALT_NON_CAUSE_REASONS`].
 const UNSPECIFIED_HALT_REASON: &str = "unspecified";
 
-/// Halt reasons that re-assert an existing halt instead of naming its cause.
+/// Halt reasons that do not name the cause of the halt. Two kinds reach here.
 ///
-/// `already_unrecoverable` is emitted on every convergence attempt against an
-/// already-halted group (`cgka-engine/src/distributed_convergence.rs`) and
+/// **Re-assertions.** `already_unrecoverable` is emitted on every convergence
+/// attempt against an already-halted group
+/// (`cgka-engine/src/distributed_convergence.rs`) and
 /// `hydrate_unrecoverable_group` on every session open over one
 /// (`cgka-engine/src/engine.rs`). Both are the halt restating itself — the
 /// property rule 5's newest-wins clearing relies on — so they arm the gate like
-/// any other halt reason. Neither says why the engine stopped. See
-/// [`is_halt_re_assertion`] for what that means for reporting.
-const HALT_RE_ASSERTION_REASONS: [&str; 2] =
-    ["already_unrecoverable", "hydrate_unrecoverable_group"];
+/// any other halt reason. Neither says why the engine stopped.
+///
+/// **The stand-in.** [`UNSPECIFIED_HALT_REASON`] names a cause even less: it is
+/// what the model substitutes for a halt row that carried no reason at all. It is
+/// a member by construction rather than by literal so the two cannot drift apart.
+///
+/// See [`is_halt_cause`] for what the distinction means for reporting.
+const HALT_NON_CAUSE_REASONS: [&str; 3] = [
+    "already_unrecoverable",
+    "hydrate_unrecoverable_group",
+    UNSPECIFIED_HALT_REASON,
+];
 
-/// Whether `reason` only re-asserts a halt rather than naming its cause.
+/// Whether `reason` names why the engine stopped, rather than only restating that
+/// it did (see [`HALT_NON_CAUSE_REASONS`]).
 ///
 /// Purely a reporting distinction: rule 5 arms on any halt reason, and a window
-/// carrying nothing but re-assertions is still a live halt. It exists because
+/// carrying nothing but non-causes is still a live halt. It exists because
 /// `reasons` is the first thing an operator reads, and once a cause is known a
-/// re-assertion adds nothing — that the halt is durable and still being retried
-/// is what rule 5 *means*, not a separate finding.
-pub(crate) fn is_halt_re_assertion(reason: &str) -> bool {
-    HALT_RE_ASSERTION_REASONS.contains(&reason)
+/// non-cause adds nothing — that the halt is durable and still being retried is
+/// what rule 5 *means*, not a separate finding.
+pub(crate) fn is_halt_cause(reason: &str) -> bool {
+    !HALT_NON_CAUSE_REASONS.contains(&reason)
 }
 
 /// A parsed export, reduced to the classifier's inputs.

--- a/crates/incident-replay/src/main.rs
+++ b/crates/incident-replay/src/main.rs
@@ -76,11 +76,20 @@ fn main() -> ExitCode {
     // attested history supersedes an archetype, and what happens when a route
     // fails closed — lives in the library; this is presentation only.
     let routing = route(&export, source_format);
+    // Every primary line is rendered here, so this match is the single source of
+    // truth for what an operator reads. Two of the four need facts only this
+    // binary has — the accepted line depends on what was written where, and an
+    // infrastructure failure is a stderr line, not a verdict — so `Outcome`
+    // deliberately renders none of them itself.
     let code = match &routing.outcome {
-        // Producing no vector is a valid outcome, so a quarantine is not an
+        // Producing no vector is a valid outcome, so neither of these is an
         // error exit.
-        Outcome::Healthy | Outcome::Quarantine { .. } => {
-            println!("{}", routing.outcome);
+        Outcome::Healthy => {
+            println!("healthy: 0 vectors");
+            ExitCode::SUCCESS
+        }
+        Outcome::Quarantine { reason } => {
+            println!("quarantine: {reason}");
             ExitCode::SUCCESS
         }
         Outcome::Accepted(artifact) => persist_or_report(artifact, out_dir.as_deref()),

--- a/crates/incident-replay/src/main.rs
+++ b/crates/incident-replay/src/main.rs
@@ -9,11 +9,12 @@
 //! Reading, format detection, and printing live here; everything about *which*
 //! route an export takes is [`incident_replay::route`].
 //!
-//! Output is one primary line — `healthy:`, `quarantine:`, or `accepted:` — plus
-//! an `advisory (<label>):` line for every co-occurring finding that line does
-//! not itself report. An accepted incident is written owner-only as the portable
-//! vector next to its `incident-scenario-artifact.v1` evidence envelope; the
-//! source export, transport ciphertext, and MLS checkpoints are never copied.
+//! Output is one primary line — `healthy:`, `quarantine:`, or
+//! `accepted (<fidelity>, <sensitivity>)` — plus an `advisory (<label>):` line
+//! for every co-occurring finding that line does not itself report. An
+//! accepted incident is written owner-only as the portable vector next to its
+//! `incident-scenario-artifact.v1` evidence envelope; the source export,
+//! transport ciphertext, and MLS checkpoints are never copied.
 //!
 //! Exits 0 for any successful classification (healthy, quarantine, and accepted
 //! are all valid outcomes). Exits 2 on usage, I/O, parse, or write failure, and

--- a/crates/incident-replay/src/route.rs
+++ b/crates/incident-replay/src/route.rs
@@ -56,10 +56,9 @@ pub const CONVERGENCE_NAME: &str = "convergence-incident/v1";
 /// A higher-precedence route quarantined, but a lower one reproduced an incident
 /// from the same export.
 const SUPERSEDED_ROUTE: &str = "superseded route";
-/// The [`IncidentScenarioArtifactV1::unavailable_fields`] entry for the same
-/// finding: the accepted archetype stands for the lower-precedence incident, and
-/// the contested convergence the export also carried is evidence it does not
-/// cover.
+/// The [`IncidentScenarioArtifactV1::unavailable_fields`] entry for that same
+/// finding, carried by the accepted artifact as well as the advisory — see
+/// [`fall_through_to_fork`] for why both.
 const CONTESTED_CONVERGENCE_REPLAY: &str = "contested_convergence_replay";
 /// A higher-precedence route quarantined and the fall-through could not rescue
 /// it either.
@@ -253,6 +252,14 @@ fn archetype(
 /// yields nothing, the convergence quarantine stays the primary — it is the
 /// higher-precedence incident, and demoting it would misreport which one the
 /// export is really about.
+///
+/// When it *does* upgrade, the superseded finding is said once and reported
+/// twice: as the stdout advisory and as the accepted artifact's own statement of
+/// what it does not cover. The artifact is what gets written to disk and read
+/// later as evidence, so a finding that lived only in `advisories` would die with
+/// the terminal, leaving an envelope that shows a clean accepted archetype with
+/// no trace of the higher-precedence incident that shared the export — failing
+/// the standard [`archetype_artifact`] already enforces on itself.
 fn fall_through_to_fork(
     export: &AgentStateExport,
     source_format: IncidentSourceFormatV1,
@@ -270,12 +277,6 @@ fn fall_through_to_fork(
     }
     match fork_route(export, source_format) {
         Ok(mut artifact) => {
-            // Said once, then reported twice: as the stdout advisory and as the
-            // accepted artifact's own statement of what it does not cover. The
-            // artifact is what gets written to disk and read later as evidence, so
-            // a finding that lives only in `advisories` dies with the terminal —
-            // and the envelope would show a clean accepted archetype with no trace
-            // of the higher-precedence incident that shared the export.
             let detail = format!("contested convergence could not be replayed: {superseded}");
             artifact
                 .unavailable_fields
@@ -286,9 +287,6 @@ fn fall_through_to_fork(
             });
             Outcome::Accepted(artifact)
         }
-        // No artifact exists on this path — both routes failed closed, so there is
-        // no accepted envelope for the finding to enter and the advisory is its
-        // only surface. Construction, not omission (AGENTS.md, `src/route.rs`).
         Err(fallback) => {
             advisories.push(Advisory {
                 label: FALLBACK_ROUTE,

--- a/crates/incident-replay/src/route.rs
+++ b/crates/incident-replay/src/route.rs
@@ -70,6 +70,16 @@ const HALT: &str = "halt";
 const LIVENESS: &str = "liveness";
 
 /// What the pipeline produced for an export: exactly one primary outcome.
+///
+/// Deliberately not [`fmt::Display`], unlike [`Advisory`]: half of these
+/// variants cannot be rendered from the outcome alone. [`Outcome::Accepted`]
+/// reads as whatever the CLI did with the artifact — which files it wrote, or
+/// how to persist it when no out-dir was given — and
+/// [`Outcome::InfrastructureFailure`] is a stderr line with a non-zero exit
+/// rather than a verdict on stdout. Rendering all four in the CLI's one match
+/// keeps a single source of truth for what an operator reads; a `Display` here
+/// could only cover the two variants that need no I/O, and its other arms were
+/// unreachable text describing output the CLI never produced.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Outcome {
     /// No incident and no liveness problem. Zero vectors.
@@ -106,19 +116,8 @@ pub struct Routing {
     pub advisories: Vec<Advisory>,
 }
 
-impl fmt::Display for Outcome {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Outcome::Healthy => f.write_str("healthy: 0 vectors"),
-            Outcome::Accepted(artifact) => {
-                write!(f, "accepted: {}", artifact.vector.scenario_name)
-            }
-            Outcome::Quarantine { reason } => write!(f, "quarantine: {reason}"),
-            Outcome::InfrastructureFailure { reason } => write!(f, "error: {reason}"),
-        }
-    }
-}
-
+/// An advisory is nothing but its message, so unlike [`Outcome`] it renders
+/// losslessly here and needs no CLI knowledge to do it.
 impl fmt::Display for Advisory {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "advisory ({}): {}", self.label, self.detail)

--- a/crates/incident-replay/tests/classify.rs
+++ b/crates/incident-replay/tests/classify.rs
@@ -495,14 +495,12 @@ fn an_untimed_repair_does_not_clear_a_halt() {
 
 #[test]
 fn one_untimed_halt_row_among_timed_ones_still_blocks_a_later_repair() {
-    // Mixed instrumentation: the same engine and group recorded an untimed halt, a
-    // timed halt, and then a repair newer than the *timed* halt. The untimed row
-    // may be the newest evidence of all — nothing in the export says otherwise —
-    // so the halt is unorderable and stands, exactly as when no halt row carries a
-    // clock at all. Reading the newest timed halt as *the* halt position is the
-    // fail-open direction: it lets a repair clear a halt whose real position is
-    // unknown, turning a live halt into a healthy verdict on partially
-    // instrumented input.
+    // Mixed instrumentation, the case that makes "the whole halt side" more than a
+    // formality: one engine and group recorded an untimed halt, a timed halt, and
+    // then a repair newer than the *timed* halt. The halt is unorderable and
+    // stands, exactly as when no halt row carries a clock at all — see
+    // `HaltLifecycle::halt_position_ms` for why reading the newest timed row
+    // instead is the fail-open direction.
     assert_eq!(
         classify(&load("quarantine-partially-timed-halt-with-repair.json")),
         Verdict::Quarantine {

--- a/crates/incident-replay/tests/classify.rs
+++ b/crates/incident-replay/tests/classify.rs
@@ -374,6 +374,44 @@ fn a_halt_that_predates_the_export_reports_its_re_assertions() {
 }
 
 #[test]
+fn an_unspecified_halt_reason_ranks_below_a_cause_and_beside_a_re_assertion() {
+    // `unspecified` is the stand-in both halt arms substitute for a row that named
+    // nothing, so it names a cause even less than a re-assertion does. It belongs
+    // in the same fallback tier, and this fixture pins both directions of that
+    // tier at once — one engine per direction, one stand-in from each arm.
+    //
+    // `engine-a` (stand-in from the `epoch_state_changed` arm) has no cause at
+    // all, so everything it recorded is reported: dropping the stand-in would
+    // silence nothing, but ranking it *above* the re-assertions would report
+    // `unspecified` alone and hide the two strings that at least name the surface
+    // the halt was re-asserted on. `engine-b` (stand-in from the
+    // `convergence_run_state` arm) recorded a real cause, so the whole tier is
+    // suppressed: `unspecified` beside a diagnosis is pure noise in the line the
+    // operator reads first.
+    assert_eq!(
+        classify(&load("quarantine-unspecified-among-re-assertions.json")),
+        Verdict::Quarantine {
+            reason: QuarantineReason::UnrecoverableHalt {
+                engines: vec![
+                    HaltedEngine {
+                        engine_id: "engine-a".into(),
+                        reasons: vec![
+                            "already_unrecoverable".into(),
+                            "hydrate_unrecoverable_group".into(),
+                            "unspecified".into(),
+                        ],
+                    },
+                    HaltedEngine {
+                        engine_id: "engine-b".into(),
+                        reasons: vec!["frozen_pass_integrity_failure".into()],
+                    },
+                ],
+            }
+        }
+    );
+}
+
+#[test]
 fn a_verified_repair_after_a_halt_clears_the_halt() {
     // The halt is a state, not a permanent record: rule 5 says the group stays
     // blocked "until a verified repair clears the marker", and there is exactly

--- a/crates/incident-replay/tests/cli.rs
+++ b/crates/incident-replay/tests/cli.rs
@@ -1,9 +1,93 @@
-//! End-to-end CLI coverage for fail-closed format detection.
+//! The CLI's printed output is the operator-facing contract, so it is pinned
+//! here against the real binary rather than against an in-process rendering.
+//!
+//! Every primary line the CLI can print is covered, because the outcome an
+//! export routes to decides *which* line the operator reads: `healthy:` and
+//! `quarantine:` are rendered from the outcome alone, while `accepted` is
+//! rendered from facts only the CLI has (whether an out-dir was given, and what
+//! it wrote there). Pinning all of them keeps the rendering honest — a line that
+//! no code path can actually produce is worse than no line at all, because it
+//! reads as documentation of what the CLI does.
+//!
+//! End-to-end coverage for fail-closed format detection lives here for the same
+//! reason: what an undetectable export must *not* print is as much a part of the
+//! contract as what a classified one does.
 
 use std::io::Write;
+use std::path::Path;
 use std::process::Command;
 
 use tempfile::NamedTempFile;
+
+/// Run the CLI against a fixture, returning `(stdout, stderr, exit code)`.
+fn run(fixture: &str) -> (String, String, i32) {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(fixture);
+    let output = Command::new(env!("CARGO_BIN_EXE_incident-replay"))
+        .arg(&path)
+        .output()
+        .unwrap_or_else(|err| panic!("run the CLI on {}: {err}", path.display()));
+    (
+        String::from_utf8(output.stdout).expect("stdout is utf-8"),
+        String::from_utf8(output.stderr).expect("stderr is utf-8"),
+        output.status.code().expect("the CLI exited normally"),
+    )
+}
+
+#[test]
+fn a_healthy_export_prints_the_healthy_line_and_nothing_else() {
+    // A cleared halt leaves nothing to report, so this is the whole of stdout:
+    // one primary line, no advisories.
+    let (stdout, stderr, code) = run("healthy-halt-cleared-by-repair.json");
+
+    assert_eq!(stdout, "healthy: 0 vectors\n");
+    assert_eq!(stderr, "");
+    assert_eq!(code, 0);
+}
+
+#[test]
+fn a_quarantined_export_prints_the_reason_and_still_exits_zero() {
+    // Producing no vector is a valid classification, not a failure, so the exit
+    // code stays 0 and the reason goes to stdout with the verdict.
+    let (stdout, stderr, code) = run("quarantine-hydrate-unrecoverable.json");
+
+    assert!(
+        stdout.starts_with("quarantine: "),
+        "expected a quarantine primary line, got {stdout:?}"
+    );
+    assert!(
+        stdout.contains("hydrate_unrecoverable_group"),
+        "the halt reason belongs in the line the operator reads first, got {stdout:?}"
+    );
+    assert_eq!(stderr, "");
+    assert_eq!(code, 0);
+}
+
+#[test]
+fn an_accepted_export_prints_its_fidelity_not_a_bare_scenario_name() {
+    // The accepted line is the one an outcome cannot render on its own: what the
+    // operator needs is the artifact's fidelity and sensitivity plus what the run
+    // could not cover, and with no out-dir there are no written paths to name.
+    // A bare `accepted: <scenario-name>` is specifically *not* what this prints,
+    // and an unreachable rendering claiming otherwise misdescribes the CLI.
+    let (stdout, stderr, code) = run("replayable-membership-fork.json");
+
+    assert!(
+        stdout.starts_with("accepted ("),
+        "expected the fidelity-carrying accepted line, got {stdout:?}"
+    );
+    assert!(
+        !stdout.contains("accepted: "),
+        "the CLI never prints a bare `accepted:` line, got {stdout:?}"
+    );
+    assert!(
+        stdout.contains("pass an out-dir to persist"),
+        "an accepted run with no out-dir should say how to persist it, got {stdout:?}"
+    );
+    assert_eq!(stderr, "");
+    assert_eq!(code, 0);
+}
 
 #[test]
 fn a_manifest_less_error_remnant_never_classifies_as_healthy() {

--- a/crates/incident-replay/tests/fixtures/quarantine-unspecified-among-re-assertions.json
+++ b/crates/incident-replay/tests/fixtures/quarantine-unspecified-among-re-assertions.json
@@ -1,0 +1,58 @@
+{
+  "schema_version": "marmot-agent-state/v1",
+  "events": [
+    {
+      "engine_id": "engine-a",
+      "group_ref": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "wall_time_ms": 1000000000000,
+      "kind": { "type": "epoch_state_changed", "epoch": 7, "new_state": "unrecoverable" }
+    },
+    {
+      "engine_id": "engine-a",
+      "group_ref": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "wall_time_ms": 1000000060000,
+      "kind": { "type": "epoch_state_changed", "epoch": 7, "new_state": "unrecoverable", "reason": "hydrate_unrecoverable_group" }
+    },
+    {
+      "engine_id": "engine-a",
+      "group_ref": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "wall_time_ms": 1000000120000,
+      "kind": {
+        "type": "convergence_run_state",
+        "phase": "unrecoverable",
+        "current_tip_epoch": 7,
+        "reason": "already_unrecoverable"
+      }
+    },
+    {
+      "engine_id": "engine-b",
+      "group_ref": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "wall_time_ms": 1000000000000,
+      "kind": { "type": "convergence_run_state", "phase": "unrecoverable", "current_tip_epoch": 7 }
+    },
+    {
+      "engine_id": "engine-b",
+      "group_ref": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "wall_time_ms": 1000000060000,
+      "kind": {
+        "type": "convergence_run_state",
+        "phase": "unrecoverable",
+        "current_tip_epoch": 7,
+        "reason": "already_unrecoverable"
+      }
+    },
+    {
+      "engine_id": "engine-b",
+      "group_ref": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "wall_time_ms": 1000000120000,
+      "kind": {
+        "type": "convergence_run_state",
+        "phase": "unrecoverable",
+        "current_tip_epoch": 7,
+        "reason": "frozen_pass_integrity_failure",
+        "error_kind": "frozen_member_integrity"
+      }
+    }
+  ],
+  "derived_projections": { "pagination": {} }
+}

--- a/crates/incident-replay/tests/route.rs
+++ b/crates/incident-replay/tests/route.rs
@@ -51,8 +51,9 @@ fn a_fail_closed_convergence_falls_through_to_a_clean_fork() {
 
 #[test]
 fn a_superseded_route_is_recorded_in_the_accepted_artifact() {
-    // The test above pins the stdout surface of the superseded finding; this pins
-    // the persisted one. `unavailable_fields` is where the artifact already states
+    // The test above pins the in-memory advisory (`routing.advisories`); this
+    // pins the persisted one — the stdout rendering of both lives in
+    // `tests/cli.rs`. `unavailable_fields` is where the artifact already states
     // what it could not cover, so that is where the finding belongs — see
     // `fall_through_to_fork` for why the artifact needs its own copy at all.
     let routing = routed("convergence-failclosed-with-clean-fork.json");

--- a/crates/incident-replay/tests/route.rs
+++ b/crates/incident-replay/tests/route.rs
@@ -51,14 +51,10 @@ fn a_fail_closed_convergence_falls_through_to_a_clean_fork() {
 
 #[test]
 fn a_superseded_route_is_recorded_in_the_accepted_artifact() {
-    // The advisory line is stdout; the artifact is what gets written to disk and
-    // passed around as evidence. Without this, someone opening the persisted
-    // envelope sees a clean accepted fork archetype with no trace that the same
-    // export carried a higher-precedence contested convergence at the same epoch
-    // that could not be replayed — which is exactly the standard `archetype`
-    // enforces on itself ("an artifact that cannot point at its own source rows is
-    // not publishable evidence"). `unavailable_fields` is where the artifact
-    // already states what it could not cover, so the finding belongs there.
+    // The test above pins the stdout surface of the superseded finding; this pins
+    // the persisted one. `unavailable_fields` is where the artifact already states
+    // what it could not cover, so that is where the finding belongs — see
+    // `fall_through_to_fork` for why the artifact needs its own copy at all.
     let routing = routed("convergence-failclosed-with-clean-fork.json");
 
     let Outcome::Accepted(artifact) = &routing.outcome else {


### PR DESCRIPTION
Delivers the three reply-promises from #1245 plus the refactor they were blocking.

### The refactor

`Display for Outcome` could only ever render half its variants. The CLI sends `Accepted` to
`persist_or_report` (which prints the artifact's fidelity, sensitivity, and written paths —
facts the library does not have) and prints `InfrastructureFailure` to stderr itself, so those
two arms were unreachable. The `accepted:` arm was also **wrong about the CLI it appeared to
describe**: no invocation has ever printed a bare `accepted: <scenario-name>` line.

The impl is dropped and the CLI's match gets an arm per variant, so one exhaustive match is
the single source of truth for the operator-facing line. `Advisory` keeps its `Display` — an
advisory is only its message, so it renders losslessly without CLI knowledge.

**Output is unchanged, proven:** both binaries diffed over all 37 fixtures (10 healthy, 24
quarantine, 3 accepted, 8 advisory lines) plus the accepted-with-out-dir form, byte for byte.

**The baseline came first.** The operator-facing output had no test at all — every existing
test asserts on the in-process `Routing`, so the strings the CLI actually prints were unpinned
and free to drift from the rendering that claims to describe them. `tests/cli.rs` now pins each
primary line against the real binary, including that an accepted run prints fidelity and
sensitivity rather than a bare scenario name. That assertion is the baseline the refactor
commit runs against.

### #1245 promise 1 — `HALT_NON_CAUSE_REASONS`

Both `unrecoverable_halt_reason` arms substitute `unspecified` for a halt row naming neither a
reason nor an `error_kind`, but the demotion tier listed only the two re-assertions. So a
single reason-less row outranked them and reported `engine-a (unspecified)` — suppressing the
strings that at least name the surface the halt was re-asserted on. The stand-in for "no reason
at all" beat the weakest thing it could beat.

`unspecified` now joins the same fallback tier, and the tier takes `UNSPECIFIED_HALT_REASON`
**by reference** so the tier and the substituted string cannot drift apart — the drift that
caused this. New fixture pins **both tier directions** in one classify, one engine each, with a
stand-in from each of the two arms.

> **Judgment call, flagging deliberately:** `HALT_RE_ASSERTION_REASONS` →
> `HALT_NON_CAUSE_REASONS`, and `is_halt_re_assertion` → `is_halt_cause` (stated positively, so
> the one call site reads as its own definition: "causes are the reasons that name a cause").
> The rename is judgment, not necessity — re-assertion simply no longer describes every member
> of the tier. Happy to revert the names if reviewers prefer the old ones.

### #1245 promise 2 — rule-5 re-flow

Two prior edits left rule 5 mis-wrapped: a 14-character orphan line ("folded back") and a
114-character line where a sentence was appended without re-wrapping. Re-flowed to the file's
~80-column convention. **The word sequence is unchanged, verified by word-diff.**

### #1245 promise 3 — one home per argument

Two arguments had been restated at every dependent site: the untimed-halt one in four places
(AGENTS.md rule 5, `HaltLifecycle::halt_position_ms`, `still_halted`, the mixed-instrumentation
test) and the superseded-artifact one in three (the `contested_convergence_replay` const, the
`Ok` arm of `fall_through_to_fork`, AGENTS.md's route bullet). Near-identical prose in n places
is n places to update and n−1 chances to leave a stale copy.

Each now has one canonical home — `halt_position_ms`'s doc and `fall_through_to_fork`'s doc —
and the other sites keep only what is theirs and point at it. Two facts that existed nowhere
else were merged into the canonical homes first: "on partially instrumented input" and that a
trace-free envelope fails the standard `archetype_artifact` enforces on itself. AGENTS.md keeps
stating both *rules* — the contract is what it is for; only the justification moved.

Also deleted the `Err`-arm comment explaining that no artifact is recorded on a path that has
no artifact: the arm cannot record one, so the reader never asks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Improved incident replay reporting for healthy, quarantined, and accepted outcomes.
  - Quarantine results now distinguish concrete halt causes from re-assertions and unspecified reasons.

- **Bug Fixes**
  - Prevented halt clearing when evidence is untimed or ambiguously ordered.
  - Ensured concrete halt causes take precedence over non-causal reasons.
  - Improved accepted and infrastructure-failure output handling.

- **Documentation**
  - Clarified halt lifecycle, fall-through behavior, repair requirements, and command-line output formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->