### PR TITLE
feat(cgka-engine): refuse set_stable over a held publication

### DIFF
--- a/crates/cgka-engine/AGENTS.md
+++ b/crates/cgka-engine/AGENTS.md
@@ -474,6 +474,16 @@ epoch visibility through `support::epoch_sealed_peeler`), plus the `convergence-
   the outbound drain behind its `Stable`-only re-check, hydration on fresh state, create/join on a group that cannot be
   holding a publication), so a fired refusal means a new caller lost that gate — fix the caller, don't relax the
   refusal.
+- **A held publication and an unresolved convergence input are mutually exclusive.** This is why the convergence pass
+  needs no held-publication gate of its own, and it is the non-obvious half of the invariant above — read it before
+  concluding that `converge_stored_openmls_messages*` is missing one because it takes any `EpochState`. Outbound:
+  `should_queue_outbound_intent` settles convergence *before* staging anything, so an unresolved input diverts the
+  intent to the retention queue and the group never leaves `Stable` — `begin_pending` is never reached. Inbound: once a
+  publication is held, `can_ingest` is false, so an arriving commit is persisted as `Retryable` transport bytes for
+  deterministic replay, never buffered as a convergence input. A pass run at that moment therefore has no branch to
+  select and cannot reach `set_stable` with one. Both halves are pinned by
+  `tests/publish_lifecycle.rs::a_publication_is_never_staged_while_a_convergence_input_is_unresolved` and
+  `::an_inbound_commit_under_a_held_publication_is_retained_not_converged`.
 - **No Nostr library/SDK dependency.** These crates do not depend on any Nostr crate and use no Nostr SDK types. They
   do reference the `marmot.transport.nostr.routing.v1` app-component by id (`NOSTR_ROUTING_COMPONENT_ID`,
   `NostrRoutingV1`) and name Nostr concepts in comments (e.g. the kind-445 exporter label), so

--- a/crates/cgka-engine/AGENTS.md
+++ b/crates/cgka-engine/AGENTS.md
@@ -465,6 +465,13 @@ epoch visibility through `support::epoch_sealed_peeler`), plus the `convergence-
   commit nothing will ever apply.
 - **Only `EpochManager` may construct non-`Stable` `EpochState` variants.** This is enforced by visibility — the
   variants' fields are private. Don't add a public constructor for `Recovering` etc. somewhere else.
+- **`EpochManager::set_stable` only overwrites `Stable` and `Recovering`.** Every other state owes its exit to a
+  specific transition and `set_stable` refuses it: `Unrecoverable` → `repair_to_stable` after a verified repair path,
+  `PendingPublish`/`Merging` → `confirm_publish` or `rollback_publish` (which carry the pending slot and
+  `committed_from` ownership a blind overwrite would strand), `Disbanded` → nothing. Callers are gated to reach it only
+  from the two overwritable states (inbound apply behind `can_ingest`, the outbound drain behind its `Stable`-only
+  re-check, hydration on fresh state, create/join on a group that cannot be holding a publication), so a fired refusal
+  means a new caller lost that gate — fix the caller, don't relax the refusal.
 - **No Nostr library/SDK dependency.** These crates do not depend on any Nostr crate and use no Nostr SDK types. They
   do reference the `marmot.transport.nostr.routing.v1` app-component by id (`NOSTR_ROUTING_COMPONENT_ID`,
   `NostrRoutingV1`) and name Nostr concepts in comments (e.g. the kind-445 exporter label), so

--- a/crates/cgka-engine/AGENTS.md
+++ b/crates/cgka-engine/AGENTS.md
@@ -467,11 +467,13 @@ epoch visibility through `support::epoch_sealed_peeler`), plus the `convergence-
   variants' fields are private. Don't add a public constructor for `Recovering` etc. somewhere else.
 - **`EpochManager::set_stable` only overwrites `Stable` and `Recovering`.** Every other state owes its exit to a
   specific transition and `set_stable` refuses it: `Unrecoverable` → `repair_to_stable` after a verified repair path,
-  `PendingPublish`/`Merging` → `confirm_publish` or `rollback_publish` (which carry the pending slot and
-  `committed_from` ownership a blind overwrite would strand), `Disbanded` → nothing. Callers are gated to reach it only
-  from the two overwritable states (inbound apply behind `can_ingest`, the outbound drain behind its `Stable`-only
-  re-check, hydration on fresh state, create/join on a group that cannot be holding a publication), so a fired refusal
-  means a new caller lost that gate — fix the caller, don't relax the refusal.
+  `PendingPublish`/`Merging` → `confirm_publish` or `rollback_publish`, the only transitions that also retire the
+  group's `pending` entry (a blind overwrite drops the staged commit handle and strands that entry with its rollback
+  epoch, leaving both exits to fail `InvalidTransition` off the freshly written `Stable`), `Disbanded` → nothing.
+  Callers reach it only from the two overwritable states or from no state at all (inbound apply behind `can_ingest`,
+  the outbound drain behind its `Stable`-only re-check, hydration on fresh state, create/join on a group that cannot be
+  holding a publication), so a fired refusal means a new caller lost that gate — fix the caller, don't relax the
+  refusal.
 - **No Nostr library/SDK dependency.** These crates do not depend on any Nostr crate and use no Nostr SDK types. They
   do reference the `marmot.transport.nostr.routing.v1` app-component by id (`NOSTR_ROUTING_COMPONENT_ID`,
   `NostrRoutingV1`) and name Nostr concepts in comments (e.g. the kind-445 exporter label), so

--- a/crates/cgka-engine/src/epoch_manager.rs
+++ b/crates/cgka-engine/src/epoch_manager.rs
@@ -118,9 +118,13 @@ impl EpochManager {
     ///
     /// Callers already reach this only from the two overwritable states, or
     /// from no state at all — every guard here reads through `is_some_and`, so
-    /// create/join and hydration pass by construction. A fired refusal means a
-    /// caller lost its gate; see the invariant in
-    /// `crates/cgka-engine/AGENTS.md`.
+    /// create/join and hydration pass by construction. The convergence caller
+    /// is gated a step earlier than it looks: a held publication and an
+    /// unresolved convergence input cannot coexist, because the outbound
+    /// preflight settles convergence before it stages anything and `can_ingest`
+    /// keeps new input out afterwards, so a pass entered under a held
+    /// publication has no branch to select. A fired refusal means a caller lost
+    /// its gate; see the invariant in `crates/cgka-engine/AGENTS.md`.
     pub(crate) fn set_stable(&mut self, group_id: GroupId, epoch: EpochId) {
         if self.is_unrecoverable(&group_id) || self.is_disbanded(&group_id) {
             tracing::warn!(

--- a/crates/cgka-engine/src/epoch_manager.rs
+++ b/crates/cgka-engine/src/epoch_manager.rs
@@ -103,16 +103,34 @@ impl EpochManager {
     /// Set a group's state to `Stable { epoch }`. Used by the join-welcome
     /// path (no prior state) and by the merge-to-stable path post-confirm.
     ///
-    /// Refuses to overwrite `Unrecoverable` or terminal `Disbanded`: the only
-    /// legal exit from `Unrecoverable` is [`Self::repair_to_stable`] after a
-    /// verified repair path (mdk#971), while `Disbanded` has no outgoing
-    /// transition.
+    /// Only `Stable` and `Recovering` may be overwritten. Every other state owes
+    /// its exit to a specific transition, and this refuses to steal it:
+    ///
+    /// - `Unrecoverable` exits only through [`Self::repair_to_stable`] after a
+    ///   verified repair path (mdk#971);
+    /// - an unresolved local publication (`PendingPublish` / `Merging`) exits
+    ///   only through [`Self::confirm_publish`] or [`Self::rollback_publish`],
+    ///   which carry the per-pending bookkeeping — the pending slot and its
+    ///   `committed_from` ownership — that a blind overwrite would strand;
+    /// - `Disbanded` has no outgoing transition.
+    ///
+    /// Callers are already gated to the two overwritable states, so a fired
+    /// refusal means a caller lost its gate; see the invariant in
+    /// `crates/cgka-engine/AGENTS.md`.
     pub(crate) fn set_stable(&mut self, group_id: GroupId, epoch: EpochId) {
         if self.is_unrecoverable(&group_id) || self.is_disbanded(&group_id) {
             tracing::warn!(
                 target: "cgka_engine::epoch_manager",
                 method = "set_stable",
                 "refusing set_stable while Unrecoverable or Disbanded; verified repair must use repair_to_stable"
+            );
+            return;
+        }
+        if self.is_resolving_local_publish(&group_id) {
+            tracing::warn!(
+                target: "cgka_engine::epoch_manager",
+                method = "set_stable",
+                "refusing set_stable while a local publication is unresolved; its outcome must use confirm_publish or rollback_publish"
             );
             return;
         }
@@ -338,6 +356,15 @@ impl EpochManager {
             .is_some_and(EpochState::is_disbanded)
     }
 
+    /// Whether the named group is mid-way through resolving a publication this
+    /// client staged (`PendingPublish` awaiting the transport outcome, or
+    /// `Merging` awaiting the local merge that outcome authorizes).
+    fn is_resolving_local_publish(&self, group_id: &GroupId) -> bool {
+        self.states
+            .get(group_id)
+            .is_some_and(EpochState::is_resolving_local_publish)
+    }
+
     pub(crate) fn mark_disbanded(
         &mut self,
         group_id: &GroupId,
@@ -495,6 +522,45 @@ mod tests {
             "set_stable must leave Unrecoverable intact"
         );
         assert_eq!(em.epoch(&group_id), Some(EpochId(4)));
+    }
+
+    /// A held publication is nobody else's to steal: while a staged commit is
+    /// still awaiting its transport outcome, `set_stable` must not overwrite it.
+    /// The publication's own outcome — `confirm_publish` or `rollback_publish` —
+    /// is the only way out, and it must still work afterwards.
+    #[test]
+    fn set_stable_refuses_while_a_local_publication_is_unresolved() {
+        let mut em = EpochManager::new();
+        let group_id = gid();
+        em.set_stable(group_id.clone(), EpochId(7));
+        let pending_ref = em.next_pending_ref();
+        em.begin_pending(
+            group_id.clone(),
+            EpochId(7),
+            EpochId(8),
+            handle(),
+            pending_ref,
+            PendingKind::GroupEvolution,
+            None,
+        )
+        .expect("begin_pending from Stable succeeds");
+
+        em.set_stable(group_id.clone(), EpochId(9));
+
+        assert_eq!(
+            em.state(&group_id).map(|s| s.name()),
+            Some("PendingPublish"),
+            "set_stable must leave an unresolved local publication intact"
+        );
+        assert_eq!(em.epoch(&group_id), Some(EpochId(8)));
+
+        // The publication still resolves through its own transition.
+        let (confirmed_group, confirmed_epoch) = em
+            .confirm_publish(pending_ref)
+            .expect("confirm_publish still exits the held publication");
+        assert_eq!(confirmed_group, group_id);
+        assert_eq!(confirmed_epoch, EpochId(8));
+        assert_eq!(em.state(&group_id).map(|s| s.name()), Some("Stable"));
     }
 
     /// mdk#971: verified repair is the only Unrecoverable exit.

--- a/crates/cgka-engine/src/epoch_manager.rs
+++ b/crates/cgka-engine/src/epoch_manager.rs
@@ -110,12 +110,16 @@ impl EpochManager {
     ///   verified repair path (mdk#971);
     /// - an unresolved local publication (`PendingPublish` / `Merging`) exits
     ///   only through [`Self::confirm_publish`] or [`Self::rollback_publish`],
-    ///   which carry the per-pending bookkeeping — the pending slot and its
-    ///   `committed_from` ownership — that a blind overwrite would strand;
+    ///   the two transitions that also retire the group's `self.pending` entry.
+    ///   A blind overwrite drops the staged commit handle and strands that
+    ///   entry: its rollback epoch is gone, and both exits then fail
+    ///   `InvalidTransition` off the `Stable` we just wrote;
     /// - `Disbanded` has no outgoing transition.
     ///
-    /// Callers are already gated to the two overwritable states, so a fired
-    /// refusal means a caller lost its gate; see the invariant in
+    /// Callers already reach this only from the two overwritable states, or
+    /// from no state at all — every guard here reads through `is_some_and`, so
+    /// create/join and hydration pass by construction. A fired refusal means a
+    /// caller lost its gate; see the invariant in
     /// `crates/cgka-engine/AGENTS.md`.
     pub(crate) fn set_stable(&mut self, group_id: GroupId, epoch: EpochId) {
         if self.is_unrecoverable(&group_id) || self.is_disbanded(&group_id) {

--- a/crates/cgka-engine/tests/publish_lifecycle.rs
+++ b/crates/cgka-engine/tests/publish_lifecycle.rs
@@ -2020,3 +2020,134 @@ async fn queued_outbound_intents_are_capped_per_group_while_a_publish_stays_unre
         "expected a direct send once the group is stable again, got {sent:?}"
     );
 }
+
+/// A held publication and an unresolved convergence input are mutually
+/// exclusive, and that is what keeps a convergence pass from ever landing on
+/// top of a staged commit.
+///
+/// This is the outbound half: the send preflight settles convergence *before*
+/// it stages anything, so an unresolved input diverts the intent to the
+/// retention queue and the group never leaves `Stable`. `begin_pending` is
+/// never reached, so there is no window in which a pass could select a branch
+/// under a publication this client is still holding.
+#[tokio::test]
+async fn a_publication_is_never_staged_while_a_convergence_input_is_unresolved() {
+    let mut alice = build_engine_with_storage(b"alice", SqliteAccountStorage::in_memory().unwrap());
+    let mut bob = build(b"bob");
+    let group_id = group_with_bob(&mut alice, &mut bob).await;
+    let stable_epoch = alice.epoch(&group_id).unwrap();
+
+    // Bob commits and Alice buffers it while she is still `Stable`, so it
+    // becomes a live convergence input rather than retained transport bytes.
+    let SendResult::GroupEvolution {
+        msg,
+        pending: bob_pending,
+        ..
+    } = bob
+        .send(SendIntent::SelfUpdate {
+            group_id: group_id.clone(),
+        })
+        .await
+        .unwrap()
+    else {
+        panic!("expected a staged self-update")
+    };
+    bob.confirm_published(bob_pending).await.unwrap();
+    assert!(matches!(
+        alice.ingest(msg).await.unwrap(),
+        IngestOutcome::Buffered { .. }
+    ));
+
+    let sent = alice
+        .send(SendIntent::SelfUpdate {
+            group_id: group_id.clone(),
+        })
+        .await
+        .unwrap();
+    assert!(
+        matches!(sent, SendResult::Queued { .. }),
+        "an unresolved convergence input must divert a group-state intent to the \
+         retention queue instead of staging a commit, got {sent:?}"
+    );
+    assert!(
+        alice
+            .epoch_state(&group_id)
+            .expect("alice tracks the group")
+            .is_stable(),
+        "the group must stay Stable: a staged commit here is the window in which \
+         a convergence pass could overwrite a held publication"
+    );
+    assert_eq!(alice.epoch(&group_id).unwrap(), stable_epoch);
+}
+
+/// The inbound half of the same exclusion: once a publication is held,
+/// `can_ingest` is false, so an arriving commit is retained as transport bytes
+/// for deterministic replay rather than buffered as a convergence input. A
+/// pass run against that group therefore has no branch to select — it is an
+/// empty no-op, and the publication still resolves through its own transition.
+#[tokio::test]
+async fn an_inbound_commit_under_a_held_publication_is_retained_not_converged() {
+    let mut alice = build_engine_with_storage(b"alice", SqliteAccountStorage::in_memory().unwrap());
+    let mut bob = build(b"bob");
+    let group_id = group_with_bob(&mut alice, &mut bob).await;
+
+    let SendResult::GroupEvolution { pending, .. } = alice
+        .send(SendIntent::SelfUpdate {
+            group_id: group_id.clone(),
+        })
+        .await
+        .unwrap()
+    else {
+        panic!("expected a staged self-update")
+    };
+    let staged_epoch = alice.epoch(&group_id).unwrap();
+    assert!(
+        alice
+            .epoch_state(&group_id)
+            .expect("alice tracks the group")
+            .is_resolving_local_publish()
+    );
+
+    let SendResult::GroupEvolution {
+        msg,
+        pending: bob_pending,
+        ..
+    } = bob
+        .send(SendIntent::SelfUpdate {
+            group_id: group_id.clone(),
+        })
+        .await
+        .unwrap()
+    else {
+        panic!("expected a staged self-update")
+    };
+    bob.confirm_published(bob_pending).await.unwrap();
+    assert!(matches!(
+        alice.ingest(msg).await.unwrap(),
+        IngestOutcome::Buffered { .. }
+    ));
+
+    // The ungated public entry point, run at the worst possible moment.
+    let result = alice
+        .converge_stored_openmls_messages_at(&group_id, 1_000_000)
+        .expect("a pass over a held publication runs against no eligible input");
+    assert!(
+        result.selected_tip.is_none(),
+        "a pass must have no branch to select while a publication is held"
+    );
+    assert!(result.accepted_commits.is_empty());
+    assert_eq!(
+        alice.epoch(&group_id).unwrap(),
+        staged_epoch,
+        "the pass must leave the held publication's epoch untouched"
+    );
+
+    let confirmed = alice
+        .confirm_published(pending)
+        .await
+        .expect("the publication still resolves through its own transition");
+    assert!(matches!(
+        confirmed,
+        cgka_traits::engine::GroupEvent::EpochChanged { to, .. } if to == staged_epoch
+    ));
+}


### PR DESCRIPTION
### Why

`EpochManager::set_stable` refused only the two terminal-ish states (`Unrecoverable`,
`Disbanded`) and silently overwrote `PendingPublish` / `Merging`. "Nothing steals a held
publication" was therefore a **caller-enforced** invariant — true today, unstated, and
inheritable as a silent epoch-state overwrite by the next caller added.

### What the callers actually do

All **seven** call sites were checked and every one is already gated to `Stable` or
`Recovering`:

- inbound apply, behind `can_ingest`
- the outbound drain, behind its `Stable`-only re-check **and** its
  `pauses_for_pending_publish` break — that break is load-bearing here, not incidental
- hydration, on fresh session state
- create/join, on a group that cannot be holding a publication

So this change is provably a no-op on current behavior and purely a guard against the next
caller.

### The change

Make it transition-enforced, in the shape the existing terminal refusal already uses: warn
and leave the state untouched.

A staged commit awaiting its transport outcome exits only through `confirm_publish` or
`rollback_publish`, which carry the per-pending bookkeeping — the pending slot and its
`committed_from` ownership — that a blind overwrite would strand. Stranding it is exactly how
a rolled-back publication leaves a phantom `committed_from` entry that poisons later fork
detection.

**Both legal exits are untouched by construction:** `confirm_publish` and `rollback_publish`
mutate `states` directly after running the `EpochState` transitions, so they never route
through `set_stable` and no internal/public seam was needed.

### On `Merging`

`Merging` is covered by the same `is_resolving_local_publish` predicate, but `EpochManager`
never parks a group there — `confirm_publish` builds and consumes it inside one atomic step —
so only `PendingPublish` is reachable to assert on. The coupling to
`is_resolving_local_publish` is deliberate: one predicate defines "a publication is being
resolved locally", and the refusal should track it rather than re-enumerate states.

### Testing

New test pins the refusal and then confirms the held publication still resolves through
`confirm_publish`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved groups with pending or in-progress publication states during stability updates.
  * Prevented unresolved local publication changes from being overwritten.
  * Retained unresolved convergence inputs without staging conflicting publications.
  * Ensured pending publications remain intact and can still be confirmed.

* **Documentation**
  * Clarified valid lifecycle transitions for stability updates and publication/convergence state handling.

* **Tests**
  * Added coverage for publication and convergence exclusion scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->