### PR TITLE
test(simulator): pin the open-pass restart catch-up path from the public boundary

### DIFF
--- a/crates/cgka-conformance-simulator/AGENTS.md
+++ b/crates/cgka-conformance-simulator/AGENTS.md
@@ -349,6 +349,26 @@ Keep these aligned with [`README.md`](README.md), [`SCENARIOS.md`](SCENARIOS.md)
 - **Admin-gated scripted steps need admin setup.** When a scenario has an invitee later send `InviteMembers` or
   `UpdateGroupData`, the runner promotes that invitee to an initial admin for the group. Direct harness tests should
   use `create_group_with_admins` explicitly for competing admin commits.
+- **Deadline-pinning virtual-time scenarios cannot become portable vectors yet.** The oracle recommends
+  `OracleBehavior::QuiescenceState` for the `VirtualTimeAdvance` stimulus, and no `TraceExpectation` produces it — only
+  the `await_quiescence` step does. That is enough for fixtures that just need to reach a fixed point, but not for ones
+  whose contract is *which* tick settles a pass: `await_quiescence` advances virtual time until the subject stops
+  changing, so it settles a pass whenever it comes due and erases the evidence that a specific deadline fired. A
+  scenario that must hold a convergence pass open across a precise boundary (see
+  `open_convergence_pass_survives_restart_and_walks_the_backlog_to_the_tip`) therefore has to tick manually, which
+  leaves the `VirtualTimeAdvance` recommendation unsatisfied and fails the `--strict-oracle` vector report CI job
+  (strict is the default; `--allow-weak-oracle` opts out). The multi-process subject blocks them independently:
+  `ProcessOrchestrator` claims `SubjectCapability::VirtualTime`, but its `AdvanceTime` is a `tokio::time::sleep` in the
+  orchestrator and `node_protocol` has no clock surface, so no subject clock moves and node deadlines run on real
+  time — fine for a step that only needs settling slack, wrong for one that must land on a boundary. Such scenarios stay
+  in `tests/canonical_scenarios.rs` until a `TraceExpectation` can bind the quiescence gate without also driving the
+  clock and the node protocol gains the virtual clock its capability advertises.
+- **`ClientsExactlyEquivalent` conflicts with deliberate mid-history divergence.** Expecting it contributes
+  `OracleBehavior::ClientConvergence`, but the observed side only records that behavior when *every* observation in the
+  trace shares an epoch, member count, and group name. A scenario that observes a deliberate mid-history divergence and
+  then converges can never produce it, so it reports `missing_observed_behaviors` and fails `--strict-oracle` even
+  though it converged. Assert the divergence through a separate mid-history `observe` in a harness test rather than a
+  vector until the observed-convergence detector is scoped to a step range.
 - **Failure minimization is intentionally conservative.** Generated reports populate `minimized_case` with a greedy
   step-removal reducer when removable app/delivery noise can be dropped without changing the semantic failure identity
   (classification, action type, and failure kind). Complete state-digest fingerprints remain diagnostic evidence. There is no

--- a/crates/cgka-conformance-simulator/AGENTS.md
+++ b/crates/cgka-conformance-simulator/AGENTS.md
@@ -349,26 +349,19 @@ Keep these aligned with [`README.md`](README.md), [`SCENARIOS.md`](SCENARIOS.md)
 - **Admin-gated scripted steps need admin setup.** When a scenario has an invitee later send `InviteMembers` or
   `UpdateGroupData`, the runner promotes that invitee to an initial admin for the group. Direct harness tests should
   use `create_group_with_admins` explicitly for competing admin commits.
-- **Deadline-pinning virtual-time scenarios cannot become portable vectors yet.** The oracle recommends
-  `OracleBehavior::QuiescenceState` for the `VirtualTimeAdvance` stimulus, and no `TraceExpectation` produces it — only
-  the `await_quiescence` step does. That is enough for fixtures that just need to reach a fixed point, but not for ones
-  whose contract is *which* tick settles a pass: `await_quiescence` advances virtual time until the subject stops
-  changing, so it settles a pass whenever it comes due and erases the evidence that a specific deadline fired. A
-  scenario that must hold a convergence pass open across a precise boundary (see
-  `open_convergence_pass_survives_restart_and_walks_the_backlog_to_the_tip`) therefore has to tick manually, which
-  leaves the `VirtualTimeAdvance` recommendation unsatisfied and fails the `--strict-oracle` vector report CI job
-  (strict is the default; `--allow-weak-oracle` opts out). The multi-process subject blocks them independently:
-  `ProcessOrchestrator` claims `SubjectCapability::VirtualTime`, but its `AdvanceTime` is a `tokio::time::sleep` in the
-  orchestrator and `node_protocol` has no clock surface, so no subject clock moves and node deadlines run on real
-  time — fine for a step that only needs settling slack, wrong for one that must land on a boundary. Such scenarios stay
-  in `tests/canonical_scenarios.rs` until a `TraceExpectation` can bind the quiescence gate without also driving the
-  clock and the node protocol gains the virtual clock its capability advertises.
-- **`ClientsExactlyEquivalent` conflicts with deliberate mid-history divergence.** Expecting it contributes
-  `OracleBehavior::ClientConvergence`, but the observed side only records that behavior when *every* observation in the
-  trace shares an epoch, member count, and group name. A scenario that observes a deliberate mid-history divergence and
-  then converges can never produce it, so it reports `missing_observed_behaviors` and fails `--strict-oracle` even
-  though it converged. Assert the divergence through a separate mid-history `observe` in a harness test rather than a
-  vector until the observed-convergence detector is scoped to a step range.
+- **Deadline-pinning virtual-time scenarios cannot become portable vectors yet.** A scenario whose contract is *which*
+  tick settles a pass (see `open_convergence_pass_survives_restart_and_walks_the_backlog_to_the_tip`) has to tick
+  manually: `await_quiescence` advances virtual time until the subject stops changing, so it settles a pass whenever it
+  comes due and erases the evidence that a specific deadline fired. That costs nothing at the oracle —
+  `VirtualTimeAdvance` recommends `QuiescenceState` *or* `NoPendingWorkObserved` and coverage is any-of, so a
+  `NoPendingWork` expectation discharges the stimulus under `--strict-oracle`. The multi-process subject is the actual
+  block: `process_subject_descriptor` deliberately does not advertise `SubjectCapability::VirtualTime`, so preflight
+  rejects `AdvanceTime` as `unsupported_subject_capability` and the orchestrator's `tokio::time::sleep` arm never
+  runs — and `node_protocol` has no clock surface, so there is no subject clock to move even if it did. Node deadlines
+  would run on real elapsed time: fine for a step that only needs settling slack, wrong for one that must land on a
+  boundary.
+  Such scenarios stay in `tests/canonical_scenarios.rs` until the node protocol grows a virtual clock the process
+  subject can honestly advertise.
 - **Failure minimization is intentionally conservative.** Generated reports populate `minimized_case` with a greedy
   step-removal reducer when removable app/delivery noise can be dropped without changing the semantic failure identity
   (classification, action type, and failure kind). Complete state-digest fingerprints remain diagnostic evidence. There is no

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -441,31 +441,30 @@ These are real simulator scenarios that are still tied to Rust harness details.
 - Expected: mid-history Carol is still at epoch 1 with Alice four epochs ahead — an active pass pins the tip across the
   crash and the backlog. The settle tick at exactly the original 1000ms deadline clears the recovered pass, and Carol
   then walks 1→2→3→4→5, one generation per quiescence window, ending exactly equivalent to Alice with no pending work.
-- Reason: scenario-level companion to the mdk#1110 stale-pass-base incident (fixed in mdk#1182). The engine tests for
-  that fix install a `base_epoch`/tip disagreement on the durable record directly, because the engine keeps a single tip
-  authority and an active pass gates every path that could move the tip. This scenario pins that precondition from the
+- Reason: scenario-level companion to the stale-pass-base field incident fixed in mdk#1182, over the durable
+  convergence passes mdk#1110 added. The engine tests for that fix install a `base_epoch`/tip disagreement on the
+  durable record directly, because the engine keeps a single tip authority and an active pass gates every path that
+  could move the tip. This scenario pins that precondition from the
   public boundary: the disagreement the incident needed never arises, and the device still converges. The timing is the
   evidence that the *same* durable pass survived the crash — a pass reopened afterwards would carry a later deadline and
   leave Carol behind.
-- Not portable yet, for three independent reasons. First, `AdvanceTime` is required to hold a pass open between ticks,
-  and the oracle maps `VirtualTimeAdvance` to `OracleBehavior::QuiescenceState`, which only the `await_quiescence` step
-  produces — and that step cannot be used here, because it advances virtual time to a fixed point and settles the
-  recovered pass whenever it comes due, which erases the exact-deadline evidence. With `await_quiescence` appended,
-  shortening the settle tick to 900ms still passes; without it, the `VirtualTimeAdvance` recommendation stays
-  unsatisfied and `--strict-oracle` fails. Second, `ClientsExactlyEquivalent` expects observed
-  `OracleBehavior::ClientConvergence`, which is only recorded when every observation in the trace agrees on epoch,
-  member count, and group name — so this scenario's deliberate mid-history divergence observation (Carol 1, Alice 5)
-  makes it unreachable and reports `missing_observed_behaviors`. Third, the multi-process subject cannot carry the
-  contract at all: `ProcessOrchestrator` advertises `SubjectCapability::VirtualTime`, but its `AdvanceTime` handler is a
-  `tokio::time::sleep` in the orchestrator process and `node_protocol` exposes no clock surface, so the step advances no
-  subject clock and each node's pass deadlines run on real elapsed time. Promoting this to `vectors/` needs a
-  `TraceExpectation` that binds the quiescence gate without driving the clock, a step-scoped observed-convergence
-  detector, and a node-side virtual clock behind the capability the process subject already claims.
+- Not portable yet, because the multi-process subject cannot carry the contract: `process_subject_descriptor`
+  deliberately does not advertise `SubjectCapability::VirtualTime`, so `AdvanceTime` fails preflight as
+  `unsupported_subject_capability` and the orchestrator's `tokio::time::sleep` arm never runs — and `node_protocol`
+  exposes no clock surface, so there is no subject clock for the step to move. Each node's pass deadlines would run on
+  real elapsed time, which is fine for a step that only needs settling slack and wrong for one whose contract is
+  landing on a boundary. Promoting this to `vectors/` needs a node-side virtual clock and a capability the process
+  subject can honestly advertise.
+- The manual `AdvanceTime`/`Tick` walk is a choice, not an oracle workaround. `await_quiescence` advances virtual time
+  to a fixed point and settles the recovered pass whenever it comes due, which erases the exact-deadline evidence —
+  with it appended, shortening the settle tick to 900ms still passes. Ticking manually costs nothing under
+  `--strict-oracle`: `VirtualTimeAdvance` recommends `OracleBehavior::QuiescenceState` *or*
+  `OracleBehavior::NoPendingWorkObserved`, and this scenario asserts `NoPendingWork`.
 - Mutation evidence: deleting the durable pass on reopen, or ignoring the quiescence cutoff, both turn this scenario
   red. Shortening the post-restart settle tick from 300ms to 200ms — landing at 900ms instead of the recovered pass's
   original 1000ms deadline — leaves Carol with an unresolved convergence input and one epoch behind, which is the direct
   evidence that the deadline survived the reopen rather than being re-derived. Leaving an applied pass active at its old
-  base epoch (producing the mdk#1110 shape live) keeps it green, because the mdk#1182 discard reopens at the tip;
+  base epoch (producing the incident shape live) keeps it green, because the mdk#1182 discard reopens at the tip;
   replacing that discard with the pre-mdk#1182 durable halt turns it red with Carol's canonical `convergence_status`
   stuck at `unrecoverable`.
 

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -432,6 +432,43 @@ These are real simulator scenarios that are still tied to Rust harness details.
 - Sentinel: an engine unit test proves that device-local committer-leaf status, roster order, and duplicate roster rows
   do not change terminal equality.
 
+### `open_convergence_pass_survives_restart_and_walks_the_backlog_to_the_tip`
+
+- Setup: Alice and Carol settle at epoch 1, the scenario moves onto virtual time, and one inbound commit edge opens
+  Carol's convergence pass at base epoch 1.
+- Pressure: Carol crashes and reopens (encrypted file storage, real close/reopen) 300ms short of the pass cutoff, then
+  three more commits from Alice land on the reopened engine while the recovered pass still holds the boundary.
+- Expected: mid-history Carol is still at epoch 1 with Alice four epochs ahead — an active pass pins the tip across the
+  crash and the backlog. The settle tick at exactly the original 1000ms deadline clears the recovered pass, and Carol
+  then walks 1→2→3→4→5, one generation per quiescence window, ending exactly equivalent to Alice with no pending work.
+- Reason: scenario-level companion to the mdk#1110 stale-pass-base incident (fixed in mdk#1182). The engine tests for
+  that fix install a `base_epoch`/tip disagreement on the durable record directly, because the engine keeps a single tip
+  authority and an active pass gates every path that could move the tip. This scenario pins that precondition from the
+  public boundary: the disagreement the incident needed never arises, and the device still converges. The timing is the
+  evidence that the *same* durable pass survived the crash — a pass reopened afterwards would carry a later deadline and
+  leave Carol behind.
+- Not portable yet, for three independent reasons. First, `AdvanceTime` is required to hold a pass open between ticks,
+  and the oracle maps `VirtualTimeAdvance` to `OracleBehavior::QuiescenceState`, which only the `await_quiescence` step
+  produces — and that step cannot be used here, because it advances virtual time to a fixed point and settles the
+  recovered pass whenever it comes due, which erases the exact-deadline evidence. With `await_quiescence` appended,
+  shortening the settle tick to 900ms still passes; without it, the `VirtualTimeAdvance` recommendation stays
+  unsatisfied and `--strict-oracle` fails. Second, `ClientsExactlyEquivalent` expects observed
+  `OracleBehavior::ClientConvergence`, which is only recorded when every observation in the trace agrees on epoch,
+  member count, and group name — so this scenario's deliberate mid-history divergence observation (Carol 1, Alice 5)
+  makes it unreachable and reports `missing_observed_behaviors`. Third, the multi-process subject cannot carry the
+  contract at all: `ProcessOrchestrator` advertises `SubjectCapability::VirtualTime`, but its `AdvanceTime` handler is a
+  `tokio::time::sleep` in the orchestrator process and `node_protocol` exposes no clock surface, so the step advances no
+  subject clock and each node's pass deadlines run on real elapsed time. Promoting this to `vectors/` needs a
+  `TraceExpectation` that binds the quiescence gate without driving the clock, a step-scoped observed-convergence
+  detector, and a node-side virtual clock behind the capability the process subject already claims.
+- Mutation evidence: deleting the durable pass on reopen, or ignoring the quiescence cutoff, both turn this scenario
+  red. Shortening the post-restart settle tick from 300ms to 200ms — landing at 900ms instead of the recovered pass's
+  original 1000ms deadline — leaves Carol with an unresolved convergence input and one epoch behind, which is the direct
+  evidence that the deadline survived the reopen rather than being re-derived. Leaving an applied pass active at its old
+  base epoch (producing the mdk#1110 shape live) keeps it green, because the mdk#1182 discard reopens at the tip;
+  replacing that discard with the pre-mdk#1182 durable halt turns it red with Carol's canonical `convergence_status`
+  stuck at `unrecoverable`.
+
 ### `bidirectional_decryptability_probe_passes_for_settled_members`
 
 - Setup: Alice creates a settled three-member group with Bob and Carol.

--- a/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
+++ b/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
@@ -265,8 +265,9 @@ async fn exact_oracle_projects_terminal_disband_tombstone_across_restart() {
 ///
 /// This is the scenario-level companion to the engine's
 /// `stale_pass_base_epoch_reopens_at_the_current_tip_instead_of_halting` family
-/// (mdk#1110, fixed in mdk#1182). The field incident was a durable pass whose
-/// `base_epoch` disagreed with the live tip, which durably halted the group.
+/// (mdk#1182, over the durable passes mdk#1110 added). The field incident was a
+/// durable pass whose `base_epoch` disagreed with the live tip, which durably
+/// halted the group.
 /// Those engine tests install the disagreement on the durable record directly,
 /// because the engine keeps a single tip authority and an active pass gates every
 /// path that could move it. This scenario pins that precondition from the public
@@ -285,7 +286,7 @@ async fn exact_oracle_projects_terminal_disband_tombstone_across_restart() {
 ///
 /// The subject adapter's `structural_wake_rebases_across_restart_without_granting_fresh_time`
 /// already covers the deadline-rebase half of this on a lone client with an empty
-/// group. This scenario is the version that matters for mdk#1110: the deadline has
+/// group. This scenario is the version that matters for the incident: the deadline has
 /// to survive a *backlog* landing on the reopened engine, which is the pressure
 /// that could plausibly re-derive it.
 ///

--- a/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
+++ b/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
@@ -15,7 +15,8 @@ use cgka_conformance_simulator::{
     generate_bounded_convergence_pressure_family, generate_convergence_chaos_family,
     generate_convergence_e2e_delivery_family, generate_send_leave_family, observe_client,
     observe_client_exact, run_generated_case_report, run_generated_case_report_with_storage_mode,
-    run_scenario_report, run_scenario_report_with_outcomes, run_scenario_spec,
+    run_scenario_report, run_scenario_report_with_outcomes,
+    run_scenario_report_with_outcomes_and_storage_mode, run_scenario_spec,
     run_vector_fixture_report, run_vector_fixture_report_with_storage_mode,
 };
 use cgka_engine::ManualConvergenceClock;
@@ -256,6 +257,185 @@ async fn exact_oracle_projects_terminal_disband_tombstone_across_restart() {
 
     alice.restart();
     assert_eq!(alice.canonical_state_snapshot(), before_restart);
+}
+
+/// A convergence pass that is open when the device crashes must survive the
+/// reopen, keep pinning the tip while a backlog piles up behind it, and then
+/// walk the device all the way to the group tip.
+///
+/// This is the scenario-level companion to the engine's
+/// `stale_pass_base_epoch_reopens_at_the_current_tip_instead_of_halting` family
+/// (mdk#1110, fixed in mdk#1182). The field incident was a durable pass whose
+/// `base_epoch` disagreed with the live tip, which durably halted the group.
+/// Those engine tests install the disagreement on the durable record directly,
+/// because the engine keeps a single tip authority and an active pass gates every
+/// path that could move it. This scenario pins that precondition from the public
+/// boundary instead: carol holds an open pass at epoch 1 across a crash/reopen and
+/// a three-commit backlog burst without her tip ever drifting off the base, so the
+/// disagreement the incident needed never arises, and she still reaches exact
+/// equivalence with alice.
+///
+/// The timing is load-bearing evidence that the *same* durable pass survived the
+/// crash rather than a fresh one reopening afterwards. The pass opens at virtual
+/// time 0 with a 1000ms quiescence deadline; the restart happens at 700ms, the
+/// backlog arrives while the reopened engine holds the pass, and the settle tick
+/// at exactly 1000ms clears the original deadline. A pass reopened after the
+/// restart would carry a later deadline and leave carol behind at epoch 1, which
+/// the pinned epoch walk rejects.
+///
+/// The subject adapter's `structural_wake_rebases_across_restart_without_granting_fresh_time`
+/// already covers the deadline-rebase half of this on a lone client with an empty
+/// group. This scenario is the version that matters for mdk#1110: the deadline has
+/// to survive a *backlog* landing on the reopened engine, which is the pressure
+/// that could plausibly re-derive it.
+///
+/// Deliberately does not use `ScenarioStep::AwaitQuiescence`. That step drives
+/// virtual time to a fixed point, which settles the recovered pass whenever it
+/// happens to come due and so erases the exact-deadline evidence — with it
+/// appended, shortening the settle tick to 900ms still passes. The manual
+/// `AdvanceTime`/`Tick` walk is what makes the timing falsifiable.
+#[tokio::test]
+async fn open_convergence_pass_survives_restart_and_walks_the_backlog_to_the_tip() {
+    let update = |name: &str, pending: &str| ScenarioStep::UpdateGroupData {
+        client: "alice".into(),
+        name: name.into(),
+        pending: pending.into(),
+    };
+    let confirm = |pending: &str| ScenarioStep::accept_publication("alice", pending);
+    let tick_carol = || ScenarioStep::Tick {
+        clients: vec!["carol".into()],
+    };
+    let both = || vec!["alice".to_owned(), "carol".to_owned()];
+
+    let spec = ScenarioSpec {
+        name: "open-pass-restart-catchup/v1".into(),
+        spec_version: "2".into(),
+        topology: Default::default(),
+        clients: both(),
+        steps: vec![
+            // 0-4: alice and carol settle at epoch 1.
+            ScenarioStep::CreateGroup {
+                creator: "alice".into(),
+                name: "open-pass-restart-catchup".into(),
+                invitees: vec!["carol".into()],
+                required_features: vec![],
+                initial_admins: None,
+                pending: "create".into(),
+            },
+            confirm("create"),
+            ScenarioStep::DeliverAll,
+            tick_carol(),
+            ScenarioStep::ClearEvents { clients: both() },
+            // 5: take the scenario onto virtual time so a pass can stay open
+            // between ticks instead of settling through the far-future shortcut.
+            ScenarioStep::AdvanceTime { delta_ms: 0 },
+            // 6-9: one inbound commit edge opens carol's pass at base epoch 1.
+            update("backlog-2", "u2"),
+            confirm("u2"),
+            ScenarioStep::DeliverAll,
+            tick_carol(),
+            // 10-12: crash and reopen 300ms short of the pass cutoff.
+            ScenarioStep::AdvanceTime { delta_ms: 700 },
+            tick_carol(),
+            ScenarioStep::RestartClient {
+                client: "carol".into(),
+            },
+            // 13-20: three more commits land on the reopened engine while the
+            // recovered pass still holds the boundary.
+            update("backlog-3", "u3"),
+            confirm("u3"),
+            update("backlog-4", "u4"),
+            confirm("u4"),
+            update("backlog-5", "u5"),
+            confirm("u5"),
+            ScenarioStep::DeliverAll,
+            tick_carol(),
+            // 21: alice is four epochs ahead; carol is still pinned to her base.
+            ScenarioStep::Observe { clients: both() },
+            // 22-29: the recovered pass settles on its original deadline, then
+            // one generation per quiescence window walks carol to the tip.
+            ScenarioStep::AdvanceTime { delta_ms: 300 },
+            tick_carol(),
+            ScenarioStep::AdvanceTime { delta_ms: 1_000 },
+            tick_carol(),
+            ScenarioStep::AdvanceTime { delta_ms: 1_000 },
+            tick_carol(),
+            ScenarioStep::AdvanceTime { delta_ms: 1_000 },
+            tick_carol(),
+            // 30-32: drain both runtimes and compare exact canonical state.
+            ScenarioStep::DeliverAll,
+            ScenarioStep::Tick { clients: both() },
+            ScenarioStep::ObserveExact { clients: both() },
+        ],
+    };
+
+    let epoch_walk = |from: u64| EpochChangeObservation { from, to: from + 1 };
+    let report = run_scenario_report_with_outcomes_and_storage_mode(
+        &spec,
+        None,
+        vec![
+            TraceExpectation::PendingResolution {
+                step_index: 1,
+                client: "alice".into(),
+                pending: "create".into(),
+                resolution: "confirmed".into(),
+            },
+            TraceExpectation::PendingResolution {
+                step_index: 7,
+                client: "alice".into(),
+                pending: "u2".into(),
+                resolution: "confirmed".into(),
+            },
+            TraceExpectation::PendingResolution {
+                step_index: 18,
+                client: "alice".into(),
+                pending: "u5".into(),
+                resolution: "confirmed".into(),
+            },
+            // Step 21, mid-history: the backlog burst never moved carol's tip
+            // off the open pass's base epoch, across the crash and reopen.
+            TraceExpectation::ClientState {
+                client: "carol".into(),
+                epoch: 1,
+                member_count: 2,
+                received_payloads: None,
+                added_members: None,
+                removed_members: None,
+            },
+            TraceExpectation::ClientState {
+                client: "alice".into(),
+                epoch: 5,
+                member_count: 2,
+                received_payloads: None,
+                added_members: None,
+                removed_members: None,
+            },
+            // Step 32: carol catches up one generation per pass, with no skipped
+            // epoch and no halt.
+            TraceExpectation::ClientEpochChanges {
+                client: "carol".into(),
+                changes: vec![epoch_walk(1), epoch_walk(2), epoch_walk(3), epoch_walk(4)],
+            },
+            TraceExpectation::ClientsExactlyEquivalent { clients: both() },
+            TraceExpectation::NoPendingWork { clients: both() },
+        ],
+        // A real close-and-reopen of the encrypted database, not just a rebuilt
+        // engine over a live handle.
+        HarnessStorageMode::TempFileBackedSqlite,
+    )
+    .await
+    .expect("run open-pass restart catch-up scenario");
+
+    assert!(
+        report.expectation_failures.is_empty(),
+        "unexpected failures: {:#?}",
+        report.expectation_failures
+    );
+    assert!(
+        report.invariant_failures.is_empty(),
+        "unexpected invariant failures: {:#?}",
+        report.invariant_failures
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Simulator-only. No production code changes.

### Lead with the negative result

**The producer hypothesis is FALSE on current code.** The #1110 incident was a durable
convergence pass whose `base_epoch` disagreed with the live tip, durably halting the group.
#1182 turned that disagreement into a repair path — and the engine keeps a single tip authority
while an active pass gates every path that could move the tip. So *active-pass-with-moved-tip
is unproducible through the public boundary.* #1182's own engine tests install the shape on the
durable record directly, because that is the only way to get it.

This scenario therefore does **not** reproduce #1110. It pins the adjacent contract — the
precondition #1182 relies on — at the public scenario boundary.

### What it actually pins

Carol opens a pass at epoch 1, crashes and reopens 300 ms short of its cutoff, then takes a
three-commit backlog burst on the reopened engine — and her tip never leaves the pass base. The
settle tick on the recovered pass's **original** deadline then walks her one generation per
quiescence window to exact equivalence with alice, with no pending work and no halt.

So: pass survives crash/reopen · deadline is wall-rebased · tip pinned across a backlog ·
exact equivalence reached · no halt.

The adapter's `structural_wake_rebases_across_restart_without_granting_fresh_time` already
covers the deadline-rebase half on a lone client with an empty group. The half that matters is
that the deadline survives a *backlog* landing on the reopened engine — the pressure that could
plausibly re-derive it. `AdvanceTime` and `RestartClient` have not appeared in the same step
list anywhere in this crate before.

### Mutation-checked

- Deleting the pass on reopen → **red**.
- Ignoring the quiescence cutoff → **red**.
- Shortening the post-restart settle tick to land at 900 ms instead of the recovered pass's
  original 1000 ms deadline → carol is left with an unresolved convergence input, one epoch
  behind. That is the direct evidence the deadline survived the reopen.
- Leaving an applied pass active at its old base (producing the #1110 shape live) stays
  **green**, because the #1182 discard reopens at the tip. Swapping that discard for the
  pre-#1182 durable halt turns it **red**, with carol stuck at `unrecoverable`.

> ⚠️ The last two engine-level mutation claims were recorded **2026-07-30 and have not been
> re-verified on current master.** Reviewers should treat them as dated evidence.

### The `AwaitQuiescence` trap

#1216 gave `await_quiescence` a way to satisfy the `VirtualTimeAdvance` stimulus, which makes
appending it look like the obvious portability fix. **It makes the claim vacuous, and this is
mutation-proven:** the step drives virtual time to a fixed point, so it settles the recovered
pass whenever it comes due and erases the exact-deadline evidence — appending it makes the
900 ms mutation *pass*. Ticking manually instead leaves the `VirtualTimeAdvance`
recommendation unsatisfied under the now-default `--strict-oracle`. That is why the scenario is
recorded as not-yet-portable rather than "fixed by #1216".

### Why it is still not a portable vector — three blockers

1. The `AwaitQuiescence` trap above (oracle-side).
2. `ClientsExactlyEquivalent` expects observed `ClientConvergence`, only recorded when every
   observation in the trace agrees on epoch and membership — so the deliberate mid-history
   divergence observation makes it unreachable (oracle-side).
3. **Independent of the oracle:** the multi-process subject added in #1248 advertises
   `SubjectCapability::VirtualTime`, but its `AdvanceTime` is a `tokio::time::sleep` **in the
   orchestrator process**, and `node_protocol` exposes no clock surface. The step moves no
   subject clock, so each node's pass deadlines run on real elapsed time. Fine for a step that
   only needs settling slack; wrong for one whose whole contract is landing on a boundary.

Closing the two oracle gaps is therefore **necessary but not sufficient** here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added coverage for recovering an open convergence pass after encrypted storage restart.
  * Verified deadline preservation, backlog processing, and stepwise catch-up to canonical equivalence.
  * Confirmed durable recovery across temporary divergence without pending or invariant failures.

* **Documentation**
  * Documented the new restart-and-backlog recovery scenario.
  * Recorded current limitations for deadline-pinning virtual-time scenarios and representing temporary divergence followed by convergence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->