### PR TITLE
test(cgka-engine): rename auto_commit_atomicity to record_write_atomicity

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -344,7 +344,7 @@ convergence-failure-corpus:
 focused-convergence-regressions:
     cargo nextest run -p cgka-engine --test fork_detection --locked -E 'test(=restarted_committer_without_source_anchor_halts_through_convergence)'
     cargo nextest run -p cgka-engine --test fork_detection --locked -E 'test(=verified_welcome_repair_survives_the_next_convergence_drain)'
-    cargo nextest run -p cgka-engine --test auto_commit_atomicity --locked -E 'test(=leave_persistence_failure_rolls_back_every_transactional_write)'
+    cargo nextest run -p cgka-engine --test record_write_atomicity --locked -E 'test(=leave_persistence_failure_rolls_back_every_transactional_write)'
     cargo nextest run -p marmot-app --lib --locked -E 'test(=tests::explicit_catch_up_arms_and_replays_without_later_traffic)'
     cargo nextest run -p cgka-engine --test fork_detection --locked -E 'test(=stale_commit_outside_rewind_horizon_is_not_treated_as_recoverable_fork)'
 

--- a/crates/cgka-engine/tests/AGENTS.md
+++ b/crates/cgka-engine/tests/AGENTS.md
@@ -74,7 +74,7 @@ epoch-scoped readability; `MockPeeler` stays right for everything else.
   - **Owns:** Crash-during-publish recovery at session open — `hydrate_all_stored_groups` detects a surviving
     `PendingCommit`, clears it, and surfaces `GroupEvent::PendingCommitRecovered` (mdk#150)
 
-- **File:** `auto_commit_atomicity.rs`
+- **File:** `record_write_atomicity.rs`
   - **Owns:** Group-projection atomicity under injected record/cache write failures (mdk#333, mdk#794), one test per
     seam that projects the record plus direct-ingest capability-cache coverage. No torn record or capability cache,
     orphaned pending publish, leaked snapshot, stale stored proposal, or epoch split between the record and the epoch

--- a/crates/cgka-engine/tests/record_write_atomicity.rs
+++ b/crates/cgka-engine/tests/record_write_atomicity.rs
@@ -124,7 +124,7 @@ impl TransportPeeler for MockPeeler {
             payload: payload.ciphertext.clone(),
             timestamp: Timestamp(0),
             causal_deps: vec![],
-            source: TransportSource("auto-commit-atomicity".into()),
+            source: TransportSource("record-write-atomicity".into()),
             envelope: TransportEnvelope::GroupMessage {
                 transport_group_id: vec![],
             },
@@ -141,7 +141,7 @@ impl TransportPeeler for MockPeeler {
             payload: payload.ciphertext.clone(),
             timestamp: Timestamp(0),
             causal_deps: vec![],
-            source: TransportSource("auto-commit-atomicity".into()),
+            source: TransportSource("record-write-atomicity".into()),
             envelope: TransportEnvelope::Welcome {
                 recipient: recipient.clone(),
             },


### PR DESCRIPTION
Test hygiene, no behavior change.

`auto_commit_atomicity.rs` → `record_write_atomicity.rs`. The file now covers four seams that
project the group record — auto-commit staging, Welcome join, group-profile staging, inbound
commit apply — so the auto-commit name undersells three quarters of it. The module header
already described it as group-record write atomicity; the filename now agrees.

Two references updated with it: the `crates/cgka-engine/tests/AGENTS.md` inventory line, and
the `focused-convergence-regressions` recipe in the `Justfile`, whose nextest selector fails
closed on renames — leaving it would have broken that CI recipe with a zero-match nonzero exit.

The branch originally carried a second commit deriving the settled-pass monotonic reading from
pinned policy instead of a bare `60_000`. It became obsolete in rebase: the convergence rework
on master replaced the two-pass drive in both target tests with a single
`converge_stored_openmls_messages_at(…, u64::MAX)`, which is already self-documenting. The idea
still has a live target in `fork_detection.rs` (`2642`, `2961`), tracked separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Tests

* Updated the focused convergence regression to use the renamed record-write atomicity test.
* Refreshed test documentation and diagnostic labels to consistently reflect the record-write atomicity terminology.
* Existing coverage continues to validate that storage writes remain atomic during group, message, Welcome, and capability operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->