### PR TITLE
Replace live account projection snapshots with delta writes

### DIFF
--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -113,6 +113,15 @@ pub struct AppClient {
     /// persisted. Before this index existed, every inbound delivery and every
     /// publish-report batch rebuilt a `HashSet` from the full 16k-entry ring.
     pub(crate) seen_events_index: HashSet<String>,
+    /// Number of ids at the tail of `state.seen_events` observed since the last
+    /// successful account-projection checkpoint. The count saturates at the
+    /// bounded ring length, so even a catch-up batch larger than the window
+    /// persists only the final retained ids. It is cleared only after commit.
+    pub(crate) pending_seen_event_count: usize,
+    /// Exact group projections changed since the last successful checkpoint.
+    /// Live saves replace only these groups; full snapshot replacement is
+    /// reserved for import/rebuild paths outside the account worker.
+    pub(crate) pending_group_projection_updates: HashSet<String>,
     /// Group-system timeline rows synthesized during the most recent publish
     /// path. The runtime account worker drains this after each command and
     /// broadcasts `ProjectionUpdated` so live timeline subscriptions refresh.
@@ -870,7 +879,7 @@ impl AppClient {
         // into a false failure that invites the caller to create a duplicate.
         let local_projection_started_at = Instant::now();
         let local_projection_saved = match self.add_group(&group_id) {
-            Ok(()) => match self.app.save_state(&self.state) {
+            Ok(()) => match self.save_state_with_pending_local_group_deletion_frontier_clears() {
                 Ok(()) => true,
                 Err(error) => {
                     tracing::warn!(
@@ -1344,7 +1353,7 @@ impl AppClient {
             self.remember_published_reports(&effects);
             self.refresh_group(group_id);
             self.prune_plaintext_retention_for_group(group_id)?;
-            self.app.save_state(&self.state)?;
+            self.save_state_with_pending_local_group_deletion_frontier_clears()?;
             self.queue_own_group_system_projection_updates(&effects);
             Ok::<_, AppError>(())
         })();
@@ -1407,7 +1416,7 @@ impl AppClient {
         self.remember_published_reports(&effects);
         self.refresh_group(group_id);
         self.cleanup_stale_push_tokens_best_effort(group_id);
-        self.app.save_state(&self.state)?;
+        self.save_state_with_pending_local_group_deletion_frontier_clears()?;
         self.queue_own_group_system_projection_updates(&effects);
         Ok(send_summary_from_effects(&effects))
     }
@@ -1452,7 +1461,7 @@ impl AppClient {
         self.record_human_action_succeeded(group_id, &audit_context, &effects);
         self.remember_published_reports(&effects);
         self.refresh_group(group_id);
-        self.app.save_state(&self.state)?;
+        self.save_state_with_pending_local_group_deletion_frontier_clears()?;
         // Enabling lifecycle-v1 changes eligibility, not group history. It
         // intentionally emits no kind-1210 system row.
         Ok(send_summary_from_effects(&effects))
@@ -1500,7 +1509,7 @@ impl AppClient {
                 "durable disband request outpaced composer draft cleanup"
             );
         }
-        self.app.save_state(&self.state)?;
+        self.save_state_with_pending_local_group_deletion_frontier_clears()?;
         self.runtime
             .disband_request(group_id)?
             .map(Into::into)
@@ -1667,7 +1676,7 @@ impl AppClient {
         };
         self.record_human_action_succeeded(group_id, &audit_context, &effects);
         self.remember_published_reports(&effects);
-        self.app.save_state(&self.state)?;
+        self.save_state_with_pending_local_group_deletion_frontier_clears()?;
         self.queue_own_group_system_projection_updates(&effects);
         // A local leave / decline is a voluntary departure, recorded as `Left`
         // so the chat list can distinguish it from an involuntary removal. The
@@ -1870,7 +1879,7 @@ impl AppClient {
         self.record_human_action_succeeded(group_id, &audit_context, &effects);
         self.remember_published_reports(&effects);
         self.refresh_group(group_id);
-        self.app.save_state(&self.state)?;
+        self.save_state_with_pending_local_group_deletion_frontier_clears()?;
         self.queue_own_group_system_projection_updates(&effects);
         Ok(send_summary_from_effects(&effects))
     }
@@ -1906,7 +1915,7 @@ impl AppClient {
         self.remember_published_reports(&effects);
         self.refresh_group(group_id);
         self.prune_plaintext_retention_for_group(group_id)?;
-        self.app.save_state(&self.state)?;
+        self.save_state_with_pending_local_group_deletion_frontier_clears()?;
         self.queue_own_group_system_projection_updates(&effects);
         Ok(send_summary_from_effects(&effects))
     }
@@ -1976,7 +1985,7 @@ impl AppClient {
         self.record_human_action_succeeded(group_id, &audit_context, &effects);
         self.remember_published_reports(&effects);
         self.refresh_group(group_id);
-        self.app.save_state(&self.state)?;
+        self.save_state_with_pending_local_group_deletion_frontier_clears()?;
         self.queue_own_group_system_projection_updates(&effects);
         Ok(send_summary_from_effects(&effects))
     }
@@ -2020,7 +2029,7 @@ impl AppClient {
         self.record_human_action_succeeded(group_id, &audit_context, &effects);
         self.remember_published_reports(&effects);
         self.refresh_group(group_id);
-        self.app.save_state(&self.state)?;
+        self.save_state_with_pending_local_group_deletion_frontier_clears()?;
         self.queue_own_group_system_projection_updates(&effects);
         Ok(send_summary_from_effects(&effects))
     }
@@ -2687,7 +2696,7 @@ impl AppClient {
         self.remember_published_reports(&effects);
         let summary = send_summary_from_effects(&effects);
         self.refresh_group(group_id);
-        self.app.save_state(&self.state)?;
+        self.save_state_with_pending_local_group_deletion_frontier_clears()?;
         self.queue_own_group_system_projection_updates(&effects);
         Ok(summary)
     }
@@ -2897,7 +2906,7 @@ impl AppClient {
         self.pending_projection_updates.extend(finalize_updates);
         self.refresh_group(group_id);
         self.prune_plaintext_retention_for_group(group_id)?;
-        self.app.save_state(&self.state)?;
+        self.save_state_with_pending_local_group_deletion_frontier_clears()?;
         self.queue_own_group_system_projection_updates(&effects);
         Ok(send_summary_from_effects(&effects))
     }
@@ -2968,7 +2977,8 @@ impl AppClient {
             &projection,
             GroupConfirmationProjection::Preserve,
         );
-        self.app.save_state(&self.state)?;
+        self.mark_group_projection_dirty(group_id);
+        self.save_state_with_pending_local_group_deletion_frontier_clears()?;
         self.queue_own_group_system_projection_updates(&effects);
         Ok(SendSummary {
             published: effects.reports.len(),
@@ -3034,11 +3044,12 @@ impl AppClient {
         let previous = group.archived;
         group.archived = archived;
         let group = group.clone();
+        self.mark_group_projection_dirty_hex(group_id_hex.clone());
         // Roll the in-memory flag back if persistence fails so the worker's
         // authoritative snapshot stays consistent with what is on disk; a later
         // unrelated `save_state` must not silently re-apply a toggle the caller
         // was told had failed.
-        if let Err(err) = self.app.save_state(&self.state) {
+        if let Err(err) = self.save_state_with_pending_local_group_deletion_frontier_clears() {
             if let Some(group) = self
                 .state
                 .groups
@@ -3068,7 +3079,8 @@ impl AppClient {
         group.pending_confirmation = pending_confirmation;
         group.archived = archived;
         let group = group.clone();
-        self.app.save_state(&self.state)?;
+        self.mark_group_projection_dirty_hex(group_id_hex);
+        self.save_state_with_pending_local_group_deletion_frontier_clears()?;
         Ok(group)
     }
 
@@ -3310,8 +3322,11 @@ impl AppClient {
                 .has_pending_convergence_inputs(&group_id)
                 .unwrap_or(true)
                 && let Ok(group_record) = self.runtime.group_record(&group_id)
+                && group.prune_prior_nostr_routes(group_record.epoch.0)
             {
-                refresh.state_pruned |= group.prune_prior_nostr_routes(group_record.epoch.0);
+                self.pending_group_projection_updates
+                    .insert(group.group_id_hex.clone());
+                refresh.state_pruned = true;
             }
             let Ok(subscriptions) = group.transport_subscriptions(&group_id) else {
                 tracing::warn!(
@@ -3344,8 +3359,26 @@ impl AppClient {
         }
         for report in &effects.reports {
             let event_id = hex::encode(report.message_id.as_slice());
-            remember_seen_event(&mut self.seen_events_index, &mut self.state, event_id);
+            self.remember_seen_event(event_id);
         }
+    }
+
+    pub(crate) fn remember_seen_event(&mut self, event_id: String) {
+        if remember_seen_event(&mut self.seen_events_index, &mut self.state, event_id) {
+            self.pending_seen_event_count = self
+                .pending_seen_event_count
+                .saturating_add(1)
+                .min(self.state.seen_events.len());
+        }
+    }
+
+    pub(crate) fn mark_group_projection_dirty(&mut self, group_id: &GroupId) {
+        self.pending_group_projection_updates
+            .insert(hex::encode(group_id.as_slice()));
+    }
+
+    pub(crate) fn mark_group_projection_dirty_hex(&mut self, group_id_hex: String) {
+        self.pending_group_projection_updates.insert(group_id_hex);
     }
 
     /// Durably record welcomes a confirmed create/invite could not deliver, so

--- a/crates/marmot-app/src/client/projection.rs
+++ b/crates/marmot-app/src/client/projection.rs
@@ -217,6 +217,7 @@ impl AppClient {
                 Ok(false) => {}
             }
         }
+        let previous = self.state_group_record(group_id);
         let group_metadata = self.runtime.group_record(group_id).ok();
         let Ok(nostr_routing) = self.nostr_routing_for_group(group_id) else {
             return;
@@ -238,9 +239,13 @@ impl AppClient {
             &projection,
             GroupConfirmationProjection::Preserve,
         );
+        if previous != self.state_group_record(group_id) {
+            self.mark_group_projection_dirty(group_id);
+        }
     }
 
     pub(crate) fn add_group(&mut self, group_id: &GroupId) -> Result<(), AppError> {
+        let previous = self.state_group_record(group_id);
         let group_metadata = self.runtime.group_record(group_id).ok();
         let nostr_routing = self.nostr_routing_for_group(group_id)?;
         let projection = EventGroupProjection {
@@ -260,6 +265,9 @@ impl AppClient {
             &projection,
             GroupConfirmationProjection::Accepted,
         );
+        if previous != self.state_group_record(group_id) {
+            self.mark_group_projection_dirty(group_id);
+        }
         let group_id_hex = hex::encode(group_id.as_slice());
         let subscriptions = self
             .state
@@ -399,7 +407,12 @@ impl AppClient {
         else {
             return Ok(false);
         };
+        let previous_routes = group.prior_nostr_routes.clone();
         group.adopt_prior_nostr_routes(routes);
+        let changed = group.prior_nostr_routes != previous_routes;
+        if changed {
+            self.mark_group_projection_dirty_hex(group_id_hex);
+        }
         Ok(true)
     }
 
@@ -465,7 +478,10 @@ impl AppClient {
                 && let Ok(group) = self.runtime.group_record(&group_id)
             {
                 projected_group.member_count = u64::try_from(group.members.len()).ok();
-                changed |= projected_group.member_count.is_some();
+                if projected_group.member_count.is_some() {
+                    self.mark_group_projection_dirty_hex(group_id_hex);
+                    changed = true;
+                }
             }
         }
         Ok(changed)
@@ -476,7 +492,7 @@ impl AppClient {
     /// pipeline; eager clients call it before returning from open.
     pub(crate) fn reconcile_hydrated_account_state(&mut self) -> Result<(), AppError> {
         if self.reconcile_live_engine_groups()? {
-            self.app.save_state(&self.state)?;
+            self.save_state_with_pending_local_group_deletion_frontier_clears()?;
         }
         self.reconcile_disband_drafts();
         self.backfill_self_membership_once()

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -16,9 +16,9 @@ use crate::groups::{
 use crate::media::media_imeta_tags_are_valid;
 use crate::notifications;
 use crate::{
-    AppError, AppGroupAdminPolicyComponent, AppMessageProjection, AppPerformanceTelemetry,
-    SDK_DRAIN_WAIT, SDK_FIRST_SYNC_WAIT, SelfMembership, SyncFailure, SyncSummary,
-    TRANSPORT_CURSOR_MAX_FUTURE_SKEW, remember_seen_event, unix_now_seconds,
+    AccountState, AppError, AppGroupAdminPolicyComponent, AppMessageProjection,
+    AppPerformanceTelemetry, SDK_DRAIN_WAIT, SDK_FIRST_SYNC_WAIT, SelfMembership, SyncFailure,
+    SyncSummary, TRANSPORT_CURSOR_MAX_FUTURE_SKEW, unix_now_seconds,
 };
 use marmot_forensics::{
     AuditEventContext, EpochBackfillActivationOutcome, EpochBackfillDeferredReason,
@@ -449,6 +449,11 @@ impl AppClient {
             }
             let updated_group =
                 event_group_id(event).and_then(|group_id| self.state_group_record(group_id));
+            if previous_group != updated_group
+                && let Some(group_id) = event_group_id(event)
+            {
+                self.mark_group_projection_dirty(group_id);
+            }
             self.audit_observed_group_event(
                 event,
                 previous_group.as_ref(),
@@ -663,7 +668,7 @@ impl AppClient {
         // the catch-up drain below. Marking at receive time would let a failed
         // ingest poison the index, so a reused client would silently skip the
         // redelivered event.
-        remember_seen_event(&mut self.seen_events_index, &mut self.state, event_id);
+        self.remember_seen_event(event_id);
         // A membership-changing ingest is already durable. Persist its app
         // projection before route reconciliation or subscription refresh can
         // fail, matching the catch-up checkpoint below.
@@ -773,7 +778,7 @@ impl AppClient {
                         .await);
                 }
             };
-            remember_seen_event(&mut self.seen_events_index, &mut self.state, event_id);
+            self.remember_seen_event(event_id);
             *deliveries = (*deliveries).saturating_add(1);
             summary.merge(delivery_summary);
             routes_dirty |= delivery_routes_dirty;
@@ -1749,12 +1754,34 @@ impl AppClient {
             .iter()
             .cloned()
             .collect::<Vec<_>>();
+        let seen_start = self
+            .state
+            .seen_events
+            .len()
+            .saturating_sub(self.pending_seen_event_count);
+        let delta = AccountState {
+            label: self.state.label.clone(),
+            seen_events: self.state.seen_events[seen_start..].to_vec(),
+            last_transport_timestamp: self.state.last_transport_timestamp,
+            groups: self
+                .state
+                .groups
+                .iter()
+                .filter(|group| {
+                    self.pending_group_projection_updates
+                        .contains(&group.group_id_hex)
+                })
+                .cloned()
+                .collect(),
+        };
         self.app
-            .save_state_clearing_local_group_deletion_frontiers_and_acking_application_events(
-                &self.state,
+            .save_state_delta_clearing_local_group_deletion_frontiers_and_acking_application_events(
+                &delta,
                 &frontiers_to_clear,
                 &application_event_ids_to_ack,
             )?;
+        self.pending_seen_event_count = 0;
+        self.pending_group_projection_updates.clear();
         self.pending_local_group_deletion_frontier_clears.clear();
         self.pending_application_event_acks.clear();
         Ok(())
@@ -1878,6 +1905,11 @@ impl AppClient {
             }
             let updated_group =
                 event_group_id(event).and_then(|group_id| self.state_group_record(group_id));
+            if previous_group != updated_group
+                && let Some(group_id) = event_group_id(event)
+            {
+                self.mark_group_projection_dirty(group_id);
+            }
             self.audit_observed_group_event(
                 event,
                 previous_group.as_ref(),

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -777,12 +777,19 @@ pub struct AppProjectionUpdate {
 /// duplicate detection. The ordered `seen_events` Vec is kept only for pruning;
 /// when pruning drops the oldest ids it removes them from `seen` incrementally
 /// so the two stay in sync without rebuilding the set.
-fn remember_seen_event(seen: &mut HashSet<String>, state: &mut AccountState, event_id: String) {
+fn remember_seen_event(
+    seen: &mut HashSet<String>,
+    state: &mut AccountState,
+    event_id: String,
+) -> bool {
     if seen.insert(event_id.clone()) {
         state.seen_events.push(event_id);
         for pruned in prune_seen_events(&mut state.seen_events) {
             seen.remove(&pruned);
         }
+        true
+    } else {
+        false
     }
 }
 
@@ -1465,6 +1472,8 @@ impl MarmotApp {
             transport_signer: open.signer,
             state: open.state,
             seen_events_index,
+            pending_seen_event_count: 0,
+            pending_group_projection_updates: std::collections::HashSet::new(),
             pending_projection_updates: Vec::new(),
             pending_applied_sync_summary: SyncSummary::default(),
             pending_failed_sync_summary: SyncSummary::default(),
@@ -2842,7 +2851,16 @@ impl MarmotApp {
             .ok_or_else(|| AppError::UnknownGroup(group_id_hex.to_owned()))?;
         group.archived = archived;
         let group = group.clone();
-        self.save_state(&state)?;
+        self.save_state_delta_clearing_local_group_deletion_frontiers_and_acking_application_events(
+            &AccountState {
+                label: state.label,
+                seen_events: Vec::new(),
+                last_transport_timestamp: state.last_transport_timestamp,
+                groups: vec![group.clone()],
+            },
+            &[],
+            &[],
+        )?;
         Ok(group)
     }
 
@@ -4017,31 +4035,30 @@ impl MarmotApp {
     /// it — bounded exposure, ~180s beyond the 120s
     /// `APP_RUNTIME_RELAY_REBUILD_LOOKBACK`. A deliberate cursor reset must be
     /// a dedicated named API; a raw save cannot lower the merged value.
+    #[cfg(test)]
     fn save_state(&self, state: &AccountState) -> Result<(), AppError> {
-        self.save_state_clearing_local_group_deletion_frontiers(state, &[])
+        self.account_storage(&state.label)?
+            .save_account_projection_state(
+                &stored_state_from_account_state(state),
+                MAX_SEEN_EVENT_IDS,
+                TRANSPORT_CURSOR_MAX_FUTURE_SKEW.as_secs(),
+            )?;
+        self.chat_list_projection_stale
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(state.label.clone());
+        Ok(())
     }
 
-    fn save_state_clearing_local_group_deletion_frontiers(
+    fn save_state_delta_clearing_local_group_deletion_frontiers_and_acking_application_events(
         &self,
-        state: &AccountState,
-        frontiers_to_clear: &[(String, u64)],
-    ) -> Result<(), AppError> {
-        self.save_state_clearing_local_group_deletion_frontiers_and_acking_application_events(
-            state,
-            frontiers_to_clear,
-            &[],
-        )
-    }
-
-    fn save_state_clearing_local_group_deletion_frontiers_and_acking_application_events(
-        &self,
-        state: &AccountState,
+        delta: &AccountState,
         frontiers_to_clear: &[(String, u64)],
         application_event_ids_to_ack: &[MessageId],
     ) -> Result<(), AppError> {
-        self.account_storage(&state.label)?
-            .save_account_projection_state_clearing_local_group_deletion_frontiers_and_acking_application_events(
-                &stored_state_from_account_state(state),
+        self.account_storage(&delta.label)?
+            .save_account_projection_delta_clearing_local_group_deletion_frontiers_and_acking_application_events(
+                &stored_state_from_account_state(delta),
                 MAX_SEEN_EVENT_IDS,
                 TRANSPORT_CURSOR_MAX_FUTURE_SKEW.as_secs(),
                 frontiers_to_clear,
@@ -4050,7 +4067,7 @@ impl MarmotApp {
         self.chat_list_projection_stale
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .insert(state.label.clone());
+            .insert(delta.label.clone());
         Ok(())
     }
 

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -1220,6 +1220,54 @@ where
 }
 
 #[test]
+fn live_group_archive_checkpoints_seen_and_target_group_deltas() {
+    run_composed_app_runtime_test("account-projection-delta", || async {
+        let dir = tempfile::tempdir().unwrap();
+        AccountHome::open(dir.path())
+            .create_account("alice")
+            .unwrap();
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+            .with_test_relay_client(Arc::new(ScriptedPushRelayClient::default()));
+        let mut client = app.client("alice").await.unwrap();
+        let alpha = client.create_group("alpha", &[]).await.unwrap();
+        let beta = client.create_group("beta", &[]).await.unwrap();
+
+        client.state.seen_events = (0..256).map(|index| format!("event-{index:05}")).collect();
+        client.seen_events_index = client.state.seen_events.iter().cloned().collect();
+        client.pending_seen_event_count = 0;
+        app.save_state(&client.state).unwrap();
+
+        client.remember_seen_event("event-new".to_owned());
+        client.set_group_archived(&alpha, true).unwrap();
+
+        assert_eq!(client.pending_seen_event_count, 0);
+        assert!(client.pending_group_projection_updates.is_empty());
+        let restored = app.load_state("alice").unwrap();
+        assert_eq!(restored.seen_events.len(), 257);
+        assert_eq!(
+            restored.seen_events.last().map(String::as_str),
+            Some("event-new")
+        );
+        assert!(
+            restored
+                .groups
+                .iter()
+                .find(|group| group.group_id_hex == hex::encode(alpha.as_slice()))
+                .unwrap()
+                .archived
+        );
+        assert!(
+            !restored
+                .groups
+                .iter()
+                .find(|group| group.group_id_hex == hex::encode(beta.as_slice()))
+                .unwrap()
+                .archived
+        );
+    });
+}
+
+#[test]
 fn account_session_guard_is_exclusive_until_client_drop() {
     run_composed_app_runtime_test("account-session-guard", || async {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/storage-sqlite/src/account_projection.rs
+++ b/crates/storage-sqlite/src/account_projection.rs
@@ -606,6 +606,53 @@ impl SqliteAccountStorage {
         frontiers_to_clear: &[(String, u64)],
         application_event_ids_to_ack: &[MessageId],
     ) -> StorageResult<()> {
+        self.save_account_projection(
+            state,
+            max_seen_events,
+            max_future_skew_secs,
+            frontiers_to_clear,
+            application_event_ids_to_ack,
+            true,
+        )
+    }
+
+    /// Apply an exact account-projection delta.
+    ///
+    /// Unlike [`Self::save_account_projection_state`], this does not interpret
+    /// `groups` as the complete retained group snapshot and therefore never
+    /// deletes groups absent from `state.groups`. Each supplied group is a full
+    /// replacement for that one group's projection/component set, while
+    /// `seen_events` contains only event ids observed since the last successful
+    /// checkpoint. Cursor merge, local-deletion frontier clears, group updates,
+    /// seen-event observations, and application-event acknowledgements remain
+    /// atomic in the same transaction.
+    pub fn save_account_projection_delta_clearing_local_group_deletion_frontiers_and_acking_application_events(
+        &self,
+        state: &StoredAccountState,
+        max_seen_events: usize,
+        max_future_skew_secs: u64,
+        frontiers_to_clear: &[(String, u64)],
+        application_event_ids_to_ack: &[MessageId],
+    ) -> StorageResult<()> {
+        self.save_account_projection(
+            state,
+            max_seen_events,
+            max_future_skew_secs,
+            frontiers_to_clear,
+            application_event_ids_to_ack,
+            false,
+        )
+    }
+
+    fn save_account_projection(
+        &self,
+        state: &StoredAccountState,
+        max_seen_events: usize,
+        max_future_skew_secs: u64,
+        frontiers_to_clear: &[(String, u64)],
+        application_event_ids_to_ack: &[MessageId],
+        replace_group_snapshot: bool,
+    ) -> StorageResult<()> {
         let now = unix_now_seconds();
         let now_i64 = i64::try_from(now).unwrap_or(i64::MAX);
         self.connection.with_transaction(|| {
@@ -652,28 +699,43 @@ impl SqliteAccountStorage {
             .storage()?;
 
             let retained_start = state.seen_events.len().saturating_sub(max_seen_events);
+            let mut inserted_seen_event = false;
             for event_id in &state.seen_events[retained_start..] {
-                conn.execute(
-                    "INSERT INTO seen_events (event_id, seen_at)
-                     VALUES (?1, ?2)
-                     ON CONFLICT(event_id) DO UPDATE SET
-                        seen_at = excluded.seen_at",
+                let inserted = conn.execute(
+                    "INSERT OR IGNORE INTO seen_events (event_id, seen_at)
+                     VALUES (?1, ?2)",
                     params![event_id, now_i64],
                 )
                 .storage()?;
+                if inserted == 0 {
+                    conn.execute(
+                        "UPDATE seen_events SET seen_at = ?2 WHERE event_id = ?1",
+                        params![event_id, now_i64],
+                    )
+                    .storage()?;
+                } else {
+                    inserted_seen_event = true;
+                }
             }
-            conn.execute(
-                "DELETE FROM seen_events
-                 WHERE event_id NOT IN (
-                    SELECT event_id FROM seen_events
-                    ORDER BY seen_at DESC, rowid DESC
-                    LIMIT ?1
-                 )",
-                params![usize_to_i64(max_seen_events)?],
-            )
-            .storage()?;
+            // A delta containing only refreshes cannot grow the table, so it
+            // needs no prune. Full snapshot writes retain the historical
+            // max-bound enforcement even when the supplied snapshot is empty.
+            if replace_group_snapshot || inserted_seen_event {
+                conn.execute(
+                    "DELETE FROM seen_events
+                     WHERE event_id NOT IN (
+                        SELECT event_id FROM seen_events
+                        ORDER BY seen_at DESC, rowid DESC
+                        LIMIT ?1
+                     )",
+                    params![usize_to_i64(max_seen_events)?],
+                )
+                .storage()?;
+            }
 
-            let locally_deleted_group_ids = {
+            let locally_deleted_group_ids = if state.groups.is_empty() {
+                std::collections::HashSet::new()
+            } else {
                 let mut statement = conn
                     .prepare("SELECT group_id_hex FROM local_group_deletion_frontiers")
                     .storage()?;
@@ -696,19 +758,21 @@ impl SqliteAccountStorage {
             // projection/chat-list reads while its draft exists. Once the draft
             // is deleted, the next save selects the group as a candidate and
             // cleans it up normally.
-            delete_stale_text_keys(
-                &conn,
-                "SELECT group_id_hex
-                 FROM account_groups
-                 WHERE NOT EXISTS (
-                    SELECT 1 FROM message_drafts
-                    WHERE message_drafts.group_id_hex = account_groups.group_id_hex
-                 )",
-                &[],
-                "DELETE FROM account_groups WHERE group_id_hex IN",
-                &[],
-                &retained_group_ids,
-            )?;
+            if replace_group_snapshot {
+                delete_stale_text_keys(
+                    &conn,
+                    "SELECT group_id_hex
+                     FROM account_groups
+                     WHERE NOT EXISTS (
+                        SELECT 1 FROM message_drafts
+                        WHERE message_drafts.group_id_hex = account_groups.group_id_hex
+                     )",
+                    &[],
+                    "DELETE FROM account_groups WHERE group_id_hex IN",
+                    &[],
+                    &retained_group_ids,
+                )?;
+            }
 
             for group in state
                 .groups

--- a/crates/storage-sqlite/src/account_projection/tests.rs
+++ b/crates/storage-sqlite/src/account_projection/tests.rs
@@ -877,6 +877,167 @@ fn account_projection_state_does_not_rewrite_unchanged_group_rows() {
 }
 
 #[test]
+fn account_projection_delta_writes_only_observations_and_changed_groups() {
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    let seen_events = (0..64)
+        .map(|index| format!("event-{index:05}"))
+        .collect::<Vec<_>>();
+    store
+        .save_account_projection_state(
+            &StoredAccountState {
+                label: "alice".to_owned(),
+                seen_events,
+                last_transport_timestamp: None,
+                groups: vec![group("aa", "alpha"), group("bb", "beta")],
+            },
+            64,
+            MAX_FUTURE_SKEW_SECS,
+        )
+        .unwrap();
+    {
+        let conn = store.lock().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE write_audit (write_kind TEXT NOT NULL);
+             CREATE TRIGGER audit_seen_insert AFTER INSERT ON seen_events BEGIN
+                INSERT INTO write_audit VALUES ('seen_insert');
+             END;
+             CREATE TRIGGER audit_seen_update AFTER UPDATE ON seen_events BEGIN
+                INSERT INTO write_audit VALUES ('seen_update');
+             END;
+             CREATE TRIGGER audit_seen_delete AFTER DELETE ON seen_events BEGIN
+                INSERT INTO write_audit VALUES ('seen_delete');
+             END;
+             CREATE TRIGGER audit_group_insert AFTER INSERT ON account_groups BEGIN
+                INSERT INTO write_audit VALUES ('group_insert');
+             END;
+             CREATE TRIGGER audit_group_update AFTER UPDATE ON account_groups BEGIN
+                INSERT INTO write_audit VALUES ('group_update');
+             END;
+             CREATE TRIGGER audit_group_delete AFTER DELETE ON account_groups BEGIN
+                INSERT INTO write_audit VALUES ('group_delete');
+             END;
+             CREATE TRIGGER audit_component_insert
+             AFTER INSERT ON account_group_app_components BEGIN
+                INSERT INTO write_audit VALUES ('component_insert');
+             END;
+             CREATE TRIGGER audit_component_update
+             AFTER UPDATE ON account_group_app_components BEGIN
+                INSERT INTO write_audit VALUES ('component_update');
+             END;
+             CREATE TRIGGER audit_component_delete
+             AFTER DELETE ON account_group_app_components BEGIN
+                INSERT INTO write_audit VALUES ('component_delete');
+             END;",
+        )
+        .unwrap();
+    }
+
+    let mut changed_group = group("bb", "beta updated");
+    changed_group.components[1].component_data_hex = "0506".to_owned();
+    store
+        .save_account_projection_delta_clearing_local_group_deletion_frontiers_and_acking_application_events(
+            &StoredAccountState {
+                label: "alice".to_owned(),
+                seen_events: vec!["event-new-a".to_owned(), "event-new-b".to_owned()],
+                last_transport_timestamp: None,
+                groups: vec![changed_group],
+            },
+            64,
+            MAX_FUTURE_SKEW_SECS,
+            &[],
+            &[],
+        )
+        .unwrap();
+
+    let write_count = |kind: &str| -> i64 {
+        store
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT count(*) FROM write_audit WHERE write_kind = ?1",
+                params![kind],
+                |row| row.get(0),
+            )
+            .unwrap()
+    };
+    assert_eq!(write_count("seen_insert"), 2);
+    assert_eq!(write_count("seen_update"), 0);
+    assert_eq!(write_count("seen_delete"), 2);
+    assert_eq!(write_count("group_insert"), 0);
+    assert_eq!(write_count("group_update"), 1);
+    assert_eq!(write_count("group_delete"), 0);
+    assert_eq!(write_count("component_insert"), 0);
+    assert_eq!(write_count("component_update"), 1);
+    assert_eq!(write_count("component_delete"), 0);
+
+    let restored = store.load_account_projection_state("alice", 64).unwrap();
+    assert_eq!(restored.seen_events.len(), 64);
+    assert_eq!(
+        &restored.seen_events[62..],
+        &["event-new-a".to_owned(), "event-new-b".to_owned()]
+    );
+    assert_eq!(
+        restored.groups.len(),
+        2,
+        "delta must not prune absent groups"
+    );
+    assert_eq!(restored.groups[0].profile_name, "alpha");
+    assert_eq!(restored.groups[1].profile_name, "beta updated");
+
+    store
+        .lock()
+        .unwrap()
+        .execute("DELETE FROM write_audit", [])
+        .unwrap();
+    store
+        .save_account_projection_delta_clearing_local_group_deletion_frontiers_and_acking_application_events(
+            &StoredAccountState {
+                label: "alice".to_owned(),
+                seen_events: vec!["event-00063".to_owned()],
+                last_transport_timestamp: None,
+                groups: Vec::new(),
+            },
+            64,
+            MAX_FUTURE_SKEW_SECS,
+            &[],
+            &[],
+        )
+        .unwrap();
+    assert_eq!(write_count("seen_insert"), 0);
+    assert_eq!(write_count("seen_update"), 1);
+    assert_eq!(write_count("seen_delete"), 0);
+
+    store
+        .lock()
+        .unwrap()
+        .execute("DELETE FROM write_audit", [])
+        .unwrap();
+    let mut archived_group = group("aa", "alpha");
+    archived_group.archived = true;
+    store
+        .save_account_projection_delta_clearing_local_group_deletion_frontiers_and_acking_application_events(
+            &StoredAccountState {
+                label: "alice".to_owned(),
+                seen_events: Vec::new(),
+                last_transport_timestamp: None,
+                groups: vec![archived_group],
+            },
+            64,
+            MAX_FUTURE_SKEW_SECS,
+            &[],
+            &[],
+        )
+        .unwrap();
+    assert_eq!(write_count("seen_insert"), 0);
+    assert_eq!(write_count("seen_update"), 0);
+    assert_eq!(write_count("seen_delete"), 0);
+    assert_eq!(write_count("group_update"), 1);
+    assert_eq!(write_count("component_insert"), 0);
+    assert_eq!(write_count("component_update"), 0);
+    assert_eq!(write_count("component_delete"), 0);
+}
+
+#[test]
 fn app_messages_list_raw_events_and_prune_updates_timeline() {
     let store = SqliteAccountStorage::in_memory().unwrap();
     store
@@ -2338,7 +2499,7 @@ fn failed_resurrection_projection_save_retains_local_deletion_frontier() {
         )
         .unwrap();
 
-    let result = store.save_account_projection_state_clearing_local_group_deletion_frontiers_and_acking_application_events(
+    let result = store.save_account_projection_delta_clearing_local_group_deletion_frontiers_and_acking_application_events(
         &StoredAccountState {
             label: "alice".to_owned(),
             seen_events: Vec::new(),


### PR DESCRIPTION
## Summary

- track newly observed seen-event IDs and changed group projections between successful checkpoints
- persist exact account-projection deltas instead of re-saving the complete retained account snapshot
- keep cursor updates, deletion-frontier clears, application-event acknowledgements, seen-event observations, and group updates atomic
- reserve full snapshot replacement for import and rebuild paths

## Root cause

Live account operations passed the full in-memory account projection to SQLite. Once the dedup window reached 16,384 entries, every inbound event refreshed every retained `seen_events` row. The same transaction also walked every retained group and component, even when accepting an invite or toggling an archive flag changed only one group.

## Behavior

The account worker now retains a bounded unsaved suffix of seen-event IDs and the exact set of changed group projections. A successful checkpoint clears those pending deltas; a failed checkpoint retains them for retry. SQLite applies supplied groups as per-group full replacements without deleting absent groups, and runs seen-event pruning only when a new row can grow the table.

Regression coverage uses SQLite write-audit triggers to prove that:

- two new observations write only two seen-event rows and prune to the bound
- refreshing one observed ID stays O(1)
- changing one group/component does not touch sibling groups
- a group-only archive checkpoint writes no seen-event rows
- the app worker checkpoints the pending seen suffix and target group together

## Validation

- `just fast-ci`
- `cargo test -p storage-sqlite account_projection_delta_writes_only_observations_and_changed_groups`
- `cargo test -p marmot-app live_group_archive_checkpoints_seen_and_target_group_deltas`
- full local crate suites during development: 374 storage tests passed with 2 ignored; all 645 marmot-app library tests passed

A broader relay-runtime run exposed five failures that were reproduced unchanged on the then-current untouched base, so they are not regressions from this patch.

Fixes #774

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved account state saving by persisting only changed groups and newly seen events.
  * Reduced unnecessary database updates during routine synchronization and refreshes.

* **Reliability**
  * Preserved unaffected group data during incremental saves.
  * Improved handling of archived groups, membership changes, and route updates.

* **Bug Fixes**
  * Ensured seen-event history and group projections remain consistent after concurrent updates.
  * Added safeguards against stale or incorrectly removed group data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->