### PR TITLE
fix(marmot-app): skip duplicate SQLCipher KDF probe on steady-state opens

### DIFF
--- a/crates/marmot-app/AGENTS.md
+++ b/crates/marmot-app/AGENTS.md
@@ -37,7 +37,7 @@ App runtime bridge for the first real Marmot app surfaces.
   validation/resolution/removal, and HTTP upload. Audit-log unit tests live in its own `#[cfg(test)] mod tests`.
 - Keep SQLCipher key derivation, per-database salt persistence, legacy-key migration/recovery, and the in-process
   v2-open probe-verdict cache (mdk#1439) in `src/sqlcipher.rs`. The verdict cache is advisory only: a durable
-  migration marker or a missing verdict always re-runs the recovery probe, so the #219 crash windows keep their
+  migration marker or a missing verdict always re-runs the recovery probe, so the mdk#568 crash windows keep their
   self-heal. Key presentation and the passphrase KDF work factor follow the decision record in
   `docs/marmot-architecture/storage-format-v2.md`.
 - Keep the user-directory domain in the `src/directory/` module instead of regrowing `src/lib.rs`. It splits along these

--- a/crates/marmot-app/AGENTS.md
+++ b/crates/marmot-app/AGENTS.md
@@ -35,6 +35,11 @@ App runtime bridge for the first real Marmot app surfaces.
 - Keep the forensic audit-log feature in `src/audit_log.rs`: the `AuditLog*` DTOs, salted-hash identity derivation,
   the upload client, and the `MarmotApp` methods for audit settings, recorder open/build, file enumeration, path
   validation/resolution/removal, and HTTP upload. Audit-log unit tests live in its own `#[cfg(test)] mod tests`.
+- Keep SQLCipher key derivation, per-database salt persistence, legacy-key migration/recovery, and the in-process
+  v2-open probe-verdict cache (mdk#1439) in `src/sqlcipher.rs`. The verdict cache is advisory only: a durable
+  migration marker or a missing verdict always re-runs the recovery probe, so the #219 crash windows keep their
+  self-heal. Key presentation and the passphrase KDF work factor follow the decision record in
+  `docs/marmot-architecture/storage-format-v2.md`.
 - Keep the user-directory domain in the `src/directory/` module instead of regrowing `src/lib.rs`. It splits along these
   seams: `records.rs` (the public `UserDirectory*`/`UserProfileMetadata`/`DirectoryKeyPackage` DTOs surfaced to
   `marmot-uniffi`/`cli`, plus the stateless record helpers — cached <-> shared record conversion, recency selection,

--- a/crates/marmot-app/src/app_telemetry.rs
+++ b/crates/marmot-app/src/app_telemetry.rs
@@ -109,6 +109,17 @@ pub struct AppPerformanceSnapshot {
     pub account_catch_up: AppPerformanceOperationSnapshot,
     pub account_sync: AppPerformanceOperationSnapshot,
     pub account_setup_advisory_step: AppPerformanceOperationSnapshot,
+    /// Interrupted-migration recovery probes executed since process start. Each
+    /// probe is a full keyed SQLCipher open paying the passphrase KDF; the
+    /// healthy steady state skips it via the cached v2-open verdict (mdk#1439).
+    /// Process-wide aggregate: no account, path, or key information.
+    #[serde(default)]
+    pub sqlcipher_migration_probe_runs: u64,
+    /// Existing-database opens that skipped the recovery probe via a cached
+    /// v2-open verdict since process start. Each skip avoided one full
+    /// passphrase KDF derivation (mdk#1439).
+    #[serde(default)]
+    pub sqlcipher_migration_probe_skips: u64,
     pub outbound_message_send: AppPerformanceOperationSnapshot,
     #[serde(default)]
     pub group_create_queue_wait: AppPerformanceOperationSnapshot,
@@ -453,6 +464,8 @@ impl AppPerformanceTelemetry {
             .inner
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let (sqlcipher_migration_probe_runs, sqlcipher_migration_probe_skips) =
+            crate::sqlcipher::sqlcipher_migration_probe_counters();
         AppPerformanceSnapshot {
             app_start: inner.app_start.snapshot(),
             directory_subscription_sync: inner.directory_subscription_sync.snapshot(),
@@ -467,6 +480,8 @@ impl AppPerformanceTelemetry {
             account_catch_up: inner.account_catch_up.snapshot(),
             account_sync: inner.account_sync.snapshot(),
             account_setup_advisory_step: inner.account_setup_advisory_step.snapshot(),
+            sqlcipher_migration_probe_runs,
+            sqlcipher_migration_probe_skips,
             outbound_message_send: inner.outbound_message_send.snapshot(),
             group_create_queue_wait: inner.group_create_queue_wait.snapshot(),
             group_create_key_package_lookup: inner.group_create_key_package_lookup.snapshot(),
@@ -726,5 +741,21 @@ mod tests {
         assert_eq!(snapshot.account_setup_advisory_step.attempts, 1);
         assert_eq!(snapshot.account_setup_advisory_step.successes, 0);
         assert_eq!(snapshot.account_setup_advisory_step.failures, 1);
+    }
+
+    #[test]
+    fn snapshot_carries_the_process_wide_sqlcipher_probe_counters() {
+        // The counters are process-global atomics shared with every test in
+        // this process, so bracket the snapshot between two direct reads
+        // instead of asserting exact values.
+        let telemetry = AppPerformanceTelemetry::default();
+        let before = crate::sqlcipher::sqlcipher_migration_probe_counters();
+        let snapshot = telemetry.snapshot();
+        let after = crate::sqlcipher::sqlcipher_migration_probe_counters();
+
+        assert!(before.0 <= snapshot.sqlcipher_migration_probe_runs);
+        assert!(snapshot.sqlcipher_migration_probe_runs <= after.0);
+        assert!(before.1 <= snapshot.sqlcipher_migration_probe_skips);
+        assert!(snapshot.sqlcipher_migration_probe_skips <= after.1);
     }
 }

--- a/crates/marmot-app/src/relay_telemetry_export.rs
+++ b/crates/marmot-app/src/relay_telemetry_export.rs
@@ -188,6 +188,12 @@ pub mod metric_names {
         "app_account_setup_advisory_step_successes";
     pub const APP_ACCOUNT_SETUP_ADVISORY_STEP_FAILURES: &str =
         "app_account_setup_advisory_step_failures";
+    /// Interrupted-migration recovery probes executed (each is one full keyed
+    /// SQLCipher open paying the passphrase KDF, mdk#1439).
+    pub const APP_SQLCIPHER_MIGRATION_PROBE_RUNS: &str = "app_sqlcipher_migration_probe_runs";
+    /// Existing-database opens that skipped the recovery probe via a cached
+    /// v2-open verdict (each avoided one passphrase KDF derivation, mdk#1439).
+    pub const APP_SQLCIPHER_MIGRATION_PROBE_SKIPS: &str = "app_sqlcipher_migration_probe_skips";
     /// One-sided outbound message send duration histogram.
     pub const APP_OUTBOUND_MESSAGE_SEND_DURATION: &str = "app_outbound_message_send_duration_ms";
     /// One-sided outbound message send attempts.
@@ -1001,6 +1007,25 @@ fn append_app_performance_points(
         metric_names::APP_HOST_FOREGROUND_LOCAL_READY_SUCCESSES,
         metric_names::APP_HOST_FOREGROUND_LOCAL_READY_FAILURES,
     );
+    // Process-wide SQLCipher probe counters (mdk#1439): runs are keyed opens
+    // paying the passphrase KDF, skips are KDF derivations avoided via cached
+    // verdicts. Population-level only, no labels.
+    for (name, value) in [
+        (
+            metric_names::APP_SQLCIPHER_MIGRATION_PROBE_RUNS,
+            app_performance.sqlcipher_migration_probe_runs,
+        ),
+        (
+            metric_names::APP_SQLCIPHER_MIGRATION_PROBE_SKIPS,
+            app_performance.sqlcipher_migration_probe_skips,
+        ),
+    ] {
+        points.push(ExportMetricPoint {
+            name,
+            relay: None,
+            value: ExportMetricValue::Counter(value),
+        });
+    }
 }
 
 fn append_app_operation_points(

--- a/crates/marmot-app/src/relay_telemetry_export/tests.rs
+++ b/crates/marmot-app/src/relay_telemetry_export/tests.rs
@@ -254,6 +254,8 @@ fn build_export_batch_appends_unlabeled_app_performance_metrics() {
             failures: 1,
             duration_ms: hist(3),
         },
+        sqlcipher_migration_probe_runs: 7,
+        sqlcipher_migration_probe_skips: 42,
         ..Default::default()
     };
     let batch = build_export_batch_with_app_performance(
@@ -304,6 +306,16 @@ fn build_export_batch_appends_unlabeled_app_performance_metrics() {
     assert!(batch.points.iter().any(|point| {
         point.name == metric_names::APP_GROUP_DETAILS_READ_ATTEMPTS
             && point.value == ExportMetricValue::Counter(2)
+    }));
+    assert!(batch.points.iter().any(|point| {
+        point.name == metric_names::APP_SQLCIPHER_MIGRATION_PROBE_RUNS
+            && point.relay.is_none()
+            && point.value == ExportMetricValue::Counter(7)
+    }));
+    assert!(batch.points.iter().any(|point| {
+        point.name == metric_names::APP_SQLCIPHER_MIGRATION_PROBE_SKIPS
+            && point.relay.is_none()
+            && point.value == ExportMetricValue::Counter(42)
     }));
     for metric_name in [
         metric_names::APP_GROUP_CREATE_QUEUE_WAIT_DURATION,

--- a/crates/marmot-app/src/sqlcipher.rs
+++ b/crates/marmot-app/src/sqlcipher.rs
@@ -12,7 +12,7 @@
 //! a successful "this database opens under the v2 key" verdict is cached
 //! in-process per database file and salt (mdk#1439). The cache is advisory
 //! only: a durable migration marker or a missing verdict always re-runs the
-//! recovery probe, so the crash windows keep the #219 self-heal. Key
+//! recovery probe, so the crash windows keep the mdk#568 self-heal. Key
 //! presentation (passphrase vs raw key) and the KDF work factor are unchanged;
 //! that decision is recorded in
 //! `docs/marmot-architecture/storage-format-v2.md`.
@@ -67,7 +67,7 @@ static SQLCIPHER_MIGRATION_PROBE_SKIPS: AtomicU64 = AtomicU64::new(0);
 ///   fresh-database path, where no database file has been observed yet.
 /// - A durable migration marker always forces the probe, verdict or not: the
 ///   marker means a migration may have been interrupted, and those crash
-///   windows must keep the #219 self-heal.
+///   windows must keep the mdk#568 self-heal.
 /// - A cache miss, an invalidated entry, or any doubt means probe. Eviction
 ///   and removal-invalidation only ever cause an *extra* probe.
 static SQLCIPHER_V2_VERDICTS: LazyLock<Mutex<SqlcipherV2VerdictCache>> =
@@ -301,7 +301,7 @@ impl MarmotApp {
             //   * a marker is present — an interrupted migration started by the
             //     crash-safe path below, or
             //   * NO marker is present, but the database is still legacy-keyed —
-            //     the pre-fix #219 bricked state, where the salt was written
+            //     the pre-fix mdk#568 bricked state, where the salt was written
             //     before the rekey and the process crashed in between. No marker
             //     was written back then, so a marker check alone never recovers
             //     these already-bricked accounts.
@@ -313,7 +313,7 @@ impl MarmotApp {
             //
             // The probe must run whenever the migration marker exists or this
             // process has not yet established that this database opens under
-            // the v2 key for this salt — those are the crash windows the #219
+            // the v2 key for this salt — those are the crash windows the mdk#568
             // self-heal exists for. Once a verdict has been established, the
             // healthy steady-state path skips the probe so a repeated open of
             // the same database pays the SQLCipher KDF once, not twice
@@ -884,7 +884,7 @@ mod tests {
 
     #[test]
     fn sqlcipher_recovers_pre_fix_bricked_db_with_salt_present_no_marker() {
-        // The pre-fix #219 bricked state: the vulnerable code wrote the salt to
+        // The pre-fix mdk#568 bricked state: the vulnerable code wrote the salt to
         // disk and then crashed before `PRAGMA rekey` committed, so the database
         // is still legacy-keyed. Crucially that code never wrote a migration
         // marker, so the salt-present branch sees `.salt` with NO `.salt-migrating`
@@ -1072,7 +1072,7 @@ mod tests {
         // mdk#1439 acceptance: a durable migration marker always forces the
         // recovery probe, even when a verdict for this database+salt is already
         // cached — the marker means a migration may have been interrupted, and
-        // those crash windows keep the #219 self-heal.
+        // those crash windows keep the mdk#568 self-heal.
         let dir = tempfile::tempdir().unwrap();
         let home = AccountHome::open(dir.path());
         home.create_account("alice").unwrap();

--- a/crates/marmot-app/src/sqlcipher.rs
+++ b/crates/marmot-app/src/sqlcipher.rs
@@ -5,10 +5,24 @@
 //! v2 key derivation, the legacy (v1) key derivation kept for migration, the
 //! crash-safe salt-write/rekey sequence, and recovery for interrupted or
 //! pre-fix bricked migrations.
+//!
+//! Every one of those recovery opens pays the full SQLCipher passphrase KDF
+//! (PBKDF2-HMAC-SHA512, 256k iterations at the pinned `cipher_compatibility =
+//! 4`). To keep the healthy steady state from paying that KDF twice per open,
+//! a successful "this database opens under the v2 key" verdict is cached
+//! in-process per database file and salt (mdk#1439). The cache is advisory
+//! only: a durable migration marker or a missing verdict always re-runs the
+//! recovery probe, so the crash windows keep the #219 self-heal. Key
+//! presentation (passphrase vs raw key) and the KDF work factor are unchanged;
+//! that decision is recorded in
+//! `docs/marmot-architecture/storage-format-v2.md`.
 
+use std::collections::{HashMap, VecDeque};
 use std::fs::{self, File, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{LazyLock, Mutex};
 
 use hkdf::Hkdf;
 use rand::RngCore;
@@ -25,6 +39,143 @@ const SQLCIPHER_SALT_SUFFIX: &str = ".salt";
 const SQLCIPHER_MIGRATION_MARKER_SUFFIX: &str = ".salt-migrating";
 const SQLCIPHER_SALT_LEN: usize = 32;
 const SQLCIPHER_KEY_LEN: usize = 32;
+
+/// Bound on the in-process v2-open verdict cache. Three databases per account
+/// (session, account projection, directory cache), so this covers ~85 accounts
+/// per process; overflow evicts oldest-first and an evicted entry simply pays
+/// one recovery probe on its next open. Tracked per the long-lived-state
+/// discipline in `docs/marmot-architecture/runtime-state-bounds.md`.
+const SQLCIPHER_V2_VERDICT_CACHE_CAPACITY: usize = 256;
+
+/// Aggregate, privacy-safe counters for the opt-in app-performance export:
+/// every run of the interrupted-migration probe is one full keyed open paying
+/// the SQLCipher passphrase KDF, and every skip is one KDF avoided via a
+/// cached verdict (mdk#1439). Counts only — no paths, accounts, or keys.
+static SQLCIPHER_MIGRATION_PROBE_RUNS: AtomicU64 = AtomicU64::new(0);
+static SQLCIPHER_MIGRATION_PROBE_SKIPS: AtomicU64 = AtomicU64::new(0);
+
+/// Process-local cache of probe verdicts: database file -> salt whose derived
+/// v2 key was *observed* to open that database earlier in this process (a
+/// successful probe, or a legacy -> v2 rekey this process performed). A verdict
+/// lets the healthy steady-state path skip the recovery probe — a full second
+/// keyed open that pays the same 256k-iteration passphrase KDF as the real open
+/// (mdk#1439).
+///
+/// Safety rules:
+/// - A verdict is recorded only after the database at that path was observed
+///   opening under the v2 key derived from that exact salt. Never on the
+///   fresh-database path, where no database file has been observed yet.
+/// - A durable migration marker always forces the probe, verdict or not: the
+///   marker means a migration may have been interrupted, and those crash
+///   windows must keep the #219 self-heal.
+/// - A cache miss, an invalidated entry, or any doubt means probe. Eviction
+///   and removal-invalidation only ever cause an *extra* probe.
+static SQLCIPHER_V2_VERDICTS: LazyLock<Mutex<SqlcipherV2VerdictCache>> =
+    LazyLock::new(|| Mutex::new(SqlcipherV2VerdictCache::new()));
+
+/// Aggregate probe run/skip counts since process start
+/// `(runs, skips)`, exported via the app-performance telemetry snapshot.
+pub(crate) fn sqlcipher_migration_probe_counters() -> (u64, u64) {
+    (
+        SQLCIPHER_MIGRATION_PROBE_RUNS.load(Ordering::Relaxed),
+        SQLCIPHER_MIGRATION_PROBE_SKIPS.load(Ordering::Relaxed),
+    )
+}
+
+struct SqlcipherV2VerdictCache {
+    by_path: HashMap<PathBuf, [u8; SQLCIPHER_SALT_LEN]>,
+    insertion_order: VecDeque<PathBuf>,
+}
+
+impl SqlcipherV2VerdictCache {
+    fn new() -> Self {
+        Self {
+            by_path: HashMap::new(),
+            insertion_order: VecDeque::new(),
+        }
+    }
+
+    fn contains(&self, db_path: &Path, salt: &[u8; SQLCIPHER_SALT_LEN]) -> bool {
+        self.by_path.get(db_path) == Some(salt)
+    }
+
+    fn record(&mut self, db_path: PathBuf, salt: [u8; SQLCIPHER_SALT_LEN]) {
+        if self.by_path.insert(db_path.clone(), salt).is_none() {
+            self.insertion_order.push_back(db_path);
+        }
+        while self.by_path.len() > SQLCIPHER_V2_VERDICT_CACHE_CAPACITY {
+            let Some(evicted) = self.insertion_order.pop_front() else {
+                break;
+            };
+            self.by_path.remove(&evicted);
+        }
+    }
+
+    fn invalidate(&mut self, db_path: &Path) {
+        if self.by_path.remove(db_path).is_some() {
+            self.insertion_order.retain(|path| path != db_path);
+        }
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.by_path.len()
+    }
+}
+
+/// Cache key for verdicts. Canonicalizing merges spellings of the same file
+/// (e.g. symlinked roots such as `/var` vs `/private/var`); on any failure the
+/// literal path is used, which can only split an entry into two — never merge
+/// two different databases into one verdict.
+fn sqlcipher_verdict_cache_key(db_path: &Path) -> PathBuf {
+    fs::canonicalize(db_path).unwrap_or_else(|_| db_path.to_path_buf())
+}
+
+fn lock_sqlcipher_v2_verdicts() -> std::sync::MutexGuard<'static, SqlcipherV2VerdictCache> {
+    SQLCIPHER_V2_VERDICTS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn sqlcipher_v2_verdict_cached(db_path: &Path, salt: &[u8; SQLCIPHER_SALT_LEN]) -> bool {
+    lock_sqlcipher_v2_verdicts().contains(&sqlcipher_verdict_cache_key(db_path), salt)
+}
+
+fn sqlcipher_v2_verdict_record(db_path: &Path, salt: &[u8; SQLCIPHER_SALT_LEN]) {
+    lock_sqlcipher_v2_verdicts().record(sqlcipher_verdict_cache_key(db_path), *salt);
+}
+
+fn sqlcipher_v2_verdict_invalidate(db_path: &Path) {
+    lock_sqlcipher_v2_verdicts().invalidate(&sqlcipher_verdict_cache_key(db_path));
+}
+
+/// Test-only per-path count of recovery probes actually executed, so tests can
+/// assert how often the full keyed probe open ran for one database regardless
+/// of other tests sharing this process (the aggregate counters above are
+/// process-global and would race under parallel test execution).
+#[cfg(test)]
+static PROBE_ATTEMPTS_BY_PATH: LazyLock<Mutex<HashMap<PathBuf, usize>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+#[cfg(test)]
+fn record_probe_attempt_for_test(db_path: &Path) {
+    let mut attempts = PROBE_ATTEMPTS_BY_PATH
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *attempts
+        .entry(sqlcipher_verdict_cache_key(db_path))
+        .or_insert(0) += 1;
+}
+
+#[cfg(test)]
+fn probe_attempts_for_test(db_path: &Path) -> usize {
+    PROBE_ATTEMPTS_BY_PATH
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(&sqlcipher_verdict_cache_key(db_path))
+        .copied()
+        .unwrap_or(0)
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum SqlcipherDatabaseKind {
@@ -155,13 +306,27 @@ impl MarmotApp {
             //     was written back then, so a marker check alone never recovers
             //     these already-bricked accounts.
             // `finish_interrupted_sqlcipher_migration` probes the v2 key first
-            // (a cheap no-op when the database is already migrated or freshly
-            // v2-keyed) and only re-runs the legacy -> v2 rekey when that probe
-            // fails. Running it on every existing-database open therefore both
-            // finishes interrupted migrations and self-heals the pre-fix bricked
-            // state, without changing behavior for healthy databases.
+            // (a cheap no-op logically when the database is already migrated or
+            // freshly v2-keyed — but a full keyed open paying the passphrase KDF
+            // physically) and only re-runs the legacy -> v2 rekey when that
+            // probe fails.
+            //
+            // The probe must run whenever the migration marker exists or this
+            // process has not yet established that this database opens under
+            // the v2 key for this salt — those are the crash windows the #219
+            // self-heal exists for. Once a verdict has been established, the
+            // healthy steady-state path skips the probe so a repeated open of
+            // the same database pays the SQLCipher KDF once, not twice
+            // (mdk#1439).
             if db_path.exists() {
-                finish_interrupted_sqlcipher_migration(label, keys, db_path, kind, &salt)?;
+                if !marker_path.exists() && sqlcipher_v2_verdict_cached(db_path, &salt) {
+                    SQLCIPHER_MIGRATION_PROBE_SKIPS.fetch_add(1, Ordering::Relaxed);
+                } else {
+                    finish_interrupted_sqlcipher_migration(label, keys, db_path, kind, &salt)?;
+                    // Success means the database was just observed opening
+                    // under the v2 key (the probe) or was just rekeyed to it.
+                    sqlcipher_v2_verdict_record(db_path, &salt);
+                }
             }
             let _ = fs::remove_file(&marker_path);
             return Ok(salt);
@@ -194,6 +359,9 @@ impl MarmotApp {
                 let _ = fs::remove_file(&marker_path);
                 return Err(err);
             }
+            // The rekey committed: the database is now v2-keyed under this
+            // salt, so later opens in this process can skip the probe.
+            sqlcipher_v2_verdict_record(db_path, &salt);
             let _ = fs::remove_file(&marker_path);
         } else {
             // Fresh database: no rekey needed. Persist the salt atomically so a
@@ -326,13 +494,18 @@ fn finish_interrupted_sqlcipher_migration(
 
     let new_key = SqlCipherKey::new(derive_sqlcipher_key_material(label, keys, salt, kind)?)?;
 
-    // Does the database already open under the v2 key?
-    {
-        let conn = Connection::open(db_path)?;
-        if open_hardened_sqlcipher(&conn, &new_key, SqlCipherHardening::cipher_only()).is_ok() {
-            return Ok(());
-        }
+    // Does the database already open under the v2 key? This probe is a full
+    // keyed open and pays the complete SQLCipher passphrase KDF (mdk#1439), so
+    // it is counted for the aggregate telemetry counters and only runs when no
+    // cached verdict covers this database+salt pair.
+    let conn = Connection::open(db_path)?;
+    SQLCIPHER_MIGRATION_PROBE_RUNS.fetch_add(1, Ordering::Relaxed);
+    #[cfg(test)]
+    record_probe_attempt_for_test(db_path);
+    if open_hardened_sqlcipher(&conn, &new_key, SqlCipherHardening::cipher_only()).is_ok() {
+        return Ok(());
     }
+    drop(conn);
 
     // Still legacy-keyed: re-run the rekey. `PRAGMA rekey` is transactional, so
     // a crash here simply leaves the marker in place for the next attempt.
@@ -419,6 +592,8 @@ fn rekey_legacy_sqlcipher_database(
 }
 
 pub(crate) fn remove_sqlite_file_set(path: &Path) -> Result<(), AppError> {
+    // The database file is going away: any cached verdict for it is stale.
+    sqlcipher_v2_verdict_invalidate(path);
     for candidate in [
         path.to_path_buf(),
         PathBuf::from(format!("{}-wal", path.display())),
@@ -814,5 +989,359 @@ mod tests {
             let name = name.to_string_lossy();
             assert!(!name.contains(".tmp."), "unexpected temp residue: {name}");
         }
+    }
+
+    /// Write a durable v2 salt and create a database already keyed with the
+    /// derived v2 key — the healthy steady state every open lands in once a
+    /// database has been migrated or created fresh.
+    fn create_healthy_v2_database(
+        label: &str,
+        keys: &nostr::Keys,
+        db_path: &Path,
+        kind: SqlcipherDatabaseKind,
+    ) {
+        let mut salt = [0_u8; SQLCIPHER_SALT_LEN];
+        OsRng.fill_bytes(&mut salt);
+        write_sqlcipher_salt(&sqlcipher_salt_path(db_path), &salt).unwrap();
+        let v2_key =
+            SqlCipherKey::new(derive_sqlcipher_key_material(label, keys, &salt, kind).unwrap())
+                .unwrap();
+        let conn = Connection::open(db_path).unwrap();
+        open_hardened_sqlcipher(&conn, &v2_key, SqlCipherHardening::cipher_only()).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE marker (value TEXT NOT NULL);
+             INSERT INTO marker (value) VALUES ('kept');",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn sqlcipher_probe_runs_at_most_once_for_healthy_v2_database_across_opens() {
+        // mdk#1439 acceptance: a healthy v2-keyed database opened repeatedly in
+        // one process runs the interrupted-migration probe — a full keyed open
+        // paying the 256k-iteration passphrase KDF — at most once. The first
+        // open establishes the verdict; later opens reuse it.
+        let dir = tempfile::tempdir().unwrap();
+        let home = AccountHome::open(dir.path());
+        home.create_account("alice").unwrap();
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+        let keys = app.account_home().load_signing_keys("alice").unwrap();
+        let projection_path = app.legacy_account_projection_path("alice");
+        fs::create_dir_all(projection_path.parent().unwrap()).unwrap();
+        create_healthy_v2_database(
+            "alice",
+            &keys,
+            &projection_path,
+            SqlcipherDatabaseKind::AccountProjection,
+        );
+
+        let first_key = app
+            .sqlcipher_key(
+                "alice",
+                &keys,
+                &projection_path,
+                SqlcipherDatabaseKind::AccountProjection,
+            )
+            .unwrap();
+        assert_eq!(
+            probe_attempts_for_test(&projection_path),
+            1,
+            "the first open of a database with no cached verdict must probe"
+        );
+
+        for _ in 0..3 {
+            let key = app
+                .sqlcipher_key(
+                    "alice",
+                    &keys,
+                    &projection_path,
+                    SqlcipherDatabaseKind::AccountProjection,
+                )
+                .unwrap();
+            assert_eq!(key.as_secret_str(), first_key.as_secret_str());
+        }
+        assert_eq!(
+            probe_attempts_for_test(&projection_path),
+            1,
+            "steady-state reopens of the same database must skip the probe"
+        );
+    }
+
+    #[test]
+    fn sqlcipher_probe_reruns_whenever_migration_marker_is_present() {
+        // mdk#1439 acceptance: a durable migration marker always forces the
+        // recovery probe, even when a verdict for this database+salt is already
+        // cached — the marker means a migration may have been interrupted, and
+        // those crash windows keep the #219 self-heal.
+        let dir = tempfile::tempdir().unwrap();
+        let home = AccountHome::open(dir.path());
+        home.create_account("alice").unwrap();
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+        let keys = app.account_home().load_signing_keys("alice").unwrap();
+        let projection_path = app.legacy_account_projection_path("alice");
+        fs::create_dir_all(projection_path.parent().unwrap()).unwrap();
+        create_healthy_v2_database(
+            "alice",
+            &keys,
+            &projection_path,
+            SqlcipherDatabaseKind::AccountProjection,
+        );
+
+        let _ = app
+            .sqlcipher_key(
+                "alice",
+                &keys,
+                &projection_path,
+                SqlcipherDatabaseKind::AccountProjection,
+            )
+            .unwrap();
+        assert_eq!(probe_attempts_for_test(&projection_path), 1);
+
+        // Stale marker: the rekey committed but the process died before the
+        // marker was cleared. The cached verdict must not suppress the probe.
+        write_sqlcipher_migration_marker(&sqlcipher_migration_marker_path(&projection_path))
+            .unwrap();
+        let _ = app
+            .sqlcipher_key(
+                "alice",
+                &keys,
+                &projection_path,
+                SqlcipherDatabaseKind::AccountProjection,
+            )
+            .unwrap();
+        assert_eq!(
+            probe_attempts_for_test(&projection_path),
+            2,
+            "a marker-present open must re-run the recovery probe even with a cached verdict"
+        );
+        assert!(!sqlcipher_migration_marker_path(&projection_path).exists());
+
+        // Marker cleared: the steady-state skip applies again.
+        let _ = app
+            .sqlcipher_key(
+                "alice",
+                &keys,
+                &projection_path,
+                SqlcipherDatabaseKind::AccountProjection,
+            )
+            .unwrap();
+        assert_eq!(probe_attempts_for_test(&projection_path), 2);
+    }
+
+    #[test]
+    fn sqlcipher_verdict_invalidation_forces_reprobe_after_file_set_removal() {
+        // A cached verdict must never cause a legacy-keyed database to be
+        // opened with the wrong assumption. Removing the database file set
+        // invalidates the verdict, so when a legacy-keyed database later
+        // appears at the same path (with the salt still durable), the probe
+        // runs again and self-heals it.
+        let dir = tempfile::tempdir().unwrap();
+        let home = AccountHome::open(dir.path());
+        home.create_account("alice").unwrap();
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+        let keys = app.account_home().load_signing_keys("alice").unwrap();
+        let projection_path = app.legacy_account_projection_path("alice");
+        fs::create_dir_all(projection_path.parent().unwrap()).unwrap();
+        create_healthy_v2_database(
+            "alice",
+            &keys,
+            &projection_path,
+            SqlcipherDatabaseKind::AccountProjection,
+        );
+
+        let _ = app
+            .sqlcipher_key(
+                "alice",
+                &keys,
+                &projection_path,
+                SqlcipherDatabaseKind::AccountProjection,
+            )
+            .unwrap();
+        assert_eq!(probe_attempts_for_test(&projection_path), 1);
+
+        // The database goes away (account/cache reset); the salt survives.
+        remove_sqlite_file_set(&projection_path).unwrap();
+        assert!(!projection_path.exists());
+
+        // A legacy-keyed database appears at the same path.
+        let legacy_key = SqlCipherKey::new(legacy_sqlcipher_key_material(
+            "alice",
+            &keys,
+            SqlcipherDatabaseKind::AccountProjection,
+        ))
+        .unwrap();
+        {
+            let conn = Connection::open(&projection_path).unwrap();
+            conn.pragma_update(None, "key", legacy_key.as_secret_str())
+                .unwrap();
+            conn.execute_batch(
+                "CREATE TABLE marker (value TEXT NOT NULL);
+                 INSERT INTO marker (value) VALUES ('restored');",
+            )
+            .unwrap();
+        }
+
+        let recovered_key = app
+            .sqlcipher_key(
+                "alice",
+                &keys,
+                &projection_path,
+                SqlcipherDatabaseKind::AccountProjection,
+            )
+            .unwrap();
+        assert_eq!(
+            probe_attempts_for_test(&projection_path),
+            2,
+            "an invalidated verdict must force the probe again"
+        );
+        let conn = Connection::open(&projection_path).unwrap();
+        conn.pragma_update(None, "key", recovered_key.as_secret_str())
+            .unwrap();
+        let value: String = conn
+            .query_row("SELECT value FROM marker", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(value, "restored");
+    }
+
+    #[test]
+    fn sqlcipher_probe_runs_when_database_appears_after_salt_only_open() {
+        // The fresh-database path (salt durable, no database file yet) must not
+        // record a verdict: no database has been observed opening under the v2
+        // key. If a legacy-keyed database then appears at that path, the probe
+        // still runs and heals it.
+        let dir = tempfile::tempdir().unwrap();
+        let home = AccountHome::open(dir.path());
+        home.create_account("alice").unwrap();
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+        let keys = app.account_home().load_signing_keys("alice").unwrap();
+        let projection_path = app.legacy_account_projection_path("alice");
+        fs::create_dir_all(projection_path.parent().unwrap()).unwrap();
+        let mut salt = [0_u8; SQLCIPHER_SALT_LEN];
+        OsRng.fill_bytes(&mut salt);
+        write_sqlcipher_salt(&sqlcipher_salt_path(&projection_path), &salt).unwrap();
+
+        let _ = app
+            .sqlcipher_key(
+                "alice",
+                &keys,
+                &projection_path,
+                SqlcipherDatabaseKind::AccountProjection,
+            )
+            .unwrap();
+        assert_eq!(
+            probe_attempts_for_test(&projection_path),
+            0,
+            "no database file means no probe and no verdict"
+        );
+
+        let legacy_key = SqlCipherKey::new(legacy_sqlcipher_key_material(
+            "alice",
+            &keys,
+            SqlcipherDatabaseKind::AccountProjection,
+        ))
+        .unwrap();
+        {
+            let conn = Connection::open(&projection_path).unwrap();
+            conn.pragma_update(None, "key", legacy_key.as_secret_str())
+                .unwrap();
+            conn.execute_batch(
+                "CREATE TABLE marker (value TEXT NOT NULL);
+                 INSERT INTO marker (value) VALUES ('appeared');",
+            )
+            .unwrap();
+        }
+
+        let recovered_key = app
+            .sqlcipher_key(
+                "alice",
+                &keys,
+                &projection_path,
+                SqlcipherDatabaseKind::AccountProjection,
+            )
+            .unwrap();
+        assert_eq!(
+            probe_attempts_for_test(&projection_path),
+            1,
+            "a database never observed under the v2 key must be probed"
+        );
+        let conn = Connection::open(&projection_path).unwrap();
+        conn.pragma_update(None, "key", recovered_key.as_secret_str())
+            .unwrap();
+        let value: String = conn
+            .query_row("SELECT value FROM marker", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(value, "appeared");
+    }
+
+    #[test]
+    fn sqlcipher_v2_verdict_cache_is_salt_scoped() {
+        let mut cache = SqlcipherV2VerdictCache::new();
+        let path = PathBuf::from("/tmp/mdk-verdict-cache-salt-scope.sqlite");
+        let salt_a = [0xaa; SQLCIPHER_SALT_LEN];
+        let salt_b = [0xbb; SQLCIPHER_SALT_LEN];
+
+        cache.record(path.clone(), salt_a);
+        assert!(cache.contains(&path, &salt_a));
+        assert!(
+            !cache.contains(&path, &salt_b),
+            "a verdict for one salt must not vouch for another salt"
+        );
+
+        // A salt rotation replaces the verdict rather than stacking.
+        cache.record(path.clone(), salt_b);
+        assert!(!cache.contains(&path, &salt_a));
+        assert!(cache.contains(&path, &salt_b));
+        assert_eq!(cache.len(), 1);
+    }
+
+    #[test]
+    fn sqlcipher_v2_verdict_cache_is_bounded_and_evicts_oldest_first() {
+        let mut cache = SqlcipherV2VerdictCache::new();
+        let salt = [0x5a; SQLCIPHER_SALT_LEN];
+        for index in 0..(SQLCIPHER_V2_VERDICT_CACHE_CAPACITY + 10) {
+            cache.record(
+                PathBuf::from(format!("/tmp/mdk-verdict-cache-churn-{index}.sqlite")),
+                salt,
+            );
+        }
+
+        assert_eq!(cache.len(), SQLCIPHER_V2_VERDICT_CACHE_CAPACITY);
+        for index in 0..10 {
+            assert!(
+                !cache.contains(
+                    &PathBuf::from(format!("/tmp/mdk-verdict-cache-churn-{index}.sqlite")),
+                    &salt
+                ),
+                "the oldest entries must be evicted first"
+            );
+        }
+        for index in 10..(SQLCIPHER_V2_VERDICT_CACHE_CAPACITY + 10) {
+            assert!(
+                cache.contains(
+                    &PathBuf::from(format!("/tmp/mdk-verdict-cache-churn-{index}.sqlite")),
+                    &salt
+                ),
+                "recent entries must survive eviction"
+            );
+        }
+    }
+
+    #[test]
+    fn sqlcipher_v2_verdict_cache_invalidate_removes_the_entry() {
+        let mut cache = SqlcipherV2VerdictCache::new();
+        let path = PathBuf::from("/tmp/mdk-verdict-cache-invalidate.sqlite");
+        let other = PathBuf::from("/tmp/mdk-verdict-cache-invalidate-other.sqlite");
+        let salt = [0x5a; SQLCIPHER_SALT_LEN];
+
+        cache.record(path.clone(), salt);
+        cache.record(other.clone(), salt);
+        cache.invalidate(&path);
+
+        assert!(!cache.contains(&path, &salt));
+        assert!(cache.contains(&other, &salt));
+        // Re-recording after invalidation works and keeps the bound intact.
+        cache.record(path.clone(), salt);
+        assert!(cache.contains(&path, &salt));
+        assert_eq!(cache.len(), 2);
     }
 }

--- a/docs/marmot-architecture/runtime-state-bounds.md
+++ b/docs/marmot-architecture/runtime-state-bounds.md
@@ -1,7 +1,7 @@
 ---
 title: "Long-lived runtime state — bounds and reclamation"
 created: 2026-07-02
-updated: 2026-07-04
+updated: 2026-08-14
 tags: [marmot, architecture, runtime, daemon, broker, memory]
 ---
 
@@ -51,6 +51,12 @@ Tracking issue: marmot-protocol/mdk#381.
 | --- | --- | --- |
 | `AgentStreamWatchManager.watches` | 256 (`AGENT_STREAM_WATCH_RETAIN_LIMIT`), including `running` watches | Enforced on both start and finish. Finished watches evict oldest-first; when running watches alone exceed the cap (a finish that never arrives), the oldest running watches evict too (mdk#343). |
 | `recent_updates` replay ring | 256 (`AGENT_STREAM_UPDATE_REPLAY_LIMIT`) | Oldest popped on publish. |
+
+### `marmot-app` (`src/sqlcipher.rs`)
+
+| Structure | Bound | Reclamation |
+| --- | --- | --- |
+| `SQLCIPHER_V2_VERDICTS` probe-verdict cache | 256 entries (`SQLCIPHER_V2_VERDICT_CACHE_CAPACITY`) | Entries are keyed by canonical database path + salt and record only an observed "opens under the v2 key" verdict (mdk#1439). Removed when the database file set is deleted via `remove_sqlite_file_set`; replaced in place when the salt rotates; oldest-first eviction at the cap. Eviction or loss of an entry only ever causes one extra recovery probe, never a wrong-key assumption. The companion `SQLCIPHER_MIGRATION_PROBE_RUNS`/`SKIPS` counters are monotonic process-lifetime aggregates by design (telemetry gauges, not tracked state). |
 
 ### `wn-cli` daemon / `wnd` (`src/daemon/`)
 

--- a/docs/marmot-architecture/storage-format-v2.md
+++ b/docs/marmot-architecture/storage-format-v2.md
@@ -250,3 +250,56 @@ rows require 64 ticks, or about 16 minutes while the account remains usable.
 The benchmark executes those batches continuously only to measure their total
 database work and worst observed transaction duration. Page reclamation is not
 required for correctness and remains a separately scheduled maintenance choice.
+
+## SQLCipher key presentation and KDF work factor (decision record, mdk#1439)
+
+Every `storage-sqlite` database is keyed with 256-bit key material derived by
+HKDF over the account secret and a stable per-database salt
+(`crates/marmot-app/src/sqlcipher.rs`). The derived bytes are hex-encoded and
+presented to SQLCipher as a *passphrase*. With `cipher_compatibility = 4`
+pinned and no `cipher_kdf_iterations` override anywhere in the workspace,
+SQLCipher then runs PBKDF2-HMAC-SHA512 with 256,000 iterations on every keyed
+open. That KDF exists to resist dictionary attacks on human passphrases; the
+HKDF-derived input is already uniform high-entropy key material, so the
+stretching adds no effective security on this path — its cost is pure latency
+(~50–500 ms per derivation depending on device class).
+
+**Decision (2026-08-14): keep passphrase presentation and the compat-4 KDF
+work factor unchanged.** Do not adopt raw `x'…'` key presentation or a reduced
+`cipher_kdf_iterations` as part of the mdk#1439 performance work. The measured
+win ships without touching on-disk cipher parameters: the in-process v2-open
+verdict cache makes each existing-database open pay the KDF once instead of
+twice, and the remaining open-count reduction is tracked by mdk#1436.
+
+Rationale for rejecting the key-presentation change in this context:
+
+1. **It is a storage-format change, not a tuning change.** Raw-key presentation
+   or a reduced iteration count changes the on-disk cipher parameters of every
+   existing database. That requires a numbered, crash-safe `PRAGMA rekey`
+   migration with the same marker/sidecar discipline as the salt migration,
+   plus a rollback plan — and a reduced iteration count additionally becomes a
+   de-facto open parameter that must be pinned before keying on *every* open
+   path (account storage, hardened cache opens, probe/rekey opens, and external
+   tooling).
+2. **It requires explicit security sign-off.** Raw presentation is sound only
+   because every presented key is HKDF-derived 256-bit uniform material; that
+   invariant must be enforced by construction (a typed raw-key variant of
+   `SqlCipherKey` that no user-supplied passphrase can ever reach) before
+   adoption. A lowered `cipher_kdf_iterations` would instead weaken brute-force
+   resistance for any future low-entropy passphrase that reaches the same
+   pragma path.
+3. **The trade is nil in both directions today, so measure first.** With the
+   verdict cache, per-open KDF count is observable in the fleet via
+   `app_sqlcipher_migration_probe_runs`/`app_sqlcipher_migration_probe_skips`
+   and the `app_account_open`/`app_account_session_open` duration buckets
+   (`telemetry.md`). If those numbers still show open-latency pain after
+   mdk#1436 lands, the accept path below can be evaluated on evidence rather
+   than stacked silently into a performance fix.
+
+Accept path, if revisited: a versioned rekey migration guarded by a durable
+marker (mirroring the salt migration's crash windows), no change to hardening
+semantics (`cipher_compatibility` pin, `cipher_memory_security`,
+`secure_delete`, `synchronous=FULL`), a downgrade story (rekey back to
+passphrase presentation), typed raw-key construction in `storage-sqlite`, and
+updated forensic/tooling docs (raw-keyed databases need raw-key open syntax in
+the `sqlcipher` CLI).

--- a/docs/marmot-architecture/telemetry.md
+++ b/docs/marmot-architecture/telemetry.md
@@ -1,7 +1,7 @@
 ---
 title: "Telemetry, Logging, and Tracing Inventory"
 created: 2026-06-10
-updated: 2026-08-07
+updated: 2026-08-14
 tags: [marmot, architecture, telemetry, logging, tracing, privacy]
 status: current
 ---
@@ -21,7 +21,7 @@ runtime. It complements the policy docs:
 | --- | --- | --- | --- |
 | Structured tracing/logging | Code uses `tracing` macros with explicit `target` and `method` fields. The app/CLI does not install a global tracing subscriber in the current source, so host apps or tests decide whether these events are collected. | No, unless a host installs and exports a subscriber. | [`overview/observability.md`](./overview/observability.md), [`tracing_audit.rs`](../../crates/cgka-conformance-simulator/tests/tracing_audit.rs) |
 | Device-local relay telemetry | Always collected by the shared Nostr relay plane while it runs: lifecycle counters, delivery-spread histograms, sync timing, and redacted relay health. | No. Exposed locally via `MarmotApp::relay_telemetry`, runtime `relay_plane().relay_telemetry()`, and `wn relay-stats`. | [`relay_plane.rs`](../../crates/marmot-app/src/relay_plane.rs), [`telemetry.rs`](../../crates/transport-nostr-adapter/src/telemetry.rs) |
-| Device-local app performance telemetry | Always available inside `RuntimeSharedServices` while the runtime exists: aggregate duration histograms plus attempts/success/failure counters for startup, directory subscription sync, local account open, transport activation, subscription registration, sync/catch-up, host splash/foreground readiness, one-sided outbound message send, group invite/admin/read operations, and media upload/download. | No by itself. Included in the OTLP export batch only after the same opt-in export gate passes. | [`app_telemetry.rs`](../../crates/marmot-app/src/app_telemetry.rs), [`runtime.rs`](../../crates/marmot-app/src/runtime.rs) |
+| Device-local app performance telemetry | Always available inside `RuntimeSharedServices` while the runtime exists: aggregate duration histograms plus attempts/success/failure counters for startup, directory subscription sync, local account open, transport activation, subscription registration, sync/catch-up, host splash/foreground readiness, one-sided outbound message send, group invite/admin/read operations, and media upload/download. Process-wide SQLCipher interrupted-migration probe run/skip counters (mdk#1439) are merged into the snapshot from `sqlcipher.rs`. | No by itself. Included in the OTLP export batch only after the same opt-in export gate passes. | [`app_telemetry.rs`](../../crates/marmot-app/src/app_telemetry.rs), [`runtime.rs`](../../crates/marmot-app/src/runtime.rs) |
 | Opt-in telemetry export | Implemented and off by default. Requires opt-in settings to be persisted, plus runtime endpoint, bearer token, and resource metadata. OTLP wire encoding and HTTP push are behind the `otlp-export` feature. Exports relay metrics and app-performance metrics in one batch. | Yes, only after the export gate passes. Relay URL is the only metric label, and only relay metrics may carry it; app-performance metrics are unlabeled population metrics. | [`relay_telemetry_export.rs`](../../crates/marmot-app/src/relay_telemetry_export.rs), [`config.rs`](../../crates/marmot-app/src/config.rs) |
 | Engine reorg telemetry | Implemented inside `cgka-engine` as aggregate post-settle reorg counters/histograms. Exposed by `Engine::engine_metrics()`. The relay-plane/export structs have an optional seam for it, but the periodic runtime exporter currently passes `None`. | No via the runtime exporter today. Engine metrics can be exported only if a caller explicitly folds a snapshot into the rollup/batch. | [`engine_metrics.rs`](../../crates/cgka-engine/src/engine_metrics.rs), [`relay_plane.rs`](../../crates/marmot-app/src/relay_plane.rs) |
 | Product analytics / crash reporting | No product analytics or crash reporting SDK integration was found in the current source. Aptabase is mentioned only as future product-analytics context in a doc; it is not wired. | No. | Workspace search on 2026-06-10 |
@@ -435,6 +435,8 @@ Unresolved relay indices are skipped rather than exported as opaque ids.
 | `app_host_foreground_local_ready_attempts` | none | Counter | `AppPerformanceSnapshot.host_foreground_local_ready.attempts` |
 | `app_host_foreground_local_ready_successes` | none | Counter | `AppPerformanceSnapshot.host_foreground_local_ready.successes` |
 | `app_host_foreground_local_ready_failures` | none | Counter | `AppPerformanceSnapshot.host_foreground_local_ready.failures` |
+| `app_sqlcipher_migration_probe_runs` | none | Counter | `AppPerformanceSnapshot.sqlcipher_migration_probe_runs`; each run is one full keyed SQLCipher open paying the passphrase KDF (mdk#1439) |
+| `app_sqlcipher_migration_probe_skips` | none | Counter | `AppPerformanceSnapshot.sqlcipher_migration_probe_skips`; each skip is one passphrase KDF derivation avoided via the cached v2-open verdict (mdk#1439) |
 
 Current implementation note: publish telemetry is device-wide attempts/successes/failures. It is not currently
 per-relay or per-Nostr-kind, even though the relay observability design doc names those as desired future ranking


### PR DESCRIPTION
Closes #1439.

## Problem

Every open of an existing SQLCipher database paid the full key-derivation cost **twice**: `finish_interrupted_sqlcipher_migration`'s "cheap no-op" probe is a complete second keyed open (`Connection::open` + hardened pragmas + `PRAGMA key` + the `sqlite_master` probe), paying the same PBKDF2-HMAC-SHA512 / 256k iterations as the real open that follows. With ~4 encrypted opens per account per cold start, the KDF alone ran ~6–8× per account before any query executed.

## Fix

Cache the probe verdict **in-process per database file + salt** once the database has been *observed* opening under the v2 key (a successful probe, or a legacy → v2 rekey this process performed), and skip the probe on the healthy steady-state path. Safety rules from the issue are preserved exactly:

- **A durable `.salt-migrating` marker always forces the recovery probe**, verdict or not — the interrupted-migration and pre-fix mdk#568 bricked-state crash windows keep their self-heal.
- Verdicts are **salt-scoped** (a salt rotation can't be masked by a stale entry), **never recorded on the fresh-database path** (no database observed yet), **invalidated** when the database file set is removed via `remove_sqlite_file_set`, and **bounded** at 256 entries with oldest-first eviction. A miss, invalidation, or eviction only ever causes an *extra* probe — never a wrong-key assumption ("when in doubt, probe").
- Pragma ordering discipline (`cipher_compatibility` pin → key → probe) and the existing `storage-sqlite` pragma-trace tests are untouched.

Open-count reduction during account setup is deliberately out of scope here — that is #1436's acceptance criterion; the open paths already share connections per `MarmotApp` instance, and this change halves the per-open cost across all of them.

## Telemetry (per-open KDF count)

New aggregate, privacy-safe counters (counts only — no paths, accounts, or keys), wired into `AppPerformanceSnapshot` and the opt-in export mapping as unlabeled population counters:

- `app_sqlcipher_migration_probe_runs` — probes executed (each = one full keyed open paying the KDF)
- `app_sqlcipher_migration_probe_skips` — probes skipped via a cached verdict (each = one KDF avoided)

The existing `AccountOpen` / `AccountSessionOpen` / `AccountSetupAdvisoryStep` duration buckets already wrap the open paths, so the latency reduction is measurable in those buckets with the KDF count alongside.

## Raw-key / KDF-iteration decision

Documented in `docs/marmot-architecture/storage-format-v2.md`: **rejected for this change** — raw `x'…'` presentation or a reduced `cipher_kdf_iterations` alters on-disk cipher parameters and requires a versioned, crash-safe rekey migration plus explicit security sign-off; it must not ship silently as a perf change. The accept path (marker-guarded versioned rekey, unchanged hardening semantics, typed raw-key construction, tooling docs) is sketched for a future evidence-driven revisit using the new counters.

## Tests

- **Acceptance**: `sqlcipher_probe_runs_at_most_once_for_healthy_v2_database_across_opens` (probe runs once across repeated opens) and `sqlcipher_probe_reruns_whenever_migration_marker_is_present` (marker bypasses a cached verdict, then the skip resumes) — via per-path probe instrumentation in `sqlcipher.rs`.
- **Wrong-assumption guards**: verdict invalidation on file-set removal and the salt-only open path re-probe and heal a legacy-keyed database; cache salt-scoping / bound / eviction unit tests.
- **Regression**: the interrupted-migration, idempotent-recovery, and mdk#568 bricked-state self-heal tests pass **unchanged**; `storage-sqlite` pragma-trace ordering tests pass.
- Export-mapping and snapshot-wiring tests for the new counters.

## Verification

- `just fast-ci` — clean (fmt, check, clippy incl. OTLP feature builds).
- `cargo test -p marmot-app` — 656 lib tests pass; the 5 `relay_runtime` integration failures (`encrypted_media_*`, `retained_media_*`, `self_removal_*`, `..._retention_change`) **pre-exist on base `b8c4e481`** (verified in a scratch worktree against the unmodified base) and are unrelated to this change.
- `cargo test -p marmot-app --features otlp-export` — pass.
- `cargo test -p storage-sqlite connection` — 31 pass, incl. both pragma-trace tests.

## Docs

`telemetry.md` (metric catalogue), `runtime-state-bounds.md` (verdict-cache bound/reclamation inventory row), `storage-format-v2.md` (KDF decision record), `crates/marmot-app/AGENTS.md` (`sqlcipher.rs` scope mapping).
