### PR TITLE
Start invite history catch-up immediately

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -28,10 +28,19 @@ leak-timeout = "500ms"
 # Reduced concurrency for the subprocess-heavy CLI end-to-end tests. Tunable: 1
 # fully serializes them, higher trades isolation for wall-clock.
 cli-e2e = { max-threads = 2 }
+# Each process-orchestrator test starts multiple application nodes and local
+# relays. Running those tests against each other can starve relay publication
+# admission long enough to trip the action-correlation timeout even though the
+# same scenario is stable in isolation.
+process-orchestrator = { max-threads = 1 }
 
 [[profile.default.overrides]]
 filter = 'package(wn-cli) & binary(cli)'
 test-group = 'cli-e2e'
+
+[[profile.default.overrides]]
+filter = 'package(cgka-conformance-simulator) & binary(process_orchestrator)'
+test-group = 'process-orchestrator'
 
 # CI profile (`cargo nextest run --profile ci`).
 #

--- a/crates/agent-connector/src/invite_policy.rs
+++ b/crates/agent-connector/src/invite_policy.rs
@@ -184,6 +184,10 @@ impl AgentConnector {
             welcomer_allowlisted,
         );
         if allowed {
+            // A catch-up-owned worker returns AccountWorkerBusy as a
+            // definitely-not-started result. Propagating it here is
+            // deliberate: apply_invite_policy_candidate records the failure
+            // in its per-invite bounded backoff and retries safely.
             self.runtime
                 .accept_group_invite(&account.label, group_id)
                 .await?;

--- a/crates/agent-connector/src/tests.rs
+++ b/crates/agent-connector/src/tests.rs
@@ -19,7 +19,7 @@ use cgka_traits::engine::{GroupEvent, GroupStateChange};
 use cgka_traits::{EpochId, GroupId, MessageId};
 use marmot_account::AccountHome;
 use marmot_app::{
-    AccountSetupRequest, MarmotApp, MarmotAppEvent, MarmotAppRuntime, ReceivedMessage,
+    AccountSetupRequest, AppError, MarmotApp, MarmotAppEvent, MarmotAppRuntime, ReceivedMessage,
     RuntimeAgentStreamMessage, RuntimeMessageReceived,
 };
 use nostr_relay_builder::MockRelay;
@@ -57,6 +57,24 @@ fn connector_media_limits_follow_the_marmot_app_blob_limit() {
 }
 
 const CONTROL_RESPONSE_TIMEOUT: Duration = Duration::from_secs(120);
+
+async fn accept_group_invite_retrying_busy(
+    runtime: &MarmotAppRuntime,
+    account_ref: &str,
+    group_id: &GroupId,
+) {
+    timeout(Duration::from_secs(5), async {
+        loop {
+            match runtime.accept_group_invite(account_ref, group_id).await {
+                Ok(_) => return,
+                Err(AppError::AccountWorkerBusy) => sleep(Duration::from_millis(10)).await,
+                Err(error) => panic!("invite acceptance failed: {error}"),
+            }
+        }
+    })
+    .await
+    .expect("invite acceptance should outlive the startup catch-up window");
+}
 
 #[tokio::test]
 async fn control_operation_timeout_bounds_a_stalled_whole_operation() {
@@ -1017,10 +1035,8 @@ async fn connector_socket_subscribes_to_inbound_messages() {
         )
         .await
         .unwrap();
-    setup_runtime
-        .accept_group_invite(&human.account.account_id_hex, &group_id)
-        .await
-        .unwrap();
+    accept_group_invite_retrying_busy(&setup_runtime, &human.account.account_id_hex, &group_id)
+        .await;
     setup_runtime.shutdown().await;
 
     let group_id_hex = hex::encode(group_id.as_slice());

--- a/crates/cgka-conformance-simulator/src/app_runtime.rs
+++ b/crates/cgka-conformance-simulator/src/app_runtime.rs
@@ -1357,25 +1357,34 @@ pub(crate) async fn accept_group_invite_retrying_busy(
     account_ref: &str,
     group_id: &GroupId,
 ) -> Result<(), AppError> {
-    match tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            match runtime.accept_group_invite(account_ref, group_id).await {
-                Ok(_) => return Ok(()),
-                Err(AppError::AccountWorkerBusy) => {
-                    tokio::time::sleep(Duration::from_millis(10)).await;
+    const BUSY_RETRY_ATTEMPTS: usize = 500;
+    const BUSY_RETRY_DELAY: Duration = Duration::from_millis(10);
+    const ACCEPT_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(5);
+
+    for attempt in 0..BUSY_RETRY_ATTEMPTS {
+        match tokio::time::timeout(
+            ACCEPT_ATTEMPT_TIMEOUT,
+            runtime.accept_group_invite(account_ref, group_id),
+        )
+        .await
+        {
+            Ok(Ok(_)) => return Ok(()),
+            Ok(Err(AppError::AccountWorkerBusy)) => {
+                if attempt + 1 < BUSY_RETRY_ATTEMPTS {
+                    tokio::time::sleep(BUSY_RETRY_DELAY).await;
                 }
-                Err(error) => return Err(error),
             }
+            Ok(Err(error)) => return Err(error),
+            // This accept may have reached the worker, so its completion is
+            // unknown. Never collapse that ambiguity into definitely-not-
+            // started AccountWorkerBusy.
+            Err(_) => return Err(AppError::AccountWorkerResponseTimedOut),
         }
-    })
-    .await
-    {
-        Ok(result) => result,
-        // Every attempt returned definitely-not-started busy, so preserving
-        // that typed result remains safe and lets the scenario classify it as
-        // retryable rather than inventing ambiguous completion.
-        Err(_) => Err(AppError::AccountWorkerBusy),
     }
+
+    // The fixed attempt budget was exhausted entirely by confirmed
+    // definitely-not-started responses.
+    Err(AppError::AccountWorkerBusy)
 }
 
 fn record_failure(participant: &mut Participant, error: &AppError) {

--- a/crates/cgka-conformance-simulator/src/app_runtime.rs
+++ b/crates/cgka-conformance-simulator/src/app_runtime.rs
@@ -1353,6 +1353,8 @@ fn drain_runtime_events(participant: &mut Participant) {
 fn record_failure(participant: &mut Participant, error: &AppError) {
     let kind = match error {
         AppError::AccountSessionBusy => "account_session_busy",
+        AppError::AccountWorkerBusy => "account_worker_busy",
+        AppError::AccountWorkerResponseTimedOut => "account_worker_response_timed_out",
         AppError::RuntimeBusy => "runtime_busy",
         AppError::RuntimeStopping => "runtime_stopping",
         AppError::TransportClosed => "transport_closed",
@@ -1367,7 +1369,10 @@ fn record_failure(participant: &mut Participant, error: &AppError) {
     participant.last_error_kind = Some(kind);
     if matches!(
         error,
-        AppError::AccountSessionBusy | AppError::RuntimeBusy | AppError::TransportClosed
+        AppError::AccountSessionBusy
+            | AppError::AccountWorkerBusy
+            | AppError::RuntimeBusy
+            | AppError::TransportClosed
     ) {
         participant.retryable_failures = participant.retryable_failures.saturating_add(1);
     } else {
@@ -1379,6 +1384,8 @@ fn app_error(error: AppError) -> SubjectError {
     let category = match error {
         AppError::RuntimeBusy
         | AppError::AccountSessionBusy
+        | AppError::AccountWorkerBusy
+        | AppError::AccountWorkerResponseTimedOut
         | AppError::RuntimeStopping
         | AppError::TransportClosed
         | AppError::AccountCatchUp(_)

--- a/crates/cgka-conformance-simulator/src/app_runtime.rs
+++ b/crates/cgka-conformance-simulator/src/app_runtime.rs
@@ -555,11 +555,13 @@ impl AppRuntimeHarness {
                 .map_err(app_error)?
                 .is_some_and(|group| group.pending_confirmation)
             {
-                participant
-                    .runtime()?
-                    .accept_group_invite(&participant.account_id, group_id)
-                    .await
-                    .map_err(app_error)?;
+                accept_group_invite_retrying_busy(
+                    participant.runtime()?,
+                    &participant.account_id,
+                    group_id,
+                )
+                .await
+                .map_err(app_error)?;
             }
         }
         Ok(())
@@ -1347,6 +1349,32 @@ fn drain_runtime_events(participant: &mut Participant) {
     };
     while events.try_recv().is_ok() {
         participant.runtime_events_observed = participant.runtime_events_observed.saturating_add(1);
+    }
+}
+
+pub(crate) async fn accept_group_invite_retrying_busy(
+    runtime: &MarmotAppRuntime,
+    account_ref: &str,
+    group_id: &GroupId,
+) -> Result<(), AppError> {
+    match tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match runtime.accept_group_invite(account_ref, group_id).await {
+                Ok(_) => return Ok(()),
+                Err(AppError::AccountWorkerBusy) => {
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+                Err(error) => return Err(error),
+            }
+        }
+    })
+    .await
+    {
+        Ok(result) => result,
+        // Every attempt returned definitely-not-started busy, so preserving
+        // that typed result remains safe and lets the scenario classify it as
+        // retryable rather than inventing ambiguous completion.
+        Err(_) => Err(AppError::AccountWorkerBusy),
     }
 }
 

--- a/crates/cgka-conformance-simulator/src/node_protocol.rs
+++ b/crates/cgka-conformance-simulator/src/node_protocol.rs
@@ -22,7 +22,9 @@ use tokio::io::{
 };
 use tokio::sync::broadcast;
 
-use crate::app_runtime::{opaque_public_identity, public_protocol_projection};
+use crate::app_runtime::{
+    accept_group_invite_retrying_busy, opaque_public_identity, public_protocol_projection,
+};
 use crate::{
     AppRuntimeApplicationProjectionV1, AppRuntimeProtocolProjectionV1, SubjectFailureCategory,
 };
@@ -706,9 +708,7 @@ async fn accept_active_invite(state: &mut NodeRuntimeState) -> Result<(), NodeEr
         .map_err(app_node_error)?
         .is_some_and(|group| group.pending_confirmation)
     {
-        state
-            .runtime
-            .accept_group_invite(&state.account_id, &group_id)
+        accept_group_invite_retrying_busy(&state.runtime, &state.account_id, &group_id)
             .await
             .map_err(app_node_error)?;
     }

--- a/crates/cgka-conformance-simulator/src/node_protocol.rs
+++ b/crates/cgka-conformance-simulator/src/node_protocol.rs
@@ -1052,8 +1052,12 @@ trait IntoAppNodeError {
 impl IntoAppNodeError for AppError {
     fn into_node_error(self) -> NodeErrorV1 {
         let retryable = is_retryable_app_error(&self);
+        let resource_failure =
+            retryable || matches!(&self, AppError::AccountWorkerResponseTimedOut);
         let code = match self {
             AppError::AccountSessionBusy => "account_session_busy",
+            AppError::AccountWorkerBusy => "account_worker_busy",
+            AppError::AccountWorkerResponseTimedOut => "account_worker_response_timed_out",
             AppError::RuntimeBusy => "runtime_busy",
             AppError::RuntimeStopping => "runtime_stopping",
             AppError::TransportClosed => "transport_closed",
@@ -1064,7 +1068,7 @@ impl IntoAppNodeError for AppError {
         };
         NodeErrorV1 {
             code: code.into(),
-            category: if retryable {
+            category: if resource_failure {
                 SubjectFailureCategory::Resource
             } else {
                 SubjectFailureCategory::Environment
@@ -1090,6 +1094,7 @@ fn is_retryable_app_error(error: &AppError) -> bool {
     matches!(
         error,
         AppError::AccountSessionBusy
+            | AppError::AccountWorkerBusy
             | AppError::RuntimeBusy
             | AppError::RuntimeStopping
             | AppError::TransportClosed

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -29,6 +29,15 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ### Fixed
 
+- Welcome joins now become durable and publish `GroupJoined` before ordinary
+  relay subscriptions rebuild, with failed rebuilds retried in the background.
+  Invite acceptance runs during startup hydration and returns a typed
+  `AccountWorkerBusy` response when catch-up definitely prevented it from
+  starting; every app-facing worker response also has an operation-class deadline whose
+  `AccountWorkerResponseTimedOut` result tells hosts to refresh state before
+  retrying. MarmotKit and `wn --json` preserve both distinct outcomes.
+  ([#1438](https://github.com/marmot-protocol/mdk/issues/1438))
+
 - Messages left waiting when a group is disbanded, or when this device is
   removed from it, no longer report as pending forever. The group's queue is
   gone in both cases, so those messages are now marked failed and hosts can show

--- a/crates/cli/src/commands/groups.rs
+++ b/crates/cli/src/commands/groups.rs
@@ -1,8 +1,12 @@
 //! `group` and `groups` command namespace handlers and group output helpers.
 
+use std::time::Duration;
+
 use cgka_traits::{GroupId, PeriodicMaintenancePolicy};
 use marmot_account::AccountHome;
-use marmot_app::{AppError, AppGroupMemberRecord, AppGroupMlsState, MarmotApp, MarmotAppRuntime};
+use marmot_app::{
+    AppError, AppGroupMemberRecord, AppGroupMlsState, AppGroupRecord, MarmotApp, MarmotAppRuntime,
+};
 use serde_json::{Value, json};
 
 use crate::{
@@ -10,6 +14,33 @@ use crate::{
     ensure_local_signing, group_json, group_list_plain, group_show_output, normalize_group_id_hex,
     npub_for_account_id, parse_public_key, resolve_account,
 };
+
+async fn accept_group_invite_retrying_busy(
+    runtime: &MarmotAppRuntime,
+    account_ref: &str,
+    group_id: &GroupId,
+) -> Result<AppGroupRecord, AppError> {
+    // A one-shot `wn groups accept` starts its own runtime and can race that
+    // runtime's initial catch-up. Keep the same runtime alive for a bounded
+    // 30-second retry window; restarting the CLI would only recreate the race.
+    const BUSY_RETRY_ATTEMPTS: usize = 600;
+    const BUSY_RETRY_DELAY: Duration = Duration::from_millis(50);
+
+    for attempt in 0..BUSY_RETRY_ATTEMPTS {
+        match runtime.accept_group_invite(account_ref, group_id).await {
+            Err(AppError::AccountWorkerBusy) => {
+                if attempt + 1 < BUSY_RETRY_ATTEMPTS {
+                    tokio::time::sleep(BUSY_RETRY_DELAY).await;
+                }
+            }
+            // Every other result is terminal for this CLI invocation. In
+            // particular, never retry an ambiguous worker response timeout.
+            result => return result,
+        }
+    }
+
+    Err(AppError::AccountWorkerBusy)
+}
 
 pub(crate) async fn group_command(
     account_home: &AccountHome,
@@ -451,9 +482,8 @@ pub(crate) async fn groups_command_with_runtime(
             ensure_local_signing(&account)?;
             app.status(&account.label)?;
             let group_id = GroupId::new(hex::decode(normalize_group_id_hex(&group_id)?)?);
-            let group = runtime
-                .accept_group_invite(&account.label, &group_id)
-                .await?;
+            let group =
+                accept_group_invite_retrying_busy(runtime, &account.label, &group_id).await?;
             let group_id_hex = hex::encode(group_id.as_slice());
             Ok(CommandOutput {
                 plain: format!("accepted invite {group_id_hex}"),

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -635,6 +635,17 @@ fn app_error_json(err: &AppError) -> Value {
             "code": "account_catch_up",
             "message": err.to_string(),
         }),
+        AppError::AccountWorkerBusy => json!({
+            "code": "account_worker_busy",
+            "message": err.to_string(),
+            "safe_to_retry": true,
+        }),
+        AppError::AccountWorkerResponseTimedOut => json!({
+            "code": "account_worker_response_timed_out",
+            "message": err.to_string(),
+            "completion_unknown": true,
+            "repair": { "action": "refresh authoritative state before retrying" },
+        }),
         AppError::AccountSetupRecoveryRequired => json!({
             "code": "account_setup_recovery_required",
             "message": err.to_string(),
@@ -767,5 +778,16 @@ mod tests {
         for (error, code) in cases {
             assert_eq!(wn_error_json(&WnError::App(error))["code"], code);
         }
+    }
+
+    #[test]
+    fn account_worker_errors_preserve_retry_safety_in_json() {
+        let busy = wn_error_json(&WnError::App(AppError::AccountWorkerBusy));
+        assert_eq!(busy["code"], "account_worker_busy");
+        assert_eq!(busy["safe_to_retry"], true);
+
+        let timed_out = wn_error_json(&WnError::App(AppError::AccountWorkerResponseTimedOut));
+        assert_eq!(timed_out["code"], "account_worker_response_timed_out");
+        assert_eq!(timed_out["completion_unknown"], true);
     }
 }

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -158,6 +158,13 @@ pub struct AppClient {
     /// acknowledged on the durable engine-to-app outbox. The acknowledgement is
     /// committed with the account projection and any frontier clear.
     pub(crate) pending_application_event_acks: HashSet<MessageId>,
+    /// A live ingest changed the in-memory transport routing table after its
+    /// durable projection was committed. The account worker publishes the
+    /// resulting app summary before it asks the relay plane to rebuild its
+    /// ordinary group subscriptions; failures remain armed here for bounded
+    /// background retry instead of turning the already-applied ingest into an
+    /// apparent receive failure.
+    pub(crate) pending_runtime_group_subscription_refresh: bool,
     /// Unit-test fault injection for the account-open replay path. This keeps
     /// the live protocol group intact while exercising a missing best-effort
     /// app projection.

--- a/crates/marmot-app/src/client/projection.rs
+++ b/crates/marmot-app/src/client/projection.rs
@@ -882,6 +882,10 @@ fn read_marker_error_code(error: &AppError) -> &'static str {
         AppError::BlockingTask(_) => "read_marker_failed:blocking_task",
         AppError::RuntimeBusy => "read_marker_failed:runtime_busy",
         AppError::AccountSessionBusy => "read_marker_failed:account_session_busy",
+        AppError::AccountWorkerBusy => "read_marker_failed:account_worker_busy",
+        AppError::AccountWorkerResponseTimedOut => {
+            "read_marker_failed:account_worker_response_timed_out"
+        }
         AppError::AccountSetupRecoveryRequired => {
             "read_marker_failed:account_setup_recovery_required"
         }

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -334,6 +334,9 @@ impl AppClient {
         self.prepare_transport_with_telemetry(telemetry)
             .await
             .map_err(SyncFailure::from)?;
+        // A complete startup/catch-up rebuild satisfies any older deferred
+        // refresh intent before this pass starts ingesting new deliveries.
+        self.pending_runtime_group_subscription_refresh = false;
         // Both the inbox/group activation and the group-subscription refresh
         // have now registered on relays; emit the rebuild audit row from the
         // drained registration log before draining inbound deliveries.
@@ -909,9 +912,17 @@ impl AppClient {
         summary.merge(std::mem::take(&mut self.pending_failed_sync_summary));
 
         if routes_dirty || routes_changed {
-            self.sync_runtime_groups()
-                .await
-                .map_err(SyncCheckpointError::AfterPersistence)?;
+            match self.sync_runtime_groups().await {
+                Ok(()) => self.pending_runtime_group_subscription_refresh = false,
+                Err(error) => {
+                    // The projection and route checkpoint above are durable.
+                    // Retain an explicit retry edge so the worker repairs the
+                    // ordinary subscriptions without replaying this prefix or
+                    // waiting for another catch-up trigger.
+                    self.pending_runtime_group_subscription_refresh = true;
+                    return Err(SyncCheckpointError::AfterPersistence(error));
+                }
+            }
         }
         Ok(())
     }
@@ -1508,6 +1519,7 @@ impl AppClient {
         self.sync_runtime_groups()
             .await
             .map_err(SyncFailure::from)?;
+        self.pending_runtime_group_subscription_refresh = false;
         self.record_subscription_rebuild(None).await;
         let mut deliveries = 0;
         let mut summary = self.sync_sdk_relay(&mut deliveries).await?;
@@ -2321,6 +2333,57 @@ mod membership_change_tests {
         let admin = GroupStateChange::AdminAdded { member };
         assert!(member_departure(&added).is_none());
         assert!(member_departure(&admin).is_none());
+    }
+}
+
+#[cfg(test)]
+mod runtime_group_subscription_refresh_tests {
+    use std::sync::Arc;
+
+    use super::{SyncCheckpointError, SyncSummary};
+    use crate::tests::ScriptedPushRelayClient;
+    use crate::{AppPerformanceTelemetry, MarmotApp};
+    use marmot_account::AccountHome;
+
+    #[tokio::test]
+    async fn catch_up_checkpoint_arms_refresh_after_durable_subscription_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        AccountHome::open(dir.path())
+            .create_account("alice")
+            .unwrap();
+        let relay = Arc::new(ScriptedPushRelayClient::default());
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+            .with_test_relay_client(relay.clone());
+        let mut client = app.client("alice").await.unwrap();
+        client.prepare_transport().await.unwrap();
+        let telemetry = AppPerformanceTelemetry::default();
+        client
+            .create_group_with_initial_profile_and_telemetry(
+                "catch-up retry intent",
+                "",
+                &[],
+                None,
+                &telemetry,
+            )
+            .await
+            .unwrap();
+
+        relay.fail_next_subscribe();
+        let mut summary = SyncSummary::default();
+        let error = client
+            .checkpoint_sync_prefix(&mut summary, true, 0)
+            .await
+            .expect_err("the injected post-checkpoint subscription rebuild must fail");
+        assert!(matches!(error, SyncCheckpointError::AfterPersistence(_)));
+        assert!(client.has_pending_runtime_group_subscription_refresh());
+
+        assert!(
+            !client
+                .retry_pending_runtime_group_subscription_refresh()
+                .await
+                .unwrap()
+        );
+        assert!(!client.has_pending_runtime_group_subscription_refresh());
     }
 }
 

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -199,6 +199,36 @@ impl AppClient {
         Ok(())
     }
 
+    pub(crate) fn has_pending_runtime_group_subscription_refresh(&self) -> bool {
+        self.pending_runtime_group_subscription_refresh
+    }
+
+    /// Retry an ordinary group-subscription rebuild that was deliberately
+    /// moved behind live-ingest visibility. A successful rebuild disarms the
+    /// intent; an error leaves it armed so the worker's bounded backoff can
+    /// try again without replaying the durable delivery.
+    pub(crate) async fn retry_pending_runtime_group_subscription_refresh(
+        &mut self,
+    ) -> Result<bool, AppError> {
+        if !self.pending_runtime_group_subscription_refresh {
+            return Ok(false);
+        }
+        if let Err(error) = self.sync_runtime_groups().await {
+            if error.is_account_not_active() {
+                // A relay notification gap or overlapping account-adapter
+                // teardown can retire the activation between durable ingest
+                // and this background retry. Re-activation installs both the
+                // account inbox and the current complete group set, satisfying
+                // the same refresh intent without replaying the delivery.
+                self.prepare_transport().await?;
+            } else {
+                return Err(error);
+            }
+        }
+        self.pending_runtime_group_subscription_refresh = false;
+        Ok(false)
+    }
+
     pub(crate) async fn prepare_transport(&self) -> Result<(), AppError> {
         self.prepare_transport_with_telemetry(None).await
     }
@@ -608,6 +638,13 @@ impl AppClient {
         loop {
             let delivery = self.receive_next_delivery().await?;
             let summary = self.ingest_received_delivery(delivery).await?;
+            // A directly-owned AppClient has no account-worker scheduler to
+            // perform the post-visibility retry. Preserve its historical
+            // contract by completing the pending rebuild before handing the
+            // summary to its caller; the managed worker uses the lower-level
+            // ingest method and owns the background retry instead.
+            self.retry_pending_runtime_group_subscription_refresh()
+                .await?;
             if summary.joined_groups.is_empty()
                 && summary.messages.is_empty()
                 && summary.events.is_empty()
@@ -684,9 +721,7 @@ impl AppClient {
         if !routes_dirty || refresh.state_pruned {
             self.save_state_with_pending_local_group_deletion_frontier_clears()?;
         }
-        if routes_dirty || refresh.routing_changed {
-            self.sync_runtime_groups().await?;
-        }
+        self.pending_runtime_group_subscription_refresh |= routes_dirty || refresh.routing_changed;
         self.drain_epoch_stall_escalations(&mut summary);
         Ok(summary)
     }

--- a/crates/marmot-app/src/error.rs
+++ b/crates/marmot-app/src/error.rs
@@ -128,6 +128,15 @@ pub enum AppError {
     /// owns the account's in-memory engine session.
     #[error("marmot account session is already in use")]
     AccountSessionBusy,
+    /// The managed account worker is in an exclusive catch-up phase and did
+    /// not start this command. Retrying after the catch-up completes is safe.
+    #[error("marmot account worker is busy catching up; operation was not started")]
+    AccountWorkerBusy,
+    /// The worker accepted the command, but its response did not arrive within
+    /// the operation-class deadline. Completion is unknown; callers must
+    /// refresh authoritative state before deciding whether to retry.
+    #[error("marmot account worker response timed out; operation completion is unknown")]
+    AccountWorkerResponseTimedOut,
     /// An account database predates the durable setup journal and has no
     /// recoverable stable KeyPackage slot. Local evidence cannot prove that a
     /// previously signed package was never exposed, so automatic rotation is
@@ -227,6 +236,8 @@ impl AppError {
             Self::BlockingTask(_) => "blocking_task",
             Self::RuntimeBusy => "runtime_busy",
             Self::AccountSessionBusy => "account_session_busy",
+            Self::AccountWorkerBusy => "account_worker_busy",
+            Self::AccountWorkerResponseTimedOut => "account_worker_response_timed_out",
             Self::AccountSetupRecoveryRequired => "account_setup_recovery_required",
             Self::AccountSetupRetryRequired => "account_setup_retry_required",
             Self::AccountSetupResetNotApplicable => "account_setup_reset_not_applicable",

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -261,6 +261,16 @@ const KEY_PACKAGE_DIR: &str = "key-packages";
 const SDK_FIRST_SYNC_WAIT: Duration = Duration::from_millis(750);
 const SDK_DRAIN_WAIT: Duration = Duration::from_millis(250);
 const APP_RUNTIME_ACCOUNT_READY_WAIT: Duration = Duration::from_secs(45);
+/// Local worker operations include SQLite's bounded busy retry but no relay or
+/// blob transfer. A missing response beyond this point indicates a wedged
+/// worker, not ordinary storage contention.
+const APP_RUNTIME_LOCAL_WORKER_RESPONSE_WAIT: Duration = Duration::from_secs(10);
+/// Default deadline for worker commands that may sign, publish, or perform a
+/// bounded relay exchange.
+const APP_RUNTIME_WORKER_RESPONSE_WAIT: Duration = Duration::from_secs(2 * 60);
+/// Media commands have their own 15-minute transfer cap; leave one minute for
+/// queueing, projection, and response delivery around that bounded operation.
+const APP_RUNTIME_LONG_WORKER_RESPONSE_WAIT: Duration = Duration::from_secs(16 * 60);
 /// Cap for advisory account-setup steps (directory discovery/refresh): their
 /// results are best-effort, so a slow indexer must not stall login.
 pub(crate) const ACCOUNT_SETUP_ADVISORY_WAIT: Duration = Duration::from_secs(10);
@@ -1481,6 +1491,7 @@ impl MarmotApp {
             pending_convergence_groups: std::collections::HashSet::new(),
             pending_local_group_deletion_frontier_clears: std::collections::HashMap::new(),
             pending_application_event_acks: std::collections::HashSet::new(),
+            pending_runtime_group_subscription_refresh: false,
             #[cfg(test)]
             force_event_group_projection_unavailable: false,
             pending_welcome_delivery_events: Vec::new(),

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -348,6 +348,9 @@ pub(crate) enum AccountWorkerCommand {
     RetryPushRegistration {
         respond: oneshot::Sender<bool>,
     },
+    RetryRuntimeGroupSubscriptions {
+        respond: oneshot::Sender<bool>,
+    },
     DeleteAuditLog {
         path: std::path::PathBuf,
         respond: oneshot::Sender<Result<bool, AppError>>,
@@ -470,14 +473,17 @@ async fn run_app_runtime_account_worker(
         scheduled_convergence_test_delay(&app),
     );
     let mut scheduled_push_retry = ScheduledPushRegistrationRetry::new();
+    let mut scheduled_runtime_group_subscription_refresh =
+        ScheduledRuntimeGroupSubscriptionRefresh::new();
 
     // The session's cheap open pass has seeded every stored group. Signal
     // command-readiness *now*: the hydration pipeline right below enters its
     // command-serving loop immediately, so "ready" genuinely means "serving
     // commands" — group reads (`Members` / `MemberIdsPage` / `GroupMlsState` /
     // `GroupRoster` / `QuarantinedGroups`) issued from this point hydrate the
-    // group(s) they name and answer live. Everything else
-    // joins the startup deferral. `AccountOpen` (recorded by `reconcile` as the ready-wait)
+    // group(s) they name and answer live; projection-only invite acceptance
+    // also runs immediately. Everything else joins the startup deferral.
+    // `AccountOpen` (recorded by `reconcile` as the ready-wait)
     // measures the seeded open; the mdk#1161 stage telemetry attributes it
     // (`AccountSessionOpen` / `AccountGroupHydration` for the open the
     // worker just awaited, with the pipeline and snapshot capture measured
@@ -505,8 +511,9 @@ async fn run_app_runtime_account_worker(
     // seeded stored groups, so fully hydrate them now — chat-list recency
     // first — while serving commands. Group reads for a not-yet-hydrated
     // group hydrate that one group and answer live ("waits for that group
-    // only"); mutations and catch-ups join the same startup deferral the
-    // catch-up window has always used and replay in arrival order after it.
+    // only"); projection-only invite acceptance also runs live. Other
+    // mutations and catch-ups join the same startup deferral the catch-up
+    // window has always used and replay in arrival order after it.
     let mut deferred: Vec<DeferredStartupCommand> = Vec::new();
     match run_startup_hydration_pipeline(
         &app,
@@ -563,8 +570,9 @@ async fn run_app_runtime_account_worker(
     // registration, and initial catch-up only after local readiness has been
     // signalled. The sync future holds `&mut client` for its whole lifetime, so
     // while it is in flight the command loop must not touch the live session:
-    // read commands are answered from `read_snapshot`, and every other command
-    // is deferred and replayed on live state once catch-up lands, in arrival
+    // read commands are answered from `read_snapshot`, invite acceptance gets
+    // a typed definitely-not-started busy response, and every other command is
+    // deferred and replayed on live state once catch-up lands, in arrival
     // order. `CatchUp` requests that arrive during the initial sync are
     // coalesced onto it.
     let sync_started_at = Instant::now();
@@ -644,6 +652,13 @@ async fn run_app_runtime_account_worker(
                                 ))),
                             }
                         }
+                        Some(AccountWorkerCommand::AcceptGroupInvite { respond, .. }) => {
+                            // `initial_sync` owns `&mut client`, so the command
+                            // cannot start here. Report that fact explicitly
+                            // instead of retaining the oneshot behind an
+                            // unbounded catch-up.
+                            let _ = respond.send(Err(AppError::AccountWorkerBusy));
+                        }
                         Some(AccountWorkerCommand::CatchUp { respond }) => {
                             // Coalesce onto the in-flight initial catch-up rather
                             // than starting a second sync; fulfilled in arrival
@@ -666,6 +681,14 @@ async fn run_app_runtime_account_worker(
     let catch_up_result = match startup_sync_result {
         Ok(summary) => {
             publish_app_runtime_summary(&events, &account_id_hex, &account_label, &summary);
+            start_post_join_history_after_visibility(
+                &mut client,
+                &summary,
+                &events,
+                &account_id_hex,
+                &account_label,
+            )
+            .await;
             schedule_pending_convergence_groups(&mut scheduled_convergence, &mut client);
             let backfill_result = run_pending_epoch_backfill_reporting_arm(
                 &mut client,
@@ -690,6 +713,14 @@ async fn run_app_runtime_account_worker(
                 &shared,
                 "startup_sync",
             );
+            start_post_join_history_after_visibility(
+                &mut client,
+                &failure.partial_summary,
+                &events,
+                &account_id_hex,
+                &account_label,
+            )
+            .await;
             // A failed initial catch-up surfaces as an account error but must not
             // fail worker readiness — readiness was already signalled above.
             let message = account_error_message("runtime startup receive failed", &failure.source);
@@ -708,6 +739,14 @@ async fn run_app_runtime_account_worker(
             match client.drain_pending_session_events().await {
                 Ok(summary) => {
                     publish_app_runtime_summary(&events, &account_id_hex, &account_label, &summary);
+                    start_post_join_history_after_visibility(
+                        &mut client,
+                        &summary,
+                        &events,
+                        &account_id_hex,
+                        &account_label,
+                    )
+                    .await;
                 }
                 Err(drain_error) => {
                     publish_app_runtime_account_error(
@@ -944,6 +983,18 @@ async fn run_app_runtime_account_worker(
                     Ok(summary) => {
                         reconnect_backoff.reset();
                         publish_app_runtime_summary(&events, &account_id_hex, &account_label, &summary);
+                        start_post_join_history_after_visibility(
+                            &mut client,
+                            &summary,
+                            &events,
+                            &account_id_hex,
+                            &account_label,
+                        )
+                        .await;
+                        scheduled_runtime_group_subscription_refresh.observe_pending(
+                            client.has_pending_runtime_group_subscription_refresh(),
+                            &command_tx,
+                        );
                         schedule_pending_convergence_groups(
                             &mut scheduled_convergence,
                             &mut client,
@@ -1069,6 +1120,14 @@ async fn run_app_runtime_account_worker(
                                                 &account_label,
                                                 &summary,
                                             );
+                                            start_post_join_history_after_visibility(
+                                                &mut reopened,
+                                                &summary,
+                                                &events,
+                                                &account_id_hex,
+                                                &account_label,
+                                            )
+                                            .await;
                                         }
                                         Err(error) => {
                                             publish_app_runtime_account_error(
@@ -1139,6 +1198,14 @@ async fn run_app_runtime_account_worker(
                                 &account_label,
                                 &summary,
                             );
+                            start_post_join_history_after_visibility(
+                                &mut client,
+                                &summary,
+                                &events,
+                                &account_id_hex,
+                                &account_label,
+                            )
+                            .await;
                             publish_client_pending_projection_updates(
                                 &mut client,
                                 &events,
@@ -1159,6 +1226,14 @@ async fn run_app_runtime_account_worker(
                                 &shared,
                                 "key_package_maintenance_catch_up",
                             );
+                            start_post_join_history_after_visibility(
+                                &mut client,
+                                &failure.partial_summary,
+                                &events,
+                                &account_id_hex,
+                                &account_label,
+                            )
+                            .await;
                             publish_app_runtime_account_error(
                                 &events,
                                 &account_id_hex,
@@ -1335,6 +1410,20 @@ async fn handle_account_worker_catch_up(
                         .expect("snapshot availability checked above");
                     let _ = respond.send(Ok(snapshot.quarantined_groups()));
                 }
+                AccountWorkerCommand::AcceptGroupInvite { respond, .. } => {
+                    // The pinned sync exclusively owns the live client. This
+                    // mutation was definitely not started, so a caller may
+                    // safely retry after catch-up rather than waiting behind
+                    // an arbitrarily slow relay drain.
+                    let _ = respond.send(Err(AppError::AccountWorkerBusy));
+                }
+                AccountWorkerCommand::RetryRuntimeGroupSubscriptions { respond } => {
+                    // This is worker-owned maintenance, not caller work. Keep
+                    // its retry armed without placing it in the deferred FIFO;
+                    // otherwise it would unnecessarily force later snapshot
+                    // reads to wait behind the whole catch-up.
+                    let _ = respond.send(true);
+                }
                 AccountWorkerCommand::CatchUp { respond } if deferred.is_empty() => {
                     catch_up_responders.push(respond);
                 }
@@ -1350,6 +1439,14 @@ async fn handle_account_worker_catch_up(
                 context.account_label,
                 &summary,
             );
+            start_post_join_history_after_visibility(
+                client,
+                &summary,
+                context.events,
+                context.account_id_hex,
+                context.account_label,
+            )
+            .await;
             let backfill_result = run_pending_epoch_backfill_reporting_arm(
                 client,
                 context.events,
@@ -1373,6 +1470,14 @@ async fn handle_account_worker_catch_up(
                 context.shared,
                 "catch_up",
             );
+            start_post_join_history_after_visibility(
+                client,
+                &failure.partial_summary,
+                context.events,
+                context.account_id_hex,
+                context.account_label,
+            )
+            .await;
             let message = account_error_message("runtime catch-up failed", &failure.source);
             publish_app_runtime_account_error(
                 context.events,
@@ -1526,8 +1631,9 @@ fn run_legacy_message_promotion_batch_with(
 /// Fully hydrate every group the deferred session open only seeded, in
 /// chat-list recency order, while serving commands between batches
 /// (mdk#1161). Group reads hydrate their one group and answer live;
-/// mutations and catch-ups join `deferred` and replay in arrival order after
-/// the initial catch-up, exactly like the catch-up window's own deferral.
+/// projection-only invite acceptance runs immediately; other mutations and
+/// catch-ups join `deferred` and replay in arrival order after the initial
+/// catch-up, exactly like the catch-up window's own deferral.
 /// Recovery events surface incrementally after each batch. A storage-level
 /// pipeline failure stops the pipeline but not the worker: remaining groups
 /// stay gated with the retryable not-hydrated state and still promote on
@@ -1581,7 +1687,15 @@ async fn run_startup_hydration_pipeline(
                     _ = &mut *shutdown => return StartupHydrationOutcome::Shutdown,
                     command = commands.recv() => match command {
                         Some(command) => {
-                            handle_startup_hydration_command(client, command, deferred).await;
+                            handle_startup_hydration_command(
+                                client,
+                                command,
+                                deferred,
+                                events,
+                                account_id_hex,
+                                account_label,
+                            )
+                            .await;
                         }
                         None => return StartupHydrationOutcome::Shutdown,
                     },
@@ -1593,7 +1707,15 @@ async fn run_startup_hydration_pipeline(
             match commands.try_recv() {
                 Ok(command) => {
                     commands_served += 1;
-                    handle_startup_hydration_command(client, command, deferred).await;
+                    handle_startup_hydration_command(
+                        client,
+                        command,
+                        deferred,
+                        events,
+                        account_id_hex,
+                        account_label,
+                    )
+                    .await;
                 }
                 Err(mpsc::error::TryRecvError::Empty) => break,
                 Err(mpsc::error::TryRecvError::Disconnected) => {
@@ -1676,12 +1798,16 @@ async fn drain_deferred_hydration(client: &mut AppClient) -> Result<(), AppError
 /// running. Group-local reads answer live — hydrating exactly the group
 /// they name first, so a read "waits for that group only". The quarantine
 /// list answers the incrementally-growing set; later additions reach
-/// subscribers through their `GroupHydrationQuarantined` events. Everything
-/// else joins the startup deferral in arrival order.
+/// subscribers through their `GroupHydrationQuarantined` events. Invite
+/// acceptance also runs live; everything else joins the startup deferral in
+/// arrival order.
 async fn handle_startup_hydration_command(
     client: &mut AppClient,
     command: AccountWorkerCommand,
     deferred: &mut Vec<DeferredStartupCommand>,
+    events: &broadcast::Sender<MarmotAppEvent>,
+    account_id_hex: &str,
+    account_label: &str,
 ) {
     match command {
         AccountWorkerCommand::Members { group_id, respond } => {
@@ -1706,6 +1832,22 @@ async fn handle_startup_hydration_command(
         }
         AccountWorkerCommand::QuarantinedGroups { respond } => {
             let _ = respond.send(Ok(client.quarantined_groups()));
+        }
+        AccountWorkerCommand::AcceptGroupInvite { group_id, respond } => {
+            // Invite confirmation is a projection-only mutation and does not
+            // need the remaining MLS groups to finish hydrating. Apply and
+            // publish it immediately so a locally visible invite cannot be
+            // held behind unrelated startup work.
+            let result = client.accept_group_invite(&group_id);
+            if result.is_ok() {
+                publish_app_runtime_group_state_updated(
+                    events,
+                    account_id_hex,
+                    account_label,
+                    &group_id,
+                );
+            }
+            let _ = respond.send(result);
         }
         #[cfg(test)]
         AccountWorkerCommand::UnhydratedGroupCount { respond } => {
@@ -1739,6 +1881,24 @@ async fn handle_account_worker_command(
     match command {
         AccountWorkerCommand::NetworkStartupSettled { respond } => {
             let _ = respond.send(());
+        }
+        AccountWorkerCommand::RetryRuntimeGroupSubscriptions { respond } => {
+            let pending = match client
+                .retry_pending_runtime_group_subscription_refresh()
+                .await
+            {
+                Ok(pending) => pending,
+                Err(error) => {
+                    publish_app_runtime_account_error(
+                        events,
+                        account_id_hex,
+                        account_label,
+                        account_error_message("runtime group subscription refresh failed", &error),
+                    );
+                    true
+                }
+            };
+            let _ = respond.send(pending);
         }
         #[cfg(test)]
         AccountWorkerCommand::UnhydratedGroupCount { respond } => {
@@ -2802,6 +2962,93 @@ impl Drop for ScheduledPushRegistrationRetry {
     }
 }
 
+fn runtime_group_subscription_retry_base_delay() -> Duration {
+    if cfg!(test) {
+        Duration::from_millis(25)
+    } else {
+        Duration::from_secs(1)
+    }
+}
+
+fn runtime_group_subscription_retry_max_delay() -> Duration {
+    if cfg!(test) {
+        Duration::from_millis(1_600)
+    } else {
+        Duration::from_secs(60)
+    }
+}
+
+fn runtime_group_subscription_retry_delay(attempt: u32) -> Duration {
+    let shift = attempt.saturating_sub(1).min(6);
+    let multiplier = 1u32 << shift;
+    runtime_group_subscription_retry_base_delay()
+        .saturating_mul(multiplier)
+        .min(runtime_group_subscription_retry_max_delay())
+}
+
+/// Bounded retry for an ordinary group-subscription rebuild that follows a
+/// durable live ingest. The task speaks through the worker queue so it never
+/// races the engine-owning [`AppClient`]; successful refresh disarms it.
+struct ScheduledRuntimeGroupSubscriptionRefresh {
+    timer_task: Option<JoinHandle<()>>,
+}
+
+impl ScheduledRuntimeGroupSubscriptionRefresh {
+    fn new() -> Self {
+        Self { timer_task: None }
+    }
+
+    fn is_armed(&self) -> bool {
+        self.timer_task
+            .as_ref()
+            .is_some_and(|task| !task.is_finished())
+    }
+
+    fn observe_pending(&mut self, pending: bool, commands: &mpsc::Sender<AccountWorkerCommand>) {
+        if !pending {
+            self.disarm();
+        } else if !self.is_armed() {
+            self.arm(commands.clone());
+        }
+    }
+
+    fn arm(&mut self, commands: mpsc::Sender<AccountWorkerCommand>) {
+        if let Some(task) = self.timer_task.take() {
+            task.abort();
+        }
+        self.timer_task = Some(tokio::spawn(async move {
+            let mut attempt = 1u32;
+            loop {
+                sleep(runtime_group_subscription_retry_delay(attempt)).await;
+                let (respond, response) = oneshot::channel();
+                if commands
+                    .send(AccountWorkerCommand::RetryRuntimeGroupSubscriptions { respond })
+                    .await
+                    .is_err()
+                {
+                    return;
+                }
+                match response.await {
+                    Ok(true) => attempt = attempt.saturating_add(1),
+                    Ok(false) | Err(_) => return,
+                }
+            }
+        }));
+    }
+
+    fn disarm(&mut self) {
+        if let Some(task) = self.timer_task.take() {
+            task.abort();
+        }
+    }
+}
+
+impl Drop for ScheduledRuntimeGroupSubscriptionRefresh {
+    fn drop(&mut self) {
+        self.disarm();
+    }
+}
+
 /// Extra delay beyond the engine quiescence window before the first scheduled
 /// convergence tick fires. Avoids off-by-one-ms races where the timer fires
 /// while `ConvergenceStatus` is still `Syncing` (mdk#494).
@@ -3077,6 +3324,31 @@ fn sync_summary_triggers_audit_tracker_update(summary: &SyncSummary) -> bool {
         // pass often ingests only undecryptable traffic), so it must trip the
         // gate on its own.
         || !summary.epoch_stall_escalations.is_empty()
+}
+
+/// Start the temporary full-history subscription only after the caller has
+/// published the summary containing `GroupJoined`. This ordering makes the
+/// durable group visible even when relay subscription installation is slow or
+/// fails; the existing maintenance tick retries any obligation still in its
+/// `CatchUp` phase without changing the engine's grace/quiet/jitter policy.
+async fn start_post_join_history_after_visibility(
+    client: &mut AppClient,
+    summary: &SyncSummary,
+    events: &broadcast::Sender<MarmotAppEvent>,
+    account_id_hex: &str,
+    account_label: &str,
+) {
+    if summary.joined_groups.is_empty() {
+        return;
+    }
+    if let Err(error) = client.advance_post_join_maintenance_subscriptions().await {
+        publish_app_runtime_account_error(
+            events,
+            account_id_hex,
+            account_label,
+            account_error_message("post-join maintenance subscription failed", &error),
+        );
+    }
 }
 
 fn publish_sync_summary_with_audit(
@@ -3959,6 +4231,37 @@ mod tests {
         tokio::task::yield_now().await;
 
         scheduled.schedule_after_attempt(false, &commands);
+        assert!(!scheduled.is_armed());
+    }
+
+    #[tokio::test]
+    async fn runtime_group_subscription_retry_is_bounded_and_disarms_when_refreshed() {
+        assert_eq!(
+            runtime_group_subscription_retry_delay(1),
+            runtime_group_subscription_retry_base_delay()
+        );
+        assert_eq!(
+            runtime_group_subscription_retry_delay(u32::MAX),
+            runtime_group_subscription_retry_max_delay()
+        );
+
+        let (commands, mut received_commands) = mpsc::channel(2);
+        let mut scheduled = ScheduledRuntimeGroupSubscriptionRefresh::new();
+        scheduled.observe_pending(true, &commands);
+        assert!(scheduled.is_armed());
+
+        let first = received_commands.recv().await.unwrap();
+        let AccountWorkerCommand::RetryRuntimeGroupSubscriptions { respond } = first else {
+            panic!("timer must enqueue an internal group-subscription retry")
+        };
+        respond.send(true).unwrap();
+
+        let second = received_commands.recv().await.unwrap();
+        let AccountWorkerCommand::RetryRuntimeGroupSubscriptions { respond } = second else {
+            panic!("pending refresh must enqueue a backed-off retry")
+        };
+        respond.send(false).unwrap();
+        scheduled.observe_pending(false, &commands);
         assert!(!scheduled.is_armed());
     }
 

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -784,6 +784,10 @@ async fn run_app_runtime_account_worker(
             }
         }
     }
+    scheduled_runtime_group_subscription_refresh.observe_pending(
+        client.has_pending_runtime_group_subscription_refresh(),
+        &command_tx,
+    );
     // Automatic gossip is best-effort network work. Run it only after startup
     // callers have received their deferred responses so a degraded relay cannot
     // extend account-open latency.
@@ -958,6 +962,10 @@ async fn run_app_runtime_account_worker(
                             schedule_pending_convergence_groups(
                                 &mut scheduled_convergence,
                                 &mut client,
+                            );
+                            scheduled_runtime_group_subscription_refresh.observe_pending(
+                                client.has_pending_runtime_group_subscription_refresh(),
+                                &command_tx,
                             );
                             if may_change_push_registration_work {
                                 scheduled_push_retry.observe_pending(
@@ -1253,6 +1261,10 @@ async fn run_app_runtime_account_worker(
                         }
                     }
                 }
+                scheduled_runtime_group_subscription_refresh.observe_pending(
+                    client.has_pending_runtime_group_subscription_refresh(),
+                    &command_tx,
+                );
                 let _ = run_pending_epoch_backfill_reporting_arm(
                     &mut client,
                     &events,
@@ -1847,7 +1859,13 @@ async fn handle_startup_hydration_command(
                     &group_id,
                 );
             }
+            let retry_after_response = result.is_ok();
             let _ = respond.send(result);
+            if retry_after_response {
+                client
+                    .retry_pending_push_registration_shares_best_effort()
+                    .await;
+            }
         }
         #[cfg(test)]
         AccountWorkerCommand::UnhydratedGroupCount { respond } => {

--- a/crates/marmot-app/src/runtime/commands.rs
+++ b/crates/marmot-app/src/runtime/commands.rs
@@ -12,8 +12,9 @@ use cgka_traits::{GroupId, SecretBytes};
 use tokio::sync::oneshot;
 
 use super::{
-    AccountManager, AccountWorkerCommand, account_worker_response, group_contributes_co_members,
-    publish_app_runtime_group_state_updated,
+    AccountManager, AccountWorkerCommand, account_worker_catch_up_response,
+    account_worker_response, group_contributes_co_members, local_account_worker_response,
+    long_account_worker_response, publish_app_runtime_group_state_updated,
 };
 use crate::app_telemetry::AppPerformanceOperation;
 use crate::messages::AppMessageIntent;
@@ -146,10 +147,7 @@ impl AccountManager {
             .send(AccountWorkerCommand::RepairFullHistory { respond })
             .await
             .map_err(|_| AppError::TransportClosed)?;
-        response
-            .await
-            .map_err(|_| AppError::TransportClosed)?
-            .map_err(AppError::AccountCatchUp)
+        account_worker_catch_up_response(response).await
     }
 
     /// Create the group and return its canonical id. Invitation delivery is
@@ -189,7 +187,7 @@ impl AccountManager {
                 })
                 .await
                 .map_err(|_| AppError::TransportClosed)?;
-            account_worker_response(response).await
+            long_account_worker_response(response).await
         }
         .await;
         self.shared.app_performance_telemetry().record(
@@ -239,7 +237,7 @@ impl AccountManager {
             })
             .await
             .map_err(|_| AppError::TransportClosed)?;
-        account_worker_response(response).await
+        local_account_worker_response(response).await
     }
 
     /// Read identifier-only rosters for a bounded page of groups in one
@@ -387,7 +385,7 @@ impl AccountManager {
             })
             .await
             .map_err(|_| AppError::TransportClosed)?;
-        account_worker_response(response).await
+        local_account_worker_response(response).await
     }
 
     /// Stored groups that failed session-open hydration and were skipped
@@ -403,7 +401,7 @@ impl AccountManager {
             .send(AccountWorkerCommand::QuarantinedGroups { respond })
             .await
             .map_err(|_| AppError::TransportClosed)?;
-        account_worker_response(response).await
+        local_account_worker_response(response).await
     }
 
     /// Re-attempt hydration of a single quarantined group (mdk#426).
@@ -643,7 +641,7 @@ impl AccountManager {
             })
             .await
             .map_err(|_| AppError::TransportClosed)?;
-        account_worker_response(response).await
+        local_account_worker_response(response).await
     }
 
     pub async fn decline_group_invite(
@@ -704,7 +702,7 @@ impl AccountManager {
             })
             .await
             .map_err(|_| AppError::TransportClosed)?;
-        account_worker_response(response).await
+        local_account_worker_response(response).await
     }
 
     pub async fn update_group_image(
@@ -725,7 +723,7 @@ impl AccountManager {
             })
             .await
             .map_err(|_| AppError::TransportClosed)?;
-        let summary = account_worker_response(response).await?;
+        let summary = long_account_worker_response(response).await?;
         self.catch_up_after_committed_mutation("update_group_image")
             .await;
         Ok(summary)
@@ -745,7 +743,7 @@ impl AccountManager {
             })
             .await
             .map_err(|_| AppError::TransportClosed)?;
-        account_worker_response(response).await
+        long_account_worker_response(response).await
     }
 
     pub async fn update_message_retention(
@@ -1186,7 +1184,7 @@ impl AccountManager {
             })
             .await
             .map_err(|_| AppError::TransportClosed)?;
-        let result = account_worker_response(response).await?;
+        let result = long_account_worker_response(response).await?;
         if result.sent.is_some() {
             self.schedule_audit_log_tracker_update("upload_media_send");
         }
@@ -1228,7 +1226,7 @@ impl AccountManager {
             })
             .await
             .map_err(|_| AppError::TransportClosed)?;
-        account_worker_response(response).await
+        long_account_worker_response(response).await
     }
 
     pub(crate) async fn secure_delete_expired_plaintext(

--- a/crates/marmot-app/src/runtime/commands.rs
+++ b/crates/marmot-app/src/runtime/commands.rs
@@ -12,8 +12,8 @@ use cgka_traits::{GroupId, SecretBytes};
 use tokio::sync::oneshot;
 
 use super::{
-    AccountManager, AccountWorkerCommand, account_worker_catch_up_response,
-    account_worker_response, group_contributes_co_members, local_account_worker_response,
+    AccountManager, AccountWorkerCommand, account_worker_response, group_contributes_co_members,
+    local_account_worker_response, long_account_worker_catch_up_response,
     long_account_worker_response, publish_app_runtime_group_state_updated,
 };
 use crate::app_telemetry::AppPerformanceOperation;
@@ -147,7 +147,7 @@ impl AccountManager {
             .send(AccountWorkerCommand::RepairFullHistory { respond })
             .await
             .map_err(|_| AppError::TransportClosed)?;
-        account_worker_catch_up_response(response).await
+        long_account_worker_catch_up_response(response).await
     }
 
     /// Create the group and return its canonical id. Invitation delivery is

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -5038,10 +5038,10 @@ pub(crate) async fn long_account_worker_response<T>(
     account_worker_response_with_wait(response, APP_RUNTIME_LONG_WORKER_RESPONSE_WAIT).await
 }
 
-pub(crate) async fn account_worker_catch_up_response(
+pub(crate) async fn long_account_worker_catch_up_response(
     response: oneshot::Receiver<Result<(), String>>,
 ) -> Result<(), AppError> {
-    match timeout(APP_RUNTIME_WORKER_RESPONSE_WAIT, response).await {
+    match timeout(APP_RUNTIME_LONG_WORKER_RESPONSE_WAIT, response).await {
         Ok(Ok(result)) => result.map_err(AppError::AccountCatchUp),
         Ok(Err(_)) => Err(AppError::TransportClosed),
         Err(_) => Err(AppError::AccountWorkerResponseTimedOut),

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -32,8 +32,9 @@ use crate::messages::AppMessageIntent;
 use crate::notifications;
 use crate::{
     ACCOUNT_SETUP_ADVISORY_WAIT, APP_RUNTIME_ACCOUNT_READY_WAIT, APP_RUNTIME_ACCOUNT_SHUTDOWN_WAIT,
-    APP_RUNTIME_RELAY_REBUILD_LOOKBACK, AccountKeyPackageRecord, AccountRelayListBootstrap,
-    AccountRelayListStatus, AccountUnread, AgentOperationEventRequest,
+    APP_RUNTIME_LOCAL_WORKER_RESPONSE_WAIT, APP_RUNTIME_LONG_WORKER_RESPONSE_WAIT,
+    APP_RUNTIME_RELAY_REBUILD_LOOKBACK, APP_RUNTIME_WORKER_RESPONSE_WAIT, AccountKeyPackageRecord,
+    AccountRelayListBootstrap, AccountRelayListStatus, AccountUnread, AgentOperationEventRequest,
     AgentTextStreamFinishRequest, AppBlobEndpoint, AppDisbandRequest, AppError,
     AppGroupMemberRecord, AppGroupMlsState, AppGroupRecord, AppGroupRoster, AppMessageQuery,
     AppMessageRecord, AppProjectionUpdate, AppQuarantinedGroup, AuditLogDeleteOutcome,
@@ -4025,7 +4026,7 @@ impl AccountManager {
                 .await
                 .is_ok()
             {
-                let _ = response.await;
+                let _ = timeout(APP_RUNTIME_LOCAL_WORKER_RESPONSE_WAIT, response).await;
             }
         }
     }
@@ -4057,7 +4058,7 @@ impl AccountManager {
                 .await
                 .is_ok()
             {
-                let _ = response.await;
+                let _ = timeout(APP_RUNTIME_LOCAL_WORKER_RESPONSE_WAIT, response).await;
             }
         }
     }
@@ -5022,7 +5023,40 @@ fn directory_discovery_relays_for_setup(request: &AccountSetupRequest) -> Vec<Tr
 pub(crate) async fn account_worker_response<T>(
     response: oneshot::Receiver<Result<T, AppError>>,
 ) -> Result<T, AppError> {
-    response.await.map_err(|_| AppError::TransportClosed)?
+    account_worker_response_with_wait(response, APP_RUNTIME_WORKER_RESPONSE_WAIT).await
+}
+
+pub(crate) async fn local_account_worker_response<T>(
+    response: oneshot::Receiver<Result<T, AppError>>,
+) -> Result<T, AppError> {
+    account_worker_response_with_wait(response, APP_RUNTIME_LOCAL_WORKER_RESPONSE_WAIT).await
+}
+
+pub(crate) async fn long_account_worker_response<T>(
+    response: oneshot::Receiver<Result<T, AppError>>,
+) -> Result<T, AppError> {
+    account_worker_response_with_wait(response, APP_RUNTIME_LONG_WORKER_RESPONSE_WAIT).await
+}
+
+pub(crate) async fn account_worker_catch_up_response(
+    response: oneshot::Receiver<Result<(), String>>,
+) -> Result<(), AppError> {
+    match timeout(APP_RUNTIME_WORKER_RESPONSE_WAIT, response).await {
+        Ok(Ok(result)) => result.map_err(AppError::AccountCatchUp),
+        Ok(Err(_)) => Err(AppError::TransportClosed),
+        Err(_) => Err(AppError::AccountWorkerResponseTimedOut),
+    }
+}
+
+async fn account_worker_response_with_wait<T>(
+    response: oneshot::Receiver<Result<T, AppError>>,
+    wait: Duration,
+) -> Result<T, AppError> {
+    match timeout(wait, response).await {
+        Ok(Ok(result)) => result,
+        Ok(Err(_)) => Err(AppError::TransportClosed),
+        Err(_) => Err(AppError::AccountWorkerResponseTimedOut),
+    }
 }
 
 pub(crate) async fn blocking_app_task<T>(

--- a/crates/marmot-app/src/runtime/tests.rs
+++ b/crates/marmot-app/src/runtime/tests.rs
@@ -2080,6 +2080,15 @@ async fn concurrent_reconcile_cannot_lose_workers_to_failed_rollback() {
     runtime.shutdown().await;
 }
 
+#[tokio::test]
+async fn account_worker_response_deadline_reports_unknown_completion() {
+    let (_respond, response) = tokio::sync::oneshot::channel::<Result<(), AppError>>();
+    let error = account_worker_response_with_wait(response, Duration::from_millis(1))
+        .await
+        .expect_err("an open response channel must not wait forever");
+    assert!(matches!(error, AppError::AccountWorkerResponseTimedOut));
+}
+
 #[test]
 fn key_package_deletion_relay_failures_dedupe_privacy_safe_publish_endpoint_categories() {
     use crate::KeyPackageDeletionResult;

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -47,9 +47,11 @@ pub(crate) struct ScriptedPushRelayClient {
     publish_results: std::sync::Mutex<std::collections::VecDeque<bool>>,
     published_events: std::sync::Mutex<Vec<NostrTransportEvent>>,
     subscriptions: std::sync::Mutex<Vec<NostrSubscription>>,
+    subscription_attempts: std::sync::Mutex<Vec<NostrSubscription>>,
     block_next_subscribe: std::sync::atomic::AtomicBool,
     block_subscribe_count: std::sync::atomic::AtomicUsize,
     blocked_subscribe_count: std::sync::atomic::AtomicUsize,
+    group_subscribe_attempts: std::sync::atomic::AtomicUsize,
     fail_blocked_subscribe: std::sync::atomic::AtomicBool,
     fail_next_subscribe: std::sync::atomic::AtomicBool,
     block_next_unsubscribe: std::sync::atomic::AtomicBool,
@@ -58,6 +60,7 @@ pub(crate) struct ScriptedPushRelayClient {
     blocked_publish_count: std::sync::atomic::AtomicUsize,
     block_account_subscribe_after_next_publish: std::sync::Mutex<Option<Vec<u8>>>,
     block_account_subscribe: std::sync::Mutex<Option<Vec<u8>>>,
+    block_account_group_subscribe: std::sync::Mutex<Option<Vec<u8>>>,
     zero_ack_next_publish: std::sync::atomic::AtomicBool,
     batch_calls: std::sync::atomic::AtomicUsize,
     publish_started: tokio::sync::Notify,
@@ -92,6 +95,16 @@ impl ScriptedPushRelayClient {
             .block_account_subscribe_after_next_publish
             .lock()
             .unwrap() = Some(account_id);
+    }
+
+    fn block_account_inbox_subscribe(&self, account_id: Vec<u8>) {
+        *self.block_account_subscribe.lock().unwrap() = Some(account_id);
+    }
+
+    fn block_and_fail_account_group_subscribe(&self, account_id: Vec<u8>) {
+        *self.block_account_group_subscribe.lock().unwrap() = Some(account_id);
+        self.fail_blocked_subscribe
+            .store(true, std::sync::atomic::Ordering::SeqCst);
     }
 
     fn block_next_subscribe(&self) {
@@ -209,6 +222,49 @@ impl ScriptedPushRelayClient {
             })
             .count()
     }
+
+    fn group_subscription_count(
+        &self,
+        expected_account_id: &MemberId,
+        expected_group_id: &GroupId,
+    ) -> usize {
+        self.subscriptions
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|subscription| {
+                matches!(
+                    subscription,
+                    NostrSubscription::Group { account_id, group_id, .. }
+                        if account_id == expected_account_id && group_id == expected_group_id
+                )
+            })
+            .count()
+    }
+
+    fn group_subscribe_attempts(&self) -> usize {
+        self.group_subscribe_attempts
+            .load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    fn matching_group_subscribe_attempts(
+        &self,
+        expected_account_id: &MemberId,
+        expected_group_id: &GroupId,
+    ) -> usize {
+        self.subscription_attempts
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|subscription| {
+                matches!(
+                    subscription,
+                    NostrSubscription::Group { account_id, group_id, .. }
+                        if account_id == expected_account_id && group_id == expected_group_id
+                )
+            })
+            .count()
+    }
 }
 
 #[async_trait]
@@ -217,6 +273,14 @@ impl NostrRelayClient for ScriptedPushRelayClient {
         &self,
         subscription: NostrSubscription,
     ) -> Result<(), cgka_traits::TransportAdapterError> {
+        self.subscription_attempts
+            .lock()
+            .unwrap()
+            .push(subscription.clone());
+        if matches!(&subscription, NostrSubscription::Group { .. }) {
+            self.group_subscribe_attempts
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        }
         if self
             .fail_next_subscribe
             .swap(false, std::sync::atomic::Ordering::SeqCst)
@@ -227,7 +291,20 @@ impl NostrRelayClient for ScriptedPushRelayClient {
         }
         let block_for_account = {
             let mut blocked_account = self.block_account_subscribe.lock().unwrap();
-            if blocked_account.as_deref() == Some(subscription.account_id().as_slice()) {
+            if matches!(&subscription, NostrSubscription::AccountInbox { .. })
+                && blocked_account.as_deref() == Some(subscription.account_id().as_slice())
+            {
+                blocked_account.take();
+                true
+            } else {
+                false
+            }
+        };
+        let block_for_account_group = {
+            let mut blocked_account = self.block_account_group_subscribe.lock().unwrap();
+            if matches!(&subscription, NostrSubscription::Group { .. })
+                && blocked_account.as_deref() == Some(subscription.account_id().as_slice())
+            {
                 blocked_account.take();
                 true
             } else {
@@ -235,6 +312,7 @@ impl NostrRelayClient for ScriptedPushRelayClient {
             }
         };
         let blocked = block_for_account
+            || block_for_account_group
             || self
                 .block_next_subscribe
                 .swap(false, std::sync::atomic::Ordering::SeqCst)
@@ -1661,6 +1739,122 @@ async fn invite_members_detaches_post_mutation_catch_up_body() {
     .await
     .expect("detached post-mutation catch-up should finish after the relay unblocks");
     runtime.shutdown().await;
+}
+
+#[test]
+fn joined_group_is_visible_before_subscription_rebuild_and_accept_is_prompt_during_catch_up() {
+    run_composed_app_runtime_test("invite-catch-up-ordering", || async {
+        let dir = tempfile::tempdir().unwrap();
+        let home = AccountHome::open(dir.path());
+        let _alice = home.create_account("alice").unwrap();
+        let bob = home.create_account("bob").unwrap();
+        let bob_member = MemberId::new(hex::decode(&bob.account_id_hex).unwrap());
+        let relay = Arc::new(ScriptedPushRelayClient::default());
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+            .with_test_relay_client(relay.clone());
+        let runtime = MarmotAppRuntime::new(app.clone());
+        runtime.reconcile_accounts().await.unwrap();
+        runtime.catch_up_accounts().await.unwrap();
+        let mut events = runtime.subscribe();
+
+        // The first ordinary group-subscription rebuild will park and fail.
+        // The distinct post-join full-history subscription remains available,
+        // so this isolates the visibility boundary the regression cares about.
+        relay.block_and_fail_account_group_subscribe(bob_member.as_slice().to_vec());
+        let group_id = runtime
+            .create_group(
+                "alice",
+                "invite catch-up ordering",
+                std::slice::from_ref(&bob.account_id_hex),
+                None,
+            )
+            .await
+            .unwrap();
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                match events.recv().await {
+                    Ok(MarmotAppEvent::GroupJoined {
+                        account_id_hex,
+                        group_id: joined,
+                        ..
+                    }) if account_id_hex == bob.account_id_hex && joined == group_id => break,
+                    Ok(_) | Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                        panic!("runtime event stream closed before GroupJoined")
+                    }
+                }
+            }
+        })
+        .await
+        .expect("GroupJoined must publish without waiting for the ordinary subscription rebuild");
+
+        let group_id_hex = hex::encode(group_id.as_slice());
+        assert!(
+            app.group("bob", &group_id_hex)
+                .unwrap()
+                .expect("joined group projection")
+                .pending_confirmation,
+            "the durable invite projection must be queryable at GroupJoined"
+        );
+
+        tokio::time::timeout(Duration::from_secs(5), relay.wait_for_blocked_subscribe())
+            .await
+            .expect("ordinary group subscription refresh should run in the background");
+        relay.release_subscribe();
+
+        // The parked attempt fails after release. Its durable retry intent must
+        // rebuild the ordinary subscription without unrelated worker traffic.
+        let retry_result = tokio::time::timeout(Duration::from_secs(5), async {
+            while relay.group_subscription_count(&bob_member, &group_id) == 0 {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await;
+        assert!(
+            retry_result.is_ok(),
+            "failed ordinary group subscription must retry with bounded backoff (all_group_attempts={}, matching_attempts={})",
+            relay.group_subscribe_attempts(),
+            relay.matching_group_subscribe_attempts(&bob_member, &group_id),
+        );
+
+        // Pin Bob's next explicit catch-up at the account-inbox subscription.
+        // Accept must be rejected as definitely-not-started, not retained
+        // behind the relay operation or reported with ambiguous completion.
+        relay.block_account_inbox_subscribe(bob_member.as_slice().to_vec());
+        let catch_up_runtime = runtime.clone();
+        let catch_up = tokio::spawn(async move { catch_up_runtime.catch_up_accounts().await });
+        tokio::time::timeout(Duration::from_secs(5), relay.wait_for_blocked_subscribe())
+            .await
+            .expect("explicit catch-up should reach the pinned subscription");
+
+        let accept_error = tokio::time::timeout(
+            Duration::from_millis(250),
+            runtime.accept_group_invite("bob", &group_id),
+        )
+        .await
+        .expect("accept must answer promptly while catch-up is pinned")
+        .expect_err("accept cannot start while catch-up owns the account client");
+        assert!(matches!(accept_error, AppError::AccountWorkerBusy));
+        assert!(
+            app.group("bob", &group_id_hex)
+                .unwrap()
+                .expect("invite remains visible")
+                .pending_confirmation,
+            "busy means the accept mutation definitely did not run"
+        );
+
+        relay.release_subscribe();
+        tokio::time::timeout(Duration::from_secs(5), catch_up)
+            .await
+            .expect("catch-up should finish after release")
+            .expect("catch-up task should not panic")
+            .expect("catch-up should succeed");
+
+        let accepted = runtime.accept_group_invite("bob", &group_id).await.unwrap();
+        assert!(!accepted.pending_confirmation);
+        runtime.shutdown().await;
+    });
 }
 
 async fn concurrent_invites_keep_projections_readable_body() {

--- a/crates/marmot-app/tests/cursor_persistence.rs
+++ b/crates/marmot-app/tests/cursor_persistence.rs
@@ -40,9 +40,11 @@ use marmot_app::{
 use nostr_relay_builder::MockRelay;
 use tokio::time::sleep;
 
-/// How long a cold boot's initial catch-up is allowed to take. Generous
-/// relative to the crate's own `SDK_FIRST_SYNC_WAIT` / `SDK_DRAIN_WAIT`.
-const CATCH_UP_DEADLINE: Duration = Duration::from_secs(10);
+/// How long a cold boot's initial catch-up is allowed to take. The integration
+/// test runs inside a workspace-wide nextest partition, where concurrent
+/// crypto, SQLite, and relay tests can delay the current-thread runtime well
+/// beyond the relay adapter's own waits without indicating a stuck catch-up.
+const CATCH_UP_DEADLINE: Duration = Duration::from_secs(30);
 
 async fn mock_relay() -> (MockRelay, String) {
     let relay = MockRelay::run().await.unwrap();

--- a/crates/marmot-app/tests/cursor_persistence.rs
+++ b/crates/marmot-app/tests/cursor_persistence.rs
@@ -86,6 +86,7 @@ async fn wait_for_wall_clock_past(reference: u64) {
 
 async fn wait_for_event<F>(
     events: &mut tokio::sync::broadcast::Receiver<MarmotAppEvent>,
+    stage: &'static str,
     mut matches_event: F,
 ) where
     F: FnMut(&MarmotAppEvent) -> bool,
@@ -99,7 +100,7 @@ async fn wait_for_event<F>(
         }
     })
     .await
-    .expect("runtime event");
+    .unwrap_or_else(|_| panic!("runtime event did not arrive during {stage}"));
 }
 
 /// Poll for a cold boot's first catch-up to complete: `start` returns once the
@@ -218,7 +219,7 @@ async fn frozen_wake_collection_body() {
         .create_group("cursor persistence", &[bob_id.as_str()])
         .await
         .unwrap();
-    wait_for_event(&mut events_boot1, |event| {
+    wait_for_event(&mut events_boot1, "boot 1 group join", |event| {
         matches!(
             event,
             MarmotAppEvent::GroupJoined { account_id_hex, group_id: joined, .. }
@@ -226,11 +227,17 @@ async fn frozen_wake_collection_body() {
         )
     })
     .await;
+    // GroupJoined deliberately publishes as soon as the durable projection is
+    // visible; it no longer implies that the background ordinary-subscription
+    // rebuild has finished. This test cares about cursor persistence, so await
+    // an explicit catch-up boundary before using live delivery to establish
+    // boot 1's baseline cursor.
+    runtime_bob_boot1.catch_up_accounts().await.unwrap();
     alice_client
         .send(&group_id, b"ordinary traffic advances the cursor")
         .await
         .unwrap();
-    wait_for_event(&mut events_boot1, |event| {
+    wait_for_event(&mut events_boot1, "boot 1 ordinary message", |event| {
         matches!(
             event,
             MarmotAppEvent::MessageReceived(message)
@@ -266,7 +273,7 @@ async fn frozen_wake_collection_body() {
     let mut events_boot2 = runtime_bob_boot2.subscribe();
     runtime_bob_boot2.start().await.unwrap();
     wait_for_first_catch_up(&runtime_bob_boot2).await;
-    wait_for_event(&mut events_boot2, |event| {
+    wait_for_event(&mut events_boot2, "boot 2 frozen message", |event| {
         matches!(
             event,
             MarmotAppEvent::MessageReceived(message)
@@ -369,7 +376,7 @@ async fn frozen_wake_collection_body() {
     let mut events_boot3 = runtime_bob_boot3.subscribe();
     runtime_bob_boot3.start().await.unwrap();
     wait_for_first_catch_up(&runtime_bob_boot3).await;
-    wait_for_event(&mut events_boot3, |event| {
+    wait_for_event(&mut events_boot3, "boot 3 advancing message", |event| {
         matches!(
             event,
             MarmotAppEvent::MessageReceived(message)

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -6,13 +6,13 @@ use std::sync::{Arc, Once};
 
 use cgka_engine::account_identity_proof::ACCOUNT_IDENTITY_PROOF_EXTENSION_TYPE;
 use cgka_engine::key_package::key_package_metadata;
-use cgka_traits::TransportEndpoint;
 use cgka_traits::app_components::GROUP_ENCRYPTED_MEDIA_V2_COMPONENT_ID;
 use cgka_traits::app_event::{
     MARMOT_APP_EVENT_KIND_CHAT, MARMOT_APP_EVENT_KIND_DELETE, MARMOT_APP_EVENT_KIND_REACTION,
     STREAM_TAG,
 };
 use cgka_traits::engine::KeyPackage;
+use cgka_traits::{GroupId, TransportEndpoint};
 use marmot_account::{AccountHome, AccountHomeError, AccountSecretStore, KeychainSecretStore};
 use marmot_app::{
     AccountRelayListBootstrap, AccountSetupRequest, AppError, AppMessageQuery, AuditDataMode,
@@ -62,6 +62,23 @@ async fn mock_app(dir: &tempfile::TempDir) -> (MockRelay, MarmotApp, String) {
             .with_allow_loopback_relay_endpoints(true),
     );
     (relay, app, url)
+}
+
+async fn accept_group_invite_retrying_busy(
+    runtime: &MarmotAppRuntime,
+    account_ref: &str,
+    group_id: &GroupId,
+) -> Result<marmot_app::AppGroupRecord, AppError> {
+    timeout(Duration::from_secs(5), async {
+        loop {
+            match runtime.accept_group_invite(account_ref, group_id).await {
+                Err(AppError::AccountWorkerBusy) => sleep(Duration::from_millis(10)).await,
+                result => return result,
+            }
+        }
+    })
+    .await
+    .map_err(|_| AppError::AccountWorkerResponseTimedOut)?
 }
 
 async fn group_message_blocking_app(
@@ -2199,8 +2216,7 @@ async fn app_runtime_delete_group_local_removes_projection_without_publishing_le
         )
     })
     .await;
-    runtime
-        .accept_group_invite(&bob_id, &group_id)
+    accept_group_invite_retrying_busy(&runtime, &bob_id, &group_id)
         .await
         .unwrap();
 
@@ -2221,8 +2237,7 @@ async fn app_runtime_delete_group_local_removes_projection_without_publishing_le
         )
     })
     .await;
-    runtime
-        .accept_group_invite(&bob_id, &second_group_id)
+    accept_group_invite_retrying_busy(&runtime, &bob_id, &second_group_id)
         .await
         .unwrap();
     let second_group_id_hex = hex::encode(second_group_id.as_slice());
@@ -3702,10 +3717,10 @@ async fn app_runtime_marks_welcome_joined_groups_pending_until_accepted() {
         Some(alice.account.account_id_hex.as_str())
     );
 
-    let accepted = runtime
-        .accept_group_invite(&bob.account.account_id_hex, &group_id)
-        .await
-        .unwrap();
+    let accepted =
+        accept_group_invite_retrying_busy(&runtime, &bob.account.account_id_hex, &group_id)
+            .await
+            .unwrap();
     assert!(!accepted.pending_confirmation);
     assert!(!accepted.archived);
 
@@ -3759,8 +3774,7 @@ async fn app_runtime_readd_after_remove_resurfaces_removed_member_group() {
     let first_pending = app.group(&bob_label, &group_id_hex).unwrap().unwrap();
     assert!(first_pending.pending_confirmation);
     let first_welcome_id = first_pending.via_welcome_message_id_hex.clone();
-    runtime
-        .accept_group_invite(&bob_id, &group_id)
+    accept_group_invite_retrying_busy(&runtime, &bob_id, &group_id)
         .await
         .unwrap();
     let accepted = app.group(&bob_label, &group_id_hex).unwrap().unwrap();
@@ -3859,8 +3873,7 @@ async fn app_runtime_readd_after_remove_resurfaces_removed_member_group() {
         "bob should be a member again after the re-add; got {bob_members:?}"
     );
 
-    runtime
-        .accept_group_invite(&bob_id, &group_id)
+    accept_group_invite_retrying_busy(&runtime, &bob_id, &group_id)
         .await
         .unwrap();
     runtime

--- a/crates/marmot-app/tests/startup_hydration.rs
+++ b/crates/marmot-app/tests/startup_hydration.rs
@@ -196,6 +196,25 @@ async fn held_hydration_body() {
         "persisted chat list must hold every group while hydration is held"
     );
 
+    // Invite acceptance only mutates the durable app projection; it does not
+    // need unrelated MLS groups to finish hydrating. This fixture's founder
+    // row is already confirmed, so the operation is idempotent, but its prompt
+    // response proves the command is executed during the hold rather than
+    // retained behind the 30-second pipeline delay.
+    let accept_started = Instant::now();
+    let accepted = tokio::time::timeout(
+        Duration::from_millis(BATCH_HOLD_MS / 2),
+        runtime.accept_group_invite(BENCH_ACCOUNT, &group_ids[0]),
+    )
+    .await
+    .expect("projection-only invite acceptance must run during startup hydration")
+    .unwrap();
+    assert!(!accepted.pending_confirmation);
+    assert!(
+        accept_started.elapsed() < Duration::from_millis(BATCH_HOLD_MS / 2),
+        "invite acceptance must not join the startup hydration deferral"
+    );
+
     // The identifier-only roster page is the bounded companion read for that
     // chat projection (mdk#1314). One worker command promotes only the named
     // groups from durable state and returns every roster without waiting for

--- a/crates/marmot-uniffi/src/errors.rs
+++ b/crates/marmot-uniffi/src/errors.rs
@@ -199,6 +199,15 @@ pub enum MarmotKitError {
     GroupUnrecoverableRepairRequired { group_id_hex: String },
     #[error("marmot runtime error: {details}")]
     Runtime { details: String },
+    /// The account worker is completing an exclusive catch-up and definitely
+    /// did not start this operation. Safe to retry after the worker becomes
+    /// available.
+    #[error("marmot account worker is busy catching up; operation was not started")]
+    AccountWorkerBusy,
+    /// The worker response exceeded its operation-class deadline. The command
+    /// may have completed, so refresh authoritative state before retrying.
+    #[error("marmot account worker response timed out; operation completion is unknown")]
+    AccountWorkerResponseTimedOut,
 }
 
 impl From<AppError> for MarmotKitError {
@@ -277,6 +286,8 @@ impl From<AppError> for MarmotKitError {
             AppError::TransportClosed => Self::TransportClosed,
             AppError::RuntimeBusy => Self::RuntimeBusy,
             AppError::AccountSessionBusy => Self::AccountSessionBusy,
+            AppError::AccountWorkerBusy => Self::AccountWorkerBusy,
+            AppError::AccountWorkerResponseTimedOut => Self::AccountWorkerResponseTimedOut,
             AppError::AccountSetupRecoveryRequired => Self::AccountSetupRecoveryRequired,
             AppError::AccountSetupRetryRequired => Self::AccountSetupRetryRequired,
             AppError::AccountSetupResetNotApplicable => Self::AccountSetupResetNotApplicable,
@@ -705,6 +716,18 @@ mod tests {
         assert!(matches!(
             MarmotKitError::from(AppError::AccountSetupKeyPackageRecoveryAvailable),
             MarmotKitError::AccountSetupKeyPackageRecoveryAvailable
+        ));
+    }
+
+    #[test]
+    fn account_worker_availability_crosses_ffi_without_losing_retry_semantics() {
+        assert!(matches!(
+            MarmotKitError::from(AppError::AccountWorkerBusy),
+            MarmotKitError::AccountWorkerBusy
+        ));
+        assert!(matches!(
+            MarmotKitError::from(AppError::AccountWorkerResponseTimedOut),
+            MarmotKitError::AccountWorkerResponseTimedOut
         ));
     }
 


### PR DESCRIPTION
## Summary

- publish a durable `GroupJoined`/chat-list update before ordinary group-subscription relay I/O, then retry that subscription rebuild in the background with bounded backoff
- start the post-join full-history subscription immediately after join visibility instead of waiting for the 15-second maintenance tick, while preserving the existing grace, quiet, and contention-jitter rules for self-update commits
- execute projection-only invite acceptance during startup hydration and return typed `AccountWorkerBusy` when exclusive catch-up owns the account session, so callers know the operation did not start
- add operation-class worker response deadlines and a typed `AccountWorkerResponseTimedOut` result whose completion is explicitly unknown
- expose the new error semantics through UniFFI, CLI JSON, and the conformance simulator

## Root cause

Live welcome ingest awaited `sync_runtime_groups` before publishing the joined-group summary, so relay connection or subscription latency delayed invite visibility. The post-join history obligation was then advanced only by the periodic maintenance tick. At the same time, invite acceptance used the general account-worker queue, which deferred it behind startup hydration and catch-up, and worker reply oneshots had no deadline.

## User impact

Accepted invites become visible as soon as their projection is durable, and history subscription starts immediately rather than after the next maintenance tick. Accept taps either complete promptly, return a definitely-not-started busy result that is safe to retry, or return an explicit response-timeout result that requires refreshing authoritative state before retrying.

## Validation

- `just fast-ci`
- `cargo test -p marmot-app --lib` — 659 passed
- focused joined-group visibility/background retry/busy regression
- focused startup-hydration accept regression
- focused bounded retry and worker-response deadline tests
- post-join rotation jitter regression
- `cargo test -p marmot-uniffi --lib` — 106 passed
- focused CLI typed-error JSON regression

A full `marmot-app` crate run is not reported as green because five unrelated `relay_runtime` tests also fail on untouched `origin/master` at `f7ddd5a9` (90 passed, 5 failed): the two encrypted-media tests, retention system-row synthesis, retained-media pruning, and self-removal unread projection. The #1438-affected re-add regression passes with the new busy-aware retry helper.

On-device before/after perf-phase measurement from #1303 remains pending; deterministic scheduling coverage is included here.

Fixes #1438


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added durable invite joining and startup invite acceptance.
  * Added bounded retries when invite acceptance encounters a busy worker.
  * Added operation-specific response deadlines.
  * Added background retries for subscription updates after new deliveries.
  * Added distinct busy-worker and timed-out-response reporting, including retry guidance and completion uncertainty.
  * Preserved these error distinctions across JSON and MarmotKit interfaces.

* **Bug Fixes**
  * Improved group history availability before subscription rebuilding completes.
  * Prevented committed deliveries from being reported as failed when background updates are delayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->