### PR TITLE
marmot-app: reduce account setup relay round trips

### DIFF
--- a/crates/marmot-account/AGENTS.md
+++ b/crates/marmot-account/AGENTS.md
@@ -45,7 +45,7 @@ relay auth, or transport-specific relay discovery.
 - Keep `AccountDeviceSession` as the owner of engine state.
 - Keep CLI account-selection ergonomics and relay-list repair out of this crate; those belong in `wn` and `marmot-app`.
 - Confirm pending work only after the adapter reports enough acknowledgements.
-- Roll back pending work when publication fails or does not meet the required acknowledgement count.
+- Roll back pending work when publication fails before any external exposure is possible. Once publication intent is durable and a relay may have accepted work, retain the journaled state and retry the exact or replaceable publication instead.
 - Do not log account ids, group ids, relay URLs, message ids, pubkeys, payloads, ciphertext, plaintext, or key material.
 
 ## Verification

--- a/crates/marmot-account/src/home.rs
+++ b/crates/marmot-account/src/home.rs
@@ -126,6 +126,15 @@ pub enum AccountSetupKind {
 pub enum AccountSetupPhase {
     #[default]
     LocalStateCreated,
+    /// Set before publishing the account's replaceable bootstrap records
+    /// (relay lists and, for generated identities, the empty follow list and
+    /// default profile). A retry may safely republish those records, but setup
+    /// rollback must stop here because a relay may already have accepted one
+    /// member of the batch.
+    BootstrapPublicationStarted,
+    /// Every required bootstrap record reached at least one relay and its
+    /// local directory projection is durable.
+    BootstrapPublicationConfirmed,
     /// Set before entering KeyPackage preparation/publication. If the task is
     /// cancelled after this point, the SQLCipher lifecycle is authoritative:
     /// exact signed bytes are persisted there before the first network send.

--- a/crates/marmot-app/src/client/push.rs
+++ b/crates/marmot-app/src/client/push.rs
@@ -474,7 +474,7 @@ impl AppClient {
                 let event =
                     notifications::build_notification_gift_wrap(&server_pubkey_hex, chunk).await?;
                 self.app
-                    .relay_client_for_endpoints(nostr_signer.clone(), &endpoints)
+                    .relay_client_for_account_id(&account.account_id_hex, nostr_signer.clone())
                     .publish_event(&endpoints, &event, 1)
                     .await
                     .map_err(AppError::Transport)?;

--- a/crates/marmot-app/src/directory/methods.rs
+++ b/crates/marmot-app/src/directory/methods.rs
@@ -361,12 +361,12 @@ impl MarmotApp {
         );
         let content = serde_json::to_string(&profile_content_json(&profile))?;
         let event = NostrTransportEvent::new_unsigned(
-            account.account_id_hex,
+            account.account_id_hex.clone(),
             KIND_NOSTR_METADATA,
             Vec::new(),
             content,
         );
-        self.relay_client_for_endpoints(signer.as_nostr_signer(), &endpoints)
+        self.relay_client_for_account_id(&account.account_id_hex, signer.as_nostr_signer())
             .publish_event(&endpoints, &event, 1)
             .await?;
         Ok(())
@@ -396,7 +396,7 @@ impl MarmotApp {
             tags,
             String::new(),
         );
-        self.relay_client_for_endpoints(signer.as_nostr_signer(), &endpoints)
+        self.relay_client_for_account_id(&account.account_id_hex, signer.as_nostr_signer())
             .publish_event(&endpoints, &event, 1)
             .await?;
         // Publishing a local kind-3 list must make its own cached edge set
@@ -781,7 +781,7 @@ impl MarmotApp {
         Ok(None)
     }
 
-    fn remember_directory_relay_lists(
+    pub(crate) fn remember_directory_relay_lists(
         &self,
         account_id_hex: &str,
         relay_lists: &AccountRelayListStatus,
@@ -876,7 +876,7 @@ impl MarmotApp {
     /// known directory entry (e.g. a local account whose contact list we sync),
     /// its own cached follow edges are refreshed too, but its follows are still
     /// not promoted.
-    fn remember_directory_follow_edges_for_search(
+    pub(crate) fn remember_directory_follow_edges_for_search(
         &self,
         account_id_hex: &str,
         follow_list: &FetchedFollowList,

--- a/crates/marmot-app/src/directory/mod.rs
+++ b/crates/marmot-app/src/directory/mod.rs
@@ -10,6 +10,7 @@ pub(crate) use cache::DirectoryCache;
 pub(crate) use cache::DirectorySearchGraphRecord;
 #[cfg(test)]
 pub(crate) use methods::cached_or_unknown_follow_list;
+pub(crate) use records::FetchedFollowList;
 pub use records::{
     DirectoryKeyPackage, MatchQuality, MatchedField, UserDirectoryLocalAccount,
     UserDirectoryRecord, UserDirectoryRefresh, UserDirectorySearch, UserDirectorySearchResult,

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -3484,9 +3484,10 @@ impl MarmotApp {
                 Err(_) => delete_failure_count += 1,
             }
         }
-        if delete_failure_count == 0 && self.mark_key_package_cutover_scan_complete(label).is_err()
-        {
-            delete_failure_count += 1;
+        if delete_failure_count == 0 {
+            // The marker helper emits its own privacy-safe warning. It is not
+            // a relay deletion failure, so do not fold it into this counter.
+            let _ = self.mark_key_package_cutover_scan_complete(label);
         }
         if non_current_event_count > 0 {
             tracing::info!(
@@ -5147,6 +5148,9 @@ impl MarmotApp {
             .account_publish_clients
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
+        // The signer is intentionally ignored on a cache hit. Callers that
+        // replace an account signer must evict this entry first, as
+        // register_external_signer and drop_account_caches do today.
         clients
             .entry(account_id_hex.to_owned())
             .or_insert_with(|| {

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -495,6 +495,10 @@ pub struct MarmotApp {
     chat_list_projection_stale: Arc<Mutex<HashSet<String>>>,
     audit_log_tracker_config: Arc<Mutex<AuditLogTrackerConfig>>,
     external_signers: Arc<Mutex<HashMap<String, RegisteredExternalSigner>>>,
+    /// One signer-bound publisher per account. Setup publishes and the managed
+    /// account worker share this client so the worker can reuse the same relay
+    /// pool instead of constructing another TCP/TLS/WebSocket stack.
+    account_publish_clients: Arc<Mutex<HashMap<String, Arc<dyn NostrRelayClient>>>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -1255,6 +1259,7 @@ impl MarmotApp {
             chat_list_projection_stale: Arc::new(Mutex::new(HashSet::new())),
             audit_log_tracker_config: Arc::new(Mutex::new(AuditLogTrackerConfig::default())),
             external_signers: Arc::new(Mutex::new(HashMap::new())),
+            account_publish_clients: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -1322,6 +1327,7 @@ impl MarmotApp {
             chat_list_projection_stale: Arc::new(Mutex::new(HashSet::new())),
             audit_log_tracker_config: Arc::new(Mutex::new(AuditLogTrackerConfig::default())),
             external_signers: Arc::new(Mutex::new(HashMap::new())),
+            account_publish_clients: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -1606,6 +1612,127 @@ impl MarmotApp {
         .await
     }
 
+    /// Publish every generated-identity bootstrap record through one scoped
+    /// relay batch. The SDK connects the endpoint union once for the two relay
+    /// lists, empty follow list, and default profile, then returns one ordered
+    /// acknowledgement result per replaceable event.
+    pub(crate) async fn publish_generated_account_bootstrap(
+        &self,
+        label: &str,
+        bootstrap: AccountRelayListBootstrap,
+        profile: &UserProfileMetadata,
+    ) -> Result<AccountRelayListStatus, AppError> {
+        if bootstrap.default_relays.is_empty() {
+            return Err(AppError::MissingDefaultRelays);
+        }
+        self.validate_account_relay_list_declarations(&bootstrap, None)?;
+        let account = self.account_home().account(label)?;
+        let signer = self.account_signer_for_summary(&account)?;
+        let account_id = MemberId::new(hex::decode(&account.account_id_hex)?);
+        // Relay-list records are discoverability maps and therefore go to the
+        // bootstrap route. Profiles and contact lists are outbox content: keep
+        // them on the declared write relays even though the mixed batch retains
+        // the union of both endpoint sets once.
+        let content_endpoints =
+            self.outbox_endpoints(&account.account_id_hex, bootstrap.default_relays.clone());
+        let requested = publish_endpoints_from_bootstrap(&bootstrap);
+        let mut endpoints = self.outbox_endpoints(&account.account_id_hex, requested.clone());
+        for endpoint in requested {
+            if !endpoints.iter().any(|existing| existing.0 == endpoint.0) {
+                endpoints.push(endpoint);
+            }
+        }
+
+        let mut requests = Vec::with_capacity(4);
+        for list_kind in [
+            NostrAccountRelayListKind::Nip65,
+            NostrAccountRelayListKind::Inbox,
+        ] {
+            requests.push(NostrEventPublishRequest {
+                endpoints: endpoints.clone(),
+                event: NostrAccountRelayListPublication {
+                    account_id: account_id.clone(),
+                    list_kind,
+                    relays: bootstrap.default_relays.clone(),
+                    publish_endpoints: endpoints.clone(),
+                }
+                .to_event()?,
+                required_acks: 1,
+            });
+        }
+        requests.push(NostrEventPublishRequest {
+            endpoints: content_endpoints.clone(),
+            event: NostrTransportEvent::new_unsigned(
+                account.account_id_hex.clone(),
+                KIND_NOSTR_CONTACT_LIST,
+                Vec::new(),
+                String::new(),
+            ),
+            required_acks: 1,
+        });
+        requests.push(NostrEventPublishRequest {
+            endpoints: content_endpoints.clone(),
+            event: NostrTransportEvent::new_unsigned(
+                account.account_id_hex.clone(),
+                KIND_NOSTR_METADATA,
+                Vec::new(),
+                serde_json::to_string(&directory::records::profile_content_json(profile))?,
+            ),
+            required_acks: 1,
+        });
+
+        let relay_client =
+            self.relay_client_for_account_id(&account.account_id_hex, signer.as_nostr_signer());
+        for outcome in relay_client.publish_events(&requests).await {
+            if outcome?.accepted.is_empty() {
+                return Err(AppError::Publish(
+                    "relay acknowledged zero account bootstrap events".to_owned(),
+                ));
+            }
+        }
+
+        let relays = bootstrap
+            .default_relays
+            .iter()
+            .map(|endpoint| endpoint.0.clone())
+            .collect::<Vec<_>>();
+        let mut status = AccountRelayListStatus {
+            complete: false,
+            missing: Vec::new(),
+            default_relays: Vec::new(),
+            bootstrap_relays: endpoints
+                .iter()
+                .map(|endpoint| endpoint.0.clone())
+                .collect(),
+            nip65: AccountRelayListState {
+                kind: KIND_NIP65_RELAY_LIST,
+                relays: relays.clone(),
+                read_relays: relays.clone(),
+                write_relays: relays.clone(),
+            },
+            inbox: AccountRelayListState {
+                kind: KIND_MARMOT_INBOX_RELAY_LIST,
+                relays,
+                read_relays: Vec::new(),
+                write_relays: Vec::new(),
+            },
+        };
+        status.refresh();
+        self.remember_directory_relay_lists(&account.account_id_hex, &status)?;
+        self.remember_directory_follow_edges_for_search(
+            &account.account_id_hex,
+            &directory::FetchedFollowList {
+                follows: Vec::new(),
+                source_relays: content_endpoints
+                    .iter()
+                    .map(|endpoint| endpoint.0.clone())
+                    .collect(),
+            },
+        )?;
+        self.remember_directory_profile(&account.account_id_hex, profile)?;
+        Ok(status)
+    }
+
     pub async fn publish_missing_account_relay_lists(
         &self,
         label: &str,
@@ -1833,7 +1960,9 @@ impl MarmotApp {
                 endpoints.push(endpoint);
             }
         }
-        let relay_client = self.relay_client_for_endpoints(signer.as_nostr_signer(), &endpoints);
+        let relay_client =
+            self.relay_client_for_account_id(&account_id_hex, signer.as_nostr_signer());
+        let mut requests = Vec::with_capacity(list_kinds.len());
         for list_kind in list_kinds {
             let event = if *list_kind == NostrAccountRelayListKind::Nip65
                 && let Some(relays) = nip65_relay_set
@@ -1853,10 +1982,80 @@ impl MarmotApp {
                 }
                 .to_event()?
             };
-            relay_client.publish_event(&endpoints, &event, 1).await?;
+            requests.push(NostrEventPublishRequest {
+                endpoints: endpoints.clone(),
+                event,
+                required_acks: 1,
+            });
         }
-        self.fetch_account_relay_list_status_for_account_id(&account_id_hex, endpoints)
-            .await
+        for outcome in relay_client.publish_events(&requests).await {
+            if outcome?.accepted.is_empty() {
+                return Err(AppError::Publish(
+                    "relay acknowledged zero account relay-list events".to_owned(),
+                ));
+            }
+        }
+
+        // The signed replaceable events above are the authoritative effect of
+        // this operation. Persist their declared state directly after every
+        // event has an acknowledgement; synchronously querying the same relays
+        // again adds no confirmation strength and used to turn a post-success
+        // read outage into account-setup rollback (mdk#1436).
+        let mut status = self.account_relay_list_status_for_account_id(&account_id_hex)?;
+        for list_kind in list_kinds {
+            match list_kind {
+                NostrAccountRelayListKind::Nip65 => {
+                    let (read_relays, write_relays) = nip65_relay_set
+                        .map(|relays| {
+                            (
+                                relays
+                                    .read_relays
+                                    .iter()
+                                    .map(|endpoint| endpoint.0.clone())
+                                    .collect::<Vec<_>>(),
+                                relays
+                                    .write_relays
+                                    .iter()
+                                    .map(|endpoint| endpoint.0.clone())
+                                    .collect::<Vec<_>>(),
+                            )
+                        })
+                        .unwrap_or_else(|| {
+                            let relays = bootstrap
+                                .default_relays
+                                .iter()
+                                .map(|endpoint| endpoint.0.clone())
+                                .collect::<Vec<_>>();
+                            (relays.clone(), relays)
+                        });
+                    status.nip65 = AccountRelayListState {
+                        kind: KIND_NIP65_RELAY_LIST,
+                        relays: write_relays.clone(),
+                        read_relays,
+                        write_relays,
+                    };
+                }
+                NostrAccountRelayListKind::Inbox => {
+                    status.inbox = AccountRelayListState {
+                        kind: KIND_MARMOT_INBOX_RELAY_LIST,
+                        relays: bootstrap
+                            .default_relays
+                            .iter()
+                            .map(|endpoint| endpoint.0.clone())
+                            .collect(),
+                        read_relays: Vec::new(),
+                        write_relays: Vec::new(),
+                    };
+                }
+            }
+        }
+        push_unique_strings(
+            &mut status.bootstrap_relays,
+            endpoints.iter().map(|endpoint| endpoint.0.clone()),
+        );
+        status.refresh();
+        self.remember_directory_relay_lists(&account_id_hex, &status)?;
+        Ok(status)
     }
 
     /// Validate caller-owned relay-list declarations without applying the dial
@@ -2956,7 +3155,7 @@ impl MarmotApp {
             AccountDeviceSession::open(session_config).map_err(external_signer_session_error)?;
 
         let publish_client =
-            self.relay_client_for_endpoints(nostr_signer.clone(), &self.relay_endpoints());
+            self.relay_client_for_account_id(&account.account_id_hex, nostr_signer.clone());
         let adapter = relay_plane.account_adapter(account_id.clone(), publish_client);
 
         let key_packages = AppKeyPackagePublisher {
@@ -3261,8 +3460,9 @@ impl MarmotApp {
                 Err(_) => delete_failure_count += 1,
             }
         }
-        if delete_failure_count == 0 {
-            self.mark_key_package_cutover_scan_complete(label);
+        if delete_failure_count == 0 && self.mark_key_package_cutover_scan_complete(label).is_err()
+        {
+            delete_failure_count += 1;
         }
         if non_current_event_count > 0 {
             tracing::info!(
@@ -3355,7 +3555,7 @@ impl MarmotApp {
         self.key_package_cutover_scan_complete_path(label).exists()
     }
 
-    fn mark_key_package_cutover_scan_complete(&self, label: &str) {
+    fn mark_key_package_cutover_scan_complete(&self, label: &str) -> Result<(), AppError> {
         let path = self.key_package_cutover_scan_complete_path(label);
         let result = path
             .parent()
@@ -3366,15 +3566,17 @@ impl MarmotApp {
                 )
             })
             .and_then(fs_private::create_dir_all_private)
-            .and_then(|()| fs_private::write_private(&path, b"complete\n"));
-        if let Err(error) = result {
+            .and_then(|()| fs_private::write_private(&path, b"complete\n"))
+            .map_err(AppError::from);
+        if let Err(error) = &result {
             tracing::warn!(
                 target: "marmot_app::key_packages",
                 method = "mark_key_package_cutover_scan_complete",
-                error_kind = AppError::from(error).privacy_safe_kind(),
+                error_kind = error.privacy_safe_kind(),
                 "could not persist completed key package relay scan"
             );
         }
+        result
     }
 
     pub fn local_key_package_records(
@@ -3579,7 +3781,6 @@ impl MarmotApp {
             .collect::<Vec<_>>();
         let mut requests = Vec::new();
         let mut request_indices = Vec::new();
-        let mut all_endpoints = Vec::new();
 
         for (index, target) in targets.into_iter().enumerate() {
             let event_id_hex = match parse_key_package_event_id_hex(&target.event_id_hex) {
@@ -3618,7 +3819,6 @@ impl MarmotApp {
                     continue;
                 }
             };
-            all_endpoints.extend(endpoints.iter().cloned());
             requests.push(NostrEventPublishRequest {
                 endpoints,
                 event: NostrTransportEvent::new_unsigned(
@@ -3637,7 +3837,7 @@ impl MarmotApp {
 
         if !requests.is_empty() {
             let relay_client =
-                self.relay_client_for_endpoints(signer.as_nostr_signer(), &all_endpoints);
+                self.relay_client_for_account_id(&account_id_hex, signer.as_nostr_signer());
             let outcomes = relay_client.publish_events(&requests).await;
             for (index, outcome) in request_indices.into_iter().zip(outcomes) {
                 results[index].result = match outcome {
@@ -4852,6 +5052,12 @@ impl MarmotApp {
     /// the warm/stale/ready flags forces the rebuilt account to re-warm its
     /// projections from the fresh database.
     fn drop_account_caches(&self, label: &str) {
+        if let Ok(account) = self.account_home().account(label) {
+            self.account_publish_clients
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .remove(&account.account_id_hex);
+        }
         self.account_storages
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
@@ -4904,18 +5110,26 @@ impl MarmotApp {
         Ok(shared.get_or_insert_with(|| storage.clone()).clone())
     }
 
-    fn relay_client_for_endpoints(
+    fn relay_client_for_account_id(
         &self,
+        account_id_hex: &str,
         signer: Arc<dyn nostr::NostrSigner>,
-        endpoints: &[TransportEndpoint],
     ) -> Arc<dyn NostrRelayClient> {
         #[cfg(test)]
         if let Some(client) = &self.test_relay_client {
             return client.clone();
         }
-        let _ = endpoints;
-        let client = NostrSdkClient::builder().signer(signer).build();
-        Arc::new(NostrSdkRelayClient::new(client))
+        let mut clients = self
+            .account_publish_clients
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        clients
+            .entry(account_id_hex.to_owned())
+            .or_insert_with(|| {
+                let client = NostrSdkClient::builder().signer(signer).build();
+                Arc::new(NostrSdkRelayClient::new(client))
+            })
+            .clone()
     }
 
     #[cfg(test)]
@@ -4953,9 +5167,13 @@ impl MarmotApp {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .insert(
-                account.account_id_hex,
+                account.account_id_hex.clone(),
                 RegisteredExternalSigner::new(public_key, signer),
             );
+        self.account_publish_clients
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(&account.account_id_hex);
         Ok(())
     }
 
@@ -5355,9 +5573,10 @@ impl KeyPackagePublisher for AppKeyPackagePublisher {
                 "persisted KeyPackage event identity does not match lifecycle record",
             ));
         }
-        let relay_client = self
-            .app
-            .relay_client_for_endpoints(self.signer.as_nostr_signer(), &publication.endpoints);
+        let relay_client = self.app.relay_client_for_account_id(
+            &hex::encode(publication.account_id.as_slice()),
+            self.signer.as_nostr_signer(),
+        );
         let outcome = NostrKeyPackagePublisher::new(relay_client)
             .publish_prepared_key_package(&nostr_publication, &event)
             .await

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -1635,13 +1635,10 @@ impl MarmotApp {
         // the union of both endpoint sets once.
         let content_endpoints =
             self.outbox_endpoints(&account.account_id_hex, bootstrap.default_relays.clone());
-        let requested = publish_endpoints_from_bootstrap(&bootstrap);
-        let mut endpoints = self.outbox_endpoints(&account.account_id_hex, requested.clone());
-        for endpoint in requested {
-            if !endpoints.iter().any(|existing| existing.0 == endpoint.0) {
-                endpoints.push(endpoint);
-            }
-        }
+        let endpoints = self.publish_route_including_requested(
+            &account.account_id_hex,
+            publish_endpoints_from_bootstrap(&bootstrap),
+        );
 
         let mut requests = Vec::with_capacity(4);
         for list_kind in [
@@ -1683,11 +1680,25 @@ impl MarmotApp {
 
         let relay_client =
             self.relay_client_for_account_id(&account.account_id_hex, signer.as_nostr_signer());
-        for outcome in relay_client.publish_events(&requests).await {
+        let record_kinds = [
+            "NIP-65 relay list",
+            "inbox relay list",
+            "contact list",
+            "profile metadata",
+        ];
+        let outcomes = relay_client.publish_events(&requests).await;
+        if outcomes.len() != record_kinds.len() {
+            return Err(AppError::Publish(format!(
+                "account bootstrap returned {} outcomes for {} records",
+                outcomes.len(),
+                record_kinds.len()
+            )));
+        }
+        for (record_kind, outcome) in record_kinds.into_iter().zip(outcomes) {
             if outcome?.accepted.is_empty() {
-                return Err(AppError::Publish(
-                    "relay acknowledged zero account bootstrap events".to_owned(),
-                ));
+                return Err(AppError::Publish(format!(
+                    "relay acknowledged zero events for bootstrap record {record_kind}"
+                )));
             }
         }
 
@@ -1953,13 +1964,10 @@ impl MarmotApp {
         // ever lands on the relays you were already on. Unioning means an
         // explicit republish reaches both your old relays (so they update) and
         // the newly-declared ones (so they learn about you for the first time).
-        let requested = publish_endpoints_from_bootstrap(&bootstrap);
-        let mut endpoints = self.outbox_endpoints(&account_id_hex, requested.clone());
-        for endpoint in requested {
-            if !endpoints.iter().any(|existing| existing.0 == endpoint.0) {
-                endpoints.push(endpoint);
-            }
-        }
+        let endpoints = self.publish_route_including_requested(
+            &account_id_hex,
+            publish_endpoints_from_bootstrap(&bootstrap),
+        );
         let relay_client =
             self.relay_client_for_account_id(&account_id_hex, signer.as_nostr_signer());
         let mut requests = Vec::with_capacity(list_kinds.len());
@@ -2121,6 +2129,22 @@ impl MarmotApp {
             "local account outbox routing",
         );
         if safe.is_empty() { fallback } else { safe }
+    }
+
+    /// Preserve the account's existing outbox route while ensuring every
+    /// explicitly requested publication endpoint is reached at least once.
+    fn publish_route_including_requested(
+        &self,
+        account_id_hex: &str,
+        requested: Vec<TransportEndpoint>,
+    ) -> Vec<TransportEndpoint> {
+        let mut endpoints = self.outbox_endpoints(account_id_hex, requested.clone());
+        for endpoint in requested {
+            if !endpoints.iter().any(|existing| existing.0 == endpoint.0) {
+                endpoints.push(endpoint);
+            }
+        }
+        endpoints
     }
 
     pub fn messages(&self, label: &str) -> Result<Vec<AppMessageRecord>, AppError> {

--- a/crates/marmot-app/src/relay_plane/directory.rs
+++ b/crates/marmot-app/src/relay_plane/directory.rs
@@ -15,6 +15,13 @@ use super::DIRECTORY_RELAY_CONNECT_WAIT;
 
 const DIRECTORY_RELAY_FETCH_WAIT: Duration = Duration::from_secs(3);
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DirectoryRelayConnectOutcome {
+    Connected,
+    TimedOut,
+    Failed,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct DirectoryEventQuery {
     pub(crate) kind: u64,
@@ -349,37 +356,55 @@ impl DirectoryRelayFetcher for NostrSdkDirectoryRelayFetcher {
     ) -> Result<Vec<DirectoryRelayEventRecord>, String> {
         let relay_urls = parsed_directory_relay_urls(&request.endpoints)?;
         let mut connect_candidates = Vec::new();
+        let mut added = vec![false; relay_urls.len()];
+        let mut add_failure_count = 0usize;
         for (index, relay_url) in relay_urls.iter().cloned().enumerate() {
             if self.client.add_relay(relay_url.clone()).await.is_ok() {
+                added[index] = true;
                 connect_candidates.push((index, relay_url));
+            } else {
+                add_failure_count += 1;
             }
         }
         let mut connects = JoinSet::new();
         for (index, relay_url) in connect_candidates {
             let client = self.client.clone();
             connects.spawn(async move {
-                let connected = matches!(
-                    timeout(
-                        DIRECTORY_RELAY_CONNECT_WAIT,
-                        client.connect_relay(relay_url.clone()),
-                    )
-                    .await,
-                    Ok(Ok(()))
-                );
-                (index, relay_url, connected)
+                let outcome = match timeout(
+                    DIRECTORY_RELAY_CONNECT_WAIT,
+                    client.connect_relay(relay_url),
+                )
+                .await
+                {
+                    Ok(Ok(())) => DirectoryRelayConnectOutcome::Connected,
+                    Ok(Err(_)) => DirectoryRelayConnectOutcome::Failed,
+                    Err(_) => DirectoryRelayConnectOutcome::TimedOut,
+                };
+                (index, outcome)
             });
         }
         let mut connected = vec![false; relay_urls.len()];
-        let mut failed_urls = Vec::new();
+        let mut connect_timeout_count = 0usize;
+        let mut connect_failure_count = 0usize;
+        let mut task_failure_count = 0usize;
         while let Some(result) = connects.join_next().await {
             match result {
-                Ok((index, _relay_url, true)) => connected[index] = true,
-                Ok((_index, relay_url, false)) => failed_urls.push(relay_url),
-                Err(_) => {}
+                Ok((index, DirectoryRelayConnectOutcome::Connected)) => connected[index] = true,
+                Ok((_index, DirectoryRelayConnectOutcome::TimedOut)) => {
+                    connect_timeout_count += 1;
+                }
+                Ok((_index, DirectoryRelayConnectOutcome::Failed)) => {
+                    connect_failure_count += 1;
+                }
+                Err(_) => task_failure_count += 1,
             }
         }
-        for relay_url in failed_urls {
-            let _ = self.client.remove_relay(relay_url).await;
+        // A task that panics or is cancelled never flips its index to
+        // connected, so this also removes relays from failed JoinSet tasks.
+        for (index, relay_url) in relay_urls.iter().cloned().enumerate() {
+            if added[index] && !connected[index] {
+                let _ = self.client.remove_relay(relay_url).await;
+            }
         }
         let relay_urls = relay_urls
             .into_iter()
@@ -387,7 +412,9 @@ impl DirectoryRelayFetcher for NostrSdkDirectoryRelayFetcher {
             .filter_map(|(relay_url, connected)| connected.then_some(relay_url))
             .collect::<Vec<_>>();
         if relay_urls.is_empty() {
-            return Err("connect relays failed".to_owned());
+            return Err(format!(
+                "connect relays failed: add_failures={add_failure_count}, connect_timeouts={connect_timeout_count}, connect_failures={connect_failure_count}, task_failures={task_failure_count}"
+            ));
         }
 
         let mut records = Vec::new();

--- a/crates/marmot-app/src/relay_plane/directory.rs
+++ b/crates/marmot-app/src/relay_plane/directory.rs
@@ -347,13 +347,7 @@ impl DirectoryRelayFetcher for NostrSdkDirectoryRelayFetcher {
         &self,
         request: DirectoryFetchRequest,
     ) -> Result<Vec<DirectoryRelayEventRecord>, String> {
-        let relay_urls = request
-            .endpoints
-            .iter()
-            .map(|endpoint| {
-                RelayUrl::parse(endpoint.as_str()).map_err(|_| "invalid relay URL".to_owned())
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+        let relay_urls = parsed_directory_relay_urls(&request.endpoints)?;
         let mut connect_candidates = Vec::new();
         for (index, relay_url) in relay_urls.iter().cloned().enumerate() {
             if self.client.add_relay(relay_url.clone()).await.is_ok() {
@@ -429,6 +423,21 @@ impl DirectoryRelayFetcher for NostrSdkDirectoryRelayFetcher {
     }
 }
 
+fn parsed_directory_relay_urls(endpoints: &[TransportEndpoint]) -> Result<Vec<RelayUrl>, String> {
+    let mut relay_urls = endpoints
+        .iter()
+        .map(|endpoint| {
+            RelayUrl::parse(endpoint.as_str()).map_err(|_| "invalid relay URL".to_owned())
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    // RelayUrl equality canonicalizes trailing slashes even though its display
+    // form preserves them. Collapse equivalent candidates before concurrent
+    // connection attempts so one failed twin cannot remove a successful one.
+    relay_urls.sort();
+    relay_urls.dedup();
+    Ok(relay_urls)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -473,5 +482,16 @@ mod tests {
 
         assert_eq!(error, "invalid relay URL");
         assert!(!error.contains(secret_url));
+    }
+
+    #[test]
+    fn parsed_directory_relay_urls_deduplicate_trailing_slash_variants() {
+        let relay_urls = parsed_directory_relay_urls(&[
+            TransportEndpoint("wss://relay.example".to_owned()),
+            TransportEndpoint("wss://relay.example/".to_owned()),
+        ])
+        .unwrap();
+
+        assert_eq!(relay_urls.len(), 1);
     }
 }

--- a/crates/marmot-app/src/relay_plane/directory.rs
+++ b/crates/marmot-app/src/relay_plane/directory.rs
@@ -7,6 +7,7 @@ use cgka_traits::TransportEndpoint;
 use nostr_sdk::prelude::{Client as NostrSdkClient, Event, Filter, Kind, PublicKey, RelayUrl};
 use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, oneshot};
+use tokio::task::JoinSet;
 use tokio::time::timeout;
 use transport_nostr_peeler::NostrTransportEvent;
 
@@ -353,18 +354,46 @@ impl DirectoryRelayFetcher for NostrSdkDirectoryRelayFetcher {
                 RelayUrl::parse(endpoint.as_str()).map_err(|_| "invalid relay URL".to_owned())
             })
             .collect::<Result<Vec<_>, _>>()?;
-        for relay_url in &relay_urls {
-            self.client
-                .add_relay(relay_url.clone())
-                .await
-                .map_err(|_| "add relay failed".to_owned())?;
-            timeout(
-                DIRECTORY_RELAY_CONNECT_WAIT,
-                self.client.connect_relay(relay_url.clone()),
-            )
-            .await
-            .map_err(|_| "connect relay timed out".to_owned())?
-            .map_err(|_| "connect relay failed".to_owned())?;
+        let mut connect_candidates = Vec::new();
+        for (index, relay_url) in relay_urls.iter().cloned().enumerate() {
+            if self.client.add_relay(relay_url.clone()).await.is_ok() {
+                connect_candidates.push((index, relay_url));
+            }
+        }
+        let mut connects = JoinSet::new();
+        for (index, relay_url) in connect_candidates {
+            let client = self.client.clone();
+            connects.spawn(async move {
+                let connected = matches!(
+                    timeout(
+                        DIRECTORY_RELAY_CONNECT_WAIT,
+                        client.connect_relay(relay_url.clone()),
+                    )
+                    .await,
+                    Ok(Ok(()))
+                );
+                (index, relay_url, connected)
+            });
+        }
+        let mut connected = vec![false; relay_urls.len()];
+        let mut failed_urls = Vec::new();
+        while let Some(result) = connects.join_next().await {
+            match result {
+                Ok((index, _relay_url, true)) => connected[index] = true,
+                Ok((_index, relay_url, false)) => failed_urls.push(relay_url),
+                Err(_) => {}
+            }
+        }
+        for relay_url in failed_urls {
+            let _ = self.client.remove_relay(relay_url).await;
+        }
+        let relay_urls = relay_urls
+            .into_iter()
+            .zip(connected)
+            .filter_map(|(relay_url, connected)| connected.then_some(relay_url))
+            .collect::<Vec<_>>();
+        if relay_urls.is_empty() {
+            return Err("connect relays failed".to_owned());
         }
 
         let mut records = Vec::new();

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -4258,10 +4258,12 @@ impl AccountManager {
                 }
                 match self.publish_initial_key_package_for_account(&account).await {
                     Ok(bytes) => {
-                        self.app.account_home().set_account_setup_phase(
-                            &account.label,
-                            AccountSetupPhase::KeyPackagePublicationConfirmed,
-                        )?;
+                        if setup_phase.is_some() {
+                            self.app.account_home().set_account_setup_phase(
+                                &account.label,
+                                AccountSetupPhase::KeyPackagePublicationConfirmed,
+                            )?;
+                        }
                         Some(bytes)
                     }
                     Err(err) => {
@@ -4269,6 +4271,13 @@ impl AccountManager {
                         // is sufficient to retry safely after any ordinary error
                         // or task cancellation. Never delete possibly exposed
                         // exact bytes/private material here.
+                        // A reactivation has no setup journal, so restore its
+                        // durable signed-out state and stop the just-started
+                        // worker. The same nsec can then resume this exact
+                        // lifecycle attempt instead of failing AccountExists.
+                        if reactivating_existing {
+                            self.deactivate_account(&account.label).await?;
+                        }
                         return Err(err);
                     }
                 }
@@ -4562,6 +4571,9 @@ impl AccountManager {
             request.default_relays.clone(),
             request.bootstrap_relays.clone(),
         );
+        // Validate before advancing the durable publication phase. The
+        // publisher validates again at its own action boundary because it is
+        // also called directly outside this setup orchestrator.
         if bootstrap.default_relays.is_empty() {
             return Err(AppError::MissingDefaultRelays);
         }
@@ -4580,9 +4592,6 @@ impl AccountManager {
                 | AccountSetupPhase::KeyPackagePublicationConfirmed
         ) {
             let status = self.app.account_relay_list_status(&account.label)?;
-            if !status.complete {
-                return Err(AppError::MissingRelayLists(status.missing));
-            }
             if let Some(cached) = self
                 .app
                 .directory_entry_for_account_id(&account.account_id_hex)?
@@ -4590,7 +4599,13 @@ impl AccountManager {
             {
                 profile = cached;
             }
-            return Ok((status, Some(profile)));
+            if status.complete {
+                return Ok((status, Some(profile)));
+            }
+            // The durable publication phase is authoritative, but the local
+            // directory projection can still be lost independently. These are
+            // replaceable records, so rebuild the projection by republishing
+            // the same bootstrap instead of trapping every retry here.
         }
         if phase == AccountSetupPhase::LocalStateCreated {
             self.app.account_home().set_account_setup_phase(
@@ -4603,10 +4618,7 @@ impl AccountManager {
             .app
             .publish_generated_account_bootstrap(&account.label, bootstrap, &profile)
             .await?;
-        self.app.account_home().set_account_setup_phase(
-            &account.label,
-            AccountSetupPhase::BootstrapPublicationConfirmed,
-        )?;
+        self.mark_bootstrap_publication_confirmed(&account.label)?;
         Ok((status, Some(profile)))
     }
 
@@ -4670,11 +4682,13 @@ impl AccountManager {
                                 target: "marmot_app::runtime",
                                 method = "setup_relay_lists_for_account",
                                 error_kind = error.privacy_safe_kind(),
-                                "using cached relay-list status after advisory import fetch failed"
+                                "import relay-list discovery failed; refusing to publish defaults"
                             );
-                            self.app.account_relay_list_status(&account.label)?
+                            return self.complete_cached_relay_list_status(&account.label);
                         }
-                        None => self.app.account_relay_list_status(&account.label)?,
+                        None => {
+                            return self.complete_cached_relay_list_status(&account.label);
+                        }
                     }
                 };
                 if current_status.complete {
@@ -4696,6 +4710,9 @@ impl AccountManager {
                     Ok(status)
                 }
             } else {
+                // Keep validation ahead of the durable publication-intent
+                // marker; the private publisher repeats these guards at its
+                // own boundary before it can be reused independently.
                 if request.default_relays.is_empty() && request.bootstrap_relays.is_empty() {
                     return self.app.account_relay_list_status(&account.label);
                 }
@@ -4751,6 +4768,18 @@ impl AccountManager {
         Ok(())
     }
 
+    fn complete_cached_relay_list_status(
+        &self,
+        label: &str,
+    ) -> Result<AccountRelayListStatus, AppError> {
+        let status = self.app.account_relay_list_status(label)?;
+        if status.complete {
+            Ok(status)
+        } else {
+            Err(AppError::MissingRelayLists(status.missing))
+        }
+    }
+
     async fn publish_relay_lists_for_new_account(
         &self,
         label: &str,
@@ -4786,11 +4815,9 @@ impl AccountManager {
                 .mark_key_package_cutover_replacement_pending(&account.label);
             return Err(AppError::AccountSetupRecoveryRequired);
         }
-        // Let the managed worker own the only session opened for this setup.
-        // Its open runs through `blocking_app_task`; publishing through the
-        // worker avoids the former one-shot session open followed immediately
-        // by a second worker session open.
-        self.reconcile().await?;
+        // Publishing through the managed worker avoids the former one-shot
+        // session open followed by a second worker session open. The command's
+        // `worker_commands` lookup reconciles before dispatch.
         self.publish_key_package(&account.label).await
     }
 
@@ -4910,6 +4937,9 @@ impl AccountManager {
                             .app
                             .mark_key_package_cutover_scan_complete(&account.label)
                         {
+                            let _ = self
+                                .app
+                                .remove_account_key_package_artifacts(&account.label);
                             let _ = account_home.remove_account(&account.label);
                             return Err(error);
                         }

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -3708,6 +3708,17 @@ impl AccountManager {
         result
     }
 
+    async fn restore_signed_out_after_key_package_failure(&self, account_ref: &str) {
+        if let Err(error) = self.deactivate_account(account_ref).await {
+            tracing::warn!(
+                target: "marmot_app::runtime",
+                method = "restore_signed_out_after_key_package_failure",
+                error_kind = error.privacy_safe_kind(),
+                "failed to restore signed-out state after key package publication failure"
+            );
+        }
+    }
+
     /// Explicitly re-activate a reversibly signed-out local account.
     pub async fn sign_in_account(&self, account_ref: &str) -> Result<ManagedAccount, AppError> {
         let _worker_transaction = self.worker_transactions.lock().await;
@@ -4276,7 +4287,8 @@ impl AccountManager {
                         // worker. The same nsec can then resume this exact
                         // lifecycle attempt instead of failing AccountExists.
                         if reactivating_existing {
-                            self.deactivate_account(&account.label).await?;
+                            self.restore_signed_out_after_key_package_failure(&account.label)
+                                .await;
                         }
                         return Err(err);
                     }
@@ -4370,6 +4382,7 @@ impl AccountManager {
             .app
             .account_home()
             .add_external_signer_account(&public_key)?;
+        let reactivating_existing = account.signed_out;
         if let Err(err) = self
             .app
             .register_external_signer(&account.account_id_hex, signer)
@@ -4451,12 +4464,20 @@ impl AccountManager {
                     )?;
                     Some(bytes)
                 }
-                // Session lifecycle state owns exact signed bytes and private
-                // material before network exposure. Once KeyPackage setup has
-                // started, deleting a freshly-added external account could
-                // orphan an ambiguously accepted publication; keep it for an
-                // exact-byte retry instead.
-                Err(err) => return Err(err),
+                Err(err) => {
+                    // Session lifecycle state owns exact signed bytes and
+                    // private material before network exposure. Once
+                    // KeyPackage setup has started, deleting a freshly-added
+                    // external account could orphan an ambiguously accepted
+                    // publication; keep it for an exact-byte retry instead.
+                    // A previously signed-out account is different: restore
+                    // that durable state while retaining its setup journal.
+                    if reactivating_existing {
+                        self.restore_signed_out_after_key_package_failure(&account.label)
+                            .await;
+                    }
+                    return Err(err);
+                }
             }
         } else {
             None

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -4150,89 +4150,63 @@ impl AccountManager {
             self.create_nostr_account_from_setup(&request)?
         };
         let reactivating_existing = account.signed_out;
-        let setup_already_reached_publication = self
-            .app
-            .account_home()
-            .account_setup_state(&account.label)?
-            .is_some_and(|state| state.phase != AccountSetupPhase::LocalStateCreated);
-        let rollback_on_setup_failure =
-            !reactivating_existing && !setup_already_reached_publication;
-
-        if imports_private_key || reactivating_existing || !account.local_signing {
-            // Resolve a pre-existing identity's profile from public indexers, not
-            // the app's own messaging relays, where its outbox metadata does not
-            // live. Runs before the relay-list setup below so discovery never
-            // clobbers, or is clobbered by, the publish-missing-relay-lists step.
-            // Advisory: bounded so a stalled indexer cannot hang import or
-            // reactivation, exactly like the external-signer login path.
-            let _ = bounded_advisory_step(
-                &self.shared.app_performance_telemetry(),
-                ACCOUNT_SETUP_ADVISORY_WAIT,
-                "import_directory_preflight",
-                self.preflight_existing_account_directory(
-                    &account.account_id_hex,
-                    directory_discovery_relays_for_setup(&request),
-                ),
-            )
-            .await;
-        }
-
-        let relay_lists = match self
-            .setup_relay_lists_for_account(
-                &account,
-                &request,
-                imports_private_key,
-                creates_new_private_key,
-            )
-            .await
-        {
-            Ok(relay_lists) => relay_lists,
-            Err(err) => {
-                if rollback_on_setup_failure {
-                    return self.rollback_import_after_setup_failure(
-                        &account,
-                        private_key_import.as_ref(),
-                        err,
-                    );
-                }
-                return Err(err);
-            }
-        };
-
-        if creates_new_private_key && account.local_signing {
-            self.shared.lifecycle().ensure_running()?;
-            if let Err(err) = self
-                .app
-                .publish_account_follow_list(
-                    &account.label,
-                    &[],
-                    AccountRelayListBootstrap::new(
-                        request.default_relays.clone(),
-                        request.bootstrap_relays.clone(),
+        let recent_relay_lists =
+            if imports_private_key || reactivating_existing || !account.local_signing {
+                // Resolve a pre-existing identity's profile from public indexers, not
+                // the app's own messaging relays, where its outbox metadata does not
+                // live. Runs before the relay-list setup below so discovery never
+                // clobbers, or is clobbered by, the publish-missing-relay-lists step.
+                // Advisory: bounded so a stalled indexer cannot hang import or
+                // reactivation, exactly like the external-signer login path.
+                bounded_advisory_step(
+                    &self.shared.app_performance_telemetry(),
+                    ACCOUNT_SETUP_ADVISORY_WAIT,
+                    "import_directory_preflight",
+                    self.preflight_existing_account_directory(
+                        &account.account_id_hex,
+                        directory_discovery_relays_for_setup(&request),
                     ),
                 )
                 .await
-            {
-                if rollback_on_setup_failure {
-                    return self.rollback_import_after_setup_failure(
-                        &account,
-                        private_key_import.as_ref(),
-                        err,
-                    );
-                }
-                return Err(err);
-            }
-        }
+                .flatten()
+            } else {
+                None
+            };
 
-        let profile = if creates_new_private_key && account.local_signing {
-            self.shared.lifecycle().ensure_running()?;
+        let (relay_lists, profile) = if creates_new_private_key && account.local_signing {
             match self
-                .publish_default_profile_for_account(&account, &request)
+                .setup_generated_account_bootstrap(&account, &request)
                 .await
             {
-                Ok(profile) => Some(profile),
+                Ok(result) => result,
                 Err(err) => {
-                    if rollback_on_setup_failure {
+                    if self.setup_failure_can_roll_back(&account, reactivating_existing)? {
+                        return self.rollback_import_after_setup_failure(
+                            &account,
+                            private_key_import.as_ref(),
+                            err,
+                        );
+                    }
+                    // Once the helper records publication intent, a relay may
+                    // hold one replaceable bootstrap record. Retain the
+                    // journaled identity and retry instead of deleting it.
+                    return Err(err);
+                }
+            }
+        } else {
+            let relay_lists = match self
+                .setup_relay_lists_for_account(
+                    &account,
+                    &request,
+                    imports_private_key,
+                    creates_new_private_key,
+                    recent_relay_lists,
+                )
+                .await
+            {
+                Ok(relay_lists) => relay_lists,
+                Err(err) => {
+                    if self.setup_failure_can_roll_back(&account, reactivating_existing)? {
                         return self.rollback_import_after_setup_failure(
                             &account,
                             private_key_import.as_ref(),
@@ -4241,9 +4215,8 @@ impl AccountManager {
                     }
                     return Err(err);
                 }
-            }
-        } else {
-            None
+            };
+            (relay_lists, None)
         };
 
         let key_package_bytes = if request.publish_initial_key_package && account.local_signing {
@@ -4268,7 +4241,7 @@ impl AccountManager {
                         AccountSetupPhase::KeyPackagePublicationStarted,
                     )
                 {
-                    if rollback_on_setup_failure {
+                    if self.setup_failure_can_roll_back(&account, reactivating_existing)? {
                         return self.rollback_import_after_setup_failure(
                             &account,
                             private_key_import.as_ref(),
@@ -4276,6 +4249,12 @@ impl AccountManager {
                         );
                     }
                     return Err(err.into());
+                }
+                if account.signed_out {
+                    account = self
+                        .app
+                        .account_home()
+                        .set_account_signed_out(&account.label, false)?;
                 }
                 match self.publish_initial_key_package_for_account(&account).await {
                     Ok(bytes) => {
@@ -4299,18 +4278,21 @@ impl AccountManager {
         };
 
         self.shared.lifecycle().ensure_running()?;
-        // Advisory refresh, bounded like the matching step in
-        // login_external_signer.
-        let _ = bounded_advisory_step(
-            &self.shared.app_performance_telemetry(),
-            ACCOUNT_SETUP_ADVISORY_WAIT,
-            "import_directory_refresh",
-            self.app.refresh_user_directory_for_account_id(
-                &account.account_id_hex,
-                directory_bootstrap_relays.clone(),
-            ),
-        )
-        .await;
+        if !creates_new_private_key {
+            // Generated setup already persisted the just-acknowledged empty
+            // follow list and profile locally. Only imported/existing accounts
+            // need a directory refresh here.
+            let _ = bounded_advisory_step(
+                &self.shared.app_performance_telemetry(),
+                ACCOUNT_SETUP_ADVISORY_WAIT,
+                "import_directory_refresh",
+                self.app.refresh_user_directory_for_account_id(
+                    &account.account_id_hex,
+                    directory_bootstrap_relays.clone(),
+                ),
+            )
+            .await;
+        }
         if account.signed_out {
             account = self
                 .app
@@ -4404,12 +4386,6 @@ impl AccountManager {
                 AccountSetupPhase::LocalStateCreated,
             )?;
         }
-        let setup_already_reached_publication = self
-            .app
-            .account_home()
-            .account_setup_state(&account.label)?
-            .is_some_and(|state| state.phase != AccountSetupPhase::LocalStateCreated);
-
         let directory_bootstrap_relays = directory_bootstrap_relays_for_setup(&request);
         // An external-signer account is pre-existing by definition, so resolve
         // its profile from public indexers (its outbox metadata does not live on
@@ -4417,7 +4393,7 @@ impl AccountManager {
         // discovery keeps its anti-clobber ordering.
         // Discovery is advisory (its error path already proceeds without it),
         // so a stalled indexer must not hold the whole login hostage.
-        let _ = bounded_advisory_step(
+        let recent_relay_lists = bounded_advisory_step(
             &self.shared.app_performance_telemetry(),
             ACCOUNT_SETUP_ADVISORY_WAIT,
             "login_directory_preflight",
@@ -4426,15 +4402,16 @@ impl AccountManager {
                 directory_discovery_relays_for_setup(&request),
             ),
         )
-        .await;
+        .await
+        .flatten();
 
         let relay_lists = match self
-            .setup_relay_lists_for_account(&account, &request, true, false)
+            .setup_relay_lists_for_account(&account, &request, true, false, recent_relay_lists)
             .await
         {
             Ok(relay_lists) => relay_lists,
             Err(err) => {
-                if setup_already_reached_publication {
+                if !self.setup_failure_can_roll_back(&account, account.signed_out)? {
                     return Err(err);
                 }
                 return self.rollback_external_signer_setup(
@@ -4447,6 +4424,12 @@ impl AccountManager {
         };
 
         let key_package_bytes = if request.publish_initial_key_package {
+            if account.signed_out {
+                account = self
+                    .app
+                    .account_home()
+                    .set_account_signed_out(&account.label, false)?;
+            }
             self.app.account_home().set_account_setup_phase(
                 &account.label,
                 AccountSetupPhase::KeyPackagePublicationStarted,
@@ -4563,31 +4546,83 @@ impl AccountManager {
         Some(status)
     }
 
-    async fn publish_default_profile_for_account(
+    async fn setup_generated_account_bootstrap(
         &self,
         account: &AccountSummary,
         request: &AccountSetupRequest,
-    ) -> Result<UserProfileMetadata, AppError> {
+    ) -> Result<(AccountRelayListStatus, Option<UserProfileMetadata>), AppError> {
         let pseudonym = default_profile_pseudonym(&account.account_id_hex);
-        let profile = UserProfileMetadata {
+        let mut profile = UserProfileMetadata {
             name: Some(pseudonym.clone()),
             display_name: Some(pseudonym),
             created_at: unix_now_seconds(),
             ..UserProfileMetadata::default()
         };
+        let bootstrap = AccountRelayListBootstrap::new(
+            request.default_relays.clone(),
+            request.bootstrap_relays.clone(),
+        );
+        if bootstrap.default_relays.is_empty() {
+            return Err(AppError::MissingDefaultRelays);
+        }
         self.app
-            .publish_user_profile(
+            .validate_account_relay_list_declarations(&bootstrap, None)?;
+        let phase = self
+            .app
+            .account_home()
+            .account_setup_state(&account.label)?
+            .map(|state| state.phase)
+            .ok_or(AppError::AccountSetupRetryRequired)?;
+        if matches!(
+            phase,
+            AccountSetupPhase::BootstrapPublicationConfirmed
+                | AccountSetupPhase::KeyPackagePublicationStarted
+                | AccountSetupPhase::KeyPackagePublicationConfirmed
+        ) {
+            let status = self.app.account_relay_list_status(&account.label)?;
+            if !status.complete {
+                return Err(AppError::MissingRelayLists(status.missing));
+            }
+            if let Some(cached) = self
+                .app
+                .directory_entry_for_account_id(&account.account_id_hex)?
+                .and_then(|entry| entry.profile)
+            {
+                profile = cached;
+            }
+            return Ok((status, Some(profile)));
+        }
+        if phase == AccountSetupPhase::LocalStateCreated {
+            self.app.account_home().set_account_setup_phase(
                 &account.label,
-                profile.clone(),
-                AccountRelayListBootstrap::new(
-                    request.default_relays.clone(),
-                    request.bootstrap_relays.clone(),
-                ),
-            )
+                AccountSetupPhase::BootstrapPublicationStarted,
+            )?;
+        }
+        self.shared.lifecycle().ensure_running()?;
+        let status = self
+            .app
+            .publish_generated_account_bootstrap(&account.label, bootstrap, &profile)
             .await?;
-        self.app
-            .remember_directory_profile(&account.account_id_hex, &profile)?;
-        Ok(profile)
+        self.app.account_home().set_account_setup_phase(
+            &account.label,
+            AccountSetupPhase::BootstrapPublicationConfirmed,
+        )?;
+        Ok((status, Some(profile)))
+    }
+
+    fn setup_failure_can_roll_back(
+        &self,
+        account: &AccountSummary,
+        reactivating_existing: bool,
+    ) -> Result<bool, AppError> {
+        if reactivating_existing {
+            return Ok(false);
+        }
+        Ok(self
+            .app
+            .account_home()
+            .account_setup_state(&account.label)?
+            .is_some_and(|state| state.phase == AccountSetupPhase::LocalStateCreated))
     }
 
     async fn setup_relay_lists_for_account(
@@ -4596,6 +4631,7 @@ impl AccountManager {
         request: &AccountSetupRequest,
         imports_private_key: bool,
         creates_new_private_key: bool,
+        recent_relay_lists: Option<AccountRelayListStatus>,
     ) -> Result<AccountRelayListStatus, AppError> {
         if account.can_sign() {
             if creates_new_private_key && request.default_relays.is_empty() {
@@ -4614,30 +4650,64 @@ impl AccountManager {
                     request.default_relays.clone(),
                     request.bootstrap_relays.clone(),
                 );
-                let current_status = self
-                    .app
-                    .fetch_account_relay_list_status_for_account_id(
-                        &account.account_id_hex,
-                        bootstrap.bootstrap_relays.clone(),
+                let current_status = if let Some(status) = recent_relay_lists {
+                    status
+                } else {
+                    match bounded_advisory_step(
+                        &self.shared.app_performance_telemetry(),
+                        ACCOUNT_SETUP_ADVISORY_WAIT,
+                        "import_relay_list_status",
+                        self.app.fetch_account_relay_list_status_for_account_id(
+                            &account.account_id_hex,
+                            bootstrap.bootstrap_relays.clone(),
+                        ),
                     )
-                    .await?;
+                    .await
+                    {
+                        Some(Ok(status)) => status,
+                        Some(Err(error)) => {
+                            tracing::debug!(
+                                target: "marmot_app::runtime",
+                                method = "setup_relay_lists_for_account",
+                                error_kind = error.privacy_safe_kind(),
+                                "using cached relay-list status after advisory import fetch failed"
+                            );
+                            self.app.account_relay_list_status(&account.label)?
+                        }
+                        None => self.app.account_relay_list_status(&account.label)?,
+                    }
+                };
                 if current_status.complete {
                     Ok(current_status)
                 } else if !request.publish_missing_relay_lists || request.default_relays.is_empty()
                 {
                     Err(AppError::MissingRelayLists(current_status.missing.clone()))
                 } else {
-                    self.app
+                    self.mark_bootstrap_publication_started(&account.label)?;
+                    let status = self
+                        .app
                         .publish_missing_account_relay_lists_from_status(
                             &account.label,
                             bootstrap,
                             current_status,
                         )
-                        .await
+                        .await?;
+                    self.mark_bootstrap_publication_confirmed(&account.label)?;
+                    Ok(status)
                 }
             } else {
-                self.publish_relay_lists_for_new_account(&account.label, request)
-                    .await
+                if request.default_relays.is_empty() && request.bootstrap_relays.is_empty() {
+                    return self.app.account_relay_list_status(&account.label);
+                }
+                if request.default_relays.is_empty() {
+                    return Err(AppError::MissingDefaultRelays);
+                }
+                self.mark_bootstrap_publication_started(&account.label)?;
+                let status = self
+                    .publish_relay_lists_for_new_account(&account.label, request)
+                    .await?;
+                self.mark_bootstrap_publication_confirmed(&account.label)?;
+                Ok(status)
             }
         } else {
             let bootstrap_relays = directory_bootstrap_relays_for_setup(request);
@@ -4651,6 +4721,34 @@ impl AccountManager {
                 )
                 .await
         }
+    }
+
+    fn mark_bootstrap_publication_started(&self, label: &str) -> Result<(), AppError> {
+        if self
+            .app
+            .account_home()
+            .account_setup_state(label)?
+            .is_some_and(|state| state.phase == AccountSetupPhase::LocalStateCreated)
+        {
+            self.app
+                .account_home()
+                .set_account_setup_phase(label, AccountSetupPhase::BootstrapPublicationStarted)?;
+        }
+        Ok(())
+    }
+
+    fn mark_bootstrap_publication_confirmed(&self, label: &str) -> Result<(), AppError> {
+        if self
+            .app
+            .account_home()
+            .account_setup_state(label)?
+            .is_some_and(|state| state.phase == AccountSetupPhase::BootstrapPublicationStarted)
+        {
+            self.app
+                .account_home()
+                .set_account_setup_phase(label, AccountSetupPhase::BootstrapPublicationConfirmed)?;
+        }
+        Ok(())
     }
 
     async fn publish_relay_lists_for_new_account(
@@ -4688,10 +4786,12 @@ impl AccountManager {
                 .mark_key_package_cutover_replacement_pending(&account.label);
             return Err(AppError::AccountSetupRecoveryRequired);
         }
-        self.app.status(&account.label)?;
-        let mut client = self.app.client(&account.label).await?;
-        let key_package = client.publish_key_package().await?;
-        Ok(key_package.bytes().len())
+        // Let the managed worker own the only session opened for this setup.
+        // Its open runs through `blocking_app_task`; publishing through the
+        // worker avoids the former one-shot session open followed immediately
+        // by a second worker session open.
+        self.reconcile().await?;
+        self.publish_key_package(&account.label).await
     }
 
     fn confirmed_setup_key_package_bytes(&self, label: &str) -> Result<Option<usize>, AppError> {
@@ -4799,7 +4899,22 @@ impl AccountManager {
             None => {
                 let account = match account_home.resumable_generated_account_setup()? {
                     Some(account) => account,
-                    None => account_home.create_nostr_account_for_setup()?,
+                    None => {
+                        let account = account_home.create_nostr_account_for_setup()?;
+                        // This identity did not exist before this process and
+                        // therefore cannot have a legacy kind-30443 event to
+                        // retire. Persist that proof before its first session
+                        // open so startup never pays a guaranteed-empty relay
+                        // scan (mdk#1436).
+                        if let Err(error) = self
+                            .app
+                            .mark_key_package_cutover_scan_complete(&account.label)
+                        {
+                            let _ = account_home.remove_account(&account.label);
+                            return Err(error);
+                        }
+                        account
+                    }
                 };
                 Ok((account, None))
             }

--- a/crates/marmot-app/src/runtime/tests.rs
+++ b/crates/marmot-app/src/runtime/tests.rs
@@ -6,6 +6,7 @@ use cgka_traits::transport_adapter::{
 
 use super::subscriptions::chat_list_mute_expiries;
 use super::*;
+use crate::tests::ScriptedPushRelayClient;
 
 #[test]
 fn default_directory_discovery_relays_use_live_indexers() {
@@ -40,10 +41,53 @@ fn generated_account_birth_marks_cutover_scan_complete_before_session_open() {
     assert!(
         !app.account_home()
             .account_dir(&account.label)
-            .join("session.sqlite")
+            .join(crate::SESSION_DB_FILE)
             .exists(),
         "the scan marker must be durable before any session can open"
     );
+}
+
+#[tokio::test]
+async fn failed_import_relay_discovery_does_not_publish_default_lists() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(directory.path());
+    let keys = nostr::Keys::generate();
+    let imported = home
+        .import_nostr_account_idempotent(&keys.secret_key().to_secret_hex())
+        .unwrap();
+    let account = imported.account().clone();
+    let app = MarmotApp::with_relay(directory.path(), "wss://relay.example")
+        .with_test_relay_client(Arc::new(ScriptedPushRelayClient::default()));
+    let runtime = MarmotAppRuntime::new(app);
+
+    let error = runtime
+        .accounts
+        .setup_relay_lists_for_account(
+            &account,
+            &AccountSetupRequest {
+                default_relays: vec![TransportEndpoint("wss://relay.example".into())],
+                // A non-WebSocket bootstrap endpoint makes the bounded
+                // fallback discovery fail before any dial.
+                bootstrap_relays: vec![TransportEndpoint("https://directory.invalid".into())],
+                publish_missing_relay_lists: true,
+                ..AccountSetupRequest::default()
+            },
+            true,
+            false,
+            None,
+        )
+        .await
+        .expect_err("failed discovery must not become a write of request defaults");
+
+    assert!(matches!(
+        error,
+        AppError::MissingRelayLists(missing)
+            if missing
+                == vec![
+                    crate::MissingRelayListKind::Nip65,
+                    crate::MissingRelayListKind::Inbox,
+                ]
+    ));
 }
 
 #[test]

--- a/crates/marmot-app/src/runtime/tests.rs
+++ b/crates/marmot-app/src/runtime/tests.rs
@@ -25,6 +25,28 @@ fn default_directory_discovery_relays_use_live_indexers() {
 }
 
 #[test]
+fn generated_account_birth_marks_cutover_scan_complete_before_session_open() {
+    let directory = tempfile::tempdir().unwrap();
+    let app = MarmotApp::with_relay(directory.path(), "wss://relay.example");
+    let runtime = MarmotAppRuntime::new(app.clone());
+
+    let (account, private_key_import) = runtime
+        .accounts
+        .create_nostr_account_from_setup(&AccountSetupRequest::default())
+        .unwrap();
+
+    assert!(private_key_import.is_none());
+    assert!(app.key_package_cutover_scan_complete(&account.label));
+    assert!(
+        !app.account_home()
+            .account_dir(&account.label)
+            .join("session.sqlite")
+            .exists(),
+        "the scan marker must be durable before any session can open"
+    );
+}
+
+#[test]
 fn message_subscription_seen_ids_are_bounded_to_recent_ids() {
     let mut seen =
         MessageSubscriptionSeenIds::from_ids((0..5).map(|index| format!("message-{index}")), 3);

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -2904,6 +2904,145 @@ async fn push_registration_removal_retry_body() {
 }
 
 #[tokio::test]
+async fn generated_account_bootstrap_uses_one_batch_and_never_refetches_after_ack() {
+    let directory = tempfile::tempdir().unwrap();
+    let account = AccountHome::open(directory.path())
+        .create_nostr_account_for_setup()
+        .unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relay(directory.path(), "wss://relay.example")
+        .with_test_relay_client(relay.clone());
+    let profile = UserProfileMetadata {
+        name: Some("Swift Otter".into()),
+        display_name: Some("Swift Otter".into()),
+        created_at: 42,
+        ..UserProfileMetadata::default()
+    };
+
+    let status = app
+        .publish_generated_account_bootstrap(
+            &account.label,
+            AccountRelayListBootstrap::new(
+                vec![TransportEndpoint("wss://relay.example".into())],
+                vec![TransportEndpoint("wss://relay.example".into())],
+            ),
+            &profile,
+        )
+        .await
+        .expect("acknowledged bootstrap must not depend on a relay refetch");
+
+    assert!(status.complete);
+    assert_eq!(
+        relay.batch_calls.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "relay lists, follow list, and profile must share one connection-amortizing batch"
+    );
+    let mut kinds = relay
+        .published_events
+        .lock()
+        .unwrap()
+        .iter()
+        .map(|event| event.kind)
+        .collect::<Vec<_>>();
+    kinds.sort_unstable();
+    assert_eq!(
+        kinds,
+        vec![
+            KIND_NOSTR_METADATA,
+            KIND_NOSTR_CONTACT_LIST,
+            KIND_NIP65_RELAY_LIST,
+            KIND_MARMOT_INBOX_RELAY_LIST,
+        ]
+    );
+    assert_eq!(
+        app.account_relay_list_status(&account.label).unwrap(),
+        status,
+        "the acknowledged declaration must be the durable local projection"
+    );
+}
+
+#[tokio::test]
+async fn relay_list_zero_ack_does_not_advance_the_local_projection() {
+    let directory = tempfile::tempdir().unwrap();
+    let account = AccountHome::open(directory.path())
+        .create_account("relay-list-zero-ack")
+        .unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    relay.zero_ack_next_publish();
+    let app = MarmotApp::with_relay(directory.path(), "wss://relay.example")
+        .with_test_relay_client(relay);
+
+    let error = app
+        .publish_account_relay_lists(
+            &account.label,
+            AccountRelayListBootstrap::new(
+                vec![TransportEndpoint("wss://relay.example".into())],
+                vec![TransportEndpoint("wss://relay.example".into())],
+            ),
+        )
+        .await
+        .expect_err("zero acknowledgements must not confirm relay-list setup");
+
+    assert!(matches!(error, AppError::Publish(_)));
+    assert!(
+        !app.account_relay_list_status(&account.label)
+            .unwrap()
+            .complete,
+        "local setup state must not advance before every required event reaches a relay"
+    );
+}
+
+#[tokio::test]
+async fn partial_generated_bootstrap_keeps_the_journaled_identity_for_retry() {
+    let directory = tempfile::tempdir().unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    relay.script([true, false, true, true]);
+    let app = MarmotApp::with_relay(directory.path(), "wss://relay.example")
+        .with_test_relay_client(relay);
+    let runtime = MarmotAppRuntime::new(app.clone());
+    let request = || AccountSetupRequest {
+        default_relays: vec![TransportEndpoint("wss://relay.example".into())],
+        bootstrap_relays: vec![TransportEndpoint("wss://relay.example".into())],
+        ..AccountSetupRequest::default()
+    };
+
+    runtime
+        .create_identity(request())
+        .await
+        .expect_err("one failed member of the bootstrap batch must fail setup");
+    let account = app
+        .account_home()
+        .accounts()
+        .unwrap()
+        .into_iter()
+        .next()
+        .unwrap();
+    assert_eq!(
+        app.account_home()
+            .account_setup_state(&account.label)
+            .unwrap()
+            .unwrap()
+            .phase,
+        marmot_account::AccountSetupPhase::BootstrapPublicationStarted,
+        "a possibly exposed bootstrap batch must stop destructive rollback"
+    );
+
+    let retried = runtime
+        .create_identity(request())
+        .await
+        .expect("replaceable bootstrap records must be retryable");
+    assert_eq!(retried.account.account_id_hex, account.account_id_hex);
+    assert!(
+        app.account_home()
+            .account_setup_state(&account.label)
+            .unwrap()
+            .is_none(),
+        "successful retry must commit and remove the setup journal"
+    );
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
 async fn key_package_cutover_replacement_intent_survives_cache_retirement_and_restart() {
     let directory = tempfile::tempdir().unwrap();
     let app = MarmotApp::with_relay(directory.path(), "wss://relay.example");

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -2996,6 +2996,7 @@ async fn relay_list_zero_ack_does_not_advance_the_local_projection() {
 async fn partial_generated_bootstrap_keeps_the_journaled_identity_for_retry() {
     let directory = tempfile::tempdir().unwrap();
     let relay = Arc::new(ScriptedPushRelayClient::default());
+    // Batch order is NIP-65, inbox, contacts, profile: fail the inbox record.
     relay.script([true, false, true, true]);
     let app = MarmotApp::with_relay(directory.path(), "wss://relay.example")
         .with_test_relay_client(relay);
@@ -3038,6 +3039,42 @@ async fn partial_generated_bootstrap_keeps_the_journaled_identity_for_retry() {
             .unwrap()
             .is_none(),
         "successful retry must commit and remove the setup journal"
+    );
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn confirmed_generated_bootstrap_republishes_when_projection_is_missing() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(directory.path());
+    let account = home.create_nostr_account_for_setup().unwrap();
+    home.set_account_setup_phase(
+        &account.label,
+        marmot_account::AccountSetupPhase::BootstrapPublicationConfirmed,
+    )
+    .unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relay(directory.path(), "wss://relay.example")
+        .with_test_relay_client(relay.clone());
+    app.mark_key_package_cutover_scan_complete(&account.label)
+        .unwrap();
+    let runtime = MarmotAppRuntime::new(app);
+
+    let retried = runtime
+        .create_identity(AccountSetupRequest {
+            default_relays: vec![TransportEndpoint("wss://relay.example".into())],
+            bootstrap_relays: vec![TransportEndpoint("wss://relay.example".into())],
+            ..AccountSetupRequest::default()
+        })
+        .await
+        .expect("a confirmed setup with a lost projection must republish safely");
+
+    assert_eq!(retried.account.account_id_hex, account.account_id_hex);
+    assert!(retried.relay_lists.complete);
+    assert_eq!(
+        relay.batch_calls.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "projection recovery should issue one idempotent bootstrap batch"
     );
     runtime.shutdown().await;
 }

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -1034,6 +1034,69 @@ async fn failed_key_package_setup_retries_same_nsec_after_restart() {
 }
 
 #[tokio::test]
+async fn failed_reactivation_key_package_publish_restores_signed_out_retry() {
+    use nostr::prelude::ToBech32;
+
+    let dir = tempfile::tempdir().unwrap();
+    let rejecting = Arc::new(AtomicBool::new(false));
+    let relay = LocalRelay::new(
+        RelayBuilder::default().write_policy(RejectKeyPackagesWhileArmed(rejecting.clone())),
+    );
+    relay.run().await.unwrap();
+    let url = relay.url().await.to_string();
+    let config = MarmotAppConfig::default().with_allow_loopback_relay_endpoints(true);
+    let secret = Keys::generate().secret_key().to_bech32().unwrap();
+    let account_id = AccountHome::account_id_for_secret(&secret).unwrap();
+    let setup = |secret: &str| AccountSetupRequest {
+        import_nsec: Some(zeroize::Zeroizing::new(secret.to_owned())),
+        default_relays: vec![endpoint(&url)],
+        bootstrap_relays: vec![endpoint(&url)],
+        discovery_relays: vec![endpoint(&url)],
+        publish_missing_relay_lists: true,
+        publish_initial_key_package: true,
+        ..AccountSetupRequest::default()
+    };
+
+    let app = MarmotApp::with_relay_and_config(dir.path(), url.clone(), config);
+    let runtime = MarmotAppRuntime::new(app.clone());
+    let created = runtime
+        .create_or_import_account(setup(&secret))
+        .await
+        .expect("initial import should publish its KeyPackage");
+    runtime
+        .sign_out(
+            &created.account.label,
+            SignOutOptions {
+                delete_key_packages: false,
+            },
+        )
+        .await
+        .unwrap();
+
+    rejecting.store(true, Ordering::Relaxed);
+    runtime
+        .create_or_import_account(setup(&secret))
+        .await
+        .expect_err("reactivation must surface the rejected KeyPackage publication");
+    assert!(
+        AccountHome::open(dir.path())
+            .account(&account_id)
+            .unwrap()
+            .signed_out,
+        "failed reactivation must restore the durable signed-out marker"
+    );
+
+    rejecting.store(false, Ordering::Relaxed);
+    let retried = runtime
+        .create_or_import_account(setup(&secret))
+        .await
+        .expect("the same nsec must resume instead of returning AccountExists");
+    assert_eq!(retried.account.account_id_hex, account_id);
+    assert!(!retried.account.signed_out);
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
 async fn failed_generated_identity_setup_resumes_same_identity_after_restart() {
     let dir = tempfile::tempdir().unwrap();
     let rejecting = Arc::new(AtomicBool::new(true));

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -831,7 +831,7 @@ async fn import_with_stalled_discovery_endpoint_completes_within_the_advisory_ca
             import_nsec: Some(zeroize::Zeroizing::new(secret)),
             default_relays: vec![endpoint(&url)],
             bootstrap_relays: vec![endpoint(&url)],
-            discovery_relays: vec![endpoint(&stall_url)],
+            discovery_relays: vec![endpoint(&url), endpoint(&stall_url)],
             publish_missing_relay_lists: true,
             publish_initial_key_package: true,
         }),
@@ -840,6 +840,27 @@ async fn import_with_stalled_discovery_endpoint_completes_within_the_advisory_ca
     .expect("import must not hang on a stalled discovery endpoint")
     .expect("import should succeed without the advisory preflight");
     assert!(imported.account.local_signing);
+    assert_eq!(
+        runtime
+            .shared_services()
+            .relay_plane()
+            .relay_health()
+            .await
+            .directory_failed_fetches,
+        0,
+        "a stalled peer must not fail a directory fetch that has one connected relay"
+    );
+    assert_eq!(
+        runtime
+            .shared_services()
+            .app_performance_telemetry()
+            .snapshot()
+            .account_session_open
+            .attempts,
+        1,
+        "nsec setup must use the worker-owned session instead of a one-shot open"
+    );
+    runtime.shutdown().await;
 }
 
 #[tokio::test]
@@ -1358,8 +1379,29 @@ async fn app_runtime_create_identity_bootstraps_managed_account_and_key_package(
     );
     let relay_health = runtime.shared_services().relay_plane().relay_health().await;
     assert!(
-        relay_health.directory_completed_fetches > 0,
-        "identity setup should use the runtime shared relay plane for directory discovery"
+        relay_health.directory_completed_fetches <= 1,
+        "generated setup must not add synchronous relay-list/follow-list refetches; observed {} directory fetches",
+        relay_health.directory_completed_fetches,
+    );
+    assert_eq!(
+        runtime
+            .shared_services()
+            .app_performance_telemetry()
+            .snapshot()
+            .account_session_open
+            .attempts,
+        1,
+        "setup must open the worker-owned session exactly once"
+    );
+    assert!(
+        dir.path()
+            .join("key-packages")
+            .join(format!(
+                "{}.capability-refresh-v1-relay-scan-complete",
+                created.account.label
+            ))
+            .exists(),
+        "a generated account must persist the guaranteed-empty cutover scan marker before opening"
     );
 
     let fetched = app
@@ -1384,6 +1426,33 @@ async fn app_runtime_create_identity_bootstraps_managed_account_and_key_package(
         "a new identity should publish a kind-3 event with no p tags"
     );
 
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn account_creation_succeeds_with_one_unreachable_bootstrap_relay() {
+    let dir = tempfile::tempdir().unwrap();
+    let (_relay, app, live_url) = mock_app(&dir).await;
+    let runtime = MarmotAppRuntime::new(app);
+    let unused = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let unreachable_url = format!("ws://{}", unused.local_addr().unwrap());
+    drop(unused);
+
+    let created = timeout(
+        Duration::from_secs(20),
+        runtime.create_identity(AccountSetupRequest {
+            default_relays: vec![endpoint(&live_url), endpoint(&unreachable_url)],
+            bootstrap_relays: vec![endpoint(&live_url), endpoint(&unreachable_url)],
+            publish_initial_key_package: true,
+            ..AccountSetupRequest::default()
+        }),
+    )
+    .await
+    .expect("one unreachable relay must not multiply setup deadlines")
+    .expect("one acknowledged relay is sufficient for account setup");
+
+    assert!(created.relay_lists.complete);
+    assert!(created.key_package_bytes.is_some());
     runtime.shutdown().await;
 }
 

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -1097,6 +1097,75 @@ async fn failed_reactivation_key_package_publish_restores_signed_out_retry() {
 }
 
 #[tokio::test]
+async fn failed_external_signer_reactivation_restores_signed_out_retry() {
+    let dir = tempfile::tempdir().unwrap();
+    let rejecting = Arc::new(AtomicBool::new(false));
+    let relay = LocalRelay::new(
+        RelayBuilder::default().write_policy(RejectKeyPackagesWhileArmed(rejecting.clone())),
+    );
+    relay.run().await.unwrap();
+    let url = relay.url().await.to_string();
+    let config = MarmotAppConfig::default().with_allow_loopback_relay_endpoints(true);
+    let keys = Keys::generate();
+    let public_key = keys.public_key().to_hex();
+    let setup = || AccountSetupRequest {
+        default_relays: vec![endpoint(&url)],
+        bootstrap_relays: vec![endpoint(&url)],
+        discovery_relays: vec![endpoint(&url)],
+        publish_missing_relay_lists: true,
+        publish_initial_key_package: true,
+        ..AccountSetupRequest::default()
+    };
+
+    let app = MarmotApp::with_relay_and_config(dir.path(), url.clone(), config.clone());
+    let runtime = MarmotAppRuntime::new(app);
+    let created = runtime
+        .login_external_signer(
+            public_key.clone(),
+            TestExternalAccountSigner { keys: keys.clone() },
+            setup(),
+        )
+        .await
+        .expect("initial external-signer login should publish its KeyPackage");
+    runtime.shutdown().await;
+    AccountHome::open(dir.path())
+        .set_account_signed_out(&created.account.label, true)
+        .unwrap();
+    let app = MarmotApp::with_relay_and_config(dir.path(), url.clone(), config);
+    let runtime = MarmotAppRuntime::new(app);
+
+    rejecting.store(true, Ordering::Relaxed);
+    runtime
+        .login_external_signer(
+            public_key.clone(),
+            TestExternalAccountSigner { keys: keys.clone() },
+            setup(),
+        )
+        .await
+        .expect_err("external-signer reactivation must surface KeyPackage rejection");
+    assert!(
+        AccountHome::open(dir.path())
+            .account(&public_key)
+            .unwrap()
+            .signed_out,
+        "failed external-signer reactivation must restore signed-out state"
+    );
+
+    rejecting.store(false, Ordering::Relaxed);
+    let retried = runtime
+        .login_external_signer(
+            public_key.clone(),
+            TestExternalAccountSigner { keys },
+            setup(),
+        )
+        .await
+        .expect("external-signer reactivation retry must resume");
+    assert_eq!(retried.account.account_id_hex, public_key);
+    assert!(!retried.account.signed_out);
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
 async fn failed_generated_identity_setup_resumes_same_identity_after_restart() {
     let dir = tempfile::tempdir().unwrap();
     let rejecting = Arc::new(AtomicBool::new(true));


### PR DESCRIPTION
Closes #1436.

## What was wrong

Account creation and nsec import serialized avoidable relay and storage work. Setup created a fresh signer-bound SDK client for each initial event, connected directory relays one at a time, and synchronously re-fetched relay lists after they had already been acknowledged. That refetch could fail after successful publication and roll the new account back.

Fresh accounts also ran a guaranteed-empty legacy KeyPackage cutover scan, while initial KeyPackage publication opened a one-shot session before the managed account worker opened the same SQLCipher database again.

## What changed

- Publish the generated account's NIP-65 list, inbox list, empty follow list, and default profile as one mixed-endpoint batch through one signer-bound client.
- Keep relay-list records on discovery/bootstrap relays while preserving the existing outbox boundary for profile and follow-list records.
- Treat relay acknowledgements as the authoritative publication result and persist the declared relay-list projection directly instead of performing a setup-fatal refetch.
- Add durable bootstrap-publication started/confirmed phases so partial or ambiguous exposure retains the account for an idempotent retry.
- Connect directory relays concurrently and ignore one failed endpoint when another endpoint is usable.
- Reuse the bounded import preflight relay-list result and cap fallback discovery with the existing setup advisory deadline.
- Mark the legacy KeyPackage cutover scan complete when a generated account record is born.
- Publish the initial KeyPackage through the managed worker, leaving setup with one off-runtime-thread session open.
- Skip the redundant generated-account directory refresh because the batch already persists its profile and empty follow projection.

## Impact

A single unreachable bootstrap/default relay no longer makes account creation fail or multiplies its connect timeout across every setup publication. The happy path uses one batch for the four replaceable bootstrap records, avoids the relay-list confirmation refetch and guaranteed-empty cutover scan, and opens the session database once.

## Validation

- `just fast-ci`
- `cargo test -p marmot-account` — 98 tests passed
- `cargo test -p marmot-app --lib` — 664 tests passed
- Generated setup with one unreachable relay succeeded in 4.2 seconds
- Import with a live plus stalled discovery endpoint completed in 7.25 seconds
- Regression coverage verifies one setup session open, the pre-open cutover marker, zero-ack projection safety, no post-publish refetch dependency, and exact retry after a partial bootstrap batch

The full `marmot-app` integration invocation still reports five existing `relay_runtime` failures. Each reproduces unchanged in a clean `origin/master` worktree at `521b9e87`; the issue-specific setup tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account setup now tracks bootstrap publication progress for improved status visibility and recovery.
  * New accounts publish relay lists, profile information, and follow data together during setup.
* **Bug Fixes**
  * Setup continues when individual relays are unavailable, provided at least one relay succeeds.
  * Prevented unnecessary directory refreshes during account creation.
  * Failed setup attempts preserve progress and support retry without losing account identity.
  * Improved recovery when reactivating accounts or using external signers.
* **Reliability**
  * Improved relay-client reuse, session handling, and relay connection deduplication.
  * Added validation for unsuccessful publication acknowledgements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->