### PR TITLE
fix(agent-connector): drive idle reconciliation by events with adaptive safety nets

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -63,6 +63,15 @@ bench-startup:
 bench-storage-upgrade:
     cargo test --release -p storage-sqlite migrations::tests::storage_format_upgrade_benchmark -- --ignored --exact --nocapture --test-threads=1
 
+# Idle reconciliation regression benchmark (mdk#1380). Builds one agent
+# account with several joined groups, idles a long-lived inbound subscription
+# over many compressed former-intervals, asserts the adaptive safety nets stay
+# bounded, and prints stable `MDK_BENCH ...` lines for pass counts, per-pass
+# latency, invite candidate rows, and the activity wake gap. Override the
+# default 8 groups with `MDK_IDLE_RECONCILE_GROUPS=<count>`.
+bench-idle-reconciliation:
+    cargo test --release -p agent-connector --lib tests::bench_idle_reconciliation_scaling -- --ignored --exact --nocapture --test-threads=1
+
 relay-up:
     docker compose up -d
     ./scripts/wait_for_relays.sh

--- a/crates/agent-connector/AGENTS.md
+++ b/crates/agent-connector/AGENTS.md
@@ -35,7 +35,14 @@ several files in the same crate); methods shared across those files are `pub(cra
 - `src/inbound.rs` — `SubscribeInbound` drain loop and storage-backed `replay_missed_inbound` recovery after broadcast
   lag.
 - `src/invite_policy.rs` — background reconciliation of pending group invites against the welcomer allowlist
-  (worker spawn, reconcile, candidate enumeration, apply).
+  (worker spawn, reconcile, candidate enumeration, apply). Event- and retry-driven: `GroupJoined` events apply
+  immediately, per-candidate retries wake on their own backoff, and full enumeration is an adaptive safety net
+  (base `INVITE_POLICY_RECONCILE_INTERVAL`, doubling to `INVITE_POLICY_RECONCILE_MAX_INTERVAL` while passes find
+  nothing) over the targeted `MarmotApp::pending_group_invites` read — never a full `app.groups()` projection
+  load (mdk#1380).
+- `src/reconcile_telemetry.rs` — privacy-safe aggregate counters for the background reconciliation loops
+  (`ReconcileTelemetry` on the connector: passes, outcomes, accounts/candidate rows considered) plus the
+  `ReconcileSource` label used on per-pass tracing events (mdk#1380).
 - `src/error.rs` — `ConnectorError` and its `code`/`client_message`/`privacy_safe_code` projections.
 - `src/socket.rs` — socket path/bind/hardening (`default_socket_path`, `bind_connector_socket*`, stale-socket recovery).
 - `src/allowlist.rs` — `AllowlistStore`/`AllowlistRecord` per-account welcomer allowlist persistence.
@@ -49,7 +56,11 @@ several files in the same crate); methods shared across those files are `pub(cra
   `$TMPDIR/marmot-media/`.
 - `src/quic.rs` — QUIC broker candidate parsing, address resolution, and trust selection.
 - `src/event_projection.rs` — runtime/debug event → control event projection, the `DeliveredInboundCursor`, and the
-  `InboundCatchUpDriver`.
+  `InboundCatchUpDriver`. The driver's scheduled passes are an adaptive safety net (base
+  `INBOUND_CATCH_UP_BASE_INTERVAL`, doubling to `INBOUND_CATCH_UP_MAX_INTERVAL` while the runtime is quiet):
+  steady-state delivery is push-driven by each account worker, so qualifying runtime activity (anything but
+  `AccountError`, which a failing pass could self-emit) resets the net and wakes a backed-off pass, never faster
+  than the base cadence (mdk#1380). Subscription initial catch-ups stay prompt out-of-band requests.
 - `src/validation.rs` — control-plane/profile/hex validation helpers and the invite-policy retry-state holders.
 - `src/bootstrap.rs` — `wn-agent bootstrap` flow.
 - `src/bin/wn-agent.rs` — the `wn-agent` binary entrypoint and clap CLI surface (`ServeArgs`, the `bootstrap`

--- a/crates/agent-connector/AGENTS.md
+++ b/crates/agent-connector/AGENTS.md
@@ -39,7 +39,8 @@ several files in the same crate); methods shared across those files are `pub(cra
   immediately, per-candidate retries wake on their own backoff, and full enumeration is an adaptive safety net
   (base `INVITE_POLICY_RECONCILE_INTERVAL`, doubling to `INVITE_POLICY_RECONCILE_MAX_INTERVAL` while passes find
   nothing) over the targeted `MarmotApp::pending_group_invites` read — never a full `app.groups()` projection
-  load (mdk#1380).
+  load (mdk#1380). Enumeration failures back off on a separate failure floor so a failing store cannot spin the
+  worker even with a matured retry pending.
 - `src/reconcile_telemetry.rs` — privacy-safe aggregate counters for the background reconciliation loops
   (`ReconcileTelemetry` on the connector: passes, outcomes, accounts/candidate rows considered) plus the
   `ReconcileSource` label used on per-pass tracing events (mdk#1380).

--- a/crates/agent-connector/src/event_projection.rs
+++ b/crates/agent-connector/src/event_projection.rs
@@ -1033,7 +1033,10 @@ pub(crate) struct InboundCatchUpSchedule {
 #[derive(Clone)]
 pub(crate) struct InboundCatchUpDriver {
     runtime: MarmotAppRuntime,
-    lock: Arc<AsyncMutex<()>>,
+    /// Serializes scheduled and explicit catch-up passes. `pub(crate)` so the
+    /// regression harness can hold a pass queued behind the lock and prove the
+    /// schedule preserves delayed cadence afterwards (mdk#1380 review).
+    pub(crate) lock: Arc<AsyncMutex<()>>,
     events: broadcast::Sender<InboundCatchUpEvent>,
     pub(crate) started: Arc<AtomicBool>,
     pub(crate) active: Arc<AtomicU64>,
@@ -1111,7 +1114,12 @@ impl InboundCatchUpDriver {
             .base
             .max(Duration::from_millis(1))
             .min(self.schedule.max);
-        let mut last_pass_started = tokio::time::Instant::now();
+        // Deadlines anchor at pass COMPLETION, preserving the old
+        // `MissedTickBehavior::Delay` semantics: a pass that runs long (or
+        // queues behind an explicit request on the serialization lock) inserts
+        // the full interval before the next pass instead of firing
+        // back-to-back (mdk#1380 review).
+        let mut last_pass_completed = tokio::time::Instant::now();
         loop {
             if self.active.load(Ordering::Acquire) == 0 {
                 self.started.store(false, Ordering::Release);
@@ -1126,17 +1134,22 @@ impl InboundCatchUpDriver {
                     break;
                 }
             }
-            let deadline = last_pass_started + interval;
-            let wake =
-                wait_for_catch_up_wake(deadline, last_pass_started, &self.schedule, &mut activity)
-                    .await;
-            last_pass_started = tokio::time::Instant::now();
+            let deadline = last_pass_completed + interval;
+            let wake = wait_for_catch_up_wake(
+                deadline,
+                last_pass_completed,
+                &self.schedule,
+                &mut activity,
+            )
+            .await;
             // A pass that observed activity since the previous pass began —
             // the wake reason itself, plus anything buffered while the pass
             // ran — keeps the next pass at the base interval.
             let observed_activity =
                 matches!(wake, CatchUpWake::Activity) || drain_pending_activity(&mut activity);
-            match self.scheduled_pass(observed_activity).await {
+            let result = self.scheduled_pass(observed_activity).await;
+            last_pass_completed = tokio::time::Instant::now();
+            match result {
                 Ok(()) if observed_activity => {
                     interval = self
                         .schedule
@@ -1154,8 +1167,8 @@ impl InboundCatchUpDriver {
     /// per-pass tracing event (source/duration/result/accounts considered).
     async fn scheduled_pass(&self, observed_activity: bool) -> Result<(), ()> {
         let started = tokio::time::Instant::now();
-        ReconcileTelemetry::bump(&self.telemetry.catch_up_passes_started);
         let _guard = self.lock.lock().await;
+        ReconcileTelemetry::bump(&self.telemetry.catch_up_passes_started);
         let result = self.runtime.catch_up_accounts_reporting().await;
         match &result {
             Ok(summary) => {

--- a/crates/agent-connector/src/event_projection.rs
+++ b/crates/agent-connector/src/event_projection.rs
@@ -1255,21 +1255,21 @@ enum CatchUpWake {
 
 /// Wait until `deadline`, returning early ([`CatchUpWake::Activity`]) when
 /// qualifying runtime activity arrives. Activity noticed less than the base
-/// interval after `last_pass_started` is deferred to that base boundary: a
+/// interval after `last_pass_completed` is deferred to that base boundary: a
 /// busy account stays at the base cadence (never one pass per event), while a
 /// backed-off (quiet) driver notices fresh work promptly (mdk#1380).
 async fn wait_for_catch_up_wake(
     deadline: tokio::time::Instant,
-    last_pass_started: tokio::time::Instant,
+    last_pass_completed: tokio::time::Instant,
     schedule: &InboundCatchUpSchedule,
     activity: &mut broadcast::Receiver<MarmotAppEvent>,
 ) -> CatchUpWake {
     let timer = tokio::time::sleep_until(deadline);
     tokio::pin!(timer);
     let base = schedule.base.max(Duration::from_millis(1));
-    // The cadence floor follows the previous pass start. The scheduled
+    // The cadence floor follows the previous pass completion. The scheduled
     // deadline never precedes it (interval >= base).
-    let cadence_floor = last_pass_started + base;
+    let cadence_floor = last_pass_completed + base;
     loop {
         tokio::select! {
             _ = &mut timer => return CatchUpWake::Timer,

--- a/crates/agent-connector/src/event_projection.rs
+++ b/crates/agent-connector/src/event_projection.rs
@@ -277,9 +277,10 @@ pub(crate) fn media_refs_from_tags(
 use cgka_traits::engine::GroupStateChange;
 use cgka_traits::{GroupId, engine::GroupEvent};
 use marmot_app::{AppError, AppMessageRecord, MarmotAppEvent, MarmotAppRuntime};
+use std::time::Duration;
 use tokio::sync::{Mutex as AsyncMutex, broadcast};
 
-use crate::INBOUND_CATCH_UP_INTERVAL;
+use crate::reconcile_telemetry::{ReconcileSource, ReconcileTelemetry};
 use crate::validation::normalize_hex;
 
 pub(crate) fn control_actor(
@@ -999,6 +1000,36 @@ pub(crate) enum InboundCatchUpEvent {
     Completed,
 }
 
+/// Cadence for the catch-up safety net. Production builds use
+/// [`crate::INBOUND_CATCH_UP_BASE_INTERVAL`] / [`crate::INBOUND_CATCH_UP_MAX_INTERVAL`];
+/// tests inject shorter intervals to exercise the adaptive schedule.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct InboundCatchUpSchedule {
+    pub(crate) base: Duration,
+    pub(crate) max: Duration,
+}
+
+/// One shared catch-up driver for every live `SubscribeInbound` subscription
+/// (mdk#574). The driver's scheduled passes are a *safety net*: steady-state
+/// delivery is push-driven through each account worker's live receive loop, so
+/// a pass exists to heal silent notification gaps, not to fetch messages —
+/// which is why the net may back off when nothing is happening (mdk#1380).
+///
+/// Scheduling discipline:
+/// - Subscription initial catch-ups arrive out-of-band through
+///   [`Self::request`] and run promptly (serialization lock coalesces them).
+/// - Scheduled passes start at `base` after the first subscription and double
+///   after every pass that observed no qualifying runtime activity, capped at
+///   `max`.
+/// - Qualifying activity — any runtime event except `AccountError` (errors can
+///   be our own failing passes and must not self-stimulate), or a lagged event
+///   stream — resets the interval to `base`. Activity observed while the
+///   driver was sleeping wakes a pass immediately, but only once the previous
+///   pass is at least `base` old, so a busy account never escalates BEYOND the
+///   base cadence.
+/// - A failed pass keeps backing off (relay outage: the per-worker reconnect
+///   backoff owns transport repair); recovery surfaces as activity events.
+/// - The driver quiesces when the last subscription drops, exactly as before.
 #[derive(Clone)]
 pub(crate) struct InboundCatchUpDriver {
     runtime: MarmotAppRuntime,
@@ -1006,10 +1037,31 @@ pub(crate) struct InboundCatchUpDriver {
     events: broadcast::Sender<InboundCatchUpEvent>,
     pub(crate) started: Arc<AtomicBool>,
     pub(crate) active: Arc<AtomicU64>,
+    schedule: InboundCatchUpSchedule,
+    telemetry: Arc<ReconcileTelemetry>,
+    /// Test-only activity channel override. Production drivers subscribe to the
+    /// runtime event broadcast; tests inject a channel they can publish
+    /// synthetic events into.
+    activity_override: Option<broadcast::Sender<MarmotAppEvent>>,
 }
 
 impl InboundCatchUpDriver {
-    pub(crate) fn new(runtime: MarmotAppRuntime) -> Self {
+    pub(crate) fn new(runtime: MarmotAppRuntime, telemetry: Arc<ReconcileTelemetry>) -> Self {
+        Self::with_schedule(
+            runtime,
+            telemetry,
+            InboundCatchUpSchedule {
+                base: crate::INBOUND_CATCH_UP_BASE_INTERVAL,
+                max: crate::INBOUND_CATCH_UP_MAX_INTERVAL,
+            },
+        )
+    }
+
+    pub(crate) fn with_schedule(
+        runtime: MarmotAppRuntime,
+        telemetry: Arc<ReconcileTelemetry>,
+        schedule: InboundCatchUpSchedule,
+    ) -> Self {
         let (events, _) = broadcast::channel(16);
         Self {
             runtime,
@@ -1017,7 +1069,19 @@ impl InboundCatchUpDriver {
             events,
             started: Arc::new(AtomicBool::new(false)),
             active: Arc::new(AtomicU64::new(0)),
+            schedule,
+            telemetry,
+            activity_override: None,
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn override_activity_for_test(
+        mut self,
+        activity: broadcast::Sender<MarmotAppEvent>,
+    ) -> Self {
+        self.activity_override = Some(activity);
+        self
     }
 
     fn spawn(&self) {
@@ -1026,29 +1090,110 @@ impl InboundCatchUpDriver {
         }
         let driver = self.clone();
         tokio::spawn(async move {
-            let mut interval = tokio::time::interval_at(
-                tokio::time::Instant::now() + INBOUND_CATCH_UP_INTERVAL,
-                INBOUND_CATCH_UP_INTERVAL,
-            );
-            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-            loop {
-                interval.tick().await;
-                if driver.active.load(Ordering::Acquire) == 0 {
-                    driver.started.store(false, Ordering::Release);
-                    if driver.active.load(Ordering::Acquire) == 0 {
-                        break;
-                    }
-                    if driver
-                        .started
-                        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-                        .is_err()
-                    {
-                        break;
-                    }
-                }
-                let _ = driver.request().await;
-            }
+            driver.run().await;
         });
+    }
+
+    fn activity_receiver(&self) -> broadcast::Receiver<MarmotAppEvent> {
+        match &self.activity_override {
+            Some(sender) => sender.subscribe(),
+            None => self.runtime.subscribe(),
+        }
+    }
+
+    async fn run(self) {
+        let mut activity = self.activity_receiver();
+        // First scheduled pass fires one base interval after spawn, unchanged
+        // from the pre-adaptive driver (the subscription's own initial request
+        // covers the "catch up now" case).
+        let mut interval = self
+            .schedule
+            .base
+            .max(Duration::from_millis(1))
+            .min(self.schedule.max);
+        let mut last_pass_started = tokio::time::Instant::now();
+        loop {
+            if self.active.load(Ordering::Acquire) == 0 {
+                self.started.store(false, Ordering::Release);
+                if self.active.load(Ordering::Acquire) == 0 {
+                    break;
+                }
+                if self
+                    .started
+                    .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                    .is_err()
+                {
+                    break;
+                }
+            }
+            let deadline = last_pass_started + interval;
+            let wake =
+                wait_for_catch_up_wake(deadline, last_pass_started, &self.schedule, &mut activity)
+                    .await;
+            last_pass_started = tokio::time::Instant::now();
+            // A pass that observed activity since the previous pass began —
+            // the wake reason itself, plus anything buffered while the pass
+            // ran — keeps the next pass at the base interval.
+            let observed_activity =
+                matches!(wake, CatchUpWake::Activity) || drain_pending_activity(&mut activity);
+            match self.scheduled_pass(observed_activity).await {
+                Ok(()) if observed_activity => {
+                    interval = self
+                        .schedule
+                        .base
+                        .max(Duration::from_millis(1))
+                        .min(self.schedule.max);
+                }
+                Ok(()) => interval = (interval * 2).min(self.schedule.max),
+                Err(()) => interval = (interval * 2).min(self.schedule.max),
+            }
+        }
+    }
+
+    /// Run one scheduled catch-up pass, recording aggregate telemetry and a
+    /// per-pass tracing event (source/duration/result/accounts considered).
+    async fn scheduled_pass(&self, observed_activity: bool) -> Result<(), ()> {
+        let started = tokio::time::Instant::now();
+        ReconcileTelemetry::bump(&self.telemetry.catch_up_passes_started);
+        let _guard = self.lock.lock().await;
+        let result = self.runtime.catch_up_accounts_reporting().await;
+        match &result {
+            Ok(summary) => {
+                ReconcileTelemetry::bump(&self.telemetry.catch_up_passes_completed);
+                ReconcileTelemetry::add(
+                    &self.telemetry.catch_up_accounts_considered,
+                    summary.accounts_considered,
+                );
+                if observed_activity {
+                    ReconcileTelemetry::bump(&self.telemetry.catch_up_passes_with_activity);
+                }
+                let _ = self.events.send(InboundCatchUpEvent::Completed);
+                tracing::debug!(
+                    target: "agent_connector",
+                    method = "inbound_catch_up_scheduled_pass",
+                    source = ReconcileSource::InboundCatchUp.as_str(),
+                    duration_ms = started.elapsed().as_millis() as u64,
+                    result = "ok",
+                    observed_activity,
+                    accounts_considered = summary.accounts_considered,
+                    "scheduled inbound catch-up pass completed"
+                );
+                Ok(())
+            }
+            Err(_) => {
+                ReconcileTelemetry::bump(&self.telemetry.catch_up_passes_failed);
+                tracing::warn!(
+                    target: "agent_connector",
+                    method = "inbound_catch_up_scheduled_pass",
+                    source = ReconcileSource::InboundCatchUp.as_str(),
+                    duration_ms = started.elapsed().as_millis() as u64,
+                    result = "error",
+                    error_code = "catch_up_failed",
+                    "scheduled inbound catch-up pass failed"
+                );
+                Err(())
+            }
+        }
     }
 
     pub(crate) fn subscribe(
@@ -1067,7 +1212,12 @@ impl InboundCatchUpDriver {
         )
     }
 
+    /// Run one out-of-band catch-up (a subscription's initial pass). Explicit
+    /// requests are not counted as scheduled passes and do not perturb the
+    /// adaptive schedule: the activity they surface arrives as runtime events,
+    /// which reset the net through the usual path.
     pub(crate) async fn request(&self) -> Result<(), AppError> {
+        ReconcileTelemetry::bump(&self.telemetry.catch_up_explicit_requests);
         let _guard = self.lock.lock().await;
         let result = self.runtime.catch_up_accounts().await;
         if result.is_ok() {
@@ -1082,6 +1232,82 @@ impl InboundCatchUpDriver {
         }
         result
     }
+}
+
+/// What ended the wait between scheduled passes.
+enum CatchUpWake {
+    Timer,
+    Activity,
+}
+
+/// Wait until `deadline`, returning early ([`CatchUpWake::Activity`]) when
+/// qualifying runtime activity arrives. Activity noticed less than the base
+/// interval after `last_pass_started` is deferred to that base boundary: a
+/// busy account stays at the base cadence (never one pass per event), while a
+/// backed-off (quiet) driver notices fresh work promptly (mdk#1380).
+async fn wait_for_catch_up_wake(
+    deadline: tokio::time::Instant,
+    last_pass_started: tokio::time::Instant,
+    schedule: &InboundCatchUpSchedule,
+    activity: &mut broadcast::Receiver<MarmotAppEvent>,
+) -> CatchUpWake {
+    let timer = tokio::time::sleep_until(deadline);
+    tokio::pin!(timer);
+    let base = schedule.base.max(Duration::from_millis(1));
+    // The cadence floor follows the previous pass start. The scheduled
+    // deadline never precedes it (interval >= base).
+    let cadence_floor = last_pass_started + base;
+    loop {
+        tokio::select! {
+            _ = &mut timer => return CatchUpWake::Timer,
+            event = activity.recv() => {
+                let qualifying = match event {
+                    Ok(event) => event_counts_as_catch_up_activity(&event),
+                    // A lagged stream means events were evicted while we waited:
+                    // conservatively treat as activity. A closed stream (runtime
+                    // shut down) leaves only the timer; the pass fails and the
+                    // driver's own backoff governs.
+                    Err(broadcast::error::RecvError::Lagged(_)) => true,
+                    Err(broadcast::error::RecvError::Closed) => false,
+                };
+                if !qualifying {
+                    continue;
+                }
+                if tokio::time::Instant::now() >= cadence_floor {
+                    return CatchUpWake::Activity;
+                }
+                // Too soon for an immediate pass: absorb this activity and run
+                // at the cadence floor instead of discarding the signal.
+                tokio::time::sleep_until(cadence_floor).await;
+                return CatchUpWake::Activity;
+            }
+        }
+    }
+}
+
+/// Drain buffered runtime events non-blockingly after a pass; any qualifying
+/// event (or lag) counts as activity observed during the pass.
+fn drain_pending_activity(activity: &mut broadcast::Receiver<MarmotAppEvent>) -> bool {
+    loop {
+        match activity.try_recv() {
+            Ok(event) => {
+                if event_counts_as_catch_up_activity(&event) {
+                    return true;
+                }
+            }
+            Err(broadcast::error::TryRecvError::Lagged(_)) => return true,
+            Err(broadcast::error::TryRecvError::Empty)
+            | Err(broadcast::error::TryRecvError::Closed) => return false,
+        }
+    }
+}
+
+/// Which runtime events mean "state changed, the safety net should be hot
+/// again". Everything except `AccountError`: account errors may be produced by
+/// the driver's own failing passes, and counting them would pin the net at the
+/// base interval for the duration of an outage (mdk#1380).
+fn event_counts_as_catch_up_activity(event: &MarmotAppEvent) -> bool {
+    !matches!(event, MarmotAppEvent::AccountError(_))
 }
 
 pub(crate) struct InboundCatchUpSubscription {

--- a/crates/agent-connector/src/invite_policy.rs
+++ b/crates/agent-connector/src/invite_policy.rs
@@ -19,16 +19,57 @@ use crate::reconcile_telemetry::{ReconcileSource, ReconcileTelemetry};
 use crate::validation::{InvitePolicyKey, InvitePolicyRetryState, PendingInvitePolicyCandidate};
 use crate::{
     AgentConnector, INVITE_POLICY_RECONCILE_INTERVAL, INVITE_POLICY_RECONCILE_MAX_INTERVAL,
+    INVITE_POLICY_RETRY_BASE, INVITE_POLICY_RETRY_MAX,
 };
 
-/// Cadence for the invite-policy safety-net enumeration. Production builds use
-/// [`crate::INVITE_POLICY_RECONCILE_INTERVAL`] /
-/// [`crate::INVITE_POLICY_RECONCILE_MAX_INTERVAL`]; tests may inject shorter
-/// intervals to exercise the adaptive schedule.
+/// Cadence for the invite-policy safety-net enumeration and the per-candidate
+/// retry backoff. Production builds use [`crate::INVITE_POLICY_RECONCILE_INTERVAL`] /
+/// [`crate::INVITE_POLICY_RECONCILE_MAX_INTERVAL`] and
+/// [`crate::INVITE_POLICY_RETRY_BASE`] / [`crate::INVITE_POLICY_RETRY_MAX`];
+/// tests may inject shorter intervals to exercise the adaptive schedule.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct InvitePolicySchedule {
     pub(crate) base: std::time::Duration,
     pub(crate) max: std::time::Duration,
+    pub(crate) retry_base: std::time::Duration,
+    pub(crate) retry_max: std::time::Duration,
+}
+
+impl Default for InvitePolicySchedule {
+    fn default() -> Self {
+        Self {
+            base: INVITE_POLICY_RECONCILE_INTERVAL,
+            max: INVITE_POLICY_RECONCILE_MAX_INTERVAL,
+            retry_base: INVITE_POLICY_RETRY_BASE,
+            retry_max: INVITE_POLICY_RETRY_MAX,
+        }
+    }
+}
+
+/// Track one enumeration outcome for the failure floor. Consecutive
+/// enumeration failures (e.g. a locked account database) double the floor up
+/// to `max`; any success clears it. The floor pushes the retry-driven wake
+/// into the future so a matured retry deadline plus a failing enumeration
+/// cannot spin the worker at full CPU (mdk#1380 review): the worker never
+/// parks — event-driven `GroupJoined` applies stay live — only the failing
+/// enumeration's re-attempts are rate-limited.
+fn note_enumeration_result(
+    failed_until: &mut Option<tokio::time::Instant>,
+    failure_delay: &mut std::time::Duration,
+    result: Option<usize>,
+    base: std::time::Duration,
+    max: std::time::Duration,
+) {
+    match result {
+        Some(_) => {
+            *failed_until = None;
+            *failure_delay = base;
+        }
+        None => {
+            *failed_until = Some(tokio::time::Instant::now() + *failure_delay);
+            *failure_delay = (*failure_delay * 2).min(max);
+        }
+    }
 }
 
 impl AgentConnector {
@@ -36,10 +77,7 @@ impl AgentConnector {
         let connector = self.clone();
         tokio::spawn(async move {
             connector
-                .run_invite_policy_worker(InvitePolicySchedule {
-                    base: INVITE_POLICY_RECONCILE_INTERVAL,
-                    max: INVITE_POLICY_RECONCILE_MAX_INTERVAL,
-                })
+                .run_invite_policy_worker(InvitePolicySchedule::default())
                 .await;
         });
     }
@@ -49,15 +87,29 @@ impl AgentConnector {
         let mut retry_state = InvitePolicyRetryState::default();
         let base = schedule.base.max(std::time::Duration::from_millis(1));
         let mut safety_interval = base.min(schedule.max);
+        let mut enumeration_failure_delay = base;
+        let mut enumeration_failed_until: Option<tokio::time::Instant> = None;
         // A pending invite can survive a process restart without any live
         // event ever reaching this worker: the startup enumeration is the
         // one pass that must always run.
-        let _ = self
-            .reconcile_pending_invite_policies(&mut retry_state)
+        let startup_result = self
+            .reconcile_pending_invite_policies(&mut retry_state, &schedule)
             .await;
+        note_enumeration_result(
+            &mut enumeration_failed_until,
+            &mut enumeration_failure_delay,
+            startup_result,
+            base,
+            schedule.max,
+        );
         let mut safety_deadline = tokio::time::Instant::now() + safety_interval;
         loop {
-            let retry_due = retry_state.next_due();
+            // The retry wake honors the enumeration-failure floor: when the
+            // last enumeration failed, a matured retry deadline is pushed out
+            // to the floor instead of completing immediately forever.
+            let retry_due = retry_state
+                .next_due()
+                .map(|due| enumeration_failed_until.map_or(due, |floor| due.max(floor)));
             let retry_sleep = async move {
                 match retry_due {
                     Some(due) => tokio::time::sleep_until(due).await,
@@ -66,24 +118,43 @@ impl AgentConnector {
             };
             tokio::select! {
                 _ = tokio::time::sleep_until(safety_deadline) => {
-                    let found_work = self
-                        .reconcile_pending_invite_policies(&mut retry_state)
-                        .await
-                        .is_some_and(|candidates| candidates > 0)
-                        || retry_state.has_pending();
-                    safety_interval = if found_work {
-                        base
-                    } else {
-                        (safety_interval * 2).min(schedule.max)
+                    let result = self
+                        .reconcile_pending_invite_policies(&mut retry_state, &schedule)
+                        .await;
+                    note_enumeration_result(
+                        &mut enumeration_failed_until,
+                        &mut enumeration_failure_delay,
+                        result,
+                        base,
+                        schedule.max,
+                    );
+                    safety_interval = match result {
+                        // A failing enumeration backs off on the failure floor
+                        // even while retries are pending: the per-candidate
+                        // retry wake is what keeps re-attempting due work.
+                        None => enumeration_failure_delay.min(schedule.max),
+                        Some(candidates)
+                            if candidates > 0 || retry_state.has_pending() =>
+                        {
+                            base
+                        }
+                        Some(_) => (safety_interval * 2).min(schedule.max),
                     };
                     safety_deadline = tokio::time::Instant::now() + safety_interval;
                 }
                 _ = retry_sleep, if retry_due.is_some() => {
                     // A matured retry is just an enumeration whose due gate now
                     // passes; it does not perturb the safety net's cadence.
-                    let _ = self
-                        .reconcile_pending_invite_policies(&mut retry_state)
+                    let result = self
+                        .reconcile_pending_invite_policies(&mut retry_state, &schedule)
                         .await;
+                    note_enumeration_result(
+                        &mut enumeration_failed_until,
+                        &mut enumeration_failure_delay,
+                        result,
+                        base,
+                        schedule.max,
+                    );
                 }
                 event = events.recv() => {
                     let event = match event {
@@ -95,9 +166,16 @@ impl AgentConnector {
                                 lagged,
                                 "invite policy event stream lagged; reconciling pending invites"
                             );
-                            let _ = self
-                                .reconcile_pending_invite_policies(&mut retry_state)
+                            let result = self
+                                .reconcile_pending_invite_policies(&mut retry_state, &schedule)
                                 .await;
+                            note_enumeration_result(
+                                &mut enumeration_failed_until,
+                                &mut enumeration_failure_delay,
+                                result,
+                                base,
+                                schedule.max,
+                            );
                             safety_interval = base;
                             safety_deadline = tokio::time::Instant::now() + safety_interval;
                             continue;
@@ -121,7 +199,7 @@ impl AgentConnector {
                     };
                     let now = tokio::time::Instant::now();
                     if retry_state.is_due(&candidate.key, now) {
-                        self.apply_invite_policy_candidate(candidate, &mut retry_state, now)
+                        self.apply_invite_policy_candidate(candidate, &mut retry_state, now, &schedule)
                             .await;
                     }
                     // A joined group means reconcile-relevant state changed:
@@ -141,6 +219,7 @@ impl AgentConnector {
     async fn reconcile_pending_invite_policies(
         &self,
         retry_state: &mut InvitePolicyRetryState,
+        schedule: &InvitePolicySchedule,
     ) -> Option<usize> {
         let started = tokio::time::Instant::now();
         ReconcileTelemetry::bump(&self.reconcile_telemetry.invite_enumerations_started);
@@ -189,7 +268,7 @@ impl AgentConnector {
         let now = tokio::time::Instant::now();
         for candidate in candidates {
             if retry_state.is_due(&candidate.key, now) {
-                self.apply_invite_policy_candidate(candidate, retry_state, now)
+                self.apply_invite_policy_candidate(candidate, retry_state, now, schedule)
                     .await;
             }
         }
@@ -204,6 +283,19 @@ impl AgentConnector {
     fn pending_invite_policy_candidates(
         &self,
     ) -> Result<(Vec<PendingInvitePolicyCandidate>, usize), ConnectorError> {
+        if cfg!(test) {
+            let remaining = self
+                .invite_enumeration_successes_before_failure
+                .load(std::sync::atomic::Ordering::Relaxed);
+            if remaining == 0 {
+                return Err(marmot_app::AppError::BlockingTask(
+                    "injected invite enumeration failure (test only)".to_owned(),
+                )
+                .into());
+            }
+            self.invite_enumeration_successes_before_failure
+                .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+        }
         let mut candidates = Vec::new();
         let accounts = self
             .account_home
@@ -232,6 +324,7 @@ impl AgentConnector {
         candidate: PendingInvitePolicyCandidate,
         retry_state: &mut InvitePolicyRetryState,
         now: tokio::time::Instant,
+        schedule: &InvitePolicySchedule,
     ) {
         match self
             .apply_invite_policy(
@@ -246,7 +339,12 @@ impl AgentConnector {
                 ReconcileTelemetry::bump(&self.reconcile_telemetry.invite_policy_applied);
             }
             Err(err) => {
-                let (attempts, retry_delay) = retry_state.record_failure(candidate.key, now);
+                let (attempts, retry_delay) = retry_state.record_failure_with(
+                    candidate.key,
+                    now,
+                    schedule.retry_base,
+                    schedule.retry_max,
+                );
                 ReconcileTelemetry::bump(&self.reconcile_telemetry.invite_policy_apply_failures);
                 tracing::warn!(
                     target: "agent_connector",

--- a/crates/agent-connector/src/invite_policy.rs
+++ b/crates/agent-connector/src/invite_policy.rs
@@ -1,4 +1,13 @@
 //! Background reconciliation of pending group invites against the welcomer allowlist.
+//!
+//! Scheduling (mdk#1380): the worker is event- and retry-driven. `GroupJoined`
+//! runtime events are applied immediately; failed applies retry on their own
+//! bounded per-candidate backoff (`InvitePolicyRetryState::next_due` wakes the
+//! worker exactly when the earliest retry matures). Full enumeration of
+//! pending invites is a *safety net* that rediscovers durably pending invites
+//! after a process restart or a missed event — it runs once at startup and
+//! then on an interval that doubles while passes keep finding nothing
+//! (capped), resetting to the base interval whenever work arrives.
 
 use std::collections::HashSet;
 
@@ -6,31 +15,75 @@ use cgka_traits::{GroupId, MemberId, engine::GroupEvent};
 use marmot_app::MarmotAppEvent;
 
 use crate::error::ConnectorError;
-use crate::validation::{
-    InvitePolicyKey, InvitePolicyRetryState, PendingInvitePolicyCandidate, normalize_hex,
+use crate::reconcile_telemetry::{ReconcileSource, ReconcileTelemetry};
+use crate::validation::{InvitePolicyKey, InvitePolicyRetryState, PendingInvitePolicyCandidate};
+use crate::{
+    AgentConnector, INVITE_POLICY_RECONCILE_INTERVAL, INVITE_POLICY_RECONCILE_MAX_INTERVAL,
 };
-use crate::{AgentConnector, INVITE_POLICY_RECONCILE_INTERVAL};
+
+/// Cadence for the invite-policy safety-net enumeration. Production builds use
+/// [`crate::INVITE_POLICY_RECONCILE_INTERVAL`] /
+/// [`crate::INVITE_POLICY_RECONCILE_MAX_INTERVAL`]; tests may inject shorter
+/// intervals to exercise the adaptive schedule.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct InvitePolicySchedule {
+    pub(crate) base: std::time::Duration,
+    pub(crate) max: std::time::Duration,
+}
 
 impl AgentConnector {
     pub(crate) fn spawn_invite_policy_worker(&self) {
         let connector = self.clone();
         tokio::spawn(async move {
-            connector.run_invite_policy_worker().await;
+            connector
+                .run_invite_policy_worker(InvitePolicySchedule {
+                    base: INVITE_POLICY_RECONCILE_INTERVAL,
+                    max: INVITE_POLICY_RECONCILE_MAX_INTERVAL,
+                })
+                .await;
         });
     }
 
-    async fn run_invite_policy_worker(self) {
+    pub(crate) async fn run_invite_policy_worker(self, schedule: InvitePolicySchedule) {
         let mut events = self.runtime.subscribe();
         let mut retry_state = InvitePolicyRetryState::default();
-        let mut reconcile_interval = tokio::time::interval_at(
-            tokio::time::Instant::now(),
-            INVITE_POLICY_RECONCILE_INTERVAL,
-        );
-        reconcile_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        let base = schedule.base.max(std::time::Duration::from_millis(1));
+        let mut safety_interval = base.min(schedule.max);
+        // A pending invite can survive a process restart without any live
+        // event ever reaching this worker: the startup enumeration is the
+        // one pass that must always run.
+        let _ = self
+            .reconcile_pending_invite_policies(&mut retry_state)
+            .await;
+        let mut safety_deadline = tokio::time::Instant::now() + safety_interval;
         loop {
+            let retry_due = retry_state.next_due();
+            let retry_sleep = async move {
+                match retry_due {
+                    Some(due) => tokio::time::sleep_until(due).await,
+                    None => std::future::pending().await,
+                }
+            };
             tokio::select! {
-                _ = reconcile_interval.tick() => {
-                    self.reconcile_pending_invite_policies(&mut retry_state).await;
+                _ = tokio::time::sleep_until(safety_deadline) => {
+                    let found_work = self
+                        .reconcile_pending_invite_policies(&mut retry_state)
+                        .await
+                        .is_some_and(|candidates| candidates > 0)
+                        || retry_state.has_pending();
+                    safety_interval = if found_work {
+                        base
+                    } else {
+                        (safety_interval * 2).min(schedule.max)
+                    };
+                    safety_deadline = tokio::time::Instant::now() + safety_interval;
+                }
+                _ = retry_sleep, if retry_due.is_some() => {
+                    // A matured retry is just an enumeration whose due gate now
+                    // passes; it does not perturb the safety net's cadence.
+                    let _ = self
+                        .reconcile_pending_invite_policies(&mut retry_state)
+                        .await;
                 }
                 event = events.recv() => {
                     let event = match event {
@@ -42,7 +95,11 @@ impl AgentConnector {
                                 lagged,
                                 "invite policy event stream lagged; reconciling pending invites"
                             );
-                            self.reconcile_pending_invite_policies(&mut retry_state).await;
+                            let _ = self
+                                .reconcile_pending_invite_policies(&mut retry_state)
+                                .await;
+                            safety_interval = base;
+                            safety_deadline = tokio::time::Instant::now() + safety_interval;
                             continue;
                         }
                         Err(tokio::sync::broadcast::error::RecvError::Closed) => return,
@@ -67,24 +124,63 @@ impl AgentConnector {
                         self.apply_invite_policy_candidate(candidate, &mut retry_state, now)
                             .await;
                     }
+                    // A joined group means reconcile-relevant state changed:
+                    // pull the safety net back to the base interval.
+                    safety_interval = base;
+                    safety_deadline = tokio::time::Instant::now() + safety_interval;
                 }
             }
         }
     }
 
-    async fn reconcile_pending_invite_policies(&self, retry_state: &mut InvitePolicyRetryState) {
-        let candidates = match self.pending_invite_policy_candidates() {
-            Ok(candidates) => candidates,
+    /// Enumerate pending invite candidates and apply the policy to every one
+    /// whose retry backoff has matured. Returns the number of pending
+    /// candidates found, or `None` when the enumeration itself failed.
+    /// Per-candidate apply failures are retried on their own backoff and do
+    /// not fail the pass.
+    async fn reconcile_pending_invite_policies(
+        &self,
+        retry_state: &mut InvitePolicyRetryState,
+    ) -> Option<usize> {
+        let started = tokio::time::Instant::now();
+        ReconcileTelemetry::bump(&self.reconcile_telemetry.invite_enumerations_started);
+        let (candidates, accounts_considered) = match self.pending_invite_policy_candidates() {
+            Ok(result) => result,
             Err(err) => {
+                ReconcileTelemetry::bump(&self.reconcile_telemetry.invite_enumerations_failed);
                 tracing::warn!(
                     target: "agent_connector",
                     method = "reconcile_pending_invite_policies",
+                    source = ReconcileSource::InvitePolicy.as_str(),
+                    duration_ms = started.elapsed().as_millis() as u64,
+                    result = "error",
                     error_code = err.privacy_safe_code(),
                     "pending invite policy reconciliation failed"
                 );
-                return;
+                return None;
             }
         };
+        let candidate_count = candidates.len();
+        ReconcileTelemetry::bump(&self.reconcile_telemetry.invite_enumerations_completed);
+        ReconcileTelemetry::add(
+            &self.reconcile_telemetry.invite_accounts_considered,
+            accounts_considered,
+        );
+        ReconcileTelemetry::add(
+            &self.reconcile_telemetry.invite_candidate_rows_considered,
+            candidate_count,
+        );
+        tracing::debug!(
+            target: "agent_connector",
+            method = "reconcile_pending_invite_policies",
+            source = ReconcileSource::InvitePolicy.as_str(),
+            duration_ms = started.elapsed().as_millis() as u64,
+            result = "ok",
+            accounts_considered,
+            candidates_considered = candidate_count,
+            retry_backoffs_pending = retry_state.has_pending(),
+            "pending invite policy reconciliation completed"
+        );
         let pending = candidates
             .iter()
             .map(|candidate| candidate.key.clone())
@@ -97,36 +193,38 @@ impl AgentConnector {
                     .await;
             }
         }
+        Some(candidate_count)
     }
 
+    /// The pending-invite candidate set, reading only the two projection
+    /// columns the policy needs (`group_id`, `welcomer`) — never the full
+    /// account projection, seen-event window, or component blobs (mdk#1380).
+    /// Returns the candidates plus how many local-signing accounts were
+    /// enumerated, for aggregate telemetry.
     fn pending_invite_policy_candidates(
         &self,
-    ) -> Result<Vec<PendingInvitePolicyCandidate>, ConnectorError> {
+    ) -> Result<(Vec<PendingInvitePolicyCandidate>, usize), ConnectorError> {
         let mut candidates = Vec::new();
-        for account in self
+        let accounts = self
             .account_home
             .accounts()?
             .into_iter()
             .filter(|account| account.local_signing)
-        {
-            for group in self.app.groups(&account.label)? {
-                if !group.pending_confirmation || group.archived {
-                    continue;
-                }
-                let group_id_hex = normalize_hex(&group.group_id_hex)?;
-                let group_id = GroupId::new(hex::decode(&group_id_hex)?);
-                let welcomer = match group.welcomer_account_id_hex.as_deref() {
-                    Some(welcomer) => Some(MemberId::new(hex::decode(normalize_hex(welcomer)?)?)),
-                    None => None,
-                };
+            .collect::<Vec<_>>();
+        let accounts_considered = accounts.len();
+        for account in accounts {
+            for invite in self.app.pending_group_invites(&account.label)? {
                 candidates.push(PendingInvitePolicyCandidate {
-                    key: InvitePolicyKey::new(&account.account_id_hex, &group_id_hex),
-                    group_id,
-                    welcomer,
+                    key: InvitePolicyKey::new(
+                        &account.account_id_hex,
+                        &hex::encode(invite.group_id.as_slice()),
+                    ),
+                    group_id: invite.group_id,
+                    welcomer: invite.welcomer,
                 });
             }
         }
-        Ok(candidates)
+        Ok((candidates, accounts_considered))
     }
 
     async fn apply_invite_policy_candidate(
@@ -143,9 +241,13 @@ impl AgentConnector {
             )
             .await
         {
-            Ok(()) => retry_state.clear(&candidate.key),
+            Ok(()) => {
+                retry_state.clear(&candidate.key);
+                ReconcileTelemetry::bump(&self.reconcile_telemetry.invite_policy_applied);
+            }
             Err(err) => {
                 let (attempts, retry_delay) = retry_state.record_failure(candidate.key, now);
+                ReconcileTelemetry::bump(&self.reconcile_telemetry.invite_policy_apply_failures);
                 tracing::warn!(
                     target: "agent_connector",
                     method = "apply_invite_policy_candidate",

--- a/crates/agent-connector/src/invite_policy.rs
+++ b/crates/agent-connector/src/invite_policy.rs
@@ -199,7 +199,7 @@ impl AgentConnector {
                     };
                     let now = tokio::time::Instant::now();
                     if retry_state.is_due(&candidate.key, now) {
-                        self.apply_invite_policy_candidate(candidate, &mut retry_state, now, &schedule)
+                        self.apply_invite_policy_candidate(candidate, &mut retry_state, &schedule)
                             .await;
                     }
                     // A joined group means reconcile-relevant state changed:
@@ -265,10 +265,11 @@ impl AgentConnector {
             .map(|candidate| candidate.key.clone())
             .collect::<HashSet<_>>();
         retry_state.retain_pending(&pending);
-        let now = tokio::time::Instant::now();
         for candidate in candidates {
-            if retry_state.is_due(&candidate.key, now) {
-                self.apply_invite_policy_candidate(candidate, retry_state, now, schedule)
+            // Fresh due-check time per candidate: an earlier attempt in this
+            // loop may itself have waited out a long worker timeout.
+            if retry_state.is_due(&candidate.key, tokio::time::Instant::now()) {
+                self.apply_invite_policy_candidate(candidate, retry_state, schedule)
                     .await;
             }
         }
@@ -283,19 +284,7 @@ impl AgentConnector {
     fn pending_invite_policy_candidates(
         &self,
     ) -> Result<(Vec<PendingInvitePolicyCandidate>, usize), ConnectorError> {
-        if cfg!(test) {
-            let remaining = self
-                .invite_enumeration_successes_before_failure
-                .load(std::sync::atomic::Ordering::Relaxed);
-            if remaining == 0 {
-                return Err(marmot_app::AppError::BlockingTask(
-                    "injected invite enumeration failure (test only)".to_owned(),
-                )
-                .into());
-            }
-            self.invite_enumeration_successes_before_failure
-                .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
-        }
+        self.fail_next_enumeration_for_test()?;
         let mut candidates = Vec::new();
         let accounts = self
             .account_home
@@ -323,9 +312,9 @@ impl AgentConnector {
         &self,
         candidate: PendingInvitePolicyCandidate,
         retry_state: &mut InvitePolicyRetryState,
-        now: tokio::time::Instant,
         schedule: &InvitePolicySchedule,
     ) {
+        self.apply_test_delay().await;
         match self
             .apply_invite_policy(
                 &candidate.key.account_id_hex,
@@ -339,9 +328,16 @@ impl AgentConnector {
                 ReconcileTelemetry::bump(&self.reconcile_telemetry.invite_policy_applied);
             }
             Err(err) => {
+                // The retry delay starts when the failed attempt RETURNS:
+                // accept can wait ~10s and decline ~2min on worker timeouts
+                // while the initial retry delay is 5s, so anchoring the
+                // backoff at attempt start would leave next_retry_at in the
+                // past and defeat the bounded retry (mdk#1380 review). A
+                // worker-response timeout may also still be completing
+                // server-side, so the pause must be real.
                 let (attempts, retry_delay) = retry_state.record_failure_with(
                     candidate.key,
-                    now,
+                    tokio::time::Instant::now(),
                     schedule.retry_base,
                     schedule.retry_max,
                 );
@@ -398,6 +394,60 @@ impl AgentConnector {
         }
         Ok(())
     }
+
+    /// Test-only fault injection: fail enumerations once the configured
+    /// success budget is spent. Production always succeeds here.
+    #[cfg(test)]
+    fn fail_next_enumeration_for_test(&self) -> Result<(), ConnectorError> {
+        let remaining = self
+            .test_hooks
+            .invite_enumeration_successes_before_failure
+            .load(std::sync::atomic::Ordering::Relaxed);
+        if remaining == 0 {
+            return Err(marmot_app::AppError::BlockingTask(
+                "injected invite enumeration failure (test only)".to_owned(),
+            )
+            .into());
+        }
+        self.test_hooks
+            .invite_enumeration_successes_before_failure
+            .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+        Ok(())
+    }
+
+    #[cfg(not(test))]
+    fn fail_next_enumeration_for_test(&self) -> Result<(), ConnectorError> {
+        Ok(())
+    }
+
+    /// Test-only fault injection: stretch an apply attempt to simulate a slow
+    /// account-worker response. Production returns immediately.
+    #[cfg(test)]
+    async fn apply_test_delay(&self) {
+        use std::sync::atomic::Ordering;
+        let delay_ms = self
+            .test_hooks
+            .invite_apply_delay_ms
+            .load(Ordering::Relaxed);
+        if delay_ms == 0 {
+            return;
+        }
+        if self
+            .test_hooks
+            .invite_apply_delays_remaining
+            .load(Ordering::Relaxed)
+            == 0
+        {
+            return;
+        }
+        self.test_hooks
+            .invite_apply_delays_remaining
+            .fetch_sub(1, Ordering::Relaxed);
+        tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+    }
+
+    #[cfg(not(test))]
+    async fn apply_test_delay(&self) {}
 }
 
 pub(crate) fn invite_policy_allows(

--- a/crates/agent-connector/src/lib.rs
+++ b/crates/agent-connector/src/lib.rs
@@ -14,9 +14,12 @@ mod media_roots;
 mod media_temp;
 mod messaging;
 mod quic;
+mod reconcile_telemetry;
 mod socket;
 mod stream;
 mod stream_session;
+#[cfg(test)]
+mod test_support;
 mod timeline;
 mod validation;
 
@@ -77,8 +80,19 @@ pub(crate) const STREAM_COMPOSE_CHUNK_BYTES: usize = 1024;
 /// resolution. A peer cannot reset it by trickling bytes or partial progress.
 pub(crate) const CONTROL_OPERATION_TIMEOUT: Duration = Duration::from_secs(15);
 pub(crate) const CONTROL_BUSY_RESPONSE_TIMEOUT: Duration = Duration::from_millis(100);
-pub(crate) const INBOUND_CATCH_UP_INTERVAL: Duration = Duration::from_secs(5);
+pub(crate) const INBOUND_CATCH_UP_BASE_INTERVAL: Duration = Duration::from_secs(5);
+/// Upper bound for the inbound catch-up safety net's adaptive backoff
+/// (mdk#1380). Steady-state delivery is push-driven through each account
+/// worker's live receive loop; the driver's scheduled passes only heal silent
+/// notification gaps, so an idle subscription may sink to this cadence while
+/// any qualifying runtime activity snaps it back to the base interval.
+pub(crate) const INBOUND_CATCH_UP_MAX_INTERVAL: Duration = Duration::from_secs(60);
 pub(crate) const INVITE_POLICY_RECONCILE_INTERVAL: Duration = Duration::from_secs(5);
+/// Upper bound for the invite-policy worker's idle safety enumeration
+/// (mdk#1380). Event-driven joins, the startup enumeration, and per-candidate
+/// retry wake-ups cover the hot paths; a fully idle safety pass only needs to
+/// rediscover state that survived a missed event or process restart.
+pub(crate) const INVITE_POLICY_RECONCILE_MAX_INTERVAL: Duration = Duration::from_secs(60);
 pub(crate) const INVITE_POLICY_RETRY_BASE: Duration = Duration::from_secs(5);
 pub(crate) const INVITE_POLICY_RETRY_MAX: Duration = Duration::from_secs(300);
 /// Maximum time a stream compose session may sit without an append/status/progress
@@ -216,6 +230,8 @@ pub struct AgentConnector {
     pub(crate) app: MarmotApp,
     pub(crate) runtime: MarmotAppRuntime,
     pub(crate) inbound_catch_up: InboundCatchUpDriver,
+    /// Aggregate counters for the background reconciliation loops (mdk#1380).
+    pub(crate) reconcile_telemetry: std::sync::Arc<reconcile_telemetry::ReconcileTelemetry>,
     relays: Vec<String>,
     connection_errors: Arc<AtomicU64>,
     /// Connections closed at accept time because the concurrency cap was hit.
@@ -239,7 +255,10 @@ impl AgentConnector {
                 .with_allow_loopback_relay_endpoints(config.allow_loopback_relays),
         )?;
         let runtime = MarmotAppRuntime::new(app.clone());
-        let inbound_catch_up = InboundCatchUpDriver::new(runtime.clone());
+        let reconcile_telemetry =
+            std::sync::Arc::new(reconcile_telemetry::ReconcileTelemetry::default());
+        let inbound_catch_up =
+            InboundCatchUpDriver::new(runtime.clone(), reconcile_telemetry.clone());
         let allowlists = AllowlistStore::new(&config.home);
         let (debug_events, _) = broadcast::channel(1024);
         Ok(Self {
@@ -257,6 +276,7 @@ impl AgentConnector {
             app,
             runtime,
             inbound_catch_up,
+            reconcile_telemetry,
             relays,
             connection_errors: Arc::new(AtomicU64::new(0)),
             connections_refused: Arc::new(AtomicU64::new(0)),

--- a/crates/agent-connector/src/lib.rs
+++ b/crates/agent-connector/src/lib.rs
@@ -232,10 +232,10 @@ pub struct AgentConnector {
     pub(crate) inbound_catch_up: InboundCatchUpDriver,
     /// Aggregate counters for the background reconciliation loops (mdk#1380).
     pub(crate) reconcile_telemetry: std::sync::Arc<reconcile_telemetry::ReconcileTelemetry>,
-    /// Test-only enumeration-failure injection for the invite-policy worker:
-    /// remaining successful enumerations before every later one fails.
-    /// `u64::MAX` means never fail. Read only under `cfg!(test)`.
-    pub(crate) invite_enumeration_successes_before_failure: std::sync::Arc<AtomicU64>,
+    /// Test-only fault-injection hooks for the invite-policy worker (absent
+    /// from production builds). Shared across connector clones.
+    #[cfg(test)]
+    pub(crate) test_hooks: std::sync::Arc<test_support::ConnectorTestHooks>,
     relays: Vec<String>,
     connection_errors: Arc<AtomicU64>,
     /// Connections closed at accept time because the concurrency cap was hit.
@@ -281,9 +281,8 @@ impl AgentConnector {
             runtime,
             inbound_catch_up,
             reconcile_telemetry,
-            invite_enumeration_successes_before_failure: std::sync::Arc::new(AtomicU64::new(
-                u64::MAX,
-            )),
+            #[cfg(test)]
+            test_hooks: std::sync::Arc::new(test_support::ConnectorTestHooks::default()),
             relays,
             connection_errors: Arc::new(AtomicU64::new(0)),
             connections_refused: Arc::new(AtomicU64::new(0)),

--- a/crates/agent-connector/src/lib.rs
+++ b/crates/agent-connector/src/lib.rs
@@ -232,6 +232,10 @@ pub struct AgentConnector {
     pub(crate) inbound_catch_up: InboundCatchUpDriver,
     /// Aggregate counters for the background reconciliation loops (mdk#1380).
     pub(crate) reconcile_telemetry: std::sync::Arc<reconcile_telemetry::ReconcileTelemetry>,
+    /// Test-only enumeration-failure injection for the invite-policy worker:
+    /// remaining successful enumerations before every later one fails.
+    /// `u64::MAX` means never fail. Read only under `cfg!(test)`.
+    pub(crate) invite_enumeration_successes_before_failure: std::sync::Arc<AtomicU64>,
     relays: Vec<String>,
     connection_errors: Arc<AtomicU64>,
     /// Connections closed at accept time because the concurrency cap was hit.
@@ -277,6 +281,9 @@ impl AgentConnector {
             runtime,
             inbound_catch_up,
             reconcile_telemetry,
+            invite_enumeration_successes_before_failure: std::sync::Arc::new(AtomicU64::new(
+                u64::MAX,
+            )),
             relays,
             connection_errors: Arc::new(AtomicU64::new(0)),
             connections_refused: Arc::new(AtomicU64::new(0)),

--- a/crates/agent-connector/src/reconcile_telemetry.rs
+++ b/crates/agent-connector/src/reconcile_telemetry.rs
@@ -1,0 +1,115 @@
+//! Privacy-safe aggregate counters for the connector's background
+//! reconciliation loops (mdk#1380): the shared inbound catch-up driver and the
+//! welcomer-allowlist invite-policy worker.
+//!
+//! Everything here is a process-local cumulative counter — no account ids,
+//! group ids, message ids, relay URLs, endpoints, or content. Per-pass
+//! duration/outcome detail is emitted through `tracing` at the call sites with
+//! an explicit `source` label; this module owns only the counters that the
+//! large-session regression harness asserts on and that operators can diff
+//! between scrapes.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Which background reconciliation source a scheduled pass belongs to. Used as
+/// the `source` field on per-pass tracing events so operators can attribute
+/// cost without any per-account or per-group label.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ReconcileSource {
+    /// The shared catch-up driver serving `SubscribeInbound` clients.
+    InboundCatchUp,
+    /// The welcomer-allowlist invite-policy worker.
+    InvitePolicy,
+}
+
+impl ReconcileSource {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::InboundCatchUp => "inbound_catch_up",
+            Self::InvitePolicy => "invite_policy",
+        }
+    }
+}
+
+/// Cumulative counters for the connector's background reconciliation loops.
+/// All counters are monotonically increasing for the process lifetime.
+#[derive(Default)]
+pub(crate) struct ReconcileTelemetry {
+    // ---- Inbound catch-up driver ----
+    /// Scheduled/safety-net or activity-triggered passes started.
+    pub(crate) catch_up_passes_started: AtomicU64,
+    pub(crate) catch_up_passes_completed: AtomicU64,
+    pub(crate) catch_up_passes_failed: AtomicU64,
+    /// Completed passes that observed qualifying runtime activity at wake time
+    /// or while running (these keep the safety net at its base interval).
+    pub(crate) catch_up_passes_with_activity: AtomicU64,
+    /// Sum of running account workers considered across completed passes.
+    pub(crate) catch_up_accounts_considered: AtomicU64,
+    /// Explicit out-of-band requests (a subscription's initial catch-up).
+    pub(crate) catch_up_explicit_requests: AtomicU64,
+
+    // ---- Invite-policy worker ----
+    /// Full enumerations of pending invite candidates started.
+    pub(crate) invite_enumerations_started: AtomicU64,
+    pub(crate) invite_enumerations_completed: AtomicU64,
+    pub(crate) invite_enumerations_failed: AtomicU64,
+    /// Sum of local-signing accounts enumerated across passes.
+    pub(crate) invite_accounts_considered: AtomicU64,
+    /// Sum of pending-invite projection rows read across enumerations. This is
+    /// the database-read amplification gauge for this source: on an idle
+    /// session it must stay zero, independent of retained history size.
+    pub(crate) invite_candidate_rows_considered: AtomicU64,
+    /// Policy decisions applied (invite accepted or declined).
+    pub(crate) invite_policy_applied: AtomicU64,
+    /// Policy apply attempts that failed and are retry-pending.
+    pub(crate) invite_policy_apply_failures: AtomicU64,
+}
+
+/// Point-in-time copy of [`ReconcileTelemetry`], for harness assertions.
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct ReconcileTelemetrySnapshot {
+    pub(crate) catch_up_passes_started: u64,
+    pub(crate) catch_up_passes_completed: u64,
+    pub(crate) catch_up_passes_failed: u64,
+    pub(crate) catch_up_passes_with_activity: u64,
+    pub(crate) catch_up_accounts_considered: u64,
+    pub(crate) catch_up_explicit_requests: u64,
+    pub(crate) invite_enumerations_started: u64,
+    pub(crate) invite_enumerations_completed: u64,
+    pub(crate) invite_enumerations_failed: u64,
+    pub(crate) invite_accounts_considered: u64,
+    pub(crate) invite_candidate_rows_considered: u64,
+    pub(crate) invite_policy_applied: u64,
+    pub(crate) invite_policy_apply_failures: u64,
+}
+
+impl ReconcileTelemetry {
+    pub(crate) fn bump(counter: &AtomicU64) {
+        counter.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn add(counter: &AtomicU64, value: usize) {
+        counter.fetch_add(value as u64, Ordering::Relaxed);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn snapshot(&self) -> ReconcileTelemetrySnapshot {
+        let load = |counter: &AtomicU64| counter.load(Ordering::Relaxed);
+        ReconcileTelemetrySnapshot {
+            catch_up_passes_started: load(&self.catch_up_passes_started),
+            catch_up_passes_completed: load(&self.catch_up_passes_completed),
+            catch_up_passes_failed: load(&self.catch_up_passes_failed),
+            catch_up_passes_with_activity: load(&self.catch_up_passes_with_activity),
+            catch_up_accounts_considered: load(&self.catch_up_accounts_considered),
+            catch_up_explicit_requests: load(&self.catch_up_explicit_requests),
+            invite_enumerations_started: load(&self.invite_enumerations_started),
+            invite_enumerations_completed: load(&self.invite_enumerations_completed),
+            invite_enumerations_failed: load(&self.invite_enumerations_failed),
+            invite_accounts_considered: load(&self.invite_accounts_considered),
+            invite_candidate_rows_considered: load(&self.invite_candidate_rows_considered),
+            invite_policy_applied: load(&self.invite_policy_applied),
+            invite_policy_apply_failures: load(&self.invite_policy_apply_failures),
+        }
+    }
+}

--- a/crates/agent-connector/src/test_support.rs
+++ b/crates/agent-connector/src/test_support.rs
@@ -1,0 +1,9 @@
+//! Test-only output support for the ignored reconciliation benchmark
+//! (`bench_idle_reconciliation_scaling`, mdk#1380). Kept in a file named
+//! exactly `test_support.rs` so the workspace direct-output audit
+//! (`tracing_audit.rs`) treats the explicit benchmark report as artifact
+//! output, matching the storage-upgrade benchmark convention.
+
+pub(crate) fn emit_benchmark_line(line: String) {
+    println!("{line}");
+}

--- a/crates/agent-connector/src/test_support.rs
+++ b/crates/agent-connector/src/test_support.rs
@@ -4,6 +4,32 @@
 //! (`tracing_audit.rs`) treats the explicit benchmark report as artifact
 //! output, matching the storage-upgrade benchmark convention.
 
+use std::sync::atomic::AtomicU64;
+
 pub(crate) fn emit_benchmark_line(line: String) {
     println!("{line}");
+}
+
+/// Test-only fault-injection hooks for the invite-policy worker (mdk#1380).
+/// Kept behind `#[cfg(test)]` so production builds carry no test surface.
+#[derive(Debug)]
+pub(crate) struct ConnectorTestHooks {
+    /// Remaining successful invite-policy enumerations before every later one
+    /// fails (simulates a locked/closed account database).
+    pub(crate) invite_enumeration_successes_before_failure: AtomicU64,
+    /// Milliseconds each invite-policy apply attempt sleeps before running,
+    /// simulating a slow account-worker response.
+    pub(crate) invite_apply_delay_ms: AtomicU64,
+    /// Remaining apply attempts that honor `invite_apply_delay_ms`.
+    pub(crate) invite_apply_delays_remaining: AtomicU64,
+}
+
+impl Default for ConnectorTestHooks {
+    fn default() -> Self {
+        Self {
+            invite_enumeration_successes_before_failure: AtomicU64::new(u64::MAX),
+            invite_apply_delay_ms: AtomicU64::new(0),
+            invite_apply_delays_remaining: AtomicU64::new(u64::MAX),
+        }
+    }
 }

--- a/crates/agent-connector/src/tests.rs
+++ b/crates/agent-connector/src/tests.rs
@@ -431,7 +431,10 @@ async fn control_event_emits_stream_update_for_agent_stream_started() {
 async fn inbound_catch_up_driver_tracks_active_subscriptions() {
     let dir = tempfile::tempdir().unwrap();
     let runtime = MarmotAppRuntime::new(MarmotApp::with_relays(dir.path(), Vec::new()));
-    let driver = InboundCatchUpDriver::new(runtime.clone());
+    let driver = InboundCatchUpDriver::new(
+        runtime.clone(),
+        std::sync::Arc::new(crate::reconcile_telemetry::ReconcileTelemetry::default()),
+    );
 
     let (_first_events, first_subscription) = driver.subscribe();
     assert_eq!(driver.active.load(Ordering::Acquire), 1);
@@ -454,7 +457,10 @@ async fn inbound_catch_up_driver_failure_does_not_close_subscribers() {
     let dir = tempfile::tempdir().unwrap();
     let runtime = MarmotAppRuntime::new(MarmotApp::with_relays(dir.path(), Vec::new()));
     runtime.shutdown().await;
-    let driver = InboundCatchUpDriver::new(runtime);
+    let driver = InboundCatchUpDriver::new(
+        runtime,
+        std::sync::Arc::new(crate::reconcile_telemetry::ReconcileTelemetry::default()),
+    );
     let (mut events, _subscription) = driver.subscribe();
 
     assert!(driver.request().await.is_err());
@@ -463,6 +469,240 @@ async fn inbound_catch_up_driver_failure_does_not_close_subscribers() {
         Err(tokio::sync::broadcast::error::TryRecvError::Empty)
     ));
     assert_eq!(driver.active.load(Ordering::Acquire), 1);
+}
+
+// ---- mdk#1380 regression harness: adaptive reconciliation scheduling ----
+//
+// These tests drive the shared catch-up driver and the invite-policy worker at
+// compressed intervals and assert *deterministic operation counters* (passes,
+// enumerations, candidate rows read) instead of wall-clock CPU. The window in
+// every test spans many "former intervals" (the whole fixed 5s cadence the
+// loops used to run at, compressed to milliseconds), so a regression to
+// fixed-rate polling overshoots the asserted bounds by a wide margin.
+
+const TEST_CATCH_UP_BASE: Duration = Duration::from_millis(150);
+const TEST_CATCH_UP_MAX: Duration = Duration::from_millis(600);
+const TEST_INVITE_BASE: Duration = Duration::from_millis(100);
+const TEST_INVITE_MAX: Duration = Duration::from_millis(400);
+
+fn adaptive_test_driver(
+    runtime: MarmotAppRuntime,
+) -> (
+    std::sync::Arc<crate::reconcile_telemetry::ReconcileTelemetry>,
+    InboundCatchUpDriver,
+    tokio::sync::broadcast::Sender<MarmotAppEvent>,
+) {
+    let telemetry = std::sync::Arc::new(crate::reconcile_telemetry::ReconcileTelemetry::default());
+    let (activity, _) = tokio::sync::broadcast::channel(16);
+    let driver = crate::event_projection::InboundCatchUpDriver::with_schedule(
+        runtime,
+        telemetry.clone(),
+        crate::event_projection::InboundCatchUpSchedule {
+            base: TEST_CATCH_UP_BASE,
+            max: TEST_CATCH_UP_MAX,
+        },
+    )
+    .override_activity_for_test(activity.clone());
+    (telemetry, driver, activity)
+}
+
+async fn wait_for_counter(counts: impl Fn() -> u64, expected: u64, within: Duration) {
+    timeout(within, async move {
+        loop {
+            if counts() >= expected {
+                return;
+            }
+            sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("counter should reach {expected} within {within:?}"));
+}
+
+#[tokio::test]
+async fn inbound_catch_up_driver_backs_off_while_idle() {
+    let dir = tempfile::tempdir().unwrap();
+    let runtime = MarmotAppRuntime::new(MarmotApp::with_relays(dir.path(), Vec::new()));
+    runtime.start().await.unwrap();
+    let (telemetry, driver, _activity) = adaptive_test_driver(runtime.clone());
+    let (mut events, subscription) = driver.subscribe();
+
+    // A subscription's initial catch-up still runs promptly and out-of-band.
+    driver.request().await.unwrap();
+    assert_eq!(telemetry.snapshot().catch_up_explicit_requests, 1);
+
+    // Span many former fixed intervals: at the old cadence this window would
+    // see one pass per base interval (~16); the adaptive net must stay far
+    // below that while still running periodically.
+    sleep(Duration::from_millis(2_400)).await;
+    let snapshot = telemetry.snapshot();
+    assert!(
+        snapshot.catch_up_passes_started >= 3,
+        "the safety net must still run while quiet: {} passes",
+        snapshot.catch_up_passes_started
+    );
+    assert!(
+        snapshot.catch_up_passes_started <= 8,
+        "idle safety net must back off: {} passes over ~16 base intervals",
+        snapshot.catch_up_passes_started
+    );
+    assert_eq!(snapshot.catch_up_passes_failed, 0);
+    // No accounts: passes ran but considered zero workers.
+    assert_eq!(snapshot.catch_up_accounts_considered, 0);
+    assert_eq!(snapshot.catch_up_passes_with_activity, 0);
+    assert!(matches!(
+        events.try_recv(),
+        Ok(crate::event_projection::InboundCatchUpEvent::Completed)
+    ));
+
+    // Dropping the last subscription still quiesces the driver (mdk#574).
+    drop(subscription);
+    sleep(2 * TEST_CATCH_UP_MAX).await;
+    let settled = telemetry.snapshot().catch_up_passes_started;
+    sleep(3 * TEST_CATCH_UP_MAX).await;
+    assert_eq!(
+        telemetry.snapshot().catch_up_passes_started,
+        settled,
+        "driver must quiesce once no subscription remains"
+    );
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn inbound_catch_up_driver_resets_promptly_on_runtime_activity() {
+    let dir = tempfile::tempdir().unwrap();
+    let runtime = MarmotAppRuntime::new(MarmotApp::with_relays(dir.path(), Vec::new()));
+    runtime.start().await.unwrap();
+    let (telemetry, driver, activity) = adaptive_test_driver(runtime.clone());
+    let (_events, _subscription) = driver.subscribe();
+
+    // Let the schedule back off past the base interval (passes at ~150ms,
+    // ~450ms, then the capped 600ms, ...).
+    wait_for_counter(
+        || telemetry.snapshot().catch_up_passes_started,
+        2,
+        Duration::from_secs(2),
+    )
+    .await;
+
+    // AccountError events must NOT wake the net: they can be produced by the
+    // driver's own failing passes and would pin the cadence during an outage.
+    let filtered_base = telemetry.snapshot().catch_up_passes_started;
+    let _ = activity.send(MarmotAppEvent::AccountError(
+        marmot_app::RuntimeAccountError {
+            account_id_hex: "self".repeat(16),
+            account_label: "self".to_owned(),
+            message: "synthetic outage marker".to_owned(),
+        },
+    ));
+    sleep(Duration::from_millis(100)).await;
+    assert_eq!(
+        telemetry.snapshot().catch_up_passes_started,
+        filtered_base,
+        "account errors must not count as qualifying activity"
+    );
+
+    // Qualifying runtime activity wakes a pass promptly even though the net is
+    // backed off to several base intervals.
+    let _ = activity.send(MarmotAppEvent::GroupStateUpdated {
+        account_id_hex: "ab".repeat(32),
+        account_label: "agent".to_owned(),
+        group_id: GroupId::new(vec![0x11; 32]),
+    });
+    let observed = telemetry.snapshot().catch_up_passes_started;
+    wait_for_counter(
+        || telemetry.snapshot().catch_up_passes_started,
+        observed + 1,
+        Duration::from_millis(250),
+    )
+    .await;
+    wait_for_counter(
+        || telemetry.snapshot().catch_up_passes_with_activity,
+        1,
+        Duration::from_millis(250),
+    )
+    .await;
+
+    // With activity observed, the cadence resets toward the base interval:
+    // another pass lands within roughly two base intervals.
+    let after_reset = telemetry.snapshot().catch_up_passes_started;
+    wait_for_counter(
+        || telemetry.snapshot().catch_up_passes_started,
+        after_reset + 1,
+        3 * TEST_CATCH_UP_BASE,
+    )
+    .await;
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn invite_policy_worker_backs_off_with_zero_candidates() {
+    let dir = tempfile::tempdir().unwrap();
+    let account_home = AccountHome::open(dir.path());
+    account_home.create_account("agent").unwrap();
+    let connector = AgentConnector::open(test_config(
+        dir.path(),
+        dir.path().join("dev").join("wn-agent.sock"),
+        Vec::new(),
+        false,
+        false,
+    ))
+    .unwrap();
+    // The runtime only needs to be alive enough to broadcast events; no relays.
+    connector.runtime.start().await.unwrap();
+    let connector_worker = connector.clone();
+    tokio::spawn(async move {
+        connector_worker
+            .run_invite_policy_worker(crate::invite_policy::InvitePolicySchedule {
+                base: TEST_INVITE_BASE,
+                max: TEST_INVITE_MAX,
+            })
+            .await;
+    });
+
+    // The startup enumeration always runs.
+    wait_for_counter(
+        || {
+            connector
+                .reconcile_telemetry
+                .snapshot()
+                .invite_enumerations_completed
+        },
+        1,
+        Duration::from_secs(2),
+    )
+    .await;
+
+    // The fixture has an account but zero pending invites. Over many former
+    // fixed intervals the enumeration count must stay logarithmic, and the
+    // read-amplification counter (candidate rows) must stay exactly zero
+    // because no group is pending — even though the account has a projection.
+    sleep(Duration::from_millis(2_000)).await;
+    let snapshot = connector.reconcile_telemetry.snapshot();
+    assert_eq!(
+        snapshot.invite_enumerations_failed, 0,
+        "idle enumerations must succeed"
+    );
+    assert!(
+        snapshot.invite_enumerations_completed >= 2,
+        "the safety net must still enumerate periodically: {}",
+        snapshot.invite_enumerations_completed
+    );
+    assert!(
+        snapshot.invite_enumerations_completed <= 7,
+        "idle enumerations must back off: {} over ~20 base intervals",
+        snapshot.invite_enumerations_completed
+    );
+    assert_eq!(
+        snapshot.invite_candidate_rows_considered, 0,
+        "an idle session must not surface candidate rows"
+    );
+    assert_eq!(snapshot.invite_policy_apply_failures, 0);
+    assert!(
+        snapshot.invite_accounts_considered >= snapshot.invite_enumerations_completed,
+        "each enumeration accounted the single local account"
+    );
+    connector.runtime.shutdown().await;
 }
 
 #[tokio::test]
@@ -2245,6 +2485,47 @@ fn invite_policy_retry_state_uses_capped_backoff_and_prunes_non_pending() {
 
     retry_state.clear(&key);
     assert!(retry_state.is_due(&key, now));
+}
+
+#[test]
+fn invite_policy_retry_state_reports_next_due_wake() {
+    let mut retry_state = crate::validation::InvitePolicyRetryState::default();
+    let key_a = crate::validation::InvitePolicyKey::new("aa", "11");
+    let key_b = crate::validation::InvitePolicyKey::new("bb", "22");
+    let now = tokio::time::Instant::now();
+
+    assert!(!retry_state.has_pending());
+    assert_eq!(retry_state.next_due(), None);
+
+    retry_state.record_failure(key_a.clone(), now);
+    assert!(retry_state.has_pending());
+    assert_eq!(
+        retry_state.next_due(),
+        Some(now + crate::INVITE_POLICY_RETRY_BASE)
+    );
+
+    // A second, later failure must not move the earliest wake earlier.
+    retry_state.record_failure(key_b.clone(), now + Duration::from_millis(500));
+    assert_eq!(
+        retry_state.next_due(),
+        Some(now + crate::INVITE_POLICY_RETRY_BASE)
+    );
+
+    retry_state.record_failure(key_a.clone(), now + Duration::from_millis(500));
+    assert_eq!(
+        retry_state.next_due(),
+        Some(now + Duration::from_millis(500) + crate::INVITE_POLICY_RETRY_BASE)
+    );
+
+    retry_state.clear(&key_b);
+    // key_a's second failure carries the doubled backoff.
+    assert_eq!(
+        retry_state.next_due(),
+        Some(now + Duration::from_millis(500) + crate::INVITE_POLICY_RETRY_BASE * 2)
+    );
+    retry_state.clear(&key_a);
+    assert!(!retry_state.has_pending());
+    assert_eq!(retry_state.next_due(), None);
 }
 
 #[tokio::test]
@@ -5444,4 +5725,193 @@ async fn quic_candidate_resolve_opt_in_admits_loopback_only() {
             "{authority} must be rejected even with the dev opt-in"
         );
     }
+}
+
+// ---- mdk#1380 opt-in large-session reconciliation benchmark ----
+//
+// `just bench-idle-reconciliation` runs this ignored test (release profile).
+// It builds one agent account with several joined groups, lets one long-lived
+// inbound subscription idle over many compressed former-intervals, then proves
+// with deterministic counters that (a) steady-state idle reconciliation no
+// longer scales as repeated full-state scans and (b) a real state change still
+// triggers a prompt pass. The MDK_BENCH lines are the recorded profile result.
+
+#[tokio::test]
+#[ignore = "opt-in reconciliation benchmark; run via just bench-idle-reconciliation"]
+async fn bench_idle_reconciliation_scaling() {
+    const BENCH_BASE: Duration = Duration::from_millis(250);
+    const BENCH_MAX: Duration = Duration::from_millis(2_000);
+    let group_total: usize = std::env::var("MDK_IDLE_RECONCILE_GROUPS")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(8);
+
+    let dir = tempfile::tempdir().unwrap();
+    let relay = MockRelay::run().await.unwrap();
+    let relay_url = relay.url().await.to_string();
+    let app = MarmotApp::with_relay(dir.path(), relay_url.clone());
+    let setup_runtime = MarmotAppRuntime::new(app);
+    let setup = AccountSetupRequest {
+        default_relays: vec![crate::validation::endpoint(&relay_url)],
+        bootstrap_relays: vec![crate::validation::endpoint(&relay_url)],
+        publish_initial_key_package: true,
+        ..AccountSetupRequest::default()
+    };
+    let agent = setup_runtime
+        .create_identity(setup.relay_options_only())
+        .await
+        .unwrap();
+    let human = setup_runtime.create_identity(setup).await.unwrap();
+    let mut group_ids = Vec::new();
+    for index in 0..group_total {
+        let group_id = setup_runtime
+            .create_group(
+                &human.account.account_id_hex,
+                &format!("idle reconcile bench {index}"),
+                std::slice::from_ref(&agent.account.account_id_hex),
+                None,
+            )
+            .await
+            .unwrap();
+        accept_group_invite_retrying_busy(&setup_runtime, &agent.account.account_id_hex, &group_id)
+            .await;
+        group_ids.push(group_id);
+    }
+    setup_runtime.shutdown().await;
+
+    let connector = AgentConnector::open(test_config(
+        dir.path(),
+        dir.path().join("dev").join("wn-agent.sock"),
+        vec![relay_url],
+        false,
+        false,
+    ))
+    .unwrap();
+    connector.start().await.unwrap();
+
+    // Drive the shared catch-up driver and the invite-policy worker over the
+    // connector's real runtime at compressed intervals, on the connector's own
+    // telemetry so the counters attribute both sources in one process.
+    let driver = crate::event_projection::InboundCatchUpDriver::with_schedule(
+        connector.runtime.clone(),
+        connector.reconcile_telemetry.clone(),
+        crate::event_projection::InboundCatchUpSchedule {
+            base: BENCH_BASE,
+            max: BENCH_MAX,
+        },
+    );
+    let (_catch_up_events, _catch_up_subscription) = driver.subscribe();
+    let invite_connector = connector.clone();
+    let invite_worker = tokio::spawn(async move {
+        invite_connector
+            .run_invite_policy_worker(crate::invite_policy::InvitePolicySchedule {
+                base: BENCH_BASE,
+                max: BENCH_MAX,
+            })
+            .await;
+    });
+
+    // One long-lived, otherwise-idle subscription: initial catch-up plus the
+    // safety net over ~10 seconds (40 former base intervals at fixed rate).
+    driver.request().await.unwrap();
+    sleep(Duration::from_millis(10_000)).await;
+
+    let snapshot = connector.reconcile_telemetry.snapshot();
+    let performance = connector
+        .runtime
+        .shared_services()
+        .app_performance_telemetry()
+        .snapshot();
+    assert_eq!(snapshot.catch_up_passes_failed, 0);
+    assert_eq!(snapshot.invite_enumerations_failed, 0);
+    assert!(
+        snapshot.catch_up_passes_started >= 3,
+        "safety net must still run while quiet"
+    );
+    assert!(
+        snapshot.catch_up_passes_started <= 10,
+        "idle passes must back off, got {}",
+        snapshot.catch_up_passes_started
+    );
+    assert!(
+        snapshot.invite_enumerations_completed <= 12,
+        "idle enumerations must back off, got {}",
+        snapshot.invite_enumerations_completed
+    );
+    assert_eq!(
+        snapshot.invite_candidate_rows_considered, 0,
+        "no pending invites: the enumeration must read zero candidate rows"
+    );
+    let catch_up_avg_ms = performance
+        .account_catch_up
+        .duration_ms
+        .sum_ms
+        .checked_div(performance.account_catch_up.attempts.max(1))
+        .unwrap_or(0);
+    let sync_avg_ms = performance
+        .account_sync
+        .duration_ms
+        .sum_ms
+        .checked_div(performance.account_sync.attempts.max(1))
+        .unwrap_or(0);
+    crate::test_support::emit_benchmark_line(format!(
+        "MDK_BENCH idle groups={group_total} scheduled_passes={} pass_avg_ms={catch_up_avg_ms} sync_avg_ms={sync_avg_ms}",
+        snapshot.catch_up_passes_started,
+    ));
+    crate::test_support::emit_benchmark_line(format!(
+        "MDK_BENCH idle invite_enumerations={} candidate_rows={} accounts={}",
+        snapshot.invite_enumerations_completed,
+        snapshot.invite_candidate_rows_considered,
+        snapshot.invite_accounts_considered,
+    ));
+
+    // A real state change must pull the net back promptly: send a live message
+    // and measure the gap until the next scheduled pass starts.
+    let before = connector
+        .reconcile_telemetry
+        .snapshot()
+        .catch_up_passes_started;
+    connector
+        .runtime
+        .send_message(
+            &agent.account.label,
+            &group_ids[0],
+            b"bench activity marker".to_vec(),
+        )
+        .await
+        .unwrap();
+    let sent_at = std::time::Instant::now();
+    wait_for_counter(
+        || {
+            connector
+                .reconcile_telemetry
+                .snapshot()
+                .catch_up_passes_started
+        },
+        before + 1,
+        4 * BENCH_BASE,
+    )
+    .await;
+    let wake_gap_ms = sent_at.elapsed().as_millis();
+    crate::test_support::emit_benchmark_line(format!(
+        "MDK_BENCH activity wake_gap_ms={wake_gap_ms} base_ms=250"
+    ));
+    assert!(
+        wake_gap_ms <= 2 * BENCH_BASE.as_millis() + 250,
+        "activity must reset the net promptly, took {wake_gap_ms}ms"
+    );
+
+    let session_db = dir
+        .path()
+        .join("accounts")
+        .join(&agent.account.label)
+        .join("session.sqlite");
+    if let Ok(metadata) = std::fs::metadata(&session_db) {
+        crate::test_support::emit_benchmark_line(format!(
+            "MDK_BENCH session_db_bytes={}",
+            metadata.len()
+        ));
+    }
+    invite_worker.abort();
+    connector.runtime.shutdown().await;
 }

--- a/crates/agent-connector/src/tests.rs
+++ b/crates/agent-connector/src/tests.rs
@@ -767,6 +767,7 @@ async fn invite_policy_worker_does_not_spin_when_enumeration_fails_with_a_due_re
     // Exactly one enumeration may succeed, then every later one fails (a
     // locked/closed account database in production).
     connector
+        .test_hooks
         .invite_enumeration_successes_before_failure
         .store(1, Ordering::Relaxed);
     // Stop the runtime so the one successful enumeration's apply fails
@@ -801,6 +802,73 @@ async fn invite_policy_worker_does_not_spin_when_enumeration_fails_with_a_due_re
         snapshot.invite_enumerations_started <= 14,
         "a failing enumeration with a matured retry must back off, not spin: {} attempts",
         snapshot.invite_enumerations_started
+    );
+    handle.abort();
+}
+
+#[tokio::test]
+async fn invite_policy_retry_delay_starts_after_the_failed_attempt_returns() {
+    let setup = setup_existing_pending_invite("retry delay after completion").await;
+    let connector = AgentConnector::open(test_config(
+        setup.dir.path(),
+        setup.dir.path().join("dev").join("wn-agent.sock"),
+        vec![setup.relay_url.clone()],
+        false,
+        false,
+    ))
+    .unwrap();
+    // Apply fails deterministically (stopped runtime), but only AFTER an
+    // 800ms attempt — far longer than the 200ms initial retry delay. Only the
+    // first attempt is stretched so the retry itself returns quickly.
+    connector
+        .test_hooks
+        .invite_apply_delay_ms
+        .store(800, Ordering::Relaxed);
+    connector
+        .test_hooks
+        .invite_apply_delays_remaining
+        .store(1, Ordering::Relaxed);
+    connector.runtime.shutdown().await;
+    let worker = connector.clone();
+    let handle = tokio::spawn(async move {
+        worker
+            .run_invite_policy_worker(crate::invite_policy::InvitePolicySchedule {
+                base: TEST_INVITE_BASE,
+                max: TEST_INVITE_MAX,
+                retry_base: Duration::from_millis(200),
+                retry_max: TEST_INVITE_MAX,
+            })
+            .await;
+    });
+
+    wait_for_counter(
+        || {
+            connector
+                .reconcile_telemetry
+                .snapshot()
+                .invite_policy_apply_failures
+        },
+        1,
+        Duration::from_secs(4),
+    )
+    .await;
+    let first_failure_at = std::time::Instant::now();
+    wait_for_counter(
+        || {
+            connector
+                .reconcile_telemetry
+                .snapshot()
+                .invite_policy_apply_failures
+        },
+        2,
+        Duration::from_secs(4),
+    )
+    .await;
+    let gap = first_failure_at.elapsed();
+    assert!(
+        gap >= Duration::from_millis(150),
+        "the retry must wait the full delay after the attempt returns, gap was {gap:?} \
+         (an attempt-start-anchored backoff would already have been in the past)"
     );
     handle.abort();
 }

--- a/crates/agent-connector/src/tests.rs
+++ b/crates/agent-connector/src/tests.rs
@@ -656,6 +656,8 @@ async fn invite_policy_worker_backs_off_with_zero_candidates() {
             .run_invite_policy_worker(crate::invite_policy::InvitePolicySchedule {
                 base: TEST_INVITE_BASE,
                 max: TEST_INVITE_MAX,
+                retry_base: TEST_INVITE_BASE,
+                retry_max: TEST_INVITE_MAX,
             })
             .await;
     });
@@ -703,6 +705,104 @@ async fn invite_policy_worker_backs_off_with_zero_candidates() {
         "each enumeration accounted the single local account"
     );
     connector.runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn inbound_catch_up_driver_preserves_delayed_cadence_after_a_slow_pass() {
+    let dir = tempfile::tempdir().unwrap();
+    let runtime = MarmotAppRuntime::new(MarmotApp::with_relays(dir.path(), Vec::new()));
+    runtime.start().await.unwrap();
+    let (telemetry, driver, _activity) = adaptive_test_driver(runtime.clone());
+
+    // Hold the serialization lock well past the first scheduled pass's
+    // deadline — long enough that even the doubled follow-up interval would
+    // already be in the past if the deadline anchored at pass START. An
+    // explicit subscription request queues the same way in production.
+    let guard = driver.lock.lock().await;
+    let (_events, _subscription) = driver.subscribe();
+    sleep(4 * TEST_CATCH_UP_BASE).await;
+    assert_eq!(
+        telemetry.snapshot().catch_up_passes_started,
+        0,
+        "the queued pass must wait for the lock"
+    );
+    drop(guard);
+
+    // The queued pass runs. With delayed cadence the next deadline is one
+    // interval AFTER completion — not already-past — so there is no
+    // back-to-back rerun of a full catch-up (mdk#1380 review).
+    wait_for_counter(
+        || telemetry.snapshot().catch_up_passes_started,
+        1,
+        Duration::from_millis(500),
+    )
+    .await;
+    sleep(TEST_CATCH_UP_BASE / 2).await;
+    assert_eq!(
+        telemetry.snapshot().catch_up_passes_started,
+        1,
+        "a slow/queued pass must not trigger an immediate rerun"
+    );
+    // And the cadence resumes normally afterwards.
+    wait_for_counter(
+        || telemetry.snapshot().catch_up_passes_started,
+        2,
+        2 * TEST_CATCH_UP_BASE,
+    )
+    .await;
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn invite_policy_worker_does_not_spin_when_enumeration_fails_with_a_due_retry() {
+    let setup = setup_existing_pending_invite("retry enumeration failure").await;
+    let connector = AgentConnector::open(test_config(
+        setup.dir.path(),
+        setup.dir.path().join("dev").join("wn-agent.sock"),
+        vec![setup.relay_url.clone()],
+        false,
+        false,
+    ))
+    .unwrap();
+    // Exactly one enumeration may succeed, then every later one fails (a
+    // locked/closed account database in production).
+    connector
+        .invite_enumeration_successes_before_failure
+        .store(1, Ordering::Relaxed);
+    // Stop the runtime so the one successful enumeration's apply fails
+    // deterministically and arms a retry that matures quickly.
+    connector.runtime.shutdown().await;
+    let worker = connector.clone();
+    let handle = tokio::spawn(async move {
+        worker
+            .run_invite_policy_worker(crate::invite_policy::InvitePolicySchedule {
+                base: TEST_INVITE_BASE,
+                max: TEST_INVITE_MAX,
+                retry_base: TEST_INVITE_BASE,
+                retry_max: TEST_INVITE_MAX,
+            })
+            .await;
+    });
+
+    // Wait for the retry to mature several times over. Without the
+    // enumeration-failure floor, the matured retry deadline stays in the past
+    // and the worker would spin thousands of failing enumerations here.
+    sleep(Duration::from_millis(1_600)).await;
+    let snapshot = connector.reconcile_telemetry.snapshot();
+    assert!(
+        snapshot.invite_policy_apply_failures >= 1,
+        "the single successful enumeration must have armed a retry"
+    );
+    assert!(
+        snapshot.invite_enumerations_failed >= 1,
+        "later enumerations must be failing"
+    );
+    assert!(
+        snapshot.invite_enumerations_started <= 14,
+        "a failing enumeration with a matured retry must back off, not spin: {} attempts",
+        snapshot.invite_enumerations_started
+    );
+    handle.abort();
 }
 
 #[tokio::test]
@@ -5807,6 +5907,8 @@ async fn bench_idle_reconciliation_scaling() {
             .run_invite_policy_worker(crate::invite_policy::InvitePolicySchedule {
                 base: BENCH_BASE,
                 max: BENCH_MAX,
+                retry_base: BENCH_BASE,
+                retry_max: BENCH_MAX,
             })
             .await;
     });

--- a/crates/agent-connector/src/validation.rs
+++ b/crates/agent-connector/src/validation.rs
@@ -8,9 +8,10 @@ use cgka_traits::{GroupId, MemberId};
 
 use crate::error::ConnectorError;
 use crate::{
-    AGENT_SOCKET_DIR_MODE, AGENT_SOCKET_MODE, AgentConnectorConfig, INVITE_POLICY_RETRY_BASE,
-    INVITE_POLICY_RETRY_MAX, MAX_PROFILE_NAME_CHARS,
+    AGENT_SOCKET_DIR_MODE, AGENT_SOCKET_MODE, AgentConnectorConfig, MAX_PROFILE_NAME_CHARS,
 };
+#[cfg(test)]
+use crate::{INVITE_POLICY_RETRY_BASE, INVITE_POLICY_RETRY_MAX};
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub(crate) struct InvitePolicyKey {
@@ -76,17 +77,35 @@ impl InvitePolicyRetryState {
             .min()
     }
 
+    /// Record a failure on the production backoff constants. The worker uses
+    /// [`Self::record_failure_with`] (its schedule is injectable for tests);
+    /// this convenience remains for tests that pin the production constants.
+    #[cfg(test)]
     pub(crate) fn record_failure(
         &mut self,
         key: InvitePolicyKey,
         now: tokio::time::Instant,
+    ) -> (u32, Duration) {
+        self.record_failure_with(key, now, INVITE_POLICY_RETRY_BASE, INVITE_POLICY_RETRY_MAX)
+    }
+
+    /// Record a failure with an explicit backoff schedule. Production callers
+    /// use [`Self::record_failure`] (the crate constants); the worker passes
+    /// its [`crate::invite_policy::InvitePolicySchedule`] through so tests can
+    /// compress the schedule.
+    pub(crate) fn record_failure_with(
+        &mut self,
+        key: InvitePolicyKey,
+        now: tokio::time::Instant,
+        retry_base: Duration,
+        retry_max: Duration,
     ) -> (u32, Duration) {
         let attempts = self
             .failures
             .get(&key)
             .map(|retry| retry.attempts.saturating_add(1))
             .unwrap_or(1);
-        let delay = invite_policy_retry_delay(attempts);
+        let delay = invite_policy_retry_delay_with(attempts, retry_base, retry_max);
         self.failures.insert(
             key,
             InvitePolicyRetry {
@@ -98,13 +117,15 @@ impl InvitePolicyRetryState {
     }
 }
 
-pub(crate) fn invite_policy_retry_delay(attempts: u32) -> Duration {
+pub(crate) fn invite_policy_retry_delay_with(
+    attempts: u32,
+    retry_base: Duration,
+    retry_max: Duration,
+) -> Duration {
     let exponent = attempts.saturating_sub(1).min(10);
     let factor = 1_u32.checked_shl(exponent).unwrap_or(u32::MAX);
-    let delay = INVITE_POLICY_RETRY_BASE
-        .checked_mul(factor)
-        .unwrap_or(INVITE_POLICY_RETRY_MAX);
-    std::cmp::min(delay, INVITE_POLICY_RETRY_MAX)
+    let delay = retry_base.checked_mul(factor).unwrap_or(retry_max);
+    std::cmp::min(delay, retry_max)
 }
 
 pub(crate) fn unsupported_request_message(request: &AgentControlRequest) -> &'static str {

--- a/crates/agent-connector/src/validation.rs
+++ b/crates/agent-connector/src/validation.rs
@@ -59,6 +59,23 @@ impl InvitePolicyRetryState {
         self.failures.retain(|key, _| pending.contains(key));
     }
 
+    /// Whether any failed candidate is still pending retry. Pending retries
+    /// keep the invite-policy worker's safety enumeration at its base interval
+    /// (mdk#1380).
+    pub(crate) fn has_pending(&self) -> bool {
+        !self.failures.is_empty()
+    }
+
+    /// Earliest retry wake-up across all failed candidates; `None` when no
+    /// failure is pending. The worker sleeps until this instead of polling on
+    /// a fixed cadence.
+    pub(crate) fn next_due(&self) -> Option<tokio::time::Instant> {
+        self.failures
+            .values()
+            .map(|retry| retry.next_retry_at)
+            .min()
+    }
+
     pub(crate) fn record_failure(
         &mut self,
         key: InvitePolicyKey,

--- a/crates/marmot-app/AGENTS.md
+++ b/crates/marmot-app/AGENTS.md
@@ -26,7 +26,8 @@ App runtime bridge for the first real Marmot app surfaces.
   per-group outcome orchestration, and classifier tests), and `audit.rs` (audit-context construction, the local/observed
   `human_action` recorders, and the `ObservedHumanActionAudit` descriptor). Private items referenced across these files
   are widened to `pub(crate)`; `pub` items keep stable `marmot_app::...` paths via the crate-root re-export.
-  Steady-state sync passes must stay O(changed), not O(retained state): the encrypted-media epoch-secret warm pass
+  Steady-state sync passes must not rescan full retained state (no full `MlsGroup::load` sweeps, no full
+  account-projection loads; cheap per-group probes are acceptable): the encrypted-media epoch-secret warm pass
   skips authoritative (`MlsGroup::load`) component re-checks at an unchanged group epoch
   (`encrypted_media_not_required_epochs`, mdk#1380), and the sync checkpoint skips its second
   `refresh_group_routes` when the drained prefix carried zero deliveries and clean routes.

--- a/crates/marmot-app/AGENTS.md
+++ b/crates/marmot-app/AGENTS.md
@@ -26,6 +26,10 @@ App runtime bridge for the first real Marmot app surfaces.
   per-group outcome orchestration, and classifier tests), and `audit.rs` (audit-context construction, the local/observed
   `human_action` recorders, and the `ObservedHumanActionAudit` descriptor). Private items referenced across these files
   are widened to `pub(crate)`; `pub` items keep stable `marmot_app::...` paths via the crate-root re-export.
+  Steady-state sync passes must stay O(changed), not O(retained state): the encrypted-media epoch-secret warm pass
+  skips authoritative (`MlsGroup::load`) component re-checks at an unchanged group epoch
+  (`encrypted_media_not_required_epochs`, mdk#1380), and the sync checkpoint skips its second
+  `refresh_group_routes` when the drained prefix carried zero deliveries and clean routes.
 - Keep group DTOs, component projections, and group event projection helpers in `src/groups.rs`.
 - Keep encrypted-media DTOs, exporter labels, and Blossom upload/download helpers in the `src/media/` module
   (`blossom.rs`, `crypto.rs`, `group_image.rs`, `host_safety.rs`).

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -189,6 +189,21 @@ pub struct AppClient {
     /// maintenance obligation is waiting for its first relay EOSE.
     pub(crate) post_join_maintenance_subscriptions:
         HashMap<GroupId, (String, cgka_traits::TransportGroupSubscription)>,
+    /// Per-group (in-memory) epoch at which the warm pass last confirmed the
+    /// authoritative encrypted-media component is NOT required. A group's
+    /// signed component can only change with a commit, and a commit always
+    /// advances the epoch, so an unchanged epoch means the negative answer is
+    /// still authoritative — the per-sync warm pass skips the expensive
+    /// `MlsGroup::load` re-check for those groups (mdk#1380). Derived state
+    /// only: never persisted, rebuilt by the first pass after open, and
+    /// entries are recorded only on successful lookups so transient failures
+    /// keep re-checking on the next pass.
+    pub(crate) encrypted_media_not_required_epochs: HashMap<String, u64>,
+    /// Count of checkpoint route recomputations actually executed (mdk#1380
+    /// harness observability: an idle catch-up pass must skip the second
+    /// per-sync `refresh_group_routes` because no delivery or drained effect
+    /// could have changed routing since the sync-start pass).
+    pub(crate) checkpoint_route_refresh_recomputes: u64,
 }
 
 /// Cross the point-of-no-return for current-profile group creation without
@@ -3175,9 +3190,45 @@ impl AppClient {
         )?;
         self.remember_encrypted_media_epoch_secret(group_id, epoch.0, secret.as_ref())
     }
+}
 
-    pub(crate) fn cache_current_encrypted_media_epoch_secrets(&self) {
+/// Per-pass accounting for one encrypted-media epoch-secret warm sweep.
+/// Aggregate counts only (privacy-safe).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct EncryptedMediaWarmStats {
+    /// Groups visited from the in-memory account projection.
+    pub(crate) groups_considered: usize,
+    /// Groups skipped because the authoritative component was already
+    /// confirmed not-required at the group's current epoch in this client.
+    pub(crate) skipped_unchanged_epoch: usize,
+    /// Authoritative component lookups (`MlsGroup::load`) performed. This
+    /// is the expensive step the epoch map exists to bound.
+    pub(crate) authoritative_checks: usize,
+    /// Groups whose current-epoch secret was cached this pass.
+    pub(crate) warmed: usize,
+    /// Groups skipped after a transient lookup/warm failure (retried next
+    /// pass).
+    pub(crate) failures: usize,
+}
+
+impl AppClient {
+    pub(crate) fn cache_current_encrypted_media_epoch_secrets(
+        &mut self,
+    ) -> EncryptedMediaWarmStats {
+        let mut stats = EncryptedMediaWarmStats::default();
+        // Drop confirmations for groups no longer in the projection (leave,
+        // archive, local deletion): the map must stay bounded by the live
+        // group set.
+        let live: HashSet<&str> = self
+            .state
+            .groups
+            .iter()
+            .map(|group| group.group_id_hex.as_str())
+            .collect();
+        self.encrypted_media_not_required_epochs
+            .retain(|group_id_hex, _| live.contains(group_id_hex.as_str()));
         for group in &self.state.groups {
+            stats.groups_considered += 1;
             let Ok(group_id_bytes) = hex::decode(&group.group_id_hex) else {
                 tracing::warn!(
                     target: "marmot_app::media",
@@ -3185,6 +3236,7 @@ impl AppClient {
                     error_code = "encrypted_media_group_record_skipped",
                     "skipping malformed encrypted media group record",
                 );
+                stats.failures += 1;
                 continue;
             };
             let group_id = GroupId::new(group_id_bytes);
@@ -3193,11 +3245,45 @@ impl AppClient {
             // stale (a rebuild error can leave it lagging the signed
             // component), so it must re-check the authoritative component
             // before skipping — a missed warm here can strand a
-            // historical epoch's media once the group advances.
-            if !group.encrypted_media.required
-                && !self.encrypted_media_for_group(&group_id).required
-            {
-                continue;
+            // historical epoch's media once the group advances. A confirmed
+            // negative is authoritative until the next commit, and a commit
+            // always advances the group epoch, so a confirmed-negative entry
+            // keyed on the current engine epoch skips the re-check (mdk#1380).
+            if !group.encrypted_media.required {
+                let epoch = match self.runtime.group_record(&group_id) {
+                    Ok(record) => record.epoch.0,
+                    Err(_) => {
+                        // Transient read failure: leave the group unconfirmed
+                        // so a later pass retries the authoritative lookup.
+                        stats.failures += 1;
+                        continue;
+                    }
+                };
+                if self
+                    .encrypted_media_not_required_epochs
+                    .get(&group.group_id_hex)
+                    .is_some_and(|confirmed| *confirmed == epoch)
+                {
+                    stats.skipped_unchanged_epoch += 1;
+                    continue;
+                }
+                let component = match self.try_encrypted_media_for_group(&group_id) {
+                    Ok(component) => component,
+                    Err(_) => {
+                        stats.failures += 1;
+                        continue;
+                    }
+                };
+                stats.authoritative_checks += 1;
+                if !component.required {
+                    self.encrypted_media_not_required_epochs
+                        .insert(group.group_id_hex.clone(), epoch);
+                    continue;
+                }
+                // Authoritative required: drop any stale confirmation so the
+                // map only ever holds live negatives.
+                self.encrypted_media_not_required_epochs
+                    .remove(&group.group_id_hex);
             }
             if self
                 .remember_current_encrypted_media_secret(&group_id)
@@ -3209,8 +3295,12 @@ impl AppClient {
                     error_code = "encrypted_media_secret_cache_skipped",
                     "failed to cache encrypted media epoch secret for one group",
                 );
+                stats.failures += 1;
+            } else {
+                stats.warmed += 1;
             }
         }
+        stats
     }
 
     fn remember_encrypted_media_epoch_secret(

--- a/crates/marmot-app/src/client/projection.rs
+++ b/crates/marmot-app/src/client/projection.rs
@@ -661,6 +661,28 @@ impl AppClient {
             })
     }
 
+    /// Authoritative encrypted-media component lookup for the epoch-secret warm
+    /// path. Unlike [`Self::encrypted_media_for_group`], lookup failures are NOT
+    /// collapsed into "disabled": a transient storage read failure must keep the
+    /// warm pass retryable instead of being latched as an authoritative
+    /// negative for the group's whole epoch.
+    pub(crate) fn try_encrypted_media_for_group(
+        &self,
+        group_id: &GroupId,
+    ) -> Result<AppGroupEncryptedMediaComponent, AppError> {
+        let profile = self.runtime.group_record(group_id)?.protocol_profile;
+        let component_id = Self::encrypted_media_component_id(profile);
+        match self.runtime.app_component(group_id, component_id)? {
+            Some(bytes) => Ok(AppGroupEncryptedMediaComponent::from_bytes(
+                component_id,
+                &bytes,
+            )),
+            None => Ok(AppGroupEncryptedMediaComponent::disabled_for_profile(
+                profile.into(),
+            )),
+        }
+    }
+
     pub(crate) fn image_for_group(&self, group_id: &GroupId) -> AppGroupImageInput {
         self.runtime
             .app_component(group_id, GROUP_BLOSSOM_IMAGE_COMPONENT_ID)

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -189,14 +189,32 @@ impl AppClient {
         }
     }
 
-    pub(crate) async fn sync_runtime_groups(&self) -> Result<(), AppError> {
+    pub(crate) async fn sync_runtime_groups(&mut self) -> Result<(), AppError> {
         let rebuild_since = self
             .relay_plane
             .subscription_rebuild_since(self.state.last_transport_timestamp);
-        self.cache_current_encrypted_media_epoch_secrets();
+        self.warm_encrypted_media_epoch_secrets("pre_subscription_sync");
         self.runtime.sync_transport_groups(rebuild_since).await?;
-        self.cache_current_encrypted_media_epoch_secrets();
+        self.warm_encrypted_media_epoch_secrets("post_subscription_sync");
         Ok(())
+    }
+
+    /// Warm the encrypted-media epoch-secret cache around a subscription sync,
+    /// recording the aggregate pass shape so idle steady-state passes are
+    /// provably free of authoritative (`MlsGroup::load`) re-checks (mdk#1380).
+    fn warm_encrypted_media_epoch_secrets(&mut self, phase: &'static str) {
+        let stats = self.cache_current_encrypted_media_epoch_secrets();
+        tracing::debug!(
+            target: "marmot_app::media",
+            method = "warm_encrypted_media_epoch_secrets",
+            phase,
+            groups_considered = stats.groups_considered,
+            skipped_unchanged_epoch = stats.skipped_unchanged_epoch,
+            authoritative_checks = stats.authoritative_checks,
+            warmed = stats.warmed,
+            failures = stats.failures,
+            "encrypted media epoch-secret warm pass"
+        );
     }
 
     pub(crate) fn has_pending_runtime_group_subscription_refresh(&self) -> bool {
@@ -229,12 +247,12 @@ impl AppClient {
         Ok(false)
     }
 
-    pub(crate) async fn prepare_transport(&self) -> Result<(), AppError> {
+    pub(crate) async fn prepare_transport(&mut self) -> Result<(), AppError> {
         self.prepare_transport_with_telemetry(None).await
     }
 
     async fn prepare_transport_with_telemetry(
-        &self,
+        &mut self,
         telemetry: Option<&AppPerformanceTelemetry>,
     ) -> Result<(), AppError> {
         // Before any subscription goes out: auth-gated relays (NIP-42)
@@ -888,10 +906,22 @@ impl AppClient {
         routes_dirty: bool,
         deliveries: u64,
     ) -> Result<(), SyncCheckpointError> {
-        let routes_changed = self
-            .refresh_group_routes()
-            .map_err(SyncCheckpointError::BeforePersistence)?
-            .routing_changed;
+        // The checkpoint re-runs `refresh_group_routes` only when the drained
+        // prefix could have changed routing: deliveries advance epochs (which
+        // gate prior-route pruning) and can mark groups disbanded. With zero
+        // deliveries and no dirty routes, engine-visible group state is
+        // byte-identical to what the sync-start refresh already read, so the
+        // recomputation here would rescan every group only to install the same
+        // routing snapshot (mdk#1380).
+        let routes_changed = if deliveries > 0 || routes_dirty {
+            self.checkpoint_route_refresh_recomputes =
+                self.checkpoint_route_refresh_recomputes.saturating_add(1);
+            self.refresh_group_routes()
+                .map_err(SyncCheckpointError::BeforePersistence)?
+                .routing_changed
+        } else {
+            false
+        };
         let checkpoint = if cfg!(feature = "test-policy-overrides")
             && self
                 .app

--- a/crates/marmot-app/src/groups.rs
+++ b/crates/marmot-app/src/groups.rs
@@ -28,7 +28,7 @@ use cgka_traits::app_event::{
 };
 use cgka_traits::engine::{GroupEvent, GroupHydrationQuarantineReason};
 use cgka_traits::group::{Group, ProtocolProfile};
-use cgka_traits::{GroupId, TransportEndpoint, TransportGroupSubscription};
+use cgka_traits::{GroupId, MemberId, TransportEndpoint, TransportGroupSubscription};
 use serde::{Deserialize, Serialize};
 
 use crate::media::{EncryptedMediaVersion, media_imeta_tags_preserve_message};
@@ -71,6 +71,17 @@ impl std::fmt::Debug for AppInitialGroupImage {
             .field("thumbhash", &self.thumbhash)
             .finish()
     }
+}
+
+/// A group invite still pending the local device's confirmation decision
+/// (`pending_confirmation && !archived` in the account projection). Carries
+/// only what an invite policy needs to accept or decline; returned by
+/// [`crate::MarmotApp::pending_group_invites`] (mdk#1380).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PendingGroupInvite {
+    pub group_id: GroupId,
+    /// Account id of the welcomer who authenticated the invite, when known.
+    pub welcomer: Option<MemberId>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -3065,23 +3065,52 @@ impl MarmotApp {
     /// decision needs — never the seen-event window, component blobs, or
     /// disband tables — so a periodic enumeration over an idle session reads
     /// O(pending invites) rows instead of the full account projection.
+    ///
+    /// A row whose stored ids cannot be decoded is skipped with a privacy-safe
+    /// warning (the same policy `routing_for` applies to malformed persisted
+    /// group routes): one corrupt row must not disable policy reconciliation
+    /// for every valid invite in the account.
     pub fn pending_group_invites(&self, label: &str) -> Result<Vec<PendingGroupInvite>, AppError> {
         self.ensure_account_state(label)?;
-        self.account_storage(label)?
+        let mut invites = Vec::new();
+        for invite in self
+            .account_storage(label)?
             .pending_confirmation_group_invites()?
-            .into_iter()
-            .map(|invite| {
-                let group_id_hex = invite.group_id_hex.trim().to_ascii_lowercase();
-                let group_id = GroupId::new(hex::decode(&group_id_hex)?);
-                let welcomer = invite
-                    .welcomer_account_id_hex
-                    .as_deref()
-                    .map(|welcomer| welcomer.trim().to_ascii_lowercase())
-                    .map(|welcomer| hex::decode(welcomer).map(MemberId::new))
-                    .transpose()?;
-                Ok(PendingGroupInvite { group_id, welcomer })
-            })
-            .collect()
+        {
+            let group_id_hex = invite.group_id_hex.trim().to_ascii_lowercase();
+            let Ok(group_id_bytes) = hex::decode(&group_id_hex) else {
+                tracing::warn!(
+                    target: "marmot_app",
+                    method = "pending_group_invites",
+                    error_kind = "invalid_persisted_group_record",
+                    "skipping malformed persisted pending invite",
+                );
+                continue;
+            };
+            let welcomer = match invite.welcomer_account_id_hex.as_deref() {
+                Some(welcomer) => {
+                    let welcomer = welcomer.trim().to_ascii_lowercase();
+                    match hex::decode(&welcomer) {
+                        Ok(welcomer) => Some(MemberId::new(welcomer)),
+                        Err(_) => {
+                            tracing::warn!(
+                                target: "marmot_app",
+                                method = "pending_group_invites",
+                                error_kind = "invalid_persisted_welcomer_record",
+                                "skipping malformed persisted pending invite",
+                            );
+                            continue;
+                        }
+                    }
+                }
+                None => None,
+            };
+            invites.push(PendingGroupInvite {
+                group_id: GroupId::new(group_id_bytes),
+                welcomer,
+            });
+        }
+        Ok(invites)
     }
 
     pub fn visible_groups(&self, label: &str) -> Result<Vec<AppGroupRecord>, AppError> {

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -106,15 +106,15 @@ pub use root_runtime_lease::{MARMOT_ROOT_RUNTIME_LOCK_FILE, MarmotRootRuntimeLea
 pub(crate) use runtime::blocking_app_task;
 pub use runtime::{
     AccountManager, AccountSetupRequest, AccountSetupResult, AgentStreamWatchOptions,
-    AgentTextStreamCryptoContext, ChatListUpdateTrigger, GroupLeaveFailure, LocalCleanupReport,
-    ManagedAccount, MarmotAppEvent, MarmotAppRuntime, RelayFailure, RuntimeAccountError,
-    RuntimeAgentStreamMessage, RuntimeAgentStreamUpdate, RuntimeAgentStreamWatch,
-    RuntimeChatListSubscription, RuntimeChatListUpdate, RuntimeChatsSubscription,
-    RuntimeEventsSubscription, RuntimeGroupEvent, RuntimeGroupStateSubscription,
-    RuntimeMessageReceived, RuntimeMessageUpdate, RuntimeMessagesSubscription,
-    RuntimeNotificationsSubscription, RuntimeProjectionUpdate, RuntimeSharedServices,
-    RuntimeTimelineMessageUpdate, RuntimeTimelineMessagesSubscription, SignOutOptions,
-    SignOutOutcome, StreamStartView, TimelineWindowHandle, WipeOutcome,
+    AgentTextStreamCryptoContext, CatchUpAccountsSummary, ChatListUpdateTrigger, GroupLeaveFailure,
+    LocalCleanupReport, ManagedAccount, MarmotAppEvent, MarmotAppRuntime, RelayFailure,
+    RuntimeAccountError, RuntimeAgentStreamMessage, RuntimeAgentStreamUpdate,
+    RuntimeAgentStreamWatch, RuntimeChatListSubscription, RuntimeChatListUpdate,
+    RuntimeChatsSubscription, RuntimeEventsSubscription, RuntimeGroupEvent,
+    RuntimeGroupStateSubscription, RuntimeMessageReceived, RuntimeMessageUpdate,
+    RuntimeMessagesSubscription, RuntimeNotificationsSubscription, RuntimeProjectionUpdate,
+    RuntimeSharedServices, RuntimeTimelineMessageUpdate, RuntimeTimelineMessagesSubscription,
+    SignOutOptions, SignOutOutcome, StreamStartView, TimelineWindowHandle, WipeOutcome,
     default_directory_discovery_relays,
 };
 pub(crate) use sqlcipher::{SqlcipherDatabaseKind, remove_sqlite_file_set};
@@ -159,7 +159,7 @@ pub use groups::{
     AppGroupNostrRoutingComponent, AppGroupOpaqueComponent, AppGroupProfileComponent,
     AppGroupRecord, AppGroupRoster, AppGroupRosterMember, AppGroupSystemEvent,
     AppInitialGroupImage, AppPriorNostrRoute, AppProtocolProfile, AppQuarantinedGroup,
-    MAX_GROUP_MEMBER_IDS_PAGE_SIZE, group_system_event_from_message,
+    MAX_GROUP_MEMBER_IDS_PAGE_SIZE, PendingGroupInvite, group_system_event_from_message,
 };
 pub use ids::{
     account_id_hex_from_ref, nprofile_for_account_id, npub_for_account_id, validate_relay_urls,
@@ -1510,6 +1510,8 @@ impl MarmotApp {
             pending_epoch_backfill: None,
             queued_epoch_backfills: std::collections::VecDeque::new(),
             post_join_maintenance_subscriptions: HashMap::new(),
+            encrypted_media_not_required_epochs: HashMap::new(),
+            checkpoint_route_refresh_recomputes: 0,
         };
         if !defer_group_hydration {
             // These repairs read live group state. Deferred runtime opens run
@@ -3054,6 +3056,32 @@ impl MarmotApp {
     pub fn pending_leave_requests(&self, label: &str) -> Result<HashMap<String, u64>, AppError> {
         self.ensure_account_state(label)?;
         Ok(self.account_storage(label)?.pending_leave_requests()?)
+    }
+
+    /// Group invites still pending the local device's confirmation decision.
+    ///
+    /// This is the invite-policy reconciliation read (mdk#1380): unlike
+    /// [`Self::groups`], it touches only the two projection columns the policy
+    /// decision needs — never the seen-event window, component blobs, or
+    /// disband tables — so a periodic enumeration over an idle session reads
+    /// O(pending invites) rows instead of the full account projection.
+    pub fn pending_group_invites(&self, label: &str) -> Result<Vec<PendingGroupInvite>, AppError> {
+        self.ensure_account_state(label)?;
+        self.account_storage(label)?
+            .pending_confirmation_group_invites()?
+            .into_iter()
+            .map(|invite| {
+                let group_id_hex = invite.group_id_hex.trim().to_ascii_lowercase();
+                let group_id = GroupId::new(hex::decode(&group_id_hex)?);
+                let welcomer = invite
+                    .welcomer_account_id_hex
+                    .as_deref()
+                    .map(|welcomer| welcomer.trim().to_ascii_lowercase())
+                    .map(|welcomer| hex::decode(welcomer).map(MemberId::new))
+                    .transpose()?;
+                Ok(PendingGroupInvite { group_id, welcomer })
+            })
+            .collect()
     }
 
     pub fn visible_groups(&self, label: &str) -> Result<Vec<AppGroupRecord>, AppError> {

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -1128,6 +1128,13 @@ impl MarmotAppRuntime {
     }
 
     pub async fn catch_up_accounts(&self) -> Result<(), AppError> {
+        self.accounts.catch_up_accounts().await.map(|_| ())
+    }
+
+    /// Catch up every running account worker and report how many account
+    /// workers were considered. Used by reconciliation drivers that expose
+    /// aggregate per-pass work telemetry (mdk#1380).
+    pub async fn catch_up_accounts_reporting(&self) -> Result<CatchUpAccountsSummary, AppError> {
         self.accounts.catch_up_accounts().await
     }
 
@@ -3462,6 +3469,14 @@ impl MarmotAppRuntime {
     }
 }
 
+/// Aggregate result of one [`MarmotAppRuntime::catch_up_accounts_reporting`]
+/// pass. Privacy-safe: counts only, no account/group identifiers.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CatchUpAccountsSummary {
+    /// Number of running account workers that received a catch-up command.
+    pub accounts_considered: usize,
+}
+
 impl AccountManager {
     fn new(
         app: MarmotApp,
@@ -3909,13 +3924,17 @@ impl AccountManager {
         self.reconcile_locked().await
     }
 
-    pub async fn catch_up_accounts(&self) -> Result<(), AppError> {
+    pub async fn catch_up_accounts(&self) -> Result<CatchUpAccountsSummary, AppError> {
         let started_at = Instant::now();
         let result = async {
             self.shared.lifecycle().ensure_running()?;
             self.reconcile().await?;
             let commands = self.running_account_commands().await;
-            self.catch_up_account_commands(commands).await
+            let accounts_considered = commands.len();
+            self.catch_up_account_commands(commands).await?;
+            Ok(CatchUpAccountsSummary {
+                accounts_considered,
+            })
         }
         .await;
         self.shared.app_performance_telemetry().record(

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -8450,3 +8450,62 @@ fn idle_sync_skips_the_checkpoint_route_recomputation() {
         );
     });
 }
+
+#[test]
+fn pending_group_invites_skips_malformed_rows() {
+    // mdk#1380 review: one undecodable row must not disable policy
+    // reconciliation for the account's valid invites.
+    let dir = tempfile::tempdir().unwrap();
+    AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+
+    let pending_group =
+        |group_id_hex: &str, welcomer: Option<&str>| storage_sqlite::StoredAccountGroup {
+            group_id_hex: group_id_hex.to_owned(),
+            endpoint: "wss://relay.example".to_owned(),
+            profile_name: "pending".to_owned(),
+            profile_description: String::new(),
+            image_hash_hex: String::new(),
+            image_key_hex: String::new(),
+            image_nonce_hex: String::new(),
+            image_upload_key_hex: String::new(),
+            image_media_type: None,
+            admin_keys_hex: String::new(),
+            archived: false,
+            pending_confirmation: true,
+            member_count: None,
+            welcomer_account_id_hex: welcomer.map(str::to_owned),
+            via_welcome_message_id_hex: None,
+            nostr_routing_last_epoch: 0,
+            prior_nostr_routes: Vec::new(),
+            self_membership: storage_sqlite::SelfMembership::Member,
+            components: Vec::new(),
+        };
+    let state = storage_sqlite::StoredAccountState {
+        label: "alice".to_owned(),
+        seen_events: Vec::new(),
+        last_transport_timestamp: None,
+        groups: vec![
+            pending_group("zz-not-hex", None),
+            pending_group(&"aa".repeat(32), Some("not-hex-either")),
+            pending_group(&"bb".repeat(32), Some(&"cc".repeat(32))),
+        ],
+    };
+    app.account_storage("alice")
+        .unwrap()
+        .save_account_projection_state(&state, 16, 300)
+        .unwrap();
+
+    let invites = app.pending_group_invites("alice").unwrap();
+    assert_eq!(invites.len(), 1);
+    assert_eq!(hex::encode(invites[0].group_id.as_slice()), "bb".repeat(32));
+    assert_eq!(
+        invites[0]
+            .welcomer
+            .as_ref()
+            .map(|welcomer| hex::encode(welcomer.as_slice())),
+        Some("cc".repeat(32))
+    );
+}

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -8330,3 +8330,123 @@ async fn a_send_that_reaches_the_transport_reports_published() {
 
     runtime.shutdown().await;
 }
+
+// ---- mdk#1380: steady-state reconciliation passes must not rescan full state ----
+
+#[test]
+fn encrypted_media_warm_skips_authoritative_rechecks_at_an_unchanged_epoch() {
+    run_composed_app_runtime_test("encrypted-media-warm-epoch-skip", || async {
+        let dir = tempfile::tempdir().unwrap();
+        AccountHome::open(dir.path())
+            .create_account("alice")
+            .unwrap();
+        let relay = Arc::new(ScriptedPushRelayClient::default());
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+            .with_test_relay_client(relay.clone());
+
+        let mut client = app.client("alice").await.unwrap();
+        let group_id = client.create_group("warm pass", &[]).await.unwrap();
+        let group_id_hex = hex::encode(group_id.as_slice());
+        assert_eq!(client.state.groups.len(), 1);
+        assert!(client.state.groups[0].encrypted_media.required);
+        let epoch = client.runtime.group_record(&group_id).unwrap().epoch;
+
+        // A group still marked as requiring encrypted media warms through the
+        // per-epoch secret cache without any authoritative component load.
+        for _ in 0..2 {
+            let stats = client.cache_current_encrypted_media_epoch_secrets();
+            assert_eq!(stats.groups_considered, 1);
+            assert_eq!(stats.warmed, 1);
+            assert_eq!(stats.authoritative_checks, 0);
+            assert_eq!(stats.skipped_unchanged_epoch, 0);
+            assert_eq!(stats.failures, 0);
+        }
+
+        // A projection saying "not required" is only a hint: with no confirmed
+        // negative on record the pass re-checks the authoritative component.
+        client.state.groups[0].encrypted_media = crate::AppGroupEncryptedMediaComponent::disabled();
+        let stats = client.cache_current_encrypted_media_epoch_secrets();
+        assert_eq!(stats.authoritative_checks, 1);
+        assert_eq!(stats.skipped_unchanged_epoch, 0);
+        assert!(
+            !client
+                .encrypted_media_not_required_epochs
+                .contains_key(&group_id_hex),
+            "an authoritative REQUIRED answer must not be latched as confirmed-negative"
+        );
+
+        // Seed a confirmed-negative at the current epoch (the state left by an
+        // authoritative not-required answer): passes skip the expensive
+        // recheck while the epoch is unchanged.
+        client
+            .encrypted_media_not_required_epochs
+            .insert(group_id_hex.clone(), epoch.0);
+        let stats = client.cache_current_encrypted_media_epoch_secrets();
+        assert_eq!(stats.groups_considered, 1);
+        assert_eq!(stats.skipped_unchanged_epoch, 1);
+        assert_eq!(stats.authoritative_checks, 0);
+        assert_eq!(stats.failures, 0);
+
+        // A commit advances the epoch and rebuilds the projection from the
+        // signed components: the group is required=true again and the stale
+        // seeded negative must be evicted, with the current-epoch secret
+        // re-warmed through the live projection path.
+        client
+            .update_group_profile(&group_id, Some("warm pass renamed"), None)
+            .await
+            .unwrap();
+        let advanced = client.runtime.group_record(&group_id).unwrap().epoch;
+        assert!(
+            advanced.0 > epoch.0,
+            "a profile commit must advance the epoch"
+        );
+        let stats = client.cache_current_encrypted_media_epoch_secrets();
+        assert_eq!(stats.groups_considered, 1);
+        assert_eq!(stats.warmed, 1);
+        assert_eq!(stats.failures, 0);
+
+        // If the group's projection later says "not required" again (a
+        // projection rebuild healed the required flag backwards — the scenario
+        // the authoritative re-check exists for), the stale map entry from the
+        // OLD epoch must not suppress the re-check.
+        client.state.groups[0].encrypted_media = crate::AppGroupEncryptedMediaComponent::disabled();
+        let stats = client.cache_current_encrypted_media_epoch_secrets();
+        assert_eq!(stats.authoritative_checks, 1);
+        assert_eq!(stats.skipped_unchanged_epoch, 0);
+        assert!(
+            !client
+                .encrypted_media_not_required_epochs
+                .contains_key(&group_id_hex),
+            "an authoritative REQUIRED answer must evict the stale confirmed-negative"
+        );
+    });
+}
+
+#[test]
+fn idle_sync_skips_the_checkpoint_route_recomputation() {
+    run_composed_app_runtime_test("idle-sync-checkpoint-skip", || async {
+        let dir = tempfile::tempdir().unwrap();
+        AccountHome::open(dir.path())
+            .create_account("alice")
+            .unwrap();
+        let relay = Arc::new(ScriptedPushRelayClient::default());
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+            .with_test_relay_client(relay.clone());
+
+        let mut client = app.client("alice").await.unwrap();
+        client.create_group("idle sync", &[]).await.unwrap();
+
+        // Settle startup/replay traffic, then reset the counter: syncs below
+        // drain an empty channel, so nothing can have changed routing.
+        client.sync().await.unwrap();
+        client.checkpoint_route_refresh_recomputes = 0;
+
+        client.sync().await.unwrap();
+        client.sync().await.unwrap();
+        assert_eq!(
+            client.checkpoint_route_refresh_recomputes, 0,
+            "a zero-delivery, clean-routes checkpoint re-scanning every group \
+             is pure read amplification (mdk#1380)"
+        );
+    });
+}

--- a/crates/storage-sqlite/src/account_projection.rs
+++ b/crates/storage-sqlite/src/account_projection.rs
@@ -107,6 +107,17 @@ pub struct StoredAccountState {
     pub groups: Vec<StoredAccountGroup>,
 }
 
+/// Minimal outline of a group still pending the local device's join
+/// confirmation, for invite-policy reconciliation. Deliberately carries no
+/// profile/component payload: the policy decision needs only the group id and
+/// the (optional) welcomer identity (mdk#1380).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StoredPendingGroupInvite {
+    pub group_id_hex: String,
+    /// Account id of the welcomer who authenticated the invite, when known.
+    pub welcomer_account_id_hex: Option<String>,
+}
+
 /// `image_key_hex`/`image_upload_key_hex` are key material mirrored from the
 /// blossom image component for chat-list projection. They are stored in
 /// SQLCipher, but must not appear in `Debug` output. Nested
@@ -405,6 +416,39 @@ impl SqliteAccountStorage {
             )
             .storage()?;
         Ok(())
+    }
+
+    /// Read only the pending-confirmation, non-archived group outlines.
+    ///
+    /// Reconciliation policies (the agent connector's welcomer-allowlist
+    /// invite policy, mdk#1380) need exactly these two columns. Unlike
+    /// [`Self::load_account_projection_state`], this never scans the seen-event
+    /// window, group components, or disband tables, so a periodic policy pass
+    /// over an idle session reads O(pending invites) rows — typically zero —
+    /// rather than the full account projection.
+    pub fn pending_confirmation_group_invites(
+        &self,
+    ) -> StorageResult<Vec<StoredPendingGroupInvite>> {
+        let conn = self.lock()?;
+        let mut statement = conn
+            .prepare(
+                "SELECT group_id_hex, welcomer_account_id_hex
+                 FROM account_groups
+                 WHERE pending_confirmation = 1 AND archived = 0
+                 ORDER BY group_id_hex",
+            )
+            .storage()?;
+        let invites = statement
+            .query_map([], |row| {
+                Ok(StoredPendingGroupInvite {
+                    group_id_hex: row.get(0)?,
+                    welcomer_account_id_hex: row.get(1)?,
+                })
+            })
+            .storage()?
+            .collect::<Result<Vec<_>, _>>()
+            .storage()?;
+        Ok(invites)
     }
 
     pub fn load_account_projection_state(

--- a/crates/storage-sqlite/src/account_projection/tests.rs
+++ b/crates/storage-sqlite/src/account_projection/tests.rs
@@ -407,6 +407,77 @@ fn account_projection_state_roundtrips_groups_components_and_seen_events() {
 }
 
 #[test]
+fn pending_confirmation_group_invites_reads_only_pending_outlines() {
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    // One applied member group, one pending invite with a welcomer, one
+    // pending invite without a welcomer, and one pending-but-archived group.
+    // Seen events and component rows are present so the outline result proves
+    // the query never fans out into them (mdk#1380).
+    let member = group("member-group", "member group");
+    let mut invited = group("invited-group", "invited group");
+    invited.pending_confirmation = true;
+    invited.welcomer_account_id_hex = Some("cc".repeat(32));
+    let mut unframed = group("unframed-invite", "unframed invite");
+    unframed.pending_confirmation = true;
+    let mut archived = group("archived-invite", "archived invite");
+    archived.pending_confirmation = true;
+    archived.archived = true;
+
+    let state = StoredAccountState {
+        label: "alice".to_owned(),
+        seen_events: vec!["seen-a".to_owned(), "seen-b".to_owned()],
+        last_transport_timestamp: None,
+        groups: vec![member, invited, unframed, archived],
+    };
+    store
+        .save_account_projection_state(&state, 16, MAX_FUTURE_SKEW_SECS)
+        .unwrap();
+
+    let invites = store.pending_confirmation_group_invites().unwrap();
+    assert_eq!(
+        invites,
+        vec![
+            StoredPendingGroupInvite {
+                group_id_hex: "invited-group".to_owned(),
+                welcomer_account_id_hex: Some("cc".repeat(32)),
+            },
+            StoredPendingGroupInvite {
+                group_id_hex: "unframed-invite".to_owned(),
+                welcomer_account_id_hex: None,
+            },
+        ]
+    );
+
+    // A once-pending group that got applied drops out of the outline set on
+    // the next reconciliation. (Full projection saves replace the snapshot,
+    // so resave the whole set.)
+    let member = group("member-group", "member group");
+    let mut invited = group("invited-group", "invited group");
+    invited.pending_confirmation = true;
+    invited.welcomer_account_id_hex = Some("cc".repeat(32));
+    let mut applied = group("unframed-invite", "unframed invite");
+    applied.pending_confirmation = false;
+    let mut archived = group("archived-invite", "archived invite");
+    archived.pending_confirmation = true;
+    archived.archived = true;
+    let state = StoredAccountState {
+        groups: vec![member, invited, applied, archived],
+        ..state
+    };
+    store
+        .save_account_projection_state(&state, 16, MAX_FUTURE_SKEW_SECS)
+        .unwrap();
+    let invites = store.pending_confirmation_group_invites().unwrap();
+    assert_eq!(
+        invites,
+        vec![StoredPendingGroupInvite {
+            group_id_hex: "invited-group".to_owned(),
+            welcomer_account_id_hex: Some("cc".repeat(32)),
+        }]
+    );
+}
+
+#[test]
 fn account_projection_state_refreshes_reseen_event_recency_before_pruning() {
     let store = SqliteAccountStorage::in_memory().unwrap();
     {

--- a/crates/storage-sqlite/src/account_projection/tests.rs
+++ b/crates/storage-sqlite/src/account_projection/tests.rs
@@ -478,6 +478,46 @@ fn pending_confirmation_group_invites_reads_only_pending_outlines() {
 }
 
 #[test]
+fn pending_confirmation_group_invites_uses_the_partial_covering_index() {
+    // mdk#1380 review: the invite-policy predicate must not scan retained
+    // group state. The partial covering index keeps examined rows at
+    // O(pending invites); pin the query plan so a regression that drops the
+    // index (or rewrites the query out of it) fails deterministically.
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    let conn = store.lock().unwrap();
+    let mut statement = conn
+        .prepare(
+            "EXPLAIN QUERY PLAN
+             SELECT group_id_hex, welcomer_account_id_hex
+             FROM account_groups
+             WHERE pending_confirmation = 1 AND archived = 0
+             ORDER BY group_id_hex",
+        )
+        .unwrap();
+    let plan = statement
+        .query_map([], |row| row.get::<_, String>(3))
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()
+        .join("\n");
+    assert!(
+        plan.contains("idx_account_groups_pending_invites"),
+        "the pending-invite predicate must use its partial covering index, got:\n{plan}"
+    );
+    // A scan of the PARTIAL index only visits rows matching the predicate
+    // (O(pending invites)); the regression to catch is a scan of the full
+    // table or of the whole primary-key index (O(retained groups)).
+    for line in plan.lines() {
+        if line.contains("SCAN account_groups") {
+            assert!(
+                line.contains("idx_account_groups_pending_invites"),
+                "the pending-invite query must not scan the full group table or its primary-key index, got:\n{plan}"
+            );
+        }
+    }
+}
+
+#[test]
 fn account_projection_state_refreshes_reseen_event_recency_before_pruning() {
     let store = SqliteAccountStorage::in_memory().unwrap();
     {

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -94,6 +94,8 @@ mod migration_0046_message_group_state_epoch_index;
 mod migration_0047_normalized_message_records;
 #[path = "migrations/0048_deferred_peel_generations.rs"]
 mod migration_0048_deferred_peel_generations;
+#[path = "migrations/0049_pending_invite_index.rs"]
+mod migration_0049_pending_invite_index;
 #[cfg(test)]
 #[path = "migrations/test_support.rs"]
 mod test_support;
@@ -348,6 +350,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 48,
         name: "0048_deferred_peel_generations",
         apply: migration_0048_deferred_peel_generations::apply,
+    },
+    Migration {
+        version: 49,
+        name: "0049_pending_invite_index",
+        apply: migration_0049_pending_invite_index::apply,
     },
 ];
 
@@ -876,7 +883,7 @@ mod tests {
         assert!(matches!(
             error,
             StorageError::UnsupportedSchemaVersion {
-                found: 48,
+                found: 49,
                 latest_supported: 46,
             }
         ));
@@ -932,7 +939,7 @@ mod tests {
         assert!(matches!(
             error,
             StorageError::UnsupportedSchemaVersion {
-                found: 48,
+                found: 49,
                 latest_supported: 46,
             }
         ));
@@ -1236,7 +1243,7 @@ mod tests {
         assert!(matches!(
             error,
             StorageError::UnsupportedSchemaVersion {
-                found: 48,
+                found: 49,
                 latest_supported: 46,
             }
         ));

--- a/crates/storage-sqlite/src/migrations/0049_pending_invite_index.rs
+++ b/crates/storage-sqlite/src/migrations/0049_pending_invite_index.rs
@@ -1,0 +1,23 @@
+use crate::SqliteResultExt;
+use cgka_traits::storage::StorageResult;
+use rusqlite::Transaction;
+
+/// Covering partial index for the invite-policy pending-confirmation
+/// predicate (mdk#1380). The agent connector's invite-policy worker asks
+/// "which groups are pending confirmation and not archived" on every
+/// reconciliation pass; without an index matching that predicate the query
+/// scans every retained group row. The partial index holds only the matching
+/// rows (typically zero), so an idle enumeration examines O(pending invites)
+/// index entries — and both selected columns are covered, so SQLite answers
+/// from the index alone with no table-row lookups, while the leading column
+/// satisfies the query's `ORDER BY group_id_hex` without a sort.
+pub(crate) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
+    tx.execute_batch(
+        r#"
+CREATE INDEX IF NOT EXISTS idx_account_groups_pending_invites
+    ON account_groups (group_id_hex, welcomer_account_id_hex)
+    WHERE pending_confirmation = 1 AND archived = 0;
+"#,
+    )
+    .storage()
+}

--- a/docs/marmot-architecture/runtime-state-bounds.md
+++ b/docs/marmot-architecture/runtime-state-bounds.md
@@ -1,7 +1,7 @@
 ---
 title: "Long-lived runtime state — bounds and reclamation"
 created: 2026-07-02
-updated: 2026-08-14
+updated: 2026-08-15
 tags: [marmot, architecture, runtime, daemon, broker, memory]
 ---
 
@@ -57,6 +57,12 @@ Tracking issue: marmot-protocol/mdk#381.
 | Structure | Bound | Reclamation |
 | --- | --- | --- |
 | `SQLCIPHER_V2_VERDICTS` probe-verdict cache | 256 entries (`SQLCIPHER_V2_VERDICT_CACHE_CAPACITY`) | Entries are keyed by canonical database path + salt and record only an observed "opens under the v2 key" verdict (mdk#1439). Removed when the database file set is deleted via `remove_sqlite_file_set`; replaced in place when the salt rotates; oldest-first eviction at the cap. Eviction or loss of an entry only ever causes one extra recovery probe, never a wrong-key assumption. The companion `SQLCIPHER_MIGRATION_PROBE_RUNS`/`SKIPS` counters are monotonic process-lifetime aggregates by design (telemetry gauges, not tracked state). |
+
+### `marmot-app` client (`src/client/`)
+
+| Structure | Bound | Reclamation |
+| --- | --- | --- |
+| `AppClient.encrypted_media_not_required_epochs` | One `u64` per live projected group (mdk#1380) | Pruned to the live group set at the start of every warm pass; stale entries are evicted when the group epoch advances and an authoritative re-check finds the component required; the whole map is dropped with the client. Entries are only ever inserted after a successful authoritative negative, so map loss or eviction costs at most one `MlsGroup::load` re-check, never a wrong skip. |
 
 ### `wn-cli` daemon / `wnd` (`src/daemon/`)
 

--- a/docs/marmot-architecture/telemetry.md
+++ b/docs/marmot-architecture/telemetry.md
@@ -1,7 +1,7 @@
 ---
 title: "Telemetry, Logging, and Tracing Inventory"
 created: 2026-06-10
-updated: 2026-08-14
+updated: 2026-08-15
 tags: [marmot, architecture, telemetry, logging, tracing, privacy]
 status: current
 ---
@@ -23,6 +23,7 @@ runtime. It complements the policy docs:
 | Device-local relay telemetry | Always collected by the shared Nostr relay plane while it runs: lifecycle counters, delivery-spread histograms, sync timing, and redacted relay health. | No. Exposed locally via `MarmotApp::relay_telemetry`, runtime `relay_plane().relay_telemetry()`, and `wn relay-stats`. | [`relay_plane.rs`](../../crates/marmot-app/src/relay_plane.rs), [`telemetry.rs`](../../crates/transport-nostr-adapter/src/telemetry.rs) |
 | Device-local app performance telemetry | Always available inside `RuntimeSharedServices` while the runtime exists: aggregate duration histograms plus attempts/success/failure counters for startup, directory subscription sync, local account open, transport activation, subscription registration, sync/catch-up, host splash/foreground readiness, one-sided outbound message send, group invite/admin/read operations, and media upload/download. Process-wide SQLCipher interrupted-migration probe run/skip counters (mdk#1439) are merged into the snapshot from `sqlcipher.rs`. | No by itself. Included in the OTLP export batch only after the same opt-in export gate passes. | [`app_telemetry.rs`](../../crates/marmot-app/src/app_telemetry.rs), [`runtime.rs`](../../crates/marmot-app/src/runtime.rs) |
 | Opt-in telemetry export | Implemented and off by default. Requires opt-in settings to be persisted, plus runtime endpoint, bearer token, and resource metadata. OTLP wire encoding and HTTP push are behind the `otlp-export` feature. Exports relay metrics and app-performance metrics in one batch. | Yes, only after the export gate passes. Relay URL is the only metric label, and only relay metrics may carry it; app-performance metrics are unlabeled population metrics. | [`relay_telemetry_export.rs`](../../crates/marmot-app/src/relay_telemetry_export.rs), [`config.rs`](../../crates/marmot-app/src/config.rs) |
+| Agent connector reconciliation telemetry | Always collected while `wn-agent` runs: process-local cumulative counters for the shared inbound catch-up driver and the invite-policy worker (passes, outcomes, accounts/candidate rows considered), plus one privacy-safe `tracing` event per scheduled pass carrying a `source` label, duration, result, and aggregate counts (mdk#1380). | No. Counters are process-local; tracing events follow the no-ids/no-urls/no-content rules. | [`reconcile_telemetry.rs`](../../crates/agent-connector/src/reconcile_telemetry.rs), [`event_projection.rs`](../../crates/agent-connector/src/event_projection.rs), [`invite_policy.rs`](../../crates/agent-connector/src/invite_policy.rs) |
 | Engine convergence/outbound telemetry | Implemented inside `cgka-engine` as aggregate post-settle reorg, convergence-pass, foreground deferred-peel, outbound-phase, and queued-intent counters/histograms. Exposed locally by `Engine::engine_metrics()`. The full `EngineMetricsSnapshot` is device-local only. The relay-plane/export structs accept only an optional `EngineReorgMetrics` projection, and the periodic runtime exporter passes `None`. | No via the runtime exporter today. | [`engine_metrics.rs`](../../crates/cgka-engine/src/engine_metrics.rs), [`relay_plane.rs`](../../crates/marmot-app/src/relay_plane.rs) |
 | Product analytics / crash reporting | No product analytics or crash reporting SDK integration was found in the current source. Aptabase is mentioned only as future product-analytics context in a doc; it is not wired. | No. | Workspace search on 2026-06-10 |
 
@@ -246,6 +247,29 @@ These app-performance samples deliberately do not include account labels, accoun
 ids, relay URLs, media URLs, payload sizes, content types, upload endpoints, download endpoints, or error strings.
 Host applications can only select the closed `HostPerformanceOperation` enum; callers cannot supply metric names,
 label names, or label values. Adding a new cross-platform operation requires an MDK API change and review.
+
+### Agent connector reconciliation telemetry
+
+`ReconcileTelemetry` (in `crates/agent-connector/src/reconcile_telemetry.rs`) holds process-local cumulative
+counters for the two background reconciliation loops in `wn-agent` (mdk#1380): the shared inbound catch-up driver
+(`source = "inbound_catch_up"`) and the welcomer-allowlist invite-policy worker (`source = "invite_policy"`). Both
+loops schedule event- or retry-driven work with an adaptive safety net, so the counters exist to prove idle passes
+stay rare and cheap.
+
+| Counter | Meaning | Sensitivity |
+| --- | --- | --- |
+| `catch_up_passes_started/completed/failed` | Scheduled safety-net catch-up passes and their outcomes. | Aggregate counts. |
+| `catch_up_passes_with_activity` | Completed passes that observed qualifying runtime activity (these hold the net at its base interval). | Aggregate count. |
+| `catch_up_accounts_considered` | Sum of running account workers fanned out across completed passes. | Aggregate count. |
+| `catch_up_explicit_requests` | Out-of-band catch-ups (e.g. a `SubscribeInbound` initial catch-up), which never perturb the adaptive schedule. | Aggregate count. |
+| `invite_enumerations_started/completed/failed` | Pending-invite safety enumerations and their outcomes. | Aggregate counts. |
+| `invite_accounts_considered` | Sum of local-signing accounts enumerated across passes. | Aggregate count. |
+| `invite_candidate_rows_considered` | Sum of pending-invite projection rows read across enumerations. Zero on an idle session regardless of retained history size; this is the database-read amplification gauge. | Aggregate count. |
+| `invite_policy_applied` / `invite_policy_apply_failures` | Policy decisions applied vs. retry-pending failures. | Aggregate counts. |
+
+Each scheduled pass also emits one `tracing` event (debug on success, warn on failure) with explicit
+`target`/`method`, a `source` label, `duration_ms`, a coarse `result`, and aggregate counts only — no account
+ids, group ids, message ids, relay URLs, or content.
 
 ## How local relay telemetry is recorded
 


### PR DESCRIPTION
## Summary

Fixes #1380.

A stock `wn-agent` with one long-lived, otherwise-idle `SubscribeInbound` client sustained ~94% CPU and ~54 MB/s of SQLite page-cache reads because **two independent fixed-rate, full-state reconciliation loops** ran every 5 seconds, while the rest of the system (account workers' live `receive_next_delivery` push loop, CLI daemon, UniFFI, post-mutation paths) is event-driven and treats catch-up as a diagnostic/repair seam.

### Root cause attribution (source-level, both 5s paths)

**Inbound catch-up driver** (`InboundCatchUpDriver` → `runtime.catch_up_accounts()` per account worker):
- `cache_current_encrypted_media_epoch_secrets` ran **twice per sync pass**, re-validating every group projected `encrypted_media.required == false` against the signed component — a **full `MlsGroup::load`** (~12 `openmls_values` blob reads + JSON, tree O(members)) per group per pass. Dominant read.
- `refresh_group_routes` also ran **twice per pass** (sync start + checkpoint): ~12 indexed `cgka_*` reads/group.
- Plus one durable `account_state` UPSERT per pass, an outbound-fanout full scan, and a ≥750ms relay drain wait per pass.

**Invite-policy worker** (per local-signing account): full `app.groups()` projection load — unindexed `seen_events` scan+sort up to 16,384 rows, `account_groups` full scan, `account_group_app_components` full scan with hex-decode of every component blob, disband tables twice, plus repeated `account.json` reads.

Both ran against two separate SQLCipher connections to the same file (no shared page cache), synchronously on one worker task — matching the measured profile.

## Changes

**Event-driven with adaptive safety nets** (base 5s → doubling to 60s cap):
- **Catch-up driver**: scheduled passes back off ×2 while the runtime is quiet; any qualifying runtime event (everything except `AccountError`, which a failing pass could self-emit) resets to base and wakes a backed-off pass promptly — but never faster than base cadence under load. Initial subscription catch-ups, broadcast-lag replay, quiesce-on-zero-subscribers (#574), and `Completed` marker semantics are preserved.
- **Invite-policy worker**: `GroupJoined` applies immediately (unchanged); failed applies wake on their own per-candidate retry backoff (`next_due()`) instead of polling; full enumeration runs once at startup, then on the same adaptive safety net.

**Each remaining pass is O(changed), not O(retained state)**:
- New `MarmotApp::pending_group_invites()` backed by a targeted `SELECT group_id_hex, welcomer_account_id_hex FROM account_groups WHERE pending_confirmation=1 AND archived=0` — replaces the full projection load.
- EM-secret warm pass skips authoritative `MlsGroup::load` re-checks at an unchanged group epoch (a commit always advances the epoch); new fallible `try_encrypted_media_for_group` keeps transient errors retryable instead of latching.
- Sync checkpoint skips its second `refresh_group_routes` on zero-delivery, clean-route passes.

**Privacy-safe telemetry**: new `ReconcileTelemetry` counters (passes/outcomes/accounts/candidate rows per source, including a read-amplification gauge that must read 0 rows when idle) + per-source tracing events (`source`, `duration_ms`, `result`, aggregate counts only) per `observability.md`.

## Verification

- **Regression harness** (deterministic operation/row counters, no wall-clock CPU assertions): driver backs off over ~16 former intervals (≤8 passes vs 16 at the old rate), quiesces with no subscribers, resets promptly on activity, filters `AccountError`; invite enumeration backs off with exactly 0 candidate rows on an idle session. EM-warm epoch-skip and checkpoint-skip behavior tests in marmot-app; targeted-query test in storage-sqlite.
- **Opt-in benchmark** `just bench-idle-reconciliation` (release): 8 groups, 7 passes over 10s (vs 40 at the old cadence), `invite_candidate_rows=0`, activity wake gap 0ms — recorded as `MDK_BENCH` lines.
- `just fast-ci` clean (fmt + workspace check + clippy, both feature sets); `agent-connector` 142 passed; `marmot-app` lib 670 passed; `storage-sqlite` 377 passed; tracing audit passes.
- `relay_runtime` integration: 93 passed / 5 failed — **verified identical on clean master** (`encrypted_media_*`, retention system-row, self-removal unread): pre-existing environment failures, not caused by this change.

Docs updated: crate AGENTS.md files, `docs/marmot-architecture/telemetry.md` (new inventory section), `runtime-state-bounds.md` (new per-group map entry).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved background synchronization responsiveness by reacting sooner to account activity while reducing unnecessary work during idle periods.
  * Improved pending group-invite reconciliation, including faster detection, retry handling, and more targeted processing.
  * Reduced redundant encrypted-media checks and route refreshes during steady-state synchronization, improving efficiency.
  * Added safeguards to keep reconciliation activity bounded and reliable during failures or extended idle periods.

* **Documentation**
  * Added guidance covering synchronization behavior, reconciliation telemetry, and runtime state limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->