### PR TITLE
fix(simulator): keep process capsules participant-owned and honor payload-count oracles

### DIFF
--- a/crates/cgka-conformance-simulator/AGENTS.md
+++ b/crates/cgka-conformance-simulator/AGENTS.md
@@ -67,7 +67,7 @@ the property-test registry. This file is the agent-facing model.
     version, seed, case index, runnable `ScenarioSpec`, and optional semantic expectations. `run_generated_case_report`
     adds generated metadata to report artifacts. Reliability families append a final global drain, exact canonical
     observation, and pending-work assertion; do not remove a red strict result merely because an earlier legacy
-    observation passed.
+    observation passed. Positive `PayloadCount` asserts are strict-oracle `AppMessage` coverage.
 
 - **Module:** `src/stateful_generator.rs`
   - **Role:** Legality-aware product journey generation into canonical Scenario IR v3. Tracks membership, admins,
@@ -77,7 +77,8 @@ the property-test registry. This file is the agent-facing model.
 
 - **Module:** `src/oracle.rs`
   - **Role:** Scenario oracle and coverage evidence. Computes scenario stimuli, expected behavior classes, observed
-    behavior classes, weak-oracle warnings, and coverage matrix rows.
+    behavior classes, weak-oracle warnings, and coverage matrix rows. Executable `PayloadCount` asserts with a
+    positive count cover `AppMessage` without inventing a cross-sender payload order.
 
 - **Module:** `cgka_engine::openmls_projection`
   - **Role:** Bytes-first OpenMLS projection and candidate materialization helpers, re-exported by this crate for tests.

--- a/crates/cgka-conformance-simulator/AGENTS.md
+++ b/crates/cgka-conformance-simulator/AGENTS.md
@@ -78,7 +78,8 @@ the property-test registry. This file is the agent-facing model.
 - **Module:** `src/oracle.rs`
   - **Role:** Scenario oracle and coverage evidence. Computes scenario stimuli, expected behavior classes, observed
     behavior classes, weak-oracle warnings, and coverage matrix rows. Executable `PayloadCount` asserts with a
-    positive count cover `AppMessage` without inventing a cross-sender payload order.
+    positive count cover `AppMessage` without inventing a cross-sender payload order. Declared asserts are
+    expected coverage; only passing assertion observations count as observed evidence.
 
 - **Module:** `cgka_engine::openmls_projection`
   - **Role:** Bytes-first OpenMLS projection and candidate materialization helpers, re-exported by this crate for tests.

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -802,8 +802,8 @@ unequal relay reconciliation; restart boundaries plus the engine's real SIGKILL 
 neighbors; replay-budget exhaustion; shared-account multi-device witnesses; full-engine app-witness A/B selection;
 mixed-binary compatibility with mixed-policy preflight rejection; and clock, scheduler, timestamp, and cursor attacks.
 The app-witness case pins the exact payload multiplicity for each candidate branch but deliberately does not claim an
-order between messages from different senders; scenarios that inject a transport reorder continue to pin ordered
-`received_payloads` explicitly.
+order between messages from different senders; those `PayloadCount` asserts are strict-oracle evidence for
+`AppMessage`. Scenarios that inject a transport reorder continue to pin ordered `received_payloads` explicitly.
 
 The normal test target runs small headline regressions. The multi-round sustained case is ignored by default and is
 invoked explicitly; the report CLI runs any number of seeded cases with either in-memory or encrypted file-backed

--- a/crates/cgka-conformance-simulator/src/oracle.rs
+++ b/crates/cgka-conformance-simulator/src/oracle.rs
@@ -142,6 +142,11 @@ pub fn build_scenario_oracle_report(
 ) -> ScenarioOracleReport {
     let stimuli = scenario_stimuli(spec);
     let mut oracle_behaviors = expected_behaviors(expected_trace, expected_outcomes);
+    for behavior in assertion_behaviors(spec) {
+        if !oracle_behaviors.contains(&behavior) {
+            oracle_behaviors.push(behavior);
+        }
+    }
     if spec
         .steps
         .iter()
@@ -149,8 +154,8 @@ pub fn build_scenario_oracle_report(
         && !oracle_behaviors.contains(&OracleBehavior::QuiescenceState)
     {
         oracle_behaviors.push(OracleBehavior::QuiescenceState);
-        oracle_behaviors.sort();
     }
+    oracle_behaviors.sort();
     let mut observed_behaviors = trace_behaviors(observed_trace);
     if expected_outcomes.iter().any(|expectation| {
         matches!(expectation, TraceExpectation::ClientsNotEquivalent { .. })
@@ -450,6 +455,36 @@ pub fn scenario_stimuli(spec: &ScenarioSpec) -> Vec<ScenarioStimulus> {
     }
 
     stimuli.into_iter().collect()
+}
+
+/// Executable scenario assertions are oracle evidence. A positive payload-count
+/// check covers `AppMessage` without inventing a cross-sender `received_payloads`
+/// order, which MLS does not define.
+fn assertion_behaviors(spec: &ScenarioSpec) -> BTreeSet<OracleBehavior> {
+    let mut behaviors = BTreeSet::new();
+    for step in &spec.steps {
+        let mut step = step;
+        while let ScenarioStep::InGroup { action, .. } = step {
+            step = action.as_ref();
+        }
+        let ScenarioStep::Assert { assertion } = step else {
+            continue;
+        };
+        let predicate = match assertion {
+            crate::ScenarioAssertionV2::Exactly { predicate }
+            | crate::ScenarioAssertionV2::Eventually { predicate, .. }
+            | crate::ScenarioAssertionV2::Within { predicate, .. } => predicate,
+            crate::ScenarioAssertionV2::Never { .. }
+            | crate::ScenarioAssertionV2::Resource { .. } => continue,
+        };
+        if matches!(
+            predicate,
+            crate::ScenarioPredicateV2::PayloadCount { count, .. } if *count > 0
+        ) {
+            behaviors.insert(OracleBehavior::DeliveredPayload);
+        }
+    }
+    behaviors
 }
 
 pub fn expected_behaviors(
@@ -1017,6 +1052,108 @@ mod tests {
 
         assert!(behaviors.contains(&OracleBehavior::BidirectionalDecryptabilityObserved));
         assert!(behaviors.contains(&OracleBehavior::DeliveredPayload));
+    }
+
+    #[test]
+    fn positive_payload_count_assert_covers_app_message() {
+        let spec = ScenarioSpec {
+            name: "payload-count-covers-app".into(),
+            spec_version: "2".into(),
+            topology: Default::default(),
+            clients: vec!["alice".into(), "carol".into()],
+            steps: vec![
+                ScenarioStep::SendAppMessage {
+                    sender: "alice".into(),
+                    payload: "eve-witness".into(),
+                },
+                ScenarioStep::Assert {
+                    assertion: crate::ScenarioAssertionV2::Exactly {
+                        predicate: crate::ScenarioPredicateV2::PayloadCount {
+                            client: "carol".into(),
+                            payload: "eve-witness".into(),
+                            count: 1,
+                        },
+                    },
+                },
+            ],
+        };
+        let report = build_scenario_oracle_report(&spec, None, &[], &trace(Vec::new()), &[]);
+        assert!(
+            report
+                .oracle_behaviors
+                .contains(&OracleBehavior::DeliveredPayload),
+            "{report:#?}"
+        );
+        assert!(
+            report.weak_oracle_warnings.is_empty(),
+            "{:#?}",
+            report.weak_oracle_warnings
+        );
+    }
+
+    #[test]
+    fn zero_payload_count_assert_does_not_cover_app_message() {
+        let spec = ScenarioSpec {
+            name: "payload-absent-does-not-cover-app".into(),
+            spec_version: "2".into(),
+            topology: Default::default(),
+            clients: vec!["alice".into(), "carol".into()],
+            steps: vec![
+                ScenarioStep::SendAppMessage {
+                    sender: "alice".into(),
+                    payload: "david-witness".into(),
+                },
+                ScenarioStep::Assert {
+                    assertion: crate::ScenarioAssertionV2::Exactly {
+                        predicate: crate::ScenarioPredicateV2::PayloadCount {
+                            client: "carol".into(),
+                            payload: "david-witness".into(),
+                            count: 0,
+                        },
+                    },
+                },
+            ],
+        };
+        let report = build_scenario_oracle_report(&spec, None, &[], &trace(Vec::new()), &[]);
+        assert!(
+            !report
+                .oracle_behaviors
+                .contains(&OracleBehavior::DeliveredPayload),
+            "{report:#?}"
+        );
+        assert!(
+            report
+                .weak_oracle_warnings
+                .iter()
+                .any(|warning| warning.stimulus == ScenarioStimulus::AppMessage),
+            "{:#?}",
+            report.weak_oracle_warnings
+        );
+    }
+
+    #[test]
+    fn app_witness_value_family_covers_app_message_under_strict_oracle() {
+        let generated = crate::generate_adversarial_reliability_case(7, 9);
+        assert!(
+            generated.scenario.name.contains("app-witness-value"),
+            "{}",
+            generated.scenario.name
+        );
+        let report = build_scenario_oracle_report(
+            &generated.scenario,
+            None,
+            &generated.expected_outcomes,
+            &trace(Vec::new()),
+            &[],
+        );
+        assert!(
+            report
+                .weak_oracle_warnings
+                .iter()
+                .all(|warning| warning.stimulus != ScenarioStimulus::AppMessage),
+            "{:#?}",
+            report.weak_oracle_warnings
+        );
     }
 
     #[test]

--- a/crates/cgka-conformance-simulator/src/oracle.rs
+++ b/crates/cgka-conformance-simulator/src/oracle.rs
@@ -4,8 +4,8 @@
 //! those inputs actually checked. This module keeps that second job explicit.
 
 use crate::{
-    QuiescenceObservation, ScenarioReport, ScenarioSpec, ScenarioStep, ScenarioTrace,
-    TraceExpectation, compare_trace_expectations,
+    QuiescenceObservation, ScenarioAssertionObservationV2, ScenarioReport, ScenarioSpec,
+    ScenarioStep, ScenarioTrace, TraceExpectation, compare_trace_expectations,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
@@ -138,6 +138,7 @@ pub fn build_scenario_oracle_report(
     expected_trace: Option<&ScenarioTrace>,
     expected_outcomes: &[TraceExpectation],
     observed_trace: &ScenarioTrace,
+    assertion_observations: &[ScenarioAssertionObservationV2],
     quiescence_observations: &[QuiescenceObservation],
 ) -> ScenarioOracleReport {
     let stimuli = scenario_stimuli(spec);
@@ -157,6 +158,12 @@ pub fn build_scenario_oracle_report(
     }
     oracle_behaviors.sort();
     let mut observed_behaviors = trace_behaviors(observed_trace);
+    for behavior in observed_assertion_behaviors(assertion_observations) {
+        if !observed_behaviors.contains(&behavior) {
+            observed_behaviors.push(behavior);
+        }
+    }
+    observed_behaviors.sort();
     if expected_outcomes.iter().any(|expectation| {
         matches!(expectation, TraceExpectation::ClientsNotEquivalent { .. })
             && compare_trace_expectations(None, std::slice::from_ref(expectation), observed_trace)
@@ -459,7 +466,8 @@ pub fn scenario_stimuli(spec: &ScenarioSpec) -> Vec<ScenarioStimulus> {
 
 /// Executable scenario assertions are oracle evidence. A positive payload-count
 /// check covers `AppMessage` without inventing a cross-sender `received_payloads`
-/// order, which MLS does not define.
+/// order, which MLS does not define. Declared asserts contribute expected
+/// coverage; only passing assertion observations count as observed evidence.
 fn assertion_behaviors(spec: &ScenarioSpec) -> BTreeSet<OracleBehavior> {
     let mut behaviors = BTreeSet::new();
     for step in &spec.steps {
@@ -470,21 +478,38 @@ fn assertion_behaviors(spec: &ScenarioSpec) -> BTreeSet<OracleBehavior> {
         let ScenarioStep::Assert { assertion } = step else {
             continue;
         };
-        let predicate = match assertion {
-            crate::ScenarioAssertionV2::Exactly { predicate }
-            | crate::ScenarioAssertionV2::Eventually { predicate, .. }
-            | crate::ScenarioAssertionV2::Within { predicate, .. } => predicate,
-            crate::ScenarioAssertionV2::Never { .. }
-            | crate::ScenarioAssertionV2::Resource { .. } => continue,
-        };
-        if matches!(
-            predicate,
-            crate::ScenarioPredicateV2::PayloadCount { count, .. } if *count > 0
-        ) {
+        if payload_count_covers_delivery(assertion) {
             behaviors.insert(OracleBehavior::DeliveredPayload);
         }
     }
     behaviors
+}
+
+fn observed_assertion_behaviors(
+    observations: &[ScenarioAssertionObservationV2],
+) -> BTreeSet<OracleBehavior> {
+    let mut behaviors = BTreeSet::new();
+    for observation in observations {
+        if observation.passed && payload_count_covers_delivery(&observation.assertion) {
+            behaviors.insert(OracleBehavior::DeliveredPayload);
+        }
+    }
+    behaviors
+}
+
+fn payload_count_covers_delivery(assertion: &crate::ScenarioAssertionV2) -> bool {
+    let predicate = match assertion {
+        crate::ScenarioAssertionV2::Exactly { predicate }
+        | crate::ScenarioAssertionV2::Eventually { predicate, .. }
+        | crate::ScenarioAssertionV2::Within { predicate, .. } => predicate,
+        crate::ScenarioAssertionV2::Never { .. } | crate::ScenarioAssertionV2::Resource { .. } => {
+            return false;
+        }
+    };
+    matches!(
+        predicate,
+        crate::ScenarioPredicateV2::PayloadCount { count, .. } if *count > 0
+    )
 }
 
 pub fn expected_behaviors(
@@ -984,6 +1009,7 @@ mod tests {
             std::slice::from_ref(&expectation),
             &trace(vec![david, eve]),
             &[],
+            &[],
         );
 
         assert!(
@@ -1026,6 +1052,7 @@ mod tests {
             std::slice::from_ref(&expectation),
             &trace(vec![alice, bob, david]),
             &[],
+            &[],
         );
 
         assert!(
@@ -1054,8 +1081,65 @@ mod tests {
         assert!(behaviors.contains(&OracleBehavior::DeliveredPayload));
     }
 
+    fn payload_count_assertion(
+        client: &str,
+        payload: &str,
+        count: usize,
+    ) -> crate::ScenarioAssertionV2 {
+        crate::ScenarioAssertionV2::Exactly {
+            predicate: crate::ScenarioPredicateV2::PayloadCount {
+                client: client.into(),
+                payload: payload.into(),
+                count,
+            },
+        }
+    }
+
+    fn payload_count_observation(
+        assertion: crate::ScenarioAssertionV2,
+        passed: bool,
+    ) -> crate::ScenarioAssertionObservationV2 {
+        crate::ScenarioAssertionObservationV2 {
+            step_index: 1,
+            assertion,
+            passed,
+            samples: 1,
+            elapsed_virtual_ms: 0,
+            final_actual: serde_json::json!(if passed { 1 } else { 0 }),
+        }
+    }
+
+    fn passing_payload_count_observations(
+        spec: &ScenarioSpec,
+    ) -> Vec<crate::ScenarioAssertionObservationV2> {
+        spec.steps
+            .iter()
+            .enumerate()
+            .filter_map(|(step_index, step)| {
+                let mut step = step;
+                while let ScenarioStep::InGroup { action, .. } = step {
+                    step = action.as_ref();
+                }
+                let ScenarioStep::Assert { assertion } = step else {
+                    return None;
+                };
+                payload_count_covers_delivery(assertion).then(|| {
+                    crate::ScenarioAssertionObservationV2 {
+                        step_index,
+                        assertion: assertion.clone(),
+                        passed: true,
+                        samples: 1,
+                        elapsed_virtual_ms: 0,
+                        final_actual: serde_json::json!(1),
+                    }
+                })
+            })
+            .collect()
+    }
+
     #[test]
     fn positive_payload_count_assert_covers_app_message() {
+        let assertion = payload_count_assertion("carol", "eve-witness", 1);
         let spec = ScenarioSpec {
             name: "payload-count-covers-app".into(),
             spec_version: "2".into(),
@@ -1067,23 +1151,60 @@ mod tests {
                     payload: "eve-witness".into(),
                 },
                 ScenarioStep::Assert {
-                    assertion: crate::ScenarioAssertionV2::Exactly {
-                        predicate: crate::ScenarioPredicateV2::PayloadCount {
-                            client: "carol".into(),
-                            payload: "eve-witness".into(),
-                            count: 1,
-                        },
-                    },
+                    assertion: assertion.clone(),
                 },
             ],
         };
-        let report = build_scenario_oracle_report(&spec, None, &[], &trace(Vec::new()), &[]);
+        let undeclared_execution =
+            build_scenario_oracle_report(&spec, None, &[], &trace(Vec::new()), &[], &[]);
+        assert!(
+            undeclared_execution
+                .oracle_behaviors
+                .contains(&OracleBehavior::DeliveredPayload),
+            "{undeclared_execution:#?}"
+        );
+        assert!(
+            undeclared_execution.weak_oracle_warnings.is_empty(),
+            "{:#?}",
+            undeclared_execution.weak_oracle_warnings
+        );
+        assert!(
+            undeclared_execution
+                .missing_observed_behaviors
+                .contains(&OracleBehavior::DeliveredPayload),
+            "a declared assert without a passing observation must remain missing: {undeclared_execution:#?}"
+        );
+
+        let failed = build_scenario_oracle_report(
+            &spec,
+            None,
+            &[],
+            &trace(Vec::new()),
+            &[payload_count_observation(assertion.clone(), false)],
+            &[],
+        );
+        assert!(
+            failed
+                .missing_observed_behaviors
+                .contains(&OracleBehavior::DeliveredPayload),
+            "a failed payload-count assert is not observed delivery: {failed:#?}"
+        );
+
+        let report = build_scenario_oracle_report(
+            &spec,
+            None,
+            &[],
+            &trace(Vec::new()),
+            &[payload_count_observation(assertion, true)],
+            &[],
+        );
         assert!(
             report
-                .oracle_behaviors
+                .observed_behaviors
                 .contains(&OracleBehavior::DeliveredPayload),
             "{report:#?}"
         );
+        assert!(report.missing_observed_behaviors.is_empty(), "{report:#?}");
         assert!(
             report.weak_oracle_warnings.is_empty(),
             "{:#?}",
@@ -1104,17 +1225,11 @@ mod tests {
                     payload: "david-witness".into(),
                 },
                 ScenarioStep::Assert {
-                    assertion: crate::ScenarioAssertionV2::Exactly {
-                        predicate: crate::ScenarioPredicateV2::PayloadCount {
-                            client: "carol".into(),
-                            payload: "david-witness".into(),
-                            count: 0,
-                        },
-                    },
+                    assertion: payload_count_assertion("carol", "david-witness", 0),
                 },
             ],
         };
-        let report = build_scenario_oracle_report(&spec, None, &[], &trace(Vec::new()), &[]);
+        let report = build_scenario_oracle_report(&spec, None, &[], &trace(Vec::new()), &[], &[]);
         assert!(
             !report
                 .oracle_behaviors
@@ -1139,11 +1254,17 @@ mod tests {
             "{}",
             generated.scenario.name
         );
+        let passing = passing_payload_count_observations(&generated.scenario);
+        assert!(
+            !passing.is_empty(),
+            "app-witness-value must declare positive payload-count asserts"
+        );
         let report = build_scenario_oracle_report(
             &generated.scenario,
             None,
             &generated.expected_outcomes,
             &trace(Vec::new()),
+            &passing,
             &[],
         );
         assert!(
@@ -1153,6 +1274,18 @@ mod tests {
                 .all(|warning| warning.stimulus != ScenarioStimulus::AppMessage),
             "{:#?}",
             report.weak_oracle_warnings
+        );
+        assert!(
+            report
+                .observed_behaviors
+                .contains(&OracleBehavior::DeliveredPayload),
+            "{report:#?}"
+        );
+        assert!(
+            !report
+                .missing_observed_behaviors
+                .contains(&OracleBehavior::DeliveredPayload),
+            "{report:#?}"
         );
     }
 

--- a/crates/cgka-conformance-simulator/src/process_orchestrator.rs
+++ b/crates/cgka-conformance-simulator/src/process_orchestrator.rs
@@ -582,19 +582,22 @@ impl ProcessOrchestrator {
                     status,
                 }),
                 Err((participant, error)) => {
-                    let capsule_path = self.write_failure_capsule(
-                        participant.as_deref().unwrap_or("orchestrator"),
-                        &action_id,
-                        &error,
-                    )?;
-                    report.failure_capsules.push(capsule_path);
                     report.actions.push(ProcessActionResultV1 {
-                        action_id,
+                        action_id: action_id.clone(),
                         action_type: action.schedule.action_type.clone(),
-                        participants: participant.into_iter().collect(),
+                        participants: participant.iter().cloned().collect(),
                         status: ProcessActionStatusV1::Failed,
                     });
                     report.lifecycle = self.lifecycle.clone();
+                    let Some(owner) = process_failure_capsule_participant(participant.as_deref())
+                    else {
+                        return Err(ProcessOrchestratorError::new(
+                            error.code,
+                            format!("{} (action {action_id})", error.message),
+                        ));
+                    };
+                    let capsule_path = self.write_failure_capsule(owner, &action_id, &error)?;
+                    report.failure_capsules.push(capsule_path);
                     return Ok(report);
                 }
             }
@@ -1956,6 +1959,13 @@ fn action_participant(step: &ScenarioStep) -> Option<String> {
     }
 }
 
+/// App-process capsules are participant-attributed node evidence. Quiescence
+/// timeouts and relay waits belong to the orchestrator and must not be recorded
+/// as if a named process produced them.
+fn process_failure_capsule_participant(participant: Option<&str>) -> Option<&str> {
+    participant.filter(|label| !label.is_empty())
+}
+
 fn validate_auto_published_acknowledgement(
     accepted_publications: &BTreeMap<String, BTreeSet<String>>,
     client: &str,
@@ -2110,6 +2120,16 @@ mod tests {
         .unwrap_err();
         assert_eq!(rollback.code, "publication_rollback_rejected");
         assert_eq!(rollback.category, SubjectFailureCategory::ExpectedRefusal);
+    }
+
+    #[test]
+    fn orchestrator_level_failures_do_not_own_app_process_capsules() {
+        assert_eq!(process_failure_capsule_participant(None), None);
+        assert_eq!(
+            process_failure_capsule_participant(Some("alice")),
+            Some("alice")
+        );
+        assert_eq!(process_failure_capsule_participant(Some("")), None);
     }
 
     #[test]

--- a/crates/cgka-conformance-simulator/src/scenario.rs
+++ b/crates/cgka-conformance-simulator/src/scenario.rs
@@ -1385,6 +1385,7 @@ async fn run_scenario_report_inner(
         expected_trace.as_ref(),
         &expected_outcomes,
         &observed_trace,
+        &assertion_observations,
         &quiescence_observations,
     );
 

--- a/crates/cgka-conformance-simulator/tests/process_orchestrator.rs
+++ b/crates/cgka-conformance-simulator/tests/process_orchestrator.rs
@@ -3,7 +3,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use cgka_conformance_simulator::process_orchestrator::{
-    ProcessNodeLaunchV1, ProcessOrchestrator, ProcessScenarioReportV1,
+    ProcessActionStatusV1, ProcessNodeLaunchV1, ProcessOrchestrator, ProcessScenarioReportV1,
 };
 use cgka_conformance_simulator::{
     AppRuntimeHarness, AppRuntimeObservationV1, GeneratedScenarioCase, GeneratedScenarioInputV1,
@@ -94,10 +94,7 @@ fn process_scenario(name: &str, lifecycle: bool) -> ScenarioSpec {
             },
         ),
         ScenarioStep::AwaitQuiescence {
-            policy: cgka_conformance_simulator::QuiescencePolicy {
-                max_iterations: 100,
-                ..Default::default()
-            },
+            policy: Default::default(),
         },
         in_group(
             "main",
@@ -1157,9 +1154,21 @@ async fn process_failures_write_replayable_privacy_safe_capsules() {
     )
     .await
     .unwrap();
-    let report = orchestrator.run().await.unwrap();
-    assert!(!report.completed);
-    assert_eq!(report.failure_capsules.len(), 1);
+    let report = orchestrator.run().await.unwrap_or_else(|error| {
+        panic!("orchestrator-level failure before the expected process capsule: {error}");
+    });
+    let failed = report
+        .actions
+        .iter()
+        .find(|action| action.status == ProcessActionStatusV1::Failed)
+        .unwrap_or_else(|| panic!("process report has no failed action: {report:#?}"));
+    assert_eq!(
+        failed.action_type, "expect_update_admin_policy_error",
+        "failed action {} ({}) was not the expected process refusal: {report:#?}",
+        failed.action_id, failed.action_type
+    );
+    assert!(!report.completed, "{report:#?}");
+    assert_eq!(report.failure_capsules.len(), 1, "{report:#?}");
     let capsule_path = &report.failure_capsules[0];
     #[cfg(unix)]
     {
@@ -1177,13 +1186,20 @@ async fn process_failures_write_replayable_privacy_safe_capsules() {
     assert!(!encoded.contains(marker));
     let capsule: cgka_conformance_simulator::node_protocol::NodeFailureCapsuleV1 =
         serde_json::from_str(&encoded).unwrap();
-    assert_eq!(capsule.participant, "alice");
+    assert_eq!(
+        capsule.participant, "alice",
+        "action_id={} code={}",
+        capsule.action_id, capsule.code
+    );
     assert!(
         capsule
             .action_id
-            .contains("expect_update_admin_policy_error")
+            .contains("expect_update_admin_policy_error"),
+        "action_id={} code={}",
+        capsule.action_id,
+        capsule.code
     );
-    assert_eq!(capsule.layer, "app_process");
+    assert_eq!(capsule.layer, "app_process", "code={}", capsule.code);
     assert!(!capsule.replay.steps.is_empty());
     assert!(!capsule.sensitive_data_included);
     orchestrator.shutdown().await;
@@ -1341,7 +1357,24 @@ fn process_cli_failure_report_keeps_capsules_after_exit() {
     assert!(!output.status.success());
     let report: cgka_conformance_simulator::process_orchestrator::ProcessScenarioReportV1 =
         serde_json::from_slice(&std::fs::read(report_path).unwrap()).unwrap();
-    assert!(!report.completed);
-    assert_eq!(report.failure_capsules.len(), 1);
+    assert!(!report.completed, "{report:#?}");
+    let failed = report
+        .actions
+        .iter()
+        .find(|action| action.status == ProcessActionStatusV1::Failed)
+        .unwrap_or_else(|| panic!("process report has no failed action: {report:#?}"));
+    assert_eq!(
+        failed.action_type, "expect_update_admin_policy_error",
+        "failed action {} ({}) was not the expected process refusal: {report:#?}",
+        failed.action_id, failed.action_type
+    );
+    assert_eq!(report.failure_capsules.len(), 1, "{report:#?}");
     assert!(report.failure_capsules[0].is_file());
+    let capsule: cgka_conformance_simulator::node_protocol::NodeFailureCapsuleV1 =
+        serde_json::from_slice(&std::fs::read(&report.failure_capsules[0]).unwrap()).unwrap();
+    assert_eq!(
+        capsule.participant, "alice",
+        "action_id={} code={}",
+        capsule.action_id, capsule.code
+    );
 }


### PR DESCRIPTION
## Summary
- Process-layer failure capsules are now participant-attributed only. Quiescence timeouts and relay waits return an orchestrator error instead of an `app_process` capsule owned by `"orchestrator"`, which is what made `process_failures_write_replayable_privacy_safe_capsules` fail on nightly.
- Capsule tests now require the failed action to be `expect_update_admin_policy_error` and print `action_id` / error code. Process scenarios use the default quiescence watchdog (256 iterations) instead of a tighter 100-iteration budget.
- Positive `PayloadCount` asserts count as `DeliveredPayload` oracle evidence, so `adversarial-reliability/app-witness-value` no longer fails `--strict-oracle` for missing AppMessage coverage.

Fixes #1450

## Test plan
- [x] New oracle tests failed before the `PayloadCount` coverage change and pass after
- [x] `process_failures_write_replayable_privacy_safe_capsules` and `process_cli_failure_report_keeps_capsules_after_exit` pass
- [x] `orchestrator_level_failures_do_not_own_app_process_capsules` pins participant-less capsule attribution
- [ ] Nightly capture of `adversarial-reliability/v1 --seed 7 --cases 12 --strict-oracle` no longer fails case-9


Made with [Cursor](https://cursor.com)