### PR TITLE
Operationalize release convergence evidence

### DIFF
--- a/.github/workflows/convergence-hardening.yml
+++ b/.github/workflows/convergence-hardening.yml
@@ -13,8 +13,8 @@ on:
         options:
           - weekly_manual
           - release_hardening
-      distributed_manifest:
-        description: Release manifest; output_dir must not nest under retained lane roots
+      baseline_revision:
+        description: Exact 40-character ancestor commit used for mixed-build release hardening
         required: false
         type: string
 
@@ -30,6 +30,7 @@ env:
   CARGO_INCREMENTAL: "0"
   CARGO_PROFILE_TEST_DEBUG: "0"
   CGKA_LANE_EVIDENCE_DIR: ${{ github.workspace }}/target/cgka-hardening-lane-evidence
+  DISTRIBUTED_MANIFEST: ${{ github.workspace }}/target/cgka-hardening-lane-evidence/release-inputs/distributed-manifest.v1.json
 
 jobs:
   hardening:
@@ -43,6 +44,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Install Rust toolchain
@@ -81,6 +83,62 @@ jobs:
             --output "$CGKA_LANE_EVIDENCE_DIR/steps/distributed-image-build.json" \
             -- docker build -f Dockerfile.convergence-campaign -t marmot-conformance:local .
 
+      - name: Require an exact release baseline revision
+        if: github.event_name == 'workflow_dispatch' && inputs.lane == 'release_hardening'
+        env:
+          BASELINE_REVISION: ${{ inputs.baseline_revision }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$BASELINE_REVISION" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "baseline_revision must be an exact lowercase 40-character commit" >&2
+            exit 1
+          fi
+          test "$BASELINE_REVISION" != "$GITHUB_SHA"
+          git cat-file -e "$BASELINE_REVISION^{commit}"
+          git merge-base --is-ancestor "$BASELINE_REVISION" "$GITHUB_SHA"
+
+      - name: Check out exact release baseline
+        if: github.event_name == 'workflow_dispatch' && inputs.lane == 'release_hardening'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 1
+          path: baseline-source
+          persist-credentials: false
+          ref: ${{ inputs.baseline_revision }}
+
+      - name: Build baseline distributed campaign image
+        if: github.event_name == 'workflow_dispatch' && inputs.lane == 'release_hardening'
+        env:
+          BASELINE_REVISION: ${{ inputs.baseline_revision }}
+        run: |
+          set -euo pipefail
+          test "$(git -C baseline-source rev-parse HEAD)" = "$BASELINE_REVISION"
+          cargo run -p convergence-campaign-runner --bin cgka-distributed-campaign --locked -- \
+            observe-step \
+            --name baseline-image-build \
+            --output "$CGKA_LANE_EVIDENCE_DIR/steps/baseline-image-build.json" \
+            -- docker build \
+              -f baseline-source/Dockerfile.convergence-campaign \
+              -t marmot-conformance:baseline \
+              baseline-source
+
+      - name: Materialize reviewed mixed-build release campaign
+        if: github.event_name == 'workflow_dispatch' && inputs.lane == 'release_hardening'
+        env:
+          BASELINE_REVISION: ${{ inputs.baseline_revision }}
+        run: |
+          set -euo pipefail
+          current_image="$(docker image inspect --format '{{.Id}}' marmot-conformance:local)"
+          baseline_image="$(docker image inspect --format '{{.Id}}' marmot-conformance:baseline)"
+          release_input_dir="$CGKA_LANE_EVIDENCE_DIR/release-inputs"
+          cargo run -p convergence-campaign-runner --bin cgka-distributed-campaign --locked -- \
+            materialize-release-campaign \
+            --output-dir "$release_input_dir" \
+            --current-revision "$GITHUB_SHA" \
+            --current-image "$current_image" \
+            --baseline-revision "$BASELINE_REVISION" \
+            --baseline-image "$baseline_image"
+
       - name: Run weekly/manual lane
         if: github.event_name == 'schedule' || inputs.lane == 'weekly_manual'
         run: |
@@ -103,18 +161,8 @@ jobs:
             -- cargo nextest run -p convergence-campaign-runner --test container_runtime --locked \
               --run-ignored ignored-only --no-tests fail
 
-      - name: Require a release manifest
-        if: github.event_name == 'workflow_dispatch' && inputs.lane == 'release_hardening'
-        env:
-          DISTRIBUTED_MANIFEST: ${{ inputs.distributed_manifest }}
-        run: |
-          test -n "$DISTRIBUTED_MANIFEST"
-          test -f "$DISTRIBUTED_MANIFEST"
-
       - name: Run release-hardening lane
         if: github.event_name == 'workflow_dispatch' && inputs.lane == 'release_hardening'
-        env:
-          DISTRIBUTED_MANIFEST: ${{ inputs.distributed_manifest }}
         run: |
           cargo run -p convergence-campaign-runner --bin cgka-distributed-campaign --locked -- \
             observe-step \
@@ -143,16 +191,18 @@ jobs:
 
       - name: Collect release-hardening lane observation
         if: always() && github.event_name == 'workflow_dispatch' && inputs.lane == 'release_hardening'
-        env:
-          DISTRIBUTED_MANIFEST: ${{ inputs.distributed_manifest }}
         run: |
+          manifest_args=()
+          if [[ -f "$DISTRIBUTED_MANIFEST" ]]; then
+            manifest_args=(--campaign-manifest "$DISTRIBUTED_MANIFEST")
+          fi
           cargo run -p convergence-campaign-runner --bin cgka-distributed-campaign --locked -- \
             collect-observation \
             --step-dir "$CGKA_LANE_EVIDENCE_DIR/steps" \
             --artifact-root target/cgka-weekly-reliability \
             --artifact-root target/cgka-adversarial-reliability-ci \
             --artifact-root target/cgka-distributed-container-evidence \
-            --campaign-manifest "$DISTRIBUTED_MANIFEST" \
+            "${manifest_args[@]}" \
             --disk-root target \
             --output "$CGKA_LANE_EVIDENCE_DIR/observed-usage.v1.json"
 
@@ -162,6 +212,22 @@ jobs:
           cargo run -p convergence-campaign-runner --bin cgka-distributed-campaign --locked -- \
             check-budget release_hardening "$CGKA_LANE_EVIDENCE_DIR/observed-usage.v1.json" \
             --output "$CGKA_LANE_EVIDENCE_DIR/budget-evaluation.v1.json"
+
+      - name: Assemble and verify release-hardening evidence bundle
+        if: success() && github.event_name == 'workflow_dispatch' && inputs.lane == 'release_hardening'
+        run: |
+          bundle="$CGKA_LANE_EVIDENCE_DIR/release-bundle/convergence-evidence.v1.json"
+          cargo run -p convergence-campaign-runner --bin cgka-distributed-campaign --locked -- \
+            assemble-release-evidence \
+            --claim crates/convergence-campaign-runner/release-claims/cross-route-mixed-build.v1.json \
+            --source-revision "$GITHUB_SHA" \
+            --manifest "$DISTRIBUTED_MANIFEST" \
+            --observation "$CGKA_LANE_EVIDENCE_DIR/observed-usage.v1.json" \
+            --budget "$CGKA_LANE_EVIDENCE_DIR/budget-evaluation.v1.json" \
+            --step-dir "$CGKA_LANE_EVIDENCE_DIR/steps" \
+            --output "$bundle"
+          cargo run -p convergence-campaign-runner --bin cgka-distributed-campaign --locked -- \
+            check-evidence "$bundle"
 
       - name: Upload convergence evidence inputs
         if: always()

--- a/crates/convergence-campaign-runner/README.md
+++ b/crates/convergence-campaign-runner/README.md
@@ -62,6 +62,21 @@ Release manifests must keep `output_dir` disjoint from the retained weekly,
 adversarial, and distributed-container artifact roots; nested roots are rejected
 to prevent double-counting.
 
+Release hardening takes an exact lowercase 40-character ancestor commit rather
+than an operator-authored mutable image tag. The workflow builds the current and
+ancestor campaign images from their exact source trees, resolves both to local
+`sha256:<image-id>` references, and uses `materialize-release-campaign` to write
+the shared four-party cross-route scenario plus its mixed-build manifest.
+`assemble-release-evidence` then joins the reviewed claim under
+`release-claims/` to the completed normalized manifest, successful command
+receipt, strict public process oracle, lane observation, budget evaluation, and
+required step records. It copies privacy-safe inputs into one owner-only bundle
+tree and writes a validation record containing only the canonical scenario and
+raw process-report digests—not their payload-bearing bytes. `check-evidence`
+then verifies every bundled SHA-256 digest. A generated bundle is evidence for
+its exact source and baseline revisions only; it is not a universal
+convergence claim.
+
 Failed distributed executions append a privacy-safe entry to the private
 `failure-corpus.v1.json` in the campaign output directory. `index-capsule` and
 `index-node-capsule` add simulator or process failures, `classify-failure`

--- a/crates/convergence-campaign-runner/release-claims/cross-route-mixed-build.v1.json
+++ b/crates/convergence-campaign-runner/release-claims/cross-route-mixed-build.v1.json
@@ -1,0 +1,84 @@
+{
+  "schema_version": "1",
+  "lane": "release_hardening",
+  "campaign_id": "cross-route-mixed-build-v1",
+  "scenario_name": "cross-route-app-runtime-recovery/v1",
+  "canonical_ir_sha256": "1d416034df130ffeb7490c29c5ef9620ed0dce5a53aaf62bc00a2db74104dcc6",
+  "assurance_claim": "At the recorded source revision, the exact four-party canonical cross-route scenario completed through a mixed-build container run using the source revision and one exact ancestor build; the validated public process report reached one stable protocol and application projection, and the complete scheduled lane stayed within its reviewed resource and flake budgets.",
+  "covered_decision_routes": [
+    "ordinary_ingest",
+    "stored_convergence",
+    "retained_history_replay",
+    "crash_restart_recovery"
+  ],
+  "models": [
+    "canonical_scenario_ir_v2",
+    "cross_route_public_projection_oracle_v1",
+    "independent_reference_model",
+    "lifecycle_model"
+  ],
+  "adapters": [
+    "marmot_app_process",
+    "container_runner",
+    "retained_relay_control"
+  ],
+  "mutation_results": {
+    "app_witness_admission_removal": true,
+    "cutoff_boundary_admission": true,
+    "frozen_member_persistence": true,
+    "group_profile_projection": true,
+    "output_invalidation": true,
+    "provisional_winner_terminalization": true,
+    "publication_acknowledgement": true,
+    "retained_history_expiration_boundary": true,
+    "scheduler_deadline_rearm": true,
+    "selector_comparison_order": true,
+    "witness_sender_epoch_deduplication": true
+  },
+  "tested_boundaries": [
+    {
+      "dimension": "participants",
+      "minimum": "4",
+      "maximum": "4"
+    },
+    {
+      "dimension": "source_revisions",
+      "minimum": "2",
+      "maximum": "2"
+    },
+    {
+      "dimension": "content_addressed_participant_images",
+      "minimum": "2",
+      "maximum": "2"
+    },
+    {
+      "dimension": "retained_relay_topologies",
+      "minimum": "1",
+      "maximum": "1"
+    },
+    {
+      "dimension": "participant_restarts",
+      "minimum": "1",
+      "maximum": "1"
+    },
+    {
+      "dimension": "terminal_application_probes",
+      "minimum": "4",
+      "maximum": "4"
+    }
+  ],
+  "unresolved_counterexamples": [],
+  "residual_assumptions": [
+    "The selected ancestor build implements the same versioned node control and canonical Scenario IR contracts; incompatibility fails the run rather than being translated.",
+    "The source revision's mandatory pull-request formal gate is trusted by revision identity and is not rerun by the release-hardening workflow.",
+    "Mutation results are inherited from the exact release-hardening lane dependency and its successful observed step; this bundle does not retain a separate per-mutant transcript.",
+    "Eventual access to the complete runner-owned retained relay history is provided by the campaign topology."
+  ],
+  "untested_surfaces": [
+    "Exact MLS exporter-state equality through public process and container adapters.",
+    "Engine-private input dispositions unavailable through the public process protocol.",
+    "Restart permutations around every durable convergence transition.",
+    "VM-only kernel, filesystem, block-device latency, and host-isolation behavior.",
+    "Unbounded executions and incident-derived production corpora."
+  ]
+}

--- a/crates/convergence-campaign-runner/src/lib.rs
+++ b/crates/convergence-campaign-runner/src/lib.rs
@@ -12,6 +12,7 @@ pub mod lane_observation;
 pub mod manifest;
 pub mod plan;
 mod relay_file_control;
+pub mod release_evidence;
 pub mod runner;
 
 pub use evidence::*;
@@ -21,6 +22,7 @@ pub use lane_observation::*;
 pub use manifest::*;
 pub use plan::*;
 pub use relay_file_control::*;
+pub use release_evidence::*;
 pub use runner::*;
 
 /// Runner-owned DNS alias attached only to the campaign relay container.

--- a/crates/convergence-campaign-runner/src/main.rs
+++ b/crates/convergence-campaign-runner/src/main.rs
@@ -7,8 +7,9 @@ use clap::{Parser, Subcommand};
 use convergence_campaign_runner::{
     CampaignAdapterV1, CampaignLaneConfigV1, CampaignLaneObservationV1, CampaignLaneV1,
     ConvergenceEvidenceBundleV1, DistributedBackendV1, FailureClassificationV1,
-    INFRASTRUCTURE_COMMAND_TIMEOUT, build_execution_plan, collect_lane_observation,
-    evidence_bundle_base_dir, load_manifest, observation_from_capsule, observe_lane_step,
+    INFRASTRUCTURE_COMMAND_TIMEOUT, assemble_release_evidence, build_execution_plan,
+    collect_lane_observation, evidence_bundle_base_dir, load_manifest,
+    materialize_release_campaign, observation_from_capsule, observe_lane_step,
     promote_capsule_into_corpus, run_manifest, update_failure_corpus, validate_scenario_bytes,
     verify_manifest_inputs, write_lane_observation_private,
 };
@@ -42,6 +43,19 @@ enum Commands {
     Doctor { manifest: PathBuf },
     /// Execute the campaign and write owner-only reports under output_dir.
     Run { manifest: PathBuf },
+    /// Write the shared mixed-build release scenario and manifest privately.
+    MaterializeReleaseCampaign {
+        #[arg(long)]
+        output_dir: PathBuf,
+        #[arg(long)]
+        current_revision: String,
+        #[arg(long)]
+        current_image: String,
+        #[arg(long)]
+        baseline_revision: String,
+        #[arg(long)]
+        baseline_image: String,
+    },
     /// Print or privately write the reviewed policy for an execution lane.
     Lane {
         lane: CampaignLaneV1,
@@ -79,6 +93,23 @@ enum Commands {
     },
     /// Validate that an evidence bundle contains every required assurance section.
     CheckEvidence { bundle: PathBuf },
+    /// Assemble a completed mixed-build run into a byte-verified evidence bundle.
+    AssembleReleaseEvidence {
+        #[arg(long)]
+        claim: PathBuf,
+        #[arg(long)]
+        source_revision: String,
+        #[arg(long)]
+        manifest: PathBuf,
+        #[arg(long)]
+        observation: PathBuf,
+        #[arg(long)]
+        budget: PathBuf,
+        #[arg(long)]
+        step_dir: PathBuf,
+        #[arg(long)]
+        output: PathBuf,
+    },
     /// Add an automatically written simulator capsule to the durable failure corpus.
     IndexCapsule {
         corpus: PathBuf,
@@ -191,6 +222,22 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
             }
             println!("completed {}", receipt.campaign_id);
         }
+        Commands::MaterializeReleaseCampaign {
+            output_dir,
+            current_revision,
+            current_image,
+            baseline_revision,
+            baseline_image,
+        } => {
+            let manifest = materialize_release_campaign(
+                &output_dir,
+                &current_revision,
+                &current_image,
+                &baseline_revision,
+                &baseline_image,
+            )?;
+            println!("release-manifest {}", manifest.display());
+        }
         Commands::Lane { lane, output } => {
             let config = CampaignLaneConfigV1::builtin(lane);
             let bytes = serde_json::to_vec_pretty(&config)?;
@@ -261,6 +308,30 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
                 serde_json::from_slice(&std::fs::read(&bundle_path)?)?;
             bundle.validate_artifacts(base_dir)?;
             println!("valid-evidence {}", bundle.source_revision);
+        }
+        Commands::AssembleReleaseEvidence {
+            claim,
+            source_revision,
+            manifest,
+            observation,
+            budget,
+            step_dir,
+            output,
+        } => {
+            let bundle = assemble_release_evidence(
+                &claim,
+                &source_revision,
+                &manifest,
+                &observation,
+                &budget,
+                &step_dir,
+                &output,
+            )?;
+            println!(
+                "release-evidence {} {}",
+                bundle.source_revision,
+                output.display()
+            );
         }
         Commands::IndexCapsule {
             corpus,

--- a/crates/convergence-campaign-runner/src/manifest.rs
+++ b/crates/convergence-campaign-runner/src/manifest.rs
@@ -56,7 +56,8 @@ pub struct ContainerBackendV1 {
     /// Safe, operator-selected namespace for the runtime network and relay.
     pub namespace: String,
     /// Local development may opt out explicitly; hardened campaigns require
-    /// every image reference to carry an immutable sha256 manifest digest.
+    /// every image reference to carry an immutable sha256 manifest digest or
+    /// an exact local content-addressed image id.
     #[serde(default)]
     pub allow_mutable_image_references: bool,
     /// Explicit operator approval for the campaign-only cleartext hop from a
@@ -319,7 +320,7 @@ impl DistributedCampaignManifestV1 {
                 {
                     return Err(RunnerError::validation(
                         "mutable_container_image",
-                        "container images must use NAME@sha256:DIGEST unless the manifest explicitly enables mutable local references",
+                        "container images must use NAME@sha256:DIGEST or sha256:IMAGE_ID unless the manifest explicitly enables mutable local references",
                     ));
                 }
                 if self
@@ -557,6 +558,9 @@ fn validate_container_namespace(value: &str) -> Result<(), RunnerError> {
 }
 
 fn is_digest_pinned_image(image: &str) -> bool {
+    if let Some(digest) = image.strip_prefix("sha256:") {
+        return digest.len() == 64 && digest.bytes().all(|byte| byte.is_ascii_hexdigit());
+    }
     let Some((name, digest)) = image.rsplit_once("@sha256:") else {
         return false;
     };

--- a/crates/convergence-campaign-runner/src/release_evidence.rs
+++ b/crates/convergence-campaign-runner/src/release_evidence.rs
@@ -1,0 +1,825 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::OpenOptions;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+use cgka_conformance_simulator::process_orchestrator::ProcessScenarioReportV1;
+use cgka_conformance_simulator::{
+    canonical_scenario_ir_sha256, cross_route_app_runtime_recovery_public_scenario,
+    resolve_scenario_input_bytes, validate_cross_route_public_process_report,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::{
+    CampaignBudgetEvaluationV1, CampaignLaneConfigV1, CampaignLaneObservationV1,
+    CampaignLaneStepObservationV1, CampaignLaneV1, ContainerBackendV1, ConvergenceEvidenceBundleV1,
+    DistributedBackendV1, DistributedCampaignManifestV1, DistributedParticipantV1,
+    DistributedRunReceiptV1, EvidenceArtifactV1, OciRuntimeV1, RunnerError, ScenarioArtifactV1,
+    TestedBoundaryV1, load_manifest, verify_manifest_inputs,
+};
+
+/// Version of the human-reviewed claim document consumed by release evidence assembly.
+pub const CONVERGENCE_EVIDENCE_CLAIM_VERSION: &str = "1";
+
+const RELEASE_CAMPAIGN_ID: &str = "cross-route-mixed-build-v1";
+const RELEASE_SCENARIO_FILE: &str = "canonical-scenario.json";
+const RELEASE_MANIFEST_FILE: &str = "distributed-manifest.v1.json";
+const RELEASE_OUTPUT_DIR: &str = "campaign-output";
+const REQUIRED_RELEASE_STEPS: &[&str] = &[
+    "distributed-image-build",
+    "baseline-image-build",
+    "release-hardening-core",
+];
+
+/// Reviewable assurance language and declared coverage, separate from runtime evidence.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConvergenceEvidenceClaimV1 {
+    pub schema_version: String,
+    pub lane: CampaignLaneV1,
+    pub campaign_id: String,
+    pub scenario_name: String,
+    pub canonical_ir_sha256: String,
+    pub assurance_claim: String,
+    pub covered_decision_routes: Vec<String>,
+    pub models: Vec<String>,
+    pub adapters: Vec<String>,
+    pub mutation_results: BTreeMap<String, bool>,
+    pub tested_boundaries: Vec<TestedBoundaryV1>,
+    #[serde(default)]
+    pub unresolved_counterexamples: Vec<String>,
+    pub residual_assumptions: Vec<String>,
+    pub untested_surfaces: Vec<String>,
+}
+
+/// Privacy-safe result of validating raw scenario and process evidence before bundling.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReleaseEvidenceVerificationV1 {
+    pub schema_version: String,
+    pub campaign_id: String,
+    pub scenario_name: String,
+    pub canonical_ir_sha256: String,
+    pub source_revision: String,
+    pub participant_build_ids: Vec<String>,
+    pub participant_image_ids: Vec<String>,
+    pub selected_scenario_bytes_sha256: String,
+    pub process_report_sha256: String,
+    pub public_process_oracle_passed: bool,
+}
+
+impl ConvergenceEvidenceClaimV1 {
+    /// Validate that the claim is scoped, complete, and pinned to one canonical scenario.
+    pub fn validate(&self) -> Result<(), RunnerError> {
+        if self.schema_version != CONVERGENCE_EVIDENCE_CLAIM_VERSION {
+            return Err(RunnerError::validation(
+                "evidence_claim_version",
+                "unsupported convergence evidence claim version",
+            ));
+        }
+        if self.lane != CampaignLaneV1::ReleaseHardening {
+            return Err(RunnerError::validation(
+                "evidence_claim_lane",
+                "release evidence claims must select the release_hardening lane",
+            ));
+        }
+        for (name, empty) in [
+            ("campaign_id", self.campaign_id.is_empty()),
+            ("scenario_name", self.scenario_name.is_empty()),
+            ("assurance_claim", self.assurance_claim.is_empty()),
+            (
+                "covered_decision_routes",
+                self.covered_decision_routes.is_empty(),
+            ),
+            ("models", self.models.is_empty()),
+            ("adapters", self.adapters.is_empty()),
+            ("mutation_results", self.mutation_results.is_empty()),
+            ("tested_boundaries", self.tested_boundaries.is_empty()),
+            ("residual_assumptions", self.residual_assumptions.is_empty()),
+            ("untested_surfaces", self.untested_surfaces.is_empty()),
+        ] {
+            if empty {
+                return Err(RunnerError::validation(
+                    "incomplete_evidence_claim",
+                    format!("evidence claim is missing {name}"),
+                ));
+            }
+        }
+        validate_lower_hex_digest("claim canonical IR", &self.canonical_ir_sha256)
+    }
+}
+
+/// Materialize the shared four-party route scenario and a mixed-image container manifest.
+///
+/// Both source revisions must be exact lowercase Git object ids and both images must be
+/// distinct local content-addressed image ids (`sha256:<64 lowercase hex>`).
+pub fn materialize_release_campaign(
+    output_root: &Path,
+    current_revision: &str,
+    current_image: &str,
+    baseline_revision: &str,
+    baseline_image: &str,
+) -> Result<PathBuf, RunnerError> {
+    validate_source_revision(current_revision)?;
+    validate_source_revision(baseline_revision)?;
+    validate_local_image_id(current_image)?;
+    validate_local_image_id(baseline_image)?;
+    if current_revision == baseline_revision {
+        return Err(RunnerError::validation(
+            "release_build_revisions",
+            "release hardening requires two distinct source revisions",
+        ));
+    }
+    if current_image == baseline_image {
+        return Err(RunnerError::validation(
+            "release_build_images",
+            "release hardening requires two distinct content-addressed images",
+        ));
+    }
+    if output_root.exists() {
+        return Err(RunnerError::validation(
+            "release_input_exists",
+            "release campaign input directory must not already exist",
+        ));
+    }
+
+    fs_private::create_dir_all_private(output_root)
+        .map_err(|error| RunnerError::environment("release_input_directory", error))?;
+    let scenario = cross_route_app_runtime_recovery_public_scenario();
+    let scenario_bytes = serde_json::to_vec_pretty(&scenario)
+        .map_err(|error| RunnerError::environment("release_scenario_serialize", error))?;
+    let scenario_path = output_root.join(RELEASE_SCENARIO_FILE);
+    fs_private::write_private(&scenario_path, &scenario_bytes)
+        .map_err(|error| RunnerError::environment("release_scenario_write", error))?;
+    let canonical_ir_sha256 = canonical_scenario_ir_sha256(&scenario)
+        .map_err(|error| RunnerError::validation("release_scenario_digest", error.to_string()))?;
+
+    let participants = scenario
+        .clients
+        .iter()
+        .enumerate()
+        .map(|(index, id)| {
+            let (build_id, image) = if index % 2 == 0 {
+                (current_revision, current_image)
+            } else {
+                (baseline_revision, baseline_image)
+            };
+            DistributedParticipantV1 {
+                id: id.clone(),
+                build_id: build_id.into(),
+                container_image: Some(image.into()),
+            }
+        })
+        .collect();
+    let manifest = DistributedCampaignManifestV1 {
+        schema_version: "1".into(),
+        campaign_id: RELEASE_CAMPAIGN_ID.into(),
+        scenario: ScenarioArtifactV1 {
+            path: scenario_path,
+            sha256: hex::encode(Sha256::digest(&scenario_bytes)),
+            canonical_ir_sha256: Some(canonical_ir_sha256),
+        },
+        participants,
+        backend: DistributedBackendV1::Container(ContainerBackendV1 {
+            runtime: OciRuntimeV1::Docker,
+            namespace: "marmot-release-cross-route".into(),
+            allow_mutable_image_references: false,
+            allow_cleartext_isolated_relay: true,
+            enable_retained_relay_control: true,
+            default_participant_image: current_image.into(),
+            relay_image: current_image.into(),
+            relay_command: vec![
+                "cgka-conformance-relay".into(),
+                "--bind".into(),
+                "0.0.0.0:8080".into(),
+            ],
+            node_command: vec!["cgka-conformance-node".into()],
+        }),
+        faults: Vec::new(),
+        output_dir: output_root.join(RELEASE_OUTPUT_DIR),
+    };
+    manifest.validate_mixed_builds()?;
+    let manifest_path = output_root.join(RELEASE_MANIFEST_FILE);
+    let manifest_bytes = serde_json::to_vec_pretty(&manifest)
+        .map_err(|error| RunnerError::environment("release_manifest_serialize", error))?;
+    fs_private::write_private(&manifest_path, &manifest_bytes)
+        .map_err(|error| RunnerError::environment("release_manifest_write", error))?;
+    Ok(manifest_path)
+}
+
+/// Validate one completed mixed-build release run and assemble a byte-pinned bundle.
+pub fn assemble_release_evidence(
+    claim_path: &Path,
+    source_revision: &str,
+    manifest_path: &Path,
+    observation_path: &Path,
+    budget_path: &Path,
+    step_dir: &Path,
+    output_path: &Path,
+) -> Result<ConvergenceEvidenceBundleV1, RunnerError> {
+    validate_source_revision(source_revision)?;
+    if output_path.exists() {
+        return Err(RunnerError::validation(
+            "evidence_output_exists",
+            "release evidence output must not already exist",
+        ));
+    }
+
+    let claim: ConvergenceEvidenceClaimV1 = read_json(claim_path, "evidence_claim")?;
+    claim.validate()?;
+    let manifest = load_manifest(manifest_path)?;
+    manifest.validate_mixed_builds()?;
+    if manifest.campaign_id != claim.campaign_id {
+        return Err(RunnerError::validation(
+            "evidence_campaign_identity",
+            "claim and distributed manifest campaign ids differ",
+        ));
+    }
+    let build_ids = manifest
+        .participants
+        .iter()
+        .map(|participant| participant.build_id.as_str())
+        .collect::<BTreeSet<_>>();
+    if !build_ids.contains(source_revision) {
+        return Err(RunnerError::validation(
+            "evidence_source_revision",
+            "source revision is not one of the executed participant builds",
+        ));
+    }
+
+    let scenario_bytes = verify_manifest_inputs(&manifest)?;
+    let selected = resolve_scenario_input_bytes(&scenario_bytes)
+        .map_err(|error| RunnerError::validation("evidence_scenario", error.to_string()))?;
+    if selected.scenario != cross_route_app_runtime_recovery_public_scenario()
+        || selected.scenario.name != claim.scenario_name
+        || selected.provenance.canonical_ir_sha256 != claim.canonical_ir_sha256
+    {
+        return Err(RunnerError::validation(
+            "evidence_scenario_identity",
+            "release evidence claim does not match the selected canonical cross-route scenario",
+        ));
+    }
+
+    let normalized_path = manifest.output_dir.join("normalized-manifest.json");
+    let normalized: DistributedCampaignManifestV1 =
+        read_json(&normalized_path, "evidence_normalized_manifest")?;
+    let mut expected_normalized = manifest.clone();
+    expected_normalized.scenario.canonical_ir_sha256 =
+        Some(selected.provenance.canonical_ir_sha256.clone());
+    if normalized != expected_normalized {
+        return Err(RunnerError::validation(
+            "evidence_normalized_manifest",
+            "executed normalized manifest differs from the selected release manifest",
+        ));
+    }
+
+    let receipt_path = manifest.output_dir.join("distributed-run.json");
+    let receipt: DistributedRunReceiptV1 = read_json(&receipt_path, "evidence_run_receipt")?;
+    let process_report_path = manifest.output_dir.join("process-report.json");
+    if !receipt.completed
+        || receipt.campaign_id != manifest.campaign_id
+        || receipt.backend != "container"
+        || !receipt.cleanup_failures.is_empty()
+        || receipt.command_receipts.is_empty()
+        || receipt
+            .command_receipts
+            .iter()
+            .any(|command| !command.accepted)
+        || receipt.process_report.as_deref() != Some(process_report_path.as_path())
+    {
+        return Err(RunnerError::validation(
+            "evidence_run_receipt",
+            "distributed run receipt is incomplete or inconsistent",
+        ));
+    }
+    let process_report: ProcessScenarioReportV1 =
+        read_json(&process_report_path, "evidence_process_report")?;
+    validate_cross_route_public_process_report(&selected.scenario, &process_report)
+        .map_err(|error| RunnerError::validation("evidence_public_oracle", error))?;
+    let DistributedBackendV1::Container(container) = &manifest.backend else {
+        return Err(RunnerError::validation(
+            "evidence_backend",
+            "release evidence assembly requires a container campaign",
+        ));
+    };
+    let participant_image_ids = manifest
+        .participants
+        .iter()
+        .map(|participant| {
+            participant
+                .container_image
+                .as_deref()
+                .unwrap_or(&container.default_participant_image)
+                .to_owned()
+        })
+        .collect::<BTreeSet<_>>();
+    let verification = ReleaseEvidenceVerificationV1 {
+        schema_version: "1".into(),
+        campaign_id: manifest.campaign_id.clone(),
+        scenario_name: selected.scenario.name.clone(),
+        canonical_ir_sha256: selected.provenance.canonical_ir_sha256.clone(),
+        source_revision: source_revision.into(),
+        participant_build_ids: build_ids.into_iter().map(str::to_owned).collect(),
+        participant_image_ids: participant_image_ids.into_iter().collect(),
+        selected_scenario_bytes_sha256: digest_regular_file(&manifest.scenario.path)?,
+        process_report_sha256: digest_regular_file(&process_report_path)?,
+        public_process_oracle_passed: true,
+    };
+
+    let observation: CampaignLaneObservationV1 =
+        read_json(observation_path, "evidence_observation")?;
+    let budget: CampaignBudgetEvaluationV1 = read_json(budget_path, "evidence_budget")?;
+    let expected_budget = CampaignLaneConfigV1::builtin(CampaignLaneV1::ReleaseHardening)
+        .evaluate(observation.clone());
+    if !expected_budget.passed || budget != expected_budget {
+        return Err(RunnerError::validation(
+            "evidence_budget",
+            "release budget evidence must equal a recomputed passing evaluation",
+        ));
+    }
+    let step_records = read_release_step_records(step_dir)?;
+
+    let bundle_dir = output_path
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or(Path::new("."));
+    fs_private::create_dir_all_private(bundle_dir)
+        .map_err(|error| RunnerError::environment("evidence_bundle_directory", error))?;
+    let artifact_dir = bundle_dir.join("artifacts");
+    if artifact_dir.exists() {
+        return Err(RunnerError::validation(
+            "evidence_artifact_directory_exists",
+            "release evidence artifact directory must not already exist",
+        ));
+    }
+    fs_private::create_dir_all_private(&artifact_dir)
+        .map_err(|error| RunnerError::environment("evidence_artifact_directory", error))?;
+
+    let mut sources = vec![
+        ("reviewed_claim".to_owned(), claim_path.to_path_buf()),
+        ("selected_manifest".to_owned(), manifest_path.to_path_buf()),
+        ("normalized_manifest".to_owned(), normalized_path),
+        ("distributed_run".to_owned(), receipt_path),
+        (
+            "lane_observation".to_owned(),
+            observation_path.to_path_buf(),
+        ),
+        ("budget_evaluation".to_owned(), budget_path.to_path_buf()),
+    ];
+    sources.extend(step_records.into_iter().map(|(name, path)| {
+        (
+            format!("step_observation_{}", sanitize_artifact_kind(&name)),
+            path,
+        )
+    }));
+    let mut artifacts = Vec::with_capacity(sources.len() + 1);
+    artifacts.push(write_json_artifact_private(
+        &artifact_dir,
+        bundle_dir,
+        "public_oracle_verification",
+        &verification,
+    )?);
+    for (kind, source) in sources {
+        artifacts.push(copy_artifact_private(
+            &artifact_dir,
+            bundle_dir,
+            &kind,
+            &source,
+        )?);
+    }
+
+    let bundle = ConvergenceEvidenceBundleV1 {
+        schema_version: "1".into(),
+        lane: claim.lane,
+        source_revision: source_revision.into(),
+        assurance_claim: claim.assurance_claim,
+        covered_decision_routes: claim.covered_decision_routes,
+        models: claim.models,
+        adapters: claim.adapters,
+        mutation_results: claim.mutation_results,
+        tested_boundaries: claim.tested_boundaries,
+        unresolved_counterexamples: claim.unresolved_counterexamples,
+        residual_assumptions: claim.residual_assumptions,
+        untested_surfaces: claim.untested_surfaces,
+        budget,
+        artifacts,
+    };
+    bundle.write_private(output_path)?;
+    Ok(bundle)
+}
+
+fn write_json_artifact_private<T: Serialize>(
+    artifact_dir: &Path,
+    bundle_dir: &Path,
+    kind: &str,
+    value: &T,
+) -> Result<EvidenceArtifactV1, RunnerError> {
+    validate_artifact_kind(kind)?;
+    let destination = artifact_dir.join(format!("{kind}.json"));
+    let bytes = serde_json::to_vec_pretty(value)
+        .map_err(|error| RunnerError::environment("evidence_artifact_serialize", error))?;
+    let mut output = fs_private::create_new_private(&destination)
+        .map_err(|error| RunnerError::environment("evidence_artifact_write", error))?;
+    output
+        .write_all(&bytes)
+        .and_then(|()| output.flush())
+        .and_then(|()| output.sync_all())
+        .map_err(|error| RunnerError::environment("evidence_artifact_write", error))?;
+    evidence_artifact_from_destination(bundle_dir, kind, &destination)
+}
+
+fn read_release_step_records(step_dir: &Path) -> Result<Vec<(String, PathBuf)>, RunnerError> {
+    let mut paths = std::fs::read_dir(step_dir)
+        .map_err(|error| RunnerError::environment("evidence_step_directory", error))?
+        .map(|entry| {
+            entry
+                .map(|entry| entry.path())
+                .map_err(|error| RunnerError::environment("evidence_step_directory", error))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    paths.sort();
+    let mut records = Vec::new();
+    let mut names = BTreeSet::new();
+    for path in paths {
+        if path.extension().and_then(|value| value.to_str()) != Some("json") {
+            continue;
+        }
+        let record: CampaignLaneStepObservationV1 = read_json(&path, "evidence_step")?;
+        record.validate()?;
+        if !record.succeeded() {
+            return Err(RunnerError::validation(
+                "evidence_step_failed",
+                "release evidence cannot include a failed observed step",
+            ));
+        }
+        if !names.insert(record.name.clone()) {
+            return Err(RunnerError::validation(
+                "evidence_step_duplicate",
+                "release evidence contains duplicate step names",
+            ));
+        }
+        records.push((record.name, path));
+    }
+    if REQUIRED_RELEASE_STEPS
+        .iter()
+        .any(|required| !names.contains(*required))
+    {
+        return Err(RunnerError::validation(
+            "evidence_step_missing",
+            "release evidence is missing a required observed step",
+        ));
+    }
+    Ok(records)
+}
+
+fn copy_artifact_private(
+    artifact_dir: &Path,
+    bundle_dir: &Path,
+    kind: &str,
+    source: &Path,
+) -> Result<EvidenceArtifactV1, RunnerError> {
+    validate_artifact_kind(kind)?;
+    let destination = artifact_dir.join(format!("{kind}.json"));
+    let mut input = open_regular_no_follow(source, "evidence_artifact_read")?;
+    let mut output = fs_private::create_new_private(&destination)
+        .map_err(|error| RunnerError::environment("evidence_artifact_write", error))?;
+    std::io::copy(&mut input, &mut output)
+        .map_err(|error| RunnerError::environment("evidence_artifact_write", error))?;
+    output
+        .flush()
+        .and_then(|()| output.sync_all())
+        .map_err(|error| RunnerError::environment("evidence_artifact_write", error))?;
+    evidence_artifact_from_destination(bundle_dir, kind, &destination)
+}
+
+fn evidence_artifact_from_destination(
+    bundle_dir: &Path,
+    kind: &str,
+    destination: &Path,
+) -> Result<EvidenceArtifactV1, RunnerError> {
+    let sha256 = digest_regular_file(destination)?;
+    let path = destination
+        .strip_prefix(bundle_dir)
+        .map_err(|_| {
+            RunnerError::validation(
+                "evidence_artifact_path",
+                "assembled artifact escaped the evidence bundle directory",
+            )
+        })?
+        .to_path_buf();
+    Ok(EvidenceArtifactV1 {
+        kind: kind.into(),
+        path,
+        sha256,
+    })
+}
+
+fn read_json<T: for<'de> Deserialize<'de>>(path: &Path, code: &str) -> Result<T, RunnerError> {
+    let mut file = open_regular_no_follow(path, code)?;
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes)
+        .map_err(|error| RunnerError::environment(code, error))?;
+    serde_json::from_slice(&bytes).map_err(|error| RunnerError::environment(code, error))
+}
+
+fn digest_regular_file(path: &Path) -> Result<String, RunnerError> {
+    let mut file = open_regular_no_follow(path, "evidence_artifact_digest")?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .map_err(|error| RunnerError::environment("evidence_artifact_digest", error))?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(hex::encode(hasher.finalize()))
+}
+
+fn open_regular_no_follow(path: &Path, code: &str) -> Result<std::fs::File, RunnerError> {
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW);
+    }
+    let file = options
+        .open(path)
+        .map_err(|error| RunnerError::environment(code, error))?;
+    if !file
+        .metadata()
+        .map_err(|error| RunnerError::environment(code, error))?
+        .file_type()
+        .is_file()
+    {
+        return Err(RunnerError::validation(
+            code,
+            "release evidence inputs must be regular files",
+        ));
+    }
+    Ok(file)
+}
+
+fn validate_source_revision(value: &str) -> Result<(), RunnerError> {
+    if value.len() != 40
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+    {
+        return Err(RunnerError::validation(
+            "release_source_revision",
+            "release source revisions must be exact 40-character lowercase hexadecimal Git object ids",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_local_image_id(value: &str) -> Result<(), RunnerError> {
+    let Some(digest) = value.strip_prefix("sha256:") else {
+        return Err(RunnerError::validation(
+            "release_image_id",
+            "release materialization requires a local content-addressed sha256 image id",
+        ));
+    };
+    validate_lower_hex_digest("release image", digest)
+}
+
+fn validate_lower_hex_digest(name: &str, value: &str) -> Result<(), RunnerError> {
+    if value.len() != 64
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+    {
+        return Err(RunnerError::validation(
+            "evidence_digest",
+            format!("{name} digest must be 64 lowercase hexadecimal characters"),
+        ));
+    }
+    Ok(())
+}
+
+fn sanitize_artifact_kind(value: &str) -> String {
+    value
+        .bytes()
+        .map(|byte| {
+            if byte.is_ascii_alphanumeric() || byte == b'_' {
+                char::from(byte.to_ascii_lowercase())
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn validate_artifact_kind(value: &str) -> Result<(), RunnerError> {
+    if value.is_empty()
+        || value.len() > 96
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_')
+    {
+        return Err(RunnerError::validation(
+            "evidence_artifact_kind",
+            "evidence artifact kinds must use 1-96 lowercase snake-case characters",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cgka_conformance_simulator::mutation_adequacy::SemanticMutation;
+
+    const CURRENT_REVISION: &str = "1111111111111111111111111111111111111111";
+    const BASELINE_REVISION: &str = "2222222222222222222222222222222222222222";
+    const CURRENT_IMAGE: &str =
+        "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const BASELINE_IMAGE: &str =
+        "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+    #[test]
+    fn release_materialization_pins_two_revisions_images_and_the_shared_scenario() {
+        let root = tempfile::tempdir().unwrap();
+        let output = root.path().join("release-inputs");
+        let manifest_path = materialize_release_campaign(
+            &output,
+            CURRENT_REVISION,
+            CURRENT_IMAGE,
+            BASELINE_REVISION,
+            BASELINE_IMAGE,
+        )
+        .unwrap();
+        let manifest = load_manifest(&manifest_path).unwrap();
+        manifest.validate_mixed_builds().unwrap();
+        assert_eq!(manifest.campaign_id, RELEASE_CAMPAIGN_ID);
+        assert_eq!(
+            manifest
+                .participants
+                .iter()
+                .map(|participant| participant.build_id.as_str())
+                .collect::<BTreeSet<_>>(),
+            BTreeSet::from([CURRENT_REVISION, BASELINE_REVISION])
+        );
+        assert_eq!(
+            manifest
+                .participants
+                .iter()
+                .filter_map(|participant| participant.container_image.as_deref())
+                .collect::<BTreeSet<_>>(),
+            BTreeSet::from([CURRENT_IMAGE, BASELINE_IMAGE])
+        );
+        let selected =
+            resolve_scenario_input_bytes(&verify_manifest_inputs(&manifest).unwrap()).unwrap();
+        assert_eq!(
+            selected.scenario,
+            cross_route_app_runtime_recovery_public_scenario()
+        );
+        assert_eq!(
+            selected.provenance.canonical_ir_sha256,
+            manifest.scenario.canonical_ir_sha256.unwrap()
+        );
+
+        #[cfg(unix)]
+        for path in [manifest_path, manifest.scenario.path] {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(path).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
+    }
+
+    #[test]
+    fn release_materialization_rejects_non_distinct_or_mutable_inputs() {
+        let root = tempfile::tempdir().unwrap();
+        let output = root.path().join("release-inputs");
+        assert_eq!(
+            materialize_release_campaign(
+                &output,
+                CURRENT_REVISION,
+                CURRENT_IMAGE,
+                CURRENT_REVISION,
+                BASELINE_IMAGE,
+            )
+            .unwrap_err()
+            .code,
+            "release_build_revisions"
+        );
+        assert_eq!(
+            materialize_release_campaign(
+                &output,
+                CURRENT_REVISION,
+                "marmot-conformance:latest",
+                BASELINE_REVISION,
+                BASELINE_IMAGE,
+            )
+            .unwrap_err()
+            .code,
+            "release_image_id"
+        );
+    }
+
+    #[test]
+    fn reviewed_release_claim_pins_the_scenario_and_complete_mutation_catalog() {
+        let claim: ConvergenceEvidenceClaimV1 = serde_json::from_str(include_str!(
+            "../release-claims/cross-route-mixed-build.v1.json"
+        ))
+        .unwrap();
+        claim.validate().unwrap();
+        let scenario = cross_route_app_runtime_recovery_public_scenario();
+        assert_eq!(claim.campaign_id, RELEASE_CAMPAIGN_ID);
+        assert_eq!(claim.scenario_name, scenario.name);
+        assert_eq!(
+            claim.canonical_ir_sha256,
+            canonical_scenario_ir_sha256(&scenario).unwrap()
+        );
+        assert_eq!(
+            claim
+                .mutation_results
+                .keys()
+                .map(String::as_str)
+                .collect::<BTreeSet<_>>(),
+            SemanticMutation::ALL
+                .iter()
+                .map(|mutation| mutation.id())
+                .collect::<BTreeSet<_>>()
+        );
+        assert!(claim.mutation_results.values().all(|killed| *killed));
+    }
+
+    #[test]
+    fn artifact_copy_is_private_digest_pinned_and_refuses_symlinks() {
+        let root = tempfile::tempdir().unwrap();
+        let bundle = root.path().join("bundle");
+        let artifacts = bundle.join("artifacts");
+        fs_private::create_dir_all_private(&artifacts).unwrap();
+        let source = root.path().join("source.json");
+        fs_private::write_private(&source, b"{\"ok\":true}").unwrap();
+        let artifact = copy_artifact_private(&artifacts, &bundle, "report", &source).unwrap();
+        assert_eq!(artifact.path, Path::new("artifacts/report.json"));
+        assert_eq!(
+            artifact.sha256,
+            hex::encode(Sha256::digest(b"{\"ok\":true}"))
+        );
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::{PermissionsExt, symlink};
+            let copied = bundle.join(&artifact.path);
+            assert_eq!(
+                std::fs::metadata(copied).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+            let link = root.path().join("source-link.json");
+            symlink(&source, &link).unwrap();
+            assert!(copy_artifact_private(&artifacts, &bundle, "linked", &link).is_err());
+        }
+    }
+
+    #[test]
+    fn release_step_evidence_requires_every_successful_named_boundary() {
+        let root = tempfile::tempdir().unwrap();
+        for name in REQUIRED_RELEASE_STEPS {
+            successful_step(name)
+                .write_private(&root.path().join(format!("{name}.json")))
+                .unwrap();
+        }
+        assert_eq!(read_release_step_records(root.path()).unwrap().len(), 3);
+
+        std::fs::remove_file(root.path().join("baseline-image-build.json")).unwrap();
+        assert_eq!(
+            read_release_step_records(root.path()).unwrap_err().code,
+            "evidence_step_missing"
+        );
+        let mut failed = successful_step("baseline-image-build");
+        failed.exit_code = Some(1);
+        failed
+            .write_private(&root.path().join("baseline-image-build.json"))
+            .unwrap();
+        assert_eq!(
+            read_release_step_records(root.path()).unwrap_err().code,
+            "evidence_step_failed"
+        );
+    }
+
+    fn successful_step(name: &str) -> CampaignLaneStepObservationV1 {
+        CampaignLaneStepObservationV1 {
+            schema_version: "1".into(),
+            name: name.into(),
+            wall_clock_us: 1,
+            user_cpu_us: Some(1),
+            system_cpu_us: Some(1),
+            peak_rss_bytes: Some(1),
+            filesystem_block_write_lower_bound_bytes: Some(0),
+            executed_cases: 0,
+            flaky_cases: 0,
+            flake_retries: 0,
+            exit_code: Some(0),
+            signal: None,
+            unavailable_process_fields: Vec::new(),
+        }
+    }
+}

--- a/crates/convergence-campaign-runner/tests/distributed_runner.rs
+++ b/crates/convergence-campaign-runner/tests/distributed_runner.rs
@@ -593,6 +593,17 @@ fn mutable_container_images_require_an_explicit_local_opt_out() {
         participant.container_image = Some(format!("marmot-conformance@sha256:{digest}"));
     }
     manifest.validate().unwrap();
+
+    let local_image_id = format!("sha256:{digest}");
+    let DistributedBackendV1::Container(container) = &mut manifest.backend else {
+        unreachable!();
+    };
+    container.default_participant_image = local_image_id.clone();
+    container.relay_image = local_image_id.clone();
+    for participant in &mut manifest.participants {
+        participant.container_image = Some(local_image_id.clone());
+    }
+    manifest.validate().unwrap();
 }
 
 #[test]

--- a/crates/convergence-campaign-runner/tests/lane_policy.rs
+++ b/crates/convergence-campaign-runner/tests/lane_policy.rs
@@ -127,6 +127,30 @@ fn scheduled_workflows_collect_and_enforce_lane_observations() {
     assert!(release_collection.contains("--campaign-manifest"));
 }
 
+#[test]
+fn release_workflow_builds_exact_ancestor_image_and_verifies_one_bundle() {
+    let hardening = include_str!("../../../.github/workflows/convergence-hardening.yml");
+    for contract in [
+        "baseline_revision:",
+        "git merge-base --is-ancestor",
+        "test \"$(git -C baseline-source rev-parse HEAD)\" = \"$BASELINE_REVISION\"",
+        "--name baseline-image-build",
+        "docker image inspect --format '{{.Id}}' marmot-conformance:local",
+        "docker image inspect --format '{{.Id}}' marmot-conformance:baseline",
+        "materialize-release-campaign",
+        "assemble-release-evidence",
+        "release-claims/cross-route-mixed-build.v1.json",
+        "check-evidence \"$bundle\"",
+    ] {
+        assert!(
+            hardening.contains(contract),
+            "missing release contract: {contract}"
+        );
+    }
+    assert!(!hardening.contains("inputs.distributed_manifest"));
+    assert!(hardening.contains("if [[ -f \"$DISTRIBUTED_MANIFEST\" ]]"));
+}
+
 fn assert_artifact_retention(workflow: &str, artifact_name: &str, expected: &str) {
     let artifact_step = workflow
         .split_once(artifact_name)

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -1128,9 +1128,14 @@ observation and evaluator result. Final regular-file sizes are not peak transien
 case floor is not a capability-completeness claim. Evidence bundles require a nonempty artifact set;
 `check-evidence` recomputes the budget result from its observation and the reviewed lane policy, resolves each relative
 artifact path beside the bundle, and verifies its SHA-256 bytes. A policy test also pins each workflow
-artifact-retention setting to the corresponding lane manifest. The remaining
-route/model/adapter/mutation/boundary/assumption fields are still producer-supplied scoped evidence rather than an
-automatic correctness attestation, so an actual reviewed release-hardening bundle remains open.
+artifact-retention setting to the corresponding lane manifest. A separately reviewed release claim now pins the
+campaign id, canonical scenario digest, route/model/adapter/mutation inventory, tested boundaries, assumptions, and
+untested surfaces. Release assembly validates that claim against the exact mixed-build manifest, normalized run,
+successful receipt, strict public process oracle, raw observation, recomputed budget, and required observed steps,
+then copies and digests the privacy-safe retained inputs into one owner-only bundle. A separate verification record
+binds the validated payload-bearing canonical scenario and raw process report by digest without copying their contents
+into the shareable bundle. The scoped claim remains human-authored rather than an automatic correctness attestation,
+and an actual downloaded and reviewed release-hardening bundle remains open.
 
 ### 6.4 Failure corpus lifecycle
 
@@ -1300,6 +1305,9 @@ residual gap.
 7. [ ] Produce and review a byte-verified release evidence bundle from an actual release-hardening run.
    - [x] Feed workflow-owned command/resource/case observations into every scheduled lane budget and retain the raw
      observation plus evaluator result.
+   - [x] Materialize the reviewed four-party campaign from one exact source revision and one distinct exact ancestor,
+     build both content-addressed images, and assemble a claim-pinned bundle only after the mixed-build manifest,
+     strict public oracle, successful receipt, observed steps, and recomputed release budget agree.
    - [ ] Review an actual release-hardening run's scoped claims and digest-pinned artifacts, then publish its complete
      evidence bundle; the workflow budget files alone are not that assurance artifact.
 8. [ ] Accumulate container soak evidence, then use the external VM driver only for the remaining
@@ -1476,6 +1484,7 @@ incorrect result.
 | 2026-08-14 | 6.1 isolated-process cross-route assurance | Extracted runner-owned reversible retained-relay control for reuse by app and process adapters, then executed the exact app-runtime four-party IR and digest through four child runtimes with separate encrypted roots. Replaced SIGSTOP offline simulation with public checkpoint plus graceful runtime/transport disconnect and durable reopen, preventing open subscriptions from buffering withheld events across the declared offline boundary. The strict process oracle pins the controlled split, canonical schedule, public terminal protocol/profile, complete duplicate-free application set, losing-branch withdrawal rule, no pending confirmation, and real Zeta reopen. Exact MLS state, durable input dispositions, and active decryptability remain unavailable through the public node protocol; container/VM and every-transition permutations remain open. No production engine or app behavior changed. | [MDK #1424](https://github.com/marmot-protocol/mdk/pull/1424); `four_party_cross_route_recovery_processes_match_unified_route`; `four_party_cross_route_recovery_process_equivalence_soak`; process-adapter capability preflight and focused simulator tests |
 | 2026-08-14 | 6.1 scheduled container cross-route checkpoint | Extracted the four-party public scenario and strict process-report oracle into one shared assurance fixture, selected that exact IR and digest through the distributed manifest, and added a real four-container checkpoint with one non-root participant container and encrypted root per member. A source-built local Docker run completed the exact checkpoint in 61.20 seconds with clean teardown. Nightly and weekly/manual workflows retain the exact scenario, normalized manifest, process report, distributed receipt, and failure corpus on success or failure; encrypted participant roots and the opaque-token relay control plane remain ephemeral. Exact engine-private evidence and VM/per-transition permutations remain open. | `container_manifest_selects_the_shared_four_party_cross_route_ir`; `four_party_cross_route_recovery_containers_match_unified_route`; `target/cgka-distributed-container-evidence` |
 | 2026-08-15 | 6.3 scheduled lane budget enforcement | Added workflow-owned command observation with Unix child resource accounting, structured Nextest case/retry counts, final working/artifact byte measurement, private raw evidence, and fail-closed nightly/weekly/release policy evaluation. Documented the lower-bound boundaries rather than treating the resulting budget pass as capability or release assurance; the first reviewed release-hardening evidence bundle remains open. | `observe-step`; `collect-observation`; `check-budget`; `lane_policy`; scheduled workflow wiring |
+| 2026-08-15 | 6.3 release evidence production path | Replaced the release lane's unprovisioned manifest-path input with an exact ancestor revision, two source-built content-addressed images, one runner-materialized canonical cross-route manifest, and deterministic evidence assembly. The assembler binds the reviewed claim to the canonical IR, normalized mixed-build execution, strict public oracle, successful receipt, raw lane observation, recomputed budget, and private digest-pinned artifact copies. No release assurance item closes until an actual workflow artifact is downloaded and reviewed. | `materialize-release-campaign`; `assemble-release-evidence`; `cross-route-mixed-build.v1.json`; release workflow contract tests |
 
 ## Capability Naming Cleanup
 

--- a/docs/marmot-architecture/distributed-convergence-campaigns.md
+++ b/docs/marmot-architecture/distributed-convergence-campaigns.md
@@ -205,6 +205,43 @@ the evaluation from the recorded observation and reviewed lane policy instead of
 fields. It rejects incomplete bundles, parent-traversing artifact paths, missing files, and SHA-256 mismatches by
 resolving artifacts relative to the bundle's directory. Valid bundles are written with owner-only permissions.
 
+The release workflow's `baseline_revision` is an exact lowercase 40-character commit that must be a distinct ancestor
+of the workflow source revision. The workflow checks out and builds both exact trees, resolves their local images to
+content-addressed `sha256:<image-id>` references, and distributes the two builds across the canonical four-party
+cross-route participants. `materialize-release-campaign` owns the canonical scenario serialization and manifest, so a
+workflow does not reconstruct the action schedule or accept mutable image labels. The current-source image owns the
+runner-controlled relay; participant nodes alternate current and baseline images.
+
+The human-reviewed claim is versioned separately under
+`crates/convergence-campaign-runner/release-claims/`. It pins the campaign id, scenario name and canonical IR digest,
+scoped claim, route/model/adapter inventory, mutation catalog, tested boundaries, assumptions, and untested surfaces.
+After a passing run, `assemble-release-evidence` requires that claim to match the selected scenario; verifies the
+mixed-build manifest, normalized manifest, completed receipt, accepted commands, clean cleanup, and strict public
+process report; recomputes the release budget from the raw observation; and requires successful observed records for
+both image builds and the release-hardening core. The shareable bundle does not copy the canonical scenario or raw
+process report because they contain synthetic application payloads. Instead it retains their SHA-256 values in a
+privacy-safe public-oracle verification record after validating the raw bytes. The reviewed claim, manifests, receipt,
+lane observation, budget decision, and step records are copied beside the bundle and bound by SHA-256 before
+`check-evidence` accepts it. The payload-bearing raw files remain private in the broader workflow artifact.
+
+Dispatch from the exact source revision and name a reviewed ancestor:
+
+```sh
+gh workflow run convergence-hardening.yml \
+  --ref <40-character-source-revision> \
+  -f lane=release_hardening \
+  -f baseline_revision=<40-character-ancestor-revision>
+```
+
+The retained GitHub artifact is `convergence-hardening-<run-id>`. Its source path is
+`target/cgka-hardening-lane-evidence/release-bundle/convergence-evidence.v1.json`; after the multi-path Actions artifact
+is downloaded, the common `target/` prefix is omitted and the bundle is at
+`cgka-hardening-lane-evidence/release-bundle/convergence-evidence.v1.json`, with byte-pinned inputs in the sibling
+`artifacts/` directory. The broader raw campaign and lane outputs remain in the same uploaded artifact. Tooling and a
+green run do not close the release gate: an engineer must still download the artifact, rerun `check-evidence` against
+the retained bytes, review the claim and residual gaps, and record the run URL and exact revisions in the tracking
+plan.
+
 ## Failure corpus lifecycle
 
 Generated simulator failures already write a portable capsule, a minimized Scenario IR reproducer, and—when enabled—a


### PR DESCRIPTION
## Summary

- replace the release lane's operator-authored manifest input with an exact ancestor revision
- build current and ancestor campaign images from exact source trees and materialize one reviewed mixed-build four-party campaign
- assemble a fail-closed, digest-pinned evidence bundle from the canonical scenario, strict public process oracle, receipts, lane observations, budgets, and required step records
- retain raw payload-bearing scenario and process-report bytes outside the shareable bundle while binding them through SHA-256 verification records
- update the convergence tracking and operator documentation

## Why

The release-hardening lane already had policy and budget machinery, but it could not independently provision its mixed-build inputs or produce the reviewed evidence bundle required by the convergence reliability plan. This makes that path operational and reproducible while keeping the final assurance claim scoped to one exact source revision, ancestor revision, canonical scenario, and observed run.

This PR changes campaign tooling, workflow configuration, tests, and documentation only. It does not change convergence-engine or app-runtime behavior.

## Validation

- `just fast-ci`
- `cargo test -p convergence-campaign-runner --locked`
- `cargo clippy -p convergence-campaign-runner --all-targets --locked -- -D warnings`
- `actionlint .github/workflows/convergence-hardening.yml`
- CLI smoke test for materialization, mixed-build validation, and owner-only output permissions

## Remaining release step

After merge, an operator must dispatch the release-hardening workflow with a reviewed exact ancestor revision, download the resulting artifact, rerun `check-evidence`, review the scoped claim and residual gaps, and record the run URL and revisions. The planning document intentionally leaves that evidence-review item open.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added release-hardening support for mixed current/baseline builds using exact ancestor revisions.
  - Added tooling to materialize convergence campaigns and assemble validated, privacy-safe evidence bundles.
  - Added CLI commands for campaign creation and evidence assembly.
  - Added support for local content-addressed image identifiers.

- **Documentation**
  - Documented release-hardening workflows, evidence requirements, dispatch commands, artifact paths, and manual review steps.

- **Bug Fixes**
  - Improved image validation and optional manifest handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->