### PR TITLE
Fix simulator pending identity across restarts

### DIFF
--- a/crates/cgka-conformance-simulator/src/subject.rs
+++ b/crates/cgka-conformance-simulator/src/subject.rs
@@ -682,6 +682,7 @@ pub struct EngineHarnessSubject {
     active_scenario_group: Option<String>,
     scenario_groups: BTreeMap<String, GroupId>,
     pending_refs: HashMap<String, EngineSubjectPendingRef>,
+    client_incarnations: BTreeMap<String, u64>,
     convergence_clock: ManualConvergenceClock,
     outbound_cursors: HashMap<String, u64>,
     outbound_records: BTreeMap<u64, EngineSubjectOutboundRecord>,
@@ -702,12 +703,14 @@ fn sqlite_database_files(path: &std::path::Path) -> [std::path::PathBuf; 3] {
 #[derive(Clone)]
 struct EngineSubjectPendingRef {
     client: String,
+    client_incarnation: u64,
     pending: PendingStateRef,
 }
 
 #[derive(Clone)]
 struct EngineSubjectOutboundRecord {
     artifact: SubjectOutboundArtifact,
+    client_incarnation: u64,
     pending: Option<PendingStateRef>,
     queued_intent: Option<(GroupId, MessageId)>,
     resolution: Option<SubjectOutboundOutcome>,
@@ -870,6 +873,7 @@ impl EngineHarnessSubject {
             active_scenario_group: None,
             scenario_groups: BTreeMap::new(),
             pending_refs: HashMap::new(),
+            client_incarnations: clients.iter().map(|client| (client.clone(), 0)).collect(),
             convergence_clock,
             outbound_cursors: HashMap::new(),
             outbound_records: BTreeMap::new(),
@@ -1117,12 +1121,14 @@ impl EngineHarnessSubject {
         client: &str,
         pending_ref: PendingStateRef,
     ) -> Result<(), SubjectError> {
+        let client_incarnation = self.client_incarnation(client)?;
         if self
             .pending_refs
             .insert(
                 label.to_string(),
                 EngineSubjectPendingRef {
                     client: client.to_owned(),
+                    client_incarnation,
                     pending: pending_ref,
                 },
             )
@@ -1136,13 +1142,29 @@ impl EngineHarnessSubject {
         Ok(())
     }
 
-    fn publication_for_pending(&self, client: &str, pending: PendingStateRef) -> Option<String> {
+    fn client_incarnation(&self, client: &str) -> Result<u64, SubjectError> {
+        self.client_incarnations
+            .get(client)
+            .copied()
+            .ok_or_else(|| SubjectError::new("unknown_client", format!("unknown client {client}")))
+    }
+
+    fn publication_for_pending(
+        &self,
+        client: &str,
+        client_incarnation: u64,
+        pending: PendingStateRef,
+    ) -> Option<String> {
         self.pending_refs.iter().find_map(|(label, candidate)| {
-            (candidate.client == client && candidate.pending == pending).then(|| label.clone())
+            (candidate.client == client
+                && candidate.client_incarnation == client_incarnation
+                && candidate.pending == pending)
+                .then(|| label.clone())
         })
     }
 
     fn sync_client_outbound(&mut self, label: &str) -> Result<(), SubjectError> {
+        let client_incarnation = self.client_incarnation(label)?;
         let client = self.client(label)?;
         let bus_id = client.bus_id;
         let after_sequence = self.outbound_cursors.get(label).copied();
@@ -1155,8 +1177,9 @@ impl EngineHarnessSubject {
             let pending = self
                 .client(label)?
                 .pending_publication_for_message(&emission.msg.id);
-            let publication =
-                pending.and_then(|pending| self.publication_for_pending(label, pending));
+            let publication = pending.and_then(|pending| {
+                self.publication_for_pending(label, client_incarnation, pending)
+            });
             let queued_intent = self
                 .client(label)?
                 .regenerated_queued_intent_for_message(&emission.msg.id);
@@ -1182,6 +1205,7 @@ impl EngineHarnessSubject {
                         state_confirmation_required,
                         regenerated_queued_intent: queued_intent.is_some(),
                     },
+                    client_incarnation,
                     pending,
                     queued_intent,
                     resolution: None,
@@ -1195,11 +1219,13 @@ impl EngineHarnessSubject {
     fn mark_pending_outbound(
         &mut self,
         client: &str,
+        client_incarnation: u64,
         pending: PendingStateRef,
         outcome: SubjectOutboundOutcome,
     ) {
         for record in self.outbound_records.values_mut() {
             if record.artifact.client == client
+                && record.client_incarnation == client_incarnation
                 && record.pending == Some(pending)
                 && record.resolution.is_none()
             {
@@ -1208,18 +1234,30 @@ impl EngineHarnessSubject {
         }
     }
 
-    fn pending_confirmation_accepted(&self, client: &str, pending: PendingStateRef) -> bool {
+    fn pending_confirmation_accepted(
+        &self,
+        client: &str,
+        client_incarnation: u64,
+        pending: PendingStateRef,
+    ) -> bool {
         self.outbound_records.values().any(|candidate| {
             candidate.artifact.client == client
+                && candidate.client_incarnation == client_incarnation
                 && candidate.pending == Some(pending)
                 && candidate.artifact.state_confirmation_required
                 && candidate.resolution == Some(SubjectOutboundOutcome::Accepted)
         })
     }
 
-    fn pending_non_confirmation_accepted(&self, client: &str, pending: PendingStateRef) -> bool {
+    fn pending_non_confirmation_accepted(
+        &self,
+        client: &str,
+        client_incarnation: u64,
+        pending: PendingStateRef,
+    ) -> bool {
         self.outbound_records.values().any(|candidate| {
             candidate.artifact.client == client
+                && candidate.client_incarnation == client_incarnation
                 && candidate.pending == Some(pending)
                 && !candidate.artifact.state_confirmation_required
                 && candidate.resolution == Some(SubjectOutboundOutcome::Accepted)
@@ -1491,13 +1529,17 @@ impl ConvergenceSubject for EngineHarnessSubject {
             };
         }
 
-        let pending_already_confirmed = record
-            .pending
-            .is_some_and(|pending| self.pending_confirmation_accepted(client, pending));
+        let current_client_incarnation = self.client_incarnation(client)?;
+        let pending_belongs_to_current_incarnation =
+            record.client_incarnation == current_client_incarnation;
+        let pending_already_confirmed = record.pending.is_some_and(|pending| {
+            self.pending_confirmation_accepted(client, record.client_incarnation, pending)
+        });
 
         match outcome {
             SubjectOutboundOutcome::Accepted => {
                 if record.artifact.state_confirmation_required
+                    && pending_belongs_to_current_incarnation
                     && !pending_already_confirmed
                     && let Some(pending) = record.pending
                 {
@@ -1505,8 +1547,11 @@ impl ConvergenceSubject for EngineHarnessSubject {
                         .try_confirm(pending)
                         .await
                         .map_err(subject_engine_error)?;
-                    self.pending_refs
-                        .retain(|_, value| value.client != client || value.pending != pending);
+                    self.pending_refs.retain(|_, value| {
+                        value.client != client
+                            || value.client_incarnation != record.client_incarnation
+                            || value.pending != pending
+                    });
                 }
                 if let Some((_, intent_id)) = &record.queued_intent {
                     self.client_mut(client)?
@@ -1525,8 +1570,17 @@ impl ConvergenceSubject for EngineHarnessSubject {
                     .pending
                     .filter(|_| record.artifact.state_confirmation_required)
                     .is_some_and(|pending| {
-                        !self.pending_confirmation_accepted(client, pending)
-                            && self.pending_non_confirmation_accepted(client, pending)
+                        pending_belongs_to_current_incarnation
+                            && !self.pending_confirmation_accepted(
+                                client,
+                                record.client_incarnation,
+                                pending,
+                            )
+                            && self.pending_non_confirmation_accepted(
+                                client,
+                                record.client_incarnation,
+                                pending,
+                            )
                     })
                 {
                     return Err(SubjectError::new(
@@ -1540,18 +1594,25 @@ impl ConvergenceSubject for EngineHarnessSubject {
                     .pending
                     .filter(|_| record.artifact.state_confirmation_required)
                     .is_some_and(|pending| {
+                        if !pending_belongs_to_current_incarnation {
+                            return false;
+                        }
                         let another_confirmation_is_unresolved =
                             self.outbound_records
                                 .iter()
                                 .any(|(candidate_sequence, candidate)| {
                                     *candidate_sequence != outbound_sequence
                                         && candidate.artifact.client == client
+                                        && candidate.client_incarnation == record.client_incarnation
                                         && candidate.pending == Some(pending)
                                         && candidate.artifact.state_confirmation_required
                                         && candidate.resolution.is_none()
                                 });
-                        let confirmation_was_accepted =
-                            self.pending_confirmation_accepted(client, pending);
+                        let confirmation_was_accepted = self.pending_confirmation_accepted(
+                            client,
+                            record.client_incarnation,
+                            pending,
+                        );
                         !another_confirmation_is_unresolved && !confirmation_was_accepted
                     });
 
@@ -1567,9 +1628,12 @@ impl ConvergenceSubject for EngineHarnessSubject {
                         .try_fail_publication(pending)
                         .await
                         .map_err(subject_publication_error)?;
-                    self.pending_refs
-                        .retain(|_, value| value.client != client || value.pending != pending);
-                    self.mark_pending_outbound(client, pending, outcome);
+                    self.pending_refs.retain(|_, value| {
+                        value.client != client
+                            || value.client_incarnation != record.client_incarnation
+                            || value.pending != pending
+                    });
+                    self.mark_pending_outbound(client, record.client_incarnation, pending, outcome);
                 } else {
                     self.bus
                         .retract_undelivered_publication(
@@ -1907,7 +1971,21 @@ impl ConvergenceSubject for EngineHarnessSubject {
     }
 
     fn restart(&mut self, client: &str) -> Result<(), SubjectError> {
+        // Capture every artifact emitted by the old engine before replacing
+        // it. `PendingStateRef` is process-local and may be reused by the new
+        // engine, so records must retain the incarnation that issued it.
+        self.sync_client_outbound(client)?;
         self.client_mut(client)?.restart();
+        let incarnation = self
+            .client_incarnation(client)?
+            .checked_add(1)
+            .ok_or_else(|| {
+                SubjectError::new("restart_overflow", "client restart counter exhausted")
+            })?;
+        self.client_incarnations
+            .insert(client.to_owned(), incarnation);
+        self.pending_refs
+            .retain(|_, pending| pending.client != client);
         Ok(())
     }
 
@@ -2607,6 +2685,61 @@ mod tests {
             "bob-second-name"
         );
         assert!(subject.pending_refs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn accepted_publication_before_restart_cannot_confirm_reused_pending_ref() {
+        let labels = vec!["alice".to_owned()];
+        let mut subject = EngineHarnessSubject::new(
+            &labels,
+            ProtocolProfile::Current,
+            HarnessStorageMode::TempFileBackedSqlite,
+        )
+        .expect("file-backed engine subject constructs");
+        create_current_group_and_join(&mut subject, "alice", &[]).await;
+
+        async fn update_and_accept(subject: &mut EngineHarnessSubject, action_id: &str) {
+            subject
+                .update_group_data(SubjectUpdateGroupData {
+                    action_id,
+                    client: "alice",
+                    name: Some(action_id),
+                    description: None,
+                    pending: action_id,
+                })
+                .await
+                .expect("group-data update produces pending publication");
+            let outbound = subject
+                .poll_outbound("alice")
+                .expect("group-data publication is pollable");
+            assert_eq!(outbound.len(), 1);
+            assert!(outbound[0].state_confirmation_required);
+            subject
+                .acknowledge_outbound(
+                    "alice",
+                    &outbound[0].outbound_id,
+                    SubjectOutboundOutcome::Accepted,
+                )
+                .await
+                .expect("accepted publication confirms staged state");
+        }
+
+        update_and_accept(&mut subject, "before-restart").await;
+        subject
+            .restart("alice")
+            .expect("file-backed client restarts");
+
+        // The fresh engine starts issuing process-local pending references
+        // from the beginning. The second post-restart update therefore reuses
+        // the reference held by the accepted pre-restart publication.
+        update_and_accept(&mut subject, "after-restart-first").await;
+        update_and_accept(&mut subject, "after-restart-reused-ref").await;
+
+        assert_eq!(
+            subject.client("alice").expect("alice exists").group_name(),
+            "after-restart-reused-ref",
+            "an accepted artifact must confirm its own engine incarnation"
+        );
     }
 
     #[tokio::test]

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -1050,9 +1050,13 @@ the app/process adapters cannot expose and the container/VM routes remain open b
     participant, resolves named publication boundaries to stable action ids after schedule mutation, and is selectable
     through the isolated app-runtime campaign path with strict per-case artifacts. A separate exact retained-engine
     family reuses the same isolated runner so panic-shaped failures cannot abort later catalog cases. The reviewed
-    seed-0 public catalog passed 12/12; the exact run passed 9/12: the three early Zeta publication-boundary restarts produced a structured `PendingPublish` refusal,
-    a `PendingPublish` panic, and an epoch-3/pending-work/decryptability stall; every later branch/repair boundary
-    passed. The exact semantic sequence and insertion index for every boundary are pinned by test, including the first
+    seed-0 public catalog passed 12/12. The initial exact run passed 9/12: the three early Zeta
+    publication-boundary restarts produced a structured `PendingPublish` refusal, a `PendingPublish` panic, and an
+    epoch-3/pending-work/decryptability stall. Minimization traced all three to the harness carrying process-local
+    `PendingStateRef` values across engine incarnations: a new publication could reuse an older accepted handle and
+    the adapter would skip the real confirmation. Incarnation-scoped bookkeeping removes that false match, and the
+    exact seed-0 catalog then passed 12/12 without a production engine change. The exact semantic sequence and
+    insertion index for every boundary are pinned by test, including the first
     full-history repair rather than the second settling round. Isolated-process execution reuses the catalog as an
     explicit manual test. Keep this item open until the permutations are carried through process/container/VM routes;
     exact evidence remains required on every adapter that can expose it.
@@ -1072,7 +1076,8 @@ The remaining 6.1 work is assurance closure, not another speculative engine rewr
 on `master`; after #1293 and #1403, the retained-engine reference settles and the corrected-input app-runtime route is
 held to the same public terminal protocol/profile/probe result. The isolated-process adapter now carries that same
 input contract and public oracle. The container checkpoint now consumes that shared contract; carry the restart
-catalog next into container/VM execution and diagnose the exact early-publication counterexamples. Do not project app/process/container public evidence
+catalog next into container/VM execution. The exact early-publication counterexamples were simulator false positives,
+not evidence for a production convergence rewrite. Do not project app/process/container public evidence
 into exact cryptographic, durable-disposition, or active-decryptability claims that those adapters cannot expose.
 
 Current exact seed-0 restart findings (generator version `1`):
@@ -1084,8 +1089,13 @@ Current exact seed-0 restart findings (generator version `1`):
 | `2` | `after-promote-yankee-accepted-zeta` | Zeta stayed at epoch 3 with pending work, quiescence timeout, and failed inbound decryptability | failure fingerprint `85a6e40f2db9ebf57caa689f423316bd293ebd6b6b1f2d42f88eaf47f7a66ca2`; input SHA-256 `25440d31481a4aa38b67d54dd3fecb21b334d0fb652edc100f3bde059098ed9c` |
 
 Cases `3` through `11` passed the exact state, profile, payload-multiset, pending-work, and twelve-direction active
-decryptability oracle. These digests identify the local discovery run; promote minimized regressions before fixing
-production behavior rather than treating a machine-local output directory as durable evidence.
+decryptability oracle in the discovery run. Minimization then proved that cases `0` through `2` shared a simulator
+identity defect: `PendingStateRef` is process-local, but accepted outbound records survived restart and were compared
+with raw handles from the new engine incarnation. The harness now scopes pending labels, outbound sibling decisions,
+confirmation, and rollback to the issuing incarnation. The focused reused-handle regression passes, followed by all
+12 exact seed-0 restart cases. No production convergence behavior changed. The failure digests above remain the
+historical discovery evidence; the post-fix local output directory is supporting evidence until the merge commit and
+its CI run provide the durable record.
 
 [MDK #1329](https://github.com/marmot-protocol/mdk/pull/1329) merged the fail-closed missing-anchor behavior and
 Welcome-repair retirement. Its formerly stacked [MDK #1293](https://github.com/marmot-protocol/mdk/pull/1293) has now
@@ -1310,10 +1320,12 @@ residual gap.
    adapters, and complete application disposition remain open. The new bounded
    `cross-route-restart-permutations/v1` catalog makes twelve current-build durable/public transition points
    selectable through the isolated app-runtime campaign. Its `cross-route-exact-restart-permutations/v1` companion
-   isolates private-state cases. The complete public seed-0 catalog passed 12/12; the exact catalog passed 9/12 and localized failures to the three early Zeta
-   publication boundaries (`PendingPublish` refusal, `PendingPublish` panic, and epoch-3/pending/decryptability stall).
-   isolated-process permutations remain an explicit manual gate. Diagnosis/remediation
-   of the exact counterexample, and container/VM lowering remain open. The decision-route
+   isolates private-state cases. The complete public seed-0 catalog passed 12/12. The initial exact catalog passed
+   9/12 and localized failures to the three early Zeta publication boundaries (`PendingPublish` refusal,
+   `PendingPublish` panic, and epoch-3/pending/decryptability stall); minimized regression proved those were caused by
+   cross-incarnation reuse of process-local pending handles in the engine harness, and the corrected exact catalog
+   passed 12/12 without production behavior changes. Isolated-process permutations remain an explicit manual gate;
+   container/VM lowering remains open. The decision-route
    inventory is machine checked against the unified route.
 
    The reviewed twenty-trial process soak belongs to the #1424 merge snapshot. Later storage/runtime changes, including
@@ -1513,6 +1525,7 @@ incorrect result.
 | 2026-08-15 | 6.3 scheduled lane budget enforcement | Added workflow-owned command observation with Unix child resource accounting, structured Nextest case/retry counts, final working/artifact byte measurement, private raw evidence, and fail-closed nightly/weekly/release policy evaluation. Documented the lower-bound boundaries rather than treating the resulting budget pass as capability or release assurance; the first reviewed release-hardening evidence bundle remains open. | `observe-step`; `collect-observation`; `check-budget`; `lane_policy`; scheduled workflow wiring |
 | 2026-08-15 | 6.3 release evidence production path | Replaced the release lane's unprovisioned manifest-path input with an exact ancestor revision, two source-built content-addressed images, one runner-materialized canonical cross-route manifest, and deterministic evidence assembly. The assembler binds the reviewed claim to the canonical IR, normalized mixed-build execution, strict public oracle, successful receipt, raw lane observation, recomputed budget, and private digest-pinned artifact copies. No release assurance item closes until an actual workflow artifact is downloaded and reviewed. | `materialize-release-campaign`; `assemble-release-evidence`; `cross-route-mixed-build.v1.json`; release workflow contract tests |
 | 2026-08-15 | 6.1 durable-transition restart catalog | Added a bounded twelve-case current-build catalog over the shared four-party cross-route topology. The builder resolves named publication boundaries to adapter-supported action ids only after inserting each restart, keeping relay faults invariant as the schedule shifts; semantic sequence and insertion-index tests pin every boundary. Public cases run through the full app runtime with strict state/admin and order-insensitive exact-payload expectations; a separate exact retained-engine family uses isolated workers so one panic cannot abort later cases. The reviewed seed-0 public catalog passed 12/12. The exact catalog passed 9/12 and localized all failures to Zeta's three early accepted-publication boundaries: structured `PendingPublish`, panic from `PendingPublish`, and epoch-3/pending-work/decryptability stall. Structured failures wrote shareable capsules; the panic preserved exact input and exit 101 but no report/capsule. Every later branch/repair restart passed, including all four restarts after the corrected first repair round. Isolated-process cases share the catalog and bind every restart to a durable lifecycle event. This is discovery evidence, not a fix; diagnosis/remediation, process/container/VM execution, and complete app-input dispositions remain open. | `cross-route-restart-permutations/v1`; `cross-route-exact-restart-permutations/v1`; public seed-0 12/12; exact seed-0 9/12; failure capsules/digests; process catalog test |
+| 2026-08-15 | 6.1 exact-restart harness remediation | Minimized all three early Zeta failures to one simulator identity bug: `PendingStateRef` is process-local, while the harness retained accepted outbound records across restart and compared only the raw handle. A fresh engine could reuse that handle, causing the adapter to report transport acceptance but skip `confirm_published` for the new staged evolution. Pending labels and outbound sibling/confirmation/rollback decisions are now scoped by client incarnation, and old-incarnation transport outcomes cannot mutate new engine state. The focused reused-handle regression failed with the original `PendingPublish` panic before the fix and passes afterward; the exact seed-0 catalog moved from 9/12 to 12/12. No production engine, storage, app, or protocol behavior changed. | `accepted_publication_before_restart_cannot_confirm_reused_pending_ref`; `just cross-route-exact-restart-campaign 0 12`; simulator adapter only |
 
 ## Capability Naming Cleanup
 


### PR DESCRIPTION
## Summary

- scope engine-harness pending labels and outbound lifecycle decisions to the client incarnation that issued them
- prevent accepted publications from an earlier engine process from suppressing confirmation of a new staged evolution that reused the same process-local pending handle
- preserve old-incarnation transport outcomes without allowing them to confirm or roll back new-incarnation engine state
- add a file-backed restart regression and update the convergence reliability tracking plan with the diagnosis

## Root cause

`PendingStateRef` is intentionally process-local. The simulator retained resolved outbound records across an engine restart and compared sibling publications using only the client label and raw pending value. Because a fresh engine restarts its pending counter, a new publication could reuse an older accepted value. The harness would then report the new outbound artifact as accepted but skip `confirm_published`, leaving the actual engine in `PendingPublish`.

That single harness bookkeeping defect caused all three early-Zeta failures from the exact restart catalog. This PR changes simulator and documentation code only; it does not change production engine, storage, app, wire, or protocol behavior.

## Verification

- focused reused-handle regression reproduces the original `PendingPublish` failure before the fix and passes afterward
- exact seed-0 restart catalog: 12/12 passed, up from 9/12
- public app-runtime seed-0 restart catalog: 12/12 passed
- simulator library tests: 155/155 passed
- `just fast-ci`
- `git diff --check`
