### PR TITLE
Include badge attention in account unread summaries

### DIFF
--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -1002,18 +1002,26 @@ pub(crate) struct KeyPackageDeletionResult {
     pub result: Result<usize, AppError>,
 }
 
-/// Per-account unread aggregate, suitable for an account-switcher badge
-/// (mdk#461). Computed from each account's materialized chat-list
-/// projection without loading a full session/timeline, so it can be reported
-/// for accounts that are not the active/running one.
+/// Per-account unread aggregate, suitable for an account-switcher and
+/// application badge (mdk#461, mdk#1460). Computed from each account's
+/// materialized chat-list projection without loading a full session/timeline,
+/// so it can be reported for accounts that are not the active/running one.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AccountUnread {
     pub account_id_hex: String,
     /// Total unread messages across all unarchived conversations.
     pub unread_count: u64,
-    /// Number of unarchived conversations with at least one unread message.
+    /// Number of unarchived conversations that require badge attention:
+    /// unread messages, a manual-unread reminder, or a pending invitation.
     pub unread_conversations: u64,
-    /// Whether the account has any unread message at all.
+    /// Conversations that contribute badge attention solely because they are
+    /// manually marked unread or pending confirmation. A row that already has
+    /// unread messages is omitted so hosts can compute
+    /// `unread_count + attention_only_conversations` without overlap.
+    #[serde(default)]
+    pub attention_only_conversations: u64,
+    /// Whether the account has any badge-worthy conversation, including a
+    /// manual-only reminder or pending invitation with no unread messages.
     pub has_unread: bool,
 }
 
@@ -2304,11 +2312,13 @@ impl MarmotApp {
             .map_err(chat_pin_error_from_storage)
     }
 
-    /// Per-account unread aggregate for the account-switcher badge
-    /// (mdk#461). Each account's count is read from its materialized
-    /// `chat_list_rows` projection (a single grouped `COUNT`/`SUM`), so this
-    /// does not require switching into, or loading a full session/timeline for,
-    /// any account — non-active accounts are reported too.
+    /// Per-account unread aggregate for the account-switcher and application
+    /// badge (mdk#461, mdk#1460). Each account's count is read from its
+    /// materialized `chat_list_rows` projection (a single grouped
+    /// `COUNT`/`SUM`), so this does not require switching into, or loading a
+    /// full session/timeline for, any account — non-active accounts are
+    /// reported too. `attention_only_conversations` covers pending invitations
+    /// and manual-only unread rows without overlapping unread-message totals.
     ///
     /// Only local-signing accounts are reported (matching `managed_accounts`).
     /// The chat-list projection is built from the on-disk store if missing;
@@ -2350,6 +2360,7 @@ impl MarmotApp {
             account_id_hex: account.account_id_hex.clone(),
             unread_count: total.unread_count,
             unread_conversations: total.unread_conversations,
+            attention_only_conversations: total.attention_only_conversations,
             has_unread: total.has_unread(),
         })
     }

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -3171,10 +3171,10 @@ impl MarmotAppRuntime {
         Ok(state)
     }
 
-    /// Per-account unread aggregate for the account-switcher badge
-    /// (mdk#461). Computed from each account's materialized chat-list
-    /// projection without loading a full session/timeline, so accounts that are
-    /// not the active/running one are reported too.
+    /// Per-account unread aggregate for the account-switcher and application
+    /// badge (mdk#461, mdk#1460). Computed from each account's materialized
+    /// chat-list projection without loading a full session/timeline, so
+    /// accounts that are not the active/running one are reported too.
     pub fn account_unread_summary(&self) -> Result<Vec<AccountUnread>, AppError> {
         self.accounts.app.account_unread_summary()
     }

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -8509,3 +8509,114 @@ fn pending_group_invites_skips_malformed_rows() {
         Some("cc".repeat(32))
     );
 }
+
+#[test]
+fn account_unread_summary_includes_badge_attention_without_session_load() {
+    // mdk#1460: one cheap summary must return unread totals plus
+    // attention-only rows (pending invites / manual unread) for accounts that
+    // have never been started.
+    let dir = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(dir.path());
+    let alice = home.create_account("alice").unwrap();
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+
+    let zero = app
+        .account_unread_summary()
+        .unwrap()
+        .into_iter()
+        .find(|summary| summary.account_id_hex == alice.account_id_hex)
+        .expect("zero-state account");
+    assert_eq!(zero.unread_count, 0);
+    assert_eq!(zero.unread_conversations, 0);
+    assert_eq!(zero.attention_only_conversations, 0);
+    assert!(!zero.has_unread);
+
+    let pending_id = "aa".repeat(16);
+    let manual_id = "bb".repeat(16);
+    let overlap_id = "cc".repeat(16);
+    let archived_id = "dd".repeat(16);
+    let seed_group =
+        |group_id_hex: &str, pending: bool, archived: bool| storage_sqlite::StoredAccountGroup {
+            group_id_hex: group_id_hex.to_owned(),
+            endpoint: "wss://relay.example".to_owned(),
+            profile_name: "seeded".to_owned(),
+            profile_description: String::new(),
+            image_hash_hex: String::new(),
+            image_key_hex: String::new(),
+            image_nonce_hex: String::new(),
+            image_upload_key_hex: String::new(),
+            image_media_type: None,
+            admin_keys_hex: String::new(),
+            archived,
+            pending_confirmation: pending,
+            member_count: None,
+            welcomer_account_id_hex: None,
+            via_welcome_message_id_hex: None,
+            nostr_routing_last_epoch: 0,
+            prior_nostr_routes: Vec::new(),
+            self_membership: storage_sqlite::SelfMembership::Member,
+            components: Vec::new(),
+        };
+    let storage = app.account_storage("alice").unwrap();
+    storage
+        .save_account_projection_state(
+            &storage_sqlite::StoredAccountState {
+                label: "alice".to_owned(),
+                groups: vec![
+                    seed_group(&pending_id, true, false),
+                    seed_group(&manual_id, false, false),
+                    seed_group(&overlap_id, false, false),
+                    seed_group(&archived_id, true, true),
+                ],
+                ..storage_sqlite::StoredAccountState::default()
+            },
+            16,
+            300,
+        )
+        .unwrap();
+    storage
+        .refresh_chat_list_rows(&alice.account_id_hex, &|_, _| false)
+        .unwrap();
+
+    app.set_chat_manually_unread("alice", &manual_id, true)
+        .unwrap();
+    app.set_chat_manually_unread("alice", &archived_id, true)
+        .unwrap();
+
+    let chat = |id: &str, at: u64| storage_sqlite::StoredAppEvent {
+        group_id_hex: overlap_id.clone(),
+        message_id_hex: id.to_owned(),
+        source_message_id_hex: Some(format!("source-{id}")),
+        source_epoch: None,
+        direction: "received".to_owned(),
+        sender: "ee".repeat(32),
+        plaintext: "hello".to_owned(),
+        kind: MARMOT_APP_EVENT_KIND_CHAT,
+        tags: Vec::new(),
+        recorded_at: at,
+        received_at: at,
+        origin_commit_id: None,
+        moderation_grant: false,
+    };
+    storage.record_app_event(&chat("old", 10)).unwrap();
+    storage
+        .initialize_chat_read_state(&alice.account_id_hex, &overlap_id, &|_, _| false)
+        .unwrap();
+    storage.record_app_event(&chat("new", 11)).unwrap();
+    storage
+        .refresh_chat_list_row(&alice.account_id_hex, &overlap_id, &|_, _| false)
+        .unwrap();
+    app.set_chat_manually_unread("alice", &overlap_id, true)
+        .unwrap();
+
+    let summary = app
+        .account_unread_summary()
+        .unwrap()
+        .into_iter()
+        .find(|summary| summary.account_id_hex == alice.account_id_hex)
+        .expect("seeded account");
+    assert_eq!(summary.unread_count, 1);
+    assert_eq!(summary.unread_conversations, 3);
+    assert_eq!(summary.attention_only_conversations, 2);
+    assert!(summary.has_unread);
+}

--- a/crates/marmot-uniffi/src/commands/account.rs
+++ b/crates/marmot-uniffi/src/commands/account.rs
@@ -33,13 +33,14 @@ impl Marmot {
             .collect())
     }
 
-    /// Per-account unread aggregate for the account-switcher badge
-    /// (mdk#461). Each entry's `unread_count` is read from that
-    /// account's materialized chat-list projection, so this does not require
-    /// switching into, or loading a full session/timeline for, any account —
-    /// non-active (not-`running`) accounts are reported too. Sign-capable
-    /// local and external-signer accounts are included, matching
-    /// `list_accounts`.
+    /// Per-account unread aggregate for the account-switcher and application
+    /// badge (mdk#461, mdk#1460). Each entry is read from that account's
+    /// materialized chat-list projection, so this does not require switching
+    /// into, or loading a full session/timeline for, any account — non-active
+    /// (not-`running`) accounts are reported too. Sign-capable local and
+    /// external-signer accounts are included, matching `list_accounts`.
+    /// `attention_only_conversations` covers pending invitations and
+    /// manual-only unread rows without overlapping unread-message totals.
     pub fn account_unread_summary(
         &self,
     ) -> Result<Vec<conversions::AccountUnreadFfi>, MarmotKitError> {
@@ -560,6 +561,26 @@ mod tests {
     use nostr_relay_builder::MockRelay;
 
     use super::*;
+
+    #[test]
+    fn account_unread_summary_reports_zero_attention_for_idle_local_account() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let home = AccountHome::open(root.path());
+        let account = home.create_account("alice").expect("create alice");
+        let app = MarmotApp::with_relay(root.path(), "wss://relay.invalid.test");
+        let runtime = app.runtime();
+        let kit = Marmot { app, runtime };
+
+        let summary = kit
+            .account_unread_summary()
+            .expect("unread summary without starting a session");
+        assert_eq!(summary.len(), 1);
+        assert_eq!(summary[0].account_id_hex, account.account_id_hex);
+        assert_eq!(summary[0].unread_count, 0);
+        assert_eq!(summary[0].unread_conversations, 0);
+        assert_eq!(summary[0].attention_only_conversations, 0);
+        assert!(!summary[0].has_unread);
+    }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn follow_bindings_preserve_the_list_and_refresh_fast_reads() {

--- a/crates/marmot-uniffi/src/conversions/account.rs
+++ b/crates/marmot-uniffi/src/conversions/account.rs
@@ -15,18 +15,25 @@ pub struct AccountSummaryFfi {
     pub running: bool,
 }
 
-/// Per-account unread aggregate for the account-switcher badge
-/// (mdk#461). Computed from each account's materialized chat-list
-/// projection without loading a full session/timeline, so accounts that are
-/// not the active/running one are reported too.
+/// Per-account unread aggregate for the account-switcher and application
+/// badge (mdk#461, mdk#1460). Computed from each account's materialized
+/// chat-list projection without loading a full session/timeline, so accounts
+/// that are not the active/running one are reported too.
 #[derive(Clone, Debug, uniffi::Record)]
 pub struct AccountUnreadFfi {
     pub account_id_hex: String,
     /// Total unread messages across all unarchived conversations.
     pub unread_count: u64,
-    /// Number of unarchived conversations with at least one unread message.
+    /// Number of unarchived conversations that require badge attention:
+    /// unread messages, a manual-unread reminder, or a pending invitation.
     pub unread_conversations: u64,
-    /// Whether the account has any unread message at all.
+    /// Conversations that contribute badge attention solely because they are
+    /// manually marked unread or pending confirmation. A row that already has
+    /// unread messages is omitted so hosts can compute
+    /// `unread_count + attention_only_conversations` without overlap.
+    pub attention_only_conversations: u64,
+    /// Whether the account has any badge-worthy conversation, including a
+    /// manual-only reminder or pending invitation with no unread messages.
     pub has_unread: bool,
 }
 
@@ -36,6 +43,7 @@ impl From<AccountUnread> for AccountUnreadFfi {
             account_id_hex: value.account_id_hex,
             unread_count: value.unread_count,
             unread_conversations: value.unread_conversations,
+            attention_only_conversations: value.attention_only_conversations,
             has_unread: value.has_unread,
         }
     }
@@ -283,6 +291,22 @@ mod tests {
     // A disposition the host cannot read is not a signal. #1177 is only closed
     // if `accepted_pending` survives the FFI boundary as a typed value rather
     // than being flattened away with the rest of the summary.
+    #[test]
+    fn badge_attention_crosses_ffi_without_overlapping_unread_totals() {
+        let ffi = AccountUnreadFfi::from(AccountUnread {
+            account_id_hex: "aa".repeat(32),
+            unread_count: 4,
+            unread_conversations: 3,
+            attention_only_conversations: 2,
+            has_unread: true,
+        });
+
+        assert_eq!(ffi.unread_count, 4);
+        assert_eq!(ffi.unread_conversations, 3);
+        assert_eq!(ffi.attention_only_conversations, 2);
+        assert!(ffi.has_unread);
+    }
+
     #[test]
     fn accepted_pending_crosses_ffi_as_a_typed_disposition() {
         let ffi = SendSummaryFfi::from(SendSummary {

--- a/crates/marmot-uniffi/tests/smoke.rs
+++ b/crates/marmot-uniffi/tests/smoke.rs
@@ -249,6 +249,7 @@ async fn account_unread_summary_reports_local_accounts_without_session_load() {
     assert_eq!(entry.account_id_hex, account.account_id_hex);
     assert_eq!(entry.unread_count, 0);
     assert_eq!(entry.unread_conversations, 0);
+    assert_eq!(entry.attention_only_conversations, 0);
     assert!(!entry.has_unread);
 }
 

--- a/crates/storage-sqlite/src/chat_list.rs
+++ b/crates/storage-sqlite/src/chat_list.rs
@@ -53,13 +53,20 @@ pub type MentionClassifier<'a> = dyn Fn(&str, &[Vec<String>]) -> bool + 'a;
 pub struct AccountUnreadTotal {
     /// Sum of `unread_count` across all unarchived conversations.
     pub unread_count: u64,
-    /// Number of unarchived conversations with at least one unread message.
+    /// Number of unarchived conversations that require badge attention:
+    /// unread messages, a manual-unread reminder, or a pending invitation.
     pub unread_conversations: u64,
+    /// Unarchived conversations that contribute badge attention solely because
+    /// they are manually marked unread or pending confirmation. A row that
+    /// already has `unread_count > 0` is omitted so
+    /// `unread_count + attention_only_conversations` is the application badge.
+    pub attention_only_conversations: u64,
 }
 
 impl AccountUnreadTotal {
-    /// Whether the account has any unread conversation, including a
-    /// manual-only reminder with no unread incoming messages.
+    /// Whether the account has any badge-worthy conversation, including a
+    /// manual-only reminder or pending invitation with no unread incoming
+    /// messages.
     pub fn has_unread(&self) -> bool {
         self.unread_conversations > 0
     }
@@ -402,13 +409,23 @@ impl SqliteAccountStorage {
     /// longer in — `account_groups.self_membership` of `'left'` or `'removed'`
     /// — are also excluded; unknown membership (`'member'`, the default, or no
     /// matching `account_groups` row) preserves the unread count so uncertainty
-    /// never suppresses.
+    /// never suppresses. Pending invitations and manual-only unread rows count
+    /// as badge attention; a row with unread messages is not counted again in
+    /// `attention_only_conversations`.
     pub fn account_unread_total(&self) -> StorageResult<AccountUnreadTotal> {
         let conn = self.lock()?;
         conn.query_row(
             "SELECT COALESCE(SUM(row.unread_count), 0),
                     COUNT(CASE
-                        WHEN row.unread_count > 0 OR row.manually_marked_unread = 1
+                        WHEN row.unread_count > 0
+                          OR row.manually_marked_unread = 1
+                          OR row.pending_confirmation = 1
+                        THEN 1
+                    END),
+                    COUNT(CASE
+                        WHEN row.unread_count = 0
+                         AND (row.manually_marked_unread = 1
+                           OR row.pending_confirmation = 1)
                         THEN 1
                     END)
              FROM chat_list_rows AS row
@@ -420,15 +437,24 @@ impl SqliteAccountStorage {
                    WHERE lower(hex(tomb.group_id)) = lower(row.group_id_hex)
                )",
             [],
-            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)),
+            |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, i64>(2)?,
+                ))
+            },
         )
         .storage()
-        .and_then(|(unread_count, unread_conversations)| {
-            Ok(AccountUnreadTotal {
-                unread_count: i64_to_u64(unread_count)?,
-                unread_conversations: i64_to_u64(unread_conversations)?,
-            })
-        })
+        .and_then(
+            |(unread_count, unread_conversations, attention_only_conversations)| {
+                Ok(AccountUnreadTotal {
+                    unread_count: i64_to_u64(unread_count)?,
+                    unread_conversations: i64_to_u64(unread_conversations)?,
+                    attention_only_conversations: i64_to_u64(attention_only_conversations)?,
+                })
+            },
+        )
     }
 
     pub fn ensure_chat_list_rows(

--- a/crates/storage-sqlite/src/chat_list/tests.rs
+++ b/crates/storage-sqlite/src/chat_list/tests.rs
@@ -161,6 +161,13 @@ fn manual_unread_is_independent_durable_and_cleared_by_mark_read() {
         store.account_unread_total().unwrap().unread_conversations,
         1
     );
+    assert_eq!(
+        store
+            .account_unread_total()
+            .unwrap()
+            .attention_only_conversations,
+        1
+    );
 
     store
         .record_app_event(&chat("incoming", REMOTE, 20, "new message"))
@@ -1846,6 +1853,200 @@ fn account_unread_total_preserves_rows_without_account_group_row() {
     let total = store.account_unread_total().unwrap();
     assert_eq!(total.unread_count, 1);
     assert_eq!(total.unread_conversations, 1);
+}
+
+fn chat_in(group_id_hex: &str, id: &str, sender: &str, at: u64, plaintext: &str) -> StoredAppEvent {
+    let mut event = chat(id, sender, at, plaintext);
+    event.group_id_hex = group_id_hex.to_owned();
+    event
+}
+
+fn materialize_one_unread(store: &SqliteAccountStorage, group_id_hex: &str) {
+    store
+        .record_app_event(&chat_in(
+            group_id_hex,
+            "old",
+            REMOTE,
+            10,
+            "before first open",
+        ))
+        .unwrap();
+    store
+        .refresh_chat_list_row(LOCAL, group_id_hex, &no_mentions)
+        .unwrap();
+    store
+        .initialize_chat_read_state(LOCAL, group_id_hex, &no_mentions)
+        .unwrap();
+    store
+        .record_app_event(&chat_in(
+            group_id_hex,
+            "new",
+            REMOTE,
+            11,
+            "after first open",
+        ))
+        .unwrap();
+    let row = store
+        .refresh_chat_list_row(LOCAL, group_id_hex, &no_mentions)
+        .unwrap()
+        .expect("chat row");
+    assert_eq!(row.unread_count, 1);
+}
+
+fn put_disband_tombstone_for(store: &SqliteAccountStorage, group_id_hex: &str) {
+    use cgka_traits::DisbandTombstone;
+    use cgka_traits::storage::DisbandTombstoneStorage;
+    use cgka_traits::types::{EpochId, MemberId};
+
+    store
+        .put_disband_tombstone(
+            &GroupId::new(hex::decode(group_id_hex).expect("group id hex")),
+            &DisbandTombstone {
+                epoch: EpochId(1),
+                actor: MemberId::new(vec![0xbb; 4]),
+                origin_commit_id: None,
+                commit_digest: [0; 32],
+                local_was_committer_leaf: false,
+                former_members: Vec::new(),
+            },
+        )
+        .unwrap();
+}
+
+#[test]
+fn account_unread_total_counts_pending_invite_as_attention_only() {
+    let mut pending = group();
+    pending.pending_confirmation = true;
+    let store = setup_store_with_group(pending);
+    store
+        .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+        .unwrap();
+
+    let total = store.account_unread_total().unwrap();
+    assert_eq!(total.unread_count, 0);
+    assert_eq!(total.unread_conversations, 1);
+    assert_eq!(total.attention_only_conversations, 1);
+    assert!(total.has_unread());
+}
+
+#[test]
+fn account_unread_total_does_not_double_count_unread_plus_manual() {
+    let store = setup_store_with_one_unread();
+    store
+        .set_chat_manually_unread(LOCAL, GROUP, true, &no_mentions)
+        .unwrap();
+
+    let total = store.account_unread_total().unwrap();
+    assert_eq!(total.unread_count, 1);
+    assert_eq!(total.unread_conversations, 1);
+    assert_eq!(total.attention_only_conversations, 0);
+}
+
+#[test]
+fn account_unread_total_does_not_double_count_unread_plus_pending() {
+    let mut pending = group();
+    pending.pending_confirmation = true;
+    let store = setup_store_with_group(pending);
+    materialize_one_unread(&store, GROUP);
+
+    let total = store.account_unread_total().unwrap();
+    assert_eq!(total.unread_count, 1);
+    assert_eq!(total.unread_conversations, 1);
+    assert_eq!(total.attention_only_conversations, 0);
+}
+
+#[test]
+fn account_unread_total_excludes_archived_attention_only_rows() {
+    let mut archived_pending = group();
+    archived_pending.pending_confirmation = true;
+    archived_pending.archived = true;
+    let store = setup_store_with_group(archived_pending);
+    store
+        .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+        .unwrap();
+    store
+        .set_chat_manually_unread(LOCAL, GROUP, true, &no_mentions)
+        .unwrap();
+
+    let total = store.account_unread_total().unwrap();
+    assert_eq!(total, AccountUnreadTotal::default());
+    assert!(!total.has_unread());
+}
+
+#[test]
+fn account_unread_total_suppresses_left_removed_and_disbanded_attention() {
+    let mut pending = group();
+    pending.pending_confirmation = true;
+    let store = setup_store_with_group(pending);
+    store
+        .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+        .unwrap();
+    assert_eq!(
+        store
+            .account_unread_total()
+            .unwrap()
+            .attention_only_conversations,
+        1
+    );
+
+    store
+        .set_group_self_membership(GROUP, SelfMembership::Left)
+        .unwrap();
+    assert_eq!(
+        store.account_unread_total().unwrap(),
+        AccountUnreadTotal::default()
+    );
+
+    store
+        .set_group_self_membership(GROUP, SelfMembership::Member)
+        .unwrap();
+    store
+        .set_group_self_membership(GROUP, SelfMembership::Removed)
+        .unwrap();
+    assert_eq!(
+        store.account_unread_total().unwrap(),
+        AccountUnreadTotal::default()
+    );
+
+    store
+        .set_group_self_membership(GROUP, SelfMembership::Member)
+        .unwrap();
+    put_disband_tombstone_for(&store, GROUP);
+    assert_eq!(
+        store.account_unread_total().unwrap(),
+        AccountUnreadTotal::default()
+    );
+}
+
+#[test]
+fn account_unread_total_sums_distinct_attention_only_rows() {
+    let pending = StoredAccountGroup {
+        group_id_hex: "22".to_owned(),
+        pending_confirmation: true,
+        ..group()
+    };
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    store
+        .save_account_projection_state(
+            &StoredAccountState {
+                label: "alice".to_owned(),
+                groups: vec![group(), pending],
+                ..StoredAccountState::default()
+            },
+            256,
+            MAX_FUTURE_SKEW_SECS,
+        )
+        .unwrap();
+    store.refresh_chat_list_rows(LOCAL, &no_mentions).unwrap();
+    store
+        .set_chat_manually_unread(LOCAL, GROUP, true, &no_mentions)
+        .unwrap();
+
+    let total = store.account_unread_total().unwrap();
+    assert_eq!(total.unread_count, 0);
+    assert_eq!(total.unread_conversations, 2);
+    assert_eq!(total.attention_only_conversations, 2);
+    assert!(total.has_unread());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- `account_unread_summary()` only counted unread messages (plus manual unread in `unread_conversations`), so iOS had to fan out `list_accounts` + `chat_list` to badge pending invitations and manual-only unread rows.
- The cheap per-account aggregate now includes those attention-only conversations and exposes `attention_only_conversations` so hosts can compute `unread_count + attention_only_conversations` without overlap. Archived, left, removed, and disbanded rows keep the existing eligibility rules.

Fixes #1460

## Test plan
- [x] New storage tests failed before the query change (pending invites uncounted, `attention_only_conversations` stuck at 0) and pass after
- [x] Storage coverage for overlap, archived rows, left/removed/disbanded suppression, manual-only, pending-only, and zero-state
- [x] Runtime test covers non-active accounts without session load
- [x] UniFFI conversion and smoke tests surface the new field
- [ ] `just fast-ci` / GitHub CI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved unread summaries for application badges.
  * Badge attention now includes pending invitations and manually marked unread conversations, even when no unread messages exist.
  * Conversations with unread messages are counted separately to prevent duplicate totals.
  * Archived, inactive, and ineligible conversations are excluded from attention counts.

* **Bug Fixes**
  * Corrected unread and attention counts for fresh accounts and overlapping unread states.

* **Tests**
  * Added coverage for invitations, manual unread status, archived conversations, and membership changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->