### PR TITLE
Document convergence simulator operations and scaling

### DIFF
--- a/crates/cgka-conformance-simulator/AGENTS.md
+++ b/crates/cgka-conformance-simulator/AGENTS.md
@@ -32,8 +32,10 @@ requires `RUST_MIN_STACK=4194304`; Cargo-launched commands inherit the repositor
 CI-like Cargo commands.
 
 Do not infer that more `--cases` means more complex scenarios. Cases are independent indices and seed selects their
-deterministic choices. The stable identity is `(family/profile version, seed, case index)`. The CLI has no case-start
-offset, so shard large campaigns by distinct seeds rather than overlapping prefixes of the same seed.
+deterministic choices. The stable identity is `(family_name, generator_version, seed, case_index)`, plus an
+independently versioned workload profile when applicable. The CLI has no case-start offset, so shard large campaigns
+by distinct seeds rather than overlapping prefixes of the same seed. Generated inputs/reports do not embed the tested
+Git commit; require a clean build and retain the exact source revision plus command matrix beside durable evidence.
 
 ## Pieces
 

--- a/crates/cgka-conformance-simulator/AGENTS.md
+++ b/crates/cgka-conformance-simulator/AGENTS.md
@@ -1,8 +1,39 @@
 # AGENTS.md — cgka-conformance-simulator
 
-Read [`README.md`](README.md) for the human framing, [`SCENARIO_IR.md`](SCENARIO_IR.md) for canonical and authoring
-semantics, [`SCENARIOS.md`](SCENARIOS.md) for the scenario registry, and [`PROPERTY_TESTS.md`](PROPERTY_TESTS.md) for
-the property-test registry. This file is the agent-facing model.
+Read [`README.md`](README.md) for the human framing, [`RUNNING_CAMPAIGNS.md`](RUNNING_CAMPAIGNS.md) for exact operator
+commands and artifact handling, [`SCALING_CAMPAIGNS.md`](SCALING_CAMPAIGNS.md) for large matrices and family design,
+[`SCENARIO_IR.md`](SCENARIO_IR.md) for canonical and authoring semantics, [`SCENARIOS.md`](SCENARIOS.md) for the
+scenario registry, and [`PROPERTY_TESTS.md`](PROPERTY_TESTS.md) for the property-test registry. This file is the
+agent-facing code model.
+
+## Agent operating workflow
+
+When asked to run, extend, diagnose, or report on convergence campaigns:
+
+1. Identify the claim before choosing the execution layer. Use an engine-capable subject for exact MLS-private state,
+   durable input dispositions, pending work, and active decryptability. Use app/process/container projections only for
+   public facts they can actually expose.
+2. Start with a strict, file-backed canary. Do not use `--allow-weak-oracle` to make an assurance run green.
+3. For broad discovery, use `cgka-conformance-campaign`: it persists the exact input before action zero, isolates each
+   case in a child, enforces a deadline, and verifies artifacts. Build once and shard distinct seeds when scaling.
+4. Reproduce from the saved `*-generated-input.json`, not from a remembered command alone. Record family version,
+   seed, case index, selected/executed IR digests, adapter, storage mode, source revision, and output path.
+5. Move a failure down to the smallest compatible adapter before debugging it. Move representative cases outward to
+   process/container/VM only when that layer answers a named hypothesis.
+6. Preserve reports and capsules before changing code. Sensitive replay capsules contain key material: keep them
+   owner-only, never commit them, and never quote their contents into issues or logs.
+7. Classify a failure before fixing it: product defect, protocol ambiguity, environment failure, or expected resource
+   refusal. A timeout, unsupported capability, weak oracle, and semantic mismatch are not interchangeable.
+8. After a fix, rerun the minimized input, original input, family canary, relevant focused test, and widest adapter
+   needed by the claim. Report local gates, remote CI, and retained evidence separately.
+
+Use a new output directory for every run; overwrite refusal is an evidence-integrity feature. Direct binary execution
+requires `RUST_MIN_STACK=4194304`; Cargo-launched commands inherit the repository configuration. Keep `--locked` on
+CI-like Cargo commands.
+
+Do not infer that more `--cases` means more complex scenarios. Cases are independent indices and seed selects their
+deterministic choices. The stable identity is `(family/profile version, seed, case index)`. The CLI has no case-start
+offset, so shard large campaigns by distinct seeds rather than overlapping prefixes of the same seed.
 
 ## Pieces
 

--- a/crates/cgka-conformance-simulator/PROPERTY_TESTS.md
+++ b/crates/cgka-conformance-simulator/PROPERTY_TESTS.md
@@ -240,10 +240,11 @@ directly. The model tracks membership, administrator authority, connectivity, pr
 delivery. It emits membership and retained-history profiles separately so pre-admission transport retry state is not
 misclassified as a no-pending failure.
 
-The generator is deterministic by family version, seed, and case index. Existing semantic reduction minimizes a saved
-failing scenario after execution. `tests/stateful_generator.rs` independently replays the legal-action preconditions,
-checks the complete action vocabulary across adjacent cases, runs both profiles through the report path, and verifies
-that the input fixture was saved privately before execution.
+The generator is deterministic by family name, independent generator version, seed, and case index, plus a separately
+versioned workload profile when applicable. Existing semantic reduction minimizes a saved failing scenario after
+execution. `tests/stateful_generator.rs` independently replays the legal-action preconditions, checks the complete
+action vocabulary across adjacent cases, runs both profiles through the report path, and verifies that the input
+fixture was saved privately before execution.
 
 ### `cross-route-restart-permutations/v1`
 

--- a/crates/cgka-conformance-simulator/PROPERTY_TESTS.md
+++ b/crates/cgka-conformance-simulator/PROPERTY_TESTS.md
@@ -253,11 +253,11 @@ all four participants after retained-history repair. Seeds rotate the catalog ra
 shards remain deterministic and a twelve-case run has a clear completeness claim. The generated family exercises the
 full app runtime and strict public projection/payload oracle. A separate exact retained-engine family uses the same
 isolated child runner so panic-shaped failures do not abort later cases. The complete public seed-0 catalog passed
-12/12; the corresponding exact run passed 9/12: the three
-early Zeta publication-boundary restarts produced two `PendingPublish` failures (one structured, one panic) and one
-epoch-3/pending-work/decryptability stall, while every later branch/repair boundary passed. An explicit ignored test replays the catalog through the
-isolated-process adapter, whose validation binds every restart action id to a matching durable `restarted` lifecycle
-event.
+12/12. The first exact run passed 9/12 and exposed three early Zeta publication-boundary failures. Minimization traced
+them to cross-incarnation reuse of process-local pending handles in the simulator harness. Incarnation-scoped
+bookkeeping fixed that adapter defect in MDK #1465, and the exact seed-0 catalog now passes 12/12 without a production
+engine change. An explicit ignored test replays the catalog through the isolated-process adapter, whose validation
+binds every restart action id to a matching durable `restarted` lifecycle event.
 
 ## Current Gaps
 

--- a/crates/cgka-conformance-simulator/README.md
+++ b/crates/cgka-conformance-simulator/README.md
@@ -505,10 +505,11 @@ permissions before executing its case. It preserves the full generated case, inc
 semantic expectations, so a crash or panic cannot erase the exact executable input. Replay one directly with
 `--generated-input FILE`. Add `--adapter engine|retained-relay|app-runtime` to deliberately run the embedded canonical
 Scenario IR through a different in-process adapter; capability preflight still rejects unsupported operations before
-action zero. Reports retain the producer's family/version/seed/case/subject provenance plus separate SHA-256 digests for
-the selected envelope bytes and the selected canonical Scenario IR inside it. An adapter override adds the executing
-adapter to report and failure-capsule filenames so A/B runs cannot overwrite one another. Override runs do not mint a
-promotable vector candidate; only the generator-recorded subject may supply that adapter-neutral fixture.
+action zero. Reports retain the producer's family name, independent generator version, seed, case index, and subject
+provenance plus separate SHA-256 digests for the selected envelope bytes and the selected canonical Scenario IR inside
+it. An adapter override adds the executing adapter to report and failure-capsule filenames so A/B runs cannot
+overwrite one another. Override runs do not mint a promotable vector candidate; only the generator-recorded subject
+may supply that adapter-neutral fixture.
 
 The fixed `cross-route-retained-history-recovery/v1` input uses the same envelope to pin the retained-relay adapter and
 the semantic oracle for the four-party cross-route regression. Run its strict encrypted-SQLite replay with:

--- a/crates/cgka-conformance-simulator/README.md
+++ b/crates/cgka-conformance-simulator/README.md
@@ -2,6 +2,16 @@
 
 In-process multi-client simulator for the CGKA engine.
 
+## Start here
+
+- [`RUNNING_CAMPAIGNS.md`](RUNNING_CAMPAIGNS.md): operator manual for vectors, generated cases, saved-input replay,
+  app/process adapters, containers, VMs, artifacts, and failure handling.
+- [`SCALING_CAMPAIGNS.md`](SCALING_CAMPAIGNS.md): how to shard thousands of cases, choose execution layers, retain
+  evidence, and add high-value workload families.
+- [`SCENARIO_IR.md`](SCENARIO_IR.md): canonical scenario and authoring contracts.
+- [`SCENARIOS.md`](SCENARIOS.md): fixed and generated scenario registry.
+- [`AGENTS.md`](AGENTS.md): agent-facing code map and safe operating workflow.
+
 The engine crate proves local engine rules. This crate asks the bigger question: if several clients run that engine and
 the network behaves badly, do they still end up with the same group state?
 
@@ -549,15 +559,14 @@ retarget or disable the intended branch topology. The two non-publication bounda
 sequence that ends them (reconnect/incremental-sync/tick for Zeta ingestion and Observer reconnect/full-sync/tick for
 the first repair), and a table-driven test pins every inserted restart's exact step and client.
 
-The complete seed-0 public app-runtime execution passed 12/12 cases. The corresponding exact current-build execution
-passed 9/12 and found three early-publication
-counterexamples. `after-create-accepted-zeta` later rejected an admin update from durable `PendingPublish` and wrote a
-shareable capsule; `after-promote-alpha-accepted-zeta` panicked on the next update from `PendingPublish` (the exact
-input and exit 101 survive, but no report/capsule does); and `after-promote-yankee-accepted-zeta` stranded Zeta at epoch
-3 with pending work, quiescence timeouts, and failed inbound decryptability. All later branch/repair boundaries passed.
-The catalog does not encode these surfaces as acceptable behavior or include a production fix. Public and exact
-artifacts carry distinct scenario-name prefixes so evidence remains attributable to the subject and oracle that
-produced it.
+The complete seed-0 public app-runtime execution passes 12/12 cases. The first exact current-build execution passed
+9/12 and exposed three early-publication failures. Minimization showed that all three were simulator false positives:
+the harness compared process-local pending handles across engine incarnations, so a newly reused handle could skip the
+real publication confirmation. Incarnation-scoped pending/outbound bookkeeping fixed the adapter defect in
+[MDK #1465](https://github.com/marmot-protocol/mdk/pull/1465); the exact seed-0 catalog now passes 12/12 without a
+production engine or protocol change. The original inputs and failure digests remain useful historical discovery
+evidence. Public and exact artifacts carry distinct scenario-name prefixes so every result remains attributable to
+the subject and oracle that produced it.
 
 The process adapter accepts the same saved input in place of a raw Scenario IR file:
 

--- a/crates/cgka-conformance-simulator/RUNNING_CAMPAIGNS.md
+++ b/crates/cgka-conformance-simulator/RUNNING_CAMPAIGNS.md
@@ -1,0 +1,294 @@
+# Running Convergence Scenarios And Campaigns
+
+This is the operator manual for the Marmot convergence reliability lab. Start here when you want to run an existing
+vector, generate deterministic scenarios, reproduce a saved case, or move one scenario through more
+production-shaped adapters.
+
+The short rule is: use the cheapest subject that can answer the question, keep strict oracle checking enabled, save
+the exact generated input, and promote only representative cases or failures to processes, containers, or VMs.
+
+For campaign scaling and family development, continue with [`SCALING_CAMPAIGNS.md`](SCALING_CAMPAIGNS.md). For the
+scenario language itself, see [`SCENARIO_IR.md`](SCENARIO_IR.md). The complete scenario registry is in
+[`SCENARIOS.md`](SCENARIOS.md).
+
+## What each execution layer proves
+
+| Layer | Entrypoint | What it adds | What it does not prove |
+| --- | --- | --- | --- |
+| Fixed vectors | `cgka-conformance-simulator-report --vectors ...` | Stable, reviewable semantic regressions | Broad generated coverage |
+| In-process report | `cgka-conformance-simulator-report --family ...` | Fast strict scenario execution and saved reports | OS process isolation or real sockets |
+| Isolated case worker | `cgka-conformance-campaign` | One child per case, timeout/reaping, OS CPU/RSS/write measurements | One OS process per participant |
+| App-runtime adapter | report replay with `--adapter app-runtime` | Production-shaped app/session/projection behavior in one process | Participant process or host isolation |
+| Process adapter | `cgka-conformance-process` | One account-device per child process, private SQLCipher roots, restart | Separate kernels or real network namespaces |
+| Container runner | `cgka-distributed-campaign` / ignored container tests | One participant per container, real sockets, isolated OCI network, network faults | A distinct kernel, block device, or VM host |
+| VM driver | distributed manifest with VM backend | External host lifecycle, kernel/filesystem/block-device isolation | More semantic coverage by itself |
+
+Public app/process/container projections cannot establish exact MLS-private state, durable internal input dispositions,
+or active decryptability when those surfaces are not exposed by the adapter. Pair wider public runs with an
+engine-capable exact control when the claim requires those facts.
+
+## Before the first run
+
+Run commands from the repository root. The workspace pins its Rust toolchain; use `--locked` for CI-like runs. Cargo
+launches supply the simulator's required stack size. When invoking a built binary directly, set
+`RUST_MIN_STACK=4194304`.
+
+Use a new output directory for every run. The isolated campaign runner intentionally refuses to overwrite earlier
+evidence. Keep generated inputs and failure artifacts private: sensitive replay capsules can contain recipient
+database/OpenMLS state and key material and must never be committed.
+
+For a quick installation and compile check:
+
+```sh
+just simulator-smoke
+```
+
+## The five-minute local workflow
+
+### 1. Run a small strict generated batch
+
+```sh
+cargo run -p cgka-conformance-simulator --bin cgka-conformance-simulator-report --locked -- \
+  --family chat-journey/v1 \
+  --seed 42 \
+  --cases 3 \
+  --storage file \
+  --out target/convergence-manual/chat-journey-seed-42
+```
+
+Strict oracle checking is the default. A zero exit means every scenario completed and its declared expectations were
+observed. It does not mean the engine is universally correct. `--allow-weak-oracle` is for deliberately exploratory
+legacy diagnostics only; never use it as green assurance evidence.
+
+### 2. Inspect the evidence
+
+The report directory contains, per case:
+
+- `*-generated-input.json`: the exact versioned input envelope to replay;
+- `*.json`: the scenario report, step log, oracle evidence, input dispositions, and campaign measurements;
+- `*-fixture.v1.json`: a candidate fixed vector, not automatically approved truth;
+- `*-failure-capsule.v1.json`: a shareable synthetic failure capsule when a failure occurs; and
+- optionally `*-sensitive-replay-capsule.v1.json`: engine byte-replay material, only when explicitly requested.
+
+Read `expectation_failures`, `oracle`, `step_log`, `pending_resolution_observations`,
+`app_invalidation_observations`, and `campaign_measurements` before deciding what failed. A timeout, resource refusal,
+unsupported adapter capability, infrastructure error, and semantic mismatch are different outcomes.
+
+### 3. Replay exactly the saved logical input
+
+Use a fresh output directory:
+
+```sh
+cargo run -p cgka-conformance-simulator --bin cgka-conformance-simulator-report --locked -- \
+  --generated-input target/convergence-manual/chat-journey-seed-42/chat-journey-v1-seed-42-case-0-generated-input.json \
+  --storage file \
+  --out target/convergence-manual/chat-journey-seed-42-case-0-replay
+```
+
+The stable logical identity of a generated case is `(family version, seed, case index)`. The saved input is stronger
+than remembering those three values because it pins the resolved scenario, subject, expectations, provenance, and
+digest. Logical replay does not recreate randomized MLS bytes. A checkpoint-bearing sensitive capsule is required for
+byte replay:
+
+```sh
+cargo run -p cgka-conformance-simulator --bin cgka-conformance-simulator-report --locked -- \
+  --replay-capsule PATH_TO_SENSITIVE_CAPSULE
+```
+
+### 4. Isolate every case in its own worker process
+
+```sh
+cargo run -p cgka-conformance-simulator --bin cgka-conformance-campaign --locked -- \
+  --family convergence-chaos/v1 \
+  --seed 42 \
+  --cases 12 \
+  --case-timeout-secs 300 \
+  --storage file \
+  --out target/convergence-manual/chaos-seed-42-isolated
+```
+
+The parent saves each input before spawning its worker, kills and reaps deadline failures, verifies artifact
+provenance, and writes `process-campaign.v1.json`. This is the preferred local discovery boundary: a panic or hang in
+one case cannot erase the remaining cases, and the summary contains real child-process resource measurements.
+
+## Choosing a generated family
+
+| Family | Use it for |
+| --- | --- |
+| `send-leave/v1` | Small membership/application lifecycle coverage |
+| `convergence-e2e-delivery/v1` | Peeler-to-engine delivery under duplicate, delay, and reorder noise |
+| `convergence-chaos/v1` | Broad adversarial forks, partitions, storms, restarts, and delayed messages |
+| `admin-churn/v1` | Sequential/competing administration, joins, restarts, and churn |
+| `adversarial-reliability/v1` | Named real-world and resource-pressure workload catalog |
+| `bounded-convergence-pressure/v1` | Finite self-update/profile/admin pressure under a bounded quiescence contract |
+| `cross-route-restart-permutations/v1` | Twelve public app-runtime restart boundaries in the four-party route scenario |
+| `cross-route-exact-restart-permutations/v1` | Exact/private engine companion to the public restart catalog |
+| `chat-journey/v1` | Legality-aware product journeys: membership, profile, app traffic, offline/catch-up, and restart |
+
+`--cases` is a count, not a complexity dial. Case index selects a deterministic arm or generated history. More cases
+increase coverage; they do not promise that later cases are larger. `--seed` changes the deterministic choices within
+each indexed case. A family defines the available operations, weights/motifs, subject, and expectations.
+
+## Running vectors and adapter comparisons
+
+Run all portable vectors:
+
+```sh
+cargo run -p cgka-conformance-simulator --bin cgka-conformance-simulator-report --locked -- \
+  --vectors crates/cgka-conformance-simulator/vectors \
+  --storage file \
+  --out target/convergence-manual/vector-reports
+```
+
+A saved generated input can be rerun on a compatible subject:
+
+```sh
+cargo run -p cgka-conformance-simulator --bin cgka-conformance-simulator-report --locked -- \
+  --generated-input PATH_TO_GENERATED_INPUT \
+  --adapter retained-relay \
+  --storage file \
+  --out target/convergence-manual/retained-relay-replay
+```
+
+Valid overrides are `engine`, `retained-relay`, and `app-runtime`. The full schedule is capability-preflighted before
+step zero. Rejection means the selected adapter cannot honestly execute that scenario; do not delete operations or
+assertions merely to force it through. Choose a capability-overlap scenario or add a deliberate, digest-recorded
+lowering in the adapter.
+
+## Running the separate-process adapter
+
+First build both binaries:
+
+```sh
+cargo build -p cgka-conformance-simulator \
+  --bin cgka-conformance-process \
+  --bin cgka-conformance-node \
+  --locked
+```
+
+Then run one saved canonical/generated input:
+
+```sh
+RUST_MIN_STACK=4194304 target/debug/cgka-conformance-process \
+  PATH_TO_GENERATED_INPUT \
+  target/debug/cgka-conformance-node \
+  target/convergence-manual/process-report.json
+```
+
+The process adapter launches one node per account-device, gives each a separate private database/artifact root, and
+writes a public process report plus participant-owned failure material. The scenario must fit the process adapter's
+declared capabilities.
+
+The bounded four-party restart catalog also has an explicit manual test:
+
+```sh
+cargo test -p cgka-conformance-simulator --test process_orchestrator --locked -- \
+  --ignored four_party_cross_route_process_restart_permutations_match_unified_route
+```
+
+## Running the restart catalogs
+
+The two stable recipes cover all twelve v1 boundaries at seed zero:
+
+```sh
+just cross-route-restart-campaign 0 12 target/convergence-manual/cross-route-public-seed-0
+just cross-route-exact-restart-campaign 0 12 target/convergence-manual/cross-route-exact-seed-0
+```
+
+Use the exact/private campaign as the correctness control and the public app-runtime campaign as the
+production-shaped projection check. A wider `--cases` value repeats the bounded v1 catalog under its documented seed
+rotation; it does not create new restart boundaries.
+
+## Running containers
+
+Containers are the right next step for real sockets, OCI network isolation, participant image separation, and network
+fault injection. They are expensive enough that broad seed discovery should stay in isolated local workers.
+
+Build the current source image and run the real-container tests:
+
+```sh
+docker build -f Dockerfile.convergence-campaign -t marmot-conformance:local .
+CGKA_CONVERGENCE_IMAGE=marmot-conformance:local \
+  cargo test -p convergence-campaign-runner --test container_runtime --locked -- --ignored
+```
+
+Retain the exact four-party checkpoint artifacts:
+
+```sh
+CGKA_CONVERGENCE_IMAGE=marmot-conformance:local \
+CGKA_DISTRIBUTED_ARTIFACTS_DIR="$PWD/target/convergence-manual/distributed-container-evidence" \
+  cargo test -p convergence-campaign-runner --test container_runtime --locked \
+    four_party_cross_route_recovery_containers_match_unified_route -- --ignored --exact
+```
+
+The runner creates an isolated relay/network and one non-root participant container per member. Each participant owns
+separate encrypted storage. All containers still share the host kernel.
+
+For a checked-in or privately prepared distributed manifest, always validate and inspect before mutation:
+
+```sh
+cargo run -p convergence-campaign-runner --bin cgka-distributed-campaign --locked -- \
+  validate PATH_TO_MANIFEST
+cargo run -p convergence-campaign-runner --bin cgka-distributed-campaign --locked -- \
+  plan PATH_TO_MANIFEST
+cargo run -p convergence-campaign-runner --bin cgka-distributed-campaign --locked -- \
+  doctor PATH_TO_MANIFEST
+cargo run -p convergence-campaign-runner --bin cgka-distributed-campaign --locked -- \
+  run PATH_TO_MANIFEST
+```
+
+Review the normalized plan for image assignments, exact scenario digest, output root, fault capability, cleanup, and
+timeouts. Never point campaign manifests at public relays or put credentials, real payloads, identifiers, or key
+material in them.
+
+## When a VM is justified
+
+The distributed runner has a versioned external VM-driver contract, but MDK intentionally does not own one universal
+provisioner. Use a VM only for a hypothesis that a container cannot represent: distinct kernels, filesystem or
+block-device behavior, host reboot, stronger host isolation, or mixed host images. A VM run should consume the same
+canonical input and oracle as its cheaper control and add only the layer-specific fault.
+
+Do not move thousands of ordinary semantic cases into VMs. First discover and minimize locally, reproduce on the
+app/process boundary, then promote the smallest representative scenario to containers or VMs.
+
+## Scheduled and release lanes
+
+Useful repository entrypoints are:
+
+```sh
+just simulator-smoke
+just convergence-nightly-lane
+just convergence-weekly-lane
+just focused-convergence-regressions
+```
+
+Nightly and weekly lanes evaluate checked-in wall-clock, CPU, RSS, disk, artifact, retry, and flake budgets. Their
+green result is evidence for the exact tested revision and declared lane contents. Release hardening additionally
+requires a reviewed mixed-build manifest:
+
+```sh
+just convergence-release-hardening-lane PATH_TO_MIXED_BUILD_MANIFEST
+```
+
+The release lane is not complete assurance until its digest-pinned evidence bundle and scoped claim have been
+downloaded and reviewed.
+
+## Failure handling checklist
+
+1. Preserve the exact generated input, report, campaign summary, and capsule. Do not rerun into the same directory.
+2. Reproduce from `--generated-input`; use byte replay only when a sensitive capsule exists and can be handled safely.
+3. Classify the outcome: product defect, protocol ambiguity, environment failure, or expected resource refusal.
+4. Minimize semantically while keeping the same failure class and action/failure identity. A changed terminal digest
+   can still be a useful diagnostic reduction, but it is not exact-fingerprint equivalence.
+5. Move down the adapter ladder. If a container failure reproduces in the process or engine subject, debug the smaller
+   boundary. If it only reproduces in the wider layer, retain the relevant receipts and environment facts.
+6. After a fix, rerun the minimized case, its original case, the family canary, and the relevant wider adapter.
+7. Promote a stable synthetic regression into `vectors/` only after human review. Never promote incident/private
+   material.
+
+## Interpreting confidence correctly
+
+A large green matrix raises confidence over the exact operation distribution, constants, resource envelope, adapters,
+and source revision it exercised. It does not prove universal correctness, optimal constants, full offline history, or
+administrator progress under infinite valid self-updates. Campaign results may motivate a policy change, but must not
+automatically tune production constants.

--- a/crates/cgka-conformance-simulator/RUNNING_CAMPAIGNS.md
+++ b/crates/cgka-conformance-simulator/RUNNING_CAMPAIGNS.md
@@ -37,6 +37,10 @@ Use a new output directory for every run. The isolated campaign runner intention
 evidence. Keep generated inputs and failure artifacts private: sensitive replay capsules can contain recipient
 database/OpenMLS state and key material and must never be committed.
 
+Generated inputs and reports do not currently embed the tested Git commit. For evidence that must outlive the local
+session, require a clean worktree and preserve the exact `git rev-parse HEAD` value plus the command matrix beside the
+artifacts. [`SCALING_CAMPAIGNS.md`](SCALING_CAMPAIGNS.md) provides a private-by-default shard recipe that does this.
+
 For a quick installation and compile check:
 
 ```sh
@@ -85,10 +89,12 @@ cargo run -p cgka-conformance-simulator --bin cgka-conformance-simulator-report 
   --out target/convergence-manual/chat-journey-seed-42-case-0-replay
 ```
 
-The stable logical identity of a generated case is `(family version, seed, case index)`. The saved input is stronger
-than remembering those three values because it pins the resolved scenario, subject, expectations, provenance, and
-digest. Logical replay does not recreate randomized MLS bytes. A checkpoint-bearing sensitive capsule is required for
-byte replay:
+The stable logical identity of a generated case is
+`(family_name, generator_version, seed, case_index)`, plus an independently versioned workload profile when one is
+defined. `family_name` and `generator_version` are separate: for example, `convergence-chaos/v1` currently uses
+generator version `6`. The saved input is stronger than remembering that tuple because it pins the resolved scenario,
+subject, expectations, provenance, and digest. Logical replay does not recreate randomized MLS bytes. A
+checkpoint-bearing sensitive capsule is required for byte replay:
 
 ```sh
 cargo run -p cgka-conformance-simulator --bin cgka-conformance-simulator-report --locked -- \
@@ -251,27 +257,37 @@ canonical input and oracle as its cheaper control and add only the layer-specifi
 Do not move thousands of ordinary semantic cases into VMs. First discover and minimize locally, reproduce on the
 app/process boundary, then promote the smallest representative scenario to containers or VMs.
 
-## Scheduled and release lanes
+## Core recipes versus budgeted workflows
 
-Useful repository entrypoints are:
+These are useful local core-test recipes:
 
 ```sh
 just simulator-smoke
 just convergence-nightly-lane
 just convergence-weekly-lane
 just focused-convergence-regressions
-```
-
-Nightly and weekly lanes evaluate checked-in wall-clock, CPU, RSS, disk, artifact, retry, and flake budgets. Their
-green result is evidence for the exact tested revision and declared lane contents. Release hardening additionally
-requires a reviewed mixed-build manifest:
-
-```sh
 just convergence-release-hardening-lane PATH_TO_MIXED_BUILD_MANIFEST
 ```
 
-The release lane is not complete assurance until its digest-pinned evidence bundle and scoped claim have been
-downloaded and reviewed.
+The bare Just recipes do **not** collect or enforce the checked-in wall-clock, CPU, RSS, disk, artifact, retry, and
+flake budgets. `convergence-weekly-lane` and recipes it invokes also remove fixed output roots before rerunning, so use
+them as local test entrypoints rather than retained campaign evidence.
+
+The GitHub workflows wrap the core commands with `observe-step`, `collect-observation`, `check-budget`, and artifact
+upload. Dispatch those workflows on the exact branch or tag to obtain a budget-evaluated, retained run:
+
+```sh
+gh workflow run simulator-nightly.yml --ref BRANCH_OR_TAG
+gh workflow run convergence-hardening.yml --ref BRANCH_OR_TAG -f lane=weekly_manual
+gh workflow run convergence-hardening.yml --ref BRANCH_OR_TAG \
+  -f lane=release_hardening \
+  -f baseline_revision=EXACT_40_CHARACTER_ANCESTOR_COMMIT
+```
+
+Use `gh run list --workflow WORKFLOW_FILE` to find the run, `gh run watch RUN_ID` to wait for it, and
+`gh run download RUN_ID` to retain its artifacts. A green workflow is evidence for the exact `GITHUB_SHA` it checked
+out and the declared lane contents. Release hardening additionally requires a reviewed baseline revision and is not
+complete assurance until its digest-pinned evidence bundle and scoped claim have been downloaded and reviewed.
 
 ## Failure handling checklist
 

--- a/crates/cgka-conformance-simulator/SCALING_CAMPAIGNS.md
+++ b/crates/cgka-conformance-simulator/SCALING_CAMPAIGNS.md
@@ -1,0 +1,202 @@
+# Scaling Convergence Campaigns
+
+This guide describes how to grow from a local canary to thousands of deterministic scenarios without losing
+reproducibility, oracle strength, privacy, or useful failure attribution. Read
+[`RUNNING_CAMPAIGNS.md`](RUNNING_CAMPAIGNS.md) first for the execution layers and commands.
+
+## Scale the cheap boundary first
+
+Use this promotion ladder:
+
+1. in-process strict report for authoring and a very small canary;
+2. file-backed isolated case workers for broad discovery;
+3. app-runtime or separate-process replay for production orchestration/projection questions;
+4. containers for real sockets, namespaces, image differences, and network faults; and
+5. VMs only for kernel, host, filesystem, or block-device hypotheses.
+
+Thousands of engine cases and dozens of process/container cases usually provide more useful coverage per hour than
+thousands of VM cases. Wider execution should confirm layer-specific behavior and representative minimized failures,
+not duplicate the entire cheap corpus.
+
+## Reproducible case identity
+
+The stable logical identity is:
+
+```text
+(family or profile version, seed, case index)
+```
+
+`--cases N` generates indices `0..N-1`. It is not a complexity setting. Increasing it must preserve the existing
+prefix. The current CLI has no case-start offset, so parallelize a large discovery run by assigning distinct seeds to
+shards. Do not run the same seed with several different case counts unless intentional prefix duplication is
+acceptable.
+
+Always retain `*-generated-input.json`. It pins more than the tuple: the selected subject, expectations, exact
+canonical IR, provenance, and digests. Any output-changing generator change requires a family/profile version bump.
+
+## A staged campaign
+
+### Stage 1: canary
+
+Run one to three cases from every relevant family with file-backed storage. Stop on infrastructure, oracle coverage,
+or artifact-integrity errors before spending the larger budget.
+
+### Stage 2: breadth matrix
+
+Build once, then invoke the worker binary directly so parallel shards do not contend on Cargo compilation:
+
+```sh
+cargo build -p cgka-conformance-simulator --bin cgka-conformance-campaign --locked
+```
+
+For example, run eight seed shards with bounded parallelism:
+
+```sh
+campaign_root="target/convergence-scale/chaos"
+mkdir -p "$campaign_root"
+export campaign_root
+seq 1000 1007 | xargs -P 4 -I SEED sh -c '
+  seed="$1"
+  RUST_MIN_STACK=4194304 target/debug/cgka-conformance-campaign \
+    --family convergence-chaos/v1 \
+    --seed "$seed" \
+    --cases 25 \
+    --case-timeout-secs 300 \
+    --storage file \
+    --out "$campaign_root/seed-$seed"
+' sh SEED
+```
+
+This example is 200 cases. Increase the seed range, cases per seed, or both only after measuring peak RSS, disk use,
+and case time. Start parallelism conservatively. A useful limit is the smaller of available CPU capacity and the
+number of worst-case workers that fit in the memory/disk budget. The campaign summary records the measurements needed
+to tune that operational limit.
+
+Use a separate immutable directory per `(source revision, family, seed)`. The runner's overwrite refusal protects
+evidence and catches accidental shard collisions.
+
+### Stage 3: sustained depth
+
+Once breadth is clean, run a smaller number of seeds with larger case counts or the named sustained workloads. Keep
+the same per-case deadline so a slow tail becomes visible rather than silently stretching the job. Compare:
+
+- completed, failed, signaled, and timed-out cases;
+- artifact integrity and missing reports/capsules;
+- wall time, user/system CPU, peak RSS, database bytes, and filesystem write lower bounds;
+- input dispositions, unresolved work, queue depth, replay probes, and reorg distributions; and
+- operation/interaction coverage when the selected family reports it.
+
+Do not treat a zero-failure aggregate as sufficient if the intended operation or interaction never occurred.
+
+### Stage 4: promote representative cases outward
+
+Choose cases because they cover a layer-specific hypothesis, a slow/resource boundary, an unusual decision route, or
+a real failure. Replay the saved input against the next compatible adapter. Preserve selected and executed IR digests
+when a wider adapter performs deterministic lowering.
+
+Run a small container matrix over representative cases and image combinations. Reserve VMs for named gaps that need a
+separate kernel/host/block device. Record the exact source revisions and image digests; a previous green soak does not
+automatically cover later production changes.
+
+## What to run first
+
+For broad defect discovery, prioritize:
+
+1. `chat-journey/v1` for legal product histories;
+2. `convergence-chaos/v1` for adversarial schedule and traffic breadth;
+3. `bounded-convergence-pressure/v1` for the self-update/admin/profile pressure boundary;
+4. `admin-churn/v1` for membership and administrator transitions; and
+5. the two twelve-case cross-route restart catalogs as fixed high-value regressions.
+
+Cover all registered families with a small seed matrix before making one family enormous. Then allocate additional
+cases using measured coverage gaps, failures, slow tails, and recent production changes.
+
+## Adding useful chaos instead of undirected randomness
+
+Every new workload must begin with a question and an oracle. “More random traffic” without a falsifiable expected
+outcome is load generation, not convergence verification.
+
+Prefer extending the legality-aware `chat-journey` product model when the behavior is a real user operation. Keep
+transport/process/storage/resource faults in the separately typed fault layer. A specialized family is justified when
+it enforces a named motif, has a distinct subject or budget, or needs a focused oracle.
+
+High-value motifs that should drive future profiles include:
+
+- an offline founding member returning to a large application/commit backlog while group profile and membership
+  change;
+- sustained application traffic interspersed with proposals, commits, administrator handoff, removals, and re-adds;
+- bounded self-update pressure racing administrator/profile commits, with explicit input closure;
+- restart after publication acceptance, ingest, freeze, selection, application, confirmation, rollback, or retained
+  history repair;
+- delayed application input from a losing branch followed by replacement, invalidation, or retry eligibility;
+- unequal multi-relay histories, reconnect, duplicates, EOSE, incremental cursor advance, and full-history repair;
+- transient resource refusal around candidate materialization, replay, database contention, disk limits, and recovery;
+  and
+- mixed-version participants applying the same canonical scenario across a rolling upgrade.
+
+For each motif, specify:
+
+1. legality preconditions and symbolic state transitions;
+2. required actions/interactions that must appear in the generated corpus;
+3. terminal and intermediate expectations, including no-pending or named non-progress outcomes;
+4. compatible adapters and capabilities;
+5. case timeout and resource envelope;
+6. deterministic prefix/replay behavior; and
+7. which assurance claim or known risk the motif owns.
+
+## Family implementation checklist
+
+1. Add or extend product actions in `src/stateful_generator.rs`; use `src/family.rs` for family registration and thin
+   workload selection. Reuse shared builders instead of creating another executor.
+2. Emit canonical Scenario IR and semantic expectations together. Never let an adapter invent the scenario's truth.
+3. Use the complete capability preflight. Do not partially execute an unsupported scenario.
+4. Add deterministic same-seed, different-seed, and prefix-invariance tests.
+5. Add reachability tests for every registered action and interaction tests for every required motif.
+6. Prove the strict oracle observes each expected behavior; add a sentinel/mutation that fails when the important
+   operation or assertion is removed.
+7. Update [`SCENARIOS.md`](SCENARIOS.md), [`PROPERTY_TESTS.md`](PROPERTY_TESTS.md), and the family table in
+   [`RUNNING_CAMPAIGNS.md`](RUNNING_CAMPAIGNS.md).
+8. Run a small memory/file-backed batch, then the isolated worker. Promote stable synthetic failures into fixed vectors
+   only after review.
+9. Bump the family/profile version if any existing `(version, seed, case index)` changes meaning or output.
+
+## Aggregation and retention
+
+Each isolated shard writes `process-campaign.v1.json`; treat the shard summaries and their referenced inputs/reports as
+one evidence set. An aggregate summary must derive totals and slowest/resource extrema from every included shard, not
+only a subset. Keep the exact source revision and command matrix beside the artifacts.
+
+Campaign artifacts can grow quickly. Retain:
+
+- all failed/timed-out/signaled cases and their exact inputs;
+- all artifact-integrity failures;
+- per-shard summaries and the aggregate manifest;
+- representative slow/resource-bound successful cases; and
+- the inputs and digests behind any published assurance claim.
+
+Routine successful case reports may use a documented retention window. Never discard the only reproducer for a
+failure. Never copy sensitive byte-replay checkpoints into a shareable aggregate or committed fixture.
+
+## Stop and investigate when
+
+Pause scale-out if any shard shows:
+
+- a strict oracle gap or missing observed behavior;
+- an unexplained timeout, signal, panic, or missing artifact;
+- different outcomes for the same saved input and compatible subject;
+- a resource trend approaching the lane budget;
+- a failure that disappears only when `--allow-weak-oracle` is used; or
+- an intended action/interaction with zero coverage.
+
+More cases do not repair an invalid oracle or nondeterministic reproducer. Fix the laboratory first, rerun the canary,
+then resume the larger matrix.
+
+## Confidence and constants
+
+Use one-variable-at-a-time policy sweeps and fixed scenario inputs to characterize a constant boundary. Campaign
+curves are evidence for review, not an auto-tuning mechanism. Compare failure rate, outcome class, latency, resource
+use, and coverage across the boundary while keeping the authenticated input and eligibility assumptions fixed.
+
+The practical success criterion is not “no failures in a very large number.” It is that high-risk interactions are
+reachable, strict oracles would detect their relevant defects, failures replay and minimize, operating envelopes are
+measured, and the same representative semantics survive increasingly production-shaped subjects.

--- a/crates/cgka-conformance-simulator/SCALING_CAMPAIGNS.md
+++ b/crates/cgka-conformance-simulator/SCALING_CAMPAIGNS.md
@@ -61,16 +61,23 @@ generator_version="6"
 case_count="25"
 case_timeout_secs="300"
 parallelism="4"
+run_id="seeds-1000-1007-cases-$case_count-attempt-1"
 
 cargo build -p cgka-conformance-simulator --bin cgka-conformance-campaign --locked
 
 umask 077
-campaign_root="target/convergence-scale/$source_revision/convergence-chaos-v1-g$generator_version"
-mkdir -p "$campaign_root"
+campaign_parent="target/convergence-scale/$source_revision/convergence-chaos-v1-g$generator_version"
+campaign_root="$campaign_parent/$run_id"
+mkdir -p "$campaign_parent"
+mkdir "$campaign_root" || {
+  echo "refusing to overwrite campaign evidence root: $campaign_root" >&2
+  exit 1
+}
 printf '%s\n' \
   "source_revision=$source_revision" \
   "family_name=$family_name" \
   "generator_version=$generator_version" \
+  "run_id=$run_id" \
   "seeds=1000..1007" \
   "cases_per_seed=$case_count" \
   "case_timeout_secs=$case_timeout_secs" \
@@ -112,7 +119,9 @@ workers that fit in the memory/disk budget. The campaign summary records the mea
 operational limit.
 
 Use a separate immutable directory per `(source revision, family name, generator version, seed)`. The runner's
-overwrite refusal protects evidence and catches accidental shard collisions.
+per-case overwrite refusal protects shard artifacts, while the recipe's exclusive run-leaf creation protects the
+top-level provenance manifest. For a second execution of the same matrix, choose a fresh `run_id`; never reuse or
+empty an earlier evidence root.
 
 ### Stage 3: sustained depth
 

--- a/crates/cgka-conformance-simulator/SCALING_CAMPAIGNS.md
+++ b/crates/cgka-conformance-simulator/SCALING_CAMPAIGNS.md
@@ -23,7 +23,7 @@ not duplicate the entire cheap corpus.
 The stable logical identity is:
 
 ```text
-(family or profile version, seed, case index)
+(family_name, generator_version, seed, case_index[, profile_version])
 ```
 
 `--cases N` generates indices `0..N-1`. It is not a complexity setting. Increasing it must preserve the existing
@@ -32,7 +32,9 @@ shards. Do not run the same seed with several different case counts unless inten
 acceptable.
 
 Always retain `*-generated-input.json`. It pins more than the tuple: the selected subject, expectations, exact
-canonical IR, provenance, and digests. Any output-changing generator change requires a family/profile version bump.
+canonical IR, provenance, and digests. `family_name` and `generator_version` are independent fields; a family-name
+version does not replace the generator version. Include a separately versioned workload profile when applicable. Any
+output-changing generator or profile change requires its corresponding version bump.
 
 ## A staged campaign
 
@@ -43,37 +45,74 @@ or artifact-integrity errors before spending the larger budget.
 
 ### Stage 2: breadth matrix
 
-Build once, then invoke the worker binary directly so parallel shards do not contend on Cargo compilation:
+Require a clean source revision, build once, and put that exact revision plus the command matrix beside the evidence.
+The generated-input and report schemas do not currently carry a Git commit, so this companion metadata is required to
+identify the implementation under test:
 
-```sh
+```bash
+set -euo pipefail
+test -z "$(git status --porcelain)" || {
+  echo "refusing to build campaign evidence from a dirty worktree" >&2
+  exit 1
+}
+source_revision="$(git rev-parse HEAD)"
+family_name="convergence-chaos/v1"
+generator_version="6"
+case_count="25"
+case_timeout_secs="300"
+parallelism="4"
+
 cargo build -p cgka-conformance-simulator --bin cgka-conformance-campaign --locked
-```
 
-For example, run eight seed shards with bounded parallelism:
-
-```sh
-campaign_root="target/convergence-scale/chaos"
+umask 077
+campaign_root="target/convergence-scale/$source_revision/convergence-chaos-v1-g$generator_version"
 mkdir -p "$campaign_root"
-export campaign_root
-seq 1000 1007 | xargs -P 4 -I SEED sh -c '
+printf '%s\n' \
+  "source_revision=$source_revision" \
+  "family_name=$family_name" \
+  "generator_version=$generator_version" \
+  "seeds=1000..1007" \
+  "cases_per_seed=$case_count" \
+  "case_timeout_secs=$case_timeout_secs" \
+  "storage=file" \
+  "parallelism=$parallelism" \
+  >"$campaign_root/campaign-matrix.txt"
+rustc --version --verbose >>"$campaign_root/campaign-matrix.txt"
+
+export campaign_root family_name case_count case_timeout_secs
+seq 1000 1007 | xargs -P "$parallelism" -I SEED sh -c '
   seed="$1"
   RUST_MIN_STACK=4194304 target/debug/cgka-conformance-campaign \
-    --family convergence-chaos/v1 \
+    --family "$family_name" \
     --seed "$seed" \
-    --cases 25 \
-    --case-timeout-secs 300 \
+    --cases "$case_count" \
+    --case-timeout-secs "$case_timeout_secs" \
     --storage file \
     --out "$campaign_root/seed-$seed"
 ' sh SEED
+
+expected_inputs="$((8 * case_count))"
+actual_inputs="$(find "$campaign_root" -name '*-generated-input.json' -type f | wc -l | tr -d ' ')"
+test "$actual_inputs" -eq "$expected_inputs"
+find "$campaign_root" -name '*-generated-input.json' -type f -print0 |
+  while IFS= read -r -d '' input; do
+    jq -e \
+      --arg family_name "$family_name" \
+      --arg generator_version "$generator_version" \
+      '.case.family_name == $family_name and .case.generator_version == $generator_version' \
+      "$input" >/dev/null
+  done
 ```
 
-This example is 200 cases. Increase the seed range, cases per seed, or both only after measuring peak RSS, disk use,
-and case time. Start parallelism conservatively. A useful limit is the smaller of available CPU capacity and the
-number of worst-case workers that fit in the memory/disk budget. The campaign summary records the measurements needed
-to tune that operational limit.
+This example is a clean-build, source-bound 200-case campaign across eight seed shards. Update the recorded generator
+version whenever the selected family changes; the final check fails when it does not match the generated inputs.
+Increase the seed range, cases per seed, or both only after measuring peak RSS, disk use, and case time. Start
+parallelism conservatively. A useful limit is the smaller of available CPU capacity and the number of worst-case
+workers that fit in the memory/disk budget. The campaign summary records the measurements needed to tune that
+operational limit.
 
-Use a separate immutable directory per `(source revision, family, seed)`. The runner's overwrite refusal protects
-evidence and catches accidental shard collisions.
+Use a separate immutable directory per `(source revision, family name, generator version, seed)`. The runner's
+overwrite refusal protects evidence and catches accidental shard collisions.
 
 ### Stage 3: sustained depth
 
@@ -158,7 +197,8 @@ For each motif, specify:
    [`RUNNING_CAMPAIGNS.md`](RUNNING_CAMPAIGNS.md).
 8. Run a small memory/file-backed batch, then the isolated worker. Promote stable synthetic failures into fixed vectors
    only after review.
-9. Bump the family/profile version if any existing `(version, seed, case index)` changes meaning or output.
+9. Bump `generator_version` if any existing `(family_name, generator_version, seed, case_index)` changes meaning or
+   output. Bump an independently versioned profile when its choices or meaning change.
 
 ## Aggregation and retention
 

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -611,10 +611,11 @@ regression, covers a new semantic edge, or is the smallest readable example of a
   candidates, process measurements, and failure capsules per case. The exact retained-engine companion is registered
   separately as `cross-route-exact-restart-permutations/v1`, ensuring a panic in one private-state case cannot stop
   the rest of the catalog. Public and exact inputs use distinct scenario-name prefixes. The complete public seed-0
-  execution passed 12/12; the exact execution passed 9/12. Restarting Zeta at the three initial accepted
-  publication boundaries produced a structured `PendingPublish` refusal, a `PendingPublish` panic, and an
-  epoch-3/pending-work/decryptability stall respectively; every later branch/repair boundary passed. Those are
-  counterexamples, not allowed results.
+  execution passes 12/12. The first exact execution passed 9/12 and exposed three early-publication failures;
+  minimization traced all three to the simulator carrying process-local pending handles across engine incarnations.
+  MDK #1465 scoped that bookkeeping to the issuing incarnation, and the exact seed-0 catalog now passes 12/12 without
+  changing production engine or protocol behavior. The original failures remain historical discovery evidence, not
+  allowed results.
 
 ### `chat-journey/v1`
 

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -590,7 +590,8 @@ These are real simulator scenarios that are still tied to Rust harness details.
 
 ## Generated Scenario Families
 
-Generated cases are deterministic for a fixed family, seed, and case index. They are run directly as generated coverage.
+Generated cases are deterministic for a fixed family name, independent generator version, seed, and case index, plus
+a separately versioned workload profile when applicable. They are run directly as generated coverage.
 A generated case becomes a vector only when we want it to be a stable named contract: for example, when it caught a
 regression, covers a new semantic edge, or is the smallest readable example of a behavior.
 

--- a/crates/cgka-conformance-simulator/src/AGENTS.md
+++ b/crates/cgka-conformance-simulator/src/AGENTS.md
@@ -1,6 +1,7 @@
 # AGENTS.md - crates/cgka-conformance-simulator/src
 
-Local map for simulator source modules. Read `../AGENTS.md` for scenario and vector workflow.
+Local map for simulator source modules. Read `../AGENTS.md` for the agent workflow,
+`../RUNNING_CAMPAIGNS.md` for operator behavior, and `../SCALING_CAMPAIGNS.md` before changing generated families.
 
 ## Rules
 
@@ -10,5 +11,9 @@ Local map for simulator source modules. Read `../AGENTS.md` for scenario and vec
 - Add new queue behavior in `bus.rs` and expose it through serializable `ScenarioStep` variants before using it in
   vectors.
 - Keep generated families versioned. A generator behavior change should bump the family generator version.
+- Preserve generated-case prefix stability: increasing the case count must not change any existing case index.
+- Put legal product actions and their expected-state transitions in the shared stateful model. Keep workload families
+  thin and keep transport/process/storage/resource faults separately typed.
+- Add strict oracle, reachability, required-interaction, and same-seed/different-seed tests with a new family or motif.
 - Keep real relay/network behavior out of this crate. The harness uses the production-shaped Nostr peeler over the
   in-memory `TransportBus`.

--- a/crates/cgka-conformance-simulator/tests/AGENTS.md
+++ b/crates/cgka-conformance-simulator/tests/AGENTS.md
@@ -2,6 +2,9 @@
 
 Map for simulator tests.
 
+Read `../RUNNING_CAMPAIGNS.md` for the supported operator entrypoints and `../SCALING_CAMPAIGNS.md` for the required
+determinism, reachability, interaction-coverage, and promotion checks when adding generated coverage.
+
 ## Files
 
 - **File:** `agent_text_stream_vectors.rs`
@@ -71,6 +74,10 @@ Map for simulator tests.
   internals.
 - Keep default property-test counts fast. Use `conformance-slow` for the wider pass, with case counts chosen by test
   cost.
+- A generated-family test must not rely only on successful execution. Pin deterministic replay/prefix behavior and
+  prove that the strict oracle observes the operation or interaction the family claims to cover.
+- Keep real process/container/VM tests explicit or ignored when their cost or external dependencies make them
+  unsuitable for the ordinary crate test. Document the exact manual command and artifact path.
 
 ## Verification
 

--- a/crates/cgka-conformance-simulator/vectors/AGENTS.md
+++ b/crates/cgka-conformance-simulator/vectors/AGENTS.md
@@ -15,11 +15,15 @@ Map for portable JSON vector fixtures.
 - Byte-level fixtures live under `byte-fixtures/` and follow `byte-fixtures/schema.v1.json`.
 - Keep fixture names stable and versioned, usually `name.v1.json`.
 - Do not store OpenMLS protocol bytes in fixtures.
+- Never commit a sensitive replay capsule, participant database, incident export, or real identifier/payload as a
+  vector. Only reviewed synthetic-shareable failures are eligible for promotion.
 - Keep traces implementation-neutral: epochs, members, payload observations, pending resolutions, app invalidations, and
   recovery observations are fine. Use semantic expectations when randomized MLS bytes can change which client observes
   recovery.
 - After editing a fixture, run the vector fixture test. Use the report CLI when you also want JSON reports and a
   pass/fail summary.
+- A generated `*-fixture.v1.json` is only a candidate. Review its scenario meaning and expectations before copying it
+  here, then update `manifest.v1.json` and `../SCENARIOS.md`.
 
 ## Verification
 

--- a/crates/convergence-campaign-runner/AGENTS.md
+++ b/crates/convergence-campaign-runner/AGENTS.md
@@ -2,7 +2,30 @@
 
 Read [`README.md`](README.md) for the operator overview and
 [`../../docs/marmot-architecture/distributed-convergence-campaigns.md`](../../docs/marmot-architecture/distributed-convergence-campaigns.md)
-for the durable evidence contract.
+for the durable evidence contract. Also read
+[`../cgka-conformance-simulator/RUNNING_CAMPAIGNS.md`](../cgka-conformance-simulator/RUNNING_CAMPAIGNS.md) before
+running a wider adapter and [`../cgka-conformance-simulator/SCALING_CAMPAIGNS.md`](../cgka-conformance-simulator/SCALING_CAMPAIGNS.md)
+before designing a large matrix.
+
+## Agent operating workflow
+
+1. Confirm that the scenario already passes the smallest subject capable of its oracle. Containers and VMs add
+   environment evidence; they do not repair an invalid scenario or oracle.
+2. Resolve and verify the exact scenario/generated-input bytes, source revision, participant images, adapter
+   capabilities, and output root. Preserve selected and executed IR digests.
+3. Run `validate`, `plan`, and `doctor` before `run`. Inspect argv, image assignment, namespace/resource token, faults,
+   cleanup, deadlines, and artifact paths. Manifests never contain shell fragments.
+4. Use containers for sockets, network namespaces, real transport lifecycle, participant image separation, and
+   supported network/disk faults. Use the external VM backend only for a named kernel, filesystem, block-device,
+   reboot, or stronger host-isolation hypothesis.
+5. Keep broad seed discovery in the simulator's isolated worker runner. Promote only representative saved inputs,
+   failures, slow/resource boundaries, and mixed-build cases to this crate.
+6. On any setup, mutation, timeout, or cleanup failure, retain every receipt and fail closed. Never manually delete
+   namespace-only resources belonging to a potentially concurrent campaign.
+7. Treat public process/container projection as public evidence only. Pair it with an exact engine-capable control for
+   cryptographic state, input dispositions, pending work, or active decryptability claims.
+8. Record exact revisions/image digests and keep evidence owner-only. Never use public relays, real identifiers,
+   payloads, credentials, ciphertext, plaintext, or key material.
 
 ## Scope
 

--- a/crates/convergence-campaign-runner/README.md
+++ b/crates/convergence-campaign-runner/README.md
@@ -12,7 +12,12 @@ manifest selects either:
 - a container backend (`docker` or `podman`) for ordinary distributed runs;
 - an external VM driver when a campaign requires kernel, block-device,
   filesystem, or stronger host-isolation behavior that containers cannot
-  represent faithfully.
+represent faithfully.
+
+For the end-to-end operator workflow, including when *not* to use containers or VMs, read
+[`../cgka-conformance-simulator/RUNNING_CAMPAIGNS.md`](../cgka-conformance-simulator/RUNNING_CAMPAIGNS.md). For
+large seed/case matrices, promotion rules, and family design, read
+[`../cgka-conformance-simulator/SCALING_CAMPAIGNS.md`](../cgka-conformance-simulator/SCALING_CAMPAIGNS.md).
 
 The selected scenario path may contain raw canonical Scenario IR or a
 `GeneratedScenarioInputV1` saved by the simulator report runner. Generated

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -132,7 +132,32 @@ The baseline is now a functioning reliability lab, but it does not yet justify t
 | 3. Adversarial campaigns | Sustained real-world workloads, resource sweeps, incident import | complete | Headline workload families produce bounded, diagnosable results |
 | 4. Independent verification | Reference model, liveness model, mutation adequacy, protocol decision gate | complete | Model and tests detect seeded policy/lifecycle defects |
 | 5. App and process simulation | Real projections and lifecycle in one or many isolated runtimes | complete | The same case agrees in-process and across N processes |
-| 6. Route assurance and distributed campaigns | Decision-route equivalence plus container/VM/network/disk/version hardening and campaign operations | in-progress | Repeatable route-equivalence, soak, and release campaigns retain actionable artifacts |
+| 6. Route assurance and distributed campaigns | Decision-route equivalence plus container/VM/network/disk/version hardening and campaign operations | deferred | The core defect-discovery lab is operational; residual cross-VM, incident, and release evidence resumes on a named trigger |
+
+## Program Checkpoint (2026-08-15)
+
+The original practical goal is met: the repository has a useful, strict, repeatable convergence defect-discovery lab.
+It can generate legal and adversarial scenarios, run them with encrypted file-backed storage in isolated workers,
+preserve exact inputs and failure capsules, minimize and classify failures, compare progressively more
+production-shaped subjects, execute real multi-container checkpoints, and enforce scheduled resource/flake budgets.
+The lab has already exposed both production defects and simulator false positives, which is the intended feedback
+loop.
+
+Milestone 6 is now `deferred`, not falsely marked complete. Its remaining items are stronger assurance or specialized
+environment evidence, not prerequisites for useful large-scale local campaigns:
+
+- complete exact/public route-equivalence evidence over every suitable app/process/container/VM adapter;
+- execution of a reviewed incident-derived corpus;
+- a reviewed mixed-build release-hardening evidence bundle;
+- wider container soak and VM-only kernel/filesystem/block-device evidence; and
+- the post-milestone shared legality/profile architecture in section 6.6.
+
+Resume those residuals when a production convergence semantic, constant, storage/lifecycle path, or adapter changes;
+when a production incident supplies a new archetype; before a release requiring mixed-build assurance; or when a
+specific kernel, network, filesystem, block-device, or host-isolation hypothesis justifies the wider layer. Routine
+confidence work should now use the operator and scaling guides beside the simulator:
+[`RUNNING_CAMPAIGNS.md`](../../crates/cgka-conformance-simulator/RUNNING_CAMPAIGNS.md) and
+[`SCALING_CAMPAIGNS.md`](../../crates/cgka-conformance-simulator/SCALING_CAMPAIGNS.md).
 
 ## Milestone 0: Assurance Foundation
 
@@ -982,9 +1007,13 @@ just fast-ci
 
 ## Milestone 6: Route Assurance And Distributed Campaigns
 
+Status: `deferred`. The operational defect-discovery core is complete; the unchecked items below are preserved as
+trigger-driven assurance work described in the program checkpoint rather than an active implementation queue.
+
 Milestone 6 strengthens and quantifies the assurance case; it does not claim an exhaustive proof that every possible
-production execution is correct. Completion means that the declared decision routes, adapters, failure dimensions,
-and bounded state spaces have evidence, and that residual assumptions and untested surfaces are explicit. Formal
+production execution is correct. A future full completion would mean that the declared decision routes, adapters,
+failure dimensions, and bounded state spaces have evidence, and that residual assumptions and untested surfaces are
+explicit. Formal
 models prove the rules represented in those models, while campaigns test the implementation routes actually placed
 under observation. Neither substitutes for checking that every production decision route is represented.
 
@@ -1080,7 +1109,7 @@ catalog next into container/VM execution. The exact early-publication counterexa
 not evidence for a production convergence rewrite. Do not project app/process/container public evidence
 into exact cryptographic, durable-disposition, or active-decryptability claims that those adapters cannot expose.
 
-Current exact seed-0 restart findings (generator version `1`):
+Historical exact seed-0 restart discovery findings (generator version `1`):
 
 | Case | Boundary | Result | Stable evidence |
 | --- | --- | --- | --- |
@@ -1094,8 +1123,8 @@ identity defect: `PendingStateRef` is process-local, but accepted outbound recor
 with raw handles from the new engine incarnation. The harness now scopes pending labels, outbound sibling decisions,
 confirmation, and rollback to the issuing incarnation. The focused reused-handle regression passes, followed by all
 12 exact seed-0 restart cases. No production convergence behavior changed. The failure digests above remain the
-historical discovery evidence; the post-fix local output directory is supporting evidence until the merge commit and
-its CI run provide the durable record.
+historical discovery evidence. [MDK #1465](https://github.com/marmot-protocol/mdk/pull/1465), merge `735c8ff2`, and
+its green [CI run](https://github.com/marmot-protocol/mdk/actions/runs/31900189547) are the durable post-fix record.
 
 [MDK #1329](https://github.com/marmot-protocol/mdk/pull/1329) merged the fail-closed missing-anchor behavior and
 Welcome-repair retirement. Its formerly stacked [MDK #1293](https://github.com/marmot-protocol/mdk/pull/1293) has now
@@ -1373,9 +1402,9 @@ rerun remains useful release evidence and must still identify its own exact sour
 - [ ] The #1285 same-source-epoch cross-route regression passes across engine, app-runtime, process, container, and VM
   adapters using the shared public oracle, while every engine-capable adapter additionally proves exact cryptographic
   agreement, active decryptability, and complete application-input dispositions.
-- [ ] Campaigns are repeatable from saved configuration and artifact manifests.
-- [ ] A failing process/container run can be reduced into a smaller adapter when the defect is not layer-specific.
-- [ ] Resource and flake budgets prevent silent campaign degradation.
+- [x] Campaigns are repeatable from saved configuration and artifact manifests.
+- [x] A failing process/container run can be reduced into a smaller adapter when the defect is not layer-specific.
+- [x] Resource and flake budgets prevent silent campaign degradation.
 - [ ] Release hardening produces a reviewed convergence evidence bundle that lists covered decision routes, models,
   adapters, mutation results, workload/constant boundaries, unresolved counterexamples, residual assumptions, and
   untested surfaces. The bundle makes a scoped assurance claim rather than asserting universal implementation
@@ -1419,23 +1448,22 @@ minimized reproducer
 The artifact schema must distinguish synthetic shareable data from sensitive incident evidence. Local sensitive
 artifacts use restrictive creation helpers and are never committed.
 
-## Immediate Implementation Sequence
+## Current Operating Sequence
 
-The first implementation series is deliberately ordered:
+The implementation sequence has landed. Ongoing use should follow this evidence ladder:
 
-1. strict Tamarin warning/derivation gate;
-2. assurance contract and constant-ledger review against the canonical protocol;
-3. exact state/scenario-input oracle;
-4. public subject boundary and complete quiescence;
-5. failure capsule;
-6. Scenario IR v2;
-7. retained multi-relay model;
-8. required workload families;
-9. independent/liveness models and mutation campaign;
-10. app-runtime, process, and distributed adapters.
+1. run a strict file-backed canary and preserve exact generated inputs;
+2. shard broad discovery across distinct seeds in isolated case workers;
+3. reproduce and semantically minimize every failure at the smallest compatible adapter;
+4. promote representative saved inputs to app-runtime and separate-process execution;
+5. use containers only for real-socket, namespace, image, or supported network/storage hypotheses; and
+6. use VMs only for a named kernel, filesystem, block-device, reboot, or host-isolation question.
 
-Large-scale process or VM work does not begin before Milestone 1 establishes that the simulator can recognize an
-incorrect result.
+The exact commands, artifacts, failure workflow, and confidence limits are maintained in
+[`RUNNING_CAMPAIGNS.md`](../../crates/cgka-conformance-simulator/RUNNING_CAMPAIGNS.md). Sharding, retention, family
+design, and high-value chaos motifs are maintained in
+[`SCALING_CAMPAIGNS.md`](../../crates/cgka-conformance-simulator/SCALING_CAMPAIGNS.md). The unchecked Milestone 6
+items resume only under the triggers in the program checkpoint.
 
 ## Progress Log
 
@@ -1526,6 +1554,7 @@ incorrect result.
 | 2026-08-15 | 6.3 release evidence production path | Replaced the release lane's unprovisioned manifest-path input with an exact ancestor revision, two source-built content-addressed images, one runner-materialized canonical cross-route manifest, and deterministic evidence assembly. The assembler binds the reviewed claim to the canonical IR, normalized mixed-build execution, strict public oracle, successful receipt, raw lane observation, recomputed budget, and private digest-pinned artifact copies. No release assurance item closes until an actual workflow artifact is downloaded and reviewed. | `materialize-release-campaign`; `assemble-release-evidence`; `cross-route-mixed-build.v1.json`; release workflow contract tests |
 | 2026-08-15 | 6.1 durable-transition restart catalog | Added a bounded twelve-case current-build catalog over the shared four-party cross-route topology. The builder resolves named publication boundaries to adapter-supported action ids only after inserting each restart, keeping relay faults invariant as the schedule shifts; semantic sequence and insertion-index tests pin every boundary. Public cases run through the full app runtime with strict state/admin and order-insensitive exact-payload expectations; a separate exact retained-engine family uses isolated workers so one panic cannot abort later cases. The reviewed seed-0 public catalog passed 12/12. The exact catalog passed 9/12 and localized all failures to Zeta's three early accepted-publication boundaries: structured `PendingPublish`, panic from `PendingPublish`, and epoch-3/pending-work/decryptability stall. Structured failures wrote shareable capsules; the panic preserved exact input and exit 101 but no report/capsule. Every later branch/repair restart passed, including all four restarts after the corrected first repair round. Isolated-process cases share the catalog and bind every restart to a durable lifecycle event. This is discovery evidence, not a fix; diagnosis/remediation, process/container/VM execution, and complete app-input dispositions remain open. | `cross-route-restart-permutations/v1`; `cross-route-exact-restart-permutations/v1`; public seed-0 12/12; exact seed-0 9/12; failure capsules/digests; process catalog test |
 | 2026-08-15 | 6.1 exact-restart harness remediation | Minimized all three early Zeta failures to one simulator identity bug: `PendingStateRef` is process-local, while the harness retained accepted outbound records across restart and compared only the raw handle. A fresh engine could reuse that handle, causing the adapter to report transport acceptance but skip `confirm_published` for the new staged evolution. Pending labels and outbound sibling/confirmation/rollback decisions are now scoped by client incarnation, and old-incarnation transport outcomes cannot mutate new engine state. The focused reused-handle regression failed with the original `PendingPublish` panic before the fix and passes afterward; the exact seed-0 catalog moved from 9/12 to 12/12. No production engine, storage, app, or protocol behavior changed. | `accepted_publication_before_restart_cannot_confirm_reused_pending_ref`; `just cross-route-exact-restart-campaign 0 12`; simulator adapter only |
+| 2026-08-15 | Program closeout and operator manuals | Recorded the defect-discovery lab as operational, deferred only the stronger cross-VM/incident/release assurance residuals behind explicit resumption triggers, and added human and agent workflows for strict execution, replay, artifact handling, scale-out, family design, and adapter promotion. The historical exact restart failures are now tied to #1465's merged simulator-only remediation and green CI evidence. | [`RUNNING_CAMPAIGNS.md`](../../crates/cgka-conformance-simulator/RUNNING_CAMPAIGNS.md); [`SCALING_CAMPAIGNS.md`](../../crates/cgka-conformance-simulator/SCALING_CAMPAIGNS.md); [MDK #1465](https://github.com/marmot-protocol/mdk/pull/1465); merge `735c8ff2` |
 
 ## Capability Naming Cleanup
 

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "Convergence Reliability And Simulation Plan"
 created: 2026-07-30
-updated: 2026-08-15
+updated: 2026-08-16
 tags: [marmot, cgka, convergence, simulation, verification, reliability]
 status: working-plan
 ---
@@ -1274,9 +1274,10 @@ operations and cross-operation interactions actually occurred.
 - [ ] Add explicit workload-size controls for dimensions such as actions, participants, message volume, commit/proposal
   frequency, and offline backlog. Do not overload `--cases` or `--seed`: cases remains the number of independently
   generated scenarios, while the seed selects reproducible choices within each case.
-- [ ] Preserve reproducibility as `(family/profile version, seed, case index)`: increasing `--cases` must preserve the
-  existing case prefix, saved inputs must replay independently, and output-changing generator work must bump the
-  generator/profile version rather than silently changing an existing corpus.
+- [ ] Preserve reproducibility as `(family_name, generator_version, seed, case_index)`, plus an independently
+  versioned workload profile where applicable: increasing `--cases` must preserve the existing case prefix, saved
+  inputs must replay independently, and output-changing generator/profile work must bump its corresponding version
+  rather than silently changing an existing corpus.
 
 Verification for this follow-up must include:
 


### PR DESCRIPTION
## Summary

- add a detailed operator runbook for vectors, generated families, saved-input replay, app/process adapters, containers, VMs, artifacts, and failure handling
- add a scaling guide for deterministic seed sharding, bounded parallelism, evidence retention, adapter promotion, and high-value chaos-family design
- strengthen simulator and distributed-runner AGENTS guidance so agents preserve oracle strength, provenance, privacy, and execution-layer boundaries
- reconcile the convergence reliability plan: record the core defect-discovery lab as operational, defer stronger cross-VM/incident/release assurance behind explicit triggers, and replace the completed implementation sequence with the current operating sequence
- update stale restart-catalog documentation to record #1465 and the current 12/12 exact result

## Why

The simulator stack is now capable, but its operating knowledge was scattered across crate documentation, the tracking plan, source, tests, and prior campaign work. This makes it too easy to choose an unnecessarily expensive adapter, weaken an oracle, lose a reproducer, overlap seed prefixes, or overstate what public process/container evidence proves.

These docs make the existing machinery self-service and give the project a concrete path from a local canary to thousands of deterministic file-backed cases, then to selective process/container/VM confirmation.

## Impact

Documentation and agent guidance only. No production, protocol, engine, simulator, storage, application, or CI behavior changes.

## Validation

- `just fast-ci`
- `cargo metadata --locked --no-deps --format-version 1`
- `cargo fmt --all -- --check`
- `git diff --check`
- relative Markdown link validation
- scaling-command shell syntax validation
- tracked filename naming gate