### PR TITLE
feat(uniffi): include admin identifiers on bounded membership pages

### DIFF
--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -1032,7 +1032,9 @@ impl AppClient {
         group_ids
             .iter()
             .map(|group_id| {
-                self.ensure_group(group_id)?;
+                let group_record = self
+                    .state_group_record(group_id)
+                    .ok_or_else(|| AppError::UnknownGroup(hex::encode(group_id.as_slice())))?;
                 let member_ids_hex = self
                     .runtime
                     .members(group_id)?
@@ -1042,7 +1044,7 @@ impl AppClient {
                 Ok(crate::AppGroupMemberIds {
                     group_id_hex: hex::encode(group_id.as_slice()),
                     member_ids_hex,
-                    admin_ids_hex: self.admin_policy_for_group(group_id).admins,
+                    admin_ids_hex: group_record.admin_policy.admins,
                 })
             })
             .collect()

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -352,12 +352,20 @@ impl GroupReadSnapshot {
             .iter()
             .map(|group_id| {
                 let members = self.members(group_id)?;
+                let admin_ids_hex = self
+                    .groups
+                    .get(group_id)
+                    .ok_or_else(|| AppError::UnknownGroup(hex::encode(group_id.as_slice())))?
+                    .admin_policy
+                    .admins
+                    .clone();
                 Ok(crate::AppGroupMemberIds {
                     group_id_hex: hex::encode(group_id.as_slice()),
                     member_ids_hex: members
                         .into_iter()
                         .map(|member| member.member_id_hex)
                         .collect(),
+                    admin_ids_hex,
                 })
             })
             .collect()
@@ -1034,6 +1042,7 @@ impl AppClient {
                 Ok(crate::AppGroupMemberIds {
                     group_id_hex: hex::encode(group_id.as_slice()),
                     member_ids_hex,
+                    admin_ids_hex: self.admin_policy_for_group(group_id).admins,
                 })
             })
             .collect()

--- a/crates/marmot-app/src/groups.rs
+++ b/crates/marmot-app/src/groups.rs
@@ -198,11 +198,14 @@ pub struct AppGroupMemberRecord {
 /// Lightweight local roster projection for one group.
 ///
 /// This deliberately contains identifiers only: profile/display-name
-/// enrichment remains on the group-detail path.
+/// enrichment remains on the group-detail path. Admin identifiers come from
+/// the durable admin-policy component so recipient-selection screens can
+/// decide add-to-group eligibility without a per-group roster read.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AppGroupMemberIds {
     pub group_id_hex: String,
     pub member_ids_hex: Vec<String>,
+    pub admin_ids_hex: Vec<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/marmot-app/src/runtime/commands.rs
+++ b/crates/marmot-app/src/runtime/commands.rs
@@ -240,8 +240,8 @@ impl AccountManager {
         local_account_worker_response(response).await
     }
 
-    /// Read identifier-only rosters for a bounded page of groups in one
-    /// account-worker round trip.
+    /// Read identifier-only member and admin rosters for a bounded page of
+    /// groups in one account-worker round trip.
     ///
     /// The response preserves input order and fails as a whole if any group is
     /// unknown or hydration-quarantined; it never returns a partial page.

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -1295,8 +1295,9 @@ impl MarmotAppRuntime {
         self.accounts.group_members(account_ref, group_id).await
     }
 
-    /// Identifier-only membership for a bounded page of groups, served in one
-    /// per-account worker command without profile enrichment.
+    /// Identifier-only membership and admin identifiers for a bounded page of
+    /// groups, served in one per-account worker command without profile
+    /// enrichment.
     pub async fn group_member_ids_page(
         &self,
         account_ref: &str,

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -8452,6 +8452,59 @@ fn idle_sync_skips_the_checkpoint_route_recomputation() {
 }
 
 #[test]
+fn member_ids_page_reads_admins_from_the_durable_group_projection() {
+    run_composed_app_runtime_test("member-ids-page-durable-admins", || async {
+        let dir = tempfile::tempdir().unwrap();
+        let alice = AccountHome::open(dir.path())
+            .create_account("alice")
+            .unwrap();
+        let relay = Arc::new(ScriptedPushRelayClient::default());
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+            .with_test_relay_client(relay.clone());
+
+        let mut client = app.client("alice").await.unwrap();
+        let group_id = client.create_group("durable admins", &[]).await.unwrap();
+        assert_eq!(
+            client.admin_policy_for_group(&group_id).admins,
+            vec![alice.account_id_hex.clone()],
+            "live MLS still reports the creator as admin"
+        );
+
+        let projected_admin = "bb4fc8665f5696e33db7e1a572e3b0f5b3d615837b0f362dcb1c8068b098c7b4";
+        let projected_admin_bytes: [u8; 32] = hex::decode(projected_admin)
+            .expect("projected admin hex")
+            .try_into()
+            .expect("32-byte projected admin");
+        client.state.groups[0].admin_policy =
+            AppGroupAdminPolicyComponent::new(vec![projected_admin_bytes]);
+
+        let page = client
+            .member_ids_page(std::slice::from_ref(&group_id))
+            .expect("steady-state page must succeed from the durable row");
+        assert_eq!(page.len(), 1);
+        assert_eq!(
+            page[0].admin_ids_hex,
+            vec![projected_admin.to_owned()],
+            "admin identifiers must come from the durable projection, not a live MLS reload"
+        );
+        assert_ne!(
+            page[0].admin_ids_hex,
+            client.admin_policy_for_group(&group_id).admins,
+            "a live admin-policy miss must not replace the durable admin list"
+        );
+
+        client.state.groups.clear();
+        assert!(
+            matches!(
+                client.member_ids_page(std::slice::from_ref(&group_id)),
+                Err(AppError::UnknownGroup(_))
+            ),
+            "a missing durable row must fail closed instead of reporting no admins"
+        );
+    });
+}
+
+#[test]
 fn pending_group_invites_skips_malformed_rows() {
     // mdk#1380 review: one undecodable row must not disable policy
     // reconciliation for the account's valid invites.

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -2724,6 +2724,14 @@ async fn app_runtime_serves_member_reads_before_initial_catch_up_completes() {
     assert_eq!(member_ids_page.len(), 1);
     assert!(member_ids_page[0].member_ids_hex.contains(&alice_id));
     assert!(member_ids_page[0].member_ids_hex.contains(&bob_id));
+    assert!(
+        member_ids_page[0].admin_ids_hex.contains(&alice_id),
+        "creator admin identifier must be present on the bounded page"
+    );
+    assert!(
+        !member_ids_page[0].admin_ids_hex.contains(&bob_id),
+        "invited member must not be reported as an admin"
+    );
     assert_eq!(
         account_sync_attempts(),
         before_restart,

--- a/crates/marmot-app/tests/startup_hydration.rs
+++ b/crates/marmot-app/tests/startup_hydration.rs
@@ -164,6 +164,7 @@ async fn held_hydration_body() {
     let dir = tempfile::tempdir().unwrap();
     let home = AccountHome::open(dir.path());
     home.create_account(BENCH_ACCOUNT).unwrap();
+    let creator_id = home.account(BENCH_ACCOUNT).unwrap().account_id_hex;
     let mut group_ids = Vec::new();
     {
         let app_fixture = open_store(&dir, &url, None);
@@ -216,9 +217,16 @@ async fn held_hydration_body() {
     );
 
     // The identifier-only roster page is the bounded companion read for that
-    // chat projection (mdk#1314). One worker command promotes only the named
-    // groups from durable state and returns every roster without waiting for
-    // the held background pipeline or doing profile enrichment.
+    // chat projection (mdk#1314 / mdk#1461). One worker command promotes only
+    // the named groups from durable state and returns every member and admin
+    // identifier without waiting for the held background pipeline or doing
+    // profile enrichment.
+    let roster_reads_before = runtime
+        .shared_services()
+        .app_performance_telemetry()
+        .snapshot()
+        .group_roster_read
+        .attempts;
     let page_started = Instant::now();
     let member_ids_page = tokio::time::timeout(
         Duration::from_millis(BATCH_HOLD_MS / 2),
@@ -232,7 +240,25 @@ async fn held_hydration_body() {
         assert_eq!(row.group_id_hex, hex::encode(group_id.as_slice()));
         assert_eq!(row.member_ids_hex.len(), 2);
         assert!(row.member_ids_hex.contains(&donor_id));
+        assert!(
+            row.admin_ids_hex.contains(&creator_id),
+            "admin identifiers must be available before deferred hydration completes"
+        );
+        assert!(
+            !row.admin_ids_hex.contains(&donor_id),
+            "invited members must not be reported as admins"
+        );
     }
+    assert_eq!(
+        runtime
+            .shared_services()
+            .app_performance_telemetry()
+            .snapshot()
+            .group_roster_read
+            .attempts,
+        roster_reads_before,
+        "admin metadata for a page of groups must not fan out to group_roster"
+    );
     assert!(
         page_started.elapsed() < Duration::from_millis(BATCH_HOLD_MS / 2),
         "bounded membership read must not wait out the pipeline hold"

--- a/crates/marmot-uniffi/src/commands/group.rs
+++ b/crates/marmot-uniffi/src/commands/group.rs
@@ -327,7 +327,9 @@ impl Marmot {
     ///
     /// This is the chat-projection companion read: it is one worker command,
     /// performs no profile enrichment, and fails the whole page if any group
-    /// is unknown or quarantined.
+    /// is unknown or quarantined. Each row includes member and admin
+    /// identifiers so recipient-selection screens do not need a per-group
+    /// `group_roster` fanout.
     pub async fn group_member_ids_page(
         &self,
         account_ref: String,

--- a/crates/marmot-uniffi/src/conversions/group.rs
+++ b/crates/marmot-uniffi/src/conversions/group.rs
@@ -210,6 +210,7 @@ pub struct AppGroupMemberRecordFfi {
 pub struct AppGroupMemberIdsFfi {
     pub group_id_hex: String,
     pub member_ids_hex: Vec<String>,
+    pub admin_ids_hex: Vec<String>,
 }
 
 impl From<AppGroupMemberIds> for AppGroupMemberIdsFfi {
@@ -217,6 +218,7 @@ impl From<AppGroupMemberIds> for AppGroupMemberIdsFfi {
         Self {
             group_id_hex: value.group_id_hex,
             member_ids_hex: value.member_ids_hex,
+            admin_ids_hex: value.admin_ids_hex,
         }
     }
 }
@@ -753,12 +755,14 @@ mod group_roster_tests {
     }
 
     #[test]
-    fn member_ids_page_row_preserves_group_and_member_identifiers() {
+    fn member_ids_page_row_preserves_group_member_and_admin_identifiers() {
         let ffi = AppGroupMemberIdsFfi::from(AppGroupMemberIds {
             group_id_hex: "01".repeat(16),
             member_ids_hex: vec!["02".repeat(32), "03".repeat(32)],
+            admin_ids_hex: vec!["02".repeat(32)],
         });
         assert_eq!(ffi.group_id_hex, "01".repeat(16));
         assert_eq!(ffi.member_ids_hex, vec!["02".repeat(32), "03".repeat(32)]);
+        assert_eq!(ffi.admin_ids_hex, vec!["02".repeat(32)]);
     }
 }


### PR DESCRIPTION
## Summary
- Bounded `group_member_ids_page` rows only returned member identifiers, so White Noise iOS still issued one `group_roster` call per group for admin metadata.
- Each page row now includes `admin_ids_hex` from durable admin-policy state, with no profile enrichment and the same page-size / unknown-group / quarantine semantics.

Fixes #1461

## Test plan
- [x] New UniFFI conversion test failed before the field existed and passes after
- [x] Startup-hydration hold proves admin identifiers before deferred profile hydration and that the page does not increment `group_roster_read`
- [x] Relay-runtime catch-up test asserts creator-only admin identifiers on the page
- [x] `just fast-ci` passed
- [ ] Host can retire the per-group `group_roster` admin-enrichment loop after consuming `admin_ids_hex`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Group member-ID results now include administrator IDs alongside member IDs.
  * Administrator information is available through the app and FFI interfaces.
  * Results use stored group information for faster, bounded roster lookups.

* **Bug Fixes**
  * Improved reliability when group roster data is unavailable, failing safely instead of producing incomplete results.

* **Tests**
  * Added coverage confirming administrators are included and regular members are not incorrectly identified as administrators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->