### PR TITLE
ci: publish Android bindings for SHA snapshots

### DIFF
--- a/.github/workflows/bindings.yaml
+++ b/.github/workflows/bindings.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       source_sha:
-        description: Full 40-character commit SHA on master to publish as an immutable Apple platform snapshot
+        description: Full 40-character commit SHA on master to publish as an immutable MarmotKit snapshot
         required: true
         type: string
 
@@ -279,7 +279,6 @@ jobs:
     name: Build Android bindings
     runs-on: ubuntu-latest
     needs: metadata
-    if: needs.metadata.outputs.is_snapshot == 'false'
     timeout-minutes: 60
 
     steps:
@@ -287,13 +286,20 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Check out packaged source
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
           ref: ${{ needs.metadata.outputs.source_sha }}
+          path: packaged-source
 
       - name: Install Rust toolchain
         shell: bash
         run: |
           set -euo pipefail
-          toolchain="$(sed -n 's/^channel = "\(.*\)"/\1/p' rust-toolchain.toml)"
+          toolchain="$(sed -n 's/^channel = "\(.*\)"/\1/p' packaged-source/rust-toolchain.toml)"
           rustup toolchain install "$toolchain" --profile minimal
           rustup default "$toolchain"
           rustup target add \
@@ -341,8 +347,13 @@ jobs:
 
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: packaged-source -> target
 
       - name: Build MarmotKit Kotlin and JNI bindings
+        env:
+          MARMOTKIT_WORKSPACE_DIR: ${{ github.workspace }}/packaged-source
+          MARMOTKIT_CRATE_DIR: ${{ github.workspace }}/packaged-source/crates/marmot-uniffi
         run: ./crates/marmot-uniffi/kotlin-bindings.sh
 
       - name: Package Android bundle
@@ -351,20 +362,21 @@ jobs:
           RELEASE_ID: ${{ needs.metadata.outputs.release_id }}
           RELEASE_TAG: ${{ needs.metadata.outputs.release_tag }}
           SOURCE_SHA: ${{ needs.metadata.outputs.source_sha }}
+          BUILDER_SHA: ${{ needs.metadata.outputs.builder_sha }}
         run: |
           set -euo pipefail
           tag="$RELEASE_TAG"
           version="$RELEASE_ID"
-          workspace_version="$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n 1)"
-          lock_sha="$(shasum -a 256 Cargo.lock | awk '{print $1}')"
+          workspace_version="$(sed -n 's/^version = "\(.*\)"/\1/p' packaged-source/Cargo.toml | head -n 1)"
+          lock_sha="$(shasum -a 256 packaged-source/Cargo.lock | awk '{print $1}')"
           stage_parent="$RUNNER_TEMP/marmotkit-android-stage"
           bundle_dir="$stage_parent/marmotkit-android-$version"
           asset="$RUNNER_TEMP/marmotkit-android-$version.zip"
 
           rm -rf "$stage_parent" "$asset" "$asset.sha256"
           mkdir -p "$bundle_dir"
-          cp -R crates/marmot-uniffi/output/android/kotlin "$bundle_dir/"
-          cp -R crates/marmot-uniffi/output/android/jniLibs "$bundle_dir/"
+          cp -R packaged-source/crates/marmot-uniffi/output/android/kotlin "$bundle_dir/"
+          cp -R packaged-source/crates/marmot-uniffi/output/android/jniLibs "$bundle_dir/"
 
           cat > "$bundle_dir/manifest.json" <<EOF
           {
@@ -372,6 +384,7 @@ jobs:
             "version": "$version",
             "tag": "$tag",
             "source_sha": "$SOURCE_SHA",
+            "builder_sha": "$BUILDER_SHA",
             "workspace_version": "$workspace_version",
             "cargo_lock_sha256": "$lock_sha",
             "rustc": "$(rustc --version)",
@@ -380,6 +393,8 @@ jobs:
             "android_api": "${ANDROID_API:-26}",
             "contents": [
               "kotlin/dev/ipf/marmotkit/marmot_uniffi.kt",
+              "kotlin/dev/ipf/marmotkit/MarmotAndroid.kt",
+              "kotlin/io/crates/keyring/Keyring.kt",
               "jniLibs/arm64-v8a/libmarmot_uniffi.so",
               "jniLibs/armeabi-v7a/libmarmot_uniffi.so",
               "jniLibs/x86/libmarmot_uniffi.so",
@@ -416,7 +431,7 @@ jobs:
       needs.metadata.result == 'success' &&
       needs.ios-bindings.result == 'success' &&
       needs.macos-bindings.result == 'success' &&
-      (needs.android-bindings.result == 'success' || needs.android-bindings.result == 'skipped')
+      needs.android-bindings.result == 'success'
     timeout-minutes: 15
     permissions:
       actions: read
@@ -428,7 +443,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SOURCE_SHA: ${{ needs.metadata.outputs.source_sha }}
-          IS_SNAPSHOT: ${{ needs.metadata.outputs.is_snapshot }}
         run: |
           set -euo pipefail
           mkdir -p dist/ios dist/macos dist/android
@@ -436,10 +450,8 @@ jobs:
             --name "marmotkit-ios-$SOURCE_SHA" --dir dist/ios
           gh run download "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" \
             --name "marmotkit-macos-$SOURCE_SHA" --dir dist/macos
-          if [[ "$IS_SNAPSHOT" == "false" ]]; then
-            gh run download "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" \
-              --name "marmotkit-android-$SOURCE_SHA" --dir dist/android
-          fi
+          gh run download "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" \
+            --name "marmotkit-android-$SOURCE_SHA" --dir dist/android
 
       - name: Create and verify immutable release
         shell: bash
@@ -500,11 +512,17 @@ jobs:
 
           macOS SwiftPM checksum: \`$macos_checksum\`
 
+          Android assets:
+          - \`marmotkit-android-$version.zip\`: generated Kotlin bindings and JNI libraries for all supported ABIs.
+          - \`marmotkit-android-$version.zip.sha256\`: ordinary SHA-256 verification for the Android bundle.
+
           Shared:
           - \`MarmotKit-$version.swift\`: generated Swift source matching both binaries.
 
           Verify source and artifact provenance with \`marmotkit-ios-$version.manifest.json\`,
           \`marmotkit-macos-$version.manifest.json\`, and the matching \`.checksums.txt\` assets.
+          Verify the Android archive with its sibling \`.sha256\`; its embedded \`manifest.json\` records the exact
+          source and workflow builder commits.
           Assets on this release are immutable.
           EOF
 
@@ -524,9 +542,8 @@ jobs:
             exit 1
           fi
 
-          assets=(dist/ios/* dist/macos/*)
+          assets=(dist/ios/* dist/macos/* dist/android/*)
           if [[ "$IS_SNAPSHOT" == "false" ]]; then
-            assets+=(dist/android/*)
             title="v$version - MarmotKit"
             release_flags=(--latest=false)
           else

--- a/.github/workflows/bindings.yaml
+++ b/.github/workflows/bindings.yaml
@@ -372,11 +372,27 @@ jobs:
           stage_parent="$RUNNER_TEMP/marmotkit-android-stage"
           bundle_dir="$stage_parent/marmotkit-android-$version"
           asset="$RUNNER_TEMP/marmotkit-android-$version.zip"
+          required_contents=(
+            "kotlin/dev/ipf/marmotkit/marmot_uniffi.kt"
+            "kotlin/dev/ipf/marmotkit/MarmotAndroid.kt"
+            "kotlin/io/crates/keyring/Keyring.kt"
+            "jniLibs/arm64-v8a/libmarmot_uniffi.so"
+            "jniLibs/armeabi-v7a/libmarmot_uniffi.so"
+            "jniLibs/x86/libmarmot_uniffi.so"
+            "jniLibs/x86_64/libmarmot_uniffi.so"
+          )
 
           rm -rf "$stage_parent" "$asset" "$asset.sha256"
           mkdir -p "$bundle_dir"
           cp -R packaged-source/crates/marmot-uniffi/output/android/kotlin "$bundle_dir/"
           cp -R packaged-source/crates/marmot-uniffi/output/android/jniLibs "$bundle_dir/"
+
+          for entry in "${required_contents[@]}"; do
+            if [[ ! -f "$bundle_dir/$entry" ]]; then
+              echo "error: Android bundle is missing required file: $entry" >&2
+              exit 1
+            fi
+          done
 
           cat > "$bundle_dir/manifest.json" <<EOF
           {
@@ -407,6 +423,36 @@ jobs:
             cd "$stage_parent"
             zip -r "$asset" "marmotkit-android-$version"
           )
+
+          bundle_root="$(basename "$bundle_dir")"
+          manifest_path="$bundle_root/manifest.json"
+          archive_entries="$(unzip -Z1 "$asset")"
+          manifest="$(unzip -p "$asset" "$manifest_path")"
+          if ! jq -e '.contents | type == "array" and length > 0 and all(.[]; type == "string" and length > 0)' \
+            <<< "$manifest" >/dev/null; then
+            echo "error: Android manifest contents must be a non-empty string array" >&2
+            exit 1
+          fi
+          mapfile -t declared_contents < <(jq -r '.contents[]' <<< "$manifest")
+
+          for entry in "${declared_contents[@]}"; do
+            if [[ "$entry" == /* || "$entry" == ".." || "$entry" == ../* || "$entry" == */../* || "$entry" == */.. ]]; then
+              echo "error: Android manifest contains unsafe path: $entry" >&2
+              exit 1
+            fi
+            if ! grep -Fqx "$bundle_root/$entry" <<< "$archive_entries"; then
+              echo "error: Android manifest declares missing archive entry: $entry" >&2
+              exit 1
+            fi
+          done
+
+          for entry in "${required_contents[@]}"; do
+            if ! printf '%s\n' "${declared_contents[@]}" | grep -Fqx "$entry"; then
+              echo "error: Android manifest omits required archive entry: $entry" >&2
+              exit 1
+            fi
+          done
+
           shasum -a 256 "$asset" | awk -v name="$(basename "$asset")" '{print $1 "  " name}' > "$asset.sha256"
           mkdir -p dist
           cp "$asset" "$asset.sha256" dist/

--- a/crates/marmot-uniffi/DISTRIBUTION.md
+++ b/crates/marmot-uniffi/DISTRIBUTION.md
@@ -157,4 +157,7 @@ publishing also fails if its derived tag already exists. Assets and snapshot tag
 changed build requires a new formal version or a new source SHA.
 
 Each platform manifest records both the packaged source SHA and the workflow builder SHA. Snapshot dispatches must use
-the workflow from `master`, so an older reachable source commit cannot substitute its own packaging logic.
+the workflow from `master`, so an older reachable source commit cannot substitute its own packaging logic. The
+builder SHA also owns the canonical Rust release profile and compiled-in public endpoint defaults. Source-coupled
+inputs—including the Cargo workspace, UniFFI configuration, and Kotlin support files—come from the packaged source
+SHA so the generated API and JNI libraries remain a matched set.

--- a/crates/marmot-uniffi/DISTRIBUTION.md
+++ b/crates/marmot-uniffi/DISTRIBUTION.md
@@ -1,8 +1,8 @@
-# MarmotKit Apple Binary Distribution
+# MarmotKit Binary Distribution
 
-MarmotKit releases publish the generated Swift API and its matching XCFrameworks as immutable GitHub Release
-assets. Consumers keep `MarmotKit.swift` in a Swift source target and declare the XCFramework as a remote binary
-target; neither the expanded XCFramework nor its static libraries need to be committed to the app repository.
+MarmotKit releases publish the generated Swift and Kotlin APIs with their matching native libraries as immutable
+GitHub Release assets. Apple consumers keep `MarmotKit.swift` in a Swift source target and declare the XCFramework as
+a remote binary target; Android consumers unpack the Kotlin and JNI bundle into their app build.
 
 Each release carries a separate iOS and macOS XCFramework under distinct asset names, and a single shared
 `MarmotKit-<identifier>.swift`. The generated Swift is platform-independent, so both platforms consume the same file:
@@ -112,16 +112,49 @@ toolchain versions, enabled features, macOS targets and deployment target, effec
 of the binary and shared generated Swift artifacts. The complete `marmotkit-macos-<identifier>.zip` retains the
 XCFramework, matching Swift source, and the same manifest for consumers that prefer a single provenance bundle.
 
+## Android
+
+Android bundles contain generated Kotlin, the required Android initialization helpers, and JNI libraries for
+`arm64-v8a`, `armeabi-v7a`, `x86`, and `x86_64`.
+
+### Exact URLs
+
+Formal release `marmotkit-v<version>`:
+
+```text
+https://github.com/marmot-protocol/mdk/releases/download/marmotkit-v<version>/marmotkit-android-<version>.zip
+https://github.com/marmot-protocol/mdk/releases/download/marmotkit-v<version>/marmotkit-android-<version>.zip.sha256
+```
+
+Snapshot for a full 40-character commit SHA `<sha>` reachable from `master`:
+
+```text
+https://github.com/marmot-protocol/mdk/releases/download/marmotkit-snapshot-<sha>/marmotkit-android-snapshot-<sha>.zip
+https://github.com/marmot-protocol/mdk/releases/download/marmotkit-snapshot-<sha>/marmotkit-android-snapshot-<sha>.zip.sha256
+```
+
+The archive has a `marmotkit-android-<identifier>` root containing:
+
+- `kotlin/dev/ipf/marmotkit/marmot_uniffi.kt`
+- `kotlin/dev/ipf/marmotkit/MarmotAndroid.kt`
+- `kotlin/io/crates/keyring/Keyring.kt`
+- `jniLibs/<abi>/libmarmot_uniffi.so` for each supported ABI
+- `manifest.json`
+
+Verify the archive against its sibling `.sha256` before extracting it. Update the generated Kotlin helpers and all
+JNI ABI libraries together; mixing identifiers can cross an incompatible UniFFI ABI. The manifest records both the
+exact packaged source SHA and the workflow builder SHA.
+
 ## Publishing
 
 Pushing a formal `marmotkit-v*` tag publishes iOS, macOS, and Android bindings. To publish an untagged snapshot, run
 the `MarmotKit Bindings` workflow with a full SHA on `master`. Its immutable release tag is derived from that SHA.
-Snapshots publish the iOS and macOS bindings; Android bindings are published only for formal tags.
+Snapshots publish the iOS, macOS, and Android bindings from the same source SHA.
 
 Publishing first uploads and verifies every asset on a draft, then publishes it under repository-enforced immutable
 releases. A retry discards only an incomplete draft. Publishing fails if a public release already exists, and snapshot
 publishing also fails if its derived tag already exists. Assets and snapshot tags are never replaced or moved; a
 changed build requires a new formal version or a new source SHA.
 
-The iOS and macOS manifests each record both the packaged source SHA and the workflow builder SHA. Snapshot dispatches
-must use the workflow from `master`, so an older reachable source commit cannot substitute its own packaging logic.
+Each platform manifest records both the packaged source SHA and the workflow builder SHA. Snapshot dispatches must use
+the workflow from `master`, so an older reachable source commit cannot substitute its own packaging logic.

--- a/crates/marmot-uniffi/README.md
+++ b/crates/marmot-uniffi/README.md
@@ -15,8 +15,8 @@ package that shared surface:
 The generated Swift file is platform-independent: `output/MarmotKit.swift` and `output/macos/MarmotKit.swift` are the
 same UniFFI surface, and releases publish it once.
 
-See [`DISTRIBUTION.md`](DISTRIBUTION.md) for immutable SwiftPM binary artifacts, exact release and snapshot URLs,
-checksums, provenance, and the generated Swift synchronization rule.
+See [`DISTRIBUTION.md`](DISTRIBUTION.md) for immutable Apple and Android artifacts, exact release and snapshot URLs,
+checksums, provenance, and generated-source synchronization rules.
 
 The Kotlin binding is generated from the same release host library metadata as Swift, so it exposes the same `Marmot`
 object, subscription objects, records, enums, and error variants.

--- a/crates/marmot-uniffi/kotlin-bindings.sh
+++ b/crates/marmot-uniffi/kotlin-bindings.sh
@@ -22,6 +22,10 @@ export PATH="$HOME/.cargo/bin:$PATH"
 # Keep the workflow/build tooling at the builder commit while allowing it to
 # compile and package an exact source checkout, matching the Apple scripts.
 TOOL_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Keep production release behavior, debug-symbol policy, and compiled-in
+# routing defaults owned by the builder checkout. Source-specific API inputs
+# such as uniffi.toml and kotlin-support/ remain under CRATE_DIR below.
+source "$TOOL_DIR/marmotkit-release-profile.env"
 WORKSPACE_DIR="${MARMOTKIT_WORKSPACE_DIR:-$(cd "$TOOL_DIR/../.." && pwd)}"
 CRATE_DIR="${MARMOTKIT_CRATE_DIR:-$WORKSPACE_DIR/crates/marmot-uniffi}"
 TARGET_DIR="${CARGO_TARGET_DIR:-$WORKSPACE_DIR/target}"
@@ -34,7 +38,7 @@ JNI_OUT_DIR="$OUT_DIR/jniLibs"
 
 # Set public first-party endpoint defaults for values compiled via option_env!.
 # Tokens remain host-app runtime configuration.
-source "$CRATE_DIR/marmotkit-endpoints.env"
+source "$TOOL_DIR/marmotkit-endpoints.env"
 
 CRATE_NAME="marmot-uniffi"
 LIB_BASENAME="marmot_uniffi"

--- a/crates/marmot-uniffi/kotlin-bindings.sh
+++ b/crates/marmot-uniffi/kotlin-bindings.sh
@@ -19,8 +19,11 @@ set -euo pipefail
 # targets installed through rustup are visible.
 export PATH="$HOME/.cargo/bin:$PATH"
 
-CRATE_DIR="$(cd "$(dirname "$0")" && pwd)"
-WORKSPACE_DIR="$(cd "$CRATE_DIR/../.." && pwd)"
+# Keep the workflow/build tooling at the builder commit while allowing it to
+# compile and package an exact source checkout, matching the Apple scripts.
+TOOL_DIR="$(cd "$(dirname "$0")" && pwd)"
+WORKSPACE_DIR="${MARMOTKIT_WORKSPACE_DIR:-$(cd "$TOOL_DIR/../.." && pwd)}"
+CRATE_DIR="${MARMOTKIT_CRATE_DIR:-$WORKSPACE_DIR/crates/marmot-uniffi}"
 TARGET_DIR="${CARGO_TARGET_DIR:-$WORKSPACE_DIR/target}"
 if [[ "$TARGET_DIR" != /* ]]; then
   TARGET_DIR="$WORKSPACE_DIR/$TARGET_DIR"

--- a/release.md
+++ b/release.md
@@ -357,8 +357,8 @@ The workflow lives at:
 
 It runs when a tag matching `marmotkit-v*` is pushed. The workflow validates version-like tags such as
 `marmotkit-v0.9.0`, builds the iOS, macOS, and Android binding bundles, and creates the matching immutable GitHub
-Release. It can also be dispatched with a full commit SHA reachable from `master` to create an immutable iOS + macOS
-snapshot; Android bindings are published only for formal tags.
+Release. It can also be dispatched with a full commit SHA reachable from `master` to create an immutable iOS, macOS,
+and Android snapshot.
 
 Create the tag:
 
@@ -396,7 +396,8 @@ Publishing fails if the iOS and macOS jobs ever generate different Swift from on
 
 Snapshot assets use `snapshot-<full-sha>` in place of `<version>` and are published under the exact
 `marmotkit-snapshot-<full-sha>` release tag. The binary-only ZIP contains `MarmotKit.xcframework` at its archive root
-for SwiftPM. See `crates/marmot-uniffi/DISTRIBUTION.md` for URL and consumer examples.
+for SwiftPM. Android snapshots publish `marmotkit-android-snapshot-<full-sha>.zip` and its sibling `.sha256` under the
+same release tag. See `crates/marmot-uniffi/DISTRIBUTION.md` for exact URLs and consumer examples.
 
 The iOS zip contains:
 
@@ -413,30 +414,36 @@ The macOS zip contains:
 The Android zip contains:
 
 - `kotlin/dev/ipf/marmotkit/marmot_uniffi.kt`
+- `kotlin/dev/ipf/marmotkit/MarmotAndroid.kt`
+- `kotlin/io/crates/keyring/Keyring.kt`
 - `jniLibs/<abi>/libmarmot_uniffi.so` for `arm64-v8a`, `armeabi-v7a`, `x86`, and `x86_64`
 - `manifest.json`
 
-Each manifest records the release identifier, exact source commit, workflow builder commit, workspace version, `Cargo.lock` hash, Rust
-toolchain versions, enabled features, targets, deployment target, effective release profile, and artifact hashes. App
-repos must pin an exact tag, update generated Swift and binary references together, and verify the ordinary SHA-256
-and SwiftPM checksum. Existing release assets and snapshot tags are never overwritten.
+Each manifest records the release identifier, exact source commit, workflow builder commit, workspace version,
+`Cargo.lock` hash, and Rust toolchain versions. Apple manifests also record enabled features, targets, deployment
+target, effective release profile, and artifact hashes. App repos must pin an exact tag, update generated source and
+native libraries together, and verify the ordinary SHA-256 (plus SwiftPM checksum for Apple binaries). Existing
+release assets and snapshot tags are never overwritten.
 
 ## App Repo Consumption
 
-For now, app repos should download a versioned MarmotKit release asset and vendor the generated files into their current
-checked-in binding locations.
+App repos should pin an exact formal MarmotKit tag or SHA-addressed snapshot, verify its published checksums, and stage
+the generated source and native libraries into ignored build inputs or another repository-approved generated-artifact
+location. Never mix generated source and native libraries from different release identifiers.
 
-iOS expects the equivalent of:
+iOS expects the staged equivalent of:
 
 ```text
 Vendored/MarmotKit/MarmotKit.xcframework
 Vendored/MarmotKit/Sources/MarmotKit/MarmotKit.swift
 ```
 
-Android expects the equivalent of:
+Android expects the staged equivalent of:
 
 ```text
 app/src/main/java/dev/ipf/marmotkit/marmot_uniffi.kt
+app/src/main/java/dev/ipf/marmotkit/MarmotAndroid.kt
+app/src/main/java/io/crates/keyring/Keyring.kt
 app/src/main/jniLibs/<abi>/libmarmot_uniffi.so
 ```
 

--- a/release.md
+++ b/release.md
@@ -146,10 +146,12 @@ available:
 ./crates/marmot-uniffi/kotlin-bindings.sh
 ```
 
-The binding build scripts source `crates/marmot-uniffi/marmotkit-endpoints.env` so production MarmotKit artifacts embed
-the public audit-log and OTLP route defaults. Override `MARMOT_AUDIT_LOG_TRACKER_ENDPOINT` or
-`MARMOT_RELAY_TELEMETRY_OTLP_ENDPOINT` in the environment only for staging or local collector builds. Bearer tokens are
-not compiled into MarmotKit; apps supply them at runtime.
+The binding build scripts source `crates/marmot-uniffi/marmotkit-endpoints.env` from the workflow builder checkout so
+production MarmotKit artifacts embed one platform-consistent set of public audit-log and OTLP route defaults. The
+canonical Rust release profile comes from that builder checkout as well; API-coupled inputs such as the Cargo
+workspace, UniFFI configuration, and Kotlin support files come from the packaged source checkout. Override
+`MARMOT_AUDIT_LOG_TRACKER_ENDPOINT` or `MARMOT_RELAY_TELEMETRY_OTLP_ENDPOINT` in the environment only for staging or
+local collector builds. Bearer tokens are not compiled into MarmotKit; apps supply them at runtime.
 
 The GitHub workflow repeats the release builds on clean runners. Local builds catch drift earlier.
 


### PR DESCRIPTION
## Summary
- build the Android Kotlin/JNI bundle for workflow-dispatched SHA snapshots
- compile the exact requested source with current-master workflow tooling and record both source and builder SHAs
- publish the Android archive and checksum alongside Apple snapshot assets
- document immutable Android snapshot URLs, contents, provenance, and consumer staging

## Verification
- `actionlint .github/workflows/bindings.yaml`
- `bash -n crates/marmot-uniffi/kotlin-bindings.sh`
- `just fmt-check`
- semantic checks for Android job gating, release assets, provenance, URLs, and required Kotlin helpers
- `just fast-ci`: formatting, repository policy gates, workspace checks, and both Clippy passes completed; the final convergence test was interrupted only by local ENOSPC
- `just test-convergence-policy-pin`: 5 passed after clearing generated build artifacts

No snapshot release was dispatched from this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Android bindings are now included in both regular and snapshot releases alongside Apple platform artifacts.
  * Android release packages include generated Kotlin sources and native libraries for supported ABIs.
  * Release manifests now provide source and build provenance details.

* **Documentation**
  * Added guidance for downloading, matching, staging, and checksum-verifying platform artifacts.
  * Updated distribution documentation with Android archive contents, URLs, and compatibility requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->