### PR TITLE
fix(cgka-engine): re-arm queued-outbound drain on pass close; skip in-flight regenerated intents (#1472)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -3,7 +3,7 @@ set shell := ["bash", "-cu"]
 otlp-features := "marmot-app/otlp-export,marmot-uniffi/otlp-export,wn-cli/otlp-export"
 test-features := "wn-cli/test-policy-overrides,cgka-engine/test-crash-hooks"
 simulator-dedicated-filter := "not binary(adversarial_reliability_campaigns) and not binary(policy_sweeps) and not binary(independent_reference_model) and not binary(lifecycle_model) and not binary(mutation_adequacy) and not binary(protocol_decision_gate)"
-simulator-smoke-filter := simulator-dedicated-filter + " and not (binary(canonical_scenarios) & (test(=convergence_chaos_family_generates_specs_with_semantic_expectations) | test(=convergence_chaos_family_seed_changes_scenarios) | test(=convergence_e2e_delivery_family_runs_generated_variants)))"
+simulator-smoke-filter := simulator-dedicated-filter + " and not (binary(canonical_scenarios) & (test(=convergence_chaos_family_generates_specs_with_semantic_expectations) | test(=convergence_chaos_family_seed_changes_scenarios) | test(=convergence_e2e_delivery_family_runs_generated_variants) | test(=bounded_convergence_pressure_family_settles_every_seeded_permutation)))"
 
 default:
     @just --list
@@ -312,6 +312,7 @@ simulator-filter-contract:
         -E '{{simulator-smoke-filter}}' --message-format json | list_tests >"$work_dir/smoke"
     comm -23 "$work_dir/full" "$work_dir/smoke" >"$work_dir/actual"
     printf '%s\n' \
+        'cgka-conformance-simulator::canonical_scenarios::bounded_convergence_pressure_family_settles_every_seeded_permutation' \
         'cgka-conformance-simulator::canonical_scenarios::convergence_chaos_family_generates_specs_with_semantic_expectations' \
         'cgka-conformance-simulator::canonical_scenarios::convergence_chaos_family_seed_changes_scenarios' \
         'cgka-conformance-simulator::canonical_scenarios::convergence_e2e_delivery_family_runs_generated_variants' \

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -706,7 +706,9 @@ regression, covers a new semantic edge, or is the smallest readable example of a
   retained join commit itself is tracked as a harness coverage gap.
 ### `bounded-convergence-pressure/v1`
 
-- Generator: `generate_bounded_convergence_pressure_family` (generator version `1`).
+- Generator: `generate_bounded_convergence_pressure_family` (generator version `2`). Version 2 adds the confirmed
+  pending-resolution expectations the strict oracle requires for the labelled publication acknowledgements; scenario
+  steps are unchanged.
 - Setup: four clients, Alice and Bob admins. Both admins race same-epoch `update_group_data` commits and both confirm
   publication; each rival commit is withheld, then released in a seed-derived order so every member ingests the fork.
 - Pressure: **finite** and deliberately so. One application send per client is issued after the rival branch is ingested
@@ -724,10 +726,9 @@ regression, covers a new semantic edge, or is the smallest readable example of a
 - Scope fence: the campaign claims eventual quiescence for **bounded** input only. It makes no progress claim under an
   unbounded self-update stream (reliability plan PDR-2/L3), which is a deliberate non-guarantee.
 - Status: `bounded_convergence_pressure_family_generates_the_declared_campaign_shape` gates the generator in CI. The
-  runnable gate `bounded_convergence_pressure_family_settles_every_seeded_permutation` is `#[ignore]`d because it fails
-  on engine behavior, not on the campaign: an application message accepted while the group is resolving a same-epoch
-  fork is queued durably and then stranded, because nothing re-arms the retained-intent drain once the pass completes.
-  Do not weaken the assertions to make it pass.
+  runnable gate `bounded_convergence_pressure_family_settles_every_seeded_permutation` passes since mdk#1472 (the
+  engine re-arms the queued-intent drain when a pass closes and no longer re-prepares an in-flight regenerated
+  intent). It runs in the nightly lane; the PR smoke lane excludes it as one of the multi-minute generated batches.
 
 ### `convergence-chaos/v1`
 

--- a/crates/cgka-conformance-simulator/src/client.rs
+++ b/crates/cgka-conformance-simulator/src/client.rs
@@ -785,8 +785,13 @@ impl HarnessClient {
         self.engine_mut().confirm_queued_outbound_intent(intent_id)
     }
 
-    pub(crate) fn retry_regenerated_queued_intent(&mut self, group_id: &GroupId) {
-        self.engine_mut().retry_queued_outbound_intent(group_id);
+    pub(crate) fn retry_regenerated_queued_intent(
+        &mut self,
+        group_id: &GroupId,
+        intent_id: &MessageId,
+    ) {
+        self.engine_mut()
+            .retry_queued_outbound_intent(group_id, intent_id);
     }
 
     pub(crate) fn forget_regenerated_queued_intent(&mut self, message_id: &MessageId) {
@@ -1706,7 +1711,7 @@ impl HarnessClient {
             } => {
                 let queued_intent = self
                     .engine_mut()
-                    .take_regenerated_queued_intent_for_message(&msg.id);
+                    .regenerated_queued_intent_for_message(&msg.id);
                 let routed = if let Some(gid) = &gid {
                     route(msg, gid)
                 } else {
@@ -1731,7 +1736,7 @@ impl HarnessClient {
             SendResult::Proposal { msg } => {
                 let queued_intent = self
                     .engine_mut()
-                    .take_regenerated_queued_intent_for_message(&msg.id);
+                    .regenerated_queued_intent_for_message(&msg.id);
                 let routed = if let Some(gid) = &gid {
                     route(msg, gid)
                 } else {
@@ -1821,7 +1826,7 @@ impl HarnessClient {
         for msg in proposals {
             let queued_intent = self
                 .engine_mut()
-                .take_regenerated_queued_intent_for_message(&msg.id);
+                .regenerated_queued_intent_for_message(&msg.id);
             let routed = if let Some(gid) = &gid {
                 route(msg, gid)
             } else {

--- a/crates/cgka-conformance-simulator/src/family.rs
+++ b/crates/cgka-conformance-simulator/src/family.rs
@@ -308,9 +308,10 @@ pub fn generate_bounded_convergence_pressure_case(
     let (mut scenario, mut expected_outcomes) =
         bounded_convergence_pressure_case(&mut rng, case_index);
     add_strict_reliability_oracle(&mut scenario, &mut expected_outcomes);
+    push_labelled_confirmation_expectations(&scenario, &mut expected_outcomes);
     GeneratedScenarioCase {
         family_name: "bounded-convergence-pressure/v1".into(),
-        generator_version: "1".into(),
+        generator_version: "2".into(),
         seed,
         case_index,
         subject: GeneratedSubjectKind::Engine,

--- a/crates/cgka-conformance-simulator/src/subject.rs
+++ b/crates/cgka-conformance-simulator/src/subject.rs
@@ -1654,9 +1654,9 @@ impl ConvergenceSubject for EngineHarnessSubject {
                         .resolution = Some(outcome);
                 }
 
-                if let Some((group_id, _)) = &record.queued_intent {
+                if let Some((group_id, intent_id)) = &record.queued_intent {
                     self.client_mut(client)?
-                        .retry_regenerated_queued_intent(group_id);
+                        .retry_regenerated_queued_intent(group_id, intent_id);
                     self.client_mut(client)?
                         .forget_regenerated_queued_intent(&record.artifact.message.id);
                 }

--- a/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
+++ b/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
@@ -1697,7 +1697,7 @@ fn bounded_convergence_pressure_family_generates_the_declared_campaign_shape() {
     assert_eq!(cases.len(), 6);
     for (case_index, case) in cases.iter().enumerate() {
         assert_eq!(case.family_name, "bounded-convergence-pressure/v1");
-        assert_eq!(case.generator_version, "1");
+        assert_eq!(case.generator_version, "2");
         assert_eq!(case.seed, 2026);
         assert_eq!(case.case_index, case_index as u64);
         compile_scenario(&case.scenario)
@@ -1802,16 +1802,14 @@ fn bounded_convergence_pressure_family_generates_the_declared_campaign_shape() {
 /// It deliberately claims nothing about progress under an unbounded
 /// self-update stream.
 ///
-/// IGNORED — this currently fails on engine behavior, not on the campaign. An
-/// application message accepted while the group is resolving a same-epoch fork
-/// is queued durably and then stranded: once the pass completes, nothing
-/// re-arms the retained-intent drain, and the engine's own conformance
-/// structural progress reports `runnable_work = 0` with no next wake while
-/// `pending_work.queued_outbound_intents > 0`. The quiescence driver therefore
-/// reports `Blocked { subsystems: ["scenario_inputs"] }` and the payload is
-/// never published. Un-ignore once the retained-intent drain is re-armed after
-/// a completed pass; do not weaken the assertions below to make it pass.
-#[ignore = "engine strands application sends accepted inside the convergence quiescence window"]
+/// This gate was ignored while the engine stranded application sends accepted
+/// inside the convergence quiescence window (mdk#1472): a drain that ran
+/// before the pass settled consumed the one-shot schedule edge, pass
+/// completion never re-armed it, and once the re-arm existed the repeated
+/// drain re-prepared the still-unconfirmed intent and double-published it.
+/// The engine now re-arms the drain when a pass closes with queued intents
+/// outstanding and skips intents that are already regenerated and awaiting
+/// the host's confirm or retry.
 #[tokio::test(flavor = "multi_thread")]
 async fn bounded_convergence_pressure_family_settles_every_seeded_permutation() {
     for case in &generate_bounded_convergence_pressure_family(2026, 6) {

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -613,6 +613,30 @@ impl<S: StorageProvider> Engine<S> {
         }
     }
 
+    /// Re-arm the queued-outbound drain edge when a pass closes.
+    ///
+    /// The schedule edge is a one-shot signal: a drain that ran while the
+    /// pass was still open consumed it without releasing the durable queue.
+    /// Closing the pass is the transition that opens the outbound gate, so
+    /// the engine owes edge-driven hosts a fresh edge whenever intents are
+    /// still queued (mdk#1472). Level-driven hosts re-arm from
+    /// `has_queued_outbound_intents` on their own; the extra edge only costs
+    /// them one no-op drain.
+    fn rearm_queued_outbound_drain_after_pass_close(
+        &mut self,
+        group_id: &GroupId,
+    ) -> Result<(), OpenMlsProjectionError> {
+        if !self
+            .storage
+            .list_queued_outbound_intents(group_id)
+            .map_err(storage_projection_error)?
+            .is_empty()
+        {
+            self.schedule_pending_convergence_group(group_id);
+        }
+        Ok(())
+    }
+
     /// Discard a pass whose base epoch disagrees with the current tip, so the
     /// caller reopens one at the tip.
     ///
@@ -1382,6 +1406,7 @@ impl<S: StorageProvider> Engine<S> {
             self.storage
                 .put_convergence_pass(&pass)
                 .map_err(storage_projection_error)?;
+            self.rearm_queued_outbound_drain_after_pass_close(group_id)?;
             return Ok(result);
         }
 
@@ -1423,6 +1448,12 @@ impl<S: StorageProvider> Engine<S> {
             }
             Ok::<_, OpenMlsProjectionError>((observations, application_events))
         })?;
+        // mdk#1472: completing the pass opens the gate that held queued
+        // outbound intents. A drain that ran before the settle consumed the
+        // one-shot schedule edge without releasing them, so completion must
+        // re-arm it — otherwise an edge-driven host never comes back for the
+        // durable queue.
+        self.rearm_queued_outbound_drain_after_pass_close(group_id)?;
         for (disposition, previous_state, epoch) in disposition_transitions {
             if previous_state == disposition.state {
                 continue;

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -613,30 +613,6 @@ impl<S: StorageProvider> Engine<S> {
         }
     }
 
-    /// Re-arm the queued-outbound drain edge when a pass closes.
-    ///
-    /// The schedule edge is a one-shot signal: a drain that ran while the
-    /// pass was still open consumed it without releasing the durable queue.
-    /// Closing the pass is the transition that opens the outbound gate, so
-    /// the engine owes edge-driven hosts a fresh edge whenever intents are
-    /// still queued (mdk#1472). Level-driven hosts re-arm from
-    /// `has_queued_outbound_intents` on their own; the extra edge only costs
-    /// them one no-op drain.
-    fn rearm_queued_outbound_drain_after_pass_close(
-        &mut self,
-        group_id: &GroupId,
-    ) -> Result<(), OpenMlsProjectionError> {
-        if !self
-            .storage
-            .list_queued_outbound_intents(group_id)
-            .map_err(storage_projection_error)?
-            .is_empty()
-        {
-            self.schedule_pending_convergence_group(group_id);
-        }
-        Ok(())
-    }
-
     /// Discard a pass whose base epoch disagrees with the current tip, so the
     /// caller reopens one at the tip.
     ///
@@ -1406,7 +1382,7 @@ impl<S: StorageProvider> Engine<S> {
             self.storage
                 .put_convergence_pass(&pass)
                 .map_err(storage_projection_error)?;
-            self.rearm_queued_outbound_drain_after_pass_close(group_id)?;
+            self.schedule_drain_for_retained_outbound_intents(group_id);
             return Ok(result);
         }
 
@@ -1453,7 +1429,7 @@ impl<S: StorageProvider> Engine<S> {
         // one-shot schedule edge without releasing them, so completion must
         // re-arm it — otherwise an edge-driven host never comes back for the
         // durable queue.
-        self.rearm_queued_outbound_drain_after_pass_close(group_id)?;
+        self.schedule_drain_for_retained_outbound_intents(group_id);
         for (disposition, previous_state, epoch) in disposition_transitions {
             if previous_state == disposition.state {
                 continue;

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -210,8 +210,10 @@ pub struct Engine<S: StorageProvider> {
     pub(crate) pending_convergence_groups: HashSet<GroupId>,
 
     /// Queued intents regenerated into standalone publish work. The session
-    /// consumes these associations when it builds `PublishWork`, then deletes
-    /// the durable intent only after the transport reports acceptance.
+    /// reads these associations when it builds `PublishWork`, then deletes
+    /// the durable intent only after the transport reports acceptance. An
+    /// intent present here is in flight: the drain must not regenerate it a
+    /// second time until the host confirms or retries it (mdk#1472).
     pub(crate) queued_intent_by_message: HashMap<MessageId, (GroupId, MessageId)>,
 
     /// Queued group evolutions stay associated with their pending publish so
@@ -2944,8 +2946,8 @@ impl<S: StorageProvider + 'static> CgkaEngine for Engine<S> {
         self.confirm_regenerated_queued_intent(intent_id)
     }
 
-    fn retry_queued_outbound_intent(&mut self, group_id: &GroupId) {
-        self.retry_regenerated_queued_intent(group_id);
+    fn retry_queued_outbound_intent(&mut self, group_id: &GroupId, intent_id: &MessageId) {
+        self.retry_regenerated_queued_intent(group_id, intent_id);
     }
 
     async fn confirm_published(

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -104,8 +104,9 @@ pub const MAX_PEEL_DEFERRED_ROWS_PER_GROUP: usize = 256;
 /// Capacity is reclaimed on confirmation, not on drain. A drained row is
 /// deleted only by `confirm_queued_outbound_intent` — or, for a group-state
 /// intent, inside `confirm_published` — so a payload that was prepared and
-/// published but never acknowledged still holds its slot and is re-prepared on
-/// the next drain. A group whose transport keeps failing therefore sits at the
+/// published but never acknowledged still holds its slot and stays in flight.
+/// A definite retry clears that in-flight association so the next drain
+/// re-prepares it. A group whose transport keeps failing therefore sits at the
 /// cap: its rows keep being re-attempted, but nothing frees a slot until a
 /// publish is accepted by at least one endpoint.
 pub const MAX_QUEUED_OUTBOUND_INTENTS_PER_GROUP: usize = 256;

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -691,6 +691,12 @@ impl<S: StorageProvider> Engine<S> {
             return Ok(Vec::new());
         }
         for record in queued {
+            // A regenerated intent the host has not yet confirmed or retired
+            // is still the host's obligation: re-preparing it would publish
+            // the same logical message twice (mdk#1472).
+            if self.queued_outbound_intent_in_flight(group_id, &record.id) {
+                continue;
+            }
             if !reservation.permits(&record.intent) {
                 continue;
             }
@@ -888,15 +894,32 @@ impl<S: StorageProvider> Engine<S> {
         ))
     }
 
+    /// Whether a durable queued intent was already regenerated into an
+    /// artifact the host has not yet confirmed or retired. The association
+    /// lives from regeneration until `confirm_regenerated_queued_intent`,
+    /// `retry_regenerated_queued_intent`, or a publish rollback clears it.
+    fn queued_outbound_intent_in_flight(&self, group_id: &GroupId, intent_id: &MessageId) -> bool {
+        self.queued_intent_by_message
+            .values()
+            .chain(self.queued_intent_by_pending.values())
+            .any(|(queued_group_id, queued_intent_id)| {
+                queued_group_id == group_id && queued_intent_id == intent_id
+            })
+    }
+
     pub(crate) fn schedule_pending_convergence_group(&mut self, group_id: &GroupId) {
         self.pending_convergence_groups.insert(group_id.clone());
     }
 
-    pub fn take_regenerated_queued_intent_for_message(
-        &mut self,
+    /// Read the durable queued intent a regenerated artifact carries. The
+    /// association is non-destructive: it stays readable until the host
+    /// confirms or retries the intent, so a later drain can see the intent
+    /// is still in flight and must not regenerate it again (mdk#1472).
+    pub fn regenerated_queued_intent_for_message(
+        &self,
         message_id: &MessageId,
     ) -> Option<(GroupId, MessageId)> {
-        self.queued_intent_by_message.remove(message_id)
+        self.queued_intent_by_message.get(message_id).cloned()
     }
 
     pub fn confirm_regenerated_queued_intent(
@@ -904,10 +927,21 @@ impl<S: StorageProvider> Engine<S> {
         intent_id: &MessageId,
     ) -> Result<(), EngineError> {
         self.storage.delete_queued_outbound_intent(intent_id)?;
+        self.queued_intent_by_message
+            .retain(|_, (_, queued_intent_id)| queued_intent_id != intent_id);
+        self.queued_intent_by_pending
+            .retain(|_, (_, queued_intent_id)| queued_intent_id != intent_id);
         Ok(())
     }
 
-    pub fn retry_regenerated_queued_intent(&mut self, group_id: &GroupId) {
+    /// Re-arm a regenerated intent whose publication reached no endpoint.
+    /// Clearing the in-flight association lets the next drain regenerate a
+    /// fresh artifact; the durable intent row is untouched.
+    pub fn retry_regenerated_queued_intent(&mut self, group_id: &GroupId, intent_id: &MessageId) {
+        self.queued_intent_by_message
+            .retain(|_, (_, queued_intent_id)| queued_intent_id != intent_id);
+        self.queued_intent_by_pending
+            .retain(|_, (_, queued_intent_id)| queued_intent_id != intent_id);
         self.schedule_pending_convergence_group(group_id);
     }
 

--- a/crates/cgka-engine/src/publish.rs
+++ b/crates/cgka-engine/src/publish.rs
@@ -546,12 +546,13 @@ impl<S: StorageProvider> Engine<S> {
     /// instead: a publish outcome and a verified repair Welcome through this
     /// helper, quarantine recovery (`retry_hydrate_quarantined_group`)
     /// unconditionally because it has already read the group. `Stable` with an
-    /// unsettled convergence pass holds it too and has no such seam: it is
-    /// carried by the level signal, staying visible as runnable work until it
-    /// releases (`has_queued_outbound_intents`), which is what a scheduler
-    /// re-reads once it has consumed the edge. (Across a restart, session-open
-    /// hydration re-arms the drain from the same durable queue whatever state
-    /// the group landed in.)
+    /// unsettled convergence pass holds it too: the pass-close seam re-arms
+    /// (`rearm_queued_outbound_drain_after_pass_close`, mdk#1472), and the
+    /// level signal keeps the group visible as runnable work until it releases
+    /// (`has_queued_outbound_intents`), which is what a scheduler re-reads once
+    /// it has consumed the edge. (Across a restart, session-open hydration
+    /// re-arms the drain from the same durable queue whatever state the group
+    /// landed in.)
     ///
     /// Best-effort by construction: this runs after the outcome is durable, so
     /// a transient backend lock here must not fail already-committed work.

--- a/crates/cgka-engine/src/publish.rs
+++ b/crates/cgka-engine/src/publish.rs
@@ -546,13 +546,12 @@ impl<S: StorageProvider> Engine<S> {
     /// instead: a publish outcome and a verified repair Welcome through this
     /// helper, quarantine recovery (`retry_hydrate_quarantined_group`)
     /// unconditionally because it has already read the group. `Stable` with an
-    /// unsettled convergence pass holds it too: the pass-close seam re-arms
-    /// (`rearm_queued_outbound_drain_after_pass_close`, mdk#1472), and the
-    /// level signal keeps the group visible as runnable work until it releases
-    /// (`has_queued_outbound_intents`), which is what a scheduler re-reads once
-    /// it has consumed the edge. (Across a restart, session-open hydration
-    /// re-arms the drain from the same durable queue whatever state the group
-    /// landed in.)
+    /// unsettled convergence pass holds it too: the pass-close seam calls this
+    /// helper to re-arm (mdk#1472), and the level signal keeps the group visible
+    /// as runnable work until it releases (`has_queued_outbound_intents`), which
+    /// is what a scheduler re-reads once it has consumed the edge. (Across a
+    /// restart, session-open hydration re-arms the drain from the same durable
+    /// queue whatever state the group landed in.)
     ///
     /// Best-effort by construction: this runs after the outcome is durable, so
     /// a transient backend lock here must not fail already-committed work.

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -5183,6 +5183,216 @@ async fn a_settled_convergence_pass_leaves_no_unscheduled_retained_intent() {
     );
 }
 
+/// mdk#1472: a drain that runs before the pass settles consumes the
+/// schedule edge without releasing the queued intent. When the pass later
+/// completes, the engine must re-arm the edge — the completion of the gate
+/// that held the intent is exactly the moment an edge-driven host can make
+/// progress. Level-driven hosts (marmot-app's `schedule_after_pass`) recover
+/// on their own; hosts that only drain `pending_convergence_groups` (the
+/// conformance harness `drive_due_convergence`) spin on `runnable_work`
+/// forever without this re-arm.
+#[tokio::test]
+async fn a_completed_pass_rearms_the_drain_for_intents_queued_inside_the_window() {
+    let (mut alice, _alice_storage) = build_client(b"alice");
+    let (mut bob, _bob_storage) = build_client(b"bob");
+    let carol_storage = SqliteAccountStorage::in_memory().unwrap();
+    let clock = ManualConvergenceClock::new(1_000, 10_000);
+    let mut carol =
+        build_client_with_storage_and_clock(b"carol", carol_storage.clone(), clock.clone());
+
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "drain-rearm".into(),
+            description: "".into(),
+            members: vec![bob_kp, carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![bob.self_id()],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    bob.join_welcome(welcome_for(&welcomes, b"bob"))
+        .await
+        .unwrap();
+    carol
+        .join_welcome(welcome_for(&welcomes, b"carol"))
+        .await
+        .unwrap();
+
+    // Alice and Bob race privileged same-epoch commits; Carol ingests both
+    // and opens one collecting pass over the fork.
+    let (alice_commit, alice_pending) = evolution(
+        alice
+            .send(SendIntent::UpdateGroupData {
+                group_id: group_id.clone(),
+                name: Some("alice-branch".into()),
+                description: None,
+            })
+            .await
+            .unwrap(),
+    );
+    alice.confirm_published(alice_pending).await.unwrap();
+    let (bob_commit, bob_pending) = evolution(
+        bob.send(SendIntent::UpdateGroupData {
+            group_id: group_id.clone(),
+            name: Some("bob-branch".into()),
+            description: None,
+        })
+        .await
+        .unwrap(),
+    );
+    bob.confirm_published(bob_pending).await.unwrap();
+    for commit in [&alice_commit, &bob_commit] {
+        assert!(matches!(
+            carol
+                .ingest(route(commit.clone(), &group_id))
+                .await
+                .unwrap(),
+            IngestOutcome::Buffered { .. }
+        ));
+    }
+    assert_eq!(
+        carol_storage
+            .convergence_pass(&group_id)
+            .unwrap()
+            .expect("the raced commits open a pass")
+            .cutoff_monotonic_ms(),
+        2_000
+    );
+
+    // Consume the edges the ingests armed, mirroring a host that has taken
+    // everything the ingest produced before the send arrives.
+    carol.drain_events();
+    carol.drain_pending_convergence_groups();
+
+    let queued = carol
+        .send(SendIntent::AppMessage {
+            group_id: group_id.clone(),
+            payload: app_payload_for(&carol, b"typed inside the fork window"),
+        })
+        .await
+        .unwrap();
+    let intent_id = match queued {
+        SendResult::Queued { intent_id, .. } => intent_id,
+        other => panic!("an unsettled pass retains the send, got {other:?}"),
+    };
+    assert!(
+        carol.drain_pending_convergence_groups().contains(&group_id),
+        "queueing the intent arms the drain edge"
+    );
+
+    // The host drains immediately — before the cutoff — so the drain refuses
+    // to release and the one-shot edge is spent. This is the harness
+    // `drive_due_convergence` order: edge-driven, not level-driven.
+    let early = carol
+        .converge_and_drain_queued_outbound_intents(&group_id, 1_500)
+        .await
+        .unwrap();
+    assert!(
+        early.is_empty(),
+        "a pre-cutoff drain must not release the intent: {early:?}"
+    );
+    assert!(
+        carol.drain_pending_convergence_groups().is_empty(),
+        "the premature drain consumes the edge"
+    );
+
+    // The pass settles at the cutoff (the harness tick's settle prepass).
+    clock.advance_ms(1_500);
+    assert!(
+        carol
+            .advance_convergence_inputs_until_settled(&group_id, 2_500)
+            .await
+            .unwrap(),
+        "the cutoff has passed, so the pass settles"
+    );
+
+    // The completion of the gate that held the intent must re-arm the drain
+    // edge; without it an edge-driven host never comes back.
+    assert!(
+        carol.drain_pending_convergence_groups().contains(&group_id),
+        "settling the pass must re-arm the drain for the retained intent"
+    );
+
+    // The committers resolve the same fork: each ingests the rival root and
+    // settles its own pass, so every client lands on carol's selected branch
+    // before the decrypt check below.
+    alice
+        .ingest(route(bob_commit.clone(), &group_id))
+        .await
+        .unwrap();
+    bob.ingest(route(alice_commit.clone(), &group_id))
+        .await
+        .unwrap();
+    assert!(
+        alice
+            .advance_convergence_inputs_until_settled(&group_id, 10_000)
+            .await
+            .unwrap()
+    );
+    assert!(
+        bob.advance_convergence_inputs_until_settled(&group_id, 10_000)
+            .await
+            .unwrap()
+    );
+
+    // And the re-armed drain really publishes the message.
+    let mut drained = carol
+        .converge_and_drain_queued_outbound_intents(&group_id, 2_500)
+        .await
+        .expect("the re-armed drain releases the retained intent");
+    assert_eq!(
+        drained.len(),
+        1,
+        "expected the retained message: {drained:?}"
+    );
+
+    // A second drain before the host's confirm must not regenerate the
+    // in-flight intent: re-preparing would publish the same logical message
+    // twice (mdk#1472).
+    let duplicate = carol
+        .converge_and_drain_queued_outbound_intents(&group_id, 2_500)
+        .await
+        .expect("an in-flight intent stays the host's obligation");
+    assert!(
+        duplicate.is_empty(),
+        "an unconfirmed intent must not regenerate a duplicate: {duplicate:?}"
+    );
+    let SendResult::ApplicationMessage { msg, .. } = drained.remove(0) else {
+        panic!("a retained app-message intent drains as an application message")
+    };
+    assert!(matches!(
+        alice.ingest(route(msg, &group_id)).await.unwrap(),
+        IngestOutcome::Processed
+    ));
+    let received = alice
+        .drain_events()
+        .into_iter()
+        .find_map(|event| match event {
+            GroupEvent::MessageReceived { payload, .. } => Some(payload),
+            _ => None,
+        })
+        .expect("alice observes the retained message");
+    assert_eq!(app_content(&received), b"typed inside the fork window");
+
+    carol
+        .confirm_queued_outbound_intent(&intent_id)
+        .expect("the drained intent is the one the pass window retained");
+    assert!(
+        carol_storage
+            .list_queued_outbound_intents(&group_id)
+            .unwrap()
+            .is_empty()
+    );
+}
+
 #[tokio::test]
 async fn engine_prunes_retained_anchor_snapshots_to_rewind_horizon() {
     let (mut alice, _alice_storage) = build_client(b"alice");

--- a/crates/cgka-engine/tests/publish_lifecycle.rs
+++ b/crates/cgka-engine/tests/publish_lifecycle.rs
@@ -2010,6 +2010,86 @@ async fn an_unreadable_intent_queue_still_schedules_the_drain() {
 }
 
 #[tokio::test]
+async fn an_unreadable_intent_queue_at_pass_close_still_rearms_and_drains() {
+    let inner = SqliteAccountStorage::in_memory().unwrap();
+    let queued_intent_list_fault = ProcessedFault::default();
+    let clock = ManualConvergenceClock::new(1_000, 10_000);
+    let mut alice = EngineBuilder::new(FaultStorage {
+        inner,
+        fault: ProcessedFault::default(),
+        lifecycle_fault: ProcessedFault::default(),
+        disband_request_fault: ProcessedFault::default(),
+        queued_intent_list_fault: queued_intent_list_fault.clone(),
+    })
+    .legacy_compatibility_profile()
+    .identity(pad32(b"alice-pass-close"))
+    .account_identity_proof_signer(proof_signer(b"alice-pass-close"))
+    .feature_registry(registry_with_reactions())
+    .peeler(Box::new(MockPeeler))
+    .convergence_clock(Arc::new(clock.clone()))
+    .build()
+    .unwrap();
+    let mut bob = build(b"bob-pass-close");
+    let group_id = group_with_bob(&mut alice, &mut bob).await;
+
+    let SendResult::GroupEvolution {
+        msg: commit,
+        pending,
+        ..
+    } = bob
+        .send(SendIntent::SelfUpdate {
+            group_id: group_id.clone(),
+        })
+        .await
+        .unwrap()
+    else {
+        panic!("self-update stages a group evolution")
+    };
+    bob.confirm_published(pending).await.unwrap();
+    assert!(matches!(
+        alice.ingest(commit).await.unwrap(),
+        IngestOutcome::Buffered { .. }
+    ));
+
+    let queued = alice
+        .send(SendIntent::AppMessage {
+            group_id: group_id.clone(),
+            payload: app_payload_for(&alice, "retained across a locked pass-close read"),
+        })
+        .await
+        .unwrap();
+    assert!(matches!(queued, SendResult::Queued { .. }));
+    assert!(
+        alice.drain_pending_convergence_groups().contains(&group_id),
+        "queueing the retained intent must arm the first drain"
+    );
+
+    clock.advance_ms(1_500);
+    queued_intent_list_fault.arm(1);
+    assert!(
+        alice
+            .advance_convergence_inputs_until_settled(&group_id, 2_500)
+            .await
+            .expect("a failed post-close queue read must not fail a durable convergence apply"),
+        "the pass must settle despite the injected queue-read failure"
+    );
+    assert!(
+        alice.drain_pending_convergence_groups().contains(&group_id),
+        "an unreadable queue at pass close must conservatively re-arm the drain"
+    );
+
+    let drained = alice
+        .converge_and_drain_queued_outbound_intents(&group_id, 2_500)
+        .await
+        .expect("the successful retry must release the retained intent");
+    assert_eq!(
+        drained.len(),
+        1,
+        "the re-armed retry must publish the retained intent"
+    );
+}
+
+#[tokio::test]
 async fn queued_outbound_intents_are_capped_per_group_while_a_publish_stays_unresolved() {
     // Retention has no deadline, and that is deliberate: a publication whose
     // exposure is ambiguous must never be rolled back. So the state that holds
@@ -2118,6 +2198,12 @@ async fn queued_outbound_intents_are_capped_per_group_while_a_publish_stays_unre
             .regenerated_queued_intent_for_message(&msg.id)
             .expect("a drained retained intent must be attributable to its durable row");
         alice.confirm_queued_outbound_intent(&intent_id).unwrap();
+        assert!(
+            alice
+                .regenerated_queued_intent_for_message(&msg.id)
+                .is_none(),
+            "confirmation must clear the regenerated-intent association"
+        );
     }
     assert!(
         storage

--- a/crates/cgka-engine/tests/publish_lifecycle.rs
+++ b/crates/cgka-engine/tests/publish_lifecycle.rs
@@ -2115,7 +2115,7 @@ async fn queued_outbound_intents_are_capped_per_group_while_a_publish_stays_unre
         // reports that the regenerated message reached the transport. Until
         // then the row is still owed a delivery, so it still occupies the cap.
         let (_, intent_id) = alice
-            .take_regenerated_queued_intent_for_message(&msg.id)
+            .regenerated_queued_intent_for_message(&msg.id)
             .expect("a drained retained intent must be attributable to its durable row");
         alice.confirm_queued_outbound_intent(&intent_id).unwrap();
     }

--- a/crates/cgka-session/src/lib.rs
+++ b/crates/cgka-session/src/lib.rs
@@ -1023,7 +1023,7 @@ impl AccountDeviceSession {
 
     pub fn retry_regenerated_queued_intent(&mut self, intent: &QueuedIntentRef) {
         self.engine
-            .retry_regenerated_queued_intent(&intent.group_id);
+            .retry_regenerated_queued_intent(&intent.group_id, &intent.intent_id);
     }
 
     pub async fn confirm_published(
@@ -1240,7 +1240,7 @@ impl AccountDeviceSession {
                 } => {
                     let queued_intent = self
                         .engine
-                        .take_regenerated_queued_intent_for_message(&msg.id)
+                        .regenerated_queued_intent_for_message(&msg.id)
                         .map(|(group_id, intent_id)| QueuedIntentRef {
                             group_id,
                             intent_id,
@@ -1257,7 +1257,7 @@ impl AccountDeviceSession {
                 SendResult::Proposal { msg } => {
                     let queued_intent = self
                         .engine
-                        .take_regenerated_queued_intent_for_message(&msg.id)
+                        .regenerated_queued_intent_for_message(&msg.id)
                         .map(|(group_id, intent_id)| QueuedIntentRef {
                             group_id,
                             intent_id,

--- a/crates/traits/src/engine.rs
+++ b/crates/traits/src/engine.rs
@@ -763,8 +763,10 @@ pub trait CgkaEngine: Send + Sync {
     fn confirm_queued_outbound_intent(&mut self, intent_id: &MessageId) -> Result<(), EngineError>;
 
     /// Re-arm a group after a regenerated standalone queued publish reached no
-    /// endpoint. The durable intent remains intact until confirmation.
-    fn retry_queued_outbound_intent(&mut self, group_id: &GroupId);
+    /// endpoint. The durable intent remains intact until confirmation; the
+    /// named intent's in-flight association is cleared so the next drain
+    /// regenerates a fresh artifact for it.
+    fn retry_queued_outbound_intent(&mut self, group_id: &GroupId, intent_id: &MessageId);
 
     /// Confirm that a [`SendResult::GroupEvolution`] (or legacy-profile
     /// [`SendResult::GroupCreated`]) was successfully published to the


### PR DESCRIPTION
Closes #1472.

## Root cause (two interlocking drain-lifecycle defects)

The `bounded-convergence-pressure/v1` acceptance gate was ignored because application sends accepted while a convergence pass resolves (e.g. inside the quiescence window of a same-epoch fork) were stranded. Investigation showed **two** defects, both reachable only through edge-driven consumers:

1. **Lost drain edge on pass close.** The drain schedule edge is one-shot: a drain that ran before the pass settled consumed it and released nothing, and pass completion never re-armed it. The conformance harness's `drive_due_convergence` (edge-driven) spun on `runnable_work` forever — a livelock. Level-driven hosts (marmot-app's `schedule_after_pass`) recover, which is why this stayed hidden.
2. **Duplicate regeneration of in-flight intents.** Once the edge was restored, the drain re-prepared an intent the host had not yet confirmed, publishing the same logical message twice; the second confirm then failed with `Storage(NotFound)`.

## Fix

- `distributed_convergence.rs`: `rearm_queued_outbound_drain_after_pass_close` schedules the drain when a pass closes (settled **and** blocked completion paths) while queued intents remain durable.
- `message_processor/mod.rs`: the drain skips in-flight intents; `regenerated_queued_intent_for_message` is now a non-destructive lookup (was `take_...`); confirm/retry clear the in-flight association. `retry_queued_outbound_intent(group_id, intent_id)` gained the intent id so retry clears precisely one association (trait + session + simulator updated).
- Engine regression test `a_completed_pass_rearms_the_drain_for_intents_queued_inside_the_window`: pre-cutoff drain consumes the edge, completion re-arms, first drain publishes, second drain before confirm stays empty.

## Simulator gate re-enabled

- `bounded_convergence_pressure_family_settles_every_seeded_permutation` un-ignored; runs nightly (PR smoke excludes it with the other multi-minute generated batches, filter contract updated).
- Family generator bumped to **v2**: labelled accepted acknowledgements now carry the confirmed pending-resolution expectations the strict oracle requires (previously masked by the hard failure).

## Verification

- `cargo test -p cgka-engine --features test-policy-overrides,test-crash-hooks` — green (25 suites).
- `cargo test -p cgka-engine --test convergence_policy_pin` (default pin gate) — green.
- `cargo test -p cgka-conformance-simulator` — green (all suites incl. the un-ignored gate).
- `cargo test -p cgka-session`, `marmot-account`, `marmot-app --features test-policy-overrides` — green.
- Isolated campaign: 3 seeds x 6 cases = 18 workers, all exit 0, no timeouts/integrity errors.
- `just fast-ci` (fmt, check, clippy) — green.
- Report CLI strict oracle passes on the previously failing saved input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed queued messages that could remain undelivered after convergence completed.
  * Prevented duplicate publication while an outbound message is still in flight.
  * Improved targeted retry handling for regenerated queued messages.
  * Ensured queued messages are rescheduled after convergence settles, including when temporary queue access issues occur.

* **Tests**
  * Added regression coverage for queued messages during unsettled convergence.
  * Re-enabled the bounded convergence-pressure scenario and updated its expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->