### PR TITLE
Feat/tui message search

### DIFF
--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -64,7 +64,9 @@ versioning through the workspace version in the root `Cargo.toml`.
 - `wn tui` can now search messages in the open chat with `/search [query]`
   (`messages timeline search`), the one thing the CLI could do that the TUI could
   not reach at all. Matches list newest first with sender, time, and text; `Enter`
-  jumps the messages pane to the highlighted match and focuses it. Matches older
+  jumps the messages pane to the highlighted match and focuses it. Matches are
+  capped at 100; a full page is reported as `100+` and asks you to refine the
+  query rather than presenting a truncated count as the total. Matches older
   than the loaded history say so instead of moving the view, because the pane
   holds one contiguous run of messages and cannot represent a gap — page back with
   `g` and search again to reach them.

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -312,6 +312,10 @@ versioning through the workspace version in the root `Cargo.toml`.
   roughly a screenful of rows the highlight fell outside the drawn area, which
   made the selection invisible rather than merely awkward — the marker and the
   highlight are drawn inside each row.
+- `wn tui` group detail can now reach its relay hints. They sit below the member
+  list, so a group with more members than the pane is tall left them permanently
+  off-screen; moving the selection to the last member now scrolls to the end of
+  the pane and brings them into view with it.
 
 ## [0.9.11] - 2026-08-09
 

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -61,6 +61,14 @@ versioning through the workspace version in the root `Cargo.toml`.
   repair.
   ([#1426](https://github.com/marmot-protocol/mdk/pull/1426))
 
+- `wn tui` can now search messages in the open chat with `/search [query]`
+  (`messages timeline search`), the one thing the CLI could do that the TUI could
+  not reach at all. Matches list newest first with sender, time, and text; `Enter`
+  jumps the messages pane to the highlighted match and focuses it. Matches older
+  than the loaded history say so instead of moving the view, because the pane
+  holds one contiguous run of messages and cannot represent a gap — page back with
+  `g` and search again to reach them.
+
 ### Changed
 
 - Account databases upgrade through storage migrations 47–50. Migration 47
@@ -144,6 +152,11 @@ versioning through the workspace version in the root `Cargo.toml`.
   at all, leaving timelines and chat lists showing pending until some unrelated
   event woke them.
   ([#1426](https://github.com/marmot-protocol/mdk/pull/1426))
+
+- `wn tui` group detail can now reach its relay hints. They sit below the member
+  list, so a group with more members than the pane is tall left them permanently
+  off-screen; moving the selection to the last member now scrolls to the end of
+  the pane and brings them into view with it.
 
 ## [0.9.12] - 2026-08-13
 
@@ -312,10 +325,6 @@ versioning through the workspace version in the root `Cargo.toml`.
   roughly a screenful of rows the highlight fell outside the drawn area, which
   made the selection invisible rather than merely awkward — the marker and the
   highlight are drawn inside each row.
-- `wn tui` group detail can now reach its relay hints. They sit below the member
-  list, so a group with more members than the pane is tall left them permanently
-  off-screen; moving the selection to the last member now scrolls to the end of
-  the pane and brings them into view with it.
 
 ## [0.9.11] - 2026-08-09
 

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -70,6 +70,7 @@ versioning through the workspace version in the root `Cargo.toml`.
   than the loaded history say so instead of moving the view, because the pane
   holds one contiguous run of messages and cannot represent a gap — page back with
   `g` and search again to reach them.
+  ([#1478](https://github.com/marmot-protocol/mdk/pull/1478))
 
 ### Changed
 
@@ -159,6 +160,7 @@ versioning through the workspace version in the root `Cargo.toml`.
   list, so a group with more members than the pane is tall left them permanently
   off-screen; moving the selection to the last member now scrolls to the end of
   the pane and brings them into view with it.
+  ([#1478](https://github.com/marmot-protocol/mdk/pull/1478))
 
 ## [0.9.12] - 2026-08-13
 

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -156,6 +156,15 @@ versioning through the workspace version in the root `Cargo.toml`.
   event woke them.
   ([#1426](https://github.com/marmot-protocol/mdk/pull/1426))
 
+- `wn tui` user search no longer leaves results under a query they do not answer.
+  Editing the query after results landed used to keep the old rows, their count,
+  and the highlight on screen, so `f`/`x` published a follow for whoever the
+  previous query had found and `c`/`a` opened a chat with them. An edit now clears
+  the results, and a page still in flight for the abandoned query is dropped
+  instead of landing — and taking focus mid-word with it. Moving the cursor, and
+  editing that changes nothing, still keep the results.
+  ([#1478](https://github.com/marmot-protocol/mdk/pull/1478))
+
 - `wn tui` group detail can now reach its relay hints. They sit below the member
   list, so a group with more members than the pane is tall left them permanently
   off-screen; moving the selection to the last member now scrolls to the end of

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -658,7 +658,8 @@ key. Because the help card is a popup, `q` under it closes the card instead of q
 
 Group detail (`g` from the chat list) shows the selected group's members with admin badges (and a `(you)` marker),
 its relay hints, and its name and description; `Esc` returns to the main view. Its keys: `j`/`k` move the member
-selection (the pane scrolls to keep the highlighted member on screen); `a` searches for someone to add (see user
+selection (the pane scrolls to keep the highlighted member on screen, and moving to the last member scrolls to the
+end of the pane so the relay hints below the list come into view); `a` searches for someone to add (see user
 search below) for when you do not have their pubkey to hand; `A` adds a member by npub/hex (text popup →
 `groups add-members`); `x` removes the selected member
 (confirm → `groups remove-members`); `P` promotes the selected member to admin (confirm → `groups promote`); `R`

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -696,7 +696,8 @@ main view. After the add lands, the group detail reopens and reloads, so the new
 from.
 
 Message search (`/search [query]`) searches the chat loaded in the messages pane
-(`messages timeline search --group <group>`, capped at 100 hits). It follows the loaded pane rather than the
+(`messages timeline search --group <group>`, capped at 100 hits — a full page reports its count as `100+` and
+says to refine the query, since the screen is a scan-and-pick list with no paging). It follows the loaded pane rather than the
 highlighted chat row, because the two can differ while a flick-through preview is pending and a hit is only useful
 if it can be jumped to. The screen has the same two regions and two-state focus as user search: type the query
 (`j`/`k` are literal text) and `Enter` runs it; once there are matches, focus moves to the list where `j`/`k` (or

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -695,6 +695,22 @@ skips the chat picker and confirms straight against that group, and `Esc` return
 main view. After the add lands, the group detail reopens and reloads, so the new member shows in the list you started
 from.
 
+Message search (`/search [query]`) searches the chat loaded in the messages pane
+(`messages timeline search --group <group>`, capped at 100 hits). It follows the loaded pane rather than the
+highlighted chat row, because the two can differ while a flick-through preview is pending and a hit is only useful
+if it can be jumped to. The screen has the same two regions and two-state focus as user search: type the query
+(`j`/`k` are literal text) and `Enter` runs it; once there are matches, focus moves to the list where `j`/`k` (or
+arrows) navigate, `i` returns to the query, and `Esc` returns to the main view. Matches are listed newest first,
+two lines each — `[HH:MM] sender`, then the message text — styled like the messages pane so a match reads as the
+message it points at.
+
+`Enter` on a match jumps the messages pane to that message and focuses it. This works for messages inside the
+loaded history: the pane holds one contiguous run of messages ending at the newest, extended backwards a page at a
+time (100 per page, up to 1000 rows), with no way to represent a gap. A match older than that run reports
+`that message is older than the loaded history; press g to page back first` and leaves the view where it is,
+rather than splicing in a disconnected window that would render as continuous while silently skipping everything
+between. Page back with `g`/PageUp and search again to reach it.
+
 Profile (`p` from the chat list) shows your own profile — name, display name, about, picture URL (as literal text; no
 avatar is fetched), nip05, lud16, and npub — from `profile show`, plus your follows from `follows list`. `j`/`k` move a
 single cursor over the six fields then the follows; `Enter` on a field opens a text popup prefilled with the current
@@ -749,6 +765,7 @@ Composer slash commands:
 /name <display-name>
 /profile name <display-name>
 /users [query]
+/search [query]
 /stream [--stream-id <hex>] [--quic-candidate <quic-url>]
 /stream start [--stream-id <hex>] --quic-candidate <quic-url>
 /stream watch [--stream-id <hex>] [--insecure-local]

--- a/crates/cli/src/tui/app.rs
+++ b/crates/cli/src/tui/app.rs
@@ -269,10 +269,11 @@ impl TuiApp {
     }
 
     /// Route pasted text (from bracketed paste) into whatever input is accepting
-    /// characters — the streaming composer, the nsec field, or the main composer —
-    /// as literal characters with no keybinding interpretation. Newlines are kept
-    /// (normalized to `\n`) so multi-line content lands verbatim. Paste elsewhere
-    /// is ignored, mirroring where typed characters are accepted.
+    /// characters — the streaming composer, a text popup's field, the nsec field,
+    /// the main composer, or a focused search query — as literal characters with
+    /// no keybinding interpretation. Newlines are kept (normalized to `\n`) so
+    /// multi-line content lands verbatim. Paste elsewhere is ignored, mirroring
+    /// where typed characters are accepted.
     pub(crate) fn handle_paste(&mut self, text: String) {
         let text = text.replace("\r\n", "\n").replace('\r', "\n");
         // A popup is modal (mirroring `handle_key`): a text-entry popup takes the
@@ -305,11 +306,18 @@ impl TuiApp {
         match self.screen {
             Screen::Login(LoginMode::NsecEntry) => self.input.insert_str(&text),
             Screen::Main if self.focus == Focus::Composer => self.input.insert_str(&text),
-            // Paste into the search query only while it has focus, mirroring
-            // where typed characters are accepted on that screen.
+            // Paste into a search query only while it has focus, mirroring where
+            // typed characters are accepted on those screens.
             Screen::UserSearch => {
                 if let Some(view) = self.user_search.as_mut()
                     && view.focus == UserSearchFocus::Query
+                {
+                    view.query.insert_str(&text);
+                }
+            }
+            Screen::MessageSearch => {
+                if let Some(view) = self.message_search.as_mut()
+                    && view.focus == MessageSearchFocus::Query
                 {
                     view.query.insert_str(&text);
                 }

--- a/crates/cli/src/tui/app.rs
+++ b/crates/cli/src/tui/app.rs
@@ -316,11 +316,7 @@ impl TuiApp {
                 }
             }
             Screen::MessageSearch => {
-                if let Some(view) = self.message_search.as_mut()
-                    && view.focus == MessageSearchFocus::Query
-                {
-                    view.query.insert_str(&text);
-                }
+                self.edit_message_search_query(|query| query.insert_str(&text))
             }
             _ => {}
         }
@@ -1766,25 +1762,43 @@ impl TuiApp {
                     view.focus = MessageSearchFocus::Results;
                 }
             }
-            KeyCode::Left => self.with_message_search_query(Input::left),
-            KeyCode::Right => self.with_message_search_query(Input::right),
-            KeyCode::Home => self.with_message_search_query(Input::home),
-            KeyCode::End => self.with_message_search_query(Input::end),
-            KeyCode::Delete => self.with_message_search_query(Input::delete),
-            KeyCode::Backspace => self.with_message_search_query(Input::backspace),
+            KeyCode::Left => self.edit_message_search_query(Input::left),
+            KeyCode::Right => self.edit_message_search_query(Input::right),
+            KeyCode::Home => self.edit_message_search_query(Input::home),
+            KeyCode::End => self.edit_message_search_query(Input::end),
+            KeyCode::Delete => self.edit_message_search_query(Input::delete),
+            KeyCode::Backspace => self.edit_message_search_query(Input::backspace),
             KeyCode::Char(character) => {
-                if let Some(view) = self.message_search.as_mut() {
-                    view.query.insert(character);
-                }
+                self.edit_message_search_query(|query| query.insert(character));
             }
             _ => {}
         }
     }
 
-    fn with_message_search_query(&mut self, edit: impl FnOnce(&mut Input)) {
-        if let Some(view) = self.message_search.as_mut() {
-            edit(&mut view.query);
+    /// The single seam every message-search query edit goes through, so no edit can
+    /// leave hits, a count, or an in-flight page answering a query the screen no
+    /// longer shows. Cursor moves come through here too and change nothing:
+    /// [`MessageSearchView::edit_query`] invalidates on the text, not on the key.
+    ///
+    /// Edits apply only while the query has focus, because the hit list's keys are
+    /// navigation. Holding that here rather than at each call site makes this safe
+    /// to call from anywhere a character can arrive, including a paste.
+    fn edit_message_search_query(&mut self, edit: impl FnOnce(&mut Input)) {
+        let Some(view) = self
+            .message_search
+            .as_mut()
+            .filter(|view| view.focus == MessageSearchFocus::Query)
+        else {
+            return;
+        };
+        if !view.edit_query(edit) {
+            return;
         }
+        // Same reasoning as `leave_screen`: clearing the anchor drops the outstanding
+        // page at fold time, and the status it stranded ("searching...", "N
+        // match(es)") described the query that just went away.
+        self.searching_messages = None;
+        self.status = String::new();
     }
 
     /// Results-focus keys: `j`/`k` navigate (with `k` at the top returning to the

--- a/crates/cli/src/tui/app.rs
+++ b/crates/cli/src/tui/app.rs
@@ -69,6 +69,9 @@ pub(crate) struct TuiApp {
     /// search is outstanding. A `UserSearch` result is folded only while its
     /// query still matches (the same stale guard as `loading_chat`).
     pub(crate) searching_users: Option<String>,
+    /// The query of the most recently requested message search, or `None`. A
+    /// `MessageSearch` result folds only while its query still matches.
+    pub(crate) searching_messages: Option<String>,
     /// The group id of the group-detail load in flight, or `None`. A
     /// `LoadGroupDetail` result is folded only while it still matches.
     pub(crate) loading_group_detail: Option<String>,
@@ -106,6 +109,9 @@ pub(crate) struct TuiApp {
     /// User-search screen state (Phase 5b). Present only while
     /// `screen == Screen::UserSearch`; a one-shot load, no per-view subscription.
     pub(crate) user_search: Option<UserSearchView>,
+    /// Message-search screen state. Present only while
+    /// `screen == Screen::MessageSearch`; a one-shot load, no subscription.
+    pub(crate) message_search: Option<MessageSearchView>,
     /// Own-profile screen state (Phase 5b). Present only while
     /// `screen == Screen::Profile`.
     pub(crate) profile_view: Option<ProfileView>,
@@ -177,6 +183,7 @@ impl TuiApp {
             pending_mark_read: false,
             loading_chat: None,
             searching_users: None,
+            searching_messages: None,
             loading_group_detail: None,
             loading_invites: false,
             flick_countdown: None,
@@ -190,6 +197,7 @@ impl TuiApp {
             pending_full_repaint: false,
             group_detail: None,
             user_search: None,
+            message_search: None,
             profile_view: None,
             relay_health: None,
             media: MediaState::new(),
@@ -563,6 +571,7 @@ impl TuiApp {
             Screen::Login(mode) => return self.handle_login_key(mode, key),
             Screen::GroupDetail => return self.handle_group_detail_key(key),
             Screen::UserSearch => return self.handle_user_search_key(key),
+            Screen::MessageSearch => return self.handle_message_search_key(key),
             Screen::Profile => return self.handle_profile_key(key),
             Screen::RelayHealth => return self.handle_relay_health_key(key),
             Screen::Main => {}
@@ -1227,6 +1236,7 @@ impl TuiApp {
                 self.open_user_search(query);
                 Ok(())
             }
+            SlashCommand::MessageSearch { query } => self.open_message_search(query),
             SlashCommand::StreamCompose {
                 stream_id,
                 quic_candidates,
@@ -1695,23 +1705,151 @@ impl TuiApp {
         }
     }
 
-    /// Drop any Phase 5b full-view state and return to the main view. Shared by
-    /// the search/profile/relay-health `Esc` handlers (their data is a one-shot
-    /// load with no per-view subscription to tear down).
+    /// Drop any secondary full-view state and return to the main view. Shared by
+    /// the user-search, message-search, profile, and relay-health `Esc` handlers
+    /// (their data is a one-shot load with no per-view subscription to tear down).
+    /// Clearing all of them unconditionally is what keeps each view's "present only
+    /// while its screen is showing" invariant true from one exit path.
     pub(crate) fn leave_screen(&mut self) {
-        // A user search may still be in flight. Clearing its anchor drops the
+        // Either search may still be in flight. Clearing its anchor drops the
         // stale result at fold time (mirroring `leave_group_detail`'s
         // `loading_group_detail` clear), so reopening the search screen never
         // inherits the abandoned query's results, and resets the "searching..."
         // status the abandoned load would otherwise strand on the status line.
-        if self.searching_users.take().is_some() {
+        if self.searching_users.take().is_some() || self.searching_messages.take().is_some() {
             self.status = String::new();
         }
         self.user_search = None;
+        self.message_search = None;
         self.profile_view = None;
         self.relay_health = None;
         self.screen = Screen::Main;
         self.focus = Focus::Chats;
+    }
+
+    /// Message-search keys. `Esc` leaves the screen from either focus; otherwise
+    /// the query field or the hit list handles the key per the screen's focus.
+    pub(crate) fn handle_message_search_key(&mut self, key: KeyEvent) -> TuiResult<()> {
+        if key.code == KeyCode::Esc {
+            self.leave_screen();
+            return Ok(());
+        }
+        match self.message_search.as_ref().map(|view| view.focus) {
+            Some(MessageSearchFocus::Query) => self.handle_message_search_query_key(key),
+            Some(MessageSearchFocus::Results) => self.handle_message_search_results_key(key),
+            None => Ok(()),
+        }
+    }
+
+    /// Query-focus keys: typing edits the query (so `j`/`k` are literal text),
+    /// `Enter` runs the search, and `Down` steps into the hits.
+    fn handle_message_search_query_key(&mut self, key: KeyEvent) -> TuiResult<()> {
+        match key.code {
+            KeyCode::Enter => {
+                if let Err(err) = self.run_message_search() {
+                    self.status = format!("error: {err}");
+                }
+            }
+            KeyCode::Down => {
+                if let Some(view) = self.message_search.as_mut()
+                    && !view.results.is_empty()
+                {
+                    view.focus = MessageSearchFocus::Results;
+                }
+            }
+            KeyCode::Left => self.with_message_search_query(Input::left),
+            KeyCode::Right => self.with_message_search_query(Input::right),
+            KeyCode::Home => self.with_message_search_query(Input::home),
+            KeyCode::End => self.with_message_search_query(Input::end),
+            KeyCode::Delete => self.with_message_search_query(Input::delete),
+            KeyCode::Backspace => self.with_message_search_query(Input::backspace),
+            KeyCode::Char(character) => {
+                if let Some(view) = self.message_search.as_mut() {
+                    view.query.insert(character);
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn with_message_search_query(&mut self, edit: impl FnOnce(&mut Input)) {
+        if let Some(view) = self.message_search.as_mut() {
+            edit(&mut view.query);
+        }
+    }
+
+    /// Results-focus keys: `j`/`k` navigate (with `k` at the top returning to the
+    /// query), `Enter` jumps the messages pane to the highlighted hit, and `i`/`/`
+    /// return to the query.
+    fn handle_message_search_results_key(&mut self, key: KeyEvent) -> TuiResult<()> {
+        match key.code {
+            KeyCode::Up | KeyCode::Char('k') => {
+                if let Some(view) = self.message_search.as_mut() {
+                    if view.selected == 0 {
+                        view.focus = MessageSearchFocus::Query;
+                    } else {
+                        view.select_up();
+                    }
+                }
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                if let Some(view) = self.message_search.as_mut() {
+                    view.select_down();
+                }
+            }
+            KeyCode::Enter => self.jump_to_selected_hit(),
+            KeyCode::Char('i') | KeyCode::Char('/') => {
+                if let Some(view) = self.message_search.as_mut() {
+                    view.focus = MessageSearchFocus::Query;
+                }
+            }
+            KeyCode::Char('?') => self.popup = Some(Popup::help()),
+            _ => {}
+        }
+        Ok(())
+    }
+
+    /// Jump the messages pane to the highlighted hit and return to it.
+    ///
+    /// Only hits inside the loaded timeline can be jumped to. The timeline is one
+    /// flat, contiguous run of rows ending at the newest message, extended
+    /// backwards a page at a time; it has no way to represent a hole. Splicing in a
+    /// window around an older hit would leave the pane rendering as continuous
+    /// while silently skipping everything between, and there is no forward paging
+    /// to walk back out of the past with — so an out-of-window hit reports what it
+    /// would take instead of moving the viewport somewhere misleading.
+    fn jump_to_selected_hit(&mut self) {
+        let Some(view) = self.message_search.as_ref() else {
+            return;
+        };
+        let Some(hit) = view.selected_hit() else {
+            return;
+        };
+        // The pane must still be showing the chat the search ran against; the
+        // search screen captures every key, but the loaded target is app state and
+        // this check is what makes the jump unable to act on the wrong chat.
+        if self.messages_group_id.as_deref() != Some(view.group_id.as_str()) {
+            self.status = "the messages pane is no longer on the searched chat".to_owned();
+            return;
+        }
+        let Some(index) = self
+            .timeline
+            .iter()
+            .position(|row| row.message_id == hit.message_id)
+        else {
+            self.status =
+                "that message is older than the loaded history; press g to page back first"
+                    .to_owned();
+            return;
+        };
+        self.timeline_scroll
+            .jump_to_index(index, self.timeline.len());
+        self.message_search = None;
+        self.searching_messages = None;
+        self.screen = Screen::Main;
+        self.focus = Focus::Messages;
+        self.status = "jumped to message".to_owned();
     }
 
     /// User-search keys. `Esc` leaves the screen from either focus; otherwise the

--- a/crates/cli/src/tui/app.rs
+++ b/crates/cli/src/tui/app.rs
@@ -306,15 +306,9 @@ impl TuiApp {
         match self.screen {
             Screen::Login(LoginMode::NsecEntry) => self.input.insert_str(&text),
             Screen::Main if self.focus == Focus::Composer => self.input.insert_str(&text),
-            // Paste into a search query only while it has focus, mirroring where
-            // typed characters are accepted on those screens.
-            Screen::UserSearch => {
-                if let Some(view) = self.user_search.as_mut()
-                    && view.focus == UserSearchFocus::Query
-                {
-                    view.query.insert_str(&text);
-                }
-            }
+            // Both funnels accept an edit only while the query has focus, mirroring
+            // where typed characters are accepted on those screens.
+            Screen::UserSearch => self.edit_user_search_query(|query| query.insert_str(&text)),
             Screen::MessageSearch => {
                 self.edit_message_search_query(|query| query.insert_str(&text))
             }
@@ -1917,25 +1911,33 @@ impl TuiApp {
                     view.focus = UserSearchFocus::Results;
                 }
             }
-            KeyCode::Left => self.with_search_query(Input::left),
-            KeyCode::Right => self.with_search_query(Input::right),
-            KeyCode::Home => self.with_search_query(Input::home),
-            KeyCode::End => self.with_search_query(Input::end),
-            KeyCode::Delete => self.with_search_query(Input::delete),
-            KeyCode::Backspace => self.with_search_query(Input::backspace),
+            KeyCode::Left => self.edit_user_search_query(Input::left),
+            KeyCode::Right => self.edit_user_search_query(Input::right),
+            KeyCode::Home => self.edit_user_search_query(Input::home),
+            KeyCode::End => self.edit_user_search_query(Input::end),
+            KeyCode::Delete => self.edit_user_search_query(Input::delete),
+            KeyCode::Backspace => self.edit_user_search_query(Input::backspace),
             KeyCode::Char(character) => {
-                if let Some(view) = self.user_search.as_mut() {
-                    view.query.insert(character);
-                }
+                self.edit_user_search_query(|query| query.insert(character));
             }
             _ => {}
         }
     }
 
-    fn with_search_query(&mut self, edit: impl FnOnce(&mut Input)) {
-        if let Some(view) = self.user_search.as_mut() {
-            edit(&mut view.query);
+    /// The user-search mirror of [`Self::edit_message_search_query`].
+    fn edit_user_search_query(&mut self, edit: impl FnOnce(&mut Input)) {
+        let Some(view) = self
+            .user_search
+            .as_mut()
+            .filter(|view| view.focus == UserSearchFocus::Query)
+        else {
+            return;
+        };
+        if !view.edit_query(edit) {
+            return;
         }
+        self.searching_users = None;
+        self.status = String::new();
     }
 
     /// Results-focus keys: `j`/`k` navigate (with `k` at the top returning to the

--- a/crates/cli/src/tui/app.rs
+++ b/crates/cli/src/tui/app.rs
@@ -1737,13 +1737,14 @@ impl TuiApp {
         match self.message_search.as_ref().map(|view| view.focus) {
             Some(MessageSearchFocus::Query) => self.handle_message_search_query_key(key),
             Some(MessageSearchFocus::Results) => self.handle_message_search_results_key(key),
-            None => Ok(()),
+            None => {}
         }
+        Ok(())
     }
 
     /// Query-focus keys: typing edits the query (so `j`/`k` are literal text),
     /// `Enter` runs the search, and `Down` steps into the hits.
-    fn handle_message_search_query_key(&mut self, key: KeyEvent) -> TuiResult<()> {
+    fn handle_message_search_query_key(&mut self, key: KeyEvent) {
         match key.code {
             KeyCode::Enter => {
                 if let Err(err) = self.run_message_search() {
@@ -1770,7 +1771,6 @@ impl TuiApp {
             }
             _ => {}
         }
-        Ok(())
     }
 
     fn with_message_search_query(&mut self, edit: impl FnOnce(&mut Input)) {
@@ -1782,7 +1782,7 @@ impl TuiApp {
     /// Results-focus keys: `j`/`k` navigate (with `k` at the top returning to the
     /// query), `Enter` jumps the messages pane to the highlighted hit, and `i`/`/`
     /// return to the query.
-    fn handle_message_search_results_key(&mut self, key: KeyEvent) -> TuiResult<()> {
+    fn handle_message_search_results_key(&mut self, key: KeyEvent) {
         match key.code {
             KeyCode::Up | KeyCode::Char('k') => {
                 if let Some(view) = self.message_search.as_mut() {
@@ -1807,7 +1807,6 @@ impl TuiApp {
             KeyCode::Char('?') => self.popup = Some(Popup::help()),
             _ => {}
         }
-        Ok(())
     }
 
     /// Jump the messages pane to the highlighted hit and return to it.

--- a/crates/cli/src/tui/client.rs
+++ b/crates/cli/src/tui/client.rs
@@ -1396,8 +1396,17 @@ impl TuiApp {
     /// Run the one-shot `messages timeline search` for the open search screen off
     /// the event loop; the hits fold in when they land. An empty query is a no-op
     /// with a hint, mirroring `run_user_search`.
+    ///
+    /// The account comes from the loaded pane, not the highlighted account row,
+    /// for the same reason `open_message_search` keys the group there: a hit is
+    /// only useful if the pane can jump to it, and the jump target is the pane's
+    /// account and group together. Resolving the two from different places lets a
+    /// search aim at a chat the jump would then refuse — reachable when a failed
+    /// `refresh_chats` commits a new selection while the pane still shows the old
+    /// one. Every other pane operation (send, reply, react, delete, retry,
+    /// load-older) already resolves the account this way.
     pub(crate) fn run_message_search(&mut self) -> TuiResult<()> {
-        let account_id = self.require_selected_local_account()?;
+        let account_id = self.message_account_id()?;
         let Some(view) = self.message_search.as_ref() else {
             return Ok(());
         };

--- a/crates/cli/src/tui/client.rs
+++ b/crates/cli/src/tui/client.rs
@@ -1375,6 +1375,7 @@ impl TuiApp {
             results: Vec::new(),
             selected: 0,
             focus: MessageSearchFocus::Query,
+            truncated: false,
         };
         if let Some(query) = query
             .map(|query| query.trim().to_owned())
@@ -1441,12 +1442,20 @@ impl TuiApp {
         let mut hits = parse_timeline_page(&page);
         hits.reverse();
         let count = hits.len();
+        view.truncated = count >= TUI_MESSAGE_SEARCH_LIMIT;
         view.results = hits;
         view.selected = 0;
         if count > 0 {
             view.focus = MessageSearchFocus::Results;
         }
-        self.status = format!("{count} match(es)");
+        // A filled page points at refining the query, which is the only thing that
+        // helps: this screen is a scan-and-pick list and does not page.
+        let refine = if view.truncated {
+            " — refine the query"
+        } else {
+            ""
+        };
+        self.status = format!("{} match(es){refine}", view.match_count_label());
     }
 
     /// Run the one-shot `users search <query>` off the event loop; the results

--- a/crates/cli/src/tui/client.rs
+++ b/crates/cli/src/tui/client.rs
@@ -1450,8 +1450,12 @@ impl TuiApp {
         // wanted one. The timeline parser sorts oldest-first for the pane.
         let mut hits = parse_timeline_page(&page);
         hits.reverse();
+        // The backend fetches one row past the limit, so this is an exact answer to
+        // "were hits dropped"; the hit count is only a proxy, and it gets a page of
+        // exactly the limit wrong. A cursorless search takes the newest rows, so
+        // anything beyond the page is older — which is what `has_more_before` names.
+        view.truncated = timeline_page_has_more_before(&page);
         let count = hits.len();
-        view.truncated = count >= TUI_MESSAGE_SEARCH_LIMIT;
         view.results = hits;
         view.selected = 0;
         if count > 0 {

--- a/crates/cli/src/tui/client.rs
+++ b/crates/cli/src/tui/client.rs
@@ -406,6 +406,9 @@ impl TuiApp {
             Effect::UserSearch { query, .. } => {
                 self.fold_user_search(query, result);
             }
+            Effect::MessageSearch { query, .. } => {
+                self.fold_message_search(query, result);
+            }
             Effect::LoadGroupDetail { account, group } => {
                 self.fold_group_detail(account, group, result);
             }
@@ -1343,6 +1346,107 @@ impl TuiApp {
         if run_now && let Err(err) = self.run_user_search() {
             self.status = format!("error: {err}");
         }
+    }
+
+    /// Enter the message-search screen for the chat loaded in the messages pane.
+    ///
+    /// Keyed on the loaded pane target rather than the highlighted chat row,
+    /// because a hit is only useful if it can be jumped to in the pane, and the
+    /// two can differ — flicking through the chat list retargets the pane on a
+    /// delay, so the highlight can sit on a chat the pane is not showing. Keying on
+    /// the highlight would let a search return hits the jump then has to refuse.
+    /// With nothing loaded there is no timeline to search or jump into, so this
+    /// reports instead of opening an empty screen.
+    pub(crate) fn open_message_search(&mut self, query: Option<String>) -> TuiResult<()> {
+        let group_id = self
+            .messages_group_id
+            .clone()
+            .ok_or_else(|| TuiError::Cli("open a chat first, then /search it".to_owned()))?;
+        let group_name = self
+            .chats
+            .iter()
+            .find(|chat| chat.group_id == group_id)
+            .map(|chat| chat.name.clone())
+            .unwrap_or_default();
+        let mut view = MessageSearchView {
+            group_id,
+            group_name,
+            query: Input::default(),
+            results: Vec::new(),
+            selected: 0,
+            focus: MessageSearchFocus::Query,
+        };
+        if let Some(query) = query
+            .map(|query| query.trim().to_owned())
+            .filter(|query| !query.is_empty())
+        {
+            view.query.set_value(query);
+        }
+        let run_now = !view.query.is_empty();
+        self.message_search = Some(view);
+        self.screen = Screen::MessageSearch;
+        self.status = "message search".to_owned();
+        if run_now {
+            self.run_message_search()?;
+        }
+        Ok(())
+    }
+
+    /// Run the one-shot `messages timeline search` for the open search screen off
+    /// the event loop; the hits fold in when they land. An empty query is a no-op
+    /// with a hint, mirroring `run_user_search`.
+    pub(crate) fn run_message_search(&mut self) -> TuiResult<()> {
+        let account_id = self.require_selected_local_account()?;
+        let Some(view) = self.message_search.as_ref() else {
+            return Ok(());
+        };
+        let group = view.group_id.clone();
+        let query = view.query.value().trim().to_owned();
+        if query.is_empty() {
+            self.status = "type a query, then Enter to search".to_owned();
+            return Ok(());
+        }
+        self.searching_messages = Some(query.clone());
+        self.status = "searching...".to_owned();
+        self.effects.enqueue(Effect::MessageSearch {
+            account: account_id,
+            group,
+            query,
+        });
+        Ok(())
+    }
+
+    /// Fold a message-search page into the view. Dropped unless its query is still
+    /// the outstanding one, so a superseded query or a left screen cannot
+    /// repopulate the list. Landing hits moves focus into them, as user search
+    /// does; an empty page leaves focus on the query so it can be edited.
+    fn fold_message_search(&mut self, query: String, result: Result<Vec<Value>, String>) {
+        if self.searching_messages.as_deref() != Some(query.as_str()) {
+            return;
+        }
+        self.searching_messages = None;
+        let values = match result {
+            Ok(values) => values,
+            Err(err) => {
+                self.status = format!("error: {err}");
+                return;
+            }
+        };
+        let page = values.first().cloned().unwrap_or(Value::Null);
+        let Some(view) = self.message_search.as_mut() else {
+            return;
+        };
+        // Newest first: a search is read top-down and the recent hit is usually the
+        // wanted one. The timeline parser sorts oldest-first for the pane.
+        let mut hits = parse_timeline_page(&page);
+        hits.reverse();
+        let count = hits.len();
+        view.results = hits;
+        view.selected = 0;
+        if count > 0 {
+            view.focus = MessageSearchFocus::Results;
+        }
+        self.status = format!("{count} match(es)");
     }
 
     /// Run the one-shot `users search <query>` off the event loop; the results

--- a/crates/cli/src/tui/mod.rs
+++ b/crates/cli/src/tui/mod.rs
@@ -54,6 +54,10 @@ const SLASH_SUGGESTION_LIMIT: usize = 8;
 const TUI_MESSAGE_SCROLLBACK_LIMIT: usize = 1_000;
 /// Materialized-timeline page size for the snapshot load and each history page.
 const TUI_TIMELINE_PAGE_SIZE: usize = 100;
+/// Hits requested per message search. Bounded because the results screen is a
+/// scan-and-pick list, not a second timeline: a query matching thousands of
+/// messages is a query to refine, not a page to walk.
+const TUI_MESSAGE_SEARCH_LIMIT: usize = 100;
 /// Blank rows rendered below each timeline message as a separator; counted in a
 /// row's rendered height so the visibility walk and the renderer agree.
 const TIMELINE_MESSAGE_SEPARATOR_ROWS: u16 = 1;

--- a/crates/cli/src/tui/model.rs
+++ b/crates/cli/src/tui/model.rs
@@ -85,6 +85,14 @@ pub(crate) enum Effect {
     /// left screen) are dropped at fold time by comparing `query` to the pending
     /// search.
     UserSearch { account: String, query: String },
+    /// Search one group's materialized timeline. Stale results (a newer query, or
+    /// a left screen) are dropped at fold time by comparing `query` to the
+    /// pending search, exactly as `UserSearch` does.
+    MessageSearch {
+        account: String,
+        group: String,
+        query: String,
+    },
     /// Load the group-detail view: members, admins, relays, and profile (four
     /// `wn` calls run in that order on the worker thread).
     LoadGroupDetail { account: String, group: String },
@@ -222,6 +230,26 @@ impl Effect {
                     args: vec!["follows".to_owned(), "list".to_owned()],
                 },
             ],
+            // `messages timeline search` rather than `messages search`: it answers
+            // in timeline-page shape, so the hits parse with the timeline parser
+            // and share message ids with the rows in the messages pane.
+            Effect::MessageSearch {
+                account,
+                group,
+                query,
+            } => vec![WnCall {
+                account: Some(account.clone()),
+                args: vec![
+                    "messages".to_owned(),
+                    "timeline".to_owned(),
+                    "search".to_owned(),
+                    query.clone(),
+                    "--group".to_owned(),
+                    group.clone(),
+                    "--limit".to_owned(),
+                    TUI_MESSAGE_SEARCH_LIMIT.to_string(),
+                ],
+            }],
             Effect::LoadGroupDetail { account, group } => vec![
                 WnCall {
                     account: Some(account.clone()),
@@ -562,6 +590,7 @@ pub(crate) enum Screen {
     Main,
     GroupDetail,
     UserSearch,
+    MessageSearch,
     Profile,
     RelayHealth,
 }
@@ -1082,6 +1111,7 @@ pub(crate) fn help_card_lines() -> Vec<String> {
         "Composer: cursor editing (arrows/Home/End, Backspace/Delete); Enter sends.",
         "Group detail: j/k move; a search for a member to add; A add by pubkey; x remove; P promote; R rename; L leave.",
         "User search: type + Enter searches; Enter opens a card; c chat; a add to a chat; f follow; x unfollow.",
+        "Message search: /search [query] searches the open chat; Enter jumps the pane to the highlighted match.",
         "A search opened by group-detail a adds to that group and Esc returns to it.",
         "Profile: j/k move; Enter edits a field; f follow; x unfollow. Relay health: r refresh.",
         "Popups capture every key; Esc or the shown key closes them.",
@@ -1334,6 +1364,52 @@ pub(crate) enum UserSearchPurpose {
         /// view still being loaded.
         group_name: String,
     },
+}
+
+/// Which region of the message-search screen has focus. Mirrors
+/// [`UserSearchFocus`]: typing edits the query until the results take over.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum MessageSearchFocus {
+    Query,
+    Results,
+}
+
+/// The message-search screen state: the chat being searched, a reusable query
+/// [`Input`], the hits, the selection, and which region has focus.
+///
+/// Hits are [`TimelineRow`]s, not a bespoke row type: `messages timeline search`
+/// returns the same page shape as `messages timeline list`, so the existing
+/// timeline parser reads them and a hit carries the real message id, sender,
+/// text, and timestamp. That shared identity is what lets a hit be located in
+/// the loaded timeline.
+///
+/// `group_id` is captured when the screen opens and checked before any jump, so a
+/// hit can never be applied to a timeline that has since been retargeted at a
+/// different chat.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct MessageSearchView {
+    pub(crate) group_id: String,
+    pub(crate) group_name: String,
+    pub(crate) query: Input,
+    pub(crate) results: Vec<TimelineRow>,
+    pub(crate) selected: usize,
+    pub(crate) focus: MessageSearchFocus,
+}
+
+impl MessageSearchView {
+    pub(crate) fn select_up(&mut self) {
+        self.selected = self.selected.saturating_sub(1);
+    }
+
+    pub(crate) fn select_down(&mut self) {
+        if self.selected + 1 < self.results.len() {
+            self.selected += 1;
+        }
+    }
+
+    pub(crate) fn selected_hit(&self) -> Option<&TimelineRow> {
+        self.results.get(self.selected)
+    }
 }
 
 /// The user-search screen state: a reusable query [`Input`], the one-shot
@@ -1822,6 +1898,19 @@ pub(crate) fn user_search_hint(focus: UserSearchFocus, purpose: &UserSearchPurpo
 /// `user_search_hint` cannot drift apart.
 const USER_SEARCH_QUERY_HINT: &str = "type query  Enter search  Down results  Esc back";
 
+/// The message-search query-focus hint, shared with `hints_line`'s fallback arm
+/// for the same reason.
+const MESSAGE_SEARCH_QUERY_HINT: &str = "type query  Enter search  Down results  Esc back";
+
+/// The message-search hints line, keyed by the screen's internal focus. `Enter`
+/// on a hit is named for what it does — jump the messages pane to that message.
+pub(crate) fn message_search_hint(focus: MessageSearchFocus) -> &'static str {
+    match focus {
+        MessageSearchFocus::Query => MESSAGE_SEARCH_QUERY_HINT,
+        MessageSearchFocus::Results => "j/k move  Enter jump to message  i query  Esc back",
+    }
+}
+
 /// A name made safe to interpolate into a keymap hint: terminal-safe, collapsed
 /// to single spaces, and shortened. The collapse matters as much as the
 /// filtering — `keymap_hint_spans` splits segments on a double space and boxes a
@@ -2102,10 +2191,12 @@ pub(crate) fn hints_line(screen: Screen, focus: Focus, entered_main: bool) -> &'
         Screen::GroupDetail => {
             "j/k move  a search+add  A add  x remove  P promote  R rename  L leave  I invites  ? help  Esc back"
         }
-        // The search screen has an internal focus the shared signature cannot
-        // carry; `render_hints` calls `user_search_hint` instead. This arm keeps
-        // `hints_line` total and returns the query-focus hint as the fallback.
+        // Both search screens have an internal focus the shared signature cannot
+        // carry; `render_hints` calls `user_search_hint` / `message_search_hint`
+        // instead. These arms keep `hints_line` total and return the query-focus
+        // hint as the fallback.
         Screen::UserSearch => USER_SEARCH_QUERY_HINT,
+        Screen::MessageSearch => MESSAGE_SEARCH_QUERY_HINT,
         Screen::Profile => "j/k move  Enter edit  f follow  x unfollow  Esc back",
         Screen::RelayHealth => "r refresh  j/k scroll  Esc back",
         Screen::Main => match focus {
@@ -2383,6 +2474,11 @@ pub(crate) enum SlashCommand {
     UsersSearch {
         query: Option<String>,
     },
+    /// Open the message-search screen for the open chat, optionally pre-running a
+    /// query.
+    MessageSearch {
+        query: Option<String>,
+    },
     StreamCompose {
         stream_id: Option<String>,
         quic_candidates: Vec<String>,
@@ -2536,6 +2632,10 @@ pub(crate) const SLASH_COMMAND_SUGGESTIONS: &[SlashCommandSuggestion] = &[
     SlashCommandSuggestion {
         usage: "/users [query]",
         description: "open user search (optionally run a query)",
+    },
+    SlashCommandSuggestion {
+        usage: "/search [query]",
+        description: "search messages in the open chat",
     },
     SlashCommandSuggestion {
         usage: "/name <display-name>",
@@ -3496,6 +3596,22 @@ mod timeline {
             self.offset = len - 1;
         }
 
+        /// Select the row at `index` and scroll it to the anchor, for landing on a
+        /// message chosen somewhere other than the pane (a search hit). The offset
+        /// convention is the one `jump_oldest` uses — `jump_oldest` is this with
+        /// `index == 0` — kept here so the arithmetic that relates an absolute
+        /// index to a bottom-anchored offset lives in one place. An out-of-range
+        /// index is ignored rather than clamped: the caller resolved it from a
+        /// message id, so a stale index means the caller's row is gone and moving
+        /// the viewport somewhere arbitrary would be worse than not moving.
+        pub(crate) fn jump_to_index(&mut self, index: usize, len: usize) {
+            if index >= len {
+                return;
+            }
+            self.selection = Some(index);
+            self.offset = len - 1 - index;
+        }
+
         fn move_selection(&mut self, len: usize, step: impl FnOnce(usize) -> usize) {
             let Some(sel) = self.resolved_selection(len) else {
                 return;
@@ -3807,7 +3923,7 @@ mod timeline {
 
     /// The author label shown before a timeline message: the sender's display name,
     /// falling back to a shortened id. Color (not "me") signals ownership.
-    fn timeline_author_label(row: &TimelineRow) -> String {
+    pub(crate) fn timeline_author_label(row: &TimelineRow) -> String {
         row.from_display_name
             .clone()
             .unwrap_or_else(|| shorten(&row.from, 18))
@@ -3837,7 +3953,7 @@ mod timeline {
     /// the `[HH:MM]` shape (fixed 8-column prefix) rather than the value and cover
     /// the arithmetic through the pure `format_hhmm_with_offset` below. Falls back
     /// to UTC when the timestamp is out of `DateTime`'s range.
-    fn local_hhmm(timeline_at: u64) -> String {
+    pub(crate) fn local_hhmm(timeline_at: u64) -> String {
         chrono::DateTime::from_timestamp(timeline_at as i64, 0)
             .map(|instant| {
                 instant

--- a/crates/cli/src/tui/model.rs
+++ b/crates/cli/src/tui/model.rs
@@ -1394,9 +1394,25 @@ pub(crate) struct MessageSearchView {
     pub(crate) results: Vec<TimelineRow>,
     pub(crate) selected: usize,
     pub(crate) focus: MessageSearchFocus,
+    /// Whether the answer filled `TUI_MESSAGE_SEARCH_LIMIT`, so matches were very
+    /// likely dropped. Recorded at fold time because the count alone cannot say it,
+    /// and the screen has no paging: an exact-looking count would read as "these
+    /// are all of them" and hide the one action that helps, refining the query.
+    pub(crate) truncated: bool,
 }
 
 impl MessageSearchView {
+    /// The match count as shown: `12` when the page is complete, `100+` when the
+    /// limit was filled. One place, so the status line and the list header cannot
+    /// disagree about how many matches there are.
+    pub(crate) fn match_count_label(&self) -> String {
+        if self.truncated {
+            format!("{}+", self.results.len())
+        } else {
+            self.results.len().to_string()
+        }
+    }
+
     pub(crate) fn select_up(&mut self) {
         self.selected = self.selected.saturating_sub(1);
     }
@@ -3589,11 +3605,7 @@ mod timeline {
 
         /// Select the oldest loaded message and scroll to the top (`g`).
         pub(crate) fn jump_oldest(&mut self, len: usize) {
-            if len == 0 {
-                return;
-            }
-            self.selection = Some(0);
-            self.offset = len - 1;
+            self.jump_to_index(0, len);
         }
 
         /// Select the row at `index` and scroll it to the anchor, for landing on a

--- a/crates/cli/src/tui/model.rs
+++ b/crates/cli/src/tui/model.rs
@@ -1394,17 +1394,18 @@ pub(crate) struct MessageSearchView {
     pub(crate) results: Vec<TimelineRow>,
     pub(crate) selected: usize,
     pub(crate) focus: MessageSearchFocus,
-    /// Whether the answer filled `TUI_MESSAGE_SEARCH_LIMIT`, so matches were very
-    /// likely dropped. Recorded at fold time because the count alone cannot say it,
-    /// and the screen has no paging: an exact-looking count would read as "these
-    /// are all of them" and hide the one action that helps, refining the query.
+    /// Whether matches remain beyond this page, per the response's
+    /// `has_more_before`. Recorded at fold time because the count alone cannot say
+    /// it, and the screen has no paging: an exact-looking count would read as
+    /// "these are all of them" and hide the one action that helps, refining the
+    /// query.
     pub(crate) truncated: bool,
 }
 
 impl MessageSearchView {
-    /// The match count as shown: `12` when the page is complete, `100+` when the
-    /// limit was filled. One place, so the status line and the list header cannot
-    /// disagree about how many matches there are.
+    /// The match count as shown: `12` when the page is complete, `100+` when hits
+    /// remain beyond the page. One place, so the status line and the list header
+    /// cannot disagree about how many matches there are.
     pub(crate) fn match_count_label(&self) -> String {
         if self.truncated {
             format!("{}+", self.results.len())

--- a/crates/cli/src/tui/model.rs
+++ b/crates/cli/src/tui/model.rs
@@ -1477,6 +1477,19 @@ impl Default for UserSearchView {
 }
 
 impl UserSearchView {
+    /// Mirrors [`MessageSearchView::edit_query`]: the results, and the selection
+    /// into them, answer the query they were fetched for, so a text change drops
+    /// them. The stakes are higher here — the results-focus keys publish follows and
+    /// open chat popups, so a row under the wrong query is acted on, not just read.
+    pub(crate) fn edit_query(&mut self, edit: impl FnOnce(&mut Input)) -> bool {
+        if !self.query.edit(edit) {
+            return false;
+        }
+        self.results.clear();
+        self.selected = 0;
+        true
+    }
+
     pub(crate) fn select_up(&mut self) {
         self.selected = self.selected.saturating_sub(1);
     }

--- a/crates/cli/src/tui/model.rs
+++ b/crates/cli/src/tui/model.rs
@@ -1403,6 +1403,28 @@ pub(crate) struct MessageSearchView {
 }
 
 impl MessageSearchView {
+    /// Apply an edit to the query, dropping the hits when the text changes.
+    ///
+    /// `results`, `truncated`, and `selected` all describe the query they were
+    /// fetched for, so carrying them past an edit would leave a hit list under a
+    /// query it does not answer — and `Down`/`Enter` would still jump into it.
+    /// Dropping them holds one invariant: the list on screen answers the query on
+    /// screen, or there is no list. Keying off the text rather than off the keys
+    /// that usually mutate is what leaves a settled list alone through a cursor
+    /// move, a `Backspace` at the start, and a `Delete` at the end.
+    ///
+    /// Returns whether the text changed, so the caller can drop the app-side state
+    /// describing the same superseded query.
+    pub(crate) fn edit_query(&mut self, edit: impl FnOnce(&mut Input)) -> bool {
+        if !self.query.edit(edit) {
+            return false;
+        }
+        self.results.clear();
+        self.truncated = false;
+        self.selected = 0;
+        true
+    }
+
     /// The match count as shown: `12` when the page is complete, `100+` when hits
     /// remain beyond the page. One place, so the status line and the list header
     /// cannot disagree about how many matches there are.
@@ -2002,6 +2024,16 @@ impl Input {
     /// The cursor position as a char index in `0..=char_count`.
     pub(crate) fn cursor(&self) -> usize {
         self.cursor
+    }
+
+    /// Apply `edit` and report whether the text changed. Cursor moves report
+    /// `false`, and so do no-op edits (`Backspace` at the start, `Delete` at the
+    /// end, an empty paste), so a caller can hang invalidation off the text instead
+    /// of off the key that produced it.
+    pub(crate) fn edit(&mut self, edit: impl FnOnce(&mut Self)) -> bool {
+        let before = self.value.clone();
+        edit(self);
+        self.value != before
     }
 
     pub(crate) fn set_masked(&mut self, masked: bool) {

--- a/crates/cli/src/tui/slash.rs
+++ b/crates/cli/src/tui/slash.rs
@@ -77,6 +77,9 @@ pub(crate) fn parse_slash_command(input: &str) -> Result<SlashCommand, String> {
         "users" => Ok(SlashCommand::UsersSearch {
             query: (!rest.is_empty()).then(|| rest.join(" ")),
         }),
+        "search" => Ok(SlashCommand::MessageSearch {
+            query: (!rest.is_empty()).then(|| rest.join(" ")),
+        }),
         "stream" => parse_stream_command(rest),
         "quit" | "q" => Ok(SlashCommand::Quit),
         other => Err(format!("unknown slash command: /{other}")),

--- a/crates/cli/src/tui/tests.rs
+++ b/crates/cli/src/tui/tests.rs
@@ -2400,6 +2400,7 @@ fn test_tui_app(client: WnClient, account_id: &str) -> TuiApp {
         pending_mark_read: false,
         loading_chat: None,
         searching_users: None,
+        searching_messages: None,
         loading_group_detail: None,
         loading_invites: false,
         flick_countdown: None,
@@ -2416,6 +2417,7 @@ fn test_tui_app(client: WnClient, account_id: &str) -> TuiApp {
         pending_full_repaint: false,
         group_detail: None,
         user_search: None,
+        message_search: None,
         profile_view: None,
         relay_health: None,
         media: MediaState::new(),
@@ -10007,6 +10009,312 @@ fn user_search_runs_query_and_navigates_results() {
     assert_eq!(
         app.user_search.as_ref().unwrap().focus,
         UserSearchFocus::Query
+    );
+}
+
+/// A timeline-row JSON object in the shape `messages timeline search` returns,
+/// which is the same page shape `messages timeline list` returns.
+fn timeline_hit_json(message_id: &str, from: &str, text: &str, timeline_at: u64) -> String {
+    format!(
+        r#"{{"message_id":"{message_id}","direction":"received","from":"{from}","from_display_name":"{from}","plaintext":"{text}","timeline_at":{timeline_at},"received_at":{timeline_at},"deleted":false}}"#
+    )
+}
+
+/// An app with one chat open and its timeline loaded, ready to search.
+fn app_with_open_chat(client: WnClient, rows: &[(&str, &str)]) -> TuiApp {
+    let account_id = "aa".repeat(32);
+    let mut app = test_tui_app(client, &account_id);
+    app.chats = vec![ChatRow {
+        group_id: "g1".to_owned(),
+        name: "Ops Room".to_owned(),
+        ..ChatRow::default()
+    }];
+    app.selected_chat = 0;
+    app.messages_account_id = Some(account_id);
+    app.messages_group_id = Some("g1".to_owned());
+    app.timeline = rows
+        .iter()
+        .enumerate()
+        .map(|(index, (message_id, text))| {
+            parse_timeline_row(
+                &serde_json::from_str::<serde_json::Value>(&timeline_hit_json(
+                    message_id,
+                    "bob",
+                    text,
+                    1_700_000_000 + index as u64,
+                ))
+                .expect("row json"),
+            )
+            .expect("row parses")
+        })
+        .collect();
+    app
+}
+
+#[test]
+fn slash_search_runs_a_message_search_over_the_open_chat() {
+    let (_dir, client) = test_json_client(&format!(
+        r#"{{"ok":true,"result":{{"messages":[{}],"has_more_before":false,"has_more_after":false,"query":"deploy"}}}}"#,
+        timeline_hit_json("m2", "bob", "the deploy is green", 1_700_000_001)
+    ));
+    let mut app = app_with_open_chat(client, &[("m1", "morning"), ("m2", "the deploy is green")]);
+
+    app.run_slash_command(parse_slash_command("/search deploy").expect("parses"))
+        .expect("slash search");
+    app.settle_effects(1);
+
+    assert_eq!(app.screen, Screen::MessageSearch);
+    let view = app.message_search.as_ref().expect("search view");
+    assert_eq!(view.query.value(), "deploy");
+    assert_eq!(view.results.len(), 1, "the hit folds in as a timeline row");
+    assert_eq!(view.results[0].message_id, "m2");
+    assert_eq!(view.results[0].plaintext, "the deploy is green");
+}
+
+#[test]
+fn message_search_navigates_hits_and_returns_to_the_query() {
+    let (_dir, client) = test_json_client(&format!(
+        r#"{{"ok":true,"result":{{"messages":[{},{}]}}}}"#,
+        timeline_hit_json("m1", "bob", "deploy one", 1_700_000_000),
+        timeline_hit_json("m2", "bob", "deploy two", 1_700_000_001)
+    ));
+    let mut app = app_with_open_chat(client, &[("m1", "deploy one"), ("m2", "deploy two")]);
+    app.open_message_search(None).expect("open search");
+    // Query focus: typed characters edit the query, so j/k are literal text here.
+    for character in "dej".chars() {
+        app.handle_key(char_key(character)).expect("type query");
+    }
+    assert_eq!(app.message_search.as_ref().unwrap().query.value(), "dej");
+    app.handle_key(KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE))
+        .expect("fix the query");
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        .expect("run search");
+    app.settle_effects(1);
+
+    // Newest first, so the later message leads.
+    {
+        let view = app.message_search.as_ref().expect("view");
+        assert_eq!(view.results.len(), 2);
+        assert_eq!(view.results[0].message_id, "m2");
+        assert_eq!(view.selected, 0);
+    }
+    app.handle_key(char_key('j')).expect("j down");
+    assert_eq!(app.message_search.as_ref().unwrap().selected, 1);
+    app.handle_key(char_key('k')).expect("k up");
+    assert_eq!(app.message_search.as_ref().unwrap().selected, 0);
+    app.handle_key(char_key('k')).expect("k to query");
+    assert_eq!(
+        app.message_search.as_ref().unwrap().focus,
+        MessageSearchFocus::Query,
+        "k at the top returns to the query"
+    );
+}
+
+#[test]
+fn a_stale_message_search_result_for_a_superseded_query_is_dropped() {
+    let (_dir, client) = test_json_client(&format!(
+        r#"{{"ok":true,"result":{{"messages":[{}]}}}}"#,
+        timeline_hit_json("m1", "bob", "stale hit", 1_700_000_000)
+    ));
+    let mut app = app_with_open_chat(client, &[("m1", "stale hit")]);
+    app.open_message_search(Some("first".to_owned()))
+        .expect("open search");
+    // A second query supersedes the first before its page lands.
+    app.searching_messages = Some("second".to_owned());
+    app.settle_effects(1);
+
+    assert!(
+        app.message_search
+            .as_ref()
+            .expect("view")
+            .results
+            .is_empty(),
+        "the superseded query's page does not repopulate the list"
+    );
+    assert_eq!(
+        app.searching_messages.as_deref(),
+        Some("second"),
+        "and the outstanding query is left alone"
+    );
+}
+
+#[test]
+fn message_search_targets_the_loaded_chat_not_the_highlighted_row() {
+    let (_dir, client) = test_json_client(r#"{"ok":true,"result":{"messages":[]}}"#);
+    let mut app = app_with_open_chat(client, &[("m1", "morning")]);
+    // Flicking the chat list moves the highlight ahead of the pane, which keeps
+    // showing `g1` until the debounced preview lands. A search keyed on the
+    // highlight would return `g2` hits the jump could only refuse.
+    app.chats.push(ChatRow {
+        group_id: "g2".to_owned(),
+        name: "Other Room".to_owned(),
+        ..ChatRow::default()
+    });
+    app.selected_chat = 1;
+
+    app.open_message_search(None).expect("open search");
+
+    assert_eq!(
+        app.message_search.as_ref().expect("view").group_id,
+        "g1",
+        "the search follows the pane, not the highlight"
+    );
+}
+
+#[test]
+fn message_search_without_a_loaded_chat_reports_instead_of_opening() {
+    let (_dir, client) = test_json_client(r#"{"ok":true,"result":{"messages":[]}}"#);
+    let mut app = test_tui_app(client, &"aa".repeat(32));
+
+    let error = app
+        .open_message_search(Some("deploy".to_owned()))
+        .expect_err("no chat is loaded");
+
+    assert!(
+        error.to_string().contains("open a chat first"),
+        "says what to do; got: {error}"
+    );
+    assert!(app.message_search.is_none(), "no empty screen is opened");
+    assert_eq!(app.screen, Screen::Main, "and the screen does not change");
+}
+
+#[test]
+fn message_search_frame_shows_matches_and_strips_control_sequences() {
+    let (_dir, client) = test_json_client(&format!(
+        r#"{{"ok":true,"result":{{"messages":[{}],"has_more_before":false,"has_more_after":false}}}}"#,
+        // An escape sequence in the message body and in the sender's display name:
+        // both are relay-supplied text rendering into a pane.
+        "{\"message_id\":\"m9\",\"direction\":\"received\",\"from\":\"bob\",\"from_display_name\":\"ev\\u001b[31mil\",\"plaintext\":\"deploy is \\u001b[2Jgreen\",\"timeline_at\":1700000000,\"received_at\":1700000000,\"deleted\":false}"
+    ));
+    let mut app = app_with_open_chat(client, &[("m9", "deploy is green")]);
+    app.open_message_search(Some("deploy".to_owned()))
+        .expect("open search");
+    app.settle_effects(1);
+
+    let rendered = rendered_buffer(&mut app);
+    assert!(rendered.contains("Message Search"), "screen title present");
+    assert!(
+        rendered.contains("Ops Room"),
+        "names the chat being searched"
+    );
+    assert!(rendered.contains("Matches (1)"), "match count present");
+    assert!(rendered.contains("deploy is"), "hit text rendered");
+
+    // Assert the escape stripping on the built lines, not on the rendered buffer:
+    // ratatui drops a zero-width ESC while writing cells whatever we hand it, so a
+    // buffer-level assertion passes even with the sanitizer removed and would be
+    // no guard at all for invariant 7.
+    let view = app.message_search.as_ref().expect("search view");
+    let body = message_search_lines(view, app.selected_account_row(), false)
+        .lines
+        .iter()
+        .flat_map(|line| line.spans.iter().map(|span| span.content.to_string()))
+        .collect::<String>();
+    assert!(
+        !body.contains('\u{1b}'),
+        "no escape reaches a rendered span; got: {body:?}"
+    );
+    assert!(
+        body.contains("deploy is [2Jgreen") && body.contains("ev[31mil"),
+        "the surrounding text survives the strip; got: {body:?}"
+    );
+}
+
+#[test]
+fn the_message_search_key_is_named_in_the_palette_hints_and_help() {
+    let palette = SLASH_COMMAND_SUGGESTIONS
+        .iter()
+        .map(|entry| entry.usage)
+        .collect::<Vec<_>>();
+    assert!(
+        palette.contains(&"/search [query]"),
+        "the command palette offers the message search; got: {palette:?}"
+    );
+    assert!(
+        message_search_hint(MessageSearchFocus::Results).contains("Enter jump to message"),
+        "the results hint names what Enter does"
+    );
+    let help = help_card_lines().join("\n");
+    assert!(
+        help.contains("/search"),
+        "the help card names the message search; got:\n{help}"
+    );
+}
+
+#[test]
+fn enter_on_a_hit_jumps_the_messages_pane_to_that_message() {
+    let (_dir, client) = test_json_client(&format!(
+        r#"{{"ok":true,"result":{{"messages":[{}],"has_more_before":false,"has_more_after":false}}}}"#,
+        timeline_hit_json("m1", "bob", "the deploy is green", 1_700_000_000)
+    ));
+    // Four loaded rows with the hit oldest, so a jump has to move the selection
+    // and the offset off the newest row it defaults to.
+    let mut app = app_with_open_chat(
+        client,
+        &[
+            ("m1", "the deploy is green"),
+            ("m2", "second"),
+            ("m3", "third"),
+            ("m4", "fourth"),
+        ],
+    );
+    app.open_message_search(Some("deploy".to_owned()))
+        .expect("open search");
+    app.settle_effects(1);
+    assert_eq!(
+        app.message_search.as_ref().expect("view").focus,
+        MessageSearchFocus::Results,
+        "landing hits move focus into them"
+    );
+
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        .expect("jump to the hit");
+
+    assert_eq!(app.screen, Screen::Main, "returns to the conversation");
+    assert_eq!(app.focus, Focus::Messages, "with the messages pane focused");
+    assert!(app.message_search.is_none(), "the search view is cleared");
+    assert_eq!(
+        app.timeline_scroll.resolved_selection(app.timeline.len()),
+        Some(0),
+        "the hit is the selected message"
+    );
+    assert_eq!(
+        app.timeline_scroll.offset, 3,
+        "and the viewport is anchored on it, not on the newest row"
+    );
+}
+
+#[test]
+fn enter_on_a_hit_outside_the_loaded_history_explains_instead_of_moving() {
+    let (_dir, client) = test_json_client(&format!(
+        r#"{{"ok":true,"result":{{"messages":[{}],"has_more_before":true,"has_more_after":false}}}}"#,
+        timeline_hit_json("ancient", "bob", "the deploy is green", 1_600_000_000)
+    ));
+    // The hit is not among the loaded rows: the timeline is one contiguous run
+    // ending at the newest message and cannot represent a hole, so the jump must
+    // decline rather than move the viewport somewhere misleading.
+    let mut app = app_with_open_chat(client, &[("m1", "morning"), ("m2", "second")]);
+    app.open_message_search(Some("deploy".to_owned()))
+        .expect("open search");
+    app.settle_effects(1);
+    let offset_before = app.timeline_scroll.offset;
+
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        .expect("attempt the jump");
+
+    assert_eq!(
+        app.screen,
+        Screen::MessageSearch,
+        "the search screen stays open so the reader keeps the result list"
+    );
+    assert_eq!(
+        app.timeline_scroll.offset, offset_before,
+        "the viewport does not move"
+    );
+    assert!(
+        app.status.contains("older than the loaded history"),
+        "the status says why, and what to do about it; got: {}",
+        app.status
     );
 }
 

--- a/crates/cli/src/tui/tests.rs
+++ b/crates/cli/src/tui/tests.rs
@@ -9790,6 +9790,35 @@ fn handle_paste_is_ignored_on_the_login_menu_and_when_messages_focused() {
 }
 
 #[test]
+fn handle_paste_fills_the_message_search_query_only_while_it_has_focus() {
+    // Typing edits the message-search query, so pasting one must too — otherwise
+    // the most natural way to search for a phrase you already have on the
+    // clipboard silently does nothing. The focus gate is what is under test: once
+    // the hits take focus the query is no longer accepting characters.
+    let mut app = app_with_open_chat(test_unused_client(), &[("m1", "the deploy is green")]);
+    app.open_message_search(None).expect("open search");
+
+    app.handle_paste("deploy".to_owned());
+    assert_eq!(
+        app.message_search.as_ref().expect("view").query.value(),
+        "deploy",
+        "paste fills the query the same way typing does"
+    );
+
+    app.message_search.as_mut().expect("view").focus = MessageSearchFocus::Results;
+    app.handle_paste(" ignored".to_owned());
+    assert_eq!(
+        app.message_search.as_ref().expect("view").query.value(),
+        "deploy",
+        "paste is ignored once the hits have focus"
+    );
+    assert!(
+        app.input.is_empty(),
+        "and never leaks into the composer behind the screen"
+    );
+}
+
+#[test]
 fn handle_paste_into_a_text_popup_lands_in_its_input_not_the_composer() {
     // Pasting an npub into the Add Member text popup fills the popup's input,
     // never the composer hidden behind it.
@@ -10069,6 +10098,50 @@ fn slash_search_runs_a_message_search_over_the_open_chat() {
     assert_eq!(view.results.len(), 1, "the hit folds in as a timeline row");
     assert_eq!(view.results[0].message_id, "m2");
     assert_eq!(view.results[0].plaintext, "the deploy is green");
+}
+
+#[cfg(unix)]
+#[test]
+fn message_search_runs_against_the_loaded_account_not_the_highlighted_one() {
+    // A failed `refresh_chats` commits the newly highlighted account while the
+    // pane keeps showing the previous account's chat. Search is a pane operation
+    // like send/reply/react/delete, so it must follow the pane: keying it on the
+    // highlight searches a database that does not hold the searched chat and
+    // reports a confident zero hits.
+    let loaded_account = "aa".repeat(32);
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let (exe, args_file) = test_arg_recording_executable(
+        tempdir.path(),
+        r#"{"ok":true,"result":{"messages":[],"has_more_before":false,"has_more_after":false,"query":"deploy"}}"#,
+    );
+    let client = WnClient {
+        exe,
+        ..test_unused_client()
+    };
+    let mut app = app_with_open_chat(client, &[("m1", "the deploy is green")]);
+    app.accounts.push(AccountRow {
+        account_id: "bb".repeat(32),
+        npub: "npub1bob".to_owned(),
+        display_name: Some("Bob".to_owned()),
+        local_signing: true,
+    });
+    app.selected_account = 1;
+
+    app.open_message_search(Some("deploy".to_owned()))
+        .expect("open search");
+    app.settle_effects(1);
+
+    let recorded = std::fs::read_to_string(&args_file).expect("recorded args");
+    let args: Vec<&str> = recorded.lines().collect();
+    let account = args
+        .iter()
+        .position(|arg| *arg == "--account")
+        .map(|index| args[index + 1])
+        .expect("the search spawns an --account-scoped child");
+    assert_eq!(
+        account, loaded_account,
+        "the search follows the loaded pane, not the highlighted row; got: {args:?}"
+    );
 }
 
 #[test]

--- a/crates/cli/src/tui/tests.rs
+++ b/crates/cli/src/tui/tests.rs
@@ -10111,6 +10111,75 @@ fn message_search_navigates_hits_and_returns_to_the_query() {
 }
 
 #[test]
+fn a_message_search_that_fills_its_limit_reports_the_count_as_partial() {
+    // A full page means hits were almost certainly dropped, and the screen is a
+    // scan-and-pick list with no paging. Reporting the cap as an exact count would
+    // read as "these are all of them" and hide the need to refine the query.
+    let hits = (0..TUI_MESSAGE_SEARCH_LIMIT)
+        .map(|index| {
+            timeline_hit_json(
+                &format!("m{index}"),
+                "bob",
+                "deploy",
+                1_700_000_000 + index as u64,
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    let (_dir, client) = test_json_client(&format!(
+        r#"{{"ok":true,"result":{{"messages":[{hits}]}}}}"#
+    ));
+    let mut app = app_with_open_chat(client, &[("m0", "deploy")]);
+    app.open_message_search(Some("deploy".to_owned()))
+        .expect("open search");
+    app.settle_effects(1);
+
+    let view = app.message_search.as_ref().expect("view");
+    assert_eq!(view.results.len(), TUI_MESSAGE_SEARCH_LIMIT);
+    assert_eq!(
+        view.match_count_label(),
+        format!("{TUI_MESSAGE_SEARCH_LIMIT}+"),
+        "a filled page is labelled as a lower bound, not an exact count"
+    );
+    assert!(
+        app.status.contains(&format!("{TUI_MESSAGE_SEARCH_LIMIT}+")),
+        "the status says the count is partial; got: {:?}",
+        app.status
+    );
+    assert!(
+        app.status.contains("refine"),
+        "the status points at the action that fixes it; got: {:?}",
+        app.status
+    );
+}
+
+#[test]
+fn a_short_message_search_page_reports_an_exact_count() {
+    let (_dir, client) = test_json_client(&format!(
+        r#"{{"ok":true,"result":{{"messages":[{}]}}}}"#,
+        timeline_hit_json("m1", "bob", "deploy one", 1_700_000_000)
+    ));
+    let mut app = app_with_open_chat(client, &[("m1", "deploy one")]);
+    app.open_message_search(Some("deploy".to_owned()))
+        .expect("open search");
+    app.settle_effects(1);
+
+    assert_eq!(
+        app.message_search
+            .as_ref()
+            .expect("view")
+            .match_count_label(),
+        "1",
+        "an unfilled page is an exact count"
+    );
+    assert!(
+        !app.status.contains('+'),
+        "no partial marker on an exact count; got: {:?}",
+        app.status
+    );
+}
+
+#[test]
 fn a_stale_message_search_result_for_a_superseded_query_is_dropped() {
     let (_dir, client) = test_json_client(&format!(
         r#"{{"ok":true,"result":{{"messages":[{}]}}}}"#,

--- a/crates/cli/src/tui/tests.rs
+++ b/crates/cli/src/tui/tests.rs
@@ -10315,17 +10315,135 @@ fn a_short_message_search_page_reports_an_exact_count() {
     );
 }
 
+/// A message search for `deploy` with its one-hit page still outstanding. A test
+/// that wants the settled screen adds a `settle_effects(1)`; one that types
+/// during the flight does not.
+fn message_search_in_flight() -> (tempfile::TempDir, TuiApp) {
+    let (dir, client) = test_json_client(&format!(
+        r#"{{"ok":true,"result":{{"messages":[{}]}}}}"#,
+        timeline_hit_json("m1", "bob", "the deploy is green", 1_700_000_000)
+    ));
+    let mut app = app_with_open_chat(client, &[("m1", "the deploy is green")]);
+    app.open_message_search(Some("deploy".to_owned()))
+        .expect("open search");
+    (dir, app)
+}
+
+#[test]
+fn editing_a_settled_message_search_query_drops_the_hits_it_answered() {
+    let (_dir, mut app) = message_search_in_flight();
+    app.settle_effects(1);
+    app.handle_key(char_key('i')).expect("back to the query");
+
+    for character in "ment".chars() {
+        app.handle_key(char_key(character)).expect("append");
+    }
+
+    let view = app.message_search.as_ref().expect("view");
+    assert_eq!(view.query.value(), "deployment");
+    assert!(
+        view.results.is_empty(),
+        "hits for `deploy` do not sit under the query `deployment`"
+    );
+    assert_eq!(view.selected, 0, "nor does a selection into them");
+    assert!(!view.truncated, "nor the old page's truncation");
+    assert!(
+        app.status.is_empty(),
+        "nor a count describing the old query; got: {:?}",
+        app.status
+    );
+
+    app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE))
+        .expect("down");
+    assert_eq!(
+        app.message_search.as_ref().expect("view").focus,
+        MessageSearchFocus::Query,
+        "there is no list to step into"
+    );
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        .expect("enter");
+    assert_eq!(
+        app.searching_messages.as_deref(),
+        Some("deployment"),
+        "and Enter runs the query the screen shows"
+    );
+}
+
+#[test]
+fn moving_the_message_search_cursor_keeps_a_settled_hit_list() {
+    let (_dir, mut app) = message_search_in_flight();
+    app.settle_effects(1);
+    let count = app.status.clone();
+    app.handle_key(char_key('i')).expect("back to the query");
+
+    // `Home` then `Backspace`, and `End` then `Delete`, are the keys that mutate on
+    // any other cursor position and change nothing here. Invalidating on the key
+    // rather than on the text would throw the hits away on both.
+    for code in [
+        KeyCode::Left,
+        KeyCode::Right,
+        KeyCode::Home,
+        KeyCode::Backspace,
+        KeyCode::End,
+        KeyCode::Delete,
+    ] {
+        app.handle_key(KeyEvent::new(code, KeyModifiers::NONE))
+            .expect("cursor key");
+    }
+
+    let view = app.message_search.as_ref().expect("view");
+    assert_eq!(view.query.value(), "deploy", "the text is untouched");
+    assert_eq!(view.results.len(), 1, "so the hits stay");
+    assert_eq!(app.status, count, "and so does the count");
+}
+
+#[test]
+fn editing_the_query_drops_an_in_flight_message_search_page() {
+    let (_dir, mut app) = message_search_in_flight();
+    assert_eq!(app.searching_messages.as_deref(), Some("deploy"));
+
+    for character in "ment".chars() {
+        app.handle_key(char_key(character)).expect("append");
+    }
+    app.settle_effects(1);
+
+    let view = app.message_search.as_ref().expect("view");
+    assert!(
+        view.results.is_empty(),
+        "the page for `deploy` does not land under `deployment`"
+    );
+    assert_eq!(
+        view.focus,
+        MessageSearchFocus::Query,
+        "and a landing page cannot yank focus out of the query mid-word"
+    );
+}
+
+#[test]
+fn pasting_into_the_message_search_query_invalidates_like_typing() {
+    let (_dir, mut app) = message_search_in_flight();
+    app.settle_effects(1);
+    app.handle_key(char_key('i')).expect("back to the query");
+
+    app.handle_paste("ment".to_owned());
+
+    let view = app.message_search.as_ref().expect("view");
+    assert_eq!(view.query.value(), "deployment");
+    assert!(view.results.is_empty(), "a paste is an edit like any other");
+}
+
 #[test]
 fn a_stale_message_search_result_for_a_superseded_query_is_dropped() {
-    let (_dir, client) = test_json_client(&format!(
-        r#"{{"ok":true,"result":{{"messages":[{}]}}}}"#,
-        timeline_hit_json("m1", "bob", "stale hit", 1_700_000_000)
-    ));
-    let mut app = app_with_open_chat(client, &[("m1", "stale hit")]);
-    app.open_message_search(Some("first".to_owned()))
-        .expect("open search");
-    // A second query supersedes the first before its page lands.
-    app.searching_messages = Some("second".to_owned());
+    let (_dir, mut app) = message_search_in_flight();
+    // Supersede the first query the way a user does — by editing and re-running it
+    // — rather than by assigning the anchor. The anchor comparison in the fold is
+    // only worth anything if an edit actually moves the anchor.
+    for character in "ment".chars() {
+        app.handle_key(char_key(character)).expect("append");
+    }
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        .expect("run the new query");
+    // Effects run in order, so this is the first search's page landing second.
     app.settle_effects(1);
 
     assert!(
@@ -10338,7 +10456,7 @@ fn a_stale_message_search_result_for_a_superseded_query_is_dropped() {
     );
     assert_eq!(
         app.searching_messages.as_deref(),
-        Some("second"),
+        Some("deployment"),
         "and the outstanding query is left alone"
     );
 }

--- a/crates/cli/src/tui/tests.rs
+++ b/crates/cli/src/tui/tests.rs
@@ -11389,6 +11389,113 @@ fn a_re_search_after_following_badges_the_row_from_the_follows_snapshot() {
     );
 }
 
+/// A user search for `bob` with its one-result page still outstanding, the
+/// user-search mirror of [`message_search_in_flight`].
+fn user_search_in_flight() -> (tempfile::TempDir, TuiApp) {
+    let (dir, client) = test_json_client(
+        r#"{"ok":true,"result":{"users":[{"account_id_hex":"bb","npub":"npubbb","radius":1,"matched_field":"name","match_quality":"prefix","profile":{"display_name":"Bob"}}]}}"#,
+    );
+    let mut app = test_tui_app(client, &"aa".repeat(32));
+    app.open_user_search(Some("bob".to_owned()));
+    (dir, app)
+}
+
+#[test]
+fn editing_a_settled_user_search_query_drops_the_results_it_answered() {
+    // It matters more here than on message search: the results-focus keys publish
+    // follows (`f`/`x`) and open chat popups (`c`/`a`), so a row left under a query
+    // it does not answer is not just misread, it is acted on.
+    let (_dir, mut app) = user_search_in_flight();
+    app.settle_effects(1);
+    assert_eq!(app.user_search.as_ref().expect("view").results.len(), 1);
+    app.handle_key(char_key('i')).expect("back to the query");
+
+    for character in "by".chars() {
+        app.handle_key(char_key(character)).expect("append");
+    }
+
+    let view = app.user_search.as_ref().expect("view");
+    assert_eq!(view.query.value(), "bobby");
+    assert!(
+        view.results.is_empty(),
+        "results for `bob` do not sit under the query `bobby`"
+    );
+    assert_eq!(view.selected, 0, "nor does a selection into them");
+    assert!(
+        app.status.is_empty(),
+        "nor a count describing the old query; got: {:?}",
+        app.status
+    );
+
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        .expect("enter");
+    assert_eq!(
+        app.searching_users.as_deref(),
+        Some("bobby"),
+        "and Enter runs the query the screen shows"
+    );
+}
+
+#[test]
+fn moving_the_user_search_cursor_keeps_a_settled_result_list() {
+    let (_dir, mut app) = user_search_in_flight();
+    app.settle_effects(1);
+    let count = app.status.clone();
+    app.handle_key(char_key('i')).expect("back to the query");
+
+    for code in [
+        KeyCode::Left,
+        KeyCode::Right,
+        KeyCode::Home,
+        KeyCode::Backspace,
+        KeyCode::End,
+        KeyCode::Delete,
+    ] {
+        app.handle_key(KeyEvent::new(code, KeyModifiers::NONE))
+            .expect("cursor key");
+    }
+
+    let view = app.user_search.as_ref().expect("view");
+    assert_eq!(view.query.value(), "bob", "the text is untouched");
+    assert_eq!(view.results.len(), 1, "so the results stay");
+    assert_eq!(app.status, count, "and so does the count");
+}
+
+#[test]
+fn editing_the_query_drops_an_in_flight_user_search_page() {
+    let (_dir, mut app) = user_search_in_flight();
+    assert_eq!(app.searching_users.as_deref(), Some("bob"));
+
+    for character in "by".chars() {
+        app.handle_key(char_key(character)).expect("append");
+    }
+    app.settle_effects(1);
+
+    let view = app.user_search.as_ref().expect("view");
+    assert!(
+        view.results.is_empty(),
+        "the page for `bob` does not land under `bobby`"
+    );
+    assert_eq!(
+        view.focus,
+        UserSearchFocus::Query,
+        "and a landing page cannot yank focus out of the query mid-word"
+    );
+}
+
+#[test]
+fn pasting_into_the_user_search_query_invalidates_like_typing() {
+    let (_dir, mut app) = user_search_in_flight();
+    app.settle_effects(1);
+    app.handle_key(char_key('i')).expect("back to the query");
+
+    app.handle_paste("by".to_owned());
+
+    let view = app.user_search.as_ref().expect("view");
+    assert_eq!(view.query.value(), "bobby");
+    assert!(view.results.is_empty(), "a paste is an edit like any other");
+}
+
 #[test]
 fn a_stale_user_search_result_for_a_superseded_query_is_dropped() {
     let account_id = "aa".repeat(32);

--- a/crates/cli/src/tui/tests.rs
+++ b/crates/cli/src/tui/tests.rs
@@ -7791,6 +7791,49 @@ fn group_detail_pane_scrolls_the_selected_member_into_view() {
 }
 
 #[test]
+fn group_detail_reveals_the_relay_section_at_the_end_of_a_long_member_list() {
+    let mut app = test_tui_app(test_unused_client(), &"aa".repeat(32));
+    app.screen = Screen::GroupDetail;
+    // The relay hints sit *after* the member list, so with more members than the
+    // pane can hold they scroll off the bottom. Nothing scrolls the pane
+    // independently of the selection, so reaching the end of the list has to be
+    // what brings the tail into view.
+    let members: Vec<GroupMemberRow> = (0..40)
+        .map(|index| GroupMemberRow {
+            member_id: format!("id{index:02}"),
+            npub: format!("npubmember{index:02}"),
+            is_admin: false,
+            is_self: false,
+        })
+        .collect();
+    let selected = members.len() - 1;
+    app.group_detail = Some(GroupDetailView {
+        group_id: "g1".to_owned(),
+        name: "Ops Room".to_owned(),
+        description: "the ops".to_owned(),
+        members,
+        relays: vec![
+            "wss://first.example".to_owned(),
+            "wss://middle.example".to_owned(),
+            "wss://last.example".to_owned(),
+        ],
+        account_is_admin: true,
+        admin_count: 1,
+        selected,
+    });
+
+    let rendered = rendered_buffer(&mut app);
+    assert!(
+        rendered.contains("first.example") && rendered.contains("last.example"),
+        "the whole relay section is reachable once the selection reaches the last member"
+    );
+    assert!(
+        rendered.contains("npubmember39"),
+        "and the selected member is still on screen with it"
+    );
+}
+
+#[test]
 fn daemon_start_args_forward_first_run_relays() {
     assert_eq!(
         daemon_start_args(&[], &[]),

--- a/crates/cli/src/tui/tests.rs
+++ b/crates/cli/src/tui/tests.rs
@@ -10183,12 +10183,10 @@ fn message_search_navigates_hits_and_returns_to_the_query() {
     );
 }
 
-#[test]
-fn a_message_search_that_fills_its_limit_reports_the_count_as_partial() {
-    // A full page means hits were almost certainly dropped, and the screen is a
-    // scan-and-pick list with no paging. Reporting the cap as an exact count would
-    // read as "these are all of them" and hide the need to refine the query.
-    let hits = (0..TUI_MESSAGE_SEARCH_LIMIT)
+/// `TUI_MESSAGE_SEARCH_LIMIT` hits, so a fixture can pair a page of exactly the
+/// limit with either answer to "were hits dropped".
+fn limit_sized_hit_page() -> String {
+    (0..TUI_MESSAGE_SEARCH_LIMIT)
         .map(|index| {
             timeline_hit_json(
                 &format!("m{index}"),
@@ -10198,21 +10196,35 @@ fn a_message_search_that_fills_its_limit_reports_the_count_as_partial() {
             )
         })
         .collect::<Vec<_>>()
-        .join(",");
-    let (_dir, client) = test_json_client(&format!(
-        r#"{{"ok":true,"result":{{"messages":[{hits}]}}}}"#
-    ));
+        .join(",")
+}
+
+/// Open the message-search screen over a canned page and settle its one effect.
+fn settled_message_search(response: &str) -> (tempfile::TempDir, TuiApp) {
+    let (dir, client) = test_json_client(response);
     let mut app = app_with_open_chat(client, &[("m0", "deploy")]);
     app.open_message_search(Some("deploy".to_owned()))
         .expect("open search");
     app.settle_effects(1);
+    (dir, app)
+}
+
+#[test]
+fn a_message_search_with_hits_beyond_the_page_reports_a_partial_count() {
+    // Hits remain past the page, and the screen is a scan-and-pick list with no
+    // paging. Reporting the page size as an exact count would read as "these are
+    // all of them" and hide the need to refine the query.
+    let hits = limit_sized_hit_page();
+    let (_dir, app) = settled_message_search(&format!(
+        r#"{{"ok":true,"result":{{"messages":[{hits}],"has_more_before":true}}}}"#
+    ));
 
     let view = app.message_search.as_ref().expect("view");
     assert_eq!(view.results.len(), TUI_MESSAGE_SEARCH_LIMIT);
     assert_eq!(
         view.match_count_label(),
         format!("{TUI_MESSAGE_SEARCH_LIMIT}+"),
-        "a filled page is labelled as a lower bound, not an exact count"
+        "a page with more behind it is labelled as a lower bound, not an exact count"
     );
     assert!(
         app.status.contains(&format!("{TUI_MESSAGE_SEARCH_LIMIT}+")),
@@ -10223,6 +10235,57 @@ fn a_message_search_that_fills_its_limit_reports_the_count_as_partial() {
         app.status.contains("refine"),
         "the status points at the action that fixes it; got: {:?}",
         app.status
+    );
+}
+
+#[test]
+fn a_message_search_page_of_exactly_the_limit_with_nothing_behind_it_is_exact() {
+    // The count alone cannot tell this page from the one above it, which is why
+    // the answer comes from the response rather than from `hits.len()`.
+    let hits = limit_sized_hit_page();
+    let (_dir, app) = settled_message_search(&format!(
+        r#"{{"ok":true,"result":{{"messages":[{hits}],"has_more_before":false}}}}"#
+    ));
+
+    let view = app.message_search.as_ref().expect("view");
+    assert_eq!(
+        view.match_count_label(),
+        TUI_MESSAGE_SEARCH_LIMIT.to_string(),
+        "a page that happens to be limit-sized is still an exact count"
+    );
+    assert!(
+        !app.status.contains('+') && !app.status.contains("refine"),
+        "so nothing asks the reader to refine a complete answer; got: {:?}",
+        app.status
+    );
+}
+
+#[test]
+fn a_short_message_search_page_with_hits_behind_it_reports_a_partial_count() {
+    // The mirror image: fewer hits than the limit, but the backend says more
+    // remain, so the count is a lower bound. Only the response can say this.
+    let hits = (0..3)
+        .map(|index| {
+            timeline_hit_json(
+                &format!("m{index}"),
+                "bob",
+                "deploy",
+                1_700_000_000 + index as u64,
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    let (_dir, app) = settled_message_search(&format!(
+        r#"{{"ok":true,"result":{{"messages":[{hits}],"has_more_before":true}}}}"#
+    ));
+
+    assert_eq!(
+        app.message_search
+            .as_ref()
+            .expect("view")
+            .match_count_label(),
+        "3+",
+        "truncation follows the response, not the hit count"
     );
 }
 

--- a/crates/cli/src/tui/view.rs
+++ b/crates/cli/src/tui/view.rs
@@ -1639,7 +1639,10 @@ pub(crate) fn message_search_lines(
         body.push(Line::from(Span::styled(text, Style::default().fg(color))));
         return body;
     }
-    body.push(Line::from(format!("Matches ({})", view.results.len())));
+    body.push(Line::from(format!(
+        "Matches ({})",
+        view.match_count_label()
+    )));
     let results_focused = view.focus == MessageSearchFocus::Results;
     for (index, hit) in view.results.iter().enumerate() {
         let is_selected = results_focused && index == view.selected;

--- a/crates/cli/src/tui/view.rs
+++ b/crates/cli/src/tui/view.rs
@@ -711,6 +711,7 @@ impl TuiApp {
             Screen::Main => self.render_main(frame),
             Screen::GroupDetail => self.render_group_detail(frame),
             Screen::UserSearch => self.render_user_search(frame),
+            Screen::MessageSearch => self.render_message_search(frame),
             Screen::Profile => self.render_profile(frame),
             Screen::RelayHealth => self.render_relay_health(frame),
         }
@@ -981,6 +982,11 @@ impl TuiApp {
             (Screen::UserSearch, Some(view)) => {
                 keymap_hint_spans(&user_search_hint(view.focus, &view.purpose))
             }
+            (Screen::MessageSearch, _) => keymap_hint_spans(message_search_hint(
+                self.message_search
+                    .as_ref()
+                    .map_or(MessageSearchFocus::Query, |view| view.focus),
+            )),
             (Screen::Main, _) => {
                 match armed_interaction_hint(self.input.value(), self.selected_timeline_row()) {
                     Some(armed) => armed_hint_spans(&armed),
@@ -1310,6 +1316,30 @@ impl TuiApp {
         self.render_status_bar(frame, root[2]);
     }
 
+    fn render_message_search(&self, frame: &mut Frame) {
+        let root = screen_body_layout(frame.area());
+        match self.message_search.as_ref() {
+            Some(view) => render_selection_pane(
+                frame,
+                root[0],
+                panel_block("Message Search", true),
+                message_search_lines(
+                    view,
+                    self.selected_account_row(),
+                    self.searching_messages.is_some(),
+                ),
+            ),
+            None => render_loading_screen(
+                frame,
+                root[0],
+                "Message Search",
+                "loading message search...",
+            ),
+        }
+        self.render_hints(frame, root[1]);
+        self.render_status_bar(frame, root[2]);
+    }
+
     fn render_user_search(&self, frame: &mut Frame) {
         let root = screen_body_layout(frame.area());
         match self.user_search.as_ref() {
@@ -1563,6 +1593,85 @@ pub(crate) fn user_search_lines(view: &UserSearchView, searching: bool) -> PaneB
                 terminal_safe_text(&result.matched_field),
                 terminal_safe_text(&result.match_quality),
             ),
+            Style::default().fg(Color::DarkGray),
+        )));
+    }
+    body
+}
+
+/// The message-search screen body: the chat being searched, the query field (with
+/// the cursor cell in query focus), then two lines per hit — `[HH:MM] author` and
+/// the message text below it. Timestamp and author styling match the messages
+/// pane (dark-gray time, cyan author, green when it is yours) so a hit reads as
+/// the same message it will jump to. Every author name and message body passes
+/// through `terminal_safe_text`.
+pub(crate) fn message_search_lines(
+    view: &MessageSearchView,
+    selected_account: Option<&AccountRow>,
+    searching: bool,
+) -> PaneBody {
+    let query_focused = view.focus == MessageSearchFocus::Query;
+    let mut body = PaneBody {
+        lines: vec![Line::from(vec![
+            Span::styled("Search in ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                shorten(&terminal_safe_text(&view.group_name), 32),
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+        ])],
+        anchor: None,
+    };
+    body.extend(input_field_lines(
+        &view.query.display(),
+        view.query.cursor(),
+        query_focused,
+        Some(Span::styled("find ", Style::default().fg(FOCUS_ACCENT))),
+    ));
+    body.push(Line::from(""));
+    if view.results.is_empty() {
+        // An in-flight search (yellow) reads differently from a settled empty
+        // result (dark gray), keyed off the async search flag.
+        let (text, color) = if searching {
+            ("searching...", Color::Yellow)
+        } else {
+            ("no matches — type a query and press Enter", Color::DarkGray)
+        };
+        body.push(Line::from(Span::styled(text, Style::default().fg(color))));
+        return body;
+    }
+    body.push(Line::from(format!("Matches ({})", view.results.len())));
+    let results_focused = view.focus == MessageSearchFocus::Results;
+    for (index, hit) in view.results.iter().enumerate() {
+        let is_selected = results_focused && index == view.selected;
+        let marker = if is_selected { ">" } else { " " };
+        let author_color = if timeline_row_is_self(hit, selected_account) {
+            Color::Green
+        } else {
+            Color::Cyan
+        };
+        body.push(Line::from(vec![
+            Span::raw(format!("{marker} ")),
+            Span::styled(
+                format!("[{}] ", local_hhmm(hit.timeline_at)),
+                Style::default().fg(Color::DarkGray),
+            ),
+            Span::styled(
+                shorten(&terminal_safe_text(&timeline_author_label(hit)), 24),
+                row_label_style(is_selected, author_color),
+            ),
+        ]));
+        // Anchor on the text line rather than the header above it, so scrolling to
+        // the last hit brings the whole two-line row into view.
+        if is_selected {
+            body.anchor_next();
+        }
+        let text = if hit.deleted {
+            "message deleted".to_owned()
+        } else {
+            terminal_safe_text(&hit.display_text)
+        };
+        body.push(Line::from(Span::styled(
+            format!("    {}", shorten(&text, 76)),
             Style::default().fg(Color::DarkGray),
         )));
     }

--- a/crates/cli/src/tui/view.rs
+++ b/crates/cli/src/tui/view.rs
@@ -383,6 +383,18 @@ impl PaneBody {
         self.anchor = Some(self.lines.len());
     }
 
+    /// Move an existing anchor to the last line of the body, for a body that ends
+    /// in content no selection can reach (group detail's relay hints). Called once
+    /// the body is complete and the anchored row was the last selectable one, so
+    /// that tail scrolls into view with it instead of sitting below the viewport
+    /// forever. Never *creates* an anchor: with nothing selected there is nothing
+    /// the viewport has to follow.
+    fn anchor_body_end(&mut self) {
+        if self.anchor.is_some() {
+            self.anchor = Some(self.lines.len().saturating_sub(1));
+        }
+    }
+
     fn push(&mut self, line: Line<'static>) {
         self.lines.push(line);
     }
@@ -1446,8 +1458,10 @@ pub(crate) fn group_detail_lines(view: Option<&GroupDetailView>) -> PaneBody {
     }
     body.push(Line::from(""));
     body.push(Line::from(format!("Members ({})", view.members.len())));
+    let mut selection_ends_the_list = false;
     for (index, member) in view.members.iter().enumerate() {
         let is_selected = index == view.selected;
+        selection_ends_the_list |= is_selected && index + 1 == view.members.len();
         let marker = if is_selected { ">" } else { " " };
         let mut spans = vec![
             Span::raw(format!("{marker} ")),
@@ -1471,6 +1485,12 @@ pub(crate) fn group_detail_lines(view: Option<&GroupDetailView>) -> PaneBody {
     body.push(Line::from(format!("Relays ({})", view.relays.len())));
     for relay in &view.relays {
         body.push(Line::from(format!("  {}", terminal_safe_text(relay))));
+    }
+    // The relay hints are the one stretch of this screen no selection can land
+    // on, so they are only reachable by riding along with the end of the member
+    // list. Moving to the last member scrolls to the end of the body.
+    if selection_ends_the_list {
+        body.anchor_body_end();
     }
     body
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TUI message search with the `/search [query]` command.
  * Search results appear newest first, with highlighted matches and keyboard navigation.
  * Results are limited to 100, with guidance to refine broader searches.
  * Selecting a result jumps to the message when it is in loaded history.
  * Added clear messaging when older history must be loaded first.
* **Bug Fixes**
  * Group details now scroll to reveal relay hints when the final member is selected.
  * Updated search results correctly when queries are edited, preventing stale results from appearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->