### PR TITLE
fix(marmotkit): harden Android snapshot artifacts

### DIFF
--- a/.github/workflows/bindings.yaml
+++ b/.github/workflows/bindings.yaml
@@ -381,6 +381,13 @@ jobs:
             "jniLibs/x86/libmarmot_uniffi.so"
             "jniLibs/x86_64/libmarmot_uniffi.so"
           )
+          manifest_contents=(
+            "kotlin/dev/ipf/marmotkit/marmot_uniffi.kt"
+            "jniLibs/arm64-v8a/libmarmot_uniffi.so"
+            "jniLibs/armeabi-v7a/libmarmot_uniffi.so"
+            "jniLibs/x86/libmarmot_uniffi.so"
+            "jniLibs/x86_64/libmarmot_uniffi.so"
+          )
 
           rm -rf "$stage_parent" "$asset" "$asset.sha256"
           mkdir -p "$bundle_dir"
@@ -409,8 +416,6 @@ jobs:
             "android_api": "${ANDROID_API:-26}",
             "contents": [
               "kotlin/dev/ipf/marmotkit/marmot_uniffi.kt",
-              "kotlin/dev/ipf/marmotkit/MarmotAndroid.kt",
-              "kotlin/io/crates/keyring/Keyring.kt",
               "jniLibs/arm64-v8a/libmarmot_uniffi.so",
               "jniLibs/armeabi-v7a/libmarmot_uniffi.so",
               "jniLibs/x86/libmarmot_uniffi.so",
@@ -435,6 +440,17 @@ jobs:
           fi
           mapfile -t declared_contents < <(jq -r '.contents[]' <<< "$manifest")
 
+          if (( ${#declared_contents[@]} != ${#manifest_contents[@]} )); then
+            echo "error: Android manifest contents do not match the consumer contract" >&2
+            exit 1
+          fi
+          for index in "${!manifest_contents[@]}"; do
+            if [[ "${declared_contents[$index]}" != "${manifest_contents[$index]}" ]]; then
+              echo "error: Android manifest contents do not match the consumer contract" >&2
+              exit 1
+            fi
+          done
+
           for entry in "${declared_contents[@]}"; do
             if [[ "$entry" == /* || "$entry" == ".." || "$entry" == ../* || "$entry" == */../* || "$entry" == */.. ]]; then
               echo "error: Android manifest contains unsafe path: $entry" >&2
@@ -442,13 +458,6 @@ jobs:
             fi
             if ! grep -Fqx "$bundle_root/$entry" <<< "$archive_entries"; then
               echo "error: Android manifest declares missing archive entry: $entry" >&2
-              exit 1
-            fi
-          done
-
-          for entry in "${required_contents[@]}"; do
-            if ! printf '%s\n' "${declared_contents[@]}" | grep -Fqx "$entry"; then
-              echo "error: Android manifest omits required archive entry: $entry" >&2
               exit 1
             fi
           done

--- a/crates/marmot-uniffi/DISTRIBUTION.md
+++ b/crates/marmot-uniffi/DISTRIBUTION.md
@@ -143,7 +143,9 @@ The archive has a `marmotkit-android-<identifier>` root containing:
 
 Verify the archive against its sibling `.sha256` before extracting it. Update the generated Kotlin helpers and all
 JNI ABI libraries together; mixing identifiers can cross an incompatible UniFFI ABI. The manifest records both the
-exact packaged source SHA and the workflow builder SHA.
+exact packaged source SHA and the workflow builder SHA. Its ordered `contents` contract lists the generated UniFFI
+Kotlin source and JNI libraries; the two required hand-written initialization helpers remain validated archive
+payloads but do not change that existing consumer-facing API contract.
 
 ## Publishing
 

--- a/crates/marmot-uniffi/README.md
+++ b/crates/marmot-uniffi/README.md
@@ -73,6 +73,9 @@ Build all Android ABIs:
 ./crates/marmot-uniffi/kotlin-bindings.sh
 ```
 
+The script keeps the host library's UniFFI metadata intact while stripping
+debug and static symbol sections from each packaged Android JNI library.
+
 To build a subset:
 
 ```sh

--- a/crates/marmot-uniffi/kotlin-bindings.sh
+++ b/crates/marmot-uniffi/kotlin-bindings.sh
@@ -184,6 +184,23 @@ configure_android_toolchain() {
   export "RANLIB_${cc_env}=$toolchain_bin/llvm-ranlib"
 }
 
+validate_stripped_android_library() {
+  local library="$1"
+  local readelf="$NDK_DIR/toolchains/llvm/prebuilt/$HOST_TAG/bin/llvm-readelf"
+  local sections
+
+  if [[ ! -x "$readelf" ]]; then
+    echo "error: Android llvm-readelf not found or not executable: $readelf" >&2
+    return 1
+  fi
+
+  sections="$("$readelf" --sections "$library")"
+  if grep -Eq '[.]debug_|[.]symtab' <<< "$sections"; then
+    echo "error: Android JNI library contains debug or static symbol sections: $library" >&2
+    return 1
+  fi
+}
+
 cd "$WORKSPACE_DIR"
 
 NDK_DIR="$(find_android_ndk)"
@@ -196,9 +213,8 @@ mkdir -p "$KOTLIN_OUT_DIR" "$JNI_OUT_DIR"
 
 echo "==> Building host dylib (used for binding generation)"
 # The host dylib must keep its symbol table: uniffi-bindgen's library mode
-# reads the uniffi metadata through it, and with RUSTFLAGS="-C strip=symbols"
-# (release.sh sets it for the Android .so's) bindgen exits 0 while emitting
-# NOTHING. Strip only the Android target builds below, never this one.
+# reads the uniffi metadata through it. Strip only the Android target builds
+# below, never this host build.
 RUSTFLAGS="" cargo build --release -p "$CRATE_NAME" ${FEATURE_ARGS[@]+"${FEATURE_ARGS[@]}"}
 
 echo "==> Generating Kotlin bindings"
@@ -225,9 +241,11 @@ for abi in $ANDROID_ABIS; do
   target="$(abi_to_target "$abi")"
   echo "==> Building Android target $target ($abi)"
   configure_android_toolchain "$NDK_DIR" "$HOST_TAG" "$target"
-  cargo build --release -p "$CRATE_NAME" --target "$target" ${FEATURE_ARGS[@]+"${FEATURE_ARGS[@]}"}
+  CARGO_PROFILE_RELEASE_STRIP=symbols \
+    cargo build --release -p "$CRATE_NAME" --target "$target" ${FEATURE_ARGS[@]+"${FEATURE_ARGS[@]}"}
   mkdir -p "$JNI_OUT_DIR/$abi"
   cp "$TARGET_DIR/$target/release/lib${LIB_BASENAME}.so" "$JNI_OUT_DIR/$abi/"
+  validate_stripped_android_library "$JNI_OUT_DIR/$abi/lib${LIB_BASENAME}.so"
 done
 
 echo ""


### PR DESCRIPTION
## Summary

- strip Android target JNI libraries while keeping the host dylib metadata intact for UniFFI generation
- fail the binding build if an Android library still contains debug or static symbol sections
- restore the existing Android manifest contents contract while continuing to package and validate both hand-written initialization helpers
- document the strip boundary and manifest contract

## Context

The first Android SHA snapshot produced after #1473 exposed two release blockers:

1. the arm64 JNI library was about 57 MB and reported `not stripped`
2. White Noise Android rejected the archive because the manifest declared helper files outside its existing ordered API contract

The published snapshot is immutable, so a corrected snapshot must be created from a new MDK commit after this PR merges.

## Verification

- `actionlint .github/workflows/bindings.yaml`
- `bash -n crates/marmot-uniffi/kotlin-bindings.sh`
- real arm64 OTLP binding build; output reports `stripped`, preserves required dynamic JNI/UniFFI exports, and falls from about 57 MB to 35 MB
- the same binding build with `CARGO_NET_OFFLINE=true`
- offline White Noise Android artifact staging from a locally packaged all-ABI bundle
- offline `:app:compileDevZapstoreDebugKotlin` in a disposable Android master worktree after supplying the new `AppGroupMemberIdsFfi.adminIdsHex` consumer field
- `just fast-ci`
- `git diff --check`
