### PR TITLE
chore(release): prepare 0.9.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agent-connector"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "agent-control",
  "agent-stream-compose",
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "agent-control"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "serde",
  "serde_json",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "agent-stream-compose"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "cgka-traits",
  "hex",
@@ -864,7 +864,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cgka-conformance-simulator"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-engine"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-session"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-traits"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "async-trait",
  "criterion",
@@ -1192,7 +1192,7 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "convergence-campaign-runner"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "async-trait",
  "cgka-conformance-simulator",
@@ -1987,7 +1987,7 @@ dependencies = [
 
 [[package]]
 name = "fs-private"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "libc",
  "tempfile",
@@ -2725,7 +2725,7 @@ dependencies = [
 
 [[package]]
 name = "incident-replay"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "cgka-conformance-simulator",
  "fs-private",
@@ -3322,7 +3322,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-account"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-app"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3399,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-forensics"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "fs-private",
  "serde",
@@ -3409,7 +3409,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-markdown"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "serde",
  "serde_json",
@@ -3417,7 +3417,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-terminal-harness"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "agent-control",
  "async-trait",
@@ -3432,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-uniffi"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "cgka-engine",
  "cgka-traits",
@@ -5652,7 +5652,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-sqlite"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "cgka-traits",
  "fs-private",
@@ -6268,7 +6268,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-adapter"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -6288,7 +6288,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-peeler"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -6305,7 +6305,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-broker"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "cgka-traits",
  "clap",
@@ -6324,7 +6324,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-stream"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "cgka-traits",
  "chacha20poly1305",
@@ -7391,7 +7391,7 @@ dependencies = [
 
 [[package]]
 name = "wn-cli"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "agent-stream-compose",
  "cgka-session",
@@ -7425,7 +7425,7 @@ dependencies = [
 
 [[package]]
 name = "wn-opencode"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "async-trait",
  "clap",
@@ -7440,7 +7440,7 @@ dependencies = [
 
 [[package]]
 name = "wn-pi"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "async-trait",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "0.9.12"
+version = "0.9.13"
 license = "MIT"
 publish = false
 

--- a/crates/cgka-conformance-simulator/vectors/admin-handover.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/admin-handover.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "admin-handover/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.12",
+  "conformance_version": "0.9.13",
   "seed": null,
   "scenario": {
     "name": "admin-handover/v1",

--- a/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "admin-policy-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.12",
+  "conformance_version": "0.9.13",
   "seed": null,
   "scenario": {
     "name": "admin-policy-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "concurrent-invite-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.12",
+  "conformance_version": "0.9.13",
   "seed": null,
   "scenario": {
     "name": "concurrent-invite-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-committer-selected/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.12",
+  "conformance_version": "0.9.13",
   "seed": null,
   "scenario": {
     "name": "convergence-committer-selected/v1",

--- a/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-witness-selected/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.12",
+  "conformance_version": "0.9.13",
   "seed": null,
   "scenario": {
     "name": "convergence-witness-selected/v1",

--- a/crates/cgka-conformance-simulator/vectors/conversation.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/conversation.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "conversation/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.12",
+  "conformance_version": "0.9.13",
   "seed": null,
   "scenario": {
     "name": "conversation/v1",

--- a/crates/cgka-conformance-simulator/vectors/cross-route-own-commit-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/cross-route-own-commit-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "cross-route-own-commit-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.12",
+  "conformance_version": "0.9.13",
   "seed": null,
   "scenario": {
     "name": "cross-route-own-commit-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/current-profile-required-set.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/current-profile-required-set.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "current-profile-required-set/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.12",
+  "conformance_version": "0.9.13",
   "seed": null,
   "application_profile": {
     "name": "current",

--- a/crates/cgka-conformance-simulator/vectors/deferred-tick-catchup.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/deferred-tick-catchup.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "deferred-tick-catchup/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.12",
+  "conformance_version": "0.9.13",
   "seed": null,
   "scenario": {
     "name": "deferred-tick-catchup/v1",

--- a/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "delayed-past-epoch-app-message/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.12",
+  "conformance_version": "0.9.13",
   "seed": null,
   "scenario": {
     "name": "delayed-past-epoch-app-message/v1",

--- a/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "drop-queued/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.12",
+  "conformance_version": "0.9.13",
   "seed": null,
   "scenario": {
     "name": "drop-queued/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.12",
+  "conformance_version": "0.9.13",
   "seed": null,
   "scenario": {
     "name": "group-data-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.12",
+  "conformance_version": "0.9.13",
   "seed": null,
   "scenario": {
     "name": "group-data-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-profile-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-profile-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-profile-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.12",
+  "conformance_version": "0.9.13",
   "seed": null,
   "scenario": {
     "name": "group-profile-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.12",
+  "conformance_version": "0.9.13",
   "seed": null,
   "scenario": {
     "name": "convergence-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "fork-recovery-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.12",
+  "conformance_version": "0.9.13",
   "seed": null,
   "scenario": {
     "name": "fork-recovery-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "membership-fork-recovery-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.12",
+  "conformance_version": "0.9.13",
   "seed": null,
   "scenario": {
     "name": "membership-fork-recovery-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incremental-growth.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incremental-growth.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "incremental-growth/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.12",
+  "conformance_version": "0.9.13",
   "seed": null,
   "scenario": {
     "name": "incremental-growth/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-member/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.12",
+  "conformance_version": "0.9.13",
   "seed": null,
   "scenario": {
     "name": "invite-member/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.12",
+  "conformance_version": "0.9.13",
   "seed": null,
   "scenario": {
     "name": "invite-publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/late-welcome-backfill.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/late-welcome-backfill.v1.json
@@ -1,7 +1,7 @@
 {
  "scenario_name": "late-welcome-backfill/v1",
  "vector_version": "1",
- "conformance_version": "0.9.12",
+ "conformance_version": "0.9.13",
  "seed": null,
  "scenario": {
   "name": "late-welcome-backfill/v1",

--- a/crates/cgka-conformance-simulator/vectors/latecomer-forward-secrecy.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/latecomer-forward-secrecy.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "latecomer-forward-secrecy/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.12",
+  "conformance_version": "0.9.13",
   "seed": null,
   "scenario": {
     "name": "latecomer-forward-secrecy/v1",

--- a/crates/cgka-conformance-simulator/vectors/leaver-removal-secrecy.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/leaver-removal-secrecy.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "leaver-removal-secrecy/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.12",
+  "conformance_version": "0.9.13",
   "seed": null,
   "scenario": {
     "name": "leaver-removal-secrecy/v1",

--- a/crates/cgka-conformance-simulator/vectors/multigroup-isolation.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/multigroup-isolation.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "multigroup-isolation/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.12",
+  "conformance_version": "0.9.13",
   "seed": null,
   "scenario": {
     "name": "multigroup-isolation/v1",

--- a/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "partition-clear-leave/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.12",
+  "conformance_version": "0.9.13",
   "seed": null,
   "scenario": {
     "name": "partition-clear-leave/v1",

--- a/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.12",
+  "conformance_version": "0.9.13",
   "seed": null,
   "scenario": {
     "name": "publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "queue-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.12",
+  "conformance_version": "0.9.13",
   "seed": null,
   "scenario": {
     "name": "queue-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/readd-after-eviction.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/readd-after-eviction.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "readd-after-eviction/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.12",
+  "conformance_version": "0.9.13",
   "seed": null,
   "scenario": {
     "name": "readd-after-eviction/v1",

--- a/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "restart-delivery-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.12",
+  "conformance_version": "0.9.13",
   "seed": null,
   "scenario": {
     "name": "restart-delivery-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/route-equivalence.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/route-equivalence.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "route-equivalence/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.12",
+  "conformance_version": "0.9.13",
   "seed": null,
   "scenario": {
     "name": "route-equivalence/v1",

--- a/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "three-client-message-exchange/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.12",
+  "conformance_version": "0.9.13",
   "seed": null,
   "scenario": {
     "name": "three-client-message-exchange/v1",

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -9,7 +9,28 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ## [Unreleased]
 
+## [0.9.13] - 2026-08-18
+
 ### Added
+
+- MarmotKit adds bounded, local-first APIs for common host reads: keyed
+  `chatListRow`, badge-ready account unread summaries, administrator ids on
+  membership pages, bulk cached identity projections, and peer-keyed existing
+  direct-conversation lookup. These replace repeated full chat-list, roster,
+  and profile scans while preserving typed missing, malformed, and not-ready
+  outcomes.
+  ([#1464](https://github.com/marmot-protocol/mdk/pull/1464),
+  [#1466](https://github.com/marmot-protocol/mdk/pull/1466),
+  [#1468](https://github.com/marmot-protocol/mdk/pull/1468),
+  [#1469](https://github.com/marmot-protocol/mdk/pull/1469),
+  [#1471](https://github.com/marmot-protocol/mdk/pull/1471))
+
+- MarmotKit release and exact-SHA snapshot workflows now package native macOS
+  artifacts and Android Kotlin/JNI bindings alongside the existing Apple
+  outputs, with immutable source identities, checksums, and provenance
+  manifests for downstream staging.
+  ([#1402](https://github.com/marmot-protocol/mdk/pull/1402),
+  [#1473](https://github.com/marmot-protocol/mdk/pull/1473))
 
 - MarmotKit exposes `appPerformanceSnapshot()`, a read-only fetch of the
   process-wide app-performance snapshot — per-phase attempt/success/failure
@@ -40,7 +61,65 @@ versioning through the workspace version in the root `Cargo.toml`.
   repair.
   ([#1426](https://github.com/marmot-protocol/mdk/pull/1426))
 
+### Changed
+
+- Account databases upgrade through storage migrations 47–50. Migration 47
+  normalizes message metadata and introduces versioned `MDKMP` message-payload
+  and `MDKS` snapshot/checkpoint codecs; existing format-1 rows remain readable
+  and promote in bounded background batches after account readiness. Later
+  migrations persist deferred-peel generations and add targeted pending-invite
+  and direct-conversation indexes. Downgrade across migration 47 is unsupported:
+  older binaries refuse the database before reading account tables, so make a
+  backup before upgrading and restore that backup if downgrade is required.
+  Migration 47 can temporarily require substantial disk space; allow at least
+  3.25 times the existing account database size as additional free space.
+  ([#1421](https://github.com/marmot-protocol/mdk/pull/1421),
+  [#1433](https://github.com/marmot-protocol/mdk/pull/1433),
+  [#1440](https://github.com/marmot-protocol/mdk/pull/1440),
+  [#1454](https://github.com/marmot-protocol/mdk/pull/1454),
+  [#1471](https://github.com/marmot-protocol/mdk/pull/1471))
+
+- Group creation and invitation return after the durable MLS mutation instead
+  of waiting for Welcome fanout; bounded background delivery retains retryable
+  recovery. Invite-with-admin now applies membership and initial administrator
+  policy in one commit instead of a follow-up promotion per administrator.
+  ([#1457](https://github.com/marmot-protocol/mdk/pull/1457))
+
+- Account setup publishes its initial replaceable records as one recoverable
+  batch, connects directory relays concurrently, avoids redundant relay-list
+  and SQLCipher work, and preserves partially exposed accounts for idempotent
+  retry. One unavailable relay no longer serializes or rolls back otherwise
+  acknowledged setup.
+  ([#1446](https://github.com/marmot-protocol/mdk/pull/1446))
+
+- WN Agent reconciliation is event-driven with adaptive quiet-period safety
+  nets instead of two fixed five-second full-state scans. Remaining passes use
+  targeted changed-state reads, reducing idle CPU and SQLite read amplification
+  while retaining prompt activity and retry wakeups.
+  ([#1454](https://github.com/marmot-protocol/mdk/pull/1454))
+
 ### Fixed
+
+- Outbound operations bound foreground deferred-peel work and durably queue
+  application, proposal, and commit intents when convergence cannot yet finish.
+  Queued messages re-arm their drain when a convergence pass closes, and an
+  in-flight regenerated intent is not published twice. This prevents accepted
+  messages from remaining stranded or later failing confirmation after a
+  duplicate publication.
+  ([#1440](https://github.com/marmot-protocol/mdk/pull/1440),
+  [#1475](https://github.com/marmot-protocol/mdk/pull/1475))
+
+- App runtime work that can block on SQLCipher, subscription recovery, wake
+  catch-up, directory reads, notifications, or media HTTP no longer stalls the
+  async runtime or exclusive account worker. Lagged subscriptions rebuild from
+  authoritative state, buffered wake events survive catch-up timeouts, and
+  projection updates from account mutations flush promptly.
+  ([#1435](https://github.com/marmot-protocol/mdk/pull/1435),
+  [#1447](https://github.com/marmot-protocol/mdk/pull/1447))
+
+- Steady-state account opens skip a duplicate SQLCipher KDF migration probe
+  without weakening marker, salt, key, or recovery checks.
+  ([#1442](https://github.com/marmot-protocol/mdk/pull/1442))
 
 - Welcome joins now become durable and publish `GroupJoined` before ordinary
   relay subscriptions rebuild, with failed rebuilds retried in the background.
@@ -1569,7 +1648,8 @@ Initial release of the `dm` command-line app, the `dmd` background daemon, and t
 - Local installation docs for `cargo install --path crates/cli --locked --bins`.
 - Homebrew release checklist and namespaced tap packaging path for `marmot-protocol/tap/darkmatter`.
 
-[Unreleased]: https://github.com/marmot-protocol/mdk/compare/v0.9.12...HEAD
+[Unreleased]: https://github.com/marmot-protocol/mdk/compare/v0.9.13...HEAD
+[0.9.13]: https://github.com/marmot-protocol/mdk/compare/v0.9.12...v0.9.13
 [0.9.12]: https://github.com/marmot-protocol/mdk/compare/v0.9.11...v0.9.12
 [0.9.11]: https://github.com/marmot-protocol/mdk/compare/v0.9.10...v0.9.11
 [0.9.10]: https://github.com/marmot-protocol/mdk/compare/v0.9.9...v0.9.10


### PR DESCRIPTION
## Summary

- bump the workspace compatibility cohort from 0.9.12 to 0.9.13 and refresh every workspace package entry in `Cargo.lock`
- move the accumulated user-facing changes into a dated 0.9.13 changelog section
- document the storage-format v2 upgrade boundary, migrations 47–50, downgrade refusal, backup remedy, and temporary free-space guidance
- update every canonical conformance fixture to `conformance_version: 0.9.13`

## Why

`v0.9.12` is the latest immutable release and current `master` is 35 merged PR commits ahead. The delta includes storage-format v2, durable queued-outbound recovery, runtime responsiveness and setup improvements, new MarmotKit host APIs, and expanded macOS/Android binding artifacts. These public and persistence changes need one synchronized MDK / WN Agent / MarmotKit compatibility cohort.

This PR is release preparation only. It creates no tags or GitHub Releases.

## Candidate scope

Prepared from fetched `origin/master` at `137a386bead83b055bfd8a05704e32073aecd1ea`. The currently open TUI search, C ABI, and sticker PRs are not included.

## Validation

- `just fast-ci`
- `cargo test -p cgka-conformance-simulator --test canonical_scenarios --locked` — 53 passed
- `cargo test -p marmot-uniffi --locked` — 149 passed across library, fixture, and smoke suites
- `cargo metadata --locked --no-deps --format-version 1`
- `git diff --check`
- `just release-all-dry-run 0.9.13`

After merge, the real release must run from clean, fetched `origin/master` so all three immutable cohort tags resolve to the merged release commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Release**
  - Updated the product version to **0.9.13**.
  - Added release notes covering API improvements, native macOS and Android artifacts, storage migrations, account setup, synchronization, and performance enhancements.

- **Conformance**
  - Updated conformance metadata to align all validation scenarios with version 0.9.13.
  - Existing scenario behavior and expected outcomes remain unchanged.

- **Documentation**
  - Updated release comparison links and changelog information for version 0.9.13.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->