### PR TITLE
chore(release): prepare 0.9.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -465,10 +465,29 @@ jobs:
           persist-credentials: false
 
       - name: Install system dependencies
+        timeout-minutes: 10
         run: |
           set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends python3 python3-venv git
+          for attempt in 1 2 3; do
+            if sudo timeout --kill-after=15s 180s apt-get \
+              -o Acquire::Retries=3 \
+              -o Acquire::http::Timeout=30 \
+              -o Acquire::https::Timeout=30 \
+              update; then
+              break
+            fi
+            if [[ "$attempt" == 3 ]]; then
+              echo "apt-get update failed after $attempt attempts" >&2
+              exit 1
+            fi
+            echo "apt-get update attempt $attempt failed; retrying" >&2
+          done
+          sudo apt-get \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 \
+            -o DPkg::Lock::Timeout=60 \
+            install -y --no-install-recommends python3 python3-venv git
 
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,7 +414,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Tamarin dependencies
-        timeout-minutes: 10
+        timeout-minutes: 15
         run: |
           set -euo pipefail
           for attempt in 1 2 3; do
@@ -465,7 +465,7 @@ jobs:
           persist-credentials: false
 
       - name: Install system dependencies
-        timeout-minutes: 10
+        timeout-minutes: 15
         run: |
           set -euo pipefail
           venv_check_dir="${RUNNER_TEMP}/hermes-venv-check"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,10 +414,29 @@ jobs:
           persist-credentials: false
 
       - name: Install Tamarin dependencies
+        timeout-minutes: 10
         run: |
           set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends graphviz maude
+          for attempt in 1 2 3; do
+            if sudo timeout --kill-after=15s 180s apt-get \
+              -o Acquire::Retries=3 \
+              -o Acquire::http::Timeout=30 \
+              -o Acquire::https::Timeout=30 \
+              update; then
+              break
+            fi
+            if [[ "$attempt" == 3 ]]; then
+              echo "apt-get update failed after $attempt attempts" >&2
+              exit 1
+            fi
+            echo "apt-get update attempt $attempt failed; retrying" >&2
+          done
+          sudo apt-get \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 \
+            -o DPkg::Lock::Timeout=60 \
+            install -y --no-install-recommends graphviz maude
 
       - name: Install Tamarin
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -468,6 +468,14 @@ jobs:
         timeout-minutes: 10
         run: |
           set -euo pipefail
+          venv_check_dir="${RUNNER_TEMP}/hermes-venv-check"
+          if command -v python3 >/dev/null \
+            && command -v git >/dev/null \
+            && python3 -m venv "$venv_check_dir"; then
+            rm -rf "$venv_check_dir"
+            exit 0
+          fi
+          rm -rf "$venv_check_dir"
           for attempt in 1 2 3; do
             if sudo timeout --kill-after=15s 180s apt-get \
               -o Acquire::Retries=3 \

--- a/.github/workflows/wn-agent-binaries.yml
+++ b/.github/workflows/wn-agent-binaries.yml
@@ -549,8 +549,35 @@ jobs:
             exit 0
           fi
 
-          latest_release="$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$latest_tag" 2>/dev/null || true)"
-          if [ -n "$latest_release" ] && [ "$(jq -r '.immutable' <<< "$latest_release")" = "true" ]; then
+          latest_release_file="$RUNNER_TEMP/latest-installer-release.json"
+          if ! latest_status="$(curl --fail-with-body --silent --show-error \
+            --header "Authorization: Bearer $GH_TOKEN" \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            --output "$latest_release_file" \
+            --write-out '%{http_code}' \
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/releases/tags/$latest_tag")"; then
+            if [ "$latest_status" != "404" ]; then
+              echo "failed to inspect $latest_tag; refusing to mutate the legacy installer alias" >&2
+              exit 1
+            fi
+          fi
+
+          if [ "$latest_status" = "200" ]; then
+            if ! latest_immutable="$(jq -er \
+              'if (.immutable | type) == "boolean" then .immutable else error("missing boolean immutable field") end' \
+              "$latest_release_file")"; then
+              echo "invalid release metadata for $latest_tag; refusing to mutate the legacy installer alias" >&2
+              exit 1
+            fi
+          elif [ "$latest_status" = "404" ]; then
+            latest_immutable="false"
+          else
+            echo "unexpected HTTP status $latest_status while inspecting $latest_tag; refusing to mutate the legacy installer alias" >&2
+            exit 1
+          fi
+
+          if [ "$latest_immutable" = "true" ]; then
             echo "warning: $latest_tag is immutable; leaving the legacy installer alias unchanged"
             echo "use the installer assets from the immutable $tag release instead"
             exit 0

--- a/.github/workflows/wn-agent-binaries.yml
+++ b/.github/workflows/wn-agent-binaries.yml
@@ -549,6 +549,13 @@ jobs:
             exit 0
           fi
 
+          latest_release="$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$latest_tag" 2>/dev/null || true)"
+          if [ -n "$latest_release" ] && [ "$(jq -r '.immutable' <<< "$latest_release")" = "true" ]; then
+            echo "warning: $latest_tag is immutable; leaving the legacy installer alias unchanged"
+            echo "use the installer assets from the immutable $tag release instead"
+            exit 0
+          fi
+
           cat > "$latest_notes" <<EOF
           Latest WN Agent installers. These scripts install WN Agent \`$version\` from immutable release \`$tag\`.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agent-connector"
-version = "0.9.13"
+version = "0.9.14"
 dependencies = [
  "agent-control",
  "agent-stream-compose",
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "agent-control"
-version = "0.9.13"
+version = "0.9.14"
 dependencies = [
  "serde",
  "serde_json",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "agent-stream-compose"
-version = "0.9.13"
+version = "0.9.14"
 dependencies = [
  "cgka-traits",
  "hex",
@@ -864,7 +864,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cgka-conformance-simulator"
-version = "0.9.13"
+version = "0.9.14"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-engine"
-version = "0.9.13"
+version = "0.9.14"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-session"
-version = "0.9.13"
+version = "0.9.14"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-traits"
-version = "0.9.13"
+version = "0.9.14"
 dependencies = [
  "async-trait",
  "criterion",
@@ -1192,7 +1192,7 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "convergence-campaign-runner"
-version = "0.9.13"
+version = "0.9.14"
 dependencies = [
  "async-trait",
  "cgka-conformance-simulator",
@@ -1987,7 +1987,7 @@ dependencies = [
 
 [[package]]
 name = "fs-private"
-version = "0.9.13"
+version = "0.9.14"
 dependencies = [
  "libc",
  "tempfile",
@@ -2725,7 +2725,7 @@ dependencies = [
 
 [[package]]
 name = "incident-replay"
-version = "0.9.13"
+version = "0.9.14"
 dependencies = [
  "cgka-conformance-simulator",
  "fs-private",
@@ -3322,7 +3322,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-account"
-version = "0.9.13"
+version = "0.9.14"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-app"
-version = "0.9.13"
+version = "0.9.14"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3399,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-forensics"
-version = "0.9.13"
+version = "0.9.14"
 dependencies = [
  "fs-private",
  "serde",
@@ -3409,7 +3409,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-markdown"
-version = "0.9.13"
+version = "0.9.14"
 dependencies = [
  "serde",
  "serde_json",
@@ -3417,7 +3417,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-terminal-harness"
-version = "0.9.13"
+version = "0.9.14"
 dependencies = [
  "agent-control",
  "async-trait",
@@ -3432,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-uniffi"
-version = "0.9.13"
+version = "0.9.14"
 dependencies = [
  "cgka-engine",
  "cgka-traits",
@@ -5652,7 +5652,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-sqlite"
-version = "0.9.13"
+version = "0.9.14"
 dependencies = [
  "cgka-traits",
  "fs-private",
@@ -6268,7 +6268,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-adapter"
-version = "0.9.13"
+version = "0.9.14"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -6288,7 +6288,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-peeler"
-version = "0.9.13"
+version = "0.9.14"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -6305,7 +6305,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-broker"
-version = "0.9.13"
+version = "0.9.14"
 dependencies = [
  "cgka-traits",
  "clap",
@@ -6324,7 +6324,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-stream"
-version = "0.9.13"
+version = "0.9.14"
 dependencies = [
  "cgka-traits",
  "chacha20poly1305",
@@ -7391,7 +7391,7 @@ dependencies = [
 
 [[package]]
 name = "wn-cli"
-version = "0.9.13"
+version = "0.9.14"
 dependencies = [
  "agent-stream-compose",
  "cgka-session",
@@ -7425,7 +7425,7 @@ dependencies = [
 
 [[package]]
 name = "wn-opencode"
-version = "0.9.13"
+version = "0.9.14"
 dependencies = [
  "async-trait",
  "clap",
@@ -7440,7 +7440,7 @@ dependencies = [
 
 [[package]]
 name = "wn-pi"
-version = "0.9.13"
+version = "0.9.14"
 dependencies = [
  "async-trait",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "0.9.13"
+version = "0.9.14"
 license = "MIT"
 publish = false
 

--- a/crates/cgka-conformance-simulator/vectors/admin-handover.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/admin-handover.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "admin-handover/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.13",
+  "conformance_version": "0.9.14",
   "seed": null,
   "scenario": {
     "name": "admin-handover/v1",

--- a/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "admin-policy-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.13",
+  "conformance_version": "0.9.14",
   "seed": null,
   "scenario": {
     "name": "admin-policy-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "concurrent-invite-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.13",
+  "conformance_version": "0.9.14",
   "seed": null,
   "scenario": {
     "name": "concurrent-invite-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-committer-selected/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.13",
+  "conformance_version": "0.9.14",
   "seed": null,
   "scenario": {
     "name": "convergence-committer-selected/v1",

--- a/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-witness-selected/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.13",
+  "conformance_version": "0.9.14",
   "seed": null,
   "scenario": {
     "name": "convergence-witness-selected/v1",

--- a/crates/cgka-conformance-simulator/vectors/conversation.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/conversation.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "conversation/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.13",
+  "conformance_version": "0.9.14",
   "seed": null,
   "scenario": {
     "name": "conversation/v1",

--- a/crates/cgka-conformance-simulator/vectors/cross-route-own-commit-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/cross-route-own-commit-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "cross-route-own-commit-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.13",
+  "conformance_version": "0.9.14",
   "seed": null,
   "scenario": {
     "name": "cross-route-own-commit-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/current-profile-required-set.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/current-profile-required-set.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "current-profile-required-set/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.13",
+  "conformance_version": "0.9.14",
   "seed": null,
   "application_profile": {
     "name": "current",

--- a/crates/cgka-conformance-simulator/vectors/deferred-tick-catchup.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/deferred-tick-catchup.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "deferred-tick-catchup/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.13",
+  "conformance_version": "0.9.14",
   "seed": null,
   "scenario": {
     "name": "deferred-tick-catchup/v1",

--- a/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "delayed-past-epoch-app-message/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.13",
+  "conformance_version": "0.9.14",
   "seed": null,
   "scenario": {
     "name": "delayed-past-epoch-app-message/v1",

--- a/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "drop-queued/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.13",
+  "conformance_version": "0.9.14",
   "seed": null,
   "scenario": {
     "name": "drop-queued/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.13",
+  "conformance_version": "0.9.14",
   "seed": null,
   "scenario": {
     "name": "group-data-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.13",
+  "conformance_version": "0.9.14",
   "seed": null,
   "scenario": {
     "name": "group-data-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-profile-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-profile-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-profile-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.13",
+  "conformance_version": "0.9.14",
   "seed": null,
   "scenario": {
     "name": "group-profile-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.13",
+  "conformance_version": "0.9.14",
   "seed": null,
   "scenario": {
     "name": "convergence-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "fork-recovery-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.13",
+  "conformance_version": "0.9.14",
   "seed": null,
   "scenario": {
     "name": "fork-recovery-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "membership-fork-recovery-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.13",
+  "conformance_version": "0.9.14",
   "seed": null,
   "scenario": {
     "name": "membership-fork-recovery-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incremental-growth.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incremental-growth.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "incremental-growth/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.13",
+  "conformance_version": "0.9.14",
   "seed": null,
   "scenario": {
     "name": "incremental-growth/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-member/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.13",
+  "conformance_version": "0.9.14",
   "seed": null,
   "scenario": {
     "name": "invite-member/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.13",
+  "conformance_version": "0.9.14",
   "seed": null,
   "scenario": {
     "name": "invite-publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/late-welcome-backfill.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/late-welcome-backfill.v1.json
@@ -1,7 +1,7 @@
 {
  "scenario_name": "late-welcome-backfill/v1",
  "vector_version": "1",
- "conformance_version": "0.9.13",
+ "conformance_version": "0.9.14",
  "seed": null,
  "scenario": {
   "name": "late-welcome-backfill/v1",

--- a/crates/cgka-conformance-simulator/vectors/latecomer-forward-secrecy.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/latecomer-forward-secrecy.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "latecomer-forward-secrecy/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.13",
+  "conformance_version": "0.9.14",
   "seed": null,
   "scenario": {
     "name": "latecomer-forward-secrecy/v1",

--- a/crates/cgka-conformance-simulator/vectors/leaver-removal-secrecy.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/leaver-removal-secrecy.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "leaver-removal-secrecy/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.13",
+  "conformance_version": "0.9.14",
   "seed": null,
   "scenario": {
     "name": "leaver-removal-secrecy/v1",

--- a/crates/cgka-conformance-simulator/vectors/multigroup-isolation.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/multigroup-isolation.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "multigroup-isolation/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.13",
+  "conformance_version": "0.9.14",
   "seed": null,
   "scenario": {
     "name": "multigroup-isolation/v1",

--- a/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "partition-clear-leave/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.13",
+  "conformance_version": "0.9.14",
   "seed": null,
   "scenario": {
     "name": "partition-clear-leave/v1",

--- a/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.13",
+  "conformance_version": "0.9.14",
   "seed": null,
   "scenario": {
     "name": "publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "queue-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.13",
+  "conformance_version": "0.9.14",
   "seed": null,
   "scenario": {
     "name": "queue-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/readd-after-eviction.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/readd-after-eviction.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "readd-after-eviction/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.13",
+  "conformance_version": "0.9.14",
   "seed": null,
   "scenario": {
     "name": "readd-after-eviction/v1",

--- a/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "restart-delivery-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.13",
+  "conformance_version": "0.9.14",
   "seed": null,
   "scenario": {
     "name": "restart-delivery-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/route-equivalence.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/route-equivalence.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "route-equivalence/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.13",
+  "conformance_version": "0.9.14",
   "seed": null,
   "scenario": {
     "name": "route-equivalence/v1",

--- a/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "three-client-message-exchange/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.13",
+  "conformance_version": "0.9.14",
   "seed": null,
   "scenario": {
     "name": "three-client-message-exchange/v1",

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -9,6 +9,21 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ## [Unreleased]
 
+## [0.9.14] - 2026-08-18
+
+### Fixed
+
+- MarmotKit Android release artifacts now strip target JNI libraries while
+  preserving the host library metadata UniFFI needs, reject residual debug or
+  static-symbol sections during packaging, and retain the established ordered
+  manifest contract expected by White Noise Android.
+  ([#1480](https://github.com/marmot-protocol/mdk/pull/1480))
+
+- WN Agent publication no longer fails after publishing the immutable
+  versioned release when the legacy `wn-agent-latest` installer release is
+  itself immutable. In that configuration the workflow leaves the stale alias
+  unchanged and directs consumers to the pinned versioned installer assets.
+
 ## [0.9.13] - 2026-08-18
 
 ### Added
@@ -1648,7 +1663,8 @@ Initial release of the `dm` command-line app, the `dmd` background daemon, and t
 - Local installation docs for `cargo install --path crates/cli --locked --bins`.
 - Homebrew release checklist and namespaced tap packaging path for `marmot-protocol/tap/darkmatter`.
 
-[Unreleased]: https://github.com/marmot-protocol/mdk/compare/v0.9.13...HEAD
+[Unreleased]: https://github.com/marmot-protocol/mdk/compare/v0.9.14...HEAD
+[0.9.14]: https://github.com/marmot-protocol/mdk/compare/v0.9.13...v0.9.14
 [0.9.13]: https://github.com/marmot-protocol/mdk/compare/v0.9.12...v0.9.13
 [0.9.12]: https://github.com/marmot-protocol/mdk/compare/v0.9.11...v0.9.12
 [0.9.11]: https://github.com/marmot-protocol/mdk/compare/v0.9.10...v0.9.11

--- a/scripts/cut-full-release.sh
+++ b/scripts/cut-full-release.sh
@@ -359,7 +359,12 @@ if [ "$push" -eq 1 ] && [ "$wait" -eq 1 ]; then
     verify_release "$mdk_tag" "v$version - MDK" "$([ "$draft" -eq 1 ] && echo true || echo false)" false 0
     verify_release "$wn_tag" "v$version - wn-agent" "$([ "$draft" -eq 1 ] && echo true || echo false)" true 14
     if [ "$draft" -eq 0 ]; then
-        verify_release "wn-agent-latest" "Latest WN Agent installers" false true 3
+        latest_immutable="$(gh api "repos/$repo/releases/tags/wn-agent-latest" --jq '.immutable' 2>/dev/null || true)"
+        if [ "$latest_immutable" = "true" ]; then
+            echo "warning: wn-agent-latest is immutable; verified the versioned WN Agent release only"
+        else
+            verify_release "wn-agent-latest" "Latest WN Agent installers" false true 3
+        fi
     fi
     verify_release "$marmotkit_tag" "v$version - MarmotKit" "$([ "$draft" -eq 1 ] && echo true || echo false)" false 4
 elif [ "$push" -eq 1 ]; then


### PR DESCRIPTION
## Summary

- bump the workspace and canonical conformance vectors to 0.9.14
- document the Android MarmotKit artifact correction from #1480
- keep WN Agent versioned publication green when the legacy `wn-agent-latest` release is immutable

## Context

The 0.9.13 MDK and WN Agent releases were published from `90b35a8d` before #1480 merged. GitHub has made those releases immutable, so this corrective cohort uses 0.9.14 from current master rather than retargeting published 0.9.13 tags. The obsolete 0.9.13 MarmotKit workflow was cancelled before release creation.

## Verification

- `actionlint .github/workflows/wn-agent-binaries.yml`
- `bash -n scripts/cut-full-release.sh`
- `just fast-ci`
- `cargo test -p cgka-conformance-simulator --test canonical_scenarios --locked` (53 passed)
- `just release-all-dry-run 0.9.14`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Release handling now detects immutable legacy installer aliases and avoids overwriting them.
  - Missing or mutable aliases continue through normal release verification.

- **Bug Fixes**
  - Improved Android MarmotKit packaging.
  - Increased reliability of dependency installation during automated checks.

- **Release**
  - Published version 0.9.14.
  - Updated conformance metadata across supported scenarios.

- **Documentation**
  - Added 0.9.14 changelog notes covering packaging and installer release handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->