### PR TITLE
Add bounded sync and catch-up failure telemetry

### DIFF
--- a/crates/cli/src/commands/sync.rs
+++ b/crates/cli/src/commands/sync.rs
@@ -32,6 +32,7 @@ fn sync_failure_error(
     let SyncFailure {
         partial_summary,
         source,
+        ..
     } = failure;
     let partial_plain = partial_sync_plain(&partial_summary);
     // Rendering the applied prefix is secondary to the sync failure. Account
@@ -170,8 +171,8 @@ mod tests {
         let home = AccountHome::open(dir.path());
         let account = home.create_account("alice").unwrap();
         let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
-        let failure = SyncFailure {
-            partial_summary: SyncSummary {
+        let failure = SyncFailure::new(
+            SyncSummary {
                 messages: vec![ReceivedMessage {
                     message_id_hex: "11".repeat(32),
                     source_message_id_hex: "22".repeat(32),
@@ -193,8 +194,8 @@ mod tests {
                 }],
                 ..Default::default()
             },
-            source: AppError::BlockingTask("injected sync failure".to_owned()),
-        };
+            AppError::BlockingTask("injected sync failure".to_owned()),
+        );
 
         let error = sync_failure_error(&app, account, failure);
         let rendered = wn_error_json(&error);
@@ -229,10 +230,10 @@ mod tests {
             external_signing: false,
             signed_out: false,
         };
-        let failure = SyncFailure {
-            partial_summary: SyncSummary::default(),
-            source: AppError::BlockingTask("original sync failure".to_owned()),
-        };
+        let failure = SyncFailure::new(
+            SyncSummary::default(),
+            AppError::BlockingTask("original sync failure".to_owned()),
+        );
 
         let error = sync_failure_error(&app, account, failure);
         let rendered = wn_error_json(&error);

--- a/crates/marmot-app/src/app_telemetry.rs
+++ b/crates/marmot-app/src/app_telemetry.rs
@@ -385,7 +385,13 @@ impl DurationHistogram {
 
 impl AppPerformanceOperationTelemetry {
     fn record(&mut self, duration: Duration, success: bool) {
-        self.record_with_failure(duration, success, None);
+        self.attempts += 1;
+        if success {
+            self.successes += 1;
+        } else {
+            self.failures += 1;
+        }
+        self.duration_ms.record(duration);
     }
 
     fn record_with_failure(
@@ -394,18 +400,14 @@ impl AppPerformanceOperationTelemetry {
         success: bool,
         failure: Option<SyncFailureClassification>,
     ) {
-        self.attempts += 1;
-        if success {
-            self.successes += 1;
-        } else {
-            self.failures += 1;
+        self.record(duration, success);
+        if !success {
             let classification = failure.unwrap_or(SyncFailureClassification::UNKNOWN);
             *self
                 .failure_classifications
                 .entry(classification)
                 .or_default() += 1;
         }
-        self.duration_ms.record(duration);
     }
 
     fn snapshot(&self) -> AppPerformanceOperationSnapshot {
@@ -740,13 +742,13 @@ pub(crate) async fn bounded_advisory_step<F: std::future::Future>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{AccountCatchUpFailure, AppError, SyncFailure, SyncSummary};
+    use crate::{AccountCatchUpFailure, AppError, ClassifiedSyncFailure, SyncSummary};
     use cgka_traits::TransportAdapterError;
     use cgka_traits::error::EngineError;
     use cgka_traits::storage::StorageError;
 
     fn classified(stage: SyncFailureStage, error: AppError) -> SyncFailureClassification {
-        SyncFailure::at_stage(SyncSummary::default(), error, stage).classification()
+        ClassifiedSyncFailure::at_stage(SyncSummary::default(), error, stage).classification()
     }
 
     #[test]
@@ -1014,6 +1016,13 @@ mod tests {
         assert_eq!(snapshot.group_accept_invite.attempts, 2);
         assert_eq!(snapshot.group_accept_invite.successes, 1);
         assert_eq!(snapshot.group_accept_invite.failures, 1);
+        assert!(
+            snapshot
+                .group_accept_invite
+                .failure_classifications
+                .is_empty(),
+            "generic operation failures must not populate sync classifications"
+        );
         assert_eq!(snapshot.group_accept_invite.duration_ms.sample_count(), 2);
         assert_eq!(snapshot.group_accept_invite.duration_ms.sum_ms, 100);
     }

--- a/crates/marmot-app/src/app_telemetry.rs
+++ b/crates/marmot-app/src/app_telemetry.rs
@@ -5,6 +5,7 @@
 //! are no fields for account, group, message, relay, URL, pubkey, payload, or
 //! key material.
 
+use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -80,6 +81,94 @@ pub enum HostPerformanceOutcome {
     Failure,
 }
 
+/// Fixed sync/catch-up boundary at which an attempt stopped.
+///
+/// These values are exported verbatim as the `failure_stage` attribute. Keep
+/// this enum closed: accepting caller-provided strings would make metric
+/// cardinality and privacy impossible to review.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SyncFailureStage {
+    TransportActivation,
+    GroupSubscriptionSync,
+    RelayReceive,
+    CgkaIngest,
+    StatePersist,
+    AccountWorker,
+    Unknown,
+}
+
+impl SyncFailureStage {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::TransportActivation => "transport_activation",
+            Self::GroupSubscriptionSync => "group_subscription_sync",
+            Self::RelayReceive => "relay_receive",
+            Self::CgkaIngest => "cgka_ingest",
+            Self::StatePersist => "state_persist",
+            Self::AccountWorker => "account_worker",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// Fixed broad cause for a sync/catch-up failure.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SyncErrorClass {
+    Timeout,
+    TransportClosed,
+    RelayDirectory,
+    Protocol,
+    Crypto,
+    Storage,
+    Cancelled,
+    Unknown,
+}
+
+impl SyncErrorClass {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Timeout => "timeout",
+            Self::TransportClosed => "transport_closed",
+            Self::RelayDirectory => "relay_directory",
+            Self::Protocol => "protocol",
+            Self::Crypto => "crypto",
+            Self::Storage => "storage",
+            Self::Cancelled => "cancelled",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// Privacy-safe, bounded classification attached only to failed account sync
+/// and catch-up counter samples.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct SyncFailureClassification {
+    pub failure_stage: SyncFailureStage,
+    pub error_class: SyncErrorClass,
+}
+
+impl SyncFailureClassification {
+    pub const UNKNOWN: Self = Self {
+        failure_stage: SyncFailureStage::Unknown,
+        error_class: SyncErrorClass::Unknown,
+    };
+
+    pub const fn new(failure_stage: SyncFailureStage, error_class: SyncErrorClass) -> Self {
+        Self {
+            failure_stage,
+            error_class,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SyncFailureCount {
+    pub classification: SyncFailureClassification,
+    pub count: u64,
+}
+
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AppPerformanceOperationSnapshot {
     /// Operation attempts since process start.
@@ -88,6 +177,10 @@ pub struct AppPerformanceOperationSnapshot {
     pub successes: u64,
     /// Failed operations since process start.
     pub failures: u64,
+    /// Bounded failure breakdown. Empty for operations other than account sync
+    /// and catch-up and for snapshots written by older MDK versions.
+    #[serde(default)]
+    pub failure_classifications: Vec<SyncFailureCount>,
     /// Operation duration histogram in local monotonic milliseconds.
     pub duration_ms: DurationHistogramSnapshot,
 }
@@ -240,6 +333,7 @@ struct AppPerformanceOperationTelemetry {
     attempts: u64,
     successes: u64,
     failures: u64,
+    failure_classifications: BTreeMap<SyncFailureClassification, u64>,
     duration_ms: DurationHistogram,
 }
 
@@ -291,11 +385,25 @@ impl DurationHistogram {
 
 impl AppPerformanceOperationTelemetry {
     fn record(&mut self, duration: Duration, success: bool) {
+        self.record_with_failure(duration, success, None);
+    }
+
+    fn record_with_failure(
+        &mut self,
+        duration: Duration,
+        success: bool,
+        failure: Option<SyncFailureClassification>,
+    ) {
         self.attempts += 1;
         if success {
             self.successes += 1;
         } else {
             self.failures += 1;
+            let classification = failure.unwrap_or(SyncFailureClassification::UNKNOWN);
+            *self
+                .failure_classifications
+                .entry(classification)
+                .or_default() += 1;
         }
         self.duration_ms.record(duration);
     }
@@ -305,6 +413,14 @@ impl AppPerformanceOperationTelemetry {
             attempts: self.attempts,
             successes: self.successes,
             failures: self.failures,
+            failure_classifications: self
+                .failure_classifications
+                .iter()
+                .map(|(classification, count)| SyncFailureCount {
+                    classification: *classification,
+                    count: *count,
+                })
+                .collect(),
             duration_ms: self.duration_ms.snapshot(),
         }
     }
@@ -468,6 +584,30 @@ impl AppPerformanceTelemetry {
         }
     }
 
+    /// Record a terminal account sync/catch-up result with its bounded failure
+    /// classification. Successful samples carry no failure attributes.
+    pub(crate) fn record_sync_result(
+        &self,
+        operation: AppPerformanceOperation,
+        duration: Duration,
+        failure: Option<SyncFailureClassification>,
+    ) {
+        debug_assert!(matches!(
+            operation,
+            AppPerformanceOperation::AccountSync | AppPerformanceOperation::AccountCatchUp
+        ));
+        let mut inner = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let target = match operation {
+            AppPerformanceOperation::AccountSync => &mut inner.account_sync,
+            AppPerformanceOperation::AccountCatchUp => &mut inner.account_catch_up,
+            _ => return,
+        };
+        target.record_with_failure(duration, failure.is_none(), failure);
+    }
+
     /// Record one approved host-app milestone without accepting arbitrary
     /// metric names, label names, or label values.
     pub fn record_host_performance(
@@ -593,6 +733,125 @@ pub(crate) async fn bounded_advisory_step<F: std::future::Future>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{AccountCatchUpFailure, AppError, SyncFailure, SyncSummary};
+    use cgka_traits::TransportAdapterError;
+    use cgka_traits::error::EngineError;
+    use cgka_traits::storage::StorageError;
+
+    fn classified(stage: SyncFailureStage, error: AppError) -> SyncFailureClassification {
+        SyncFailure::at_stage(SyncSummary::default(), error, stage).classification()
+    }
+
+    #[test]
+    fn sync_failure_classification_is_typed_bounded_and_propagates() {
+        let cases = [
+            (
+                classified(
+                    SyncFailureStage::TransportActivation,
+                    AppError::Transport(TransportAdapterError::Timeout),
+                ),
+                SyncFailureClassification::new(
+                    SyncFailureStage::TransportActivation,
+                    SyncErrorClass::Timeout,
+                ),
+            ),
+            (
+                classified(
+                    SyncFailureStage::RelayReceive,
+                    AppError::Transport(TransportAdapterError::Closed),
+                ),
+                SyncFailureClassification::new(
+                    SyncFailureStage::RelayReceive,
+                    SyncErrorClass::TransportClosed,
+                ),
+            ),
+            (
+                classified(
+                    SyncFailureStage::GroupSubscriptionSync,
+                    AppError::Transport(TransportAdapterError::Subscription(
+                        "raw relay detail must not become an attribute".into(),
+                    )),
+                ),
+                SyncFailureClassification::new(
+                    SyncFailureStage::GroupSubscriptionSync,
+                    SyncErrorClass::Unknown,
+                ),
+            ),
+            (
+                classified(
+                    SyncFailureStage::CgkaIngest,
+                    AppError::Account(marmot_account::AccountError::Engine(
+                        EngineError::InvalidWelcome,
+                    )),
+                ),
+                SyncFailureClassification::new(
+                    SyncFailureStage::CgkaIngest,
+                    SyncErrorClass::Protocol,
+                ),
+            ),
+            (
+                classified(
+                    SyncFailureStage::StatePersist,
+                    AppError::Storage(StorageError::Backend(
+                        "/private/account.sqlite secret detail".into(),
+                    )),
+                ),
+                SyncFailureClassification::new(
+                    SyncFailureStage::StatePersist,
+                    SyncErrorClass::Storage,
+                ),
+            ),
+            (
+                classified(
+                    SyncFailureStage::Unknown,
+                    AppError::BlockingTask("untyped raw failure".into()),
+                ),
+                SyncFailureClassification::UNKNOWN,
+            ),
+        ];
+        for (actual, expected) in cases {
+            assert_eq!(actual, expected);
+        }
+
+        let child = cases[3].0;
+        let propagated = AppError::AccountCatchUp(AccountCatchUpFailure::new(
+            "runtime catch-up failed: attacker-controlled detail".into(),
+            child,
+        ));
+        assert_eq!(propagated.sync_error_class(), child.error_class);
+
+        let telemetry = AppPerformanceTelemetry::default();
+        telemetry.record_sync_result(
+            AppPerformanceOperation::AccountSync,
+            Duration::from_millis(1),
+            Some(child),
+        );
+        telemetry.record_sync_result(
+            AppPerformanceOperation::AccountCatchUp,
+            Duration::from_millis(2),
+            Some(child),
+        );
+        let snapshot = telemetry.snapshot();
+        assert_eq!(snapshot.account_sync.attempts, 1);
+        assert_eq!(snapshot.account_sync.successes, 0);
+        assert_eq!(snapshot.account_sync.failures, 1);
+        assert_eq!(snapshot.account_catch_up.attempts, 1);
+        assert_eq!(snapshot.account_catch_up.successes, 0);
+        assert_eq!(snapshot.account_catch_up.failures, 1);
+        assert_eq!(
+            snapshot.account_sync.failure_classifications[0].classification,
+            child
+        );
+        assert_eq!(
+            snapshot.account_catch_up.failure_classifications[0].classification,
+            child
+        );
+
+        let serialized = serde_json::to_string(&snapshot).unwrap();
+        assert!(!serialized.contains("attacker-controlled"));
+        assert!(!serialized.contains("account.sqlite"));
+        assert!(!serialized.contains("raw relay detail"));
+    }
 
     #[test]
     fn records_success_failure_counts_and_duration_buckets() {

--- a/crates/marmot-app/src/app_telemetry.rs
+++ b/crates/marmot-app/src/app_telemetry.rs
@@ -433,6 +433,16 @@ impl AppPerformanceTelemetry {
         duration: Duration,
         success: bool,
     ) {
+        if matches!(
+            operation,
+            AppPerformanceOperation::AccountSync | AppPerformanceOperation::AccountCatchUp
+        ) {
+            debug_assert!(
+                false,
+                "account sync/catch-up must use record_sync_result with a bounded failure classification"
+            );
+            return;
+        }
         let mut inner = self
             .inner
             .lock()
@@ -466,10 +476,7 @@ impl AppPerformanceTelemetry {
                     .account_subscription_registration
                     .record(duration, success);
             }
-            AppPerformanceOperation::AccountCatchUp => {
-                inner.account_catch_up.record(duration, success);
-            }
-            AppPerformanceOperation::AccountSync => inner.account_sync.record(duration, success),
+            AppPerformanceOperation::AccountCatchUp | AppPerformanceOperation::AccountSync => {}
             AppPerformanceOperation::AccountSetupAdvisoryStep => {
                 inner.account_setup_advisory_step.record(duration, success)
             }
@@ -747,11 +754,11 @@ mod tests {
         let cases = [
             (
                 classified(
-                    SyncFailureStage::TransportActivation,
-                    AppError::Transport(TransportAdapterError::Timeout),
+                    SyncFailureStage::AccountWorker,
+                    AppError::AccountWorkerResponseTimedOut,
                 ),
                 SyncFailureClassification::new(
-                    SyncFailureStage::TransportActivation,
+                    SyncFailureStage::AccountWorker,
                     SyncErrorClass::Timeout,
                 ),
             ),
@@ -851,6 +858,18 @@ mod tests {
         assert!(!serialized.contains("attacker-controlled"));
         assert!(!serialized.contains("account.sqlite"));
         assert!(!serialized.contains("raw relay detail"));
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "account sync/catch-up must use record_sync_result with a bounded failure classification"
+    )]
+    fn generic_record_rejects_classified_sync_operations() {
+        AppPerformanceTelemetry::default().record(
+            AppPerformanceOperation::AccountSync,
+            Duration::from_millis(1),
+            false,
+        );
     }
 
     #[test]

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -8,7 +8,7 @@ use storage_sqlite::clamp_to_max_future_skew;
 use tokio::time::timeout;
 use transport_nostr_peeler::NostrTransportEvent;
 
-use crate::app_telemetry::{AppPerformanceOperation, SyncErrorClass, SyncFailureStage};
+use crate::app_telemetry::{AppPerformanceOperation, SyncFailureStage};
 use crate::groups::{
     EventGroupProjection, decode_received_event, event_group_id, fail_if_publish_failed,
     observe_event,
@@ -405,12 +405,14 @@ impl AppClient {
         let drained = match self.drain_pending_session_events().await {
             Ok(drained) => drained,
             Err(error) => {
-                let stage = if error.sync_error_class() == SyncErrorClass::Storage {
-                    SyncFailureStage::StatePersist
-                } else {
-                    SyncFailureStage::CgkaIngest
-                };
-                return Err(SyncFailure::at_stage(summary, error, stage));
+                // This composite drain spans engine drain, app-state reads,
+                // publish checks, and projection. Its AppError does not retain
+                // the inner boundary, so do not infer a stage from the cause.
+                return Err(SyncFailure::at_stage(
+                    summary,
+                    error,
+                    SyncFailureStage::Unknown,
+                ));
             }
         };
         summary.merge(drained);
@@ -788,12 +790,10 @@ impl AppClient {
     }
 
     async fn sync_sdk_relay(&mut self, deliveries: &mut u64) -> Result<SyncSummary, SyncFailure> {
+        // These are local app-state reads before the relay receive loop. They
+        // are not failures of the account-worker command boundary.
         let display_names = self.app.display_names_by_id().map_err(|error| {
-            SyncFailure::at_stage(
-                SyncSummary::default(),
-                error,
-                SyncFailureStage::AccountWorker,
-            )
+            SyncFailure::at_stage(SyncSummary::default(), error, SyncFailureStage::Unknown)
         })?;
         let local_account_id_hex = self
             .app
@@ -803,7 +803,7 @@ impl AppClient {
                 SyncFailure::at_stage(
                     SyncSummary::default(),
                     AppError::from(source),
-                    SyncFailureStage::AccountWorker,
+                    SyncFailureStage::Unknown,
                 )
             })?
             .account_id_hex;
@@ -1618,12 +1618,15 @@ impl AppClient {
                     .run_pending_epoch_backfill(EpochBackfillExecutionSeam::ExplicitCatchUp)
                     .await
                     .map_err(|error| {
-                        let stage = if error.sync_error_class() == SyncErrorClass::Storage {
-                            SyncFailureStage::StatePersist
-                        } else {
-                            SyncFailureStage::CgkaIngest
-                        };
-                        SyncFailure::at_stage(SyncSummary::default(), error, stage)
+                        // The backfill's AppError no longer carries which of
+                        // its activation, subscription, drain, or projection
+                        // boundaries failed. Keep the cause, but do not invent
+                        // a stage from it.
+                        SyncFailure::at_stage(
+                            SyncSummary::default(),
+                            error,
+                            SyncFailureStage::Unknown,
+                        )
                     })? {
                     EpochBackfillRunOutcome::Completed(summary) => return Ok(summary),
                     EpochBackfillRunOutcome::Deferred => continue,
@@ -1655,12 +1658,12 @@ impl AppClient {
         let drained = match self.drain_pending_session_events().await {
             Ok(drained) => drained,
             Err(error) => {
-                let stage = if error.sync_error_class() == SyncErrorClass::Storage {
-                    SyncFailureStage::StatePersist
-                } else {
-                    SyncFailureStage::CgkaIngest
-                };
-                return Err(SyncFailure::at_stage(summary, error, stage));
+                // As above, this composite drain has lost its inner boundary.
+                return Err(SyncFailure::at_stage(
+                    summary,
+                    error,
+                    SyncFailureStage::Unknown,
+                ));
             }
         };
         summary.merge(drained);

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -17,8 +17,8 @@ use crate::media::media_imeta_tags_are_valid;
 use crate::notifications;
 use crate::{
     AccountState, AppError, AppGroupAdminPolicyComponent, AppMessageProjection,
-    AppPerformanceTelemetry, SDK_DRAIN_WAIT, SDK_FIRST_SYNC_WAIT, SelfMembership, SyncFailure,
-    SyncSummary, TRANSPORT_CURSOR_MAX_FUTURE_SKEW, unix_now_seconds,
+    AppPerformanceTelemetry, ClassifiedSyncFailure, SDK_DRAIN_WAIT, SDK_FIRST_SYNC_WAIT,
+    SelfMembership, SyncFailure, SyncSummary, TRANSPORT_CURSOR_MAX_FUTURE_SKEW, unix_now_seconds,
 };
 use marmot_forensics::{
     AuditEventContext, EpochBackfillActivationOutcome, EpochBackfillDeferredReason,
@@ -329,6 +329,14 @@ impl AppClient {
 
     /// Synchronize while retaining the durably applied prefix on failure.
     pub async fn sync_with_partial_progress(&mut self) -> Result<SyncSummary, SyncFailure> {
+        self.sync_with_classified_partial_progress()
+            .await
+            .map_err(SyncFailure::from)
+    }
+
+    pub(crate) async fn sync_with_classified_partial_progress(
+        &mut self,
+    ) -> Result<SyncSummary, ClassifiedSyncFailure> {
         match self.sync_inner(None).await {
             Ok(summary) => Ok(summary),
             Err(mut failure) => {
@@ -341,7 +349,7 @@ impl AppClient {
     pub(crate) async fn sync_with_startup_stage_telemetry(
         &mut self,
         telemetry: &AppPerformanceTelemetry,
-    ) -> Result<SyncSummary, SyncFailure> {
+    ) -> Result<SyncSummary, ClassifiedSyncFailure> {
         match self.sync_inner(Some(telemetry)).await {
             Ok(summary) => Ok(summary),
             Err(mut failure) => {
@@ -354,12 +362,12 @@ impl AppClient {
     async fn sync_inner(
         &mut self,
         telemetry: Option<&AppPerformanceTelemetry>,
-    ) -> Result<SyncSummary, SyncFailure> {
+    ) -> Result<SyncSummary, ClassifiedSyncFailure> {
         // Reconcile epoch-bounded prior routes before issuing the first relay
         // subscriptions. This makes retirement deterministic even for a quiet
         // group that has no new inbound events after restart.
         let refresh = self.refresh_group_routes().map_err(|error| {
-            SyncFailure::at_stage(
+            ClassifiedSyncFailure::at_stage(
                 SyncSummary::default(),
                 error,
                 SyncFailureStage::StatePersist,
@@ -371,7 +379,7 @@ impl AppClient {
         if refresh.state_pruned {
             self.save_state_with_pending_local_group_deletion_frontier_clears()
                 .map_err(|error| {
-                    SyncFailure::at_stage(
+                    ClassifiedSyncFailure::at_stage(
                         SyncSummary::default(),
                         error,
                         SyncFailureStage::StatePersist,
@@ -385,7 +393,7 @@ impl AppClient {
         self.prepare_transport_for_sync(telemetry)
             .await
             .map_err(|(stage, error)| {
-                SyncFailure::at_stage(SyncSummary::default(), error, stage)
+                ClassifiedSyncFailure::at_stage(SyncSummary::default(), error, stage)
             })?;
         // A complete startup/catch-up rebuild satisfies any older deferred
         // refresh intent before this pass starts ingesting new deliveries.
@@ -408,7 +416,7 @@ impl AppClient {
                 // This composite drain spans engine drain, app-state reads,
                 // publish checks, and projection. Its AppError does not retain
                 // the inner boundary, so do not infer a stage from the cause.
-                return Err(SyncFailure::at_stage(
+                return Err(ClassifiedSyncFailure::at_stage(
                     summary,
                     error,
                     SyncFailureStage::Unknown,
@@ -789,18 +797,41 @@ impl AppClient {
         Ok(summary)
     }
 
-    async fn sync_sdk_relay(&mut self, deliveries: &mut u64) -> Result<SyncSummary, SyncFailure> {
+    fn checkpoint_error_stage_and_cursor(
+        &self,
+        error: &SyncCheckpointError,
+        cursor_before_secs: Option<u64>,
+    ) -> (SyncFailureStage, Option<u64>) {
+        match error {
+            SyncCheckpointError::BeforePersistence(_) => {
+                (SyncFailureStage::StatePersist, cursor_before_secs)
+            }
+            SyncCheckpointError::AfterPersistence(_) => (
+                SyncFailureStage::GroupSubscriptionSync,
+                self.state.last_transport_timestamp,
+            ),
+        }
+    }
+
+    async fn sync_sdk_relay(
+        &mut self,
+        deliveries: &mut u64,
+    ) -> Result<SyncSummary, ClassifiedSyncFailure> {
         // These are local app-state reads before the relay receive loop. They
         // are not failures of the account-worker command boundary.
         let display_names = self.app.display_names_by_id().map_err(|error| {
-            SyncFailure::at_stage(SyncSummary::default(), error, SyncFailureStage::Unknown)
+            ClassifiedSyncFailure::at_stage(
+                SyncSummary::default(),
+                error,
+                SyncFailureStage::Unknown,
+            )
         })?;
         let local_account_id_hex = self
             .app
             .account_home()
             .account(&self.state.label)
             .map_err(|source| {
-                SyncFailure::at_stage(
+                ClassifiedSyncFailure::at_stage(
                     SyncSummary::default(),
                     AppError::from(source),
                     SyncFailureStage::Unknown,
@@ -899,14 +930,8 @@ impl AppClient {
             .checkpoint_sync_prefix(&mut summary, routes_dirty, *deliveries)
             .await
         {
-            let stage = match &error {
-                SyncCheckpointError::BeforePersistence(_) => SyncFailureStage::StatePersist,
-                SyncCheckpointError::AfterPersistence(_) => SyncFailureStage::GroupSubscriptionSync,
-            };
-            let cursor_after_secs = match &error {
-                SyncCheckpointError::BeforePersistence(_) => cursor_before_secs,
-                SyncCheckpointError::AfterPersistence(_) => self.state.last_transport_timestamp,
-            };
+            let (stage, cursor_after_secs) =
+                self.checkpoint_error_stage_and_cursor(&error, cursor_before_secs);
             let (summary, source) = self.checkpoint_failure_summary(summary, error);
             self.record_sync_drain(
                 drain_started.elapsed().as_millis() as u64,
@@ -914,7 +939,7 @@ impl AppClient {
                 cursor_before_secs,
                 cursor_after_secs,
             );
-            return Err(SyncFailure::at_stage(summary, source, stage));
+            return Err(ClassifiedSyncFailure::at_stage(summary, source, stage));
         }
         self.record_sync_drain(
             drain_started.elapsed().as_millis() as u64,
@@ -933,7 +958,7 @@ impl AppClient {
         original: StagedSyncError,
         drain_started: std::time::Instant,
         cursor_before_secs: Option<u64>,
-    ) -> SyncFailure {
+    ) -> ClassifiedSyncFailure {
         let (source, stage, cursor_after_secs) = match self
             .checkpoint_sync_prefix(&mut summary, routes_dirty, deliveries)
             .await
@@ -944,16 +969,8 @@ impl AppClient {
                 self.state.last_transport_timestamp,
             ),
             Err(error) => {
-                let stage = match &error {
-                    SyncCheckpointError::BeforePersistence(_) => SyncFailureStage::StatePersist,
-                    SyncCheckpointError::AfterPersistence(_) => {
-                        SyncFailureStage::GroupSubscriptionSync
-                    }
-                };
-                let cursor_after_secs = match &error {
-                    SyncCheckpointError::BeforePersistence(_) => cursor_before_secs,
-                    SyncCheckpointError::AfterPersistence(_) => self.state.last_transport_timestamp,
-                };
+                let (stage, cursor_after_secs) =
+                    self.checkpoint_error_stage_and_cursor(&error, cursor_before_secs);
                 let (retained_summary, checkpoint_error) =
                     self.checkpoint_failure_summary(summary, error);
                 summary = retained_summary;
@@ -966,7 +983,7 @@ impl AppClient {
             cursor_before_secs,
             cursor_after_secs,
         );
-        SyncFailure::at_stage(summary, source, stage)
+        ClassifiedSyncFailure::at_stage(summary, source, stage)
     }
 
     async fn checkpoint_sync_prefix(
@@ -1580,9 +1597,11 @@ impl AppClient {
     /// participant that has no new traffic capable of arming epoch-stall
     /// detection). Unlike the automatic detector path, this is a caller-owned
     /// operation and therefore does not mutate the detector's debounce state.
-    pub(crate) async fn repair_full_history(&mut self) -> Result<SyncSummary, SyncFailure> {
+    pub(crate) async fn repair_full_history(
+        &mut self,
+    ) -> Result<SyncSummary, ClassifiedSyncFailure> {
         let refresh = self.refresh_group_routes().map_err(|error| {
-            SyncFailure::at_stage(
+            ClassifiedSyncFailure::at_stage(
                 SyncSummary::default(),
                 error,
                 SyncFailureStage::StatePersist,
@@ -1593,7 +1612,7 @@ impl AppClient {
         if refresh.state_pruned {
             self.save_state_with_pending_local_group_deletion_frontier_clears()
                 .map_err(|error| {
-                    SyncFailure::at_stage(
+                    ClassifiedSyncFailure::at_stage(
                         SyncSummary::default(),
                         error,
                         SyncFailureStage::StatePersist,
@@ -1622,7 +1641,7 @@ impl AppClient {
                         // its activation, subscription, drain, or projection
                         // boundaries failed. Keep the cause, but do not invent
                         // a stage from it.
-                        SyncFailure::at_stage(
+                        ClassifiedSyncFailure::at_stage(
                             SyncSummary::default(),
                             error,
                             SyncFailureStage::Unknown,
@@ -1638,14 +1657,14 @@ impl AppClient {
             .activate_transport(None)
             .await
             .map_err(|source| {
-                SyncFailure::at_stage(
+                ClassifiedSyncFailure::at_stage(
                     SyncSummary::default(),
                     AppError::from(source),
                     SyncFailureStage::TransportActivation,
                 )
             })?;
         self.sync_runtime_groups().await.map_err(|error| {
-            SyncFailure::at_stage(
+            ClassifiedSyncFailure::at_stage(
                 SyncSummary::default(),
                 error,
                 SyncFailureStage::GroupSubscriptionSync,
@@ -1659,7 +1678,7 @@ impl AppClient {
             Ok(drained) => drained,
             Err(error) => {
                 // As above, this composite drain has lost its inner boundary.
-                return Err(SyncFailure::at_stage(
+                return Err(ClassifiedSyncFailure::at_stage(
                     summary,
                     error,
                     SyncFailureStage::Unknown,

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -8,7 +8,7 @@ use storage_sqlite::clamp_to_max_future_skew;
 use tokio::time::timeout;
 use transport_nostr_peeler::NostrTransportEvent;
 
-use crate::app_telemetry::AppPerformanceOperation;
+use crate::app_telemetry::{AppPerformanceOperation, SyncErrorClass, SyncFailureStage};
 use crate::groups::{
     EventGroupProjection, decode_received_event, event_group_id, fail_if_publish_failed,
     observe_event,
@@ -93,6 +93,17 @@ pub(crate) enum ConvergenceScheduleState {
 enum SyncCheckpointError {
     BeforePersistence(AppError),
     AfterPersistence(AppError),
+}
+
+struct StagedSyncError {
+    source: AppError,
+    stage: SyncFailureStage,
+}
+
+impl StagedSyncError {
+    fn new(source: AppError, stage: SyncFailureStage) -> Self {
+        Self { source, stage }
+    }
 }
 
 impl AppClient {
@@ -255,6 +266,15 @@ impl AppClient {
         &mut self,
         telemetry: Option<&AppPerformanceTelemetry>,
     ) -> Result<(), AppError> {
+        self.prepare_transport_for_sync(telemetry)
+            .await
+            .map_err(|(_, error)| error)
+    }
+
+    async fn prepare_transport_for_sync(
+        &mut self,
+        telemetry: Option<&AppPerformanceTelemetry>,
+    ) -> Result<(), (SyncFailureStage, AppError)> {
         // Before any subscription goes out: auth-gated relays (NIP-42)
         // withhold gift-wrapped welcomes from unauthenticated subscribers.
         let activation_started = Instant::now();
@@ -272,7 +292,8 @@ impl AppClient {
                 activation.is_ok(),
             );
         }
-        activation?;
+        activation
+            .map_err(|error| (SyncFailureStage::TransportActivation, AppError::from(error)))?;
 
         let registration_started = Instant::now();
         let registration = self.sync_runtime_groups().await;
@@ -283,7 +304,7 @@ impl AppClient {
                 registration.is_ok(),
             );
         }
-        registration
+        registration.map_err(|error| (SyncFailureStage::GroupSubscriptionSync, error))
     }
 
     /// Transport-first startup sync. All authenticated, newly-applied effects
@@ -337,21 +358,35 @@ impl AppClient {
         // Reconcile epoch-bounded prior routes before issuing the first relay
         // subscriptions. This makes retirement deterministic even for a quiet
         // group that has no new inbound events after restart.
-        let refresh = self.refresh_group_routes().map_err(SyncFailure::from)?;
+        let refresh = self.refresh_group_routes().map_err(|error| {
+            SyncFailure::at_stage(
+                SyncSummary::default(),
+                error,
+                SyncFailureStage::StatePersist,
+            )
+        })?;
         // A routing-table delta lives in memory and obligates the subscription
         // refresh below, not a state write; only route retirement mutates
         // persisted group state.
         if refresh.state_pruned {
             self.save_state_with_pending_local_group_deletion_frontier_clears()
-                .map_err(SyncFailure::from)?;
+                .map_err(|error| {
+                    SyncFailure::at_stage(
+                        SyncSummary::default(),
+                        error,
+                        SyncFailureStage::StatePersist,
+                    )
+                })?;
         }
         let rebuild_since_secs = self
             .relay_plane
             .subscription_rebuild_since(self.state.last_transport_timestamp)
             .map(|timestamp| timestamp.0);
-        self.prepare_transport_with_telemetry(telemetry)
+        self.prepare_transport_for_sync(telemetry)
             .await
-            .map_err(SyncFailure::from)?;
+            .map_err(|(stage, error)| {
+                SyncFailure::at_stage(SyncSummary::default(), error, stage)
+            })?;
         // A complete startup/catch-up rebuild satisfies any older deferred
         // refresh intent before this pass starts ingesting new deliveries.
         self.pending_runtime_group_subscription_refresh = false;
@@ -370,7 +405,12 @@ impl AppClient {
         let drained = match self.drain_pending_session_events().await {
             Ok(drained) => drained,
             Err(error) => {
-                return Err(SyncFailure::new(summary, error));
+                let stage = if error.sync_error_class() == SyncErrorClass::Storage {
+                    SyncFailureStage::StatePersist
+                } else {
+                    SyncFailureStage::CgkaIngest
+                };
+                return Err(SyncFailure::at_stage(summary, error, stage));
             }
         };
         summary.merge(drained);
@@ -748,12 +788,24 @@ impl AppClient {
     }
 
     async fn sync_sdk_relay(&mut self, deliveries: &mut u64) -> Result<SyncSummary, SyncFailure> {
-        let display_names = self.app.display_names_by_id().map_err(SyncFailure::from)?;
+        let display_names = self.app.display_names_by_id().map_err(|error| {
+            SyncFailure::at_stage(
+                SyncSummary::default(),
+                error,
+                SyncFailureStage::AccountWorker,
+            )
+        })?;
         let local_account_id_hex = self
             .app
             .account_home()
             .account(&self.state.label)
-            .map_err(|source| SyncFailure::from(AppError::from(source)))?
+            .map_err(|source| {
+                SyncFailure::at_stage(
+                    SyncSummary::default(),
+                    AppError::from(source),
+                    SyncFailureStage::AccountWorker,
+                )
+            })?
             .account_id_hex;
         let mut summary = SyncSummary::default();
         let mut first_wait = true;
@@ -782,7 +834,7 @@ impl AppClient {
                             summary,
                             routes_dirty,
                             *deliveries,
-                            error.into(),
+                            StagedSyncError::new(error.into(), SyncFailureStage::RelayReceive),
                             drain_started,
                             cursor_before_secs,
                         )
@@ -809,7 +861,10 @@ impl AppClient {
                         summary,
                         routes_dirty,
                         *deliveries,
-                        AppError::BlockingTask("injected catch-up delivery failure".to_owned()),
+                        StagedSyncError::new(
+                            AppError::BlockingTask("injected catch-up delivery failure".to_owned()),
+                            SyncFailureStage::Unknown,
+                        ),
                         drain_started,
                         cursor_before_secs,
                     )
@@ -827,7 +882,7 @@ impl AppClient {
                             summary,
                             routes_dirty,
                             *deliveries,
-                            error,
+                            StagedSyncError::new(error, SyncFailureStage::CgkaIngest),
                             drain_started,
                             cursor_before_secs,
                         )
@@ -844,6 +899,10 @@ impl AppClient {
             .checkpoint_sync_prefix(&mut summary, routes_dirty, *deliveries)
             .await
         {
+            let stage = match &error {
+                SyncCheckpointError::BeforePersistence(_) => SyncFailureStage::StatePersist,
+                SyncCheckpointError::AfterPersistence(_) => SyncFailureStage::GroupSubscriptionSync,
+            };
             let cursor_after_secs = match &error {
                 SyncCheckpointError::BeforePersistence(_) => cursor_before_secs,
                 SyncCheckpointError::AfterPersistence(_) => self.state.last_transport_timestamp,
@@ -855,7 +914,7 @@ impl AppClient {
                 cursor_before_secs,
                 cursor_after_secs,
             );
-            return Err(SyncFailure::new(summary, source));
+            return Err(SyncFailure::at_stage(summary, source, stage));
         }
         self.record_sync_drain(
             drain_started.elapsed().as_millis() as u64,
@@ -871,16 +930,26 @@ impl AppClient {
         mut summary: SyncSummary,
         routes_dirty: bool,
         deliveries: u64,
-        original_error: AppError,
+        original: StagedSyncError,
         drain_started: std::time::Instant,
         cursor_before_secs: Option<u64>,
     ) -> SyncFailure {
-        let (source, cursor_after_secs) = match self
+        let (source, stage, cursor_after_secs) = match self
             .checkpoint_sync_prefix(&mut summary, routes_dirty, deliveries)
             .await
         {
-            Ok(()) => (original_error, self.state.last_transport_timestamp),
+            Ok(()) => (
+                original.source,
+                original.stage,
+                self.state.last_transport_timestamp,
+            ),
             Err(error) => {
+                let stage = match &error {
+                    SyncCheckpointError::BeforePersistence(_) => SyncFailureStage::StatePersist,
+                    SyncCheckpointError::AfterPersistence(_) => {
+                        SyncFailureStage::GroupSubscriptionSync
+                    }
+                };
                 let cursor_after_secs = match &error {
                     SyncCheckpointError::BeforePersistence(_) => cursor_before_secs,
                     SyncCheckpointError::AfterPersistence(_) => self.state.last_transport_timestamp,
@@ -888,7 +957,7 @@ impl AppClient {
                 let (retained_summary, checkpoint_error) =
                     self.checkpoint_failure_summary(summary, error);
                 summary = retained_summary;
-                (checkpoint_error, cursor_after_secs)
+                (checkpoint_error, stage, cursor_after_secs)
             }
         };
         self.record_sync_drain(
@@ -897,7 +966,7 @@ impl AppClient {
             cursor_before_secs,
             cursor_after_secs,
         );
-        SyncFailure::new(summary, source)
+        SyncFailure::at_stage(summary, source, stage)
     }
 
     async fn checkpoint_sync_prefix(
@@ -1512,12 +1581,24 @@ impl AppClient {
     /// detection). Unlike the automatic detector path, this is a caller-owned
     /// operation and therefore does not mutate the detector's debounce state.
     pub(crate) async fn repair_full_history(&mut self) -> Result<SyncSummary, SyncFailure> {
-        let refresh = self.refresh_group_routes().map_err(SyncFailure::from)?;
+        let refresh = self.refresh_group_routes().map_err(|error| {
+            SyncFailure::at_stage(
+                SyncSummary::default(),
+                error,
+                SyncFailureStage::StatePersist,
+            )
+        })?;
         // As in `sync_inner`: save only for persisted-state pruning, not for
         // in-memory routing-table deltas.
         if refresh.state_pruned {
             self.save_state_with_pending_local_group_deletion_frontier_clears()
-                .map_err(SyncFailure::from)?;
+                .map_err(|error| {
+                    SyncFailure::at_stage(
+                        SyncSummary::default(),
+                        error,
+                        SyncFailureStage::StatePersist,
+                    )
+                })?;
         }
         // Caller-directed repair is a fresh transport preparation, not an
         // assumption that startup ordering already installed the signer and
@@ -1536,8 +1617,14 @@ impl AppClient {
                 match self
                     .run_pending_epoch_backfill(EpochBackfillExecutionSeam::ExplicitCatchUp)
                     .await
-                    .map_err(SyncFailure::from)?
-                {
+                    .map_err(|error| {
+                        let stage = if error.sync_error_class() == SyncErrorClass::Storage {
+                            SyncFailureStage::StatePersist
+                        } else {
+                            SyncFailureStage::CgkaIngest
+                        };
+                        SyncFailure::at_stage(SyncSummary::default(), error, stage)
+                    })? {
                     EpochBackfillRunOutcome::Completed(summary) => return Ok(summary),
                     EpochBackfillRunOutcome::Deferred => continue,
                     EpochBackfillRunOutcome::NotPending => break,
@@ -1547,17 +1634,34 @@ impl AppClient {
         self.runtime
             .activate_transport(None)
             .await
-            .map_err(|source| SyncFailure::from(AppError::from(source)))?;
-        self.sync_runtime_groups()
-            .await
-            .map_err(SyncFailure::from)?;
+            .map_err(|source| {
+                SyncFailure::at_stage(
+                    SyncSummary::default(),
+                    AppError::from(source),
+                    SyncFailureStage::TransportActivation,
+                )
+            })?;
+        self.sync_runtime_groups().await.map_err(|error| {
+            SyncFailure::at_stage(
+                SyncSummary::default(),
+                error,
+                SyncFailureStage::GroupSubscriptionSync,
+            )
+        })?;
         self.pending_runtime_group_subscription_refresh = false;
         self.record_subscription_rebuild(None).await;
         let mut deliveries = 0;
         let mut summary = self.sync_sdk_relay(&mut deliveries).await?;
         let drained = match self.drain_pending_session_events().await {
             Ok(drained) => drained,
-            Err(error) => return Err(SyncFailure::new(summary, error)),
+            Err(error) => {
+                let stage = if error.sync_error_class() == SyncErrorClass::Storage {
+                    SyncFailureStage::StatePersist
+                } else {
+                    SyncFailureStage::CgkaIngest
+                };
+                return Err(SyncFailure::at_stage(summary, error, stage));
+            }
         };
         summary.merge(drained);
         Ok(summary)

--- a/crates/marmot-app/src/error.rs
+++ b/crates/marmot-app/src/error.rs
@@ -2,6 +2,35 @@ use cgka_traits::{TransportAdapterError, storage::StorageError};
 use marmot_account::{AccountError, AccountHomeError};
 
 use crate::MissingRelayListKind;
+use crate::app_telemetry::{SyncErrorClass, SyncFailureClassification};
+
+/// Worker-safe account catch-up failure. The human-facing message remains for
+/// compatibility, while telemetry propagation uses only the closed
+/// classification value.
+#[derive(Clone, Debug)]
+pub struct AccountCatchUpFailure {
+    message: String,
+    classification: SyncFailureClassification,
+}
+
+impl AccountCatchUpFailure {
+    pub fn new(message: String, classification: SyncFailureClassification) -> Self {
+        Self {
+            message,
+            classification,
+        }
+    }
+
+    pub(crate) const fn classification(&self) -> SyncFailureClassification {
+        self.classification
+    }
+}
+
+impl std::fmt::Display for AccountCatchUpFailure {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.message.fmt(formatter)
+    }
+}
 
 #[derive(Debug, thiserror::Error)]
 pub enum AppError {
@@ -71,7 +100,7 @@ pub enum AppError {
     /// failures were once wrapped as relay-directory errors, which sent an
     /// earlier investigation chasing the wrong subsystem.
     #[error("account catch-up failed: {0}")]
-    AccountCatchUp(String),
+    AccountCatchUp(AccountCatchUpFailure),
     #[error("invalid Nostr public key")]
     InvalidPublicKey,
     #[error("this operation does not accept a private key")]
@@ -258,6 +287,27 @@ impl AppError {
         }
     }
 
+    /// Broad, bounded cause derived only from typed variants.
+    pub(crate) fn sync_error_class(&self) -> SyncErrorClass {
+        match self {
+            Self::Storage(_) | Self::Io(_) | Self::Sqlite(_) => SyncErrorClass::Storage,
+            Self::Session(error) => session_error_class(error),
+            Self::Account(error) => account_sync_error_class(error),
+            Self::Transport(error) => transport_error_class(error),
+            Self::RelayDirectory(_) => SyncErrorClass::RelayDirectory,
+            Self::AccountCatchUp(error) => error.classification().error_class,
+            Self::AccountWorkerResponseTimedOut => SyncErrorClass::Timeout,
+            Self::TransportClosed => SyncErrorClass::TransportClosed,
+            Self::RuntimeStopping | Self::ExternalSignerRejected => SyncErrorClass::Cancelled,
+            Self::Json(_)
+            | Self::Hex(_)
+            | Self::InvalidAppMessagePayload(_)
+            | Self::InvalidNostrRouting(_)
+            | Self::InvalidKeyPackageEvent(_) => SyncErrorClass::Protocol,
+            _ => SyncErrorClass::Unknown,
+        }
+    }
+
     pub fn as_engine_error(&self) -> Option<&cgka_traits::error::EngineError> {
         match self {
             Self::Account(marmot_account::AccountError::Engine(err))
@@ -267,6 +317,59 @@ impl AppError {
             | Self::Session(cgka_session::SessionError::Engine(err)) => Some(err),
             _ => None,
         }
+    }
+}
+
+fn transport_error_class(error: &TransportAdapterError) -> SyncErrorClass {
+    match error {
+        TransportAdapterError::Timeout => SyncErrorClass::Timeout,
+        TransportAdapterError::Closed => SyncErrorClass::TransportClosed,
+        TransportAdapterError::InvalidInboundEncoding
+        | TransportAdapterError::InvalidInboundSignature
+        | TransportAdapterError::PublishTargetMismatch { .. } => SyncErrorClass::Protocol,
+        _ => SyncErrorClass::Unknown,
+    }
+}
+
+fn account_sync_error_class(error: &AccountError) -> SyncErrorClass {
+    match error {
+        AccountError::Session(error) => session_error_class(error),
+        AccountError::Engine(error) => engine_error_class(error),
+        AccountError::Transport(error) => transport_error_class(error),
+        AccountError::TransportRouting(_) | AccountError::WrongAccountDelivery => {
+            SyncErrorClass::Protocol
+        }
+        _ => SyncErrorClass::Unknown,
+    }
+}
+
+fn session_error_class(error: &cgka_session::SessionError) -> SyncErrorClass {
+    match error {
+        cgka_session::SessionError::Storage(_) => SyncErrorClass::Storage,
+        cgka_session::SessionError::Engine(error) => engine_error_class(error),
+    }
+}
+
+fn engine_error_class(error: &cgka_traits::error::EngineError) -> SyncErrorClass {
+    use cgka_traits::error::{EngineError, PeelerError};
+
+    match error {
+        EngineError::Storage(_) => SyncErrorClass::Storage,
+        EngineError::Peeler(
+            PeelerError::DecryptFailed
+            | PeelerError::MissingContext { .. }
+            | PeelerError::InvalidSignature,
+        ) => SyncErrorClass::Crypto,
+        EngineError::Peeler(_)
+        | EngineError::InvalidCredentialIdentity(_)
+        | EngineError::InvalidAppMessagePayload(_)
+        | EngineError::InvalidAccountIdentityProof(_)
+        | EngineError::InvalidKeyPackageLifetime { .. }
+        | EngineError::InvalidWelcome
+        | EngineError::Serialize(_)
+        | EngineError::ForkedEpoch { .. }
+        | EngineError::InvalidTransition(_) => SyncErrorClass::Protocol,
+        _ => SyncErrorClass::Unknown,
     }
 }
 
@@ -326,7 +429,8 @@ fn storage_error_kind(error: &StorageError) -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use super::AppError;
+    use super::{AccountCatchUpFailure, AppError};
+    use crate::SyncFailureClassification;
 
     // Kind strings leave the runtime: `account_error_message` interpolates
     // them into messages the CLI daemon persists and host apps log. Pin the
@@ -334,7 +438,10 @@ mod tests {
     // the label operators will grep for after the RelayDirectory mislabel.
     #[test]
     fn account_catch_up_kind_is_stable() {
-        let err = AppError::AccountCatchUp("runtime catch-up failed: account_session".into());
+        let err = AppError::AccountCatchUp(AccountCatchUpFailure::new(
+            "runtime catch-up failed: account_session".into(),
+            SyncFailureClassification::UNKNOWN,
+        ));
         assert_eq!(err.privacy_safe_kind(), "account_catch_up");
         assert_eq!(
             err.to_string(),

--- a/crates/marmot-app/src/error.rs
+++ b/crates/marmot-app/src/error.rs
@@ -322,7 +322,6 @@ impl AppError {
 
 fn transport_error_class(error: &TransportAdapterError) -> SyncErrorClass {
     match error {
-        TransportAdapterError::Timeout => SyncErrorClass::Timeout,
         TransportAdapterError::Closed => SyncErrorClass::TransportClosed,
         TransportAdapterError::InvalidInboundEncoding
         | TransportAdapterError::InvalidInboundSignature

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -128,7 +128,8 @@ pub use agent_streams::{
 };
 pub use app_telemetry::{
     AppPerformanceOperationSnapshot, AppPerformanceSnapshot, AppPerformanceTelemetry,
-    HostPerformanceOperation, HostPerformanceOutcome,
+    HostPerformanceOperation, HostPerformanceOutcome, SyncErrorClass, SyncFailureClassification,
+    SyncFailureCount, SyncFailureStage,
 };
 pub use audit_log::{
     AuditLogDeleteOutcome, AuditLogFile, AuditLogSettings, AuditLogTrackerUpdateResult,
@@ -151,7 +152,7 @@ pub use directory::{
 pub use drafts::{
     MessageDraft, MessageDraftAttachment, MessageDraftAttachmentSummary, MessageDraftSummary,
 };
-pub use error::AppError;
+pub use error::{AccountCatchUpFailure, AppError};
 pub use groups::{
     AppAgentTextStreamComponent, AppBlobEndpoint, AppDisbandFailureReason, AppDisbandRequest,
     AppGroupAdminPolicyComponent, AppGroupAvatarUrlComponent, AppGroupEncryptedMediaComponent,
@@ -724,14 +725,36 @@ pub struct SyncFailure {
     pub partial_summary: SyncSummary,
     #[source]
     pub source: AppError,
+    classification: app_telemetry::SyncFailureClassification,
 }
 
 impl SyncFailure {
     pub fn new(partial_summary: SyncSummary, source: AppError) -> Self {
+        Self::at_stage(
+            partial_summary,
+            source,
+            app_telemetry::SyncFailureStage::Unknown,
+        )
+    }
+
+    pub(crate) fn at_stage(
+        partial_summary: SyncSummary,
+        source: AppError,
+        failure_stage: app_telemetry::SyncFailureStage,
+    ) -> Self {
+        let error_class = source.sync_error_class();
         Self {
             partial_summary,
             source,
+            classification: app_telemetry::SyncFailureClassification::new(
+                failure_stage,
+                error_class,
+            ),
         }
+    }
+
+    pub(crate) const fn classification(&self) -> app_telemetry::SyncFailureClassification {
+        self.classification
     }
 }
 

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -725,18 +725,35 @@ pub struct SyncFailure {
     pub partial_summary: SyncSummary,
     #[source]
     pub source: AppError,
-    classification: app_telemetry::SyncFailureClassification,
 }
 
 impl SyncFailure {
     pub fn new(partial_summary: SyncSummary, source: AppError) -> Self {
-        Self::at_stage(
+        Self {
             partial_summary,
             source,
-            app_telemetry::SyncFailureStage::Unknown,
-        )
+        }
     }
+}
 
+impl From<AppError> for SyncFailure {
+    fn from(source: AppError) -> Self {
+        Self::new(SyncSummary::default(), source)
+    }
+}
+
+/// Internal sync failure that retains the bounded telemetry classification.
+///
+/// The sidecar is deliberately separate from [`SyncFailure`] so the public
+/// two-field struct remains constructible by downstream callers.
+#[derive(Debug)]
+pub(crate) struct ClassifiedSyncFailure {
+    pub(crate) partial_summary: SyncSummary,
+    pub(crate) source: AppError,
+    classification: app_telemetry::SyncFailureClassification,
+}
+
+impl ClassifiedSyncFailure {
     pub(crate) fn at_stage(
         partial_summary: SyncSummary,
         source: AppError,
@@ -758,9 +775,12 @@ impl SyncFailure {
     }
 }
 
-impl From<AppError> for SyncFailure {
-    fn from(source: AppError) -> Self {
-        Self::new(SyncSummary::default(), source)
+impl From<ClassifiedSyncFailure> for SyncFailure {
+    fn from(failure: ClassifiedSyncFailure) -> Self {
+        Self {
+            partial_summary: failure.partial_summary,
+            source: failure.source,
+        }
     }
 }
 

--- a/crates/marmot-app/src/relay_telemetry_export.rs
+++ b/crates/marmot-app/src/relay_telemetry_export.rs
@@ -13,9 +13,10 @@
 //!   is the single construction gate: it returns `None` unless export is
 //!   enabled and a full metrics URL, bearer token, and resource metadata are
 //!   configured. No exporter, no resolution, no push.
-//! - **Relay identity is the only label (req. 3).** The export batch is a flat
-//!   list of [`ExportMetricPoint`]s, each of which can carry at most a single
-//!   `relay` label and nothing else — there is deliberately no field for an
+//! - **Labels are structurally bounded.** The export batch is a flat list of
+//!   [`ExportMetricPoint`]s. Relay points can carry only `relay`; account
+//!   sync/catch-up failure points can carry only the closed `failure_stage`
+//!   and `error_class` enums. There is deliberately no field for an
 //!   account, member, device, group, subscription, pubkey, message, event, or
 //!   IP value, so a forbidden label cannot be attached.
 //! - **Aggregate only (req. 4).** Point values are monotonic counters, gauges,
@@ -29,7 +30,9 @@
 
 use transport_nostr_adapter::{DurationHistogramSnapshot, RelayIndex, RelayLabelResolution};
 
-use crate::app_telemetry::{AppPerformanceOperationSnapshot, AppPerformanceSnapshot};
+use crate::app_telemetry::{
+    AppPerformanceOperationSnapshot, AppPerformanceSnapshot, SyncFailureClassification,
+};
 use crate::config::RelayTelemetryExportConfig;
 use crate::relay_plane::{EngineReorgMetrics, MarmotRelayPlane, RelayTelemetryRollup};
 
@@ -531,9 +534,12 @@ pub enum ExportMetricValue {
 pub struct ExportMetricPoint {
     /// Metric name from [`metric_names`].
     pub name: &'static str,
-    /// Relay-identity label (a relay URL), or `None` for population-level
-    /// metrics. The sole label permitted to leave the device.
+    /// Relay-identity label (a relay URL), or `None` for population-level and
+    /// classified app failure metrics.
     pub relay: Option<String>,
+    /// Closed sync/catch-up failure attributes, or `None` for every other
+    /// metric point.
+    pub failure: Option<SyncFailureClassification>,
     /// The aggregate value.
     pub value: ExportMetricValue,
 }
@@ -618,6 +624,7 @@ pub fn build_export_batch(
         points.push(ExportMetricPoint {
             name: metric_names::FIRST_EVENT_LATENCY,
             relay: Some(relay.clone()),
+            failure: None,
             value: ExportMetricValue::Histogram(ExportHistogram::from_snapshot(
                 &entry.first_event_latency,
             )),
@@ -625,6 +632,7 @@ pub fn build_export_batch(
         points.push(ExportMetricPoint {
             name: metric_names::EOSE_LATENCY,
             relay: Some(relay.clone()),
+            failure: None,
             value: ExportMetricValue::Histogram(ExportHistogram::from_snapshot(
                 &entry.eose_latency,
             )),
@@ -632,17 +640,20 @@ pub fn build_export_batch(
         points.push(ExportMetricPoint {
             name: metric_names::DELIVERY_COUNT,
             relay: Some(relay.clone()),
+            failure: None,
             value: ExportMetricValue::Counter(entry.delivery_count()),
         });
         points.push(ExportMetricPoint {
             name: metric_names::REDUNDANT_COUNT,
             relay: Some(relay.clone()),
+            failure: None,
             value: ExportMetricValue::Counter(entry.redundant_count()),
         });
         if let Some(rate) = entry.first_deliverer_rate() {
             points.push(ExportMetricPoint {
                 name: metric_names::FIRST_DELIVERER_RATE,
                 relay: Some(relay),
+                failure: None,
                 value: ExportMetricValue::Gauge(rate),
             });
         }
@@ -652,6 +663,7 @@ pub fn build_export_batch(
     points.push(ExportMetricPoint {
         name: metric_names::CROSS_RELAY_SPREAD,
         relay: None,
+        failure: None,
         value: ExportMetricValue::Histogram(ExportHistogram::from_snapshot(
             &rollup.cross_relay_spread,
         )),
@@ -681,6 +693,7 @@ pub fn build_export_batch(
         points.push(ExportMetricPoint {
             name,
             relay: None,
+            failure: None,
             value: ExportMetricValue::Counter(value),
         });
     }
@@ -689,23 +702,27 @@ pub fn build_export_batch(
         points.push(ExportMetricPoint {
             name: metric_names::SETTLES,
             relay: None,
+            failure: None,
             value: ExportMetricValue::Counter(engine.settles),
         });
         points.push(ExportMetricPoint {
             name: metric_names::POST_SETTLE_REORGS,
             relay: None,
+            failure: None,
             value: ExportMetricValue::Counter(engine.post_settle_reorgs),
         });
         if let Some(rate) = rollup.observed_reorg_rate() {
             points.push(ExportMetricPoint {
                 name: metric_names::OBSERVED_REORG_RATE,
                 relay: None,
+                failure: None,
                 value: ExportMetricValue::Gauge(rate),
             });
         }
         points.push(ExportMetricPoint {
             name: metric_names::REORG_LATENESS,
             relay: None,
+            failure: None,
             value: ExportMetricValue::Histogram(ExportHistogram::from_snapshot(
                 &engine.reorg_lateness_ms,
             )),
@@ -1095,6 +1112,7 @@ fn append_app_performance_points(
         points.push(ExportMetricPoint {
             name,
             relay: None,
+            failure: None,
             value: ExportMetricValue::Counter(value),
         });
     }
@@ -1111,17 +1129,53 @@ fn append_app_operation_points(
     points.push(ExportMetricPoint {
         name: duration_name,
         relay: None,
+        failure: None,
         value: ExportMetricValue::Histogram(ExportHistogram::from_snapshot(&operation.duration_ms)),
     });
     for (name, value) in [
         (attempts_name, operation.attempts),
         (successes_name, operation.successes),
-        (failures_name, operation.failures),
     ] {
         points.push(ExportMetricPoint {
             name,
             relay: None,
+            failure: None,
             value: ExportMetricValue::Counter(value),
+        });
+    }
+    let classified_metric = failures_name == metric_names::APP_ACCOUNT_SYNC_FAILURES
+        || failures_name == metric_names::APP_ACCOUNT_CATCH_UP_FAILURES;
+    if !classified_metric {
+        points.push(ExportMetricPoint {
+            name: failures_name,
+            relay: None,
+            failure: None,
+            value: ExportMetricValue::Counter(operation.failures),
+        });
+        return;
+    }
+    let classified_failures = operation
+        .failure_classifications
+        .iter()
+        .map(|entry| entry.count)
+        .sum::<u64>();
+    for entry in &operation.failure_classifications {
+        points.push(ExportMetricPoint {
+            name: failures_name,
+            relay: None,
+            failure: Some(entry.classification),
+            value: ExportMetricValue::Counter(entry.count),
+        });
+    }
+    // Backward-compatible snapshots, and any legacy internal recorder call,
+    // cannot supply a typed classification. Preserve their count explicitly
+    // as the bounded fallback instead of dropping it.
+    if classified_failures < operation.failures {
+        points.push(ExportMetricPoint {
+            name: failures_name,
+            relay: None,
+            failure: Some(SyncFailureClassification::UNKNOWN),
+            value: ExportMetricValue::Counter(operation.failures - classified_failures),
         });
     }
 }
@@ -1263,17 +1317,22 @@ mod otlp {
             .unwrap_or_default()
     }
 
-    fn relay_attributes(relay: &Option<String>) -> Vec<KeyValue> {
-        match relay {
-            Some(relay) => vec![KeyValue {
+    fn point_attributes(point: &super::ExportMetricPoint) -> Vec<KeyValue> {
+        if let Some(relay) = &point.relay {
+            return vec![KeyValue {
                 key: "relay".to_owned(),
                 value: Some(AnyValue {
                     value: Some(any_value::Value::StringValue(relay.clone())),
                 }),
                 ..Default::default()
-            }],
-            None => Vec::new(),
+            }];
         }
+        point.failure.map_or_else(Vec::new, |failure| {
+            vec![
+                string_key_value("failure_stage", failure.failure_stage.as_str()),
+                string_key_value("error_class", failure.error_class.as_str()),
+            ]
+        })
     }
 
     fn string_key_value(key: &str, value: impl Into<String>) -> KeyValue {
@@ -1328,7 +1387,7 @@ mod otlp {
             .points
             .iter()
             .map(|point| {
-                let attributes = relay_attributes(&point.relay);
+                let attributes = point_attributes(point);
                 let data = match &point.value {
                     ExportMetricValue::Counter(value) => metric::Data::Sum(Sum {
                         data_points: vec![NumberDataPoint {
@@ -1443,6 +1502,7 @@ mod otlp {
     #[cfg(test)]
     mod tests {
         use super::*;
+        use crate::app_telemetry::{SyncErrorClass, SyncFailureClassification, SyncFailureStage};
         use crate::config::RelayTelemetryResource;
         use crate::relay_telemetry_export::{
             ExportHistogram, ExportMetricPoint, ExportMetricValue, RelayTelemetryExportBatch,
@@ -1456,22 +1516,34 @@ mod otlp {
                     ExportMetricPoint {
                         name: metric_names::DELIVERY_COUNT,
                         relay: Some("wss://a.example".into()),
+                        failure: None,
                         value: ExportMetricValue::Counter(7),
                     },
                     ExportMetricPoint {
                         name: metric_names::FIRST_DELIVERER_RATE,
                         relay: Some("wss://a.example".into()),
+                        failure: None,
                         value: ExportMetricValue::Gauge(0.5),
                     },
                     ExportMetricPoint {
                         name: metric_names::CROSS_RELAY_SPREAD,
                         relay: None,
+                        failure: None,
                         value: ExportMetricValue::Histogram(ExportHistogram {
                             bounds_ms: vec![10, 50],
                             bucket_counts: vec![1, 2],
                             overflow_count: 3,
                             sum_ms: 123,
                         }),
+                    },
+                    ExportMetricPoint {
+                        name: metric_names::APP_ACCOUNT_SYNC_FAILURES,
+                        relay: None,
+                        failure: Some(SyncFailureClassification::new(
+                            SyncFailureStage::CgkaIngest,
+                            SyncErrorClass::Protocol,
+                        )),
+                        value: ExportMetricValue::Counter(2),
                     },
                 ],
             };
@@ -1522,11 +1594,30 @@ mod otlp {
 
             let scope_metrics = &request.resource_metrics[0].scope_metrics[0];
             assert_eq!(scope_metrics.scope.as_ref().unwrap().name, SCOPE_NAME);
-            assert_eq!(scope_metrics.metrics.len(), 3);
+            assert_eq!(scope_metrics.metrics.len(), 4);
             assert_eq!(scope_metrics.metrics[0].unit, "1");
             assert_eq!(scope_metrics.metrics[1].unit, "1");
             assert_eq!(scope_metrics.metrics[2].name, "cross_relay_spread_ms");
             assert_eq!(scope_metrics.metrics[2].unit, "ms");
+            let classified = match &scope_metrics.metrics[3].data {
+                Some(metric::Data::Sum(sum)) => &sum.data_points[0],
+                other => panic!("expected classified failure sum, got {other:?}"),
+            };
+            let attribute = |key: &str| {
+                classified
+                    .attributes
+                    .iter()
+                    .find(|attribute| attribute.key == key)
+                    .and_then(|attribute| attribute.value.as_ref())
+                    .and_then(|value| value.value.as_ref())
+                    .map(|value| match value {
+                        any_value::Value::StringValue(value) => value.as_str(),
+                        other => panic!("expected string failure attr, got {other:?}"),
+                    })
+            };
+            assert_eq!(attribute("failure_stage"), Some("cgka_ingest"));
+            assert_eq!(attribute("error_class"), Some("protocol"));
+            assert_eq!(classified.attributes.len(), 2);
 
             // Counter -> monotonic cumulative Sum, carrying the relay label.
             let sum = match &scope_metrics.metrics[0].data {

--- a/crates/marmot-app/src/relay_telemetry_export.rs
+++ b/crates/marmot-app/src/relay_telemetry_export.rs
@@ -1143,9 +1143,7 @@ fn append_app_operation_points(
             value: ExportMetricValue::Counter(value),
         });
     }
-    let classified_metric = failures_name == metric_names::APP_ACCOUNT_SYNC_FAILURES
-        || failures_name == metric_names::APP_ACCOUNT_CATCH_UP_FAILURES;
-    if !classified_metric {
+    if operation.failure_classifications.is_empty() {
         points.push(ExportMetricPoint {
             name: failures_name,
             relay: None,
@@ -1167,9 +1165,8 @@ fn append_app_operation_points(
             value: ExportMetricValue::Counter(entry.count),
         });
     }
-    // Backward-compatible snapshots, and any legacy internal recorder call,
-    // cannot supply a typed classification. Preserve their count explicitly
-    // as the bounded fallback instead of dropping it.
+    // Preserve any count not represented by the supplied classification
+    // entries as the bounded fallback instead of dropping it.
     if classified_failures < operation.failures {
         points.push(ExportMetricPoint {
             name: failures_name,

--- a/crates/marmot-app/src/relay_telemetry_export/tests.rs
+++ b/crates/marmot-app/src/relay_telemetry_export/tests.rs
@@ -1,7 +1,10 @@
 use cgka_traits::TransportEndpoint;
 use transport_nostr_adapter::HistogramBucket;
 
-use crate::app_telemetry::{AppPerformanceOperationSnapshot, AppPerformanceSnapshot};
+use crate::app_telemetry::{
+    AppPerformanceOperationSnapshot, AppPerformanceSnapshot, SyncErrorClass,
+    SyncFailureClassification, SyncFailureCount, SyncFailureStage,
+};
 use crate::config::{RelayTelemetryResource, RelayTelemetryRuntimeConfig};
 use crate::relay_plane::{EngineReorgMetrics, RelayRollupEntry, RelayTelemetryRollup};
 
@@ -216,55 +219,77 @@ fn build_export_batch_appends_unlabeled_app_performance_metrics() {
             attempts: 3,
             successes: 2,
             failures: 1,
+            failure_classifications: Vec::new(),
             duration_ms: hist(2),
         },
         group_invite_engine_publish: AppPerformanceOperationSnapshot {
             attempts: 1,
             successes: 1,
             failures: 0,
+            failure_classifications: Vec::new(),
             duration_ms: hist(4),
         },
         group_details_read: AppPerformanceOperationSnapshot {
             attempts: 2,
             successes: 2,
             failures: 0,
+            failure_classifications: Vec::new(),
             duration_ms: hist(1),
         },
         chat_list_row_read: AppPerformanceOperationSnapshot {
             attempts: 3,
             successes: 3,
             failures: 0,
+            failure_classifications: Vec::new(),
             duration_ms: hist(1),
         },
         group_roster_read: AppPerformanceOperationSnapshot {
             attempts: 1,
             successes: 1,
             failures: 0,
+            failure_classifications: Vec::new(),
             duration_ms: hist(1),
         },
         group_accept_invite: AppPerformanceOperationSnapshot {
             attempts: 2,
             successes: 1,
             failures: 1,
+            failure_classifications: Vec::new(),
             duration_ms: hist(3),
         },
         host_splash_ready: AppPerformanceOperationSnapshot {
             attempts: 1,
             successes: 1,
             failures: 0,
+            failure_classifications: Vec::new(),
             duration_ms: hist(5),
         },
         account_transport_activation: AppPerformanceOperationSnapshot {
             attempts: 1,
             successes: 1,
             failures: 0,
+            failure_classifications: Vec::new(),
             duration_ms: hist(2),
         },
         account_subscription_registration: AppPerformanceOperationSnapshot {
             attempts: 1,
             successes: 0,
             failures: 1,
+            failure_classifications: Vec::new(),
             duration_ms: hist(3),
+        },
+        account_sync: AppPerformanceOperationSnapshot {
+            attempts: 1,
+            successes: 0,
+            failures: 1,
+            failure_classifications: vec![SyncFailureCount {
+                classification: SyncFailureClassification::new(
+                    SyncFailureStage::CgkaIngest,
+                    SyncErrorClass::Protocol,
+                ),
+                count: 1,
+            }],
+            duration_ms: hist(1),
         },
         sqlcipher_migration_probe_runs: 7,
         sqlcipher_migration_probe_skips: 42,
@@ -277,6 +302,19 @@ fn build_export_batch_appends_unlabeled_app_performance_metrics() {
     );
 
     assert!(batch.points.iter().all(|point| point.relay.is_none()));
+    let sync_failure = batch
+        .points
+        .iter()
+        .find(|point| point.name == metric_names::APP_ACCOUNT_SYNC_FAILURES)
+        .expect("classified sync failure point");
+    assert_eq!(
+        sync_failure.failure,
+        Some(SyncFailureClassification::new(
+            SyncFailureStage::CgkaIngest,
+            SyncErrorClass::Protocol,
+        ))
+    );
+    assert_eq!(sync_failure.value, ExportMetricValue::Counter(1));
     assert!(batch.points.iter().any(|point| {
         point.name == metric_names::APP_START_ATTEMPTS
             && point.value == ExportMetricValue::Counter(3)

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -23,9 +23,7 @@ use super::{
     RuntimeLifecycle, RuntimeMessageReceived, RuntimeProjectionUpdate, RuntimeSharedServices,
     wait_for_runtime_shutdown,
 };
-use crate::app_telemetry::{
-    AppPerformanceOperation, SyncErrorClass, SyncFailureClassification, SyncFailureStage,
-};
+use crate::app_telemetry::{AppPerformanceOperation, SyncFailureClassification, SyncFailureStage};
 use crate::client::{CompletedWelcomeDeliveryRecovery, EncryptedMediaUploadFinish};
 use crate::messages::AppMessageIntent;
 use crate::{
@@ -4038,14 +4036,12 @@ async fn run_pending_epoch_backfill_reporting_arm(
                 account_label,
                 message.clone(),
             );
-            let failure_stage = if error.sync_error_class() == SyncErrorClass::Storage {
-                SyncFailureStage::StatePersist
-            } else {
-                SyncFailureStage::CgkaIngest
-            };
+            // run_pending_epoch_backfill returns only AppError, after several
+            // distinct sync boundaries. Preserve its typed broad cause but do
+            // not derive a stage from that cause.
             Err(AccountCatchUpFailure::new(
                 message,
-                SyncFailureClassification::new(failure_stage, error.sync_error_class()),
+                SyncFailureClassification::new(SyncFailureStage::Unknown, error.sync_error_class()),
             ))
         }
     };

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -31,12 +31,12 @@ use crate::{
     ACCOUNT_WORKER_RECONNECT_MAX_DELAY, APP_RUNTIME_ACCOUNT_SHUTDOWN_WAIT, AccountCatchUpFailure,
     AgentTextStreamFinishRequest, AppBlobEndpoint, AppClient, AppDisbandRequest, AppError,
     AppGroupMemberRecord, AppGroupMlsState, AppGroupRecord, AppInitialGroupImage,
-    AppProjectionUpdate, AppQuarantinedGroup, ConvergenceScheduleState, EpochBackfillRunOutcome,
-    GroupInviteDeclineResult, MaintenanceRunSummary, MarmotApp, MarmotRelayPlane,
-    MediaAttachmentReference, MediaDownloadResult, MediaUploadRequest, MediaUploadResult,
-    NotificationSettings, PendingWelcomeDelivery, PushPlatform, PushRegistration,
-    PushRegistrationShareOutcome, PushRegistrationSyncResult, ReceivedMessage,
-    RetentionSweepReport, SecureDeleteExpiredResult, SendSummary, SyncFailure, SyncSummary,
+    AppProjectionUpdate, AppQuarantinedGroup, ClassifiedSyncFailure, ConvergenceScheduleState,
+    EpochBackfillRunOutcome, GroupInviteDeclineResult, MaintenanceRunSummary, MarmotApp,
+    MarmotRelayPlane, MediaAttachmentReference, MediaDownloadResult, MediaUploadRequest,
+    MediaUploadResult, NotificationSettings, PendingWelcomeDelivery, PushPlatform,
+    PushRegistration, PushRegistrationShareOutcome, PushRegistrationSyncResult, ReceivedMessage,
+    RetentionSweepReport, SecureDeleteExpiredResult, SendSummary, SyncSummary,
 };
 use cgka_traits::app_event::MarmotAppEvent as MarmotInnerEvent;
 
@@ -615,7 +615,7 @@ async fn run_app_runtime_account_worker(
                 .await?;
             app.finish_client_open_network_maintenance(&mut client)
                 .await;
-            Ok::<_, SyncFailure>(summary)
+            Ok::<_, ClassifiedSyncFailure>(summary)
         });
         loop {
             tokio::select! {
@@ -710,7 +710,7 @@ async fn run_app_runtime_account_worker(
         startup_sync_result
             .as_ref()
             .err()
-            .map(SyncFailure::classification),
+            .map(ClassifiedSyncFailure::classification),
     );
     let catch_up_result = match startup_sync_result {
         Ok(summary) => {
@@ -1520,7 +1520,7 @@ async fn handle_account_worker_catch_up(
     let mut commands_open = true;
     let sync_started_at = Instant::now();
     let sync_result = {
-        let mut sync = std::pin::pin!(client.sync_with_partial_progress());
+        let mut sync = std::pin::pin!(client.sync_with_classified_partial_progress());
         loop {
             let command = if let Some(command) = pending.pop_front() {
                 Some(command)
@@ -2349,7 +2349,7 @@ async fn handle_account_worker_command(
         }
         AccountWorkerCommand::CatchUp { respond } => {
             let sync_started_at = Instant::now();
-            let result = match client.sync_with_partial_progress().await {
+            let result = match client.sync_with_classified_partial_progress().await {
                 Ok(summary) => {
                     publish_app_runtime_summary(events, account_id_hex, account_label, &summary);
                     let backfill_result = run_pending_epoch_backfill_reporting_arm(

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -23,12 +23,14 @@ use super::{
     RuntimeLifecycle, RuntimeMessageReceived, RuntimeProjectionUpdate, RuntimeSharedServices,
     wait_for_runtime_shutdown,
 };
-use crate::app_telemetry::AppPerformanceOperation;
+use crate::app_telemetry::{
+    AppPerformanceOperation, SyncErrorClass, SyncFailureClassification, SyncFailureStage,
+};
 use crate::client::{CompletedWelcomeDeliveryRecovery, EncryptedMediaUploadFinish};
 use crate::messages::AppMessageIntent;
 use crate::{
     ACCOUNT_WORKER_RECONNECT_BASE_DELAY, ACCOUNT_WORKER_RECONNECT_JITTER_MAX_MS,
-    ACCOUNT_WORKER_RECONNECT_MAX_DELAY, APP_RUNTIME_ACCOUNT_SHUTDOWN_WAIT,
+    ACCOUNT_WORKER_RECONNECT_MAX_DELAY, APP_RUNTIME_ACCOUNT_SHUTDOWN_WAIT, AccountCatchUpFailure,
     AgentTextStreamFinishRequest, AppBlobEndpoint, AppClient, AppDisbandRequest, AppError,
     AppGroupMemberRecord, AppGroupMlsState, AppGroupRecord, AppInitialGroupImage,
     AppProjectionUpdate, AppQuarantinedGroup, ConvergenceScheduleState, EpochBackfillRunOutcome,
@@ -95,16 +97,16 @@ pub(crate) struct AccountWorkerRuntime {
 
 pub(crate) enum AccountWorkerCommand {
     CatchUp {
-        respond: oneshot::Sender<Result<(), String>>,
+        respond: oneshot::Sender<Result<(), AccountCatchUpFailure>>,
     },
     /// Startup-coalesced catch-up response held in the same FIFO as deferred
     /// mutations so later live reads cannot bypass those mutations.
     StartupCatchUpResult {
-        result: Result<(), String>,
-        respond: oneshot::Sender<Result<(), String>>,
+        result: Result<(), AccountCatchUpFailure>,
+        respond: oneshot::Sender<Result<(), AccountCatchUpFailure>>,
     },
     RepairFullHistory {
-        respond: oneshot::Sender<Result<(), String>>,
+        respond: oneshot::Sender<Result<(), AccountCatchUpFailure>>,
     },
     CreateGroup {
         queued_at: Instant,
@@ -413,7 +415,7 @@ enum DeferredStartupCommand {
     Command(Box<AccountWorkerCommand>),
     /// A `CatchUp` coalesced onto the initial catch-up, fulfilled with its
     /// result at this position in the sequence.
-    CatchUp(oneshot::Sender<Result<(), String>>),
+    CatchUp(oneshot::Sender<Result<(), AccountCatchUpFailure>>),
 }
 
 /// Relay-only startup Welcome work. Dropping the worker aborts the task so no
@@ -704,10 +706,13 @@ async fn run_app_runtime_account_worker(
             }
         }
     };
-    shared.app_performance_telemetry().record(
+    shared.app_performance_telemetry().record_sync_result(
         AppPerformanceOperation::AccountSync,
         sync_started_at.elapsed(),
-        startup_sync_result.is_ok(),
+        startup_sync_result
+            .as_ref()
+            .err()
+            .map(SyncFailure::classification),
     );
     let catch_up_result = match startup_sync_result {
         Ok(summary) => {
@@ -791,7 +796,10 @@ async fn run_app_runtime_account_worker(
                     );
                 }
             }
-            Err(message)
+            Err(AccountCatchUpFailure::new(
+                message,
+                failure.classification(),
+            ))
         }
     };
     // Replay commands deferred during the initial catch-up in arrival order, now
@@ -1487,7 +1495,7 @@ struct AccountWorkerCatchUpContext<'a> {
 
 async fn handle_account_worker_catch_up(
     client: &mut AppClient,
-    respond: oneshot::Sender<Result<(), String>>,
+    respond: oneshot::Sender<Result<(), AccountCatchUpFailure>>,
     commands: &mut mpsc::Receiver<AccountWorkerCommand>,
     pending: &mut VecDeque<AccountWorkerCommand>,
     context: AccountWorkerCatchUpContext<'_>,
@@ -1651,14 +1659,23 @@ async fn handle_account_worker_catch_up(
                 context.account_label,
                 message.clone(),
             );
-            Err(message)
+            Err(AccountCatchUpFailure::new(
+                message,
+                failure.classification(),
+            ))
         }
     };
-    context.shared.app_performance_telemetry().record(
-        AppPerformanceOperation::AccountSync,
-        sync_started_at.elapsed(),
-        result.is_ok(),
-    );
+    context
+        .shared
+        .app_performance_telemetry()
+        .record_sync_result(
+            AppPerformanceOperation::AccountSync,
+            sync_started_at.elapsed(),
+            result
+                .as_ref()
+                .err()
+                .map(AccountCatchUpFailure::classification),
+        );
     let retry_after_response = result.is_ok();
     for respond in catch_up_responders {
         let _ = respond.send(result.clone());
@@ -2367,13 +2384,19 @@ async fn handle_account_worker_command(
                         account_label,
                         message.clone(),
                     );
-                    Err(message)
+                    Err(AccountCatchUpFailure::new(
+                        message,
+                        failure.classification(),
+                    ))
                 }
             };
-            shared.app_performance_telemetry().record(
+            shared.app_performance_telemetry().record_sync_result(
                 AppPerformanceOperation::AccountSync,
                 sync_started_at.elapsed(),
-                result.is_ok(),
+                result
+                    .as_ref()
+                    .err()
+                    .map(AccountCatchUpFailure::classification),
             );
             let retry_after_response = result.is_ok();
             let _ = respond.send(result);
@@ -2410,13 +2433,19 @@ async fn handle_account_worker_command(
                         account_label,
                         message.clone(),
                     );
-                    Err(message)
+                    Err(AccountCatchUpFailure::new(
+                        message,
+                        failure.classification(),
+                    ))
                 }
             };
-            shared.app_performance_telemetry().record(
+            shared.app_performance_telemetry().record_sync_result(
                 AppPerformanceOperation::AccountSync,
                 sync_started_at.elapsed(),
-                result.is_ok(),
+                result
+                    .as_ref()
+                    .err()
+                    .map(AccountCatchUpFailure::classification),
             );
             let _ = respond.send(result);
         }
@@ -3993,7 +4022,7 @@ async fn run_pending_epoch_backfill_reporting_arm(
     account_label: &str,
     shared: &RuntimeSharedServices,
     seam: EpochBackfillExecutionSeam,
-) -> Result<(), String> {
+) -> Result<(), AccountCatchUpFailure> {
     let backfill_armed = client.has_pending_epoch_backfill();
     let result = match client.run_pending_epoch_backfill(seam).await {
         Ok(EpochBackfillRunOutcome::Completed(summary)) => {
@@ -4009,7 +4038,15 @@ async fn run_pending_epoch_backfill_reporting_arm(
                 account_label,
                 message.clone(),
             );
-            Err(message)
+            let failure_stage = if error.sync_error_class() == SyncErrorClass::Storage {
+                SyncFailureStage::StatePersist
+            } else {
+                SyncFailureStage::CgkaIngest
+            };
+            Err(AccountCatchUpFailure::new(
+                message,
+                SyncFailureClassification::new(failure_stage, error.sync_error_class()),
+            ))
         }
     };
     if backfill_armed {
@@ -4495,7 +4532,10 @@ mod tests {
         .await
         .expect_err("failed replay activation must be returned");
 
-        assert_eq!(error, "epoch-gap backfill failed: account_transport");
+        assert_eq!(
+            error.to_string(),
+            "epoch-gap backfill failed: account_transport"
+        );
         assert!(client.has_pending_epoch_backfill());
         let failed_rows: Vec<serde_json::Value> = app
             .audit_log_files()

--- a/crates/marmot-app/src/runtime/commands.rs
+++ b/crates/marmot-app/src/runtime/commands.rs
@@ -117,11 +117,17 @@ impl AccountManager {
             }
             let started_at = Instant::now();
             let result = manager.catch_up_account_commands(commands).await;
-            manager.shared.app_performance_telemetry().record(
-                AppPerformanceOperation::AccountCatchUp,
-                started_at.elapsed(),
-                result.is_ok(),
-            );
+            manager
+                .shared
+                .app_performance_telemetry()
+                .record_sync_result(
+                    AppPerformanceOperation::AccountCatchUp,
+                    started_at.elapsed(),
+                    result
+                        .as_ref()
+                        .err()
+                        .map(super::account_catch_up_metric_classification),
+                );
             manager.shared.app_performance_telemetry().record(
                 AppPerformanceOperation::GroupCreatePostMutationCatchUp,
                 started_at.elapsed(),

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -24,7 +24,8 @@ use tokio::time::timeout;
 
 use crate::agent_streams::AgentStreamWatchManager;
 use crate::app_telemetry::{
-    AppPerformanceOperation, AppPerformanceTelemetry, bounded_advisory_step,
+    AppPerformanceOperation, AppPerformanceTelemetry, SyncErrorClass, SyncFailureClassification,
+    SyncFailureStage, bounded_advisory_step,
 };
 use crate::directory::DirectorySyncHandle;
 use crate::ids::{account_id_hex_from_ref, normalize_group_id_hex_app};
@@ -33,24 +34,25 @@ use crate::notifications;
 use crate::{
     ACCOUNT_SETUP_ADVISORY_WAIT, APP_RUNTIME_ACCOUNT_READY_WAIT, APP_RUNTIME_ACCOUNT_SHUTDOWN_WAIT,
     APP_RUNTIME_LOCAL_WORKER_RESPONSE_WAIT, APP_RUNTIME_LONG_WORKER_RESPONSE_WAIT,
-    APP_RUNTIME_RELAY_REBUILD_LOOKBACK, APP_RUNTIME_WORKER_RESPONSE_WAIT, AccountKeyPackageRecord,
-    AccountRelayListBootstrap, AccountRelayListStatus, AccountUnread, AgentOperationEventRequest,
-    AgentTextStreamFinishRequest, AppBlobEndpoint, AppDisbandRequest, AppError,
-    AppGroupMemberRecord, AppGroupMlsState, AppGroupRecord, AppGroupRoster, AppMessageQuery,
-    AppMessageRecord, AppProjectionUpdate, AppQuarantinedGroup, AuditLogDeleteOutcome,
-    AuditLogFile, AuditLogSettings, AuditLogTrackerConfig, AuditLogTrackerUpdateResult,
-    AuditLogUploadResult, BackgroundNotificationCollection, ChatListRow, ChatNotificationSettings,
-    ChatPinState, ExistingDirectConversation, GroupInviteDeclineResult, GroupPushDebugInfo,
-    KeyPackageDeletionResult, KeyPackageDeletionTarget, MAX_SEEN_EVENT_IDS, MarmotApp,
-    MarmotRelayPlane, MarmotServiceEndpoints, MediaAttachmentReference, MediaDownloadResult,
-    MediaUploadRequest, MediaUploadResult, MessageDraft, MessageDraftAttachment,
-    MessageDraftSummary, NotificationCollectionStatus, NotificationSettings, NotificationUpdate,
-    NotificationWakeSource, PendingWelcomeDelivery, PushPlatform, PushRegistration,
-    PushRegistrationShareOutcome, PushRegistrationSyncResult, ReceivedMessage,
-    RelayTelemetryExportConfig, RelayTelemetryRuntimeConfig, RelayTelemetrySettings,
-    RetentionSweepReport, SecureDeleteExpiredResult, SendSummary, TimelineMessageQuery,
-    TimelineMessageRecord, TimelinePage, UserDirectoryRefresh, UserProfileMetadata,
-    default_profile_pseudonym, unix_now_seconds,
+    APP_RUNTIME_RELAY_REBUILD_LOOKBACK, APP_RUNTIME_WORKER_RESPONSE_WAIT, AccountCatchUpFailure,
+    AccountKeyPackageRecord, AccountRelayListBootstrap, AccountRelayListStatus, AccountUnread,
+    AgentOperationEventRequest, AgentTextStreamFinishRequest, AppBlobEndpoint, AppDisbandRequest,
+    AppError, AppGroupMemberRecord, AppGroupMlsState, AppGroupRecord, AppGroupRoster,
+    AppMessageQuery, AppMessageRecord, AppProjectionUpdate, AppQuarantinedGroup,
+    AuditLogDeleteOutcome, AuditLogFile, AuditLogSettings, AuditLogTrackerConfig,
+    AuditLogTrackerUpdateResult, AuditLogUploadResult, BackgroundNotificationCollection,
+    ChatListRow, ChatNotificationSettings, ChatPinState, ExistingDirectConversation,
+    GroupInviteDeclineResult, GroupPushDebugInfo, KeyPackageDeletionResult,
+    KeyPackageDeletionTarget, MAX_SEEN_EVENT_IDS, MarmotApp, MarmotRelayPlane,
+    MarmotServiceEndpoints, MediaAttachmentReference, MediaDownloadResult, MediaUploadRequest,
+    MediaUploadResult, MessageDraft, MessageDraftAttachment, MessageDraftSummary,
+    NotificationCollectionStatus, NotificationSettings, NotificationUpdate, NotificationWakeSource,
+    PendingWelcomeDelivery, PushPlatform, PushRegistration, PushRegistrationShareOutcome,
+    PushRegistrationSyncResult, ReceivedMessage, RelayTelemetryExportConfig,
+    RelayTelemetryRuntimeConfig, RelayTelemetrySettings, RetentionSweepReport,
+    SecureDeleteExpiredResult, SendSummary, TimelineMessageQuery, TimelineMessageRecord,
+    TimelinePage, UserDirectoryRefresh, UserProfileMetadata, default_profile_pseudonym,
+    unix_now_seconds,
 };
 
 mod account_worker;
@@ -4125,10 +4127,13 @@ impl AccountManager {
             })
         }
         .await;
-        self.shared.app_performance_telemetry().record(
+        self.shared.app_performance_telemetry().record_sync_result(
             AppPerformanceOperation::AccountCatchUp,
             started_at.elapsed(),
-            result.is_ok(),
+            result
+                .as_ref()
+                .err()
+                .map(account_catch_up_metric_classification),
         );
         result
     }
@@ -4159,12 +4164,16 @@ impl AccountManager {
         for response in responses {
             match timeout(APP_RUNTIME_ACCOUNT_READY_WAIT, response).await {
                 Ok(Ok(Ok(()))) => {}
-                Ok(Ok(Err(message))) => return Err(AppError::AccountCatchUp(message)),
+                Ok(Ok(Err(failure))) => return Err(AppError::AccountCatchUp(failure)),
                 Ok(Err(_)) => return Err(AppError::TransportClosed),
                 Err(_) => {
-                    return Err(AppError::AccountCatchUp(
+                    return Err(AppError::AccountCatchUp(AccountCatchUpFailure::new(
                         "account worker catch-up timed out".into(),
-                    ));
+                        SyncFailureClassification::new(
+                            SyncFailureStage::AccountWorker,
+                            SyncErrorClass::Timeout,
+                        ),
+                    )));
                 }
             }
         }
@@ -5438,12 +5447,22 @@ pub(crate) async fn long_account_worker_response<T>(
 }
 
 pub(crate) async fn long_account_worker_catch_up_response(
-    response: oneshot::Receiver<Result<(), String>>,
+    response: oneshot::Receiver<Result<(), AccountCatchUpFailure>>,
 ) -> Result<(), AppError> {
     match timeout(APP_RUNTIME_LONG_WORKER_RESPONSE_WAIT, response).await {
         Ok(Ok(result)) => result.map_err(AppError::AccountCatchUp),
         Ok(Err(_)) => Err(AppError::TransportClosed),
         Err(_) => Err(AppError::AccountWorkerResponseTimedOut),
+    }
+}
+
+fn account_catch_up_metric_classification(error: &AppError) -> SyncFailureClassification {
+    match error {
+        AppError::AccountCatchUp(failure) => failure.classification(),
+        _ => SyncFailureClassification::new(
+            SyncFailureStage::AccountWorker,
+            error.sync_error_class(),
+        ),
     }
 }
 

--- a/crates/marmot-app/tests/sync_failure_public_api.rs
+++ b/crates/marmot-app/tests/sync_failure_public_api.rs
@@ -1,0 +1,11 @@
+use marmot_app::{AppError, SyncFailure, SyncSummary};
+
+#[test]
+fn sync_failure_remains_constructible_with_its_original_public_fields() {
+    let failure = SyncFailure {
+        partial_summary: SyncSummary::default(),
+        source: AppError::RuntimeStopping,
+    };
+
+    assert!(matches!(failure.source, AppError::RuntimeStopping));
+}

--- a/crates/marmot-uniffi/src/errors.rs
+++ b/crates/marmot-uniffi/src/errors.rs
@@ -307,7 +307,9 @@ impl From<AppError> for MarmotKitError {
                 Self::AccountSetupKeyPackageRecoveryAvailable
             }
             AppError::RuntimeStopping => Self::RuntimeStopping,
-            AppError::AccountCatchUp(details) => Self::AccountCatchUp { details },
+            AppError::AccountCatchUp(details) => Self::AccountCatchUp {
+                details: details.to_string(),
+            },
             // #484: a transient storage busy error can also surface directly at
             // the app layer (not only wrapped in an EngineError). Classify it
             // as the typed transient variant here too, so Android never sees
@@ -445,7 +447,10 @@ mod tests {
     // earlier investigation chasing the wrong subsystem).
     #[test]
     fn account_catch_up_crosses_ffi_as_typed_variant() {
-        let app_err = AppError::AccountCatchUp("runtime catch-up failed: account_session".into());
+        let app_err = AppError::AccountCatchUp(marmot_app::AccountCatchUpFailure::new(
+            "runtime catch-up failed: account_session".into(),
+            marmot_app::SyncFailureClassification::UNKNOWN,
+        ));
         let ffi: MarmotKitError = app_err.into();
         match ffi {
             MarmotKitError::AccountCatchUp { details } => {

--- a/crates/traits/src/transport_adapter.rs
+++ b/crates/traits/src/transport_adapter.rs
@@ -697,10 +697,6 @@ pub enum TransportAdapterError {
     #[error("account not active")]
     AccountNotActive(MemberId),
 
-    /// A bounded transport operation exceeded its explicit deadline.
-    #[error("transport operation timed out")]
-    Timeout,
-
     /// The transport delivery stream or its backing task has closed.
     #[error("transport closed")]
     Closed,

--- a/crates/traits/src/transport_adapter.rs
+++ b/crates/traits/src/transport_adapter.rs
@@ -697,6 +697,14 @@ pub enum TransportAdapterError {
     #[error("account not active")]
     AccountNotActive(MemberId),
 
+    /// A bounded transport operation exceeded its explicit deadline.
+    #[error("transport operation timed out")]
+    Timeout,
+
+    /// The transport delivery stream or its backing task has closed.
+    #[error("transport closed")]
+    Closed,
+
     /// An inbound transport object failed its transport-specific syntax or
     /// exact-shape validation. Carries no attacker-controlled detail so it is
     /// safe to classify in runtime telemetry.

--- a/crates/transport-nostr-adapter/src/lib.rs
+++ b/crates/transport-nostr-adapter/src/lib.rs
@@ -617,7 +617,7 @@ impl NostrTransportAdapter {
                     },
                 })
                 .await
-                .map_err(|_| TransportAdapterError::Backend("delivery queue closed".into()))?;
+                .map_err(|_| TransportAdapterError::Closed)?;
             delivered += 1;
         }
 
@@ -1010,7 +1010,7 @@ impl NostrTransportAdapter {
                         },
                     })
                     .await
-                    .map_err(|_| TransportAdapterError::Backend("delivery queue closed".into()))?;
+                    .map_err(|_| TransportAdapterError::Closed)?;
                 delivered += 1;
             }
         }

--- a/docs/marmot-architecture/telemetry.md
+++ b/docs/marmot-architecture/telemetry.md
@@ -261,10 +261,14 @@ metric attributes. Every failed attempt emits exactly one point in a bounded cla
 | `error_class` | `timeout`, `transport_closed`, `relay_directory`, `protocol`, `crypto`, `storage`, `cancelled`, `unknown` |
 
 `failure_stage` is the explicit sync boundary that stopped; `error_class` is derived from typed error variants. A
-catch-up failure propagated to its parent account catch-up retains the same pair. The implementation never parses
+catch-up failure propagated to its parent account sync retains the same pair. The implementation never parses
 `Display` or debug text. If a typed cause is unavailable, it uses `unknown`; it does not infer a class from backend
 strings. Raw errors, relay URLs, account/group/event ids, pubkeys, file paths, and caller-generated strings cannot enter
 these fields because the snapshot and export types store closed enums rather than strings.
+
+Transport `Backend`, `Subscription`, and `Publish` errors intentionally use `error_class=unknown`: their current typed
+variants carry backend text but do not expose a safe, more specific cause. Their explicit `failure_stage` remains the
+useful diagnostic dimension until those lower layers preserve additional typed source information.
 
 ### Agent connector reconciliation telemetry
 

--- a/docs/marmot-architecture/telemetry.md
+++ b/docs/marmot-architecture/telemetry.md
@@ -1,7 +1,7 @@
 ---
 title: "Telemetry, Logging, and Tracing Inventory"
 created: 2026-06-10
-updated: 2026-08-15
+updated: 2026-08-18
 tags: [marmot, architecture, telemetry, logging, tracing, privacy]
 status: current
 ---
@@ -22,7 +22,7 @@ runtime. It complements the policy docs:
 | Structured tracing/logging | Code uses `tracing` macros with explicit `target` and `method` fields. The app/CLI does not install a global tracing subscriber in the current source, so host apps or tests decide whether these events are collected. | No, unless a host installs and exports a subscriber. | [`overview/observability.md`](./overview/observability.md), [`tracing_audit.rs`](../../crates/cgka-conformance-simulator/tests/tracing_audit.rs) |
 | Device-local relay telemetry | Always collected by the shared Nostr relay plane while it runs: lifecycle counters, delivery-spread histograms, sync timing, and redacted relay health. | No. Exposed locally via `MarmotApp::relay_telemetry`, runtime `relay_plane().relay_telemetry()`, and `wn relay-stats`. | [`relay_plane.rs`](../../crates/marmot-app/src/relay_plane.rs), [`telemetry.rs`](../../crates/transport-nostr-adapter/src/telemetry.rs) |
 | Device-local app performance telemetry | Always available inside `RuntimeSharedServices` while the runtime exists: aggregate duration histograms plus attempts/success/failure counters for startup, directory subscription sync, local account open, transport activation, subscription registration, sync/catch-up, host splash/foreground readiness, one-sided outbound message send, group invite/admin/read/accept operations, and media upload/download. Process-wide SQLCipher interrupted-migration probe run/skip counters (mdk#1439) are merged into the snapshot from `sqlcipher.rs`. Exposed locally via `MarmotAppRuntime::app_performance_snapshot()` and the MarmotKit `appPerformanceSnapshot()` binding. | No by itself. Local getters return the aggregate snapshot to the host process only. Included in the OTLP export batch only after the same opt-in export gate passes. | [`app_telemetry.rs`](../../crates/marmot-app/src/app_telemetry.rs), [`runtime.rs`](../../crates/marmot-app/src/runtime.rs) |
-| Opt-in telemetry export | Implemented and off by default. Requires opt-in settings to be persisted, plus runtime endpoint, bearer token, and resource metadata. OTLP wire encoding and HTTP push are behind the `otlp-export` feature. Exports relay metrics and app-performance metrics in one batch. | Yes, only after the export gate passes. Relay URL is the only metric label, and only relay metrics may carry it; app-performance metrics are unlabeled population metrics. | [`relay_telemetry_export.rs`](../../crates/marmot-app/src/relay_telemetry_export.rs), [`config.rs`](../../crates/marmot-app/src/config.rs) |
+| Opt-in telemetry export | Implemented and off by default. Requires opt-in settings to be persisted, plus runtime endpoint, bearer token, and resource metadata. OTLP wire encoding and HTTP push are behind the `otlp-export` feature. Exports relay metrics and app-performance metrics in one batch. | Yes, only after the export gate passes. Relay metrics may carry only `relay`; account sync/catch-up failure counters carry only the closed `failure_stage` and `error_class` attributes. Other app-performance metrics are unlabeled population metrics. | [`relay_telemetry_export.rs`](../../crates/marmot-app/src/relay_telemetry_export.rs), [`config.rs`](../../crates/marmot-app/src/config.rs) |
 | Agent connector reconciliation telemetry | Always collected while `wn-agent` runs: process-local cumulative counters for the shared inbound catch-up driver and the invite-policy worker (passes, outcomes, accounts/candidate rows considered), plus one privacy-safe `tracing` event per scheduled pass carrying a `source` label, duration, result, and aggregate counts (mdk#1380). | No. Counters are process-local; tracing events follow the no-ids/no-urls/no-content rules. | [`reconcile_telemetry.rs`](../../crates/agent-connector/src/reconcile_telemetry.rs), [`event_projection.rs`](../../crates/agent-connector/src/event_projection.rs), [`invite_policy.rs`](../../crates/agent-connector/src/invite_policy.rs) |
 | Engine convergence/outbound telemetry | Implemented inside `cgka-engine` as aggregate post-settle reorg, convergence-pass, foreground deferred-peel, outbound-phase, and queued-intent counters/histograms. Exposed locally by `Engine::engine_metrics()`. The full `EngineMetricsSnapshot` is device-local only. The relay-plane/export structs accept only an optional `EngineReorgMetrics` projection, and the periodic runtime exporter passes `None`. | No via the runtime exporter today. | [`engine_metrics.rs`](../../crates/cgka-engine/src/engine_metrics.rs), [`relay_plane.rs`](../../crates/marmot-app/src/relay_plane.rs) |
 | Product analytics / crash reporting | No product analytics or crash reporting SDK integration was found in the current source. Aptabase is mentioned only as future product-analytics context in a doc; it is not wired. | No. | Workspace search on 2026-06-10 |
@@ -252,6 +252,20 @@ ids, relay URLs, media URLs, payload sizes, content types, upload endpoints, dow
 Host applications can only select the closed `HostPerformanceOperation` enum; callers cannot supply metric names,
 label names, or label values. Adding a new cross-platform operation requires an MDK API change and review.
 
+The `app_account_sync_failures` and `app_account_catch_up_failures` counters are the only app-performance metrics with
+metric attributes. Every failed attempt emits exactly one point in a bounded classification bucket:
+
+| Attribute | Allowed values |
+| --- | --- |
+| `failure_stage` | `transport_activation`, `group_subscription_sync`, `relay_receive`, `cgka_ingest`, `state_persist`, `account_worker`, `unknown` |
+| `error_class` | `timeout`, `transport_closed`, `relay_directory`, `protocol`, `crypto`, `storage`, `cancelled`, `unknown` |
+
+`failure_stage` is the explicit sync boundary that stopped; `error_class` is derived from typed error variants. A
+catch-up failure propagated to its parent account catch-up retains the same pair. The implementation never parses
+`Display` or debug text. If a typed cause is unavailable, it uses `unknown`; it does not infer a class from backend
+strings. Raw errors, relay URLs, account/group/event ids, pubkeys, file paths, and caller-generated strings cannot enter
+these fields because the snapshot and export types store closed enums rather than strings.
+
 ### Agent connector reconciliation telemetry
 
 `ReconcileTelemetry` (in `crates/agent-connector/src/reconcile_telemetry.rs`) holds process-local cumulative
@@ -373,7 +387,8 @@ the batch now carries both relay metrics and app-performance metrics. Each point
 | Field | Meaning |
 | --- | --- |
 | `name` | Static metric name from `metric_names`. |
-| `relay` | Optional relay URL label. This is the only metric label the batch type permits. Population metrics use `None`. |
+| `relay` | Optional relay URL label, used only by relay metrics. |
+| `failure` | Optional closed sync/catch-up classification, encoded as `failure_stage` and `error_class`; used only by the two account failure counters. |
 | `value` | `Counter(u64)`, `Gauge(f64)`, or `Histogram(ExportHistogram)`. |
 
 `ExportHistogram` carries:
@@ -453,11 +468,11 @@ Unresolved relay indices are skipped rather than exported as opaque ids.
 | `app_account_catch_up_duration_ms` | none | Histogram | `AppPerformanceSnapshot.account_catch_up.duration_ms` |
 | `app_account_catch_up_attempts` | none | Counter | `AppPerformanceSnapshot.account_catch_up.attempts` |
 | `app_account_catch_up_successes` | none | Counter | `AppPerformanceSnapshot.account_catch_up.successes` |
-| `app_account_catch_up_failures` | none | Counter | `AppPerformanceSnapshot.account_catch_up.failures` |
+| `app_account_catch_up_failures` | `failure_stage`, `error_class` | Counter | `AppPerformanceSnapshot.account_catch_up.failure_classifications` (sums to `.failures`) |
 | `app_account_sync_duration_ms` | none | Histogram | `AppPerformanceSnapshot.account_sync.duration_ms` |
 | `app_account_sync_attempts` | none | Counter | `AppPerformanceSnapshot.account_sync.attempts` |
 | `app_account_sync_successes` | none | Counter | `AppPerformanceSnapshot.account_sync.successes` |
-| `app_account_sync_failures` | none | Counter | `AppPerformanceSnapshot.account_sync.failures` |
+| `app_account_sync_failures` | `failure_stage`, `error_class` | Counter | `AppPerformanceSnapshot.account_sync.failure_classifications` (sums to `.failures`) |
 | `app_outbound_message_send_duration_ms` | none | Histogram | `AppPerformanceSnapshot.outbound_message_send.duration_ms` |
 | `app_outbound_message_send_attempts` | none | Counter | `AppPerformanceSnapshot.outbound_message_send.attempts` |
 | `app_outbound_message_send_successes` | none | Counter | `AppPerformanceSnapshot.outbound_message_send.successes` |
@@ -515,6 +530,14 @@ Resource attributes on every OTLP request:
 | `os.type` | `RelayTelemetryResource.os_type`. |
 | `os.version` | `RelayTelemetryResource.os_version`. |
 | `device.model.identifier` | Optional `RelayTelemetryResource.device_model_identifier`. |
+
+Example PromQL (for collectors that expose OTLP monotonic sums with the conventional `_total` suffix):
+
+```promql
+sum by (failure_stage, error_class, service_version) (
+  increase(app_account_catch_up_failures_total[24h])
+)
+```
 
 Exporter timing:
 


### PR DESCRIPTION
## What changed

- add shared, bounded `failure_stage` and `error_class` classifications for account sync and catch-up failures
- classify errors at explicit transport activation, subscription refresh, relay receive, CGKA ingest, persistence, and account-worker boundaries
- preserve catch-up classifications when failures propagate to the parent account-sync metric
- export only closed-set metric attributes and add regression coverage preventing raw error text or high-cardinality identifiers
- document the allowed values, privacy/cardinality contract, and a Grafana/PromQL aggregation example

## Why

The existing counters identify failed account sync and catch-up attempts but cannot distinguish relay transport failures from subscription, CGKA, persistence, or timeout failures. This keeps the existing metric names and terminal-counting behavior while making the failing layer operationally visible on both iOS and Android.

## Validation

Passed:

- `just fast-ci`
- focused classification, propagation, privacy, exporter, and OTLP tests
- `cargo test -p transport-nostr-adapter` (28 unit and 36 integration tests)
- CLI sync failure tests
- all 686 `marmot-app` library unit tests
- `git diff --check`

Broader test caveat:

- the `marmot-app` `relay_runtime` binary suite passed 98 tests and failed 5 existing timing/state-sensitive scenarios (encrypted-media endpoint replacement, encrypted-media secret rehydration, retention system-row delivery, retained-media rehydration, and self-removal unread suppression). A serial rerun reproduced the first two; the failures are outside the telemetry paths changed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved synchronization and catch-up error reporting with clearer failure stages and categories.
  * Preserved useful failure details across retries, repairs, and startup recovery.
  * Improved handling and reporting when transport delivery channels close unexpectedly.
  * Added privacy-safe, bounded failure classifications to performance and relay telemetry.

* **Documentation**
  * Updated telemetry documentation with classification values, fallback behavior, privacy guidance, and query examples.

* **Testing**
  * Expanded coverage for failure classification, propagation, telemetry counts, exports, and transport failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->