### PR TITLE
fix(ci): isolate process orchestrator simulator tests

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -2,7 +2,7 @@ set shell := ["bash", "-cu"]
 
 otlp-features := "marmot-app/otlp-export,marmot-uniffi/otlp-export,wn-cli/otlp-export"
 test-features := "wn-cli/test-policy-overrides,cgka-engine/test-crash-hooks"
-simulator-dedicated-filter := "not binary(adversarial_reliability_campaigns) and not binary(policy_sweeps) and not binary(independent_reference_model) and not binary(lifecycle_model) and not binary(mutation_adequacy) and not binary(protocol_decision_gate)"
+simulator-dedicated-filter := "not binary(adversarial_reliability_campaigns) and not binary(policy_sweeps) and not binary(independent_reference_model) and not binary(lifecycle_model) and not binary(mutation_adequacy) and not binary(protocol_decision_gate) and not binary(process_orchestrator)"
 simulator-smoke-filter := simulator-dedicated-filter + " and not (binary(canonical_scenarios) & (test(=convergence_chaos_family_generates_specs_with_semantic_expectations) | test(=convergence_chaos_family_seed_changes_scenarios) | test(=convergence_e2e_delivery_family_runs_generated_variants) | test(=bounded_convergence_pressure_family_settles_every_seeded_permutation)))"
 
 default:
@@ -287,9 +287,12 @@ conformance-slow:
     cargo nextest run -p cgka-conformance-simulator --features conformance-slow
 
 # Fast PR feedback: ordinary simulator coverage without dedicated verification
-# binaries or the generated multi-minute reliability batches.
+# binaries or the generated multi-minute reliability batches. Run the
+# subprocess-heavy process suite separately so relay tasks do not compete with
+# the parallel simulator tests.
 simulator-smoke:
     cargo nextest run -p cgka-conformance-simulator --locked --profile ci -E '{{simulator-smoke-filter}}'
+    cargo nextest run -p cgka-conformance-simulator --test process_orchestrator --locked --profile ci
 
 # Complete generic simulator coverage for the nightly lane. Dedicated
 # adversarial and independent-verification binaries run in later recipes.

--- a/crates/cgka-conformance-simulator/tests/process_orchestrator.rs
+++ b/crates/cgka-conformance-simulator/tests/process_orchestrator.rs
@@ -1390,9 +1390,20 @@ fn process_cli_failure_report_keeps_capsules_after_exit() {
         .arg(&report_path)
         .output()
         .unwrap();
-    assert!(!output.status.success());
+    assert!(
+        !output.status.success(),
+        "controlled failure unexpectedly succeeded; stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report_bytes = std::fs::read(&report_path).unwrap_or_else(|error| {
+        panic!(
+            "process CLI did not write its failure report: status={} read_error={error}; stderr={}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
     let report: cgka_conformance_simulator::process_orchestrator::ProcessScenarioReportV1 =
-        serde_json::from_slice(&std::fs::read(report_path).unwrap()).unwrap();
+        serde_json::from_slice(&report_bytes).unwrap();
     assert!(!report.completed, "{report:#?}");
     let failed = report
         .actions

--- a/crates/convergence-campaign-runner/tests/lane_policy.rs
+++ b/crates/convergence-campaign-runner/tests/lane_policy.rs
@@ -128,6 +128,35 @@ fn scheduled_workflows_collect_and_enforce_lane_observations() {
 }
 
 #[test]
+fn process_orchestrator_coverage_runs_outside_the_parallel_simulator_suites() {
+    let justfile = include_str!("../../../Justfile");
+    let dedicated_filter = justfile
+        .lines()
+        .find(|line| line.starts_with("simulator-dedicated-filter :="))
+        .expect("simulator dedicated filter");
+    assert!(
+        dedicated_filter.contains("not binary(process_orchestrator)"),
+        "the subprocess-heavy process suite must not compete with parallel simulator tests"
+    );
+
+    let smoke = recipe_body(justfile, "simulator-smoke");
+    assert!(
+        smoke.contains(
+            "cargo nextest run -p cgka-conformance-simulator --test process_orchestrator --locked --profile ci"
+        ),
+        "PR smoke coverage must retain a dedicated process-orchestrator pass"
+    );
+
+    let nightly = recipe_body(justfile, "convergence-nightly-lane");
+    assert!(
+        nightly.contains(
+            "cargo nextest run -p cgka-conformance-simulator --test process_orchestrator --locked"
+        ),
+        "nightly coverage must retain a dedicated process-orchestrator pass"
+    );
+}
+
+#[test]
 fn release_workflow_builds_exact_ancestor_image_and_verifies_one_bundle() {
     let hardening = include_str!("../../../.github/workflows/convergence-hardening.yml");
     for contract in [
@@ -163,6 +192,16 @@ fn assert_artifact_retention(workflow: &str, artifact_name: &str, expected: &str
         artifact_step.contains(&format!("retention-days: {expected}")),
         "artifact {artifact_name} retention does not match lane policy {expected}"
     );
+}
+
+fn recipe_body<'a>(justfile: &'a str, recipe: &str) -> &'a str {
+    justfile
+        .split_once(&format!("\n{recipe}:"))
+        .unwrap_or_else(|| panic!("Justfile is missing recipe {recipe}"))
+        .1
+        .split("\n\n")
+        .next()
+        .expect("recipe has a body")
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- exclude the subprocess-heavy `process_orchestrator` binary from broad parallel simulator passes
- preserve PR and nightly coverage through dedicated isolated invocations
- enforce the scheduling contract and surface captured CLI stderr when a failure report is missing

Fixes #1479.
Fixes #1470.

## Test plan
- [x] New scheduling-contract test failed before the fix and passes after
- [x] `cargo test -p convergence-campaign-runner --test lane_policy --locked`
- [x] `just simulator-filter-contract`
- [x] `cargo nextest run -p cgka-conformance-simulator --test process_orchestrator --locked` (13 passed, zero retries)
- [x] `just fast-ci`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved failure reporting for process-orchestrator command tests, including explicit checks for unsuccessful exits and diagnostic output.
  * Added coverage to verify process-orchestrator tests run through dedicated smoke and nightly recipes rather than parallel simulator suites.

* **Chores**
  * Updated simulator test commands to document and separately execute process-orchestrator smoke tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->