### PR TITLE
Prioritize setup KeyPackage publication

### DIFF
--- a/crates/marmot-app/src/app_telemetry.rs
+++ b/crates/marmot-app/src/app_telemetry.rs
@@ -23,6 +23,7 @@ pub(crate) enum AppPerformanceOperation {
     DirectorySubscriptionSync,
     AccountReconcile,
     AccountOpen,
+    AccountWorkerReadiness,
     AccountSessionOpen,
     AccountGroupHydration,
     AccountProfileLoad,
@@ -32,6 +33,10 @@ pub(crate) enum AppPerformanceOperation {
     AccountCatchUp,
     AccountSync,
     AccountSetupAdvisoryStep,
+    AccountBootstrapRelayAndFollowPublish,
+    AccountDefaultProfilePublish,
+    AccountInitialKeyPackagePublish,
+    AccountInitialSyncOverlap,
     OutboundMessageSend,
     GroupCreateQueueWait,
     GroupCreateKeyPackageLookup,
@@ -192,6 +197,8 @@ pub struct AppPerformanceSnapshot {
     pub account_reconcile: AppPerformanceOperationSnapshot,
     pub account_open: AppPerformanceOperationSnapshot,
     #[serde(default)]
+    pub account_worker_readiness: AppPerformanceOperationSnapshot,
+    #[serde(default)]
     pub account_session_open: AppPerformanceOperationSnapshot,
     #[serde(default)]
     pub account_group_hydration: AppPerformanceOperationSnapshot,
@@ -206,6 +213,14 @@ pub struct AppPerformanceSnapshot {
     pub account_catch_up: AppPerformanceOperationSnapshot,
     pub account_sync: AppPerformanceOperationSnapshot,
     pub account_setup_advisory_step: AppPerformanceOperationSnapshot,
+    #[serde(default)]
+    pub account_bootstrap_relay_and_follow_publish: AppPerformanceOperationSnapshot,
+    #[serde(default)]
+    pub account_default_profile_publish: AppPerformanceOperationSnapshot,
+    #[serde(default)]
+    pub account_initial_key_package_publish: AppPerformanceOperationSnapshot,
+    #[serde(default)]
+    pub account_initial_sync_overlap: AppPerformanceOperationSnapshot,
     /// Interrupted-migration recovery probes executed since process start. Each
     /// probe is a full keyed SQLCipher open paying the passphrase KDF; the
     /// healthy steady state skips it via the cached v2-open verdict (mdk#1439).
@@ -287,6 +302,7 @@ struct AppPerformanceTelemetryInner {
     directory_subscription_sync: AppPerformanceOperationTelemetry,
     account_reconcile: AppPerformanceOperationTelemetry,
     account_open: AppPerformanceOperationTelemetry,
+    account_worker_readiness: AppPerformanceOperationTelemetry,
     account_session_open: AppPerformanceOperationTelemetry,
     account_group_hydration: AppPerformanceOperationTelemetry,
     account_profile_load: AppPerformanceOperationTelemetry,
@@ -296,6 +312,10 @@ struct AppPerformanceTelemetryInner {
     account_catch_up: AppPerformanceOperationTelemetry,
     account_sync: AppPerformanceOperationTelemetry,
     account_setup_advisory_step: AppPerformanceOperationTelemetry,
+    account_bootstrap_relay_and_follow_publish: AppPerformanceOperationTelemetry,
+    account_default_profile_publish: AppPerformanceOperationTelemetry,
+    account_initial_key_package_publish: AppPerformanceOperationTelemetry,
+    account_initial_sync_overlap: AppPerformanceOperationTelemetry,
     outbound_message_send: AppPerformanceOperationTelemetry,
     group_create_queue_wait: AppPerformanceOperationTelemetry,
     group_create_key_package_lookup: AppPerformanceOperationTelemetry,
@@ -458,6 +478,9 @@ impl AppPerformanceTelemetry {
                 inner.account_reconcile.record(duration, success);
             }
             AppPerformanceOperation::AccountOpen => inner.account_open.record(duration, success),
+            AppPerformanceOperation::AccountWorkerReadiness => {
+                inner.account_worker_readiness.record(duration, success);
+            }
             AppPerformanceOperation::AccountSessionOpen => {
                 inner.account_session_open.record(duration, success);
             }
@@ -481,6 +504,18 @@ impl AppPerformanceTelemetry {
             AppPerformanceOperation::AccountCatchUp | AppPerformanceOperation::AccountSync => {}
             AppPerformanceOperation::AccountSetupAdvisoryStep => {
                 inner.account_setup_advisory_step.record(duration, success)
+            }
+            AppPerformanceOperation::AccountBootstrapRelayAndFollowPublish => inner
+                .account_bootstrap_relay_and_follow_publish
+                .record(duration, success),
+            AppPerformanceOperation::AccountDefaultProfilePublish => inner
+                .account_default_profile_publish
+                .record(duration, success),
+            AppPerformanceOperation::AccountInitialKeyPackagePublish => inner
+                .account_initial_key_package_publish
+                .record(duration, success),
+            AppPerformanceOperation::AccountInitialSyncOverlap => {
+                inner.account_initial_sync_overlap.record(duration, success)
             }
             AppPerformanceOperation::OutboundMessageSend => {
                 inner.outbound_message_send.record(duration, success);
@@ -650,6 +685,7 @@ impl AppPerformanceTelemetry {
             directory_subscription_sync: inner.directory_subscription_sync.snapshot(),
             account_reconcile: inner.account_reconcile.snapshot(),
             account_open: inner.account_open.snapshot(),
+            account_worker_readiness: inner.account_worker_readiness.snapshot(),
             account_session_open: inner.account_session_open.snapshot(),
             account_group_hydration: inner.account_group_hydration.snapshot(),
             account_profile_load: inner.account_profile_load.snapshot(),
@@ -659,6 +695,14 @@ impl AppPerformanceTelemetry {
             account_catch_up: inner.account_catch_up.snapshot(),
             account_sync: inner.account_sync.snapshot(),
             account_setup_advisory_step: inner.account_setup_advisory_step.snapshot(),
+            account_bootstrap_relay_and_follow_publish: inner
+                .account_bootstrap_relay_and_follow_publish
+                .snapshot(),
+            account_default_profile_publish: inner.account_default_profile_publish.snapshot(),
+            account_initial_key_package_publish: inner
+                .account_initial_key_package_publish
+                .snapshot(),
+            account_initial_sync_overlap: inner.account_initial_sync_overlap.snapshot(),
             sqlcipher_migration_probe_runs,
             sqlcipher_migration_probe_skips,
             outbound_message_send: inner.outbound_message_send.snapshot(),
@@ -943,15 +987,24 @@ mod tests {
     fn records_account_open_stage_operations() {
         let telemetry = AppPerformanceTelemetry::default();
         for (operation, duration_ms) in [
+            (AppPerformanceOperation::AccountWorkerReadiness, 10),
             (AppPerformanceOperation::AccountSessionOpen, 120),
             (AppPerformanceOperation::AccountGroupHydration, 80),
             (AppPerformanceOperation::AccountProfileLoad, 15),
             (AppPerformanceOperation::AccountGroupReadSnapshot, 40),
+            (
+                AppPerformanceOperation::AccountBootstrapRelayAndFollowPublish,
+                55,
+            ),
+            (AppPerformanceOperation::AccountDefaultProfilePublish, 35),
+            (AppPerformanceOperation::AccountInitialKeyPackagePublish, 25),
+            (AppPerformanceOperation::AccountInitialSyncOverlap, 0),
         ] {
             telemetry.record(operation, Duration::from_millis(duration_ms), true);
         }
 
         let snapshot = telemetry.snapshot();
+        assert_eq!(snapshot.account_worker_readiness.duration_ms.sum_ms, 10);
         assert_eq!(snapshot.account_session_open.successes, 1);
         assert_eq!(snapshot.account_session_open.duration_ms.sum_ms, 120);
         assert_eq!(snapshot.account_group_hydration.successes, 1);
@@ -960,6 +1013,26 @@ mod tests {
         assert_eq!(snapshot.account_profile_load.duration_ms.sum_ms, 15);
         assert_eq!(snapshot.account_group_read_snapshot.successes, 1);
         assert_eq!(snapshot.account_group_read_snapshot.duration_ms.sum_ms, 40);
+        assert_eq!(
+            snapshot
+                .account_bootstrap_relay_and_follow_publish
+                .duration_ms
+                .sum_ms,
+            55
+        );
+        assert_eq!(
+            snapshot.account_default_profile_publish.duration_ms.sum_ms,
+            35
+        );
+        assert_eq!(
+            snapshot
+                .account_initial_key_package_publish
+                .duration_ms
+                .sum_ms,
+            25
+        );
+        assert_eq!(snapshot.account_initial_sync_overlap.successes, 1);
+        assert_eq!(snapshot.account_initial_sync_overlap.duration_ms.sum_ms, 0);
     }
 
     #[test]

--- a/crates/marmot-app/src/app_telemetry.rs
+++ b/crates/marmot-app/src/app_telemetry.rs
@@ -36,6 +36,10 @@ pub(crate) enum AppPerformanceOperation {
     AccountBootstrapRelayAndFollowPublish,
     AccountDefaultProfilePublish,
     AccountInitialKeyPackagePublish,
+    /// Time during which the initial KeyPackage publication and initial sync
+    /// overlap. The setup-priority path deliberately serializes them, so its
+    /// successful sample is zero; a non-zero sample would mean a future path
+    /// allowed both network phases to run concurrently.
     AccountInitialSyncOverlap,
     OutboundMessageSend,
     GroupCreateQueueWait,
@@ -219,6 +223,9 @@ pub struct AppPerformanceSnapshot {
     pub account_default_profile_publish: AppPerformanceOperationSnapshot,
     #[serde(default)]
     pub account_initial_key_package_publish: AppPerformanceOperationSnapshot,
+    /// Overlap between initial KeyPackage publication and initial sync. A
+    /// successful zero-duration sample is the intentional setup-priority
+    /// sentinel: KeyPackage publication completed before sync began.
     #[serde(default)]
     pub account_initial_sync_overlap: AppPerformanceOperationSnapshot,
     /// Interrupted-migration recovery probes executed since process start. Each

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -520,6 +520,22 @@ impl AppClient {
             .await?;
         self.refresh_routing()?;
         self.runtime.activate_transport(None).await?;
+        self.publish_key_package_from_lifecycle().await
+    }
+
+    /// Publish the exact lifecycle-owned KeyPackage authorized by the durable
+    /// setup journal without installing receive subscriptions first. The
+    /// managed worker runs this only for `KeyPackagePublicationStarted`; all
+    /// general publication continues through [`Self::publish_key_package`].
+    pub(crate) async fn publish_setup_key_package(&mut self) -> Result<KeyPackage, AppError> {
+        self.app
+            .ensure_local_account_relay_lists(&self.state.label)
+            .await?;
+        self.refresh_routing()?;
+        self.publish_key_package_from_lifecycle().await
+    }
+
+    async fn publish_key_package_from_lifecycle(&mut self) -> Result<KeyPackage, AppError> {
         let lifecycle = self.runtime.key_package_maintenance_status()?;
         if lifecycle.as_ref().is_some_and(|lifecycle| {
             lifecycle.pending_replacement.is_some() || lifecycle.current_key_package.is_none()

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -577,6 +577,12 @@ pub struct AccountRelayListStatus {
     pub inbox: AccountRelayListState,
 }
 
+pub(crate) struct GeneratedAccountBootstrapPublication {
+    pub status: AccountRelayListStatus,
+    pub relay_and_follow_duration: Duration,
+    pub default_profile_duration: Duration,
+}
+
 /// A relay list the account is missing. Typed so FFI clients can localize
 /// each kind without parsing protocol-jargon strings (mdk#565).
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -1693,7 +1699,7 @@ impl MarmotApp {
         label: &str,
         bootstrap: AccountRelayListBootstrap,
         profile: &UserProfileMetadata,
-    ) -> Result<AccountRelayListStatus, AppError> {
+    ) -> Result<GeneratedAccountBootstrapPublication, AppError> {
         if bootstrap.default_relays.is_empty() {
             return Err(AppError::MissingDefaultRelays);
         }
@@ -1758,7 +1764,8 @@ impl MarmotApp {
             "contact list",
             "profile metadata",
         ];
-        let outcomes = relay_client.publish_events(&requests).await;
+        let batch = relay_client.publish_events_with_timings(&requests).await;
+        let outcomes = batch.outcomes;
         if outcomes.len() != record_kinds.len() {
             return Err(AppError::Publish(format!(
                 "account bootstrap returned {} outcomes for {} records",
@@ -1766,6 +1773,19 @@ impl MarmotApp {
                 record_kinds.len()
             )));
         }
+        if batch.request_durations.len() != record_kinds.len() {
+            return Err(AppError::Publish(format!(
+                "account bootstrap returned {} timings for {} records",
+                batch.request_durations.len(),
+                record_kinds.len()
+            )));
+        }
+        let relay_and_follow_duration = batch.request_durations[..3]
+            .iter()
+            .copied()
+            .max()
+            .unwrap_or_default();
+        let default_profile_duration = batch.request_durations[3];
         for (record_kind, outcome) in record_kinds.into_iter().zip(outcomes) {
             if outcome?.accepted.is_empty() {
                 return Err(AppError::Publish(format!(
@@ -1813,7 +1833,11 @@ impl MarmotApp {
             },
         )?;
         self.remember_directory_profile(&account.account_id_hex, profile)?;
-        Ok(status)
+        Ok(GeneratedAccountBootstrapPublication {
+            status,
+            relay_and_follow_duration,
+            default_profile_duration,
+        })
     }
 
     pub async fn publish_missing_account_relay_lists(

--- a/crates/marmot-app/src/relay_telemetry_export.rs
+++ b/crates/marmot-app/src/relay_telemetry_export.rs
@@ -221,6 +221,9 @@ pub mod metric_names {
         "app_account_initial_key_package_publish_successes";
     pub const APP_ACCOUNT_INITIAL_KEY_PACKAGE_PUBLISH_FAILURES: &str =
         "app_account_initial_key_package_publish_failures";
+    /// Overlap between initial KeyPackage publication and initial sync. The
+    /// setup-priority path emits a successful zero-duration sample to state
+    /// that publication completed before sync began.
     pub const APP_ACCOUNT_INITIAL_SYNC_OVERLAP_DURATION: &str =
         "app_account_initial_sync_overlap_duration_ms";
     pub const APP_ACCOUNT_INITIAL_SYNC_OVERLAP_ATTEMPTS: &str =

--- a/crates/marmot-app/src/relay_telemetry_export.rs
+++ b/crates/marmot-app/src/relay_telemetry_export.rs
@@ -126,6 +126,12 @@ pub mod metric_names {
     pub const APP_ACCOUNT_OPEN_SUCCESSES: &str = "app_account_open_successes";
     /// Failed account opens.
     pub const APP_ACCOUNT_OPEN_FAILURES: &str = "app_account_open_failures";
+    pub const APP_ACCOUNT_WORKER_READINESS_DURATION: &str =
+        "app_account_worker_readiness_duration_ms";
+    pub const APP_ACCOUNT_WORKER_READINESS_ATTEMPTS: &str = "app_account_worker_readiness_attempts";
+    pub const APP_ACCOUNT_WORKER_READINESS_SUCCESSES: &str =
+        "app_account_worker_readiness_successes";
+    pub const APP_ACCOUNT_WORKER_READINESS_FAILURES: &str = "app_account_worker_readiness_failures";
     /// Engine session open (storage + engine build + hydration) duration histogram.
     pub const APP_ACCOUNT_SESSION_OPEN_DURATION: &str = "app_account_session_open_duration_ms";
     pub const APP_ACCOUNT_SESSION_OPEN_ATTEMPTS: &str = "app_account_session_open_attempts";
@@ -191,6 +197,38 @@ pub mod metric_names {
         "app_account_setup_advisory_step_successes";
     pub const APP_ACCOUNT_SETUP_ADVISORY_STEP_FAILURES: &str =
         "app_account_setup_advisory_step_failures";
+    pub const APP_ACCOUNT_BOOTSTRAP_RELAY_AND_FOLLOW_PUBLISH_DURATION: &str =
+        "app_account_bootstrap_relay_and_follow_publish_duration_ms";
+    pub const APP_ACCOUNT_BOOTSTRAP_RELAY_AND_FOLLOW_PUBLISH_ATTEMPTS: &str =
+        "app_account_bootstrap_relay_and_follow_publish_attempts";
+    pub const APP_ACCOUNT_BOOTSTRAP_RELAY_AND_FOLLOW_PUBLISH_SUCCESSES: &str =
+        "app_account_bootstrap_relay_and_follow_publish_successes";
+    pub const APP_ACCOUNT_BOOTSTRAP_RELAY_AND_FOLLOW_PUBLISH_FAILURES: &str =
+        "app_account_bootstrap_relay_and_follow_publish_failures";
+    pub const APP_ACCOUNT_DEFAULT_PROFILE_PUBLISH_DURATION: &str =
+        "app_account_default_profile_publish_duration_ms";
+    pub const APP_ACCOUNT_DEFAULT_PROFILE_PUBLISH_ATTEMPTS: &str =
+        "app_account_default_profile_publish_attempts";
+    pub const APP_ACCOUNT_DEFAULT_PROFILE_PUBLISH_SUCCESSES: &str =
+        "app_account_default_profile_publish_successes";
+    pub const APP_ACCOUNT_DEFAULT_PROFILE_PUBLISH_FAILURES: &str =
+        "app_account_default_profile_publish_failures";
+    pub const APP_ACCOUNT_INITIAL_KEY_PACKAGE_PUBLISH_DURATION: &str =
+        "app_account_initial_key_package_publish_duration_ms";
+    pub const APP_ACCOUNT_INITIAL_KEY_PACKAGE_PUBLISH_ATTEMPTS: &str =
+        "app_account_initial_key_package_publish_attempts";
+    pub const APP_ACCOUNT_INITIAL_KEY_PACKAGE_PUBLISH_SUCCESSES: &str =
+        "app_account_initial_key_package_publish_successes";
+    pub const APP_ACCOUNT_INITIAL_KEY_PACKAGE_PUBLISH_FAILURES: &str =
+        "app_account_initial_key_package_publish_failures";
+    pub const APP_ACCOUNT_INITIAL_SYNC_OVERLAP_DURATION: &str =
+        "app_account_initial_sync_overlap_duration_ms";
+    pub const APP_ACCOUNT_INITIAL_SYNC_OVERLAP_ATTEMPTS: &str =
+        "app_account_initial_sync_overlap_attempts";
+    pub const APP_ACCOUNT_INITIAL_SYNC_OVERLAP_SUCCESSES: &str =
+        "app_account_initial_sync_overlap_successes";
+    pub const APP_ACCOUNT_INITIAL_SYNC_OVERLAP_FAILURES: &str =
+        "app_account_initial_sync_overlap_failures";
     /// Interrupted-migration recovery probes executed (each is one full keyed
     /// SQLCipher open paying the passphrase KDF, mdk#1439).
     pub const APP_SQLCIPHER_MIGRATION_PROBE_RUNS: &str = "app_sqlcipher_migration_probe_runs";
@@ -786,6 +824,14 @@ fn append_app_performance_points(
     );
     append_app_operation_points(
         points,
+        &app_performance.account_worker_readiness,
+        metric_names::APP_ACCOUNT_WORKER_READINESS_DURATION,
+        metric_names::APP_ACCOUNT_WORKER_READINESS_ATTEMPTS,
+        metric_names::APP_ACCOUNT_WORKER_READINESS_SUCCESSES,
+        metric_names::APP_ACCOUNT_WORKER_READINESS_FAILURES,
+    );
+    append_app_operation_points(
+        points,
         &app_performance.account_session_open,
         metric_names::APP_ACCOUNT_SESSION_OPEN_DURATION,
         metric_names::APP_ACCOUNT_SESSION_OPEN_ATTEMPTS,
@@ -855,6 +901,38 @@ fn append_app_performance_points(
         metric_names::APP_ACCOUNT_SETUP_ADVISORY_STEP_ATTEMPTS,
         metric_names::APP_ACCOUNT_SETUP_ADVISORY_STEP_SUCCESSES,
         metric_names::APP_ACCOUNT_SETUP_ADVISORY_STEP_FAILURES,
+    );
+    append_app_operation_points(
+        points,
+        &app_performance.account_bootstrap_relay_and_follow_publish,
+        metric_names::APP_ACCOUNT_BOOTSTRAP_RELAY_AND_FOLLOW_PUBLISH_DURATION,
+        metric_names::APP_ACCOUNT_BOOTSTRAP_RELAY_AND_FOLLOW_PUBLISH_ATTEMPTS,
+        metric_names::APP_ACCOUNT_BOOTSTRAP_RELAY_AND_FOLLOW_PUBLISH_SUCCESSES,
+        metric_names::APP_ACCOUNT_BOOTSTRAP_RELAY_AND_FOLLOW_PUBLISH_FAILURES,
+    );
+    append_app_operation_points(
+        points,
+        &app_performance.account_default_profile_publish,
+        metric_names::APP_ACCOUNT_DEFAULT_PROFILE_PUBLISH_DURATION,
+        metric_names::APP_ACCOUNT_DEFAULT_PROFILE_PUBLISH_ATTEMPTS,
+        metric_names::APP_ACCOUNT_DEFAULT_PROFILE_PUBLISH_SUCCESSES,
+        metric_names::APP_ACCOUNT_DEFAULT_PROFILE_PUBLISH_FAILURES,
+    );
+    append_app_operation_points(
+        points,
+        &app_performance.account_initial_key_package_publish,
+        metric_names::APP_ACCOUNT_INITIAL_KEY_PACKAGE_PUBLISH_DURATION,
+        metric_names::APP_ACCOUNT_INITIAL_KEY_PACKAGE_PUBLISH_ATTEMPTS,
+        metric_names::APP_ACCOUNT_INITIAL_KEY_PACKAGE_PUBLISH_SUCCESSES,
+        metric_names::APP_ACCOUNT_INITIAL_KEY_PACKAGE_PUBLISH_FAILURES,
+    );
+    append_app_operation_points(
+        points,
+        &app_performance.account_initial_sync_overlap,
+        metric_names::APP_ACCOUNT_INITIAL_SYNC_OVERLAP_DURATION,
+        metric_names::APP_ACCOUNT_INITIAL_SYNC_OVERLAP_ATTEMPTS,
+        metric_names::APP_ACCOUNT_INITIAL_SYNC_OVERLAP_SUCCESSES,
+        metric_names::APP_ACCOUNT_INITIAL_SYNC_OVERLAP_FAILURES,
     );
     append_app_operation_points(
         points,

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -570,6 +570,10 @@ async fn run_app_runtime_account_worker(
                 started_at.elapsed(),
                 result.is_ok(),
             );
+            // The durable setup lane serializes these phases by design. Record
+            // an explicit zero rather than omitting the sample so hosts can
+            // distinguish "publication finished before sync" from "overlap
+            // was not observed".
             shared.app_performance_telemetry().record(
                 AppPerformanceOperation::AccountInitialSyncOverlap,
                 Duration::ZERO,

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -10,6 +10,7 @@ use std::time::{Duration, Instant};
 use cgka_traits::app_event::MARMOT_APP_EVENT_KIND_AGENT_STREAM_START;
 use cgka_traits::engine::KeyPackage;
 use cgka_traits::{GroupId, MessageId, SecretBytes};
+use marmot_account::AccountSetupPhase;
 use marmot_forensics::EpochBackfillExecutionSeam;
 use rand::RngCore;
 use rand::rngs::OsRng;
@@ -307,6 +308,12 @@ pub(crate) enum AccountWorkerCommand {
     PublishKeyPackage {
         respond: oneshot::Sender<Result<usize, AppError>>,
     },
+    /// Complete the exact KeyPackage publication authorized by the durable
+    /// account-setup journal. This is deliberately distinct from the general
+    /// publication command so no other mutation can enter the startup lane.
+    PublishSetupKeyPackage {
+        respond: oneshot::Sender<Result<usize, AppError>>,
+    },
     RotateKeyPackage {
         respond: oneshot::Sender<Result<usize, AppError>>,
     },
@@ -450,6 +457,7 @@ async fn run_app_runtime_account_worker(
     ready: oneshot::Sender<Result<(), AppError>>,
     mut shutdown: oneshot::Receiver<()>,
 ) {
+    let worker_started_at = Instant::now();
     let mut ready = Some(ready);
     let AccountWorkerRuntime {
         app,
@@ -535,8 +543,43 @@ async fn run_app_runtime_account_worker(
         );
     }
     if let Some(ready) = ready.take() {
+        shared.app_performance_telemetry().record(
+            AppPerformanceOperation::AccountWorkerReadiness,
+            worker_started_at.elapsed(),
+            true,
+        );
         let _ = ready.send(Ok(()));
     }
+
+    // The durable setup journal records publication intent before the worker
+    // is reconciled. That marker authorizes exactly one narrow startup action:
+    // publish (or retry) the lifecycle-owned exact KeyPackage before unrelated
+    // hydration and initial catch-up. General mutations, including the public
+    // PublishKeyPackage command, remain on the ordinary startup FIFO.
+    let mut setup_key_package_result = match app.account_home().account_setup_state(&account_label)
+    {
+        Ok(Some(state)) if state.phase == AccountSetupPhase::KeyPackagePublicationStarted => {
+            let started_at = Instant::now();
+            let result = async {
+                let key_package = client.publish_setup_key_package().await?;
+                Ok(key_package.bytes().len())
+            }
+            .await;
+            shared.app_performance_telemetry().record(
+                AppPerformanceOperation::AccountInitialKeyPackagePublish,
+                started_at.elapsed(),
+                result.is_ok(),
+            );
+            shared.app_performance_telemetry().record(
+                AppPerformanceOperation::AccountInitialSyncOverlap,
+                Duration::ZERO,
+                result.is_ok(),
+            );
+            Some(result)
+        }
+        Ok(_) => None,
+        Err(error) => Some(Err(error.into())),
+    };
 
     // Background hydration pipeline (mdk#1161): the deferred open above only
     // seeded stored groups, so fully hydrate them now — chat-list recency
@@ -555,6 +598,7 @@ async fn run_app_runtime_account_worker(
         &account_id_hex,
         &account_label,
         &shared,
+        &mut setup_key_package_result,
         &mut shutdown,
         &lifecycle,
     )
@@ -695,6 +739,16 @@ async fn run_app_runtime_account_worker(
                             // than starting a second sync; fulfilled in arrival
                             // order below when it completes.
                             deferred.push(DeferredStartupCommand::CatchUp(respond));
+                        }
+                        Some(AccountWorkerCommand::PublishSetupKeyPackage { respond }) => {
+                            match setup_key_package_result.take() {
+                                Some(result) => {
+                                    let _ = respond.send(result);
+                                }
+                                None => deferred.push(DeferredStartupCommand::Command(Box::new(
+                                    AccountWorkerCommand::PublishSetupKeyPackage { respond },
+                                ))),
+                            }
                         }
                         Some(other) => {
                             deferred.push(DeferredStartupCommand::Command(Box::new(other)))
@@ -1829,6 +1883,7 @@ async fn run_startup_hydration_pipeline(
     account_id_hex: &str,
     account_label: &str,
     shared: &RuntimeSharedServices,
+    setup_key_package_result: &mut Option<Result<usize, AppError>>,
     shutdown: &mut oneshot::Receiver<()>,
     lifecycle: &RuntimeLifecycle,
 ) -> StartupHydrationOutcome {
@@ -1875,6 +1930,7 @@ async fn run_startup_hydration_pipeline(
                                 events,
                                 account_id_hex,
                                 account_label,
+                                setup_key_package_result,
                             )
                             .await;
                         }
@@ -1895,6 +1951,7 @@ async fn run_startup_hydration_pipeline(
                         events,
                         account_id_hex,
                         account_label,
+                        setup_key_package_result,
                     )
                     .await;
                 }
@@ -1989,6 +2046,7 @@ async fn handle_startup_hydration_command(
     events: &broadcast::Sender<MarmotAppEvent>,
     account_id_hex: &str,
     account_label: &str,
+    setup_key_package_result: &mut Option<Result<usize, AppError>>,
 ) {
     match command {
         AccountWorkerCommand::Members { group_id, respond } => {
@@ -2043,6 +2101,16 @@ async fn handle_startup_hydration_command(
         }
         AccountWorkerCommand::CatchUp { respond } => {
             deferred.push(DeferredStartupCommand::CatchUp(respond));
+        }
+        AccountWorkerCommand::PublishSetupKeyPackage { respond } => {
+            match setup_key_package_result.take() {
+                Some(result) => {
+                    let _ = respond.send(result);
+                }
+                None => deferred.push(DeferredStartupCommand::Command(Box::new(
+                    AccountWorkerCommand::PublishSetupKeyPackage { respond },
+                ))),
+            }
         }
         other => deferred.push(DeferredStartupCommand::Command(Box::new(other))),
     }
@@ -3283,6 +3351,20 @@ async fn handle_account_worker_command(
                 Ok(key_package.bytes().len())
             }
             .await;
+            let _ = respond.send(result);
+        }
+        AccountWorkerCommand::PublishSetupKeyPackage { respond } => {
+            let started_at = Instant::now();
+            let result = async {
+                let key_package = client.publish_setup_key_package().await?;
+                Ok(key_package.bytes().len())
+            }
+            .await;
+            shared.app_performance_telemetry().record(
+                AppPerformanceOperation::AccountInitialKeyPackagePublish,
+                started_at.elapsed(),
+                result.is_ok(),
+            );
             let _ = respond.send(result);
         }
         AccountWorkerCommand::RotateKeyPackage { respond } => {

--- a/crates/marmot-app/src/runtime/commands.rs
+++ b/crates/marmot-app/src/runtime/commands.rs
@@ -1397,6 +1397,19 @@ impl AccountManager {
         account_worker_response(response).await
     }
 
+    pub(crate) async fn publish_setup_key_package(
+        &self,
+        account_ref: &str,
+    ) -> Result<usize, AppError> {
+        let command = self.worker_commands(account_ref).await?;
+        let (respond, response) = oneshot::channel();
+        command
+            .send(AccountWorkerCommand::PublishSetupKeyPackage { respond })
+            .await
+            .map_err(|_| AppError::TransportClosed)?;
+        account_worker_response(response).await
+    }
+
     pub async fn rotate_key_package(&self, account_ref: &str) -> Result<usize, AppError> {
         let command = self.worker_commands(account_ref).await?;
         let (respond, response) = oneshot::channel();

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -4851,12 +4851,42 @@ impl AccountManager {
             )?;
         }
         self.shared.lifecycle().ensure_running()?;
-        let status = self
+        let publish_started_at = Instant::now();
+        let publication = match self
             .app
             .publish_generated_account_bootstrap(&account.label, bootstrap, &profile)
-            .await?;
+            .await
+        {
+            Ok(publication) => {
+                self.shared.app_performance_telemetry().record(
+                    AppPerformanceOperation::AccountBootstrapRelayAndFollowPublish,
+                    publication.relay_and_follow_duration,
+                    true,
+                );
+                self.shared.app_performance_telemetry().record(
+                    AppPerformanceOperation::AccountDefaultProfilePublish,
+                    publication.default_profile_duration,
+                    true,
+                );
+                publication
+            }
+            Err(error) => {
+                let elapsed = publish_started_at.elapsed();
+                self.shared.app_performance_telemetry().record(
+                    AppPerformanceOperation::AccountBootstrapRelayAndFollowPublish,
+                    elapsed,
+                    false,
+                );
+                self.shared.app_performance_telemetry().record(
+                    AppPerformanceOperation::AccountDefaultProfilePublish,
+                    elapsed,
+                    false,
+                );
+                return Err(error);
+            }
+        };
         self.mark_bootstrap_publication_confirmed(&account.label)?;
-        Ok((status, Some(profile)))
+        Ok((publication.status, Some(profile)))
     }
 
     fn setup_failure_can_roll_back(
@@ -5055,7 +5085,7 @@ impl AccountManager {
         // Publishing through the managed worker avoids the former one-shot
         // session open followed by a second worker session open. The command's
         // `worker_commands` lookup reconciles before dispatch.
-        self.publish_key_package(&account.label).await
+        self.publish_setup_key_package(&account.label).await
     }
 
     fn confirmed_setup_key_package_bytes(&self, label: &str) -> Result<Option<usize>, AppError> {

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -2919,7 +2919,7 @@ async fn generated_account_bootstrap_uses_one_batch_and_never_refetches_after_ac
         ..UserProfileMetadata::default()
     };
 
-    let status = app
+    let publication = app
         .publish_generated_account_bootstrap(
             &account.label,
             AccountRelayListBootstrap::new(
@@ -2930,6 +2930,7 @@ async fn generated_account_bootstrap_uses_one_batch_and_never_refetches_after_ac
         )
         .await
         .expect("acknowledged bootstrap must not depend on a relay refetch");
+    let status = publication.status;
 
     assert!(status.complete);
     assert_eq!(
@@ -2958,6 +2959,102 @@ async fn generated_account_bootstrap_uses_one_batch_and_never_refetches_after_ac
         app.account_relay_list_status(&account.label).unwrap(),
         status,
         "the acknowledged declaration must be the durable local projection"
+    );
+}
+
+#[tokio::test]
+async fn generated_account_setup_records_distinct_network_ready_phases() {
+    let directory = tempfile::tempdir().unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relay(directory.path(), "wss://relay.example")
+        .with_test_relay_client(relay);
+    let runtime = MarmotAppRuntime::new(app);
+
+    runtime
+        .create_identity(AccountSetupRequest {
+            default_relays: vec![TransportEndpoint("wss://relay.example".into())],
+            bootstrap_relays: vec![TransportEndpoint("wss://relay.example".into())],
+            publish_initial_key_package: true,
+            ..AccountSetupRequest::default()
+        })
+        .await
+        .unwrap();
+
+    let telemetry = runtime
+        .shared_services()
+        .app_performance_telemetry()
+        .snapshot();
+    assert_eq!(telemetry.account_worker_readiness.successes, 1);
+    assert_eq!(
+        telemetry
+            .account_bootstrap_relay_and_follow_publish
+            .successes,
+        1
+    );
+    assert_eq!(telemetry.account_default_profile_publish.successes, 1);
+    assert_eq!(telemetry.account_initial_key_package_publish.successes, 1);
+    assert_eq!(telemetry.account_initial_sync_overlap.successes, 1);
+    assert_eq!(
+        telemetry.account_initial_sync_overlap.duration_ms.sum_ms, 0,
+        "the setup-priority publication must finish before initial sync starts"
+    );
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn initial_setup_key_package_publishes_before_stalled_initial_sync_finishes() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(directory.path());
+    let account = home.create_nostr_account_for_setup().unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relay(directory.path(), "wss://relay.example")
+        .with_test_relay_client(relay.clone());
+    app.publish_generated_account_bootstrap(
+        &account.label,
+        AccountRelayListBootstrap::new(
+            vec![TransportEndpoint("wss://relay.example".into())],
+            vec![TransportEndpoint("wss://relay.example".into())],
+        ),
+        &UserProfileMetadata::default(),
+    )
+    .await
+    .unwrap();
+    home.set_account_setup_phase(
+        &account.label,
+        marmot_account::AccountSetupPhase::KeyPackagePublicationStarted,
+    )
+    .unwrap();
+    relay.block_account_inbox_subscribe(hex::decode(&account.account_id_hex).unwrap());
+    let runtime = MarmotAppRuntime::new(app);
+
+    runtime.reconcile_accounts().await.unwrap();
+    tokio::time::timeout(Duration::from_secs(5), relay.wait_for_blocked_subscribe())
+        .await
+        .expect("initial sync must reach the injected stalled subscription");
+    let key_package_published_before_sync = relay
+        .published_events
+        .lock()
+        .unwrap()
+        .iter()
+        .any(|event| event.kind == KIND_MARMOT_KEY_PACKAGE);
+    let setup_finished_before_sync = tokio::time::timeout(
+        Duration::from_millis(250),
+        runtime.accounts().publish_setup_key_package(&account.label),
+    )
+    .await
+    .expect("setup publication result must bypass stalled initial sync")
+    .is_ok();
+
+    relay.release_subscribe();
+    runtime.shutdown().await;
+
+    assert!(
+        key_package_published_before_sync,
+        "the journaled initial KeyPackage must publish before unrelated initial sync completes"
+    );
+    assert!(
+        setup_finished_before_sync,
+        "setup must receive the priority publication result without waiting for initial sync"
     );
 }
 

--- a/crates/marmot-uniffi/src/conversions/telemetry.rs
+++ b/crates/marmot-uniffi/src/conversions/telemetry.rs
@@ -78,6 +78,7 @@ pub struct AppPerformanceSnapshotFfi {
     pub directory_subscription_sync: AppPerformanceOperationSnapshotFfi,
     pub account_reconcile: AppPerformanceOperationSnapshotFfi,
     pub account_open: AppPerformanceOperationSnapshotFfi,
+    pub account_worker_readiness: AppPerformanceOperationSnapshotFfi,
     pub account_session_open: AppPerformanceOperationSnapshotFfi,
     pub account_group_hydration: AppPerformanceOperationSnapshotFfi,
     pub account_profile_load: AppPerformanceOperationSnapshotFfi,
@@ -87,6 +88,10 @@ pub struct AppPerformanceSnapshotFfi {
     pub account_catch_up: AppPerformanceOperationSnapshotFfi,
     pub account_sync: AppPerformanceOperationSnapshotFfi,
     pub account_setup_advisory_step: AppPerformanceOperationSnapshotFfi,
+    pub account_bootstrap_relay_and_follow_publish: AppPerformanceOperationSnapshotFfi,
+    pub account_default_profile_publish: AppPerformanceOperationSnapshotFfi,
+    pub account_initial_key_package_publish: AppPerformanceOperationSnapshotFfi,
+    pub account_initial_sync_overlap: AppPerformanceOperationSnapshotFfi,
     /// Interrupted-migration recovery probes executed since process start.
     /// Process-wide aggregate: no account, path, or key information.
     pub sqlcipher_migration_probe_runs: u64,
@@ -136,6 +141,7 @@ impl From<marmot_app::AppPerformanceSnapshot> for AppPerformanceSnapshotFfi {
             directory_subscription_sync,
             account_reconcile,
             account_open,
+            account_worker_readiness,
             account_session_open,
             account_group_hydration,
             account_profile_load,
@@ -145,6 +151,10 @@ impl From<marmot_app::AppPerformanceSnapshot> for AppPerformanceSnapshotFfi {
             account_catch_up,
             account_sync,
             account_setup_advisory_step,
+            account_bootstrap_relay_and_follow_publish,
+            account_default_profile_publish,
+            account_initial_key_package_publish,
+            account_initial_sync_overlap,
             sqlcipher_migration_probe_runs,
             sqlcipher_migration_probe_skips,
             outbound_message_send,
@@ -183,6 +193,7 @@ impl From<marmot_app::AppPerformanceSnapshot> for AppPerformanceSnapshotFfi {
             directory_subscription_sync: directory_subscription_sync.into(),
             account_reconcile: account_reconcile.into(),
             account_open: account_open.into(),
+            account_worker_readiness: account_worker_readiness.into(),
             account_session_open: account_session_open.into(),
             account_group_hydration: account_group_hydration.into(),
             account_profile_load: account_profile_load.into(),
@@ -192,6 +203,11 @@ impl From<marmot_app::AppPerformanceSnapshot> for AppPerformanceSnapshotFfi {
             account_catch_up: account_catch_up.into(),
             account_sync: account_sync.into(),
             account_setup_advisory_step: account_setup_advisory_step.into(),
+            account_bootstrap_relay_and_follow_publish: account_bootstrap_relay_and_follow_publish
+                .into(),
+            account_default_profile_publish: account_default_profile_publish.into(),
+            account_initial_key_package_publish: account_initial_key_package_publish.into(),
+            account_initial_sync_overlap: account_initial_sync_overlap.into(),
             sqlcipher_migration_probe_runs,
             sqlcipher_migration_probe_skips,
             outbound_message_send: outbound_message_send.into(),
@@ -293,6 +309,11 @@ mod tests {
         assert_eq!(ffi.group_accept_invite.attempts, 0);
         assert_eq!(ffi.group_create_total_caller_latency.attempts, 0);
         assert_eq!(ffi.group_roster_read.attempts, 0);
+        assert_eq!(ffi.account_worker_readiness.attempts, 0);
+        assert_eq!(ffi.account_bootstrap_relay_and_follow_publish.attempts, 0);
+        assert_eq!(ffi.account_default_profile_publish.attempts, 0);
+        assert_eq!(ffi.account_initial_key_package_publish.attempts, 0);
+        assert_eq!(ffi.account_initial_sync_overlap.attempts, 0);
         // Process-wide counters mirror the source snapshot exactly.
         assert_eq!(
             ffi.sqlcipher_migration_probe_runs,

--- a/crates/marmot-uniffi/src/conversions/telemetry.rs
+++ b/crates/marmot-uniffi/src/conversions/telemetry.rs
@@ -91,6 +91,9 @@ pub struct AppPerformanceSnapshotFfi {
     pub account_bootstrap_relay_and_follow_publish: AppPerformanceOperationSnapshotFfi,
     pub account_default_profile_publish: AppPerformanceOperationSnapshotFfi,
     pub account_initial_key_package_publish: AppPerformanceOperationSnapshotFfi,
+    /// Overlap between initial KeyPackage publication and initial sync. A
+    /// successful zero-duration sample means publication completed before
+    /// sync began; it is not a missing duration sample.
     pub account_initial_sync_overlap: AppPerformanceOperationSnapshotFfi,
     /// Interrupted-migration recovery probes executed since process start.
     /// Process-wide aggregate: no account, path, or key information.

--- a/crates/transport-nostr-adapter/src/lib.rs
+++ b/crates/transport-nostr-adapter/src/lib.rs
@@ -12,7 +12,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 use cgka_traits::MessageId;
@@ -312,6 +312,16 @@ pub struct NostrEventPublishRequest {
     pub required_acks: usize,
 }
 
+/// Ordered outcomes and per-request completion latencies for one publish
+/// batch. Durations are local monotonic values measured from the start of the
+/// shared batch, so callers can compare fixed publication phases without
+/// adding relay-, account-, event-, or caller-defined labels.
+#[derive(Debug)]
+pub struct NostrPublishBatch {
+    pub outcomes: Vec<Result<NostrPublishOutcome, TransportAdapterError>>,
+    pub request_durations: Vec<Duration>,
+}
+
 /// Relay event as observed by the Nostr relay client.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct NostrRelayEvent {
@@ -358,6 +368,22 @@ pub trait NostrRelayClient: Send + Sync {
             );
         }
         outcomes
+    }
+
+    /// Publish an ordered batch and expose bounded per-request completion
+    /// timings. Injected clients inherit a conservative whole-batch duration;
+    /// socket implementations may override this with precise request timings.
+    async fn publish_events_with_timings(
+        &self,
+        requests: &[NostrEventPublishRequest],
+    ) -> NostrPublishBatch {
+        let started_at = Instant::now();
+        let outcomes = self.publish_events(requests).await;
+        let elapsed = started_at.elapsed();
+        NostrPublishBatch {
+            request_durations: vec![elapsed; outcomes.len()],
+            outcomes,
+        }
     }
 }
 

--- a/crates/transport-nostr-adapter/src/sdk_client.rs
+++ b/crates/transport-nostr-adapter/src/sdk_client.rs
@@ -15,12 +15,12 @@ use nostr_sdk::prelude::{
 };
 use tokio::sync::{Mutex, RwLock};
 use tokio::task::{JoinHandle, JoinSet};
-use tokio::time::timeout;
+use tokio::time::{timeout, timeout_at};
 use transport_nostr_peeler::{KIND_MARMOT_GROUP_MESSAGE, NostrTransportEvent};
 
 use crate::{
-    NostrEventPublishRequest, NostrPublishOutcome, NostrRelayClient, NostrRelayEvent,
-    NostrSubscription, NostrTransportAdapter,
+    NostrEventPublishRequest, NostrPublishBatch, NostrPublishOutcome, NostrRelayClient,
+    NostrRelayEvent, NostrSubscription, NostrTransportAdapter,
 };
 
 const SDK_RELAY_CONNECT_WAIT: Duration = Duration::from_secs(5);
@@ -45,6 +45,11 @@ const SDK_RELAY_PUBLISH_OVERALL_WAIT: Duration = Duration::from_secs(20);
 /// ceiling, while a pathological multi-event teardown cannot multiply that
 /// bound without limit.
 const SDK_RELAY_BATCH_OVERALL_WAIT: Duration = Duration::from_secs(60);
+/// Independent events in one bootstrap batch may publish concurrently, but a
+/// caller-controlled batch must not create an unbounded number of relay-send
+/// fan-outs. Four covers the generated-account bootstrap cohort while keeping
+/// larger batches backpressured.
+const SDK_RELAY_BATCH_MAX_IN_FLIGHT: usize = 4;
 
 /// Planned SDK subscription derived from a transport-adapter subscription.
 #[derive(Clone, Debug)]
@@ -662,7 +667,9 @@ impl NostrSdkRelayClient {
     async fn publish_prepared_batch(
         &self,
         requests: Vec<Result<PreparedPublish, TransportAdapterError>>,
-    ) -> Vec<Result<NostrPublishOutcome, TransportAdapterError>> {
+        batch_started_at: std::time::Instant,
+    ) -> NostrPublishBatch {
+        let deadline = tokio::time::Instant::now() + SDK_RELAY_BATCH_OVERALL_WAIT;
         let mut unique_endpoints = Vec::new();
         let mut seen_endpoints = HashSet::new();
         for request in requests.iter().filter_map(|request| request.as_ref().ok()) {
@@ -697,45 +704,102 @@ impl NostrSdkRelayClient {
             let client = self.clone();
             connects.spawn(async move { client.connect_publish_relay(endpoint).await });
         }
-        while let Some(result) = connects.join_next().await {
-            if let Ok(Err(failure)) = result
-                && let Ok(endpoint) = RelayUrl::parse(failure.endpoint.as_str())
-            {
-                unavailable.insert(endpoint, failure);
-            }
-        }
-
-        let deadline = tokio::time::Instant::now() + SDK_RELAY_BATCH_OVERALL_WAIT;
-        let mut outcomes = Vec::with_capacity(requests.len());
-        for request in requests {
-            let request = match request {
-                Ok(request) => request,
-                Err(error) => {
-                    outcomes.push(Err(error));
-                    continue;
-                }
-            };
+        loop {
             let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
             if remaining.is_zero() {
-                outcomes.push(Err(TransportAdapterError::Publish(
-                    "publish batch timed out".to_owned(),
-                )));
+                connects.abort_all();
+                break;
+            }
+            match timeout(remaining, connects.join_next()).await {
+                Ok(Some(Ok(Err(failure)))) => {
+                    if let Ok(endpoint) = RelayUrl::parse(failure.endpoint.as_str()) {
+                        unavailable.insert(endpoint, failure);
+                    }
+                }
+                Ok(Some(_)) => {}
+                Ok(None) => break,
+                Err(_) => {
+                    connects.abort_all();
+                    break;
+                }
+            }
+        }
+        while connects.join_next().await.is_some() {}
+
+        let request_count = requests.len();
+        let unavailable = Arc::new(unavailable);
+        let mut pending = requests.into_iter().enumerate();
+        let mut publishes = JoinSet::new();
+        let mut outcomes = std::iter::repeat_with(|| None)
+            .take(request_count)
+            .collect::<Vec<Option<Result<NostrPublishOutcome, TransportAdapterError>>>>();
+        let mut request_durations = vec![Duration::ZERO; request_count];
+        let mut exhausted = false;
+        loop {
+            while publishes.len() < SDK_RELAY_BATCH_MAX_IN_FLIGHT && !exhausted {
+                match pending.next() {
+                    Some((index, Err(error))) => {
+                        outcomes[index] = Some(Err(error));
+                        request_durations[index] = batch_started_at.elapsed();
+                    }
+                    Some((index, Ok(request))) => {
+                        if tokio::time::Instant::now() >= deadline {
+                            outcomes[index] = Some(Err(TransportAdapterError::Publish(
+                                "publish batch timed out".to_owned(),
+                            )));
+                            request_durations[index] = batch_started_at.elapsed();
+                            continue;
+                        }
+                        let client = self.clone();
+                        let unavailable = unavailable.clone();
+                        publishes.spawn(async move {
+                            let outcome = match timeout_at(
+                                deadline,
+                                client.publish_prepared_event(request, &unavailable, false),
+                            )
+                            .await
+                            {
+                                Ok(outcome) => outcome,
+                                Err(_) => Err(TransportAdapterError::Publish(
+                                    "publish batch timed out".to_owned(),
+                                )),
+                            };
+                            (index, batch_started_at.elapsed(), outcome)
+                        });
+                    }
+                    None => exhausted = true,
+                }
+            }
+            if publishes.is_empty() {
+                if exhausted {
+                    break;
+                }
                 continue;
             }
-            match timeout(
-                remaining,
-                self.publish_prepared_event(request, &unavailable, false),
-            )
-            .await
-            {
-                Ok(outcome) => outcomes.push(outcome),
-                Err(_) => outcomes.push(Err(TransportAdapterError::Publish(
-                    "publish batch timed out".to_owned(),
-                ))),
+            match publishes.join_next().await {
+                Some(Ok((index, elapsed, outcome))) => {
+                    outcomes[index] = Some(outcome);
+                    request_durations[index] = elapsed;
+                }
+                Some(Err(_)) => {}
+                None => break,
             }
         }
         lease.release().await;
-        outcomes
+        let outcomes = outcomes
+            .into_iter()
+            .map(|outcome| {
+                outcome.unwrap_or_else(|| {
+                    Err(TransportAdapterError::Publish(
+                        "publish batch task failed".to_owned(),
+                    ))
+                })
+            })
+            .collect();
+        NostrPublishBatch {
+            outcomes,
+            request_durations,
+        }
     }
 
     async fn add_subscription_relay(
@@ -1032,6 +1096,14 @@ impl NostrRelayClient for NostrSdkRelayClient {
         &self,
         requests: &[NostrEventPublishRequest],
     ) -> Vec<Result<NostrPublishOutcome, TransportAdapterError>> {
+        self.publish_events_with_timings(requests).await.outcomes
+    }
+
+    async fn publish_events_with_timings(
+        &self,
+        requests: &[NostrEventPublishRequest],
+    ) -> NostrPublishBatch {
+        let batch_started_at = std::time::Instant::now();
         let mut prepared = Vec::with_capacity(requests.len());
         for request in requests {
             let endpoints = match parse_endpoints(&request.endpoints, "publish") {
@@ -1067,12 +1139,17 @@ impl NostrRelayClient for NostrSdkRelayClient {
             "publishing SDK relay event batch"
         );
         if prepared.len() == 1 {
-            return match prepared.pop().expect("one prepared publish") {
+            let outcome = match prepared.pop().expect("one prepared publish") {
                 Ok(request) => vec![self.publish_prepared_single(request).await],
                 Err(error) => vec![Err(error)],
             };
+            return NostrPublishBatch {
+                request_durations: vec![batch_started_at.elapsed()],
+                outcomes: outcome,
+            };
         }
-        self.publish_prepared_batch(prepared).await
+        self.publish_prepared_batch(prepared, batch_started_at)
+            .await
     }
 }
 
@@ -2056,6 +2133,142 @@ mod tests {
         assert_eq!(
             sdk.publish_release_attempts.lock().await.get(&relay_url),
             Some(&1)
+        );
+        assert_eq!(sdk.relay_health().await.total_relays, 0);
+    }
+
+    #[tokio::test]
+    async fn publish_batch_starts_healthy_request_while_another_request_is_stalled() {
+        let healthy_relay = MockRelay::run().await.unwrap();
+        let healthy_endpoint = TransportEndpoint(healthy_relay.url().await.to_string());
+        let silent_endpoint = TransportEndpoint(silent_relay_url().await);
+
+        let observer = Client::builder().build();
+        let mut notifications = observer.notifications();
+        observer.add_relay(healthy_endpoint.as_str()).await.unwrap();
+        observer.connect().await;
+        let subscription_id = SubscriptionId::new("concurrent-batch-observer");
+        observer
+            .subscribe_with_id_to(
+                [healthy_endpoint.as_str()],
+                subscription_id,
+                Filter::new().kind(Kind::MlsGroupMessage),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let stalled_event = signed_group_event_dto();
+        let healthy_event = signed_group_event_dto();
+        let healthy_event_id = healthy_event.id.clone();
+        let sdk = NostrSdkRelayClient::new(Client::builder().build());
+        let publishing_sdk = sdk.clone();
+        let publish = tokio::spawn(async move {
+            publishing_sdk
+                .publish_events(&[
+                    NostrEventPublishRequest {
+                        endpoints: vec![silent_endpoint],
+                        event: stalled_event,
+                        required_acks: 1,
+                    },
+                    NostrEventPublishRequest {
+                        endpoints: vec![healthy_endpoint],
+                        event: healthy_event,
+                        required_acks: 1,
+                    },
+                ])
+                .await
+        });
+
+        timeout(Duration::from_secs(2), async {
+            loop {
+                match notifications
+                    .recv()
+                    .await
+                    .expect("observer notification channel remains open")
+                {
+                    RelayPoolNotification::Event { event, .. }
+                        if event.id.to_hex() == healthy_event_id =>
+                    {
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+        })
+        .await
+        .expect("a stalled request must not prevent an independent healthy publish");
+
+        publish.abort();
+        let _ = publish.await;
+        observer.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn publish_batch_preserves_request_order_after_partial_failure() {
+        let healthy_relay = MockRelay::run().await.unwrap();
+        let healthy_endpoint = TransportEndpoint(healthy_relay.url().await.to_string());
+        let unavailable_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let unavailable_endpoint = TransportEndpoint(format!(
+            "ws://{}",
+            unavailable_listener.local_addr().unwrap()
+        ));
+        drop(unavailable_listener);
+        let sdk = NostrSdkRelayClient::new(Client::builder().build());
+
+        let outcomes = sdk
+            .publish_events(&[
+                NostrEventPublishRequest {
+                    endpoints: vec![unavailable_endpoint],
+                    event: signed_group_event_dto(),
+                    required_acks: 1,
+                },
+                NostrEventPublishRequest {
+                    endpoints: vec![healthy_endpoint],
+                    event: signed_group_event_dto(),
+                    required_acks: 1,
+                },
+            ])
+            .await;
+
+        assert_eq!(outcomes.len(), 2);
+        assert!(
+            outcomes[0].is_err(),
+            "stalled request must fail in slot zero"
+        );
+        assert!(
+            outcomes[1].is_ok(),
+            "healthy request must remain successful in slot one"
+        );
+        assert_eq!(sdk.relay_health().await.total_relays, 0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn publish_batch_all_stalled_requests_share_one_deadline_window() {
+        let first_silent = TransportEndpoint(silent_relay_url().await);
+        let second_silent = TransportEndpoint(silent_relay_url().await);
+        let sdk = NostrSdkRelayClient::new(Client::builder().build());
+        let started_at = tokio::time::Instant::now();
+
+        let outcomes = sdk
+            .publish_events(&[
+                NostrEventPublishRequest {
+                    endpoints: vec![first_silent],
+                    event: signed_group_event_dto(),
+                    required_acks: 1,
+                },
+                NostrEventPublishRequest {
+                    endpoints: vec![second_silent],
+                    event: signed_group_event_dto(),
+                    required_acks: 1,
+                },
+            ])
+            .await;
+
+        assert!(outcomes.iter().all(Result::is_err));
+        assert!(
+            started_at.elapsed() <= SDK_RELAY_PUBLISH_OVERALL_WAIT + Duration::from_secs(1),
+            "all-unavailable latency must stay within one concurrent request window"
         );
         assert_eq!(sdk.relay_health().await.total_relays, 0);
     }


### PR DESCRIPTION
## Summary
- prioritize the exact journaled setup KeyPackage before initial sync while keeping general mutations on the startup FIFO
- publish independent bootstrap events concurrently with bounded fan-out, one shared deadline, and input-ordered outcomes
- expose privacy-safe timings for worker readiness, bootstrap relay/follow publication, default profile publication, initial KeyPackage publication, and initial-sync overlap

## Test plan
- [x] New priority and batch-concurrency tests failed before the fix and pass after it
- [x] `cargo test -p transport-nostr-adapter --features sdk`
- [x] `cargo test -p marmot-uniffi`
- [x] `cargo test -p marmot-app` unit tests: 689 passed
- [x] `just fast-ci`

`marmot-app` integration `relay_runtime` still has five unrelated baseline failures; `encrypted_media_endpoint_updates_are_full_replacement_and_admin_only` was reproduced unchanged from pristine `origin/master`.

Fixes #1484