### PR TITLE
marmot-uniffi: publish profiles with account-owned relays

### DIFF
--- a/crates/marmot-app/src/directory/methods.rs
+++ b/crates/marmot-app/src/directory/methods.rs
@@ -530,13 +530,14 @@ impl MarmotApp {
         &self,
         relay_lists: &AccountRelayListStatus,
     ) -> Result<Vec<TransportEndpoint>, AppError> {
-        let published = if relay_lists.nip65.relays.is_empty() {
-            &relay_lists.default_relays
-        } else {
-            &relay_lists.nip65.relays
-        };
         let published = self.retain_safe_discovered_endpoints(
-            published.iter().cloned().map(TransportEndpoint).collect(),
+            relay_lists
+                .nip65
+                .relays
+                .iter()
+                .cloned()
+                .map(TransportEndpoint)
+                .collect(),
             "account-owned profile publish relays",
         );
         if !published.is_empty() {

--- a/crates/marmot-app/src/directory/methods.rs
+++ b/crates/marmot-app/src/directory/methods.rs
@@ -485,11 +485,26 @@ impl MarmotApp {
         bootstrap: AccountRelayListBootstrap,
     ) -> Result<(), AppError> {
         let account = self.account_home().account(label)?;
-        let signer = self.account_signer_for_summary(&account)?;
         let endpoints = self.outbox_endpoints(
             &account.account_id_hex,
             publish_endpoints_from_bootstrap(&bootstrap),
         );
+        self.publish_user_profile_to_endpoints(&account.label, profile, endpoints)
+            .await
+    }
+
+    /// Publish kind-0 metadata to an already-selected, account-scoped route.
+    ///
+    /// This is the action boundary used when the runtime has captured one
+    /// coherent relay-list snapshot and must not re-read it before publishing.
+    pub(crate) async fn publish_user_profile_to_endpoints(
+        &self,
+        label: &str,
+        profile: UserProfileMetadata,
+        endpoints: Vec<TransportEndpoint>,
+    ) -> Result<(), AppError> {
+        let account = self.account_home().account(label)?;
+        let signer = self.account_signer_for_summary(&account)?;
         let content = serde_json::to_string(&profile_content_json(&profile))?;
         let event = NostrTransportEvent::new_unsigned(
             account.account_id_hex.clone(),
@@ -501,6 +516,48 @@ impl MarmotApp {
             .publish_event(&endpoints, &event, 1)
             .await?;
         Ok(())
+    }
+
+    /// Select profile publication endpoints from one account relay-list
+    /// snapshot. Prefer the account's published NIP-65 write relays, then its
+    /// remembered bootstrap relays. A missing bootstrap list falls back to the
+    /// snapshot's compatibility default/publish list.
+    ///
+    /// Every tier is filtered through the discovered-endpoint safety policy.
+    /// If a tier contains only invalid, unsafe, or retired endpoints, selection
+    /// continues to the next tier; no unusable endpoint reaches the dialer.
+    pub(crate) fn account_profile_publish_endpoints(
+        &self,
+        relay_lists: &AccountRelayListStatus,
+    ) -> Result<Vec<TransportEndpoint>, AppError> {
+        let published = if relay_lists.nip65.relays.is_empty() {
+            &relay_lists.default_relays
+        } else {
+            &relay_lists.nip65.relays
+        };
+        let published = self.retain_safe_discovered_endpoints(
+            published.iter().cloned().map(TransportEndpoint).collect(),
+            "account-owned profile publish relays",
+        );
+        if !published.is_empty() {
+            return Ok(published);
+        }
+
+        let bootstrap = if relay_lists.bootstrap_relays.is_empty() {
+            &relay_lists.default_relays
+        } else {
+            &relay_lists.bootstrap_relays
+        };
+        let bootstrap = self.retain_safe_discovered_endpoints(
+            bootstrap.iter().cloned().map(TransportEndpoint).collect(),
+            "account-owned profile bootstrap relays",
+        );
+        if bootstrap.is_empty() {
+            return Err(AppError::RelayDirectory(
+                "account relay configuration has no usable profile publication endpoints".into(),
+            ));
+        }
+        Ok(bootstrap)
     }
 
     pub async fn publish_account_follow_list(

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -2752,12 +2752,64 @@ impl MarmotAppRuntime {
     pub async fn publish_user_profile(
         &self,
         account_ref: &str,
-        mut profile: UserProfileMetadata,
+        profile: UserProfileMetadata,
         bootstrap: AccountRelayListBootstrap,
     ) -> Result<UserProfileMetadata, AppError> {
         let account = self.accounts.resolve(account_ref)?;
+        let merge_source_relays = bootstrap.bootstrap_relays.clone();
+        let publish_endpoints = self.accounts.app.outbox_endpoints(
+            &account.account_id_hex,
+            crate::key_package_records::publish_endpoints_from_bootstrap(&bootstrap),
+        );
+        self.publish_user_profile_to_selected_endpoints(
+            &account,
+            profile,
+            &merge_source_relays,
+            publish_endpoints,
+        )
+        .await
+    }
+
+    /// Publish kind-0 metadata using the selected account's own relay-list
+    /// projection. The projection is captured once at the operation boundary;
+    /// profile merge reads and publication use endpoints derived from that same
+    /// snapshot, so a concurrent directory refresh cannot mix configurations.
+    pub async fn publish_user_profile_using_account_relays(
+        &self,
+        account_ref: &str,
+        profile: UserProfileMetadata,
+    ) -> Result<UserProfileMetadata, AppError> {
+        self.shared.lifecycle().ensure_running()?;
+        let account = self.accounts.resolve(account_ref)?;
+        if account.signed_out {
+            return Err(AppError::RelayDirectory("account is signed out".into()));
+        }
+        let relay_lists = self
+            .accounts
+            .app
+            .account_relay_list_status_for_account_id(&account.account_id_hex)?;
+        let endpoints = self
+            .accounts
+            .app
+            .account_profile_publish_endpoints(&relay_lists)?;
+        self.publish_user_profile_to_selected_endpoints(
+            &account,
+            profile,
+            &endpoints,
+            endpoints.clone(),
+        )
+        .await
+    }
+
+    async fn publish_user_profile_to_selected_endpoints(
+        &self,
+        account: &AccountSummary,
+        mut profile: UserProfileMetadata,
+        merge_source_relays: &[TransportEndpoint],
+        publish_endpoints: Vec<TransportEndpoint>,
+    ) -> Result<UserProfileMetadata, AppError> {
         if let Some(current) = self
-            .latest_known_user_profile_for_publish(&account.account_id_hex, &bootstrap)
+            .latest_known_user_profile_for_publish(&account.account_id_hex, merge_source_relays)
             .await?
         {
             profile = merge_user_profile_update(current, profile);
@@ -2775,7 +2827,7 @@ impl MarmotAppRuntime {
         stamp_published_profile_created_at(&mut profile, unix_now_seconds());
         self.accounts
             .app
-            .publish_user_profile(&account.label, profile.clone(), bootstrap)
+            .publish_user_profile_to_endpoints(&account.label, profile.clone(), publish_endpoints)
             .await?;
         self.accounts
             .app
@@ -2812,7 +2864,7 @@ impl MarmotAppRuntime {
     async fn latest_known_user_profile_for_publish(
         &self,
         account_id_hex: &str,
-        bootstrap: &AccountRelayListBootstrap,
+        source_relays: &[TransportEndpoint],
     ) -> Result<Option<UserProfileMetadata>, AppError> {
         let cached = self
             .accounts
@@ -2822,10 +2874,7 @@ impl MarmotAppRuntime {
         match self
             .accounts
             .app
-            .fetch_current_user_profile_for_account_id(
-                account_id_hex,
-                bootstrap.bootstrap_relays.clone(),
-            )
+            .fetch_current_user_profile_for_account_id(account_id_hex, source_relays.to_vec())
             .await
         {
             Ok(fetched) => Ok(newest_user_profile(cached, fetched)),

--- a/crates/marmot-app/src/runtime/tests.rs
+++ b/crates/marmot-app/src/runtime/tests.rs
@@ -6,20 +6,17 @@ use cgka_traits::transport_adapter::{
 
 use super::subscriptions::chat_list_mute_expiries;
 use super::*;
+use crate::publish_endpoints_from_bootstrap;
 use crate::tests::ScriptedPushRelayClient;
 
 fn profile_relay_status(
     publish_relays: &[&str],
     bootstrap_relays: &[&str],
-    default_relays: &[&str],
 ) -> AccountRelayListStatus {
-    AccountRelayListStatus {
+    let mut status = AccountRelayListStatus {
         complete: false,
         missing: Vec::new(),
-        default_relays: default_relays
-            .iter()
-            .map(|relay| (*relay).to_owned())
-            .collect(),
+        default_relays: Vec::new(),
         bootstrap_relays: bootstrap_relays
             .iter()
             .map(|relay| (*relay).to_owned())
@@ -42,7 +39,9 @@ fn profile_relay_status(
             read_relays: Vec::new(),
             write_relays: Vec::new(),
         },
-    }
+    };
+    status.refresh();
+    status
 }
 
 #[test]
@@ -50,35 +49,23 @@ fn account_profile_publish_endpoint_selection_centralizes_fallback_and_safety() 
     let directory = tempfile::tempdir().unwrap();
     let app = MarmotApp::with_relay(directory.path(), "wss://configured.example");
 
-    let populated = profile_relay_status(
-        &["wss://publish.example"],
-        &["wss://bootstrap.example"],
-        &["wss://default.example"],
-    );
+    let populated = profile_relay_status(&["wss://publish.example"], &["wss://bootstrap.example"]);
     assert_eq!(
         app.account_profile_publish_endpoints(&populated).unwrap(),
         vec![TransportEndpoint("wss://publish.example".into())]
     );
 
-    let empty_publish = profile_relay_status(&[], &["wss://bootstrap.example"], &[]);
+    let empty_publish = profile_relay_status(&[], &["wss://bootstrap.example"]);
     assert_eq!(
         app.account_profile_publish_endpoints(&empty_publish)
             .unwrap(),
         vec![TransportEndpoint("wss://bootstrap.example".into())]
     );
 
-    let missing_bootstrap = profile_relay_status(&[], &[], &["wss://default.example"]);
-    assert_eq!(
-        app.account_profile_publish_endpoints(&missing_bootstrap)
-            .unwrap(),
-        vec![TransportEndpoint("wss://default.example".into())]
-    );
-
     let retired = format!("wss://{}", crate::retired_relay_hosts()[0]);
     let unsafe_with_safe_sibling = profile_relay_status(
         &["not-a-relay", retired.as_str(), "wss://safe.example"],
         &["wss://bootstrap.example"],
-        &[],
     );
     assert_eq!(
         app.account_profile_publish_endpoints(&unsafe_with_safe_sibling)
@@ -86,12 +73,65 @@ fn account_profile_publish_endpoint_selection_centralizes_fallback_and_safety() 
         vec![TransportEndpoint("wss://safe.example".into())]
     );
 
-    let unusable = profile_relay_status(&["not-a-relay", retired.as_str()], &[], &[]);
+    let unsafe_publish_with_safe_bootstrap = profile_relay_status(
+        &["not-a-relay", retired.as_str()],
+        &["wss://bootstrap.example"],
+    );
+    assert_eq!(
+        app.account_profile_publish_endpoints(&unsafe_publish_with_safe_bootstrap)
+            .unwrap(),
+        vec![TransportEndpoint("wss://bootstrap.example".into())]
+    );
+
+    let unusable = profile_relay_status(&[], &["not-a-relay", retired.as_str()]);
     assert!(matches!(
         app.account_profile_publish_endpoints(&unusable),
         Err(AppError::RelayDirectory(message))
             if message == "account relay configuration has no usable profile publication endpoints"
     ));
+}
+
+#[test]
+fn account_profile_publish_endpoint_selection_matches_canonical_outbox_fallback() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(directory.path());
+    let account = home.create_account("alice").unwrap();
+    let app = MarmotApp::with_relay(directory.path(), "wss://configured.example");
+    // `refresh()` creates the production cache shape. A distinct default list
+    // represents a compatibility snapshot from an older cache schema; when
+    // both fallback lists exist, canonical publication still picks bootstrap.
+    let mut status = profile_relay_status(&[], &["wss://bootstrap.example"]);
+    status.default_relays = vec!["wss://default.example".into()];
+    app.remember_directory_relay_lists(&account.account_id_hex, &status)
+        .unwrap();
+
+    let bootstrap = AccountRelayListBootstrap::new(
+        status
+            .default_relays
+            .iter()
+            .cloned()
+            .map(TransportEndpoint)
+            .collect(),
+        status
+            .bootstrap_relays
+            .iter()
+            .cloned()
+            .map(TransportEndpoint)
+            .collect(),
+    );
+    let canonical = app.outbox_endpoints(
+        &account.account_id_hex,
+        publish_endpoints_from_bootstrap(&bootstrap),
+    );
+
+    assert_eq!(
+        app.account_profile_publish_endpoints(&status).unwrap(),
+        canonical
+    );
+    assert_eq!(
+        canonical,
+        vec![TransportEndpoint("wss://bootstrap.example".into())]
+    );
 }
 
 #[tokio::test]

--- a/crates/marmot-app/src/runtime/tests.rs
+++ b/crates/marmot-app/src/runtime/tests.rs
@@ -8,6 +8,121 @@ use super::subscriptions::chat_list_mute_expiries;
 use super::*;
 use crate::tests::ScriptedPushRelayClient;
 
+fn profile_relay_status(
+    publish_relays: &[&str],
+    bootstrap_relays: &[&str],
+    default_relays: &[&str],
+) -> AccountRelayListStatus {
+    AccountRelayListStatus {
+        complete: false,
+        missing: Vec::new(),
+        default_relays: default_relays
+            .iter()
+            .map(|relay| (*relay).to_owned())
+            .collect(),
+        bootstrap_relays: bootstrap_relays
+            .iter()
+            .map(|relay| (*relay).to_owned())
+            .collect(),
+        nip65: crate::AccountRelayListState {
+            kind: crate::KIND_NIP65_RELAY_LIST,
+            relays: publish_relays
+                .iter()
+                .map(|relay| (*relay).to_owned())
+                .collect(),
+            read_relays: Vec::new(),
+            write_relays: publish_relays
+                .iter()
+                .map(|relay| (*relay).to_owned())
+                .collect(),
+        },
+        inbox: crate::AccountRelayListState {
+            kind: crate::KIND_MARMOT_INBOX_RELAY_LIST,
+            relays: Vec::new(),
+            read_relays: Vec::new(),
+            write_relays: Vec::new(),
+        },
+    }
+}
+
+#[test]
+fn account_profile_publish_endpoint_selection_centralizes_fallback_and_safety() {
+    let directory = tempfile::tempdir().unwrap();
+    let app = MarmotApp::with_relay(directory.path(), "wss://configured.example");
+
+    let populated = profile_relay_status(
+        &["wss://publish.example"],
+        &["wss://bootstrap.example"],
+        &["wss://default.example"],
+    );
+    assert_eq!(
+        app.account_profile_publish_endpoints(&populated).unwrap(),
+        vec![TransportEndpoint("wss://publish.example".into())]
+    );
+
+    let empty_publish = profile_relay_status(&[], &["wss://bootstrap.example"], &[]);
+    assert_eq!(
+        app.account_profile_publish_endpoints(&empty_publish)
+            .unwrap(),
+        vec![TransportEndpoint("wss://bootstrap.example".into())]
+    );
+
+    let missing_bootstrap = profile_relay_status(&[], &[], &["wss://default.example"]);
+    assert_eq!(
+        app.account_profile_publish_endpoints(&missing_bootstrap)
+            .unwrap(),
+        vec![TransportEndpoint("wss://default.example".into())]
+    );
+
+    let retired = format!("wss://{}", crate::retired_relay_hosts()[0]);
+    let unsafe_with_safe_sibling = profile_relay_status(
+        &["not-a-relay", retired.as_str(), "wss://safe.example"],
+        &["wss://bootstrap.example"],
+        &[],
+    );
+    assert_eq!(
+        app.account_profile_publish_endpoints(&unsafe_with_safe_sibling)
+            .unwrap(),
+        vec![TransportEndpoint("wss://safe.example".into())]
+    );
+
+    let unusable = profile_relay_status(&["not-a-relay", retired.as_str()], &[], &[]);
+    assert!(matches!(
+        app.account_profile_publish_endpoints(&unusable),
+        Err(AppError::RelayDirectory(message))
+            if message == "account relay configuration has no usable profile publication endpoints"
+    ));
+}
+
+#[tokio::test]
+async fn account_owned_profile_publish_rejects_signed_out_and_stopped_accounts() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(directory.path());
+    let account = home.create_account("alice").unwrap();
+    home.set_account_signed_out(&account.label, true).unwrap();
+    let app = MarmotApp::with_relay(directory.path(), "wss://relay.example");
+    let runtime = MarmotAppRuntime::new(app);
+
+    let signed_out = runtime
+        .publish_user_profile_using_account_relays(&account.label, UserProfileMetadata::default())
+        .await
+        .expect_err("signed-out account must not publish");
+    assert!(
+        matches!(
+            signed_out,
+            AppError::RelayDirectory(ref message) if message == "account is signed out"
+        ),
+        "unexpected signed-out error: {signed_out:?}"
+    );
+
+    runtime.shutdown().await;
+    let stopped = runtime
+        .publish_user_profile_using_account_relays(&account.label, UserProfileMetadata::default())
+        .await
+        .expect_err("stopped runtime must not publish");
+    assert!(matches!(stopped, AppError::RuntimeStopping));
+}
+
 #[test]
 fn default_directory_discovery_relays_use_live_indexers() {
     let relays = default_directory_discovery_relays();

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -7997,34 +7997,34 @@ async fn account_owned_profile_publish_uses_the_selected_accounts_relay_configur
 
     runtime
         .publish_user_profile_using_account_relays(
-            &alice.account.account_id_hex,
+            &bob.account.account_id_hex,
             UserProfileMetadata {
-                name: Some("AliceAccountOwned".to_owned()),
+                name: Some("BobAccountOwned".to_owned()),
                 ..UserProfileMetadata::default()
             },
         )
         .await
         .unwrap();
 
-    let from_alice_relay = app
-        .fetch_current_user_profile_for_account_id(
-            &alice.account.account_id_hex,
-            vec![endpoint(&alice_relay_url)],
-        )
-        .await
-        .unwrap()
-        .and_then(|profile| profile.name);
-    assert_eq!(from_alice_relay.as_deref(), Some("AliceAccountOwned"));
-
     let from_bob_relay = app
         .fetch_current_user_profile_for_account_id(
-            &alice.account.account_id_hex,
+            &bob.account.account_id_hex,
             vec![endpoint(&bob_relay_url)],
         )
         .await
         .unwrap()
         .and_then(|profile| profile.name);
-    assert_ne!(from_bob_relay.as_deref(), Some("AliceAccountOwned"));
+    assert_eq!(from_bob_relay.as_deref(), Some("BobAccountOwned"));
+
+    let from_alice_relay = app
+        .fetch_current_user_profile_for_account_id(
+            &bob.account.account_id_hex,
+            vec![endpoint(&alice_relay_url)],
+        )
+        .await
+        .unwrap()
+        .and_then(|profile| profile.name);
+    assert_ne!(from_alice_relay.as_deref(), Some("BobAccountOwned"));
 
     assert_ne!(alice.account.account_id_hex, bob.account.account_id_hex);
 }

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -1785,13 +1785,13 @@ async fn runtime_profile_publish_preserves_unknown_kind0_fields() {
                 ]),
                 ..UserProfileMetadata::default()
             },
-            bootstrap.clone(),
+            bootstrap,
         )
         .await
         .unwrap();
 
     let updated = runtime
-        .publish_user_profile(
+        .publish_user_profile_using_account_relays(
             &created.account.label,
             UserProfileMetadata {
                 name: Some("second".to_owned()),
@@ -1799,7 +1799,6 @@ async fn runtime_profile_publish_preserves_unknown_kind0_fields() {
                 banner: Some("https://example.test/banner.png".to_owned()),
                 ..UserProfileMetadata::default()
             },
-            bootstrap,
         )
         .await
         .unwrap();
@@ -7963,6 +7962,71 @@ async fn account_publishes_route_to_own_nip65_not_bootstrap() {
         Some("OutboxTest"),
         "profile should be retrievable from the account's nip65 (home) relay"
     );
+}
+
+#[tokio::test]
+async fn account_owned_profile_publish_uses_the_selected_accounts_relay_configuration() {
+    let dir = tempfile::tempdir().unwrap();
+    let (_alice_relay, alice_relay_url) = mock_relay().await;
+    let (_bob_relay, bob_relay_url) = mock_relay().await;
+    let app = MarmotApp::with_relay_and_config(
+        dir.path(),
+        alice_relay_url.clone(),
+        MarmotAppConfig::default().with_allow_loopback_relay_endpoints(true),
+    );
+    let runtime = MarmotAppRuntime::new(app.clone());
+
+    let alice = runtime
+        .create_identity(AccountSetupRequest {
+            default_relays: vec![endpoint(&alice_relay_url)],
+            bootstrap_relays: vec![endpoint(&alice_relay_url)],
+            publish_initial_key_package: true,
+            ..AccountSetupRequest::default()
+        })
+        .await
+        .unwrap();
+    let bob = runtime
+        .create_identity(AccountSetupRequest {
+            default_relays: vec![endpoint(&bob_relay_url)],
+            bootstrap_relays: vec![endpoint(&bob_relay_url)],
+            publish_initial_key_package: true,
+            ..AccountSetupRequest::default()
+        })
+        .await
+        .unwrap();
+
+    runtime
+        .publish_user_profile_using_account_relays(
+            &alice.account.account_id_hex,
+            UserProfileMetadata {
+                name: Some("AliceAccountOwned".to_owned()),
+                ..UserProfileMetadata::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    let from_alice_relay = app
+        .fetch_current_user_profile_for_account_id(
+            &alice.account.account_id_hex,
+            vec![endpoint(&alice_relay_url)],
+        )
+        .await
+        .unwrap()
+        .and_then(|profile| profile.name);
+    assert_eq!(from_alice_relay.as_deref(), Some("AliceAccountOwned"));
+
+    let from_bob_relay = app
+        .fetch_current_user_profile_for_account_id(
+            &alice.account.account_id_hex,
+            vec![endpoint(&bob_relay_url)],
+        )
+        .await
+        .unwrap()
+        .and_then(|profile| profile.name);
+    assert_ne!(from_bob_relay.as_deref(), Some("AliceAccountOwned"));
+
+    assert_ne!(alice.account.account_id_hex, bob.account.account_id_hex);
 }
 
 #[tokio::test]

--- a/crates/marmot-uniffi/src/commands/account.rs
+++ b/crates/marmot-uniffi/src/commands/account.rs
@@ -495,9 +495,14 @@ impl Marmot {
         )?)
     }
 
-    /// Publish the Nostr kind:0 metadata for `account_ref`. The returned
-    /// metadata is what marmot-app actually published (any server-applied
-    /// defaults are reflected here).
+    /// Publish Nostr kind:0 metadata with explicit caller-supplied relay
+    /// overrides. Most app clients should use
+    /// [`publish_user_profile_using_account_relays`](Self::publish_user_profile_using_account_relays)
+    /// so relay selection remains owned by MDK. This override remains for
+    /// diagnostics, tests, and specialized clients.
+    ///
+    /// The returned metadata is what marmot-app actually published (including
+    /// preserved unknown fields and any merge defaults).
     pub async fn publish_user_profile(
         &self,
         account_ref: String,
@@ -512,6 +517,30 @@ impl Marmot {
         let pushed = self
             .runtime
             .publish_user_profile(&account_ref, UserProfileMetadata::from(profile), bootstrap)
+            .await?;
+        Ok(pushed.into())
+    }
+
+    /// Publish Nostr kind:0 metadata using one coherent snapshot of the
+    /// selected account's MDK-owned relay configuration.
+    ///
+    /// Published NIP-65 write relays are preferred. When that list is empty,
+    /// remembered bootstrap relays are used; when bootstrap relays are absent,
+    /// the account's default/publish list is the fallback. Invalid, unsafe, and
+    /// retired endpoints are removed by the relay safety policy before any
+    /// network work starts. No preceding [`account_relay_lists`](Self::account_relay_lists)
+    /// call is needed.
+    pub async fn publish_user_profile_using_account_relays(
+        &self,
+        account_ref: String,
+        profile: UserProfileMetadataFfi,
+    ) -> Result<UserProfileMetadataFfi, MarmotKitError> {
+        let pushed = self
+            .runtime
+            .publish_user_profile_using_account_relays(
+                &account_ref,
+                UserProfileMetadata::from(profile),
+            )
             .await?;
         Ok(pushed.into())
     }
@@ -665,5 +694,40 @@ mod tests {
             .await
             .expect_err("missing current kind-3 must not be treated as empty");
         assert!(matches!(error, MarmotKitError::FollowListUnavailable));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn account_owned_profile_publish_binding_needs_no_relay_arguments() {
+        let relay = MockRelay::run().await.expect("start mock relay");
+        let relay_url = relay.url().await.to_string();
+        let root = tempfile::tempdir().expect("tempdir");
+        let app = MarmotApp::with_relays(root.path(), vec![relay_url.clone()]);
+        let runtime = app.runtime();
+        let kit = Marmot { app, runtime };
+        let endpoint = TransportEndpoint(relay_url);
+        let account = kit
+            .runtime
+            .create_identity(marmot_app::AccountSetupRequest {
+                default_relays: vec![endpoint.clone()],
+                bootstrap_relays: vec![endpoint],
+                publish_missing_relay_lists: true,
+                publish_initial_key_package: true,
+                ..marmot_app::AccountSetupRequest::default()
+            })
+            .await
+            .expect("create identity");
+
+        let published = kit
+            .publish_user_profile_using_account_relays(
+                account.account.account_id_hex,
+                UserProfileMetadataFfi {
+                    display_name: Some("Account Owned".to_owned()),
+                    ..UserProfileMetadataFfi::default()
+                },
+            )
+            .await
+            .expect("publish without a host relay-list read");
+
+        assert_eq!(published.display_name.as_deref(), Some("Account Owned"));
     }
 }


### PR DESCRIPTION
## Summary
- add `publish_user_profile_using_account_relays`, which captures one account-scoped relay projection and uses it for both profile merge reads and publication
- centralize publish/bootstrap fallback plus invalid, unsafe, and retired endpoint filtering while preserving the explicit relay-override API and kind-0 merge behavior
- reduce the normal host path from two FFI calls (`account_relay_lists` plus publish) to one, with no added network operations

## Test plan
- [x] New test failed before the fix and passes after
- [x] Account-owned selection covers populated, empty-publish, missing-bootstrap, invalid, retired, cross-account, signed-out, and stopped cases
- [x] `cargo test -p marmot-uniffi`
- [x] `cargo test -p marmot-app profile_publish -- --nocapture`
- [x] `just fast-ci`
- [x] iOS and macOS XCFramework generation plus native and SwiftPM validation
- [x] Kotlin generation plus all four Android JNI ABI builds
- [ ] Full `cargo test -p marmot-app` remains blocked by five unrelated `relay_runtime` failures that reproduce on clean `origin/master`; all 689 library tests and 99 of 104 relay-runtime tests passed

Fixes #1491

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added account-specific profile publishing using the account’s configured relay settings.
  * Added safe relay selection with publish-relay preference and fallback options.
  * Profile publishing now supports explicit relay overrides.
  * Added validation for signed-out accounts and cases with no usable relays.

* **Bug Fixes**
  * Prevented profile updates from being published to another account’s relay configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->