### PR TITLE
Apply initial message retention atomically during group creation

### DIFF
--- a/crates/cgka-engine/benches/group_lifecycle.rs
+++ b/crates/cgka-engine/benches/group_lifecycle.rs
@@ -21,6 +21,9 @@ use cgka_engine::account_identity_proof::{
     AccountIdentityProofRequest, AccountIdentityProofSigner,
 };
 use cgka_engine::{Engine, EngineBuilder};
+use cgka_traits::app_components::{
+    AppComponentData, GROUP_MESSAGE_RETENTION_COMPONENT_ID, default_group_components,
+};
 use cgka_traits::app_event::{MARMOT_APP_EVENT_KIND_CHAT, MarmotAppEvent};
 use cgka_traits::engine::{CgkaEngine, CreateGroupRequest, KeyPackage, SendIntent, SendResult};
 use cgka_traits::error::PeelerError;
@@ -254,6 +257,21 @@ fn build_client_with_storage(
         .expect("build bench engine")
 }
 
+fn build_retention_client(identity: &[u8]) -> Engine<SqliteAccountStorage> {
+    EngineBuilder::new(SqliteAccountStorage::in_memory().unwrap())
+        .identity(pad32(identity))
+        .account_identity_proof_signer(proof_signer(identity))
+        .supported_app_components(
+            default_group_components()
+                .into_iter()
+                .chain([GROUP_MESSAGE_RETENTION_COMPONENT_ID]),
+        )
+        .protocol_profile(ProtocolProfile::Current)
+        .peeler(Box::new(BenchPeeler))
+        .build()
+        .expect("build retention bench engine")
+}
+
 fn build_deferred_bench_client(
     identity: &[u8],
     storage: SqliteAccountStorage,
@@ -328,13 +346,42 @@ fn invitee_key_packages(count: usize) -> Vec<KeyPackage> {
     out
 }
 
+fn retention_invitee_key_packages(count: usize) -> Vec<KeyPackage> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("helper runtime");
+    let mut out = Vec::with_capacity(count);
+    for index in 0..count {
+        let identity = format!("bench-retention-invitee-{index}");
+        let mut engine = build_retention_client(identity.as_bytes());
+        out.push(
+            rt.block_on(engine.fresh_key_package())
+                .expect("mint retention-aware invitee key package"),
+        );
+    }
+    out
+}
+
 fn create_request(members: Vec<KeyPackage>) -> CreateGroupRequest {
+    create_request_with_retention(members, None)
+}
+
+fn create_request_with_retention(
+    members: Vec<KeyPackage>,
+    disappearing_message_secs: Option<u64>,
+) -> CreateGroupRequest {
     CreateGroupRequest {
         name: "bench".into(),
         description: "bench".into(),
         members,
         required_features: vec![],
-        app_components: vec![],
+        app_components: disappearing_message_secs
+            .map(|seconds| AppComponentData {
+                component_id: GROUP_MESSAGE_RETENTION_COMPONENT_ID,
+                data: seconds.to_be_bytes().to_vec(),
+            })
+            .into_iter()
+            .collect(),
         initial_admins: vec![],
     }
 }
@@ -415,31 +462,39 @@ fn bench_create_group(c: &mut Criterion) {
         .expect("bench runtime");
     let mut group = c.benchmark_group("create_group");
     for invitees in [1_usize, 8, 32] {
-        let key_packages = invitee_key_packages(invitees);
-        group.bench_with_input(
-            BenchmarkId::from_parameter(format!("{invitees} invitees")),
-            &key_packages,
-            |b, key_packages| {
-                let alice = std::sync::Arc::new(tokio::sync::Mutex::new(build_client(
-                    b"bench-alice-create",
-                )));
-                b.to_async(&rt).iter(|| {
-                    let alice = alice.clone();
-                    async move {
-                        let request = create_request(key_packages.clone());
-                        let (group_id, result) = alice
-                            .lock()
-                            .await
-                            .create_group(request)
-                            .await
-                            .expect("create_group succeeds");
-                        // Sanity: founding creation returns one Welcome per invitee.
-                        debug_assert!(matches!(result, SendResult::FoundingGroupCreated { .. }));
-                        group_id
-                    }
-                });
-            },
-        );
+        for (retention, disappearing_message_secs) in [("disabled", None), ("enabled", Some(300))] {
+            let key_packages = retention_invitee_key_packages(invitees);
+            group.bench_with_input(
+                BenchmarkId::from_parameter(format!("{invitees} invitees, retention {retention}")),
+                &key_packages,
+                |b, key_packages| {
+                    let alice = std::sync::Arc::new(tokio::sync::Mutex::new(
+                        build_retention_client(b"bench-alice-create"),
+                    ));
+                    b.to_async(&rt).iter(|| {
+                        let alice = alice.clone();
+                        async move {
+                            let request = create_request_with_retention(
+                                key_packages.clone(),
+                                disappearing_message_secs,
+                            );
+                            let (group_id, result) = alice
+                                .lock()
+                                .await
+                                .create_group(request)
+                                .await
+                                .expect("create_group succeeds");
+                            // Sanity: founding creation returns one Welcome per invitee.
+                            debug_assert!(matches!(
+                                result,
+                                SendResult::FoundingGroupCreated { .. }
+                            ));
+                            group_id
+                        }
+                    });
+                },
+            );
+        }
     }
     group.finish();
 }

--- a/crates/cgka-engine/tests/group_creation.rs
+++ b/crates/cgka-engine/tests/group_creation.rs
@@ -17,8 +17,8 @@ use cgka_traits::EngineError;
 use cgka_traits::app_components::{
     ACCOUNT_IDENTITY_PROOF_COMPONENT_ID, APP_COMPONENTS_COMPONENT_ID, AppComponentData,
     EncryptedMediaPolicyV2, GROUP_ADMIN_POLICY_COMPONENT_ID, GROUP_ENCRYPTED_MEDIA_V2_COMPONENT_ID,
-    GROUP_LIFECYCLE_COMPONENT_ID, GROUP_PROFILE_COMPONENT_ID, GroupLifecycleV1,
-    NOSTR_ROUTING_COMPONENT_ID, NostrRoutingV1, decode_group_lifecycle_v1,
+    GROUP_LIFECYCLE_COMPONENT_ID, GROUP_MESSAGE_RETENTION_COMPONENT_ID, GROUP_PROFILE_COMPONENT_ID,
+    GroupLifecycleV1, NOSTR_ROUTING_COMPONENT_ID, NostrRoutingV1, decode_group_lifecycle_v1,
     default_group_components, encode_components_list, encode_encrypted_media_policy_v2,
     encode_nostr_routing_v1,
 };
@@ -50,7 +50,7 @@ use openmls::prelude::{
 use openmls_basic_credential::SignatureKeyPair;
 use openmls_traits::types::Ciphersuite;
 use std::sync::Arc;
-use storage_sqlite::SqliteAccountStorage;
+use storage_sqlite::{SqlCipherKey, SqliteAccountStorage};
 use tls_codec::{Deserialize as _, Serialize as _};
 
 mod support;
@@ -520,6 +520,43 @@ impl TransportPeeler for MockPeeler {
                 recipient: recipient.clone(),
             },
         })
+    }
+}
+
+struct BlockingWelcomePeeler {
+    inner: MockPeeler,
+    started: Arc<tokio::sync::Notify>,
+}
+
+#[async_trait]
+impl TransportPeeler for BlockingWelcomePeeler {
+    async fn peel_group_message(
+        &self,
+        msg: &TransportMessage,
+        ctx: &GroupContextSnapshot,
+    ) -> Result<PeeledMessage, PeelerError> {
+        self.inner.peel_group_message(msg, ctx).await
+    }
+
+    async fn peel_welcome(&self, msg: &TransportMessage) -> Result<PeeledMessage, PeelerError> {
+        self.inner.peel_welcome(msg).await
+    }
+
+    async fn wrap_group_message(
+        &self,
+        payload: &EncryptedPayload,
+        ctx: &GroupContextSnapshot,
+    ) -> Result<TransportMessage, PeelerError> {
+        self.inner.wrap_group_message(payload, ctx).await
+    }
+
+    async fn wrap_welcome(
+        &self,
+        _payload: &EncryptedPayload,
+        _recipient: &MemberId,
+    ) -> Result<TransportMessage, PeelerError> {
+        self.started.notify_one();
+        std::future::pending().await
     }
 }
 
@@ -1125,6 +1162,196 @@ async fn current_group_persists_profile_and_rejects_legacy_key_packages() {
     let (stored_group, stored_welcome) = reopened.stored_sent_welcome(&welcome_id).unwrap();
     assert_eq!(stored_group, group_id);
     assert_eq!(stored_welcome.id, welcome_id);
+}
+
+#[tokio::test]
+async fn current_group_initial_retention_is_canonical_for_creator_invitee_and_restart() {
+    let directory = tempfile::tempdir().unwrap();
+    let database = directory.path().join("founding-retention.sqlite");
+    let database_key = SqlCipherKey::new("founding retention restart key").unwrap();
+    let storage = SqliteAccountStorage::open_encrypted(&database, &database_key).unwrap();
+    let supported = default_group_components()
+        .into_iter()
+        .chain([GROUP_MESSAGE_RETENTION_COMPONENT_ID])
+        .collect::<Vec<_>>();
+    let mut alice = EngineBuilder::new(storage)
+        .identity(pad32(b"alice-founding-retention"))
+        .account_identity_proof_signer(proof_signer(b"alice-founding-retention"))
+        .supported_app_components(supported.clone())
+        .protocol_profile(ProtocolProfile::Current)
+        .peeler(Box::new(MockPeeler::default()))
+        .build()
+        .unwrap();
+    let mut bob = EngineBuilder::new(SqliteAccountStorage::in_memory().unwrap())
+        .identity(pad32(b"bob-founding-retention"))
+        .account_identity_proof_signer(proof_signer(b"bob-founding-retention"))
+        .supported_app_components(supported.clone())
+        .protocol_profile(ProtocolProfile::Current)
+        .peeler(Box::new(MockPeeler::default()))
+        .build()
+        .unwrap();
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+
+    let (group_id, created) = alice
+        .create_group(CreateGroupRequest {
+            name: "founding retention".into(),
+            description: String::new(),
+            members: vec![bob_kp],
+            required_features: vec![],
+            app_components: vec![AppComponentData {
+                component_id: GROUP_MESSAGE_RETENTION_COMPONENT_ID,
+                data: 300u64.to_be_bytes().to_vec(),
+            }],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let welcome = match created {
+        SendResult::FoundingGroupCreated { mut welcomes } => welcomes.remove(0),
+        other => panic!("expected one canonical founding result, got {other:?}"),
+    };
+
+    assert_eq!(
+        alice
+            .app_component(&group_id, GROUP_MESSAGE_RETENTION_COMPONENT_ID)
+            .unwrap(),
+        Some(300u64.to_be_bytes().to_vec())
+    );
+    let joined = bob.join_welcome(welcome).await.unwrap();
+    assert_eq!(joined, group_id);
+    assert_eq!(
+        bob.app_component(&joined, GROUP_MESSAGE_RETENTION_COMPONENT_ID)
+            .unwrap(),
+        Some(300u64.to_be_bytes().to_vec()),
+        "the Welcome must carry the founding retention state"
+    );
+
+    drop(alice);
+    let reopened_storage = SqliteAccountStorage::open_encrypted(&database, &database_key).unwrap();
+    let mut reopened = EngineBuilder::new(reopened_storage)
+        .identity(pad32(b"alice-founding-retention"))
+        .account_identity_proof_signer(proof_signer(b"alice-founding-retention"))
+        .supported_app_components(supported)
+        .protocol_profile(ProtocolProfile::Current)
+        .peeler(Box::new(MockPeeler::default()))
+        .build()
+        .unwrap();
+    reopened.hydrate_all_stored_groups().unwrap();
+    assert_eq!(
+        reopened
+            .app_component(&group_id, GROUP_MESSAGE_RETENTION_COMPONENT_ID)
+            .unwrap(),
+        Some(300u64.to_be_bytes().to_vec())
+    );
+}
+
+#[tokio::test]
+async fn current_group_initial_retention_rejects_unsupported_invitee_before_state() {
+    let storage = SqliteAccountStorage::in_memory().unwrap();
+    let supported = default_group_components()
+        .into_iter()
+        .chain([GROUP_MESSAGE_RETENTION_COMPONENT_ID])
+        .collect::<Vec<_>>();
+    let mut alice = EngineBuilder::new(storage)
+        .identity(pad32(b"alice-unsupported-retention"))
+        .account_identity_proof_signer(proof_signer(b"alice-unsupported-retention"))
+        .supported_app_components(supported)
+        .protocol_profile(ProtocolProfile::Current)
+        .peeler(Box::new(MockPeeler::default()))
+        .build()
+        .unwrap();
+    let mut bob = build_current_client(b"bob-unsupported-retention");
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+
+    let error = alice
+        .create_group(CreateGroupRequest {
+            name: "unsupported retention".into(),
+            description: String::new(),
+            members: vec![bob_kp],
+            required_features: vec![],
+            app_components: vec![AppComponentData {
+                component_id: GROUP_MESSAGE_RETENTION_COMPONENT_ID,
+                data: 300u64.to_be_bytes().to_vec(),
+            }],
+            initial_admins: vec![],
+        })
+        .await
+        .expect_err("retention must be supported by every founding member");
+
+    assert!(matches!(
+        error,
+        EngineError::MissingRequiredCapabilities { ref required, .. }
+            if required
+                .app_components
+                .contains(GROUP_MESSAGE_RETENTION_COMPONENT_ID)
+    ));
+    assert!(alice.live_group_ids().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn cancelling_founding_retention_before_canonicalization_leaves_no_group() {
+    let storage = SqliteAccountStorage::in_memory().unwrap();
+    let supported = default_group_components()
+        .into_iter()
+        .chain([GROUP_MESSAGE_RETENTION_COMPONENT_ID])
+        .collect::<Vec<_>>();
+    let mut bob = EngineBuilder::new(SqliteAccountStorage::in_memory().unwrap())
+        .identity(pad32(b"bob-cancel-founding-retention"))
+        .account_identity_proof_signer(proof_signer(b"bob-cancel-founding-retention"))
+        .supported_app_components(supported.clone())
+        .protocol_profile(ProtocolProfile::Current)
+        .peeler(Box::new(MockPeeler::default()))
+        .build()
+        .unwrap();
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let started = Arc::new(tokio::sync::Notify::new());
+    let task_storage = storage.clone();
+    let task_supported = supported.clone();
+    let task_started = started.clone();
+    let creation = tokio::spawn(async move {
+        let mut alice = EngineBuilder::new(task_storage)
+            .identity(pad32(b"alice-cancel-founding-retention"))
+            .account_identity_proof_signer(proof_signer(b"alice-cancel-founding-retention"))
+            .supported_app_components(task_supported)
+            .protocol_profile(ProtocolProfile::Current)
+            .peeler(Box::new(BlockingWelcomePeeler {
+                inner: MockPeeler::default(),
+                started: task_started,
+            }))
+            .build()
+            .unwrap();
+        alice
+            .create_group(CreateGroupRequest {
+                name: "cancel founding retention".into(),
+                description: String::new(),
+                members: vec![bob_kp],
+                required_features: vec![],
+                app_components: vec![AppComponentData {
+                    component_id: GROUP_MESSAGE_RETENTION_COMPONENT_ID,
+                    data: 300u64.to_be_bytes().to_vec(),
+                }],
+                initial_admins: vec![],
+            })
+            .await
+    });
+
+    started.notified().await;
+    creation.abort();
+    assert!(creation.await.unwrap_err().is_cancelled());
+
+    let mut reopened = EngineBuilder::new(storage)
+        .identity(pad32(b"alice-cancel-founding-retention"))
+        .account_identity_proof_signer(proof_signer(b"alice-cancel-founding-retention"))
+        .supported_app_components(supported)
+        .protocol_profile(ProtocolProfile::Current)
+        .peeler(Box::new(MockPeeler::default()))
+        .build()
+        .unwrap();
+    reopened.hydrate_all_stored_groups().unwrap();
+    assert!(
+        reopened.live_group_ids().unwrap().is_empty(),
+        "cancellation before the canonical transaction must clean up the provisional MLS group"
+    );
 }
 
 #[tokio::test]

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -7,8 +7,8 @@ use cgka_traits::agent_text_stream::{
     AGENT_TEXT_STREAM_EXPORTER_CACHE_KEY, AgentTextStreamQuicPolicyV1,
 };
 use cgka_traits::app_components::{
-    AGENT_TEXT_STREAM_QUIC_COMPONENT_ID, AppComponentData, BLOSSOM_LOCATOR_KIND_V1,
-    BlobStoreEndpointV1, BlobStoreEndpointV2, ENCRYPTED_MEDIA_FORMAT_V1, ENCRYPTED_MEDIA_FORMAT_V2,
+    AppComponentData, AppComponentSet, BLOSSOM_LOCATOR_KIND_V1, BlobStoreEndpointV1,
+    BlobStoreEndpointV2, ENCRYPTED_MEDIA_FORMAT_V1, ENCRYPTED_MEDIA_FORMAT_V2,
     EncryptedMediaPolicyV1, EncryptedMediaPolicyV2, GROUP_ADMIN_POLICY_COMPONENT_ID,
     GROUP_AVATAR_URL_COMPONENT_ID, GROUP_BLOSSOM_IMAGE_COMPONENT_ID,
     GROUP_ENCRYPTED_MEDIA_EXPORTER_CACHE_KEY, GROUP_MESSAGE_RETENTION_COMPONENT_ID,
@@ -19,11 +19,11 @@ use cgka_traits::capabilities::GroupCapabilities;
 use cgka_traits::engine::{CreateGroupRequest, KeyPackage, SendIntent};
 use cgka_traits::group::ProtocolProfile;
 use cgka_traits::transport::TransportEnvelope;
-use cgka_traits::{GroupId, MessageId, SecretBytes};
+use cgka_traits::{EngineError, GroupId, MessageId, SecretBytes};
 #[cfg(test)]
 use futures::StreamExt;
 use marmot_account::{
-    CompletedWelcomePublishTask, PreparedSessionSend, PreparedWelcomePublishTask,
+    AccountError, CompletedWelcomePublishTask, PreparedSessionSend, PreparedWelcomePublishTask,
 };
 use marmot_forensics::AuditEventContext;
 use nostr::NostrSigner;
@@ -43,14 +43,14 @@ use crate::messages::{AppMessageIntent, build_inner_event, encode_inner_event};
 use crate::notifications;
 use crate::{
     AccountState, AgentOperationEventRequest, AgentTextStreamFinishRequest, AppBlobEndpoint,
-    AppDisbandRequest, AppError, AppGroupAdminPolicyComponent, AppGroupAvatarUrlComponent,
-    AppGroupEncryptedMediaComponent, AppGroupImageComponent, AppGroupImageInput,
-    AppGroupMemberRecord, AppGroupMessageRetentionComponent, AppGroupMlsState, AppGroupRecord,
-    AppInitialGroupImage, AppPerformanceTelemetry, AppQuarantinedGroup, AppRoutingState,
-    AppRuntime, AppTransportRouting, GroupInviteDeclineResult, MarmotApp, MarmotRelayPlane,
-    MarmotRelayPlaneAccountAdapter, MediaAttachmentReference, MediaDownloadResult,
-    MediaUploadRequest, MediaUploadResult, PendingWelcomeDelivery, SelfMembership, SendSummary,
-    remember_seen_event, unix_now_seconds,
+    AppCreateGroupOptions, AppDisbandRequest, AppError, AppGroupAdminPolicyComponent,
+    AppGroupAvatarUrlComponent, AppGroupEncryptedMediaComponent, AppGroupImageComponent,
+    AppGroupImageInput, AppGroupMemberRecord, AppGroupMessageRetentionComponent, AppGroupMlsState,
+    AppGroupRecord, AppInitialGroupImage, AppPerformanceTelemetry, AppQuarantinedGroup,
+    AppRoutingState, AppRuntime, AppTransportRouting, GroupInviteDeclineResult, MarmotApp,
+    MarmotRelayPlane, MarmotRelayPlaneAccountAdapter, MediaAttachmentReference,
+    MediaDownloadResult, MediaUploadRequest, MediaUploadResult, PendingWelcomeDelivery,
+    SelfMembership, SendSummary, remember_seen_event, unix_now_seconds,
 };
 
 mod audit;
@@ -837,7 +837,7 @@ impl AppClient {
         name: &str,
         member_refs: &[&str],
     ) -> Result<GroupId, AppError> {
-        self.create_group_with_initial_image(name, member_refs, None)
+        self.create_group_with_options(name, member_refs, AppCreateGroupOptions::default())
             .await
     }
 
@@ -847,14 +847,25 @@ impl AppClient {
         member_refs: &[&str],
         initial_image: Option<AppInitialGroupImage>,
     ) -> Result<GroupId, AppError> {
-        let group_id = self
-            .create_group_with_initial_profile_and_optional_telemetry(
-                name,
-                "",
-                member_refs,
+        self.create_group_with_options(
+            name,
+            member_refs,
+            AppCreateGroupOptions {
                 initial_image,
-                None,
-            )
+                ..Default::default()
+            },
+        )
+        .await
+    }
+
+    pub async fn create_group_with_options(
+        &mut self,
+        name: &str,
+        member_refs: &[&str],
+        options: AppCreateGroupOptions,
+    ) -> Result<GroupId, AppError> {
+        let group_id = self
+            .create_group_with_options_and_optional_telemetry(name, member_refs, options, None)
             .await?;
         self.drive_unpublished_welcome_delivery(None).await;
         // Direct `AppClient` callers do not have the managed account worker to
@@ -873,33 +884,35 @@ impl AppClient {
         Ok(group_id)
     }
 
-    pub(crate) async fn create_group_with_initial_profile_and_telemetry(
+    pub(crate) async fn create_group_with_options_and_telemetry(
         &mut self,
         name: &str,
-        description: &str,
         member_refs: &[&str],
-        initial_image: Option<AppInitialGroupImage>,
+        options: AppCreateGroupOptions,
         telemetry: &AppPerformanceTelemetry,
     ) -> Result<GroupId, AppError> {
-        self.create_group_with_initial_profile_and_optional_telemetry(
+        self.create_group_with_options_and_optional_telemetry(
             name,
-            description,
             member_refs,
-            initial_image,
+            options,
             Some(telemetry),
         )
         .await
     }
 
-    async fn create_group_with_initial_profile_and_optional_telemetry(
+    async fn create_group_with_options_and_optional_telemetry(
         &mut self,
         name: &str,
-        description: &str,
         member_refs: &[&str],
-        initial_image: Option<AppInitialGroupImage>,
+        options: AppCreateGroupOptions,
         telemetry: Option<&AppPerformanceTelemetry>,
     ) -> Result<GroupId, AppError> {
-        validate_group_profile(name, description)?;
+        let AppCreateGroupOptions {
+            description,
+            initial_image,
+            disappearing_message_secs,
+        } = options;
+        validate_group_profile(name, &description)?;
         let key_package_started_at = Instant::now();
         let key_packages = self
             .app
@@ -943,9 +956,15 @@ impl AppClient {
                 .map_err(|err| AppError::InvalidAgentTextStreamPolicy(err.to_string()))?,
         );
         let encrypted_media = self.encrypted_media_component_for_new_group()?;
-        let encrypted_media_component_id = encrypted_media.component_id;
         app_components.push(encrypted_media);
+        if disappearing_message_secs != 0 {
+            app_components.push(
+                AppGroupMessageRetentionComponent::new(disappearing_message_secs)
+                    .to_app_component_data()?,
+            );
+        }
         let constructable = self.runtime.constructable_capabilities(&members)?;
+        require_initial_group_component_support(&constructable, &app_components)?;
         let has_initial_image = initial_image.is_some();
         let image_started_at = Instant::now();
         let optional_app_components = async {
@@ -987,11 +1006,10 @@ impl AppClient {
             );
         }
         let optional_app_components = optional_app_components?;
-        let mut touched_components = vec![
-            NOSTR_ROUTING_COMPONENT_ID,
-            AGENT_TEXT_STREAM_QUIC_COMPONENT_ID,
-            encrypted_media_component_id,
-        ];
+        let mut touched_components = app_components
+            .iter()
+            .map(|component| component.component_id)
+            .collect::<Vec<_>>();
         touched_components.extend(
             optional_app_components
                 .iter()
@@ -1000,6 +1018,9 @@ impl AppClient {
         let mut changed_fields = vec!["name", "members"];
         if !description.is_empty() {
             changed_fields.push("description");
+        }
+        if disappearing_message_secs != 0 {
+            changed_fields.push("message_retention");
         }
         if !optional_app_components.is_empty() {
             changed_fields.push("image");
@@ -1017,7 +1038,7 @@ impl AppClient {
             .prepare_create_group_with_optional_app_components_and_audit_context(
                 CreateGroupRequest {
                     name: name.to_owned(),
-                    description: description.to_owned(),
+                    description,
                     members,
                     required_features: Vec::new(),
                     app_components,
@@ -4308,6 +4329,32 @@ fn preferred_initial_group_image_component(
     }
 }
 
+fn require_initial_group_component_support(
+    constructable: &GroupCapabilities,
+    app_components: &[AppComponentData],
+) -> Result<(), AppError> {
+    let required = AppComponentSet::new(
+        app_components
+            .iter()
+            .map(|component| component.component_id),
+    );
+    if required
+        .missing_from(&constructable.app_components)
+        .is_empty()
+    {
+        return Ok(());
+    }
+    Err(AppError::Account(AccountError::Engine(
+        EngineError::MissingRequiredCapabilities {
+            required: Box::new(GroupCapabilities {
+                app_components: required,
+                ..GroupCapabilities::default()
+            }),
+            had: Box::new(constructable.clone()),
+        },
+    )))
+}
+
 /// Whether the local account (`local_account_id_hex`) is absent from a group's
 /// engine roster — the backfill's suppression decision. MLS member ids in this
 /// design are the Nostr account pubkey hex, so an account is "still a member"
@@ -4329,10 +4376,12 @@ mod post_canonical_create_tests {
     use super::{
         CREATE_GROUP_LOOKUP_CONCURRENCY, INVITE_LOOKUP_CONCURRENCY, collect_bounded_ordered,
         preferred_initial_group_image_component, recover_post_canonical_result,
+        require_initial_group_component_support,
     };
     use crate::AppError;
     use cgka_traits::app_components::{
-        GROUP_AVATAR_URL_COMPONENT_ID, GROUP_BLOSSOM_IMAGE_COMPONENT_ID,
+        AppComponentData, GROUP_AVATAR_URL_COMPONENT_ID, GROUP_BLOSSOM_IMAGE_COMPONENT_ID,
+        GROUP_MESSAGE_RETENTION_COMPONENT_ID,
     };
     use cgka_traits::capabilities::GroupCapabilities;
 
@@ -4362,6 +4411,33 @@ mod post_canonical_create_tests {
             preferred_initial_group_image_component(&capabilities, false),
             None
         );
+    }
+
+    #[test]
+    fn founding_required_components_are_preflighted_against_every_member() {
+        let retention = AppComponentData {
+            component_id: GROUP_MESSAGE_RETENTION_COMPONENT_ID,
+            data: 300u64.to_be_bytes().to_vec(),
+        };
+        let mut capabilities = GroupCapabilities::default();
+        let error = require_initial_group_component_support(
+            &capabilities,
+            std::slice::from_ref(&retention),
+        )
+        .expect_err("unsupported retention must fail before founding side effects");
+        assert!(matches!(
+            error,
+            AppError::Account(marmot_account::AccountError::Engine(
+                cgka_traits::EngineError::MissingRequiredCapabilities { ref required, .. }
+            )) if required
+                .app_components
+                .contains(GROUP_MESSAGE_RETENTION_COMPONENT_ID)
+        ));
+
+        capabilities
+            .app_components
+            .insert(GROUP_MESSAGE_RETENTION_COMPONENT_ID);
+        require_initial_group_component_support(&capabilities, &[retention]).unwrap();
     }
 
     #[test]

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -2516,11 +2516,10 @@ mod runtime_group_subscription_refresh_tests {
         client.prepare_transport().await.unwrap();
         let telemetry = AppPerformanceTelemetry::default();
         client
-            .create_group_with_initial_profile_and_telemetry(
+            .create_group_with_options_and_telemetry(
                 "catch-up retry intent",
-                "",
                 &[],
-                None,
+                crate::AppCreateGroupOptions::default(),
                 &telemetry,
             )
             .await

--- a/crates/marmot-app/src/groups.rs
+++ b/crates/marmot-app/src/groups.rs
@@ -73,6 +73,18 @@ impl std::fmt::Debug for AppInitialGroupImage {
     }
 }
 
+/// Forward-compatible options for creating a group.
+///
+/// A zero retention value preserves the historical disabled-retention
+/// behavior and does not make message retention a founding capability
+/// requirement.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct AppCreateGroupOptions {
+    pub description: String,
+    pub initial_image: Option<AppInitialGroupImage>,
+    pub disappearing_message_secs: u64,
+}
+
 /// A group invite still pending the local device's confirmation decision
 /// (`pending_confirmation && !archived` in the account projection). Carries
 /// only what an invite policy needs to accept or decline; returned by

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -154,15 +154,15 @@ pub use drafts::{
 };
 pub use error::{AccountCatchUpFailure, AppError};
 pub use groups::{
-    AppAgentTextStreamComponent, AppBlobEndpoint, AppDisbandFailureReason, AppDisbandRequest,
-    AppGroupAdminPolicyComponent, AppGroupAvatarUrlComponent, AppGroupConversationSnapshot,
-    AppGroupEncryptedMediaComponent, AppGroupHydrationQuarantineReason, AppGroupImageComponent,
-    AppGroupLifecycleState, AppGroupMemberIds, AppGroupMemberRecord,
-    AppGroupMessageRetentionComponent, AppGroupMlsState, AppGroupNostrRoutingComponent,
-    AppGroupOpaqueComponent, AppGroupProfileComponent, AppGroupRecord, AppGroupRoster,
-    AppGroupRosterMember, AppGroupSystemEvent, AppInitialGroupImage, AppPriorNostrRoute,
-    AppProtocolProfile, AppQuarantinedGroup, MAX_GROUP_MEMBER_IDS_PAGE_SIZE, PendingGroupInvite,
-    group_system_event_from_message,
+    AppAgentTextStreamComponent, AppBlobEndpoint, AppCreateGroupOptions, AppDisbandFailureReason,
+    AppDisbandRequest, AppGroupAdminPolicyComponent, AppGroupAvatarUrlComponent,
+    AppGroupConversationSnapshot, AppGroupEncryptedMediaComponent,
+    AppGroupHydrationQuarantineReason, AppGroupImageComponent, AppGroupLifecycleState,
+    AppGroupMemberIds, AppGroupMemberRecord, AppGroupMessageRetentionComponent, AppGroupMlsState,
+    AppGroupNostrRoutingComponent, AppGroupOpaqueComponent, AppGroupProfileComponent,
+    AppGroupRecord, AppGroupRoster, AppGroupRosterMember, AppGroupSystemEvent,
+    AppInitialGroupImage, AppPriorNostrRoute, AppProtocolProfile, AppQuarantinedGroup,
+    MAX_GROUP_MEMBER_IDS_PAGE_SIZE, PendingGroupInvite, group_system_event_from_message,
 };
 pub use ids::{
     account_id_hex_from_ref, nprofile_for_account_id, npub_for_account_id, validate_relay_urls,

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -30,8 +30,8 @@ use crate::messages::AppMessageIntent;
 use crate::{
     ACCOUNT_WORKER_RECONNECT_BASE_DELAY, ACCOUNT_WORKER_RECONNECT_JITTER_MAX_MS,
     ACCOUNT_WORKER_RECONNECT_MAX_DELAY, APP_RUNTIME_ACCOUNT_SHUTDOWN_WAIT, AccountCatchUpFailure,
-    AgentTextStreamFinishRequest, AppBlobEndpoint, AppClient, AppDisbandRequest, AppError,
-    AppGroupMemberRecord, AppGroupMlsState, AppGroupRecord, AppInitialGroupImage,
+    AgentTextStreamFinishRequest, AppBlobEndpoint, AppClient, AppCreateGroupOptions,
+    AppDisbandRequest, AppError, AppGroupMemberRecord, AppGroupMlsState, AppGroupRecord,
     AppProjectionUpdate, AppQuarantinedGroup, ClassifiedSyncFailure, ConvergenceScheduleState,
     EpochBackfillRunOutcome, GroupInviteDeclineResult, MaintenanceRunSummary, MarmotApp,
     MarmotRelayPlane, MediaAttachmentReference, MediaDownloadResult, MediaUploadRequest,
@@ -111,8 +111,7 @@ pub(crate) enum AccountWorkerCommand {
         queued_at: Instant,
         name: String,
         members: Vec<String>,
-        description: Option<String>,
-        initial_image: Option<AppInitialGroupImage>,
+        options: AppCreateGroupOptions,
         respond: oneshot::Sender<Result<GroupId, AppError>>,
     },
     Members {
@@ -2523,8 +2522,7 @@ async fn handle_account_worker_command(
             queued_at,
             name,
             members,
-            description,
-            initial_image,
+            options,
             respond,
         } => {
             let telemetry = shared.app_performance_telemetry();
@@ -2535,13 +2533,7 @@ async fn handle_account_worker_command(
             );
             let member_refs = members.iter().map(String::as_str).collect::<Vec<_>>();
             let result = client
-                .create_group_with_initial_profile_and_telemetry(
-                    &name,
-                    description.as_deref().unwrap_or_default(),
-                    &member_refs,
-                    initial_image,
-                    &telemetry,
-                )
+                .create_group_with_options_and_telemetry(&name, &member_refs, options, &telemetry)
                 .await;
             if let Ok(group_id) = &result {
                 publish_app_runtime_group_state_updated(

--- a/crates/marmot-app/src/runtime/commands.rs
+++ b/crates/marmot-app/src/runtime/commands.rs
@@ -19,13 +19,13 @@ use super::{
 use crate::app_telemetry::AppPerformanceOperation;
 use crate::messages::AppMessageIntent;
 use crate::{
-    AgentOperationEventRequest, AgentTextStreamFinishRequest, AppBlobEndpoint, AppDisbandRequest,
-    AppError, AppGroupConversationSnapshot, AppGroupMemberRecord, AppGroupMlsState, AppGroupRecord,
-    AppGroupRoster, AppQuarantinedGroup, GroupInviteDeclineResult, GroupPushDebugInfo,
-    MaintenanceRunSummary, MediaAttachmentReference, MediaDownloadResult, MediaUploadRequest,
-    MediaUploadResult, NotificationSettings, PendingWelcomeDelivery, PushPlatform,
-    PushRegistration, PushRegistrationShareOutcome, PushRegistrationSyncResult,
-    RetentionSweepReport, SecureDeleteExpiredResult, SendSummary,
+    AgentOperationEventRequest, AgentTextStreamFinishRequest, AppBlobEndpoint,
+    AppCreateGroupOptions, AppDisbandRequest, AppError, AppGroupConversationSnapshot,
+    AppGroupMemberRecord, AppGroupMlsState, AppGroupRecord, AppGroupRoster, AppQuarantinedGroup,
+    GroupInviteDeclineResult, GroupPushDebugInfo, MaintenanceRunSummary, MediaAttachmentReference,
+    MediaDownloadResult, MediaUploadRequest, MediaUploadResult, NotificationSettings,
+    PendingWelcomeDelivery, PushPlatform, PushRegistration, PushRegistrationShareOutcome,
+    PushRegistrationSyncResult, RetentionSweepReport, SecureDeleteExpiredResult, SendSummary,
 };
 
 impl AccountManager {
@@ -166,8 +166,16 @@ impl AccountManager {
         members: &[String],
         description: Option<String>,
     ) -> Result<GroupId, AppError> {
-        self.create_group_with_initial_image(account_ref, name, members, description, None)
-            .await
+        self.create_group_with_options(
+            account_ref,
+            name,
+            members,
+            AppCreateGroupOptions {
+                description: description.unwrap_or_default(),
+                ..Default::default()
+            },
+        )
+        .await
     }
 
     /// Prewarm the current group-composition roster outside the account-worker
@@ -203,6 +211,26 @@ impl AccountManager {
         description: Option<String>,
         initial_image: Option<crate::AppInitialGroupImage>,
     ) -> Result<GroupId, AppError> {
+        self.create_group_with_options(
+            account_ref,
+            name,
+            members,
+            AppCreateGroupOptions {
+                description: description.unwrap_or_default(),
+                initial_image,
+                ..Default::default()
+            },
+        )
+        .await
+    }
+
+    pub async fn create_group_with_options(
+        &self,
+        account_ref: &str,
+        name: &str,
+        members: &[String],
+        options: AppCreateGroupOptions,
+    ) -> Result<GroupId, AppError> {
         let started_at = Instant::now();
         let result = async {
             let command = self.worker_commands(account_ref).await?;
@@ -212,8 +240,7 @@ impl AccountManager {
                     queued_at: Instant::now(),
                     name: name.to_owned(),
                     members: members.to_vec(),
-                    description,
-                    initial_image,
+                    options,
                     respond,
                 })
                 .await

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -36,23 +36,23 @@ use crate::{
     APP_RUNTIME_LOCAL_WORKER_RESPONSE_WAIT, APP_RUNTIME_LONG_WORKER_RESPONSE_WAIT,
     APP_RUNTIME_RELAY_REBUILD_LOOKBACK, APP_RUNTIME_WORKER_RESPONSE_WAIT, AccountCatchUpFailure,
     AccountKeyPackageRecord, AccountRelayListBootstrap, AccountRelayListStatus, AccountUnread,
-    AgentOperationEventRequest, AgentTextStreamFinishRequest, AppBlobEndpoint, AppDisbandRequest,
-    AppError, AppGroupConversationSnapshot, AppGroupMemberRecord, AppGroupMlsState, AppGroupRecord,
-    AppGroupRoster, AppMessageQuery, AppMessageRecord, AppProjectionUpdate, AppQuarantinedGroup,
-    AuditLogDeleteOutcome, AuditLogFile, AuditLogSettings, AuditLogTrackerConfig,
-    AuditLogTrackerUpdateResult, AuditLogUploadResult, BackgroundNotificationCollection,
-    ChatListRow, ChatNotificationSettings, ChatPinState, ExistingDirectConversation,
-    GroupInviteDeclineResult, GroupPushDebugInfo, KeyPackageDeletionResult,
-    KeyPackageDeletionTarget, MAX_SEEN_EVENT_IDS, MarmotApp, MarmotRelayPlane,
-    MarmotServiceEndpoints, MediaAttachmentReference, MediaDownloadResult, MediaUploadRequest,
-    MediaUploadResult, MessageDraft, MessageDraftAttachment, MessageDraftSummary,
-    NotificationCollectionStatus, NotificationSettings, NotificationUpdate, NotificationWakeSource,
-    PendingWelcomeDelivery, PushPlatform, PushRegistration, PushRegistrationShareOutcome,
-    PushRegistrationSyncResult, ReceivedMessage, RelayTelemetryExportConfig,
-    RelayTelemetryRuntimeConfig, RelayTelemetrySettings, RetentionSweepReport,
-    SecureDeleteExpiredResult, SendSummary, TimelineMessageQuery, TimelineMessageRecord,
-    TimelinePage, UserDirectoryRefresh, UserProfileMetadata, default_profile_pseudonym,
-    unix_now_seconds,
+    AgentOperationEventRequest, AgentTextStreamFinishRequest, AppBlobEndpoint,
+    AppCreateGroupOptions, AppDisbandRequest, AppError, AppGroupConversationSnapshot,
+    AppGroupMemberRecord, AppGroupMlsState, AppGroupRecord, AppGroupRoster, AppMessageQuery,
+    AppMessageRecord, AppProjectionUpdate, AppQuarantinedGroup, AuditLogDeleteOutcome,
+    AuditLogFile, AuditLogSettings, AuditLogTrackerConfig, AuditLogTrackerUpdateResult,
+    AuditLogUploadResult, BackgroundNotificationCollection, ChatListRow, ChatNotificationSettings,
+    ChatPinState, ExistingDirectConversation, GroupInviteDeclineResult, GroupPushDebugInfo,
+    KeyPackageDeletionResult, KeyPackageDeletionTarget, MAX_SEEN_EVENT_IDS, MarmotApp,
+    MarmotRelayPlane, MarmotServiceEndpoints, MediaAttachmentReference, MediaDownloadResult,
+    MediaUploadRequest, MediaUploadResult, MessageDraft, MessageDraftAttachment,
+    MessageDraftSummary, NotificationCollectionStatus, NotificationSettings, NotificationUpdate,
+    NotificationWakeSource, PendingWelcomeDelivery, PushPlatform, PushRegistration,
+    PushRegistrationShareOutcome, PushRegistrationSyncResult, ReceivedMessage,
+    RelayTelemetryExportConfig, RelayTelemetryRuntimeConfig, RelayTelemetrySettings,
+    RetentionSweepReport, SecureDeleteExpiredResult, SendSummary, TimelineMessageQuery,
+    TimelineMessageRecord, TimelinePage, UserDirectoryRefresh, UserProfileMetadata,
+    default_profile_pseudonym, unix_now_seconds,
 };
 
 mod account_worker;
@@ -1308,6 +1308,18 @@ impl MarmotAppRuntime {
     ) -> Result<GroupId, AppError> {
         self.accounts
             .create_group_with_initial_image(account_ref, name, members, description, initial_image)
+            .await
+    }
+
+    pub async fn create_group_with_options(
+        &self,
+        account_ref: &str,
+        name: &str,
+        members: &[String],
+        options: AppCreateGroupOptions,
+    ) -> Result<GroupId, AppError> {
+        self.accounts
+            .create_group_with_options(account_ref, name, members, options)
             .await
     }
 

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -1354,6 +1354,57 @@ where
 }
 
 #[test]
+fn create_group_options_apply_initial_retention_atomically() {
+    run_composed_app_runtime_test("initial-group-retention", || async {
+        let dir = tempfile::tempdir().unwrap();
+        AccountHome::open(dir.path())
+            .create_account("alice")
+            .unwrap();
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+            .with_test_relay_client(Arc::new(ScriptedPushRelayClient::default()));
+        let mut client = app.client("alice").await.unwrap();
+
+        let retained = client
+            .create_group_with_options(
+                "retained from founding state",
+                &[],
+                AppCreateGroupOptions {
+                    disappearing_message_secs: 300,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        let disabled = client
+            .create_group_with_options(
+                "disabled retention compatibility",
+                &[],
+                AppCreateGroupOptions::default(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(client.group_mls_state(&retained).unwrap().epoch, 0);
+        assert_eq!(
+            app.group("alice", &hex::encode(retained.as_slice()))
+                .unwrap()
+                .unwrap()
+                .message_retention
+                .disappearing_message_secs,
+            300
+        );
+        assert_eq!(
+            app.group("alice", &hex::encode(disabled.as_slice()))
+                .unwrap()
+                .unwrap()
+                .message_retention
+                .disappearing_message_secs,
+            0
+        );
+    });
+}
+
+#[test]
 fn live_group_archive_checkpoints_seen_and_target_group_deltas() {
     run_composed_app_runtime_test("account-projection-delta", || async {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/marmot-uniffi/src/commands/group.rs
+++ b/crates/marmot-uniffi/src/commands/group.rs
@@ -61,6 +61,37 @@ impl std::fmt::Debug for InitialGroupImageFfi {
     }
 }
 
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct CreateGroupOptionsFfi {
+    pub description: Option<String>,
+    pub initial_image: Option<InitialGroupImageFfi>,
+    /// Zero preserves the compatibility behavior: disappearing messages are
+    /// disabled and retention is not a founding capability requirement.
+    pub disappearing_message_secs: u64,
+}
+
+impl From<InitialGroupImageFfi> for marmot_app::AppInitialGroupImage {
+    fn from(image: InitialGroupImageFfi) -> Self {
+        Self {
+            plaintext: image.plaintext,
+            media_type: image.media_type,
+            source_url: image.source_url,
+            dim: image.dim,
+            thumbhash: image.thumbhash,
+        }
+    }
+}
+
+impl From<CreateGroupOptionsFfi> for marmot_app::AppCreateGroupOptions {
+    fn from(options: CreateGroupOptionsFfi) -> Self {
+        Self {
+            description: options.description.unwrap_or_default(),
+            initial_image: options.initial_image.map(Into::into),
+            disappearing_message_secs: options.disappearing_message_secs,
+        }
+    }
+}
+
 pub(crate) async fn group_details_for(
     kit: &Marmot,
     account_ref: &str,
@@ -300,6 +331,23 @@ impl Marmot {
         Ok(hex::encode(group_id.as_slice()))
     }
 
+    /// Create a group with forward-compatible founding options. A nonzero
+    /// retention value is written into the founding MLS state and Welcome;
+    /// it does not emit a follow-up retention commit or publication.
+    pub async fn create_group_with_options(
+        &self,
+        account_ref: String,
+        name: String,
+        member_refs: Vec<String>,
+        options: CreateGroupOptionsFfi,
+    ) -> Result<String, MarmotKitError> {
+        let group_id = self
+            .runtime
+            .create_group_with_options(&account_ref, &name, &member_refs, options.into())
+            .await?;
+        Ok(hex::encode(group_id.as_slice()))
+    }
+
     /// Create a group with an optional initial avatar. MDK prefers an
     /// encrypted Blossom image and uses `source_url` only when the founding
     /// members do not all support that component but do support URL avatars.
@@ -311,13 +359,7 @@ impl Marmot {
         description: Option<String>,
         initial_image: Option<InitialGroupImageFfi>,
     ) -> Result<String, MarmotKitError> {
-        let initial_image = initial_image.map(|image| marmot_app::AppInitialGroupImage {
-            plaintext: image.plaintext,
-            media_type: image.media_type,
-            source_url: image.source_url,
-            dim: image.dim,
-            thumbhash: image.thumbhash,
-        });
+        let initial_image = initial_image.map(Into::into);
         let group_id = self
             .runtime
             .create_group_with_initial_image(
@@ -1169,6 +1211,26 @@ mod tests {
             .await
             .expect_err("stopped account must retain typed error mapping");
         assert!(matches!(stopped, MarmotKitError::RuntimeStopping));
+    }
+
+    #[test]
+    fn create_group_options_preserve_founding_retention_and_optional_fields() {
+        let options: marmot_app::AppCreateGroupOptions = CreateGroupOptionsFfi {
+            description: Some("founding description".into()),
+            initial_image: Some(InitialGroupImageFfi {
+                plaintext: vec![1, 2, 3],
+                media_type: "image/png".into(),
+                source_url: None,
+                dim: Some("1x1".into()),
+                thumbhash: None,
+            }),
+            disappearing_message_secs: 300,
+        }
+        .into();
+
+        assert_eq!(options.description, "founding description");
+        assert_eq!(options.disappearing_message_secs, 300);
+        assert_eq!(options.initial_image.unwrap().plaintext, vec![1, 2, 3]);
     }
 
     fn state(self_admin: bool, last_admin: bool) -> GroupManagementStateFfi {

--- a/crates/marmot-uniffi/src/commands/mod.rs
+++ b/crates/marmot-uniffi/src/commands/mod.rs
@@ -23,5 +23,5 @@ mod subscription;
 mod telemetry;
 mod timeline;
 
-pub use group::{InitialGroupImageFfi, MemberKeyPackagePrewarmSummaryFfi};
+pub use group::{CreateGroupOptionsFfi, InitialGroupImageFfi, MemberKeyPackagePrewarmSummaryFfi};
 pub use media::parse_media_imeta_tag;

--- a/crates/marmot-uniffi/src/lib.rs
+++ b/crates/marmot-uniffi/src/lib.rs
@@ -43,7 +43,8 @@ pub use markdown::{
 uniffi::setup_scaffolding!();
 
 pub use commands::{
-    InitialGroupImageFfi, MemberKeyPackagePrewarmSummaryFfi, parse_media_imeta_tag,
+    CreateGroupOptionsFfi, InitialGroupImageFfi, MemberKeyPackagePrewarmSummaryFfi,
+    parse_media_imeta_tag,
 };
 pub use conversions::{
     AppBlobEndpointFfi, AppGroupEncryptedMediaComponentFfi, AppGroupMemberIdsFfi,


### PR DESCRIPTION
## Summary

- add forward-compatible group creation options across AppClient, managed runtime, and UniFFI
- encode nonzero message retention directly in the founding MLS app components and Welcome, with no follow-up commit or publication
- preflight founding component capabilities before optional image upload or durable group mutation
- preserve zero as disabled compatibility behavior
- cover creator, invitee, restart, unsupported-member, cancellation, FFI, and benchmark paths

## Root cause

The engine already supports atomic founding app components and durable Welcome creation. The missing piece was app/runtime/UniFFI plumbing: group creation had no retention option, so clients could only apply retention after creation. This patch uses the existing founding transaction instead of adding a second mutation path.

## Verification

- [x] failing-first app regression test demonstrated the missing options API before implementation
- [x] `cargo test -p cgka-engine --features test-policy-overrides,test-crash-hooks`
- [x] post-rebase retention matrix: `cargo test -p cgka-engine --features test-policy-overrides,test-crash-hooks --test group_creation retention`
- [x] `cargo test -p marmot-uniffi`
- [x] post-rebase app and FFI option regressions
- [x] `just fast-ci` on current `origin/master`
- [x] iOS and macOS XCFramework generation
- [x] Kotlin generation and JNI builds for arm64-v8a, armeabi-v7a, x86, and x86_64

The focused Criterion smoke comparison covered 1, 8, and 32 invitees with retention disabled and enabled. It showed no systematic creation-time regression, and the implementation adds no network operation or publication. The filtered Criterion command emitted all measurements, then exited on an unrelated deferred-preflight fixture assertion at `group_lifecycle.rs:881`.

The full `cargo test -p marmot-app` library suite passed. Its relay-runtime integration phase retained five existing failures; representative endpoint and retention-system-row failures were reproduced on the then-current clean `origin/master` baseline.

Fixes #1489

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable disappearing-message retention when creating groups.
  * Group creation options now support descriptions, initial images, and retention settings across supported interfaces.
  * Added validation to detect unsupported member capabilities before group creation begins.

* **Bug Fixes**
  * Prevented incomplete group state when creation is cancelled or a member lacks required retention support.
  * Ensured retention settings are consistently preserved for creators, invitees, and restarts.

* **Tests**
  * Added coverage for enabled and disabled retention, capability validation, cancellation cleanup, and option conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->