### PR TITLE
Add Codex terminal harness connector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Test Pi and OpenCode installers
+      - name: Test Codex, Pi, and OpenCode installers
         run: |
           set -euo pipefail
+          integrations/terminal-harness/tests/test_installer.sh codex
           integrations/terminal-harness/tests/test_installer.sh pi
           integrations/terminal-harness/tests/test_installer.sh opencode
 

--- a/.github/workflows/wn-agent-binaries.yml
+++ b/.github/workflows/wn-agent-binaries.yml
@@ -460,6 +460,11 @@ jobs:
                 > "dist/install/install-$harness-marmot.sh"
             chmod 0755 "dist/install/install-$harness-marmot.sh"
           done
+          for installer in dist/install/install-*.sh; do
+            shasum -a 256 "$installer" | \
+              awk -v name="$(basename "$installer")" '{print $1 "  " name}' \
+              > "$installer.sha256"
+          done
 
       - name: Create or update wn-agent release
         shell: bash
@@ -547,10 +552,15 @@ jobs:
             dist/plugin/openclaw-marmot-plugin-"$version".tgz
             dist/plugin/openclaw-marmot-plugin-"$version".tgz.sha256
             dist/install/install-hermes-marmot.sh
+            dist/install/install-hermes-marmot.sh.sha256
             dist/install/install-openclaw-marmot.sh
+            dist/install/install-openclaw-marmot.sh.sha256
             dist/install/install-codex-marmot.sh
+            dist/install/install-codex-marmot.sh.sha256
             dist/install/install-opencode-marmot.sh
+            dist/install/install-opencode-marmot.sh.sha256
             dist/install/install-pi-marmot.sh
+            dist/install/install-pi-marmot.sh.sha256
           )
 
           if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
@@ -641,10 +651,15 @@ jobs:
 
           assets=(
             dist/install/install-hermes-marmot.sh
+            dist/install/install-hermes-marmot.sh.sha256
             dist/install/install-openclaw-marmot.sh
+            dist/install/install-openclaw-marmot.sh.sha256
             dist/install/install-codex-marmot.sh
+            dist/install/install-codex-marmot.sh.sha256
             dist/install/install-opencode-marmot.sh
+            dist/install/install-opencode-marmot.sh.sha256
             dist/install/install-pi-marmot.sh
+            dist/install/install-pi-marmot.sh.sha256
           )
 
           if gh release view "$latest_tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then

--- a/.github/workflows/wn-agent-binaries.yml
+++ b/.github/workflows/wn-agent-binaries.yml
@@ -11,6 +11,8 @@ on:
       - integrations/hermes/marmot/**
       - scripts/install-openclaw-marmot.sh
       - integrations/openclaw/marmot/**
+      - scripts/install-codex-marmot.sh
+      - integrations/codex/marmot/**
       - scripts/install-opencode-marmot.sh
       - integrations/opencode/marmot/**
       - scripts/install-pi-marmot.sh
@@ -100,6 +102,12 @@ jobs:
       - name: Smoke test wn-agent
         run: ./target/${{ matrix.rust_target }}/release/wn-agent --help
 
+      - name: Build wn-codex
+        run: cargo build --locked --release -p wn-codex --bin wn-codex --target "${{ matrix.rust_target }}"
+
+      - name: Smoke test wn-codex
+        run: ./target/${{ matrix.rust_target }}/release/wn-codex --help
+
       - name: Build wn-opencode
         run: cargo build --locked --release -p wn-opencode --bin wn-opencode --target "${{ matrix.rust_target }}"
 
@@ -116,7 +124,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          for binary in wn-agent wn-opencode wn-pi; do
+          for binary in wn-agent wn-codex wn-opencode wn-pi; do
             ./scripts/package-binary-bundle.sh \
               "$binary" \
               "${{ matrix.target }}" \
@@ -128,6 +136,13 @@ jobs:
         with:
           name: wn-agent-${{ matrix.target }}
           path: dist/wn-agent-${{ matrix.target }}/*
+          if-no-files-found: error
+
+      - name: Upload wn-codex bundle
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: wn-codex-${{ matrix.target }}
+          path: dist/wn-codex-${{ matrix.target }}/*
           if-no-files-found: error
 
       - name: Upload wn-opencode bundle
@@ -388,11 +403,15 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          mkdir -p dist/linux dist/linux-arm dist/darwin dist/darwin-intel dist/opencode-linux dist/opencode-linux-arm dist/opencode-darwin dist/opencode-darwin-intel dist/pi-linux dist/pi-linux-arm dist/pi-darwin dist/pi-darwin-intel dist/plugin
+          mkdir -p dist/linux dist/linux-arm dist/darwin dist/darwin-intel dist/codex-linux dist/codex-linux-arm dist/codex-darwin dist/codex-darwin-intel dist/opencode-linux dist/opencode-linux-arm dist/opencode-darwin dist/opencode-darwin-intel dist/pi-linux dist/pi-linux-arm dist/pi-darwin dist/pi-darwin-intel dist/plugin
           gh run download "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" --name wn-agent-linux-x86_64 --dir dist/linux
           gh run download "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" --name wn-agent-linux-aarch64 --dir dist/linux-arm
           gh run download "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" --name wn-agent-darwin-aarch64 --dir dist/darwin
           gh run download "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" --name wn-agent-darwin-x86_64 --dir dist/darwin-intel
+          gh run download "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" --name wn-codex-linux-x86_64 --dir dist/codex-linux
+          gh run download "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" --name wn-codex-linux-aarch64 --dir dist/codex-linux-arm
+          gh run download "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" --name wn-codex-darwin-aarch64 --dir dist/codex-darwin
+          gh run download "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" --name wn-codex-darwin-x86_64 --dir dist/codex-darwin-intel
           gh run download "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" --name wn-opencode-linux-x86_64 --dir dist/opencode-linux
           gh run download "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" --name wn-opencode-linux-aarch64 --dir dist/opencode-linux-arm
           gh run download "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" --name wn-opencode-darwin-aarch64 --dir dist/opencode-darwin
@@ -431,7 +450,7 @@ jobs:
             -e "s/^WN_AGENT_VERSION_DEFAULT=.*/WN_AGENT_VERSION_DEFAULT=\"${version}\"/" \
             scripts/install-openclaw-marmot.sh > dist/install/install-openclaw-marmot.sh
           chmod 0755 dist/install/install-openclaw-marmot.sh
-          for harness in opencode pi; do
+          for harness in codex opencode pi; do
             awk -v harness="$harness" \
               'NR == 1 { print; print "export MARMOT_TERMINAL_HARNESS=" harness; next } { print }' \
               scripts/install-terminal-harness-marmot.sh | \
@@ -459,6 +478,7 @@ jobs:
           \`\`\`sh
           curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/wn-agent-latest/install-hermes-marmot.sh | bash
           curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/wn-agent-latest/install-openclaw-marmot.sh | bash
+          curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/wn-agent-latest/install-codex-marmot.sh | bash
           curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/wn-agent-latest/install-opencode-marmot.sh | bash
           curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/wn-agent-latest/install-pi-marmot.sh | bash
           \`\`\`
@@ -468,18 +488,21 @@ jobs:
           \`\`\`sh
           curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/$tag/install-hermes-marmot.sh | bash
           curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/$tag/install-openclaw-marmot.sh | bash
+          curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/$tag/install-codex-marmot.sh | bash
           curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/$tag/install-opencode-marmot.sh | bash
           curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/$tag/install-pi-marmot.sh | bash
           \`\`\`
 
           Assets:
           - \`wn-agent-<platform>-$version.tar.gz\`: versioned binary bundle.
+          - \`wn-codex-<platform>-$version.tar.gz\`: Codex harness binary bundle.
           - \`wn-opencode-<platform>-$version.tar.gz\`: OpenCode harness binary bundle.
           - \`wn-pi-<platform>-$version.tar.gz\`: Pi harness binary bundle.
           - \`hermes-marmot-plugin-$version.tar.gz\`: Hermes platform plugin directory bundle.
           - \`openclaw-marmot-plugin-$version.tgz\`: OpenClaw channel plugin npm tarball.
           - \`install-hermes-marmot.sh\`: installer for testers with Hermes already installed.
           - \`install-openclaw-marmot.sh\`: installer for testers with OpenClaw already installed.
+          - \`install-codex-marmot.sh\`: installer for testers with Codex already installed.
           - \`install-opencode-marmot.sh\`: installer for testers with OpenCode already installed.
           - \`install-pi-marmot.sh\`: installer for testers with Pi already installed.
 
@@ -495,6 +518,14 @@ jobs:
             dist/darwin/wn-agent-darwin-aarch64-"$version".tar.gz.sha256
             dist/darwin-intel/wn-agent-darwin-x86_64-"$version".tar.gz
             dist/darwin-intel/wn-agent-darwin-x86_64-"$version".tar.gz.sha256
+            dist/codex-linux/wn-codex-linux-x86_64-"$version".tar.gz
+            dist/codex-linux/wn-codex-linux-x86_64-"$version".tar.gz.sha256
+            dist/codex-linux-arm/wn-codex-linux-aarch64-"$version".tar.gz
+            dist/codex-linux-arm/wn-codex-linux-aarch64-"$version".tar.gz.sha256
+            dist/codex-darwin/wn-codex-darwin-aarch64-"$version".tar.gz
+            dist/codex-darwin/wn-codex-darwin-aarch64-"$version".tar.gz.sha256
+            dist/codex-darwin-intel/wn-codex-darwin-x86_64-"$version".tar.gz
+            dist/codex-darwin-intel/wn-codex-darwin-x86_64-"$version".tar.gz.sha256
             dist/opencode-linux/wn-opencode-linux-x86_64-"$version".tar.gz
             dist/opencode-linux/wn-opencode-linux-x86_64-"$version".tar.gz.sha256
             dist/opencode-linux-arm/wn-opencode-linux-aarch64-"$version".tar.gz
@@ -517,6 +548,7 @@ jobs:
             dist/plugin/openclaw-marmot-plugin-"$version".tgz.sha256
             dist/install/install-hermes-marmot.sh
             dist/install/install-openclaw-marmot.sh
+            dist/install/install-codex-marmot.sh
             dist/install/install-opencode-marmot.sh
             dist/install/install-pi-marmot.sh
           )
@@ -589,6 +621,7 @@ jobs:
           \`\`\`sh
           curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/$latest_tag/install-hermes-marmot.sh | bash
           curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/$latest_tag/install-openclaw-marmot.sh | bash
+          curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/$latest_tag/install-codex-marmot.sh | bash
           curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/$latest_tag/install-opencode-marmot.sh | bash
           curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/$latest_tag/install-pi-marmot.sh | bash
           \`\`\`
@@ -609,6 +642,7 @@ jobs:
           assets=(
             dist/install/install-hermes-marmot.sh
             dist/install/install-openclaw-marmot.sh
+            dist/install/install-codex-marmot.sh
             dist/install/install-opencode-marmot.sh
             dist/install/install-pi-marmot.sh
           )

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ The canonical protocol specification lives in
 | Agent stream composition | `crates/agent-stream-compose/AGENTS.md` |
 | `wn-agent` connector daemon | `crates/agent-connector/AGENTS.md` |
 | Host integrations / connector coexistence | `integrations/AGENTS.md` |
+| Codex terminal harness | `integrations/codex/marmot/AGENTS.md` |
 | Forensic audit schema | `crates/marmot-forensics/AGENTS.md` |
 | App runtime UniFFI bindings | `crates/marmot-uniffi/AGENTS.md` |
 | CLI / daemon / TUI surface | `crates/cli/AGENTS.md` |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7425,6 +7425,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "wn-codex"
+version = "0.9.14"
+dependencies = [
+ "async-trait",
+ "clap",
+ "marmot-terminal-harness",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "wn-opencode"
 version = "0.9.14"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "crates/marmot-uniffi",
     "crates/cli",
     "integrations/terminal-harness",
+    "integrations/codex/marmot",
     "integrations/opencode/marmot",
     "integrations/pi/marmot",
 ]

--- a/Justfile
+++ b/Justfile
@@ -208,6 +208,12 @@ openclaw-host-compat-test:
 openclaw-dev-script-test:
     integrations/openclaw/marmot/test/dev-scripts.sh
 
+codex-installer-test:
+    integrations/codex/marmot/tests/test_installer.sh
+
+codex-dev-e2e-connector:
+    cargo test -p wn-codex --test e2e_connector -- --ignored --nocapture
+
 opencode-installer-test:
     integrations/opencode/marmot/tests/test_installer.sh
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Primary implementation areas:
 - `crates/cli` - CLI app surface plus `wnd` daemon and `wn tui`.
 - `integrations/hermes/marmot` - Hermes gateway plugin for the local `wn-agent` control socket.
 - `integrations/openclaw/marmot` - OpenClaw channel plugin for the local `wn-agent` control socket.
+- `integrations/codex/marmot` - Codex terminal harness for the local `wn-agent` control socket.
 - `integrations/opencode/marmot` - OpenCode terminal harness for the local `wn-agent` control socket.
 - `integrations/pi/marmot` - Pi terminal harness for the local `wn-agent` control socket.
 - `integrations/terminal-harness` - shared hardened runtime for terminal-harness connectors.

--- a/crates/agent-connector/README.md
+++ b/crates/agent-connector/README.md
@@ -11,8 +11,9 @@ Hermes is the first supported adapter. OpenClaw is the second: a TypeScript chan
 [`integrations/openclaw/marmot`](../../integrations/openclaw/marmot) that speaks the same agent-control protocol to this
 connector. `wn-opencode` is a pure Rust harness at
 [`integrations/opencode/marmot`](../../integrations/opencode/marmot) for routing allowed Marmot messages to
-OpenCode. `wn-pi` is the corresponding Pi harness at
-[`integrations/pi/marmot`](../../integrations/pi/marmot). Both use the shared hardened runtime in
+OpenCode. `wn-codex` and `wn-pi` are the corresponding Codex and Pi harnesses at
+[`integrations/codex/marmot`](../../integrations/codex/marmot) and
+[`integrations/pi/marmot`](../../integrations/pi/marmot). All three use the shared hardened runtime in
 [`integrations/terminal-harness`](../../integrations/terminal-harness).
 
 ## Names
@@ -146,6 +147,28 @@ The OpenClaw installer follows the same release flow, but uses its own default c
 `~/.marmot-agents/openclaw`, `wn-agent-openclaw.service` on Linux, or `org.marmot.wn-agent.openclaw` on macOS. It
 installs/enables the OpenClaw plugin and updates only `channels.marmot` in OpenClaw config so existing channels
 continue to work.
+
+## Codex Harness Install
+
+The same WN Agent release publishes the `wn-codex` harness binary and installer. Codex itself must already be installed
+and authenticated.
+
+```sh
+curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-codex-marmot.sh" | bash
+```
+
+For repeatable noninteractive setup:
+
+```sh
+curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-codex-marmot.sh" | \
+  bash -s -- --yes --allow-welcomer npub1...
+```
+
+The Codex installer creates or reuses the isolated agent home at `~/.marmot-agents/codex`, writes a private
+`wn-codex.env`, and starts same-user `wn-agent` and `wn-codex` services where supported. Its connector service is
+`wn-agent-codex.service` on Linux or `org.marmot.wn-agent.codex` on macOS. Codex-specific configuration and
+development commands live in
+[`integrations/codex/marmot/README.md`](../../integrations/codex/marmot/README.md).
 
 ## OpenCode Harness Install
 
@@ -282,9 +305,11 @@ Use the narrow checks first:
 cargo test -p agent-connector
 cargo check -p agent-connector --bin wn-agent
 bash scripts/install-hermes-marmot.sh --dry-run
+bash scripts/install-codex-marmot.sh --dry-run --yes --allow-welcomer "$(printf '11%.0s' {1..32})" --codex-bin /bin/echo
 bash scripts/install-opencode-marmot.sh --dry-run --yes --allow-welcomer "$(printf '11%.0s' {1..32})" --opencode-bin /bin/echo
 bash scripts/install-pi-marmot.sh --dry-run --yes --allow-welcomer "$(printf '11%.0s' {1..32})" --pi-bin /bin/echo
 integrations/hermes/marmot/tests/test_dev_scripts.sh
+just codex-installer-test
 just opencode-installer-test
 just pi-installer-test
 ```

--- a/crates/agent-connector/README.md
+++ b/crates/agent-connector/README.md
@@ -305,9 +305,10 @@ Use the narrow checks first:
 cargo test -p agent-connector
 cargo check -p agent-connector --bin wn-agent
 bash scripts/install-hermes-marmot.sh --dry-run
-bash scripts/install-codex-marmot.sh --dry-run --yes --allow-welcomer "$(printf '11%.0s' {1..32})" --codex-bin /bin/echo
-bash scripts/install-opencode-marmot.sh --dry-run --yes --allow-welcomer "$(printf '11%.0s' {1..32})" --opencode-bin /bin/echo
-bash scripts/install-pi-marmot.sh --dry-run --yes --allow-welcomer "$(printf '11%.0s' {1..32})" --pi-bin /bin/echo
+sender_hex="$(awk 'BEGIN { for (i = 0; i < 32; i++) printf "11" }')"
+bash scripts/install-codex-marmot.sh --dry-run --yes --allow-welcomer "$sender_hex" --codex-bin /bin/echo
+bash scripts/install-opencode-marmot.sh --dry-run --yes --allow-welcomer "$sender_hex" --opencode-bin /bin/echo
+bash scripts/install-pi-marmot.sh --dry-run --yes --allow-welcomer "$sender_hex" --pi-bin /bin/echo
 integrations/hermes/marmot/tests/test_dev_scripts.sh
 just codex-installer-test
 just opencode-installer-test

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -9,6 +9,13 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ## [Unreleased]
 
+### Added
+
+- Added the `wn-codex` terminal-harness connector with per-group Codex thread
+  resumption, stdin prompts, completed-assistant-only JSONL parsing, isolated
+  installer/service defaults, and WN Agent release bundles for supported Linux
+  and macOS targets.
+
 ## [0.9.14] - 2026-08-18
 
 ### Fixed

--- a/docs/marmot-architecture/AGENTS.md
+++ b/docs/marmot-architecture/AGENTS.md
@@ -82,10 +82,11 @@ Agent map for the Marmot architecture docs.
   - **Role:** Working plan for the Hermes/OpenClaw agent integration. Check status and dates before relying on it.
 
 - **Path:** `../../integrations/AGENTS.md`, `../../integrations/hermes/marmot/AGENTS.md`,
-  `../../integrations/openclaw/marmot/AGENTS.md`, `../../integrations/opencode/marmot/AGENTS.md`,
+  `../../integrations/openclaw/marmot/AGENTS.md`, `../../integrations/codex/marmot/AGENTS.md`,
+  `../../integrations/opencode/marmot/AGENTS.md`,
   `../../integrations/pi/marmot/AGENTS.md`, and `../../integrations/terminal-harness/AGENTS.md`
   - **Role:** Host integration boundaries, connector coexistence, and verification for the Hermes, OpenClaw,
-    OpenCode, and Pi integrations plus their shared terminal-harness runtime.
+    Codex, OpenCode, and Pi integrations plus their shared terminal-harness runtime.
 
 - **Repo:** `github.com/marmot-protocol/marmot`
   - **Role:** Marmot protocol specification by stable surface and app component.

--- a/integrations/AGENTS.md
+++ b/integrations/AGENTS.md
@@ -10,6 +10,7 @@ systems to Marmot through `wn-agent`.
 
 - `hermes/marmot` - Hermes platform plugin.
 - `openclaw/marmot` - OpenClaw channel plugin.
+- `codex/marmot` - `wn-codex` Codex harness binary.
 - `opencode/marmot` - `wn-opencode` OpenCode harness binary.
 - `pi/marmot` - `wn-pi` Pi harness binary.
 - `terminal-harness` - shared terminal-harness control/runtime library.
@@ -48,7 +49,7 @@ runtime to Marmot and may own activation policy, message-tool routing, live
 preview adaptation, media staging policy, profile onboarding, and gateway
 session behavior.
 
-`wn-opencode` and `wn-pi` are pure terminal harnesses. They subscribe to allowed
+`wn-codex`, `wn-opencode`, and `wn-pi` are pure terminal harnesses. They subscribe to allowed
 Marmot prompts and invoke their respective binaries; they should stay narrower than the
 gateway integrations unless there is a concrete product reason to broaden it.
 
@@ -120,10 +121,10 @@ Installer expectations:
 The default Hermes, OpenClaw, and terminal-harness service names are
 connector-specific
 (`wn-agent-hermes.service`, `wn-agent-openclaw.service`,
-`wn-agent-harnesses.service`, `wn-agent-pi.service`,
+`wn-agent-codex.service`, `wn-agent-harnesses.service`, `wn-agent-pi.service`,
 `org.marmot.wn-agent.hermes`, `org.marmot.wn-agent.openclaw`,
-`org.marmot.wn-agent.harnesses`, and `org.marmot.wn-agent.pi`). Harness services
-are also connector-specific (`wn-opencode` and `wn-pi`). If you add a new
+`org.marmot.wn-agent.codex`, `org.marmot.wn-agent.harnesses`, and `org.marmot.wn-agent.pi`). Harness services
+are also connector-specific (`wn-codex`, `wn-opencode`, and `wn-pi`). If you add a new
 production installer, choose names that can coexist with the existing
 integrations on the same login.
 
@@ -140,6 +141,10 @@ just hermes-dev-e2e-connector
 just openclaw-dev-test
 just openclaw-dev-script-test
 just openclaw-dev-e2e-connector
+
+cargo test -p wn-codex
+just codex-dev-e2e-connector
+just codex-installer-test
 
 cargo test -p wn-opencode
 just opencode-dev-e2e-connector
@@ -166,5 +171,5 @@ New integrations should follow the existing shape:
 - share installer/release conventions with the existing scripts;
 - document whether the integration is a gateway/channel plugin or a pure
   harness;
-- document coexistence with Hermes, OpenClaw, OpenCode, and Pi before landing
+- document coexistence with Hermes, OpenClaw, Codex, OpenCode, and Pi before landing
   production install support.

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -7,10 +7,11 @@ Current integrations:
 
 - [`hermes/marmot`](hermes/marmot) - Hermes platform plugin.
 - [`openclaw/marmot`](openclaw/marmot) - OpenClaw channel plugin.
+- [`codex/marmot`](codex/marmot) - `wn-codex` Codex harness binary.
 - [`opencode/marmot`](opencode/marmot) - `wn-opencode` OpenCode harness binary.
 - [`pi/marmot`](pi/marmot) - `wn-pi` Pi harness binary.
 - [`terminal-harness`](terminal-harness) - shared hardened runtime for the
-  OpenCode and Pi terminal harnesses.
+  Codex, OpenCode, and Pi terminal harnesses.
 
 All integrations are intentionally thin at the Marmot boundary. They do not own MLS
 state, Nostr transport, local account storage, relay access, QUIC preview
@@ -28,6 +29,7 @@ The release installers are published with the `wn-agent-v*` release family:
 
 - `scripts/install-hermes-marmot.sh`
 - `scripts/install-openclaw-marmot.sh`
+- `scripts/install-codex-marmot.sh`
 - `scripts/install-opencode-marmot.sh`
 - `scripts/install-pi-marmot.sh`
 
@@ -38,26 +40,27 @@ per connector:
 | --- | --- | --- |
 | Hermes | `$HOME/.marmot-agents/hermes` | `wn-agent-hermes.service` / `org.marmot.wn-agent.hermes` |
 | OpenClaw | `$HOME/.marmot-agents/openclaw` | `wn-agent-openclaw.service` / `org.marmot.wn-agent.openclaw` |
+| Codex harness | `$HOME/.marmot-agents/codex` | `wn-agent-codex.service` / `org.marmot.wn-agent.codex` plus `wn-codex.service` / `org.marmot.wn-codex` |
 | OpenCode harness | `$HOME/.marmot-agents/harnesses` | `wn-agent-harnesses.service` / `org.marmot.wn-agent.harnesses` plus `wn-opencode.service` / `org.marmot.wn-opencode` |
 | Pi harness | `$HOME/.marmot-agents/pi` | `wn-agent-pi.service` / `org.marmot.wn-agent.pi` plus `wn-pi.service` / `org.marmot.wn-pi` |
 
 Each home derives its own default socket at `$MARMOT_HOME/dev/wn-agent.sock` and
-uses the public relay defaults shared with the phone app pilot setup. OpenCode
-and Pi use separate connector homes and Marmot identities by default. They share
+uses the public relay defaults shared with the phone app pilot setup. Codex,
+OpenCode, and Pi use separate connector homes and Marmot identities by default. They share
 implementation in `integrations/terminal-harness`, but they do not share prompts,
 sessions, sockets, or services unless an operator explicitly configures a shared
 deployment.
 
 Hermes and OpenClaw install or patch their host-runtime plugin configuration and
 then print restart guidance for the existing gateway. They do not restart the
-gateway automatically. `wn-opencode` and `wn-pi` each install their own harness
+gateway automatically. `wn-codex`, `wn-opencode`, and `wn-pi` each install their own harness
 binary and service in addition to `wn-agent`, because they are standalone
 harnesses rather than plugins loaded by an existing gateway.
 
 ## Identity Model
 
 The default topology creates or reuses one Marmot account per connector home,
-which means Hermes, OpenClaw, OpenCode, and Pi present as separate Nostr
+which means Hermes, OpenClaw, Codex, OpenCode, and Pi present as separate Nostr
 identities when installed with default options.
 
 Within each home, `wn-agent bootstrap` lists local-signing accounts and reuses one
@@ -69,10 +72,11 @@ The installers persist the selected account into connector-specific config:
 
 - Hermes uses `MARMOT_ACCOUNT_ID_HEX` or the Marmot plugin config.
 - OpenClaw uses `channels.marmot.accountIdHex` or `MARMOT_ACCOUNT_ID_HEX`.
+- `wn-codex` uses `WN_CODEX_ACCOUNT_ID_HEX`.
 - `wn-opencode` uses `WN_OPENCODE_ACCOUNT_ID_HEX`.
 - `wn-pi` uses `WN_PI_ACCOUNT_ID_HEX`.
 
-Installing all four connectors on one machine with default options therefore
+Installing all five connectors on one machine with default options therefore
 creates distinct agent identities and distinct chat/group memberships.
 
 ## What Is Shared
@@ -101,6 +105,8 @@ Each host runtime keeps its own runtime state:
 
 - Hermes keeps Hermes gateway/plugin state under `HERMES_HOME`.
 - OpenClaw keeps OpenClaw gateway/channel state under `OPENCLAW_HOME`.
+- `wn-codex` keeps harness configuration in `$MARMOT_HOME/dev/wn-codex.env`
+  and session state under `$XDG_STATE_HOME/wn-codex` by default.
 - `wn-opencode` keeps harness configuration in
   `$MARMOT_HOME/dev/wn-opencode.env` and session state under
   `$XDG_STATE_HOME/wn-opencode` by default.
@@ -114,7 +120,7 @@ Each integration also makes its own activation decision:
   they default to mention-style activation and always reply in effective DMs.
   They also support richer gateway features such as live previews, durable reply
   routing, profile onboarding, and media handling.
-- `wn-opencode` and `wn-pi` are pure harnesses. They currently support only
+- `wn-codex`, `wn-opencode`, and `wn-pi` are pure harnesses. They currently support only
   `always` activation for prompt messages from explicitly allowed senders, and
   have no media, profile onboarding, or live-preview behavior.
 
@@ -122,7 +128,7 @@ Because activation is per integration, there is no global "claim this message"
 lease in shared-account deployments. If several integrations subscribe to the
 same account and group, every eligible integration can reply. For example, a
 direct message from an allowlisted sender could trigger Hermes/OpenClaw,
-`wn-opencode`, and `wn-pi` if all are running and configured for that account.
+`wn-codex`, `wn-opencode`, and `wn-pi` if all are running and configured for that account.
 
 ## Allowlist Behavior
 
@@ -133,11 +139,12 @@ the same account.
 
 Hermes and OpenClaw can mirror configured `allowFrom`/welcomer entries into
 `wn-agent`. Their sync path is config-driven and may reconcile the connector
-allowlist to the configured set. Both terminal harnesses require at least one
+allowlist to the configured set. All terminal harnesses require at least one
 allowed sender and install those senders into both the prompt allowlist and the
 `wn-agent` welcomer allowlist. Their startup mirroring is additive: removing a
 sender only from `wn-agent` is not a full harness revoke while the sender remains
-in `WN_OPENCODE_ALLOWED_SENDERS_HEX` or `WN_PI_ALLOWED_SENDERS_HEX`.
+in `WN_CODEX_ALLOWED_SENDERS_HEX`, `WN_OPENCODE_ALLOWED_SENDERS_HEX`, or
+`WN_PI_ALLOWED_SENDERS_HEX`.
 
 For shared-account deployments, prefer one explicit source of truth for the
 account's allowed welcomers, or configure every integration with the same
@@ -189,6 +196,10 @@ just hermes-dev-e2e-connector
 just openclaw-dev-test
 just openclaw-dev-script-test
 just openclaw-dev-e2e-connector
+
+cargo test -p wn-codex
+just codex-dev-e2e-connector
+just codex-installer-test
 
 cargo test -p wn-opencode
 just opencode-dev-e2e-connector

--- a/integrations/codex/marmot/AGENTS.md
+++ b/integrations/codex/marmot/AGENTS.md
@@ -1,0 +1,51 @@
+# AGENTS.md - integrations/codex/marmot
+
+Rust Codex harness for Marmot through the local `wn-agent` control socket. Read
+`README.md`, `../../AGENTS.md`, and `../../terminal-harness/AGENTS.md` first.
+
+## Scope
+
+- A control-plane-only harness. `wn-agent` owns Marmot state, MLS, Nostr,
+  durable sends, and invite handling; this crate invokes Codex and parses its
+  JSONL event stream.
+- Every message from an allowed sender is a prompt. Do not add gateway,
+  mention-activation, media, profile, or QUIC preview behavior here.
+- Send prompts over stdin, emit only completed `agent_message` text, and never
+  expose reasoning, command output, tool output, or partial items.
+- Preserve the shared workdir/session mapping rules. One Marmot group maps to
+  one Codex thread id and later prompts use `codex exec resume`.
+- The CLI contract is `codex exec --json -` for a new thread and
+  `codex exec resume --json <thread-id> -` for a resumed thread. Re-verify the
+  official non-interactive-mode contract before changing invocation flags or
+  JSON event parsing.
+
+## Key Files
+
+- `src/main.rs` - binary entrypoint, CLI help, tracing setup, and shared runtime wiring.
+- `src/config.rs` - Codex-specific environment configuration.
+- `src/codex.rs` - Codex command construction, stdin prompting, JSONL parsing, and process lifecycle.
+- `tests/e2e_connector.rs` - ignored process-level test using real `wn-agent` and a fake Codex executable.
+- `tests/test_installer.sh` - Codex entrypoint for the shared terminal-harness installer test suite.
+- `scripts/install-codex-marmot.sh` - release-installer wrapper over the shared terminal-harness installer.
+
+## Rules
+
+- Keep prompts on stdin; do not move prompt text into process arguments.
+- Do not add `--full-auto`, `--dangerously-bypass-approvals-and-sandbox`, or
+  connector-specific sandbox/approval overrides until the shared connector
+  permission model is designed.
+- Split completed assistant text into byte-budgeted Marmot messages. Keep
+  `WN_CODEX_MAX_REPLY_BYTES=30000` below the Marmot message cap.
+- Keep request/response and Codex event validation strict; malformed or
+  unsupported events must not become durable replies.
+
+## Verification
+
+```sh
+cargo test -p wn-codex
+cargo fmt --check -p wn-codex
+cargo clippy -p wn-codex --all-targets -- -D warnings
+bash -n scripts/install-codex-marmot.sh scripts/install-terminal-harness-marmot.sh
+just codex-dev-e2e-connector
+just codex-installer-test
+```

--- a/integrations/codex/marmot/AGENTS.md
+++ b/integrations/codex/marmot/AGENTS.md
@@ -17,7 +17,8 @@ Rust Codex harness for Marmot through the local `wn-agent` control socket. Read
 - The CLI contract is `codex exec --json -` for a new thread and
   `codex exec resume --json <thread-id> -` for a resumed thread. Re-verify the
   official non-interactive-mode contract before changing invocation flags or
-  JSON event parsing.
+  JSON event parsing. The new-thread and resume paths were verified end-to-end
+  against `codex-cli 0.146.0`.
 
 ## Key Files
 

--- a/integrations/codex/marmot/CLAUDE.md
+++ b/integrations/codex/marmot/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/integrations/codex/marmot/Cargo.toml
+++ b/integrations/codex/marmot/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "wn-codex"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[[bin]]
+name = "wn-codex"
+path = "src/main.rs"
+
+[dependencies]
+async-trait.workspace = true
+clap.workspace = true
+marmot-terminal-harness.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true, features = ["io-util", "macros", "process", "rt-multi-thread", "sync", "time"] }
+tracing.workspace = true
+tracing-subscriber.workspace = true
+
+[dev-dependencies]
+marmot-terminal-harness = { workspace = true, features = ["test-support"] }
+tempfile.workspace = true
+tokio = { workspace = true, features = ["test-util"] }

--- a/integrations/codex/marmot/README.md
+++ b/integrations/codex/marmot/README.md
@@ -1,0 +1,139 @@
+# wn-codex
+
+`wn-codex` is a terminal-harness connector that sends authorized Marmot group
+messages to [Codex](https://learn.chatgpt.com/) through the local
+`wn-agent` control socket. It is intentionally a thin harness: no mention
+activation, media handling, profile onboarding, live previews, MLS, or relay
+logic.
+
+It uses Codex's documented non-interactive JSONL interface: a new group starts
+with `codex exec --json -`, and later messages resume the group's Codex thread
+with `codex exec resume --json <thread-id> -`.
+
+## Install (Codex Already Installed)
+
+Versioned `wn-agent-v*` releases publish `wn-agent`, `wn-codex`, checksums, and
+a same-user service installer for Linux and macOS.
+
+Prerequisites:
+
+- Codex installed, authenticated, and runnable on `PATH`, or an executable path
+  set with `WN_CODEX_BIN` / `--codex-bin`
+- White Noise phone app pointed at the same public relay set
+- Linux x86_64, Linux arm64, macOS Apple Silicon, or macOS Intel
+
+```sh
+curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-codex-marmot.sh" | bash
+```
+
+For noninteractive setup, provide the allowed inviter and prompt sender:
+
+```sh
+curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-codex-marmot.sh" | \
+  bash -s -- --yes --allow-welcomer npub1...
+```
+
+The default install uses its own `~/.marmot-agents/codex` identity and services,
+so it does not share prompts or replies with installed OpenCode or Pi harnesses.
+It installs `wn-agent` and `wn-codex` in `~/.local/bin`, writes a private
+`~/.marmot-agents/codex/dev/wn-codex.env`, and starts `wn-agent-codex` and
+`wn-codex` same-user services where supported.
+
+Use a versioned `wn-agent-v<version>` release URL for a pinned install. Report
+all installed versions when filing a connector bug:
+
+```sh
+wn-agent --version
+wn-codex --version
+codex --version
+```
+
+## Manual Setup
+
+Install Codex first and authenticate it normally, then run an isolated
+`wn-agent` identity and the harness:
+
+```sh
+export MARMOT_HOME="$HOME/.marmot-agents/codex"
+export MARMOT_AGENT_SOCKET="$MARMOT_HOME/dev/wn-agent.sock"
+export WN_CODEX_ALLOWED_SENDERS_HEX="..."
+
+# Shell 1: wn-agent runs in the foreground.
+wn-agent --home "$MARMOT_HOME" --socket "$MARMOT_AGENT_SOCKET" \
+  --relay wss://relay.eu.whitenoise.chat \
+  --relay wss://relay.us.whitenoise.chat
+
+# Shell 2: bootstrap the identity, then start the harness.
+wn-agent bootstrap --home "$MARMOT_HOME" --socket "$MARMOT_AGENT_SOCKET" \
+  --label codex-harness-agent --allow-welcomer "$WN_CODEX_ALLOWED_SENDERS_HEX" --qr
+
+wn-codex
+```
+
+On the first message in a group, use `/<path>` to select a Git working
+directory under `$HOME`. A picker-only message stores the workdir without
+starting Codex. Subsequent prompts resume that group's Codex thread.
+
+## Configuration
+
+| Environment variable | Default | Meaning |
+| --- | --- | --- |
+| `MARMOT_HOME` | `~/.marmot-agents/codex` | Isolated Codex connector home |
+| `MARMOT_AGENT_SOCKET` | `$MARMOT_HOME/dev/wn-agent.sock` | Control socket |
+| `MARMOT_AGENT_AUTH_TOKEN_FILE` / `MARMOT_AGENT_AUTH_TOKEN` | unset | Optional control authentication |
+| `WN_CODEX_ALLOWED_SENDERS_HEX` | required | Comma-separated authorized sender ids |
+| `WN_CODEX_ACCOUNT_ID_HEX` | sole local account | Explicit account selection |
+| `WN_CODEX_BIN` | `codex` | Codex executable |
+| `WN_CODEX_IDLE_TIMEOUT_SECS` | `120` | Maximum silence per invocation |
+| `WN_CODEX_TIMEOUT_SECS` | `3600` | Total invocation cap |
+| `WN_CODEX_REQUEST_TIMEOUT_SECS` | `30` | Control request timeout |
+| `WN_CODEX_MAX_REPLY_BYTES` | `30000` | Durable reply chunk limit |
+| `WN_CODEX_MAX_PENDING_PER_GROUP` | `4` | Per-group prompt queue limit |
+| `WN_CODEX_STATE_PATH` | `$XDG_STATE_HOME/wn-codex/sessions.json` | Group thread/workdir map |
+| `WN_CODEX_ACTIVATION` | `always` | Only supported activation mode |
+
+Codex credentials, model, config, sandbox, approval policy, and project trust
+remain authoritative. This first connector version deliberately adds no
+permission-broadening flags; common permission/configuration controls will be
+designed across all terminal harnesses separately. Prompts are written to Codex
+over stdin, and only completed `agent_message` text is returned to Marmot.
+
+The optional bearer token grants the complete `wn-agent` control API for every
+account in its home; the sender allowlist does not narrow that authority. Use a
+separate connector home, socket, token, and account for a separate trust
+boundary.
+
+## Security Notes
+
+- The configured sender list controls prompt execution and is mirrored
+  additively into the `wn-agent` welcomer allowlist. To revoke access, remove the
+  sender from `WN_CODEX_ALLOWED_SENDERS_HEX`, restart `wn-codex`, and remove it
+  from `wn-agent` separately if invite acceptance must also be revoked.
+- Prompts are passed to Codex over stdin rather than process arguments.
+- Only completed assistant messages are returned. Reasoning, command/tool
+  events, partial items, and usage events are not sent to Marmot.
+- Logs exclude identifiers, paths, prompts, Codex output, relay URLs, pubkeys,
+  ciphertext, plaintext, and key material.
+- Connector state is created with owner-only permissions by the shared harness.
+
+## Development
+
+```sh
+cargo test -p marmot-terminal-harness
+cargo test -p wn-codex
+just codex-dev-e2e-connector
+just codex-installer-test
+cargo run -p wn-codex
+bash scripts/install-codex-marmot.sh --dry-run --yes --allow-welcomer "$(printf '11%.0s' {1..32})" --codex-bin /bin/echo
+```
+
+The real Codex contract test is ignored by default because it requires an
+installed, authenticated Codex and makes a model request:
+
+```sh
+cargo test -p wn-codex real_codex_exec_contract -- --ignored --nocapture
+```
+
+The crate is a workspace member at `integrations/codex/marmot`. The upstream
+event contract is documented in [Codex non-interactive
+mode](https://learn.chatgpt.com/docs/non-interactive-mode).

--- a/integrations/codex/marmot/README.md
+++ b/integrations/codex/marmot/README.md
@@ -23,14 +23,39 @@ Prerequisites:
 - Linux x86_64, Linux arm64, macOS Apple Silicon, or macOS Intel
 
 ```sh
-curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-codex-marmot.sh" | bash
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' 0 HUP INT TERM
+curl -fsSL "$base_url/install-codex-marmot.sh" -o "$tmpdir/install-codex-marmot.sh"
+curl -fsSL "$base_url/install-codex-marmot.sh.sha256" -o "$tmpdir/install-codex-marmot.sh.sha256"
+if command -v shasum >/dev/null 2>&1; then
+  (cd "$tmpdir" && shasum -a 256 -c install-codex-marmot.sh.sha256)
+elif command -v sha256sum >/dev/null 2>&1; then
+  (cd "$tmpdir" && sha256sum -c install-codex-marmot.sh.sha256)
+else
+  echo "error: need shasum or sha256sum to verify the installer" >&2
+  exit 1
+fi
+bash "$tmpdir/install-codex-marmot.sh"
 ```
 
 For noninteractive setup, provide the allowed inviter and prompt sender:
 
 ```sh
-curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-codex-marmot.sh" | \
-  bash -s -- --yes --allow-welcomer npub1...
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' 0 HUP INT TERM
+curl -fsSL "$base_url/install-codex-marmot.sh" -o "$tmpdir/install-codex-marmot.sh"
+curl -fsSL "$base_url/install-codex-marmot.sh.sha256" -o "$tmpdir/install-codex-marmot.sh.sha256"
+if command -v shasum >/dev/null 2>&1; then
+  (cd "$tmpdir" && shasum -a 256 -c install-codex-marmot.sh.sha256)
+elif command -v sha256sum >/dev/null 2>&1; then
+  (cd "$tmpdir" && sha256sum -c install-codex-marmot.sh.sha256)
+else
+  echo "error: need shasum or sha256sum to verify the installer" >&2
+  exit 1
+fi
+bash "$tmpdir/install-codex-marmot.sh" --yes --allow-welcomer npub1...
 ```
 
 The default install uses its own `~/.marmot-agents/codex` identity and services,
@@ -72,7 +97,9 @@ wn-codex
 
 On the first message in a group, use `/<path>` to select a Git working
 directory under `$HOME`. A picker-only message stores the workdir without
-starting Codex. Subsequent prompts resume that group's Codex thread.
+starting Codex. Subsequent prompts resume that group's Codex thread. Without a
+picker, the shared harness uses `$HOME`; Codex rejects a non-Git working
+directory by default, so select a repository before sending the first prompt.
 
 ## Configuration
 
@@ -124,7 +151,7 @@ cargo test -p wn-codex
 just codex-dev-e2e-connector
 just codex-installer-test
 cargo run -p wn-codex
-bash scripts/install-codex-marmot.sh --dry-run --yes --allow-welcomer "$(printf '11%.0s' {1..32})" --codex-bin /bin/echo
+bash scripts/install-codex-marmot.sh --dry-run --yes --allow-welcomer "$(awk 'BEGIN { for (i = 0; i < 32; i++) printf "11" }')" --codex-bin /bin/echo
 ```
 
 The real Codex contract test is ignored by default because it requires an

--- a/integrations/codex/marmot/src/codex.rs
+++ b/integrations/codex/marmot/src/codex.rs
@@ -1,0 +1,429 @@
+use std::process::Stdio;
+use std::time::Instant;
+
+use async_trait::async_trait;
+use marmot_terminal_harness::{
+    Backend, HarnessError, Invocation, Outcome, RunFailure, RunnerEvent, TRACE_TARGET,
+    process::{capture_stderr, cleanup_failed_run, next_stdout_line, strip_ansi, write_stdin},
+};
+use serde_json::Value;
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::Command;
+use tokio::sync::mpsc;
+use tokio::time::timeout_at;
+use tracing::debug;
+
+#[derive(Clone)]
+pub(crate) struct CodexBackend {
+    bin: String,
+}
+
+impl CodexBackend {
+    pub(crate) fn new(bin: String) -> Self {
+        Self { bin }
+    }
+}
+
+#[async_trait]
+impl Backend for CodexBackend {
+    async fn run(
+        &self,
+        invocation: Invocation,
+        tx: mpsc::Sender<RunnerEvent>,
+    ) -> std::result::Result<Outcome, RunFailure> {
+        run_with_bin(&self.bin, invocation, tx).await
+    }
+}
+
+async fn run_with_bin(
+    bin: &str,
+    invocation: Invocation,
+    tx: mpsc::Sender<RunnerEvent>,
+) -> std::result::Result<Outcome, RunFailure> {
+    let mut command = Command::new(bin);
+    command
+        .args(build_exec_args(invocation.session_id.as_deref()))
+        .current_dir(&invocation.cwd)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+
+    let mut child = command.spawn().map_err(|_| RunFailure {
+        error: HarnessError::BackendSpawn,
+        observed_session: None,
+    })?;
+    let total_deadline = tokio::time::Instant::now() + invocation.timeout;
+    let stdin = child.stdin.take().ok_or(RunFailure {
+        error: HarnessError::BackendSpawn,
+        observed_session: None,
+    })?;
+    let stdout = child.stdout.take().ok_or(RunFailure {
+        error: HarnessError::BackendSpawn,
+        observed_session: None,
+    })?;
+    let stderr = child.stderr.take().ok_or(RunFailure {
+        error: HarnessError::BackendSpawn,
+        observed_session: None,
+    })?;
+    let mut stderr_task = tokio::spawn(capture_stderr(stderr));
+    let mut writer_task = write_stdin(stdin, invocation.prompt);
+    let start = Instant::now();
+    let mut observed_session = None;
+    let mut error_summary = None;
+    let mut idle_deadline = tokio::time::Instant::now() + invocation.idle_timeout;
+
+    let lifecycle_result = timeout_at(total_deadline, async {
+        let mut lines = BufReader::new(stdout).lines();
+        loop {
+            let Some(line) = next_stdout_line(&mut lines, idle_deadline).await? else {
+                break;
+            };
+            if line.is_empty() {
+                idle_deadline = tokio::time::Instant::now() + invocation.idle_timeout;
+                continue;
+            }
+            match parse_event_line(&line) {
+                Ok(Some(ParsedEvent::Session(session_id))) => {
+                    if observed_session.is_none() {
+                        observed_session = Some(session_id);
+                    }
+                }
+                Ok(Some(ParsedEvent::Text(text))) => {
+                    if !text.trim().is_empty() {
+                        tx.send(RunnerEvent::Text(text))
+                            .await
+                            .map_err(|_| HarnessError::BackendStream)?;
+                    }
+                }
+                Ok(Some(ParsedEvent::Error(summary))) => {
+                    if error_summary.is_none() {
+                        error_summary = Some(summary);
+                    }
+                }
+                Ok(None) => {}
+                Err(_) => debug!(
+                    target: TRACE_TARGET,
+                    method = "codex_exec",
+                    error_kind = "json",
+                    "dropping undecodable Codex event"
+                ),
+            }
+            idle_deadline = tokio::time::Instant::now() + invocation.idle_timeout;
+        }
+
+        let (status, stderr) = match timeout_at(idle_deadline, async {
+            let (writer, status, stderr) =
+                tokio::join!(&mut writer_task, child.wait(), &mut stderr_task,);
+            let status = status.map_err(HarnessError::from)?;
+            let stderr = stderr.map_err(HarnessError::from)?;
+            match writer.map_err(HarnessError::from)? {
+                Ok(()) => {}
+                Err(err) if err.kind() == std::io::ErrorKind::BrokenPipe => debug!(
+                    target: TRACE_TARGET,
+                    method = "codex_exec",
+                    error_kind = "stdin_closed",
+                    "backend closed stdin before draining the prompt"
+                ),
+                Err(_) => return Err(HarnessError::BackendStream),
+            }
+            Ok::<_, HarnessError>((status, stderr))
+        })
+        .await
+        {
+            Err(_) => return Err(HarnessError::BackendIdle),
+            Ok(result) => result?,
+        };
+        Ok::<_, HarnessError>(Outcome {
+            observed_session: observed_session.clone(),
+            exit_code: status.code(),
+            error_summary,
+            stderr: strip_ansi(stderr.trim()),
+            elapsed_ms: start.elapsed().as_millis(),
+        })
+    })
+    .await;
+
+    match lifecycle_result {
+        Ok(Ok(outcome)) => Ok(outcome),
+        Ok(Err(error)) => {
+            cleanup_failed_run(&mut child, &mut stderr_task, Some(&mut writer_task)).await;
+            Err(RunFailure {
+                error,
+                observed_session,
+            })
+        }
+        Err(_) => {
+            cleanup_failed_run(&mut child, &mut stderr_task, Some(&mut writer_task)).await;
+            Err(RunFailure {
+                error: HarnessError::BackendTimedOut,
+                observed_session,
+            })
+        }
+    }
+}
+
+fn build_exec_args(session_id: Option<&str>) -> Vec<String> {
+    match session_id.filter(|value| !value.is_empty()) {
+        Some(session_id) => vec![
+            "exec".to_owned(),
+            "resume".to_owned(),
+            "--json".to_owned(),
+            session_id.to_owned(),
+            "-".to_owned(),
+        ],
+        None => vec!["exec".to_owned(), "--json".to_owned(), "-".to_owned()],
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ParsedEvent {
+    Session(String),
+    Text(String),
+    Error(String),
+}
+
+fn parse_event_line(line: &str) -> serde_json::Result<Option<ParsedEvent>> {
+    let value: Value = serde_json::from_str(line)?;
+    match value.get("type").and_then(Value::as_str) {
+        Some("thread.started") => Ok(value
+            .get("thread_id")
+            .and_then(Value::as_str)
+            .filter(|id| !id.is_empty())
+            .map(|id| ParsedEvent::Session(id.to_owned()))),
+        Some("item.completed") => {
+            let Some(item) = value.get("item") else {
+                return Ok(None);
+            };
+            if item.get("type").and_then(Value::as_str) != Some("agent_message") {
+                return Ok(None);
+            }
+            Ok(item
+                .get("text")
+                .and_then(Value::as_str)
+                .filter(|text| !text.trim().is_empty())
+                .map(|text| ParsedEvent::Text(text.to_owned())))
+        }
+        Some("turn.failed") => Ok(Some(ParsedEvent::Error("turn_failed".to_owned()))),
+        Some("error") => Ok(Some(ParsedEvent::Error("error".to_owned()))),
+        _ => Ok(None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::PathBuf;
+    use std::time::Duration;
+
+    use super::*;
+
+    #[test]
+    fn args_select_json_stdin_and_optional_resume() {
+        assert_eq!(build_exec_args(None), vec!["exec", "--json", "-"]);
+        assert_eq!(
+            build_exec_args(Some("thread-123")),
+            vec!["exec", "resume", "--json", "thread-123", "-"]
+        );
+        assert_eq!(build_exec_args(Some("")), vec!["exec", "--json", "-"]);
+    }
+
+    #[test]
+    fn parser_emits_thread_and_completed_agent_messages_only() {
+        assert_eq!(
+            parse_event_line(r#"{"type":"thread.started","thread_id":"thread-123"}"#).unwrap(),
+            Some(ParsedEvent::Session("thread-123".to_owned()))
+        );
+        assert_eq!(
+            parse_event_line(r#"{"type":"item.completed","item":{"id":"item-1","type":"agent_message","text":"hello"}}"#).unwrap(),
+            Some(ParsedEvent::Text("hello".to_owned()))
+        );
+        for line in [
+            r#"{"type":"item.started","item":{"type":"agent_message","text":"partial"}}"#,
+            r#"{"type":"item.completed","item":{"type":"reasoning","text":"secret"}}"#,
+            r#"{"type":"item.completed","item":{"type":"command_execution","aggregated_output":"private"}}"#,
+            r#"{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}"#,
+        ] {
+            assert!(parse_event_line(line).unwrap().is_none());
+        }
+    }
+
+    #[test]
+    fn parser_reports_failures_without_exposing_backend_messages() {
+        assert_eq!(
+            parse_event_line(r#"{"type":"turn.failed","error":{"message":"secret"}}"#).unwrap(),
+            Some(ParsedEvent::Error("turn_failed".to_owned()))
+        );
+        assert_eq!(
+            parse_event_line(r#"{"type":"error","message":"secret"}"#).unwrap(),
+            Some(ParsedEvent::Error("error".to_owned()))
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn runner_pipes_prompt_and_streams_completed_text() {
+        let root = tempfile::tempdir().unwrap();
+        let script = root.path().join("fake-codex");
+        fs::write(
+            &script,
+            r#"#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" != "exec" ] || [ "${2:-}" != "--json" ] || [ "${3:-}" != "-" ]; then
+  exit 64
+fi
+prompt="$(cat)"
+printf '%s\n' '{"type":"thread.started","thread_id":"codex-mock"}'
+printf '%s\n' '{"type":"item.completed","item":{"id":"reasoning","type":"reasoning","text":"ignore"}}'
+printf '{"type":"item.completed","item":{"id":"message","type":"agent_message","text":"reply: %s"}}\n' "$prompt"
+printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}'
+"#,
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&script).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script, permissions).unwrap();
+        let (tx, mut rx) = mpsc::channel(4);
+        let outcome = run_with_bin(
+            script.to_str().unwrap(),
+            Invocation {
+                timeout: Duration::from_secs(5),
+                idle_timeout: Duration::from_secs(2),
+                cwd: root.path().to_path_buf(),
+                session_id: None,
+                prompt: "--prompt-via-stdin".to_owned(),
+            },
+            tx,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome.observed_session.as_deref(), Some("codex-mock"));
+        assert_eq!(outcome.exit_code, Some(0));
+        assert_eq!(
+            rx.recv().await,
+            Some(RunnerEvent::Text("reply: --prompt-via-stdin".to_owned()))
+        );
+        assert!(rx.recv().await.is_none());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn runner_resumes_session_and_reads_stdout_while_writing_large_prompt() {
+        let root = tempfile::tempdir().unwrap();
+        let script = root.path().join("chatty-codex");
+        fs::write(
+            &script,
+            r#"#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" != "exec" ] || [ "${2:-}" != "resume" ] || [ "${3:-}" != "--json" ] || [ "${4:-}" != "thread-123" ] || [ "${5:-}" != "-" ]; then
+  exit 64
+fi
+for _ in $(seq 1 5000); do
+  printf '%s\n' '{"type":"item.started","item":{"type":"command_execution"}}'
+done
+prompt="$(cat)"
+printf '%s\n' '{"type":"thread.started","thread_id":"thread-123"}'
+printf '{"type":"item.completed","item":{"type":"agent_message","text":"received:%s"}}\n' "${#prompt}"
+"#,
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&script).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script, permissions).unwrap();
+        let (tx, mut rx) = mpsc::channel(4);
+        let outcome = run_with_bin(
+            script.to_str().unwrap(),
+            Invocation {
+                timeout: Duration::from_secs(5),
+                idle_timeout: Duration::from_secs(2),
+                cwd: root.path().to_path_buf(),
+                session_id: Some("thread-123".to_owned()),
+                prompt: "p".repeat(60_000),
+            },
+            tx,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome.observed_session.as_deref(), Some("thread-123"));
+        assert_eq!(
+            rx.recv().await,
+            Some(RunnerEvent::Text("received:60000".to_owned()))
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn runner_preserves_exit_and_stderr_when_backend_closes_stdin() {
+        let root = tempfile::tempdir().unwrap();
+        let script = root.path().join("early-exit-codex");
+        fs::write(
+            &script,
+            r#"#!/usr/bin/env bash
+printf '%s\n' 'authentication required' >&2
+exit 64
+"#,
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&script).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script, permissions).unwrap();
+        let (tx, _rx) = mpsc::channel(1);
+        let outcome = run_with_bin(
+            script.to_str().unwrap(),
+            Invocation {
+                timeout: Duration::from_secs(5),
+                idle_timeout: Duration::from_secs(2),
+                cwd: root.path().to_path_buf(),
+                session_id: None,
+                prompt: "p".repeat(60_000),
+            },
+            tx,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome.exit_code, Some(64));
+        assert_eq!(outcome.stderr, "authentication required");
+    }
+
+    #[tokio::test]
+    #[ignore = "requires authenticated Codex and makes a real model request"]
+    async fn real_codex_exec_contract() {
+        let version = std::process::Command::new("codex")
+            .arg("--version")
+            .output()
+            .expect("run codex --version");
+        assert!(version.status.success());
+        assert!(
+            String::from_utf8_lossy(&version.stdout).starts_with("codex-cli "),
+            "unexpected Codex version output"
+        );
+
+        let (tx, mut rx) = mpsc::channel(8);
+        let outcome = run_with_bin(
+            "codex",
+            Invocation {
+                timeout: Duration::from_secs(120),
+                idle_timeout: Duration::from_secs(30),
+                cwd: PathBuf::from(env!("CARGO_MANIFEST_DIR")),
+                session_id: None,
+                prompt: "Reply with exactly CODEX_CONNECTOR_OK and nothing else.".to_owned(),
+            },
+            tx,
+        )
+        .await
+        .unwrap();
+
+        assert!(outcome.observed_session.is_some());
+        assert_eq!(outcome.exit_code, Some(0));
+        let mut reply = String::new();
+        while let Some(RunnerEvent::Text(text)) = rx.recv().await {
+            reply.push_str(&text);
+        }
+        assert_eq!(reply.trim(), "CODEX_CONNECTOR_OK");
+    }
+}

--- a/integrations/codex/marmot/src/codex.rs
+++ b/integrations/codex/marmot/src/codex.rs
@@ -420,10 +420,37 @@ exit 64
 
         assert!(outcome.observed_session.is_some());
         assert_eq!(outcome.exit_code, Some(0));
+        let session_id = outcome.observed_session.unwrap();
         let mut reply = String::new();
         while let Some(RunnerEvent::Text(text)) = rx.recv().await {
             reply.push_str(&text);
         }
         assert_eq!(reply.trim(), "CODEX_CONNECTOR_OK");
+
+        let (resume_tx, mut resume_rx) = mpsc::channel(8);
+        let resumed = run_with_bin(
+            "codex",
+            Invocation {
+                timeout: Duration::from_secs(120),
+                idle_timeout: Duration::from_secs(30),
+                cwd: PathBuf::from(env!("CARGO_MANIFEST_DIR")),
+                session_id: Some(session_id.clone()),
+                prompt: "Reply with exactly CODEX_RESUME_OK and nothing else.".to_owned(),
+            },
+            resume_tx,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            resumed.observed_session.as_deref(),
+            Some(session_id.as_str())
+        );
+        assert_eq!(resumed.exit_code, Some(0));
+        let mut resumed_reply = String::new();
+        while let Some(RunnerEvent::Text(text)) = resume_rx.recv().await {
+            resumed_reply.push_str(&text);
+        }
+        assert_eq!(resumed_reply.trim(), "CODEX_RESUME_OK");
     }
 }

--- a/integrations/codex/marmot/src/config.rs
+++ b/integrations/codex/marmot/src/config.rs
@@ -1,0 +1,116 @@
+#[cfg(test)]
+use std::collections::HashMap;
+use std::env;
+
+use marmot_terminal_harness::{ConfigSpec, LoadedConfig, Result, load_config_with};
+
+use crate::codex::CodexBackend;
+
+const SPEC: ConfigSpec = ConfigSpec {
+    env_prefix: "WN_CODEX",
+    default_home_name: "codex",
+    default_bin: "codex",
+    display_name: "Codex",
+    reply_prefix: "wn-codex",
+    bin_env_name: "WN_CODEX_BIN",
+    account_env_name: "WN_CODEX_ACCOUNT_ID_HEX",
+    legacy_allowed_senders_env: None,
+};
+
+#[derive(Clone)]
+pub(crate) struct Config {
+    shared: LoadedConfig,
+}
+
+impl Config {
+    pub(crate) fn from_env() -> Result<Self> {
+        Self::from_lookup(&mut |name| env::var(name).ok())
+    }
+
+    #[cfg(test)]
+    fn from_pairs(pairs: &[(&str, &str)]) -> Result<Self> {
+        let map: HashMap<&str, &str> = pairs.iter().copied().collect();
+        Self::from_lookup(&mut |name| map.get(name).map(|value| (*value).to_owned()))
+    }
+
+    fn from_lookup(lookup: &mut impl FnMut(&str) -> Option<String>) -> Result<Self> {
+        Ok(Self {
+            shared: load_config_with(SPEC, lookup)?,
+        })
+    }
+
+    pub(crate) fn into_harness(self) -> (marmot_terminal_harness::Config, CodexBackend) {
+        let backend = CodexBackend::new(self.shared.bin);
+        (self.shared.harness, backend)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use marmot_terminal_harness::DEFAULT_MAX_REPLY_BYTES;
+
+    use super::*;
+
+    const SENDER: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    fn defaults() -> Vec<(&'static str, &'static str)> {
+        vec![
+            ("HOME", "/home/test"),
+            ("WN_CODEX_ALLOWED_SENDERS_HEX", SENDER),
+        ]
+    }
+
+    #[test]
+    fn defaults_are_isolated_and_match_terminal_harness_limits() {
+        let config = Config::from_pairs(&defaults()).unwrap();
+        assert!(
+            config
+                .shared
+                .harness
+                .socket
+                .ends_with(".marmot-agents/codex/dev/wn-agent.sock")
+        );
+        assert_eq!(config.shared.bin, "codex");
+        assert_eq!(
+            config.shared.harness.max_reply_bytes,
+            DEFAULT_MAX_REPLY_BYTES
+        );
+        assert_eq!(
+            config.shared.harness.backend_timeout,
+            Duration::from_secs(3600)
+        );
+        assert_eq!(
+            config.shared.harness.backend_idle_timeout,
+            Duration::from_secs(120)
+        );
+    }
+
+    #[test]
+    fn rejects_missing_sender_invalid_activation_and_zero_timeouts() {
+        assert!(Config::from_pairs(&[("HOME", "/home/test")]).is_err());
+        let mut invalid_activation = defaults();
+        invalid_activation.push(("WN_CODEX_ACTIVATION", "mention"));
+        assert!(Config::from_pairs(&invalid_activation).is_err());
+        for name in [
+            "WN_CODEX_TIMEOUT_SECS",
+            "WN_CODEX_IDLE_TIMEOUT_SECS",
+            "WN_CODEX_REQUEST_TIMEOUT_SECS",
+        ] {
+            let mut pairs = defaults();
+            pairs.push((name, "0"));
+            assert!(Config::from_pairs(&pairs).is_err(), "accepted zero {name}");
+        }
+    }
+
+    #[test]
+    fn account_error_names_the_actual_source_variable() {
+        let mut pairs = defaults();
+        pairs.push(("MARMOT_ACCOUNT_ID_HEX", "invalid"));
+        let error = Config::from_pairs(&pairs)
+            .err()
+            .expect("invalid account id");
+        assert!(error.to_string().contains("MARMOT_ACCOUNT_ID_HEX"));
+    }
+}

--- a/integrations/codex/marmot/src/main.rs
+++ b/integrations/codex/marmot/src/main.rs
@@ -1,0 +1,51 @@
+mod codex;
+mod config;
+
+use std::process::ExitCode;
+
+use clap::Parser;
+use marmot_terminal_harness::Result;
+use tracing::error;
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "wn-codex",
+    version,
+    about = "Marmot harness that routes allowed group messages to Codex"
+)]
+struct Cli {}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    let _cli = Cli::parse();
+    init_tracing();
+
+    match run().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            error!(
+                target: marmot_terminal_harness::TRACE_TARGET,
+                method = "main",
+                error_kind = err.privacy_safe_kind(),
+                "wn-codex exiting after error"
+            );
+            eprintln!("wn-codex: {err}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn run() -> Result<()> {
+    let (config, backend) = config::Config::from_env()?.into_harness();
+    marmot_terminal_harness::run(config, backend).await
+}
+
+fn init_tracing() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                tracing_subscriber::EnvFilter::new("info,marmot_terminal_harness=info")
+            }),
+        )
+        .init();
+}

--- a/integrations/codex/marmot/tests/e2e_connector.rs
+++ b/integrations/codex/marmot/tests/e2e_connector.rs
@@ -6,13 +6,13 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use marmot_terminal_harness::test_support::{
-    HarnessContext, MAX_REPLY_BYTES, SENDER_ACCOUNT_ID_HEX, SpawnedChild, run_connector_e2e,
+    HarnessContext, MAX_REPLY_BYTES, SENDER_ACCOUNT_ID_HEX, SpawnedChild, run_connector_resume_e2e,
 };
 
 #[tokio::test]
 #[ignore = "spawns real wn-agent and wn-codex processes"]
 async fn debug_inbound_reaches_fake_codex_and_records_chunked_finals() {
-    run_connector_e2e("wn-codex", spawn_wn_codex).await;
+    run_connector_resume_e2e("wn-codex", spawn_wn_codex).await;
 }
 
 fn spawn_wn_codex(context: HarnessContext<'_>) -> SpawnedChild {
@@ -41,11 +41,21 @@ fn write_fake_codex(root: &Path) -> PathBuf {
         &script,
         r#"#!/usr/bin/env bash
 set -euo pipefail
-if [ "${1:-}" != "exec" ] || [ "${2:-}" != "--json" ] || [ "${3:-}" != "-" ]; then
+mode=""
+if [ "$#" -eq 3 ] && [ "$1" = "exec" ] && [ "$2" = "--json" ] && [ "$3" = "-" ]; then
+  mode="new"
+elif [ "$#" -eq 5 ] && [ "$1" = "exec" ] && [ "$2" = "resume" ] && [ "$3" = "--json" ] && [ "$4" = "thread_e2e" ] && [ "$5" = "-" ]; then
+  mode="resume"
+else
   echo "unexpected codex args: $*" >&2
   exit 64
 fi
 prompt="$(cat)"
+if [ "$mode" = "resume" ]; then
+  printf '%s\n' '{"type":"thread.started","thread_id":"thread_e2e"}'
+  printf '{"type":"item.completed","item":{"type":"agent_message","text":"marmot-e2e-resume-ok: %s"}}\n' "$prompt"
+  exit 0
+fi
 tail=""
 for _ in $(seq 1 40); do
   tail="${tail}chunk "

--- a/integrations/codex/marmot/tests/e2e_connector.rs
+++ b/integrations/codex/marmot/tests/e2e_connector.rs
@@ -1,0 +1,65 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use marmot_terminal_harness::test_support::{
+    HarnessContext, MAX_REPLY_BYTES, SENDER_ACCOUNT_ID_HEX, SpawnedChild, run_connector_e2e,
+};
+
+#[tokio::test]
+#[ignore = "spawns real wn-agent and wn-codex processes"]
+async fn debug_inbound_reaches_fake_codex_and_records_chunked_finals() {
+    run_connector_e2e("wn-codex", spawn_wn_codex).await;
+}
+
+fn spawn_wn_codex(context: HarnessContext<'_>) -> SpawnedChild {
+    let fake_codex = write_fake_codex(context.root);
+    let mut command = Command::new(env!("CARGO_BIN_EXE_wn-codex"));
+    command
+        .env("MARMOT_HOME", context.root.join("wn-codex-home"))
+        .env("MARMOT_AGENT_SOCKET", context.socket)
+        .env("WN_CODEX_ACCOUNT_ID_HEX", context.account_id_hex)
+        .env("WN_CODEX_ALLOWED_SENDERS_HEX", SENDER_ACCOUNT_ID_HEX)
+        .env("WN_CODEX_BIN", fake_codex)
+        .env(
+            "WN_CODEX_STATE_PATH",
+            context.root.join("wn-codex-state/sessions.json"),
+        )
+        .env("WN_CODEX_MAX_REPLY_BYTES", MAX_REPLY_BYTES.to_string())
+        .env("WN_CODEX_TIMEOUT_SECS", "5")
+        .env("WN_CODEX_REQUEST_TIMEOUT_SECS", "5")
+        .env("RUST_LOG", "warn,marmot_terminal_harness=info");
+    SpawnedChild::spawn("wn-codex", &mut command, context.root)
+}
+
+fn write_fake_codex(root: &Path) -> PathBuf {
+    let script = root.join("fake-codex");
+    fs::write(
+        &script,
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" != "exec" ] || [ "${2:-}" != "--json" ] || [ "${3:-}" != "-" ]; then
+  echo "unexpected codex args: $*" >&2
+  exit 64
+fi
+prompt="$(cat)"
+tail=""
+for _ in $(seq 1 40); do
+  tail="${tail}chunk "
+done
+printf '%s\n' '{"type":"thread.started","thread_id":"thread_e2e"}'
+printf '%s\n' '{"type":"item.completed","item":{"type":"reasoning","text":"ignore"}}'
+printf '{"type":"item.completed","item":{"type":"agent_message","text":"marmot-e2e-ok: %s %s"}}\n' "$prompt" "$tail"
+"#,
+    )
+    .expect("write fake codex");
+    let mut permissions = fs::metadata(&script)
+        .expect("fake codex metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&script, permissions).expect("chmod fake codex");
+    script
+}

--- a/integrations/codex/marmot/tests/test_installer.sh
+++ b/integrations/codex/marmot/tests/test_installer.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+exec "$repo_root/integrations/terminal-harness/tests/test_installer.sh" codex

--- a/integrations/terminal-harness/AGENTS.md
+++ b/integrations/terminal-harness/AGENTS.md
@@ -18,6 +18,7 @@ before changing this crate.
 
 ```sh
 cargo test -p marmot-terminal-harness
+cargo test -p wn-codex
 cargo test -p wn-opencode
 cargo test -p wn-pi
 ```

--- a/integrations/terminal-harness/README.md
+++ b/integrations/terminal-harness/README.md
@@ -1,7 +1,8 @@
 # Marmot Terminal Harness
 
 `marmot-terminal-harness` is the shared Rust runtime behind
-[`wn-opencode`](../opencode/marmot) and [`wn-pi`](../pi/marmot). It keeps the
+[`wn-codex`](../codex/marmot), [`wn-opencode`](../opencode/marmot), and
+[`wn-pi`](../pi/marmot). It keeps the
 Marmot-facing behavior of pure terminal connectors consistent while leaving
 backend command construction and event parsing in each connector crate.
 
@@ -27,13 +28,13 @@ Connector crates are responsible for:
 - exposing only completed assistant output, never thinking or tool output;
 - preserving or reporting the backend session id needed for the next prompt.
 
-OpenCode keeps prompt text after its command's `--` delimiter. Pi writes prompt
-text to stdin. Backend-specific behavior belongs in those connector crates, not
+OpenCode keeps prompt text after its command's `--` delimiter. Codex and Pi
+write prompt text to stdin. Backend-specific behavior belongs in those connector crates, not
 in this shared runtime.
 
 ## Shared Behavior
 
-Both connectors:
+All connectors:
 
 - speak `marmot.agent-control.v2` over a local Unix socket;
 - require an explicit sender allowlist and mirror it additively into the
@@ -50,25 +51,29 @@ Both connectors:
 The connector READMEs document their environment variables, installer topology,
 and backend contracts:
 
+- [`integrations/codex/marmot/README.md`](../codex/marmot/README.md)
 - [`integrations/opencode/marmot/README.md`](../opencode/marmot/README.md)
 - [`integrations/pi/marmot/README.md`](../pi/marmot/README.md)
 
 ## Development
 
-Run the shared suite and both connector suites after changing this crate:
+Run the shared suite and all connector suites after changing this crate:
 
 ```sh
 cargo test -p marmot-terminal-harness
+cargo test -p wn-codex
 cargo test -p wn-opencode
 cargo test -p wn-pi
 
+just codex-dev-e2e-connector
 just opencode-dev-e2e-connector
 just pi-dev-e2e-connector
 
+just codex-installer-test
 just opencode-installer-test
 just pi-installer-test
 ```
 
 The process-level connector tests are ignored by default and use real
 `wn-agent` and connector binaries with fake backend executables. They do not
-install or authenticate the real OpenCode or Pi CLIs.
+install or authenticate the real Codex, OpenCode, or Pi CLIs.

--- a/integrations/terminal-harness/src/test_support.rs
+++ b/integrations/terminal-harness/src/test_support.rs
@@ -18,11 +18,16 @@ use tokio::time::sleep;
 const GROUP_ID_HEX: &str = "2222222222222222222222222222222222222222222222222222222222222222";
 /// Stable synthetic message id used by connector e2e tests.
 const MESSAGE_ID_HEX: &str = "3333333333333333333333333333333333333333333333333333333333333333";
+/// Stable synthetic follow-up message id used by resume connector e2e tests.
+const RESUME_MESSAGE_ID_HEX: &str =
+    "5555555555555555555555555555555555555555555555555555555555555555";
 /// Stable synthetic sender id permitted by connector e2e tests.
 pub const SENDER_ACCOUNT_ID_HEX: &str =
     "4444444444444444444444444444444444444444444444444444444444444444";
 /// Prompt injected through the debug control socket.
 const INBOUND_TEXT: &str = "ping from connector";
+/// Follow-up prompt injected after the first backend session is persisted.
+const RESUME_INBOUND_TEXT: &str = "followup from connector";
 /// Small reply cap that forces chunking in connector e2e tests.
 pub const MAX_REPLY_BYTES: usize = 64;
 const AGENT_READY_TIMEOUT: Duration = Duration::from_secs(120);
@@ -41,6 +46,22 @@ pub struct HarnessContext<'a> {
 pub async fn run_connector_e2e(
     harness_name: &'static str,
     spawn_harness: impl FnOnce(HarnessContext<'_>) -> SpawnedChild,
+) {
+    run_connector_e2e_scenario(harness_name, spawn_harness, false).await;
+}
+
+/// Runs the shared connector scenario and then verifies a same-group resume.
+pub async fn run_connector_resume_e2e(
+    harness_name: &'static str,
+    spawn_harness: impl FnOnce(HarnessContext<'_>) -> SpawnedChild,
+) {
+    run_connector_e2e_scenario(harness_name, spawn_harness, true).await;
+}
+
+async fn run_connector_e2e_scenario(
+    harness_name: &'static str,
+    spawn_harness: impl FnOnce(HarnessContext<'_>) -> SpawnedChild,
+    exercise_resume: bool,
 ) {
     let temp = TempDir::new().expect("temp dir");
     fs::set_permissions(temp.path(), fs::Permissions::from_mode(0o700))
@@ -61,31 +82,45 @@ pub async fn run_connector_e2e(
     let finals = inject_until_recorded_finals(
         &socket,
         &account.account_id_hex,
+        MESSAGE_ID_HEX,
+        INBOUND_TEXT,
         &expected_text,
         harness_name,
     )
     .await;
-    assert!(
-        finals.len() >= 2,
-        "expected chunked final sends, got {}",
-        finals.len()
+    assert_final_sends(
+        &finals,
+        &account.account_id_hex,
+        MESSAGE_ID_HEX,
+        &expected_text,
+        0,
+        2,
     );
-    assert_eq!(
-        finals
-            .iter()
-            .map(|send| send.text.as_str())
-            .collect::<String>(),
-        expected_text
-    );
-    for (index, send) in finals.iter().enumerate() {
-        assert_eq!(send.account_id_hex, account.account_id_hex);
-        assert_eq!(send.group_id_hex, GROUP_ID_HEX);
-        assert_eq!(
-            send.reply_to_message_id_hex.as_deref(),
-            Some(MESSAGE_ID_HEX)
+
+    if exercise_resume {
+        let resumed_text = expected_resume_reply_text();
+        let all_expected_text = format!("{expected_text}{resumed_text}");
+        let all_finals = inject_until_recorded_finals(
+            &socket,
+            &account.account_id_hex,
+            RESUME_MESSAGE_ID_HEX,
+            RESUME_INBOUND_TEXT,
+            &all_expected_text,
+            harness_name,
+        )
+        .await;
+        assert!(
+            all_finals.len() > finals.len(),
+            "expected resumed final sends"
         );
-        assert!(send.text.len() <= MAX_REPLY_BYTES);
-        assert_eq!(send.message_ids_hex, vec![format!("{:064x}", index + 1)]);
+        assert_final_sends(
+            &all_finals[finals.len()..],
+            &account.account_id_hex,
+            RESUME_MESSAGE_ID_HEX,
+            &resumed_text,
+            finals.len(),
+            1,
+        );
     }
 
     drop(harness);
@@ -158,6 +193,45 @@ fn expected_reply_text() -> String {
     format!("marmot-e2e-ok: {INBOUND_TEXT} {}", "chunk ".repeat(40))
 }
 
+fn expected_resume_reply_text() -> String {
+    format!("marmot-e2e-resume-ok: {RESUME_INBOUND_TEXT}")
+}
+
+fn assert_final_sends(
+    finals: &[AgentControlDebugFinalSend],
+    account_id_hex: &str,
+    reply_to_message_id_hex: &str,
+    expected_text: &str,
+    prior_send_count: usize,
+    minimum_chunks: usize,
+) {
+    assert!(
+        finals.len() >= minimum_chunks,
+        "expected at least {minimum_chunks} final sends, got {}",
+        finals.len()
+    );
+    assert_eq!(
+        finals
+            .iter()
+            .map(|send| send.text.as_str())
+            .collect::<String>(),
+        expected_text
+    );
+    for (index, send) in finals.iter().enumerate() {
+        assert_eq!(send.account_id_hex, account_id_hex);
+        assert_eq!(send.group_id_hex, GROUP_ID_HEX);
+        assert_eq!(
+            send.reply_to_message_id_hex.as_deref(),
+            Some(reply_to_message_id_hex)
+        );
+        assert!(send.text.len() <= MAX_REPLY_BYTES);
+        assert_eq!(
+            send.message_ids_hex,
+            vec![format!("{:064x}", prior_send_count + index + 1)]
+        );
+    }
+}
+
 async fn wait_for_agent(socket: &Path) {
     wait_for(
         || async {
@@ -197,6 +271,8 @@ async fn create_account(socket: &Path, harness_name: &str) -> AgentControlAccoun
 async fn inject_until_recorded_finals(
     socket: &Path,
     account_id_hex: &str,
+    message_id_hex: &str,
+    inbound_text: &str,
     expected_text: &str,
     harness_name: &str,
 ) -> Vec<AgentControlDebugFinalSend> {
@@ -208,9 +284,9 @@ async fn inject_until_recorded_finals(
                 AgentControlRequest::DebugInjectInbound {
                     account_id_hex: account_id_hex.to_owned(),
                     group_id_hex: GROUP_ID_HEX.to_owned(),
-                    message_id_hex: MESSAGE_ID_HEX.to_owned(),
+                    message_id_hex: message_id_hex.to_owned(),
                     sender_account_id_hex: SENDER_ACCOUNT_ID_HEX.to_owned(),
-                    text: INBOUND_TEXT.to_owned(),
+                    text: inbound_text.to_owned(),
                 },
             )
             .await;

--- a/integrations/terminal-harness/tests/test_installer.sh
+++ b/integrations/terminal-harness/tests/test_installer.sh
@@ -1,8 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-kind="${1:?usage: test_installer.sh pi|opencode}"
+kind="${1:?usage: test_installer.sh codex|pi|opencode}"
 case "$kind" in
+    codex)
+        env_prefix="WN_CODEX"
+        display_name="Codex"
+        default_home="$HOME/.marmot-agents/codex"
+        agent_service="wn-agent-codex.service"
+        agent_launchd="org.marmot.wn-agent.codex"
+        agent_label="codex-harness-agent"
+        ;;
     pi)
         env_prefix="WN_PI"
         display_name="Pi"

--- a/release.md
+++ b/release.md
@@ -230,7 +230,8 @@ GitHub-generated source archives are the downloadable artifacts.
 
 Use this for the White Noise agent connector entry point. The release publishes `wn-agent` binaries for supported
 platforms plus adapter/harness install assets: the Hermes Marmot plugin + `install-hermes-marmot.sh`, the OpenClaw
-Marmot channel plugin + `install-openclaw-marmot.sh`, the `wn-opencode` harness +
+Marmot channel plugin + `install-openclaw-marmot.sh`, the `wn-codex` harness +
+`install-codex-marmot.sh`, the `wn-opencode` harness +
 `install-opencode-marmot.sh`, and the `wn-pi` harness + `install-pi-marmot.sh`.
 
 The workflow lives at:
@@ -248,15 +249,17 @@ Before a WN Agent release, run the normal preflight plus:
 ```sh
 cargo test -p agent-connector
 cargo test -p marmot-terminal-harness
+cargo test -p wn-codex
 cargo test -p wn-opencode
 cargo test -p wn-pi
 bash scripts/install-hermes-marmot.sh --dry-run --yes
 bash scripts/install-openclaw-marmot.sh --dry-run --yes
+bash scripts/install-codex-marmot.sh --dry-run --yes --allow-welcomer "$(printf '11%.0s' {1..32})" --codex-bin /bin/echo
 bash scripts/install-opencode-marmot.sh --dry-run --yes --allow-welcomer "$(printf '11%.0s' {1..32})" --opencode-bin /bin/echo
 bash scripts/install-pi-marmot.sh --dry-run --yes --allow-welcomer "$(printf '11%.0s' {1..32})" --pi-bin /bin/echo
 ```
 
-Bridge and control logs for both terminal harnesses now use the
+Bridge and control logs for all terminal harnesses use the
 `marmot_terminal_harness` tracing target. Include
 `marmot_terminal_harness=debug` in `RUST_LOG`. The former `wn_opencode` target
 no longer emits events, so existing filters that reference it must be updated.
@@ -294,6 +297,14 @@ The release job creates these assets:
 - `wn-agent-darwin-aarch64-<version>.tar.gz.sha256`
 - `wn-agent-darwin-x86_64-<version>.tar.gz`
 - `wn-agent-darwin-x86_64-<version>.tar.gz.sha256`
+- `wn-codex-linux-x86_64-<version>.tar.gz`
+- `wn-codex-linux-x86_64-<version>.tar.gz.sha256`
+- `wn-codex-linux-aarch64-<version>.tar.gz`
+- `wn-codex-linux-aarch64-<version>.tar.gz.sha256`
+- `wn-codex-darwin-aarch64-<version>.tar.gz`
+- `wn-codex-darwin-aarch64-<version>.tar.gz.sha256`
+- `wn-codex-darwin-x86_64-<version>.tar.gz`
+- `wn-codex-darwin-x86_64-<version>.tar.gz.sha256`
 - `wn-opencode-linux-x86_64-<version>.tar.gz`
 - `wn-opencode-linux-x86_64-<version>.tar.gz.sha256`
 - `wn-opencode-linux-aarch64-<version>.tar.gz`
@@ -316,6 +327,7 @@ The release job creates these assets:
 - `openclaw-marmot-plugin-<version>.tgz.sha256`
 - `install-hermes-marmot.sh`
 - `install-openclaw-marmot.sh`
+- `install-codex-marmot.sh`
 - `install-opencode-marmot.sh`
 - `install-pi-marmot.sh`
 
@@ -332,6 +344,8 @@ The installer assets are generated during the release and default to their own `
 curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-hermes-marmot.sh | bash
 # OpenClaw gateway
 curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-openclaw-marmot.sh | bash
+# Codex terminal harness
+curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-codex-marmot.sh | bash
 # OpenCode terminal harness
 curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-opencode-marmot.sh | bash
 # Pi terminal harness
@@ -345,7 +359,8 @@ These one-liners perform full setup by default: they install `wn-agent`, install
 harness binary, start same-user services where supported, bootstrap or reuse the default connector-specific Marmot
 agent home, and patch only the Marmot-specific gateway config when a gateway is involved. Use `--no-service`,
 `--no-start-wn-agent`, `--no-configure-hermes`, `--no-configure-openclaw`, or `--no-start-wn-opencode` when you need a
-partial/manual install.
+partial/manual install. Terminal-harness installers also accept the matching
+`--no-start-wn-codex` or `--no-start-wn-pi` option.
 
 ## MarmotKit Binding Release
 

--- a/release.md
+++ b/release.md
@@ -254,9 +254,10 @@ cargo test -p wn-opencode
 cargo test -p wn-pi
 bash scripts/install-hermes-marmot.sh --dry-run --yes
 bash scripts/install-openclaw-marmot.sh --dry-run --yes
-bash scripts/install-codex-marmot.sh --dry-run --yes --allow-welcomer "$(printf '11%.0s' {1..32})" --codex-bin /bin/echo
-bash scripts/install-opencode-marmot.sh --dry-run --yes --allow-welcomer "$(printf '11%.0s' {1..32})" --opencode-bin /bin/echo
-bash scripts/install-pi-marmot.sh --dry-run --yes --allow-welcomer "$(printf '11%.0s' {1..32})" --pi-bin /bin/echo
+sender_hex="$(awk 'BEGIN { for (i = 0; i < 32; i++) printf "11" }')"
+bash scripts/install-codex-marmot.sh --dry-run --yes --allow-welcomer "$sender_hex" --codex-bin /bin/echo
+bash scripts/install-opencode-marmot.sh --dry-run --yes --allow-welcomer "$sender_hex" --opencode-bin /bin/echo
+bash scripts/install-pi-marmot.sh --dry-run --yes --allow-welcomer "$sender_hex" --pi-bin /bin/echo
 ```
 
 Bridge and control logs for all terminal harnesses use the
@@ -326,10 +327,15 @@ The release job creates these assets:
 - `openclaw-marmot-plugin-<version>.tgz`
 - `openclaw-marmot-plugin-<version>.tgz.sha256`
 - `install-hermes-marmot.sh`
+- `install-hermes-marmot.sh.sha256`
 - `install-openclaw-marmot.sh`
+- `install-openclaw-marmot.sh.sha256`
 - `install-codex-marmot.sh`
+- `install-codex-marmot.sh.sha256`
 - `install-opencode-marmot.sh`
+- `install-opencode-marmot.sh.sha256`
 - `install-pi-marmot.sh`
+- `install-pi-marmot.sh.sha256`
 
 Each binary/plugin tarball carries a `manifest.json` recording the release tag, artifact version, source commit, and
 workspace version (the OpenClaw tarball's `package.json` version is also stamped to the cohort version at release time).

--- a/scripts/install-codex-marmot.sh
+++ b/scripts/install-codex-marmot.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export MARMOT_TERMINAL_HARNESS=codex
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "$SCRIPT_DIR/install-terminal-harness-marmot.sh" "$@"

--- a/scripts/install-terminal-harness-marmot.sh
+++ b/scripts/install-terminal-harness-marmot.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Shared installer implementation for Marmot terminal harnesses.
-# MARMOT_TERMINAL_HARNESS must be `pi` or `opencode`.
+# MARMOT_TERMINAL_HARNESS must be `codex`, `pi`, or `opencode`.
 
 SCRIPT_SOURCE="${BASH_SOURCE[0]:-}"
 SCRIPT_DIR=""
@@ -12,6 +12,16 @@ fi
 
 HARNESS_KIND="${MARMOT_TERMINAL_HARNESS:-}"
 case "$HARNESS_KIND" in
+    codex)
+        HARNESS_DISPLAY_NAME="Codex"
+        HARNESS_ENV_PREFIX="WN_CODEX"
+        HARNESS_DEFAULT_BIN="codex"
+        HARNESS_FALLBACK_BIN_DIR="$HOME/.local/bin"
+        HARNESS_DEFAULT_HOME="$HOME/.marmot-agents/codex"
+        HARNESS_DEFAULT_AGENT_LABEL="codex-harness-agent"
+        HARNESS_DEFAULT_AGENT_SERVICE="wn-agent-codex"
+        HARNESS_DEFAULT_AGENT_LAUNCHD="org.marmot.wn-agent.codex"
+        ;;
     pi)
         HARNESS_DISPLAY_NAME="Pi"
         HARNESS_ENV_PREFIX="WN_PI"
@@ -33,7 +43,7 @@ case "$HARNESS_KIND" in
         HARNESS_DEFAULT_AGENT_LAUNCHD="org.marmot.wn-agent.harnesses"
         ;;
     *)
-        echo "error: MARMOT_TERMINAL_HARNESS must be pi or opencode" >&2
+        echo "error: MARMOT_TERMINAL_HARNESS must be codex, pi, or opencode" >&2
         exit 64
         ;;
 esac

--- a/scripts/package-binary-bundle.sh
+++ b/scripts/package-binary-bundle.sh
@@ -6,7 +6,7 @@ target="${2:?usage: package-binary-bundle.sh <binary> <target> <rust-target>}"
 rust_target="${3:?usage: package-binary-bundle.sh <binary> <target> <rust-target>}"
 
 case "$binary" in
-    wn-agent | wn-opencode | wn-pi) ;;
+    wn-agent | wn-codex | wn-opencode | wn-pi) ;;
     *) echo "error: unsupported release binary: $binary" >&2; exit 64 ;;
 esac
 if [[ ! "$target" =~ ^[A-Za-z0-9._-]+$ ]] || [[ ! "$rust_target" =~ ^[A-Za-z0-9._-]+$ ]]; then


### PR DESCRIPTION
## Summary

- add `wn-codex` as a direct terminal-harness backend using Codex's non-interactive JSONL interface
- persist one Codex thread per Marmot group and resume subsequent prompts with `codex exec resume`
- send prompts over stdin and forward only completed assistant messages, excluding reasoning and tool events
- add isolated installer/service defaults, release bundles, CI packaging, documentation, and connector tests

## Permissions

This initial connector does not add auto-approval, sandbox-bypass, or other permission-broadening flags. Codex's existing configuration remains authoritative; common permission controls across terminal harnesses are deferred to follow-up work.

## Validation

- `just fast-ci`
- `cargo test --locked -p wn-codex`
- `cargo test -p marmot-terminal-harness`
- `just codex-dev-e2e-connector`
- `just codex-installer-test`
- `just opencode-installer-test`
- `just pi-installer-test`
- `actionlint .github/workflows/wn-agent-binaries.yml`
- shell syntax checks for connector installer and packaging scripts

The ignored live Codex contract test was not run because it requires an authenticated model request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `wn-codex` terminal harness for running Codex sessions, including prompt handling, session resumption, streaming responses, timeouts, and error reporting.
  * Added Codex installation support with isolated defaults, service configuration, environment settings, and manual setup options.
  * Added Codex binaries, installers, and release assets for supported Linux and macOS platforms.

* **Documentation**
  * Updated integration, setup, verification, and release documentation with Codex instructions.

* **Tests**
  * Added automated connector, installer, and end-to-end validation for Codex.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->