### PR TITLE
Extract shared JSONL subprocess runner for terminal harnesses

### DIFF
--- a/integrations/codex/marmot/src/codex.rs
+++ b/integrations/codex/marmot/src/codex.rs
@@ -1,18 +1,11 @@
-use std::process::Stdio;
-use std::time::Instant;
-
 use async_trait::async_trait;
 use marmot_terminal_harness::{
-    ApprovalSupport, Backend, ExecutionProfile, ExecutionSupport, HarnessError, Invocation,
-    IsolationSupport, Outcome, RunFailure, RunnerEvent, TRACE_TARGET,
-    process::{capture_stderr, cleanup_failed_run, next_stdout_line, strip_ansi, write_stdin},
+    ApprovalSupport, Backend, ExecutionProfile, ExecutionSupport, Invocation, IsolationSupport,
+    Outcome, ParsedEvent, PromptTransport, RunFailure, RunnerEvent,
+    process::{ProcessSpec, run_jsonl_process},
 };
 use serde_json::Value;
-use tokio::io::{AsyncBufReadExt, BufReader};
-use tokio::process::Command;
 use tokio::sync::mpsc;
-use tokio::time::timeout_at;
-use tracing::debug;
 
 #[derive(Clone)]
 pub(crate) struct CodexBackend {
@@ -62,130 +55,29 @@ async fn run_with_bin(
     invocation: Invocation,
     tx: mpsc::Sender<RunnerEvent>,
 ) -> std::result::Result<Outcome, RunFailure> {
-    let mut command = Command::new(bin);
-    command
-        .args(build_exec_args(
-            invocation.session_id.as_deref(),
-            execution_profile,
-        ))
-        .current_dir(&invocation.cwd)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .kill_on_drop(true);
-
-    let mut child = command.spawn().map_err(|_| RunFailure {
-        error: HarnessError::BackendSpawn,
-        observed_session: None,
-    })?;
-    let total_deadline = tokio::time::Instant::now() + invocation.timeout;
-    let stdin = child.stdin.take().ok_or(RunFailure {
-        error: HarnessError::BackendSpawn,
-        observed_session: None,
-    })?;
-    let stdout = child.stdout.take().ok_or(RunFailure {
-        error: HarnessError::BackendSpawn,
-        observed_session: None,
-    })?;
-    let stderr = child.stderr.take().ok_or(RunFailure {
-        error: HarnessError::BackendSpawn,
-        observed_session: None,
-    })?;
-    let mut stderr_task = tokio::spawn(capture_stderr(stderr));
-    let mut writer_task = write_stdin(stdin, invocation.prompt);
-    let start = Instant::now();
-    let mut observed_session = None;
-    let mut error_summary = None;
-    let mut idle_deadline = tokio::time::Instant::now() + invocation.idle_timeout;
-
-    let lifecycle_result = timeout_at(total_deadline, async {
-        let mut lines = BufReader::new(stdout).lines();
-        loop {
-            let Some(line) = next_stdout_line(&mut lines, idle_deadline).await? else {
-                break;
-            };
-            if line.is_empty() {
-                idle_deadline = tokio::time::Instant::now() + invocation.idle_timeout;
-                continue;
-            }
-            match parse_event_line(&line) {
-                Ok(Some(ParsedEvent::Session(session_id))) => {
-                    if observed_session.is_none() {
-                        observed_session = Some(session_id);
-                    }
-                }
-                Ok(Some(ParsedEvent::Text(text))) => {
-                    if !text.trim().is_empty() {
-                        tx.send(RunnerEvent::Text(text))
-                            .await
-                            .map_err(|_| HarnessError::BackendStream)?;
-                    }
-                }
-                Ok(Some(ParsedEvent::Error(summary))) => {
-                    if error_summary.is_none() {
-                        error_summary = Some(summary);
-                    }
-                }
-                Ok(None) => {}
-                Err(_) => debug!(
-                    target: TRACE_TARGET,
-                    method = "codex_exec",
-                    error_kind = "json",
-                    "dropping undecodable Codex event"
-                ),
-            }
-            idle_deadline = tokio::time::Instant::now() + invocation.idle_timeout;
-        }
-
-        let (status, stderr) = match timeout_at(idle_deadline, async {
-            let (writer, status, stderr) =
-                tokio::join!(&mut writer_task, child.wait(), &mut stderr_task,);
-            let status = status.map_err(HarnessError::from)?;
-            let stderr = stderr.map_err(HarnessError::from)?;
-            match writer.map_err(HarnessError::from)? {
-                Ok(()) => {}
-                Err(err) if err.kind() == std::io::ErrorKind::BrokenPipe => debug!(
-                    target: TRACE_TARGET,
-                    method = "codex_exec",
-                    error_kind = "stdin_closed",
-                    "backend closed stdin before draining the prompt"
-                ),
-                Err(_) => return Err(HarnessError::BackendStream),
-            }
-            Ok::<_, HarnessError>((status, stderr))
-        })
-        .await
-        {
-            Err(_) => return Err(HarnessError::BackendIdle),
-            Ok(result) => result?,
-        };
-        Ok::<_, HarnessError>(Outcome {
-            observed_session: observed_session.clone(),
-            exit_code: status.code(),
-            error_summary,
-            stderr: strip_ansi(stderr.trim()),
-            elapsed_ms: start.elapsed().as_millis(),
-        })
-    })
-    .await;
-
-    match lifecycle_result {
-        Ok(Ok(outcome)) => Ok(outcome),
-        Ok(Err(error)) => {
-            cleanup_failed_run(&mut child, &mut stderr_task, Some(&mut writer_task)).await;
-            Err(RunFailure {
-                error,
-                observed_session,
-            })
-        }
-        Err(_) => {
-            cleanup_failed_run(&mut child, &mut stderr_task, Some(&mut writer_task)).await;
-            Err(RunFailure {
-                error: HarnessError::BackendTimedOut,
-                observed_session,
-            })
-        }
-    }
+    let Invocation {
+        timeout,
+        idle_timeout,
+        cwd,
+        session_id,
+        prompt,
+    } = invocation;
+    run_jsonl_process(
+        ProcessSpec {
+            executable: bin.to_owned(),
+            args: build_exec_args(session_id.as_deref(), execution_profile),
+            cwd,
+            environment: Vec::new(),
+            prompt: PromptTransport::Stdin(prompt),
+            trace_method: "codex_exec",
+            backend_name: "codex",
+            total_timeout: timeout,
+            idle_timeout,
+        },
+        tx,
+        parse_event_line,
+    )
+    .await
 }
 
 fn build_exec_args(session_id: Option<&str>, profile: ExecutionProfile) -> Vec<String> {
@@ -211,37 +103,38 @@ fn build_exec_args(session_id: Option<&str>, profile: ExecutionProfile) -> Vec<S
     args
 }
 
-#[derive(Debug, PartialEq, Eq)]
-enum ParsedEvent {
-    Session(String),
-    Text(String),
-    Error(String),
-}
-
-fn parse_event_line(line: &str) -> serde_json::Result<Option<ParsedEvent>> {
+fn parse_event_line(line: &str) -> serde_json::Result<ParsedEvent> {
     let value: Value = serde_json::from_str(line)?;
     match value.get("type").and_then(Value::as_str) {
         Some("thread.started") => Ok(value
             .get("thread_id")
             .and_then(Value::as_str)
             .filter(|id| !id.is_empty())
-            .map(|id| ParsedEvent::Session(id.to_owned()))),
+            .map(|id| ParsedEvent::Session(id.to_owned()))
+            .unwrap_or(ParsedEvent::Ignored)),
         Some("item.completed") => {
             let Some(item) = value.get("item") else {
-                return Ok(None);
+                return Ok(ParsedEvent::Ignored);
             };
             if item.get("type").and_then(Value::as_str) != Some("agent_message") {
-                return Ok(None);
+                return Ok(ParsedEvent::Ignored);
             }
             Ok(item
                 .get("text")
                 .and_then(Value::as_str)
                 .filter(|text| !text.trim().is_empty())
-                .map(|text| ParsedEvent::Text(text.to_owned())))
+                .map(|text| ParsedEvent::Text(text.to_owned()))
+                .unwrap_or(ParsedEvent::Ignored))
         }
-        Some("turn.failed") => Ok(Some(ParsedEvent::Error("turn_failed".to_owned()))),
-        Some("error") => Ok(Some(ParsedEvent::Error("error".to_owned()))),
-        _ => Ok(None),
+        Some("turn.failed") => Ok(ParsedEvent::Error {
+            session_id: None,
+            summary: "turn_failed".to_owned(),
+        }),
+        Some("error") => Ok(ParsedEvent::Error {
+            session_id: None,
+            summary: "error".to_owned(),
+        }),
+        _ => Ok(ParsedEvent::Ignored),
     }
 }
 
@@ -320,11 +213,11 @@ mod tests {
     fn parser_emits_thread_and_completed_agent_messages_only() {
         assert_eq!(
             parse_event_line(r#"{"type":"thread.started","thread_id":"thread-123"}"#).unwrap(),
-            Some(ParsedEvent::Session("thread-123".to_owned()))
+            ParsedEvent::Session("thread-123".to_owned())
         );
         assert_eq!(
             parse_event_line(r#"{"type":"item.completed","item":{"id":"item-1","type":"agent_message","text":"hello"}}"#).unwrap(),
-            Some(ParsedEvent::Text("hello".to_owned()))
+            ParsedEvent::Text("hello".to_owned())
         );
         for line in [
             r#"{"type":"item.started","item":{"type":"agent_message","text":"partial"}}"#,
@@ -332,7 +225,7 @@ mod tests {
             r#"{"type":"item.completed","item":{"type":"command_execution","aggregated_output":"private"}}"#,
             r#"{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}"#,
         ] {
-            assert!(parse_event_line(line).unwrap().is_none());
+            assert_eq!(parse_event_line(line).unwrap(), ParsedEvent::Ignored);
         }
     }
 
@@ -340,11 +233,17 @@ mod tests {
     fn parser_reports_failures_without_exposing_backend_messages() {
         assert_eq!(
             parse_event_line(r#"{"type":"turn.failed","error":{"message":"secret"}}"#).unwrap(),
-            Some(ParsedEvent::Error("turn_failed".to_owned()))
+            ParsedEvent::Error {
+                session_id: None,
+                summary: "turn_failed".to_owned()
+            }
         );
         assert_eq!(
             parse_event_line(r#"{"type":"error","message":"secret"}"#).unwrap(),
-            Some(ParsedEvent::Error("error".to_owned()))
+            ParsedEvent::Error {
+                session_id: None,
+                summary: "error".to_owned()
+            }
         );
     }
 

--- a/integrations/opencode/marmot/src/opencode.rs
+++ b/integrations/opencode/marmot/src/opencode.rs
@@ -1,21 +1,11 @@
-use std::process::Stdio;
-use std::time::Instant;
-
 use async_trait::async_trait;
 use marmot_terminal_harness::{
-    ApprovalSupport, Backend, ExecutionProfile, ExecutionSupport, HarnessError, Invocation,
-    IsolationSupport, Outcome, Result, RunFailure, RunnerEvent, TRACE_TARGET,
-    process::{
-        capture_stderr, cleanup_failed_run, kill_and_reap, next_stdout_line, strip_ansi,
-        write_stdin,
-    },
+    ApprovalSupport, Backend, ExecutionProfile, ExecutionSupport, Invocation, IsolationSupport,
+    Outcome, ParsedEvent, PromptTransport, Result, RunFailure, RunnerEvent,
+    process::{EnvironmentChange, ProcessSpec, run_jsonl_process},
 };
 use serde::Deserialize;
-use tokio::io::{AsyncBufReadExt, BufReader};
-use tokio::process::Command;
 use tokio::sync::mpsc;
-use tokio::time::timeout_at;
-use tracing::debug;
 
 #[derive(Clone)]
 pub(crate) struct OpencodeBackend {
@@ -88,165 +78,40 @@ async fn run_with_bin(
     invocation: Invocation,
     tx: mpsc::Sender<RunnerEvent>,
 ) -> std::result::Result<Outcome, RunFailure> {
-    let mut command = Command::new(bin);
-    command
-        .args(build_run_args(
-            invocation.session_id.as_deref(),
-            execution_profile,
-        ))
-        .current_dir(&invocation.cwd)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .kill_on_drop(true);
-    if let Some((remove, name, value)) = config_overlay(execution_profile) {
-        command.env_remove(remove).env(name, value);
-    }
-
-    let mut child = command.spawn().map_err(|_| RunFailure {
-        error: HarnessError::BackendSpawn,
-        observed_session: None,
-    })?;
-    let total_deadline = tokio::time::Instant::now() + invocation.timeout;
-    let stdin = match child.stdin.take() {
-        Some(stdin) => stdin,
-        None => {
-            kill_and_reap(&mut child).await;
-            return Err(RunFailure {
-                error: HarnessError::BackendSpawn,
-                observed_session: None,
-            });
-        }
-    };
-    let stdout = match child.stdout.take() {
-        Some(stdout) => stdout,
-        None => {
-            kill_and_reap(&mut child).await;
-            return Err(RunFailure {
-                error: HarnessError::BackendSpawn,
-                observed_session: None,
-            });
-        }
-    };
-    let stderr = match child.stderr.take() {
-        Some(stderr) => stderr,
-        None => {
-            kill_and_reap(&mut child).await;
-            return Err(RunFailure {
-                error: HarnessError::BackendSpawn,
-                observed_session: None,
-            });
-        }
-    };
-    let mut lines = BufReader::new(stdout).lines();
-    let mut stderr_task = tokio::spawn(capture_stderr(stderr));
-    let mut writer_task = write_stdin(stdin, invocation.prompt);
-    let start = Instant::now();
-    let mut observed_session: Option<String> = None;
-    let mut error_summary: Option<String> = None;
-    let mut idle_deadline = tokio::time::Instant::now() + invocation.idle_timeout;
-
-    let lifecycle_result = timeout_at(total_deadline, async {
-        loop {
-            let Some(line) = next_stdout_line(&mut lines, idle_deadline).await? else {
-                break;
-            };
-
-            if line.is_empty() {
-                idle_deadline = tokio::time::Instant::now() + invocation.idle_timeout;
-                continue;
-            }
-            match parse_event_line(&line) {
-                Ok(Some(ParsedEvent::Text(text))) => {
-                    if !text.trim().is_empty() {
-                        // The idle clock measures actual stdout reads, not time intentionally
-                        // spent applying bounded reply-channel backpressure. The total deadline
-                        // still caps both operations.
-                        tx.send(RunnerEvent::Text(text))
-                            .await
-                            .map_err(|_| HarnessError::BackendStream)?;
-                    }
-                }
-                Ok(Some(ParsedEvent::Session(session_id))) => {
-                    if observed_session.is_none() {
-                        observed_session = Some(session_id);
-                    }
-                }
-                Ok(Some(ParsedEvent::Error {
-                    session_id,
-                    summary,
-                })) => {
-                    if let Some(session_id) = session_id
-                        && observed_session.is_none()
-                    {
-                        observed_session = Some(session_id);
-                    }
-                    if error_summary.is_none() {
-                        error_summary = Some(summary);
-                    }
-                }
-                Ok(None) => {}
-                Err(_) => {
-                    debug!(
-                        target: TRACE_TARGET,
-                        method = "opencode_run",
-                        error_kind = "json",
-                        "dropping undecodable opencode event"
-                    );
-                }
-            }
-            idle_deadline = tokio::time::Instant::now() + invocation.idle_timeout;
-        }
-
-        let (status, stderr) = match timeout_at(idle_deadline, async {
-            let (writer, status, stderr) =
-                tokio::join!(&mut writer_task, child.wait(), &mut stderr_task);
-            let status = status.map_err(HarnessError::from)?;
-            let stderr = stderr.map_err(HarnessError::from)?;
-            match writer.map_err(HarnessError::from)? {
-                Ok(()) => {}
-                Err(err) if err.kind() == std::io::ErrorKind::BrokenPipe => debug!(
-                    target: TRACE_TARGET,
-                    method = "opencode_run",
-                    error_kind = "stdin_closed",
-                    "backend closed stdin before draining the prompt"
-                ),
-                Err(_) => return Err(HarnessError::BackendStream),
-            }
-            Ok::<_, HarnessError>((status, stderr))
+    let Invocation {
+        timeout,
+        idle_timeout,
+        cwd,
+        session_id,
+        prompt,
+    } = invocation;
+    let environment = config_overlay(execution_profile)
+        .map(|(remove, name, value)| {
+            vec![
+                EnvironmentChange::Remove(remove),
+                EnvironmentChange::Set {
+                    name,
+                    value: value.to_owned(),
+                },
+            ]
         })
-        .await
-        {
-            Err(_) => return Err(HarnessError::BackendIdle),
-            Ok(result) => result?,
-        };
-        Ok::<Outcome, HarnessError>(Outcome {
-            observed_session: observed_session.clone(),
-            exit_code: status.code(),
-            error_summary,
-            stderr: strip_ansi(stderr.trim()),
-            elapsed_ms: start.elapsed().as_millis(),
-        })
-    })
-    .await;
-
-    match lifecycle_result {
-        Ok(Ok(outcome)) => Ok(outcome),
-        Ok(Err(error)) => {
-            cleanup_failed_run(&mut child, &mut stderr_task, Some(&mut writer_task)).await;
-            Err(RunFailure {
-                error,
-                observed_session,
-            })
-        }
-        Err(_) => {
-            cleanup_failed_run(&mut child, &mut stderr_task, Some(&mut writer_task)).await;
-            Err(RunFailure {
-                error: HarnessError::BackendTimedOut,
-                observed_session,
-            })
-        }
-    }
+        .unwrap_or_default();
+    run_jsonl_process(
+        ProcessSpec {
+            executable: bin.to_owned(),
+            args: build_run_args(session_id.as_deref(), execution_profile),
+            cwd,
+            environment,
+            prompt: PromptTransport::Stdin(prompt),
+            trace_method: "opencode_run",
+            backend_name: "opencode",
+            total_timeout: timeout,
+            idle_timeout,
+        },
+        tx,
+        parse_event_line,
+    )
+    .await
 }
 
 pub(crate) fn build_run_args(
@@ -277,30 +142,20 @@ fn config_overlay(profile: ExecutionProfile) -> Option<(&'static str, &'static s
     ))
 }
 
-#[derive(Debug, PartialEq, Eq)]
-enum ParsedEvent {
-    Text(String),
-    Session(String),
-    Error {
-        session_id: Option<String>,
-        summary: String,
-    },
-}
-
-fn parse_event_line(line: &str) -> Result<Option<ParsedEvent>> {
+fn parse_event_line(line: &str) -> Result<ParsedEvent> {
     let event = serde_json::from_str::<OpencodeEvent>(line)?;
     Ok(match event {
-        OpencodeEvent::Text { part } => Some(ParsedEvent::Text(part.text)),
-        OpencodeEvent::Error { session_id, error } => Some(ParsedEvent::Error {
+        OpencodeEvent::Text { part } => ParsedEvent::Text(part.text),
+        OpencodeEvent::Error { session_id, error } => ParsedEvent::Error {
             session_id,
             summary: error.summary(),
-        }),
+        },
         OpencodeEvent::StepStart {
             session_id: Some(session_id),
-        } => Some(ParsedEvent::Session(session_id)),
+        } => ParsedEvent::Session(session_id),
         OpencodeEvent::StepStart { session_id: None }
         | OpencodeEvent::StepFinish {}
-        | OpencodeEvent::Other => None,
+        | OpencodeEvent::Other => ParsedEvent::Ignored,
     })
 }
 
@@ -316,9 +171,9 @@ impl OpencodeError {
 
 #[cfg(test)]
 mod tests {
-    use marmot_terminal_harness::ExecutionProfile;
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
 
+    use marmot_terminal_harness::{ExecutionProfile, HarnessError};
     use tokio::sync::mpsc;
 
     use super::*;
@@ -357,11 +212,11 @@ mod tests {
     fn parse_opencode_text_and_session_events() {
         assert_eq!(
             parse_event_line(r#"{"type":"step_start","sessionID":"ses_1"}"#).unwrap(),
-            Some(ParsedEvent::Session("ses_1".to_owned()))
+            ParsedEvent::Session("ses_1".to_owned())
         );
         assert_eq!(
             parse_event_line(r#"{"type":"text","part":{"text":"hello"}}"#).unwrap(),
-            Some(ParsedEvent::Text("hello".to_owned()))
+            ParsedEvent::Text("hello".to_owned())
         );
     }
 
@@ -372,10 +227,10 @@ mod tests {
                 r#"{"type":"error","sessionID":"ses_err","error":{"name":"APIError","data":{"statusCode":404}}}"#
             )
             .unwrap(),
-            Some(ParsedEvent::Error {
+            ParsedEvent::Error {
                 session_id: Some("ses_err".to_owned()),
                 summary: "APIError status=404".to_owned()
-            })
+            }
         );
     }
 
@@ -415,49 +270,6 @@ mod tests {
         .unwrap_err();
         assert!(matches!(failure.error, HarnessError::BackendIdle));
         assert_eq!(failure.observed_session.as_deref(), Some("ses_idle"));
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn stdout_lines_reset_idle_past_old_wall_clock_deadline() {
-        use tokio::io::AsyncWriteExt;
-        use tokio::time::sleep;
-
-        const IDLE: Duration = Duration::from_secs(120);
-        const GAP: Duration = Duration::from_secs(70);
-        const TOTAL: Duration = Duration::from_secs(3600);
-        const LINE_COUNT: usize = 6;
-
-        let (mut writer, reader) = tokio::io::duplex(1024);
-        let producer = tokio::spawn(async move {
-            for index in 0..LINE_COUNT {
-                if index != 0 {
-                    sleep(GAP).await;
-                }
-                writer.write_all(b"line\n").await.unwrap();
-            }
-        });
-        let mut lines = BufReader::new(reader).lines();
-        let started = tokio::time::Instant::now();
-        let received = tokio::time::timeout(TOTAL, async {
-            let mut count = 0;
-            let mut idle_deadline = tokio::time::Instant::now() + IDLE;
-            while next_stdout_line(&mut lines, idle_deadline)
-                .await
-                .unwrap()
-                .is_some()
-            {
-                count += 1;
-                idle_deadline = tokio::time::Instant::now() + IDLE;
-            }
-            count
-        })
-        .await
-        .unwrap();
-
-        producer.await.unwrap();
-        assert_eq!(received, LINE_COUNT);
-        assert!(started.elapsed() > Duration::from_secs(300));
-        assert!(started.elapsed() < TOTAL);
     }
 
     #[cfg(unix)]

--- a/integrations/pi/marmot/src/pi.rs
+++ b/integrations/pi/marmot/src/pi.rs
@@ -1,19 +1,13 @@
 use std::path::Path;
-use std::process::Stdio;
-use std::time::Instant;
 
 use async_trait::async_trait;
 use marmot_terminal_harness::{
-    ApprovalSupport, Backend, ExecutionProfile, ExecutionSupport, HarnessError, Invocation,
-    IsolationSupport, Outcome, Result, RunFailure, RunnerEvent, TRACE_TARGET,
-    process::{capture_stderr, cleanup_failed_run, next_stdout_line, strip_ansi, write_stdin},
+    ApprovalSupport, Backend, ExecutionProfile, ExecutionSupport, Invocation, IsolationSupport,
+    Outcome, ParsedEvent, PromptTransport, Result, RunFailure, RunnerEvent,
+    process::{ProcessSpec, run_jsonl_process},
 };
 use serde_json::Value;
-use tokio::io::{AsyncBufReadExt, BufReader};
-use tokio::process::Command;
 use tokio::sync::mpsc;
-use tokio::time::timeout_at;
-use tracing::debug;
 
 #[derive(Clone)]
 pub(crate) struct PiBackend {
@@ -69,131 +63,29 @@ async fn run_with_bin(
     invocation: Invocation,
     tx: mpsc::Sender<RunnerEvent>,
 ) -> std::result::Result<Outcome, RunFailure> {
-    let mut command = Command::new(bin);
-    command
-        .args(build_run_args(
-            session_dir,
-            invocation.session_id.as_deref(),
-            execution_profile,
-        ))
-        .current_dir(&invocation.cwd)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .kill_on_drop(true);
-
-    let mut child = command.spawn().map_err(|_| RunFailure {
-        error: HarnessError::BackendSpawn,
-        observed_session: None,
-    })?;
-    let total_deadline = tokio::time::Instant::now() + invocation.timeout;
-    let stdin = child.stdin.take().ok_or(RunFailure {
-        error: HarnessError::BackendSpawn,
-        observed_session: None,
-    })?;
-    let stdout = child.stdout.take().ok_or(RunFailure {
-        error: HarnessError::BackendSpawn,
-        observed_session: None,
-    })?;
-    let stderr = child.stderr.take().ok_or(RunFailure {
-        error: HarnessError::BackendSpawn,
-        observed_session: None,
-    })?;
-    let mut stderr_task = tokio::spawn(capture_stderr(stderr));
-    let mut writer_task = write_stdin(stdin, invocation.prompt);
-    let start = Instant::now();
-    let mut observed_session = None;
-    let mut error_summary = None;
-    let mut idle_deadline = tokio::time::Instant::now() + invocation.idle_timeout;
-
-    let lifecycle_result = timeout_at(total_deadline, async {
-        let mut lines = BufReader::new(stdout).lines();
-        loop {
-            let Some(line) = next_stdout_line(&mut lines, idle_deadline).await? else {
-                break;
-            };
-            if line.is_empty() {
-                idle_deadline = tokio::time::Instant::now() + invocation.idle_timeout;
-                continue;
-            }
-            match parse_event_line(&line) {
-                Ok(Some(ParsedEvent::Session(session_id))) => {
-                    if observed_session.is_none() {
-                        observed_session = Some(session_id);
-                    }
-                }
-                Ok(Some(ParsedEvent::Text(text))) => {
-                    if !text.trim().is_empty() {
-                        tx.send(RunnerEvent::Text(text))
-                            .await
-                            .map_err(|_| HarnessError::BackendStream)?;
-                    }
-                }
-                Ok(Some(ParsedEvent::Error(summary))) => {
-                    if error_summary.is_none() {
-                        error_summary = Some(summary);
-                    }
-                }
-                Ok(None) => {}
-                Err(_) => debug!(
-                    target: TRACE_TARGET,
-                    method = "pi_run",
-                    error_kind = "json",
-                    "dropping undecodable Pi event"
-                ),
-            }
-            idle_deadline = tokio::time::Instant::now() + invocation.idle_timeout;
-        }
-
-        let (status, stderr) = match timeout_at(idle_deadline, async {
-            let (writer, status, stderr) =
-                tokio::join!(&mut writer_task, child.wait(), &mut stderr_task,);
-            let status = status.map_err(HarnessError::from)?;
-            let stderr = stderr.map_err(HarnessError::from)?;
-            match writer.map_err(HarnessError::from)? {
-                Ok(()) => {}
-                Err(err) if err.kind() == std::io::ErrorKind::BrokenPipe => debug!(
-                    target: TRACE_TARGET,
-                    method = "pi_run",
-                    error_kind = "stdin_closed",
-                    "backend closed stdin before draining the prompt"
-                ),
-                Err(_) => return Err(HarnessError::BackendStream),
-            }
-            Ok::<_, HarnessError>((status, stderr))
-        })
-        .await
-        {
-            Err(_) => return Err(HarnessError::BackendIdle),
-            Ok(result) => result?,
-        };
-        Ok::<_, HarnessError>(Outcome {
-            observed_session: observed_session.clone(),
-            exit_code: status.code(),
-            error_summary,
-            stderr: strip_ansi(stderr.trim()),
-            elapsed_ms: start.elapsed().as_millis(),
-        })
-    })
-    .await;
-
-    match lifecycle_result {
-        Ok(Ok(outcome)) => Ok(outcome),
-        Ok(Err(error)) => {
-            cleanup_failed_run(&mut child, &mut stderr_task, Some(&mut writer_task)).await;
-            Err(RunFailure {
-                error,
-                observed_session,
-            })
-        }
-        Err(_) => {
-            cleanup_failed_run(&mut child, &mut stderr_task, Some(&mut writer_task)).await;
-            Err(RunFailure {
-                error: HarnessError::BackendTimedOut,
-                observed_session,
-            })
-        }
-    }
+    let Invocation {
+        timeout,
+        idle_timeout,
+        cwd,
+        session_id,
+        prompt,
+    } = invocation;
+    run_jsonl_process(
+        ProcessSpec {
+            executable: bin.to_owned(),
+            args: build_run_args(session_dir, session_id.as_deref(), execution_profile),
+            cwd,
+            environment: Vec::new(),
+            prompt: PromptTransport::Stdin(prompt),
+            trace_method: "pi_run",
+            backend_name: "pi",
+            total_timeout: timeout,
+            idle_timeout,
+        },
+        tx,
+        parse_event_line,
+    )
+    .await
 }
 
 fn build_run_args(
@@ -214,45 +106,40 @@ fn build_run_args(
     args
 }
 
-#[derive(Debug, PartialEq, Eq)]
-enum ParsedEvent {
-    Session(String),
-    Text(String),
-    Error(String),
-}
-
-fn parse_event_line(line: &str) -> serde_json::Result<Option<ParsedEvent>> {
+fn parse_event_line(line: &str) -> serde_json::Result<ParsedEvent> {
     let value: Value = serde_json::from_str(line)?;
     let Some(event_type) = value.get("type").and_then(Value::as_str) else {
-        return Ok(None);
+        return Ok(ParsedEvent::Ignored);
     };
     if event_type == "session" {
         return Ok(value
             .get("id")
             .and_then(Value::as_str)
             .filter(|id| !id.is_empty())
-            .map(|id| ParsedEvent::Session(id.to_owned())));
+            .map(|id| ParsedEvent::Session(id.to_owned()))
+            .unwrap_or(ParsedEvent::Ignored));
     }
     if event_type != "message_end" {
-        return Ok(None);
+        return Ok(ParsedEvent::Ignored);
     }
     let Some(message) = value.get("message") else {
-        return Ok(None);
+        return Ok(ParsedEvent::Ignored);
     };
     if message.get("role").and_then(Value::as_str) != Some("assistant") {
-        return Ok(None);
+        return Ok(ParsedEvent::Ignored);
     }
     let text = assistant_text(message.get("content"));
     if !text.is_empty() {
-        return Ok(Some(ParsedEvent::Text(text)));
+        return Ok(ParsedEvent::Text(text));
     }
     let stop_reason = message.get("stopReason").and_then(Value::as_str);
     if matches!(stop_reason, Some("error" | "aborted")) {
-        return Ok(Some(ParsedEvent::Error(
-            stop_reason.unwrap_or("error").to_owned(),
-        )));
+        return Ok(ParsedEvent::Error {
+            session_id: None,
+            summary: stop_reason.unwrap_or("error").to_owned(),
+        });
     }
-    Ok(None)
+    Ok(ParsedEvent::Ignored)
 }
 
 fn assistant_text(content: Option<&Value>) -> String {
@@ -304,21 +191,21 @@ mod tests {
     fn parser_emits_session_and_completed_assistant_text_only() {
         assert_eq!(
             parse_event_line(r#"{"type":"session","version":3,"id":"pi-session"}"#).unwrap(),
-            Some(ParsedEvent::Session("pi-session".to_owned()))
+            ParsedEvent::Session("pi-session".to_owned())
         );
-        assert!(
+        assert_eq!(
             parse_event_line(r#"{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"partial"}}"#)
-                .unwrap()
-                .is_none()
+                .unwrap(),
+            ParsedEvent::Ignored
         );
         assert_eq!(
             parse_event_line(r#"{"type":"message_end","message":{"role":"assistant","content":[{"type":"thinking","thinking":"secret"},{"type":"text","text":"hello "},{"type":"toolCall","name":"bash"},{"type":"text","text":"world"}],"stopReason":"stop"}}"#).unwrap(),
-            Some(ParsedEvent::Text("hello world".to_owned()))
+            ParsedEvent::Text("hello world".to_owned())
         );
-        assert!(
+        assert_eq!(
             parse_event_line(r#"{"type":"message_end","message":{"role":"toolResult","content":[{"type":"text","text":"private output"}]}}"#)
-                .unwrap()
-                .is_none()
+                .unwrap(),
+            ParsedEvent::Ignored
         );
     }
 
@@ -326,7 +213,10 @@ mod tests {
     fn parser_reports_textless_error_without_exposing_error_message() {
         assert_eq!(
             parse_event_line(r#"{"type":"message_end","message":{"role":"assistant","content":[],"stopReason":"error","errorMessage":"secret"}}"#).unwrap(),
-            Some(ParsedEvent::Error("error".to_owned()))
+            ParsedEvent::Error {
+                session_id: None,
+                summary: "error".to_owned()
+            }
         );
     }
 

--- a/integrations/terminal-harness/README.md
+++ b/integrations/terminal-harness/README.md
@@ -8,8 +8,8 @@ backend command construction and event parsing in each connector crate.
 
 The crate owns the `wn-agent` control client, account and sender selection,
 inbound reconnect and resync, per-group bounded queues, deduplication, working
-directory selection, private group-to-session mappings, reply chunking, and
-backend process lifecycle helpers. It does not own MLS, Nostr transport,
+directory selection, private group-to-session mappings, reply chunking, and a
+shared JSONL child-process runner. It does not own MLS, Nostr transport,
 storage, QUIC previews, or backend-specific CLI semantics.
 
 ## Backend Boundary
@@ -27,6 +27,11 @@ Connector crates are responsible for:
 - parsing the backend's documented machine-readable event stream;
 - exposing only completed assistant output, never thinking or tool output;
 - preserving or reporting the backend session id needed for the next prompt.
+
+Each backend provides a typed `ProcessSpec`, selects its prompt transport, and
+maps its strict decoder into the shared `ParsedEvent` vocabulary. The shared
+runner owns spawning, bounded stderr, stdout and total deadlines, reply-channel
+backpressure, first-session capture, and child termination and reaping.
 
 Codex, OpenCode, and Pi write prompt text to stdin. Backend-specific behavior
 belongs in those connector crates, not in this shared runtime.

--- a/integrations/terminal-harness/src/lib.rs
+++ b/integrations/terminal-harness/src/lib.rs
@@ -21,6 +21,7 @@ use tokio::sync::mpsc;
 pub use bridge::run;
 pub use config::{ConfigSpec, ExecutionProfile, LoadedConfig, load_config_with};
 pub use error::{HarnessError, Result};
+pub use process::{ParsedEvent, PromptTransport};
 
 /// Default maximum byte length for one Marmot reply chunk.
 pub const DEFAULT_MAX_REPLY_BYTES: usize = 30_000;

--- a/integrations/terminal-harness/src/process.rs
+++ b/integrations/terminal-harness/src/process.rs
@@ -1,14 +1,346 @@
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
-use tokio::process::{Child, ChildStderr, ChildStdin};
+use std::fmt;
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::time::{Duration, Instant as StdInstant};
+
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStderr, ChildStdin, Command};
+use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio::time::{Instant, timeout_at};
+use tracing::debug;
 
-use crate::{HarnessError, Result};
+use crate::{HarnessError, Outcome, Result, RunFailure, RunnerEvent, TRACE_TARGET};
 
 const STDERR_CAPTURE_BYTES: usize = 4096;
 
+/// How one backend prompt reaches the child process.
+pub enum PromptTransport {
+    /// Write the prompt to the child's standard input and then close it.
+    Stdin(String),
+    /// Append an explicit option delimiter and the prompt to the argument list.
+    DelimitedArgument {
+        /// Backend-specific delimiter that prevents prompt option injection.
+        delimiter: &'static str,
+        /// Prompt appended immediately after `delimiter`.
+        prompt: String,
+    },
+}
+
+impl fmt::Debug for PromptTransport {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Stdin(prompt) => formatter
+                .debug_struct("Stdin")
+                .field("prompt_len", &prompt.len())
+                .finish(),
+            Self::DelimitedArgument { prompt, .. } => formatter
+                .debug_struct("DelimitedArgument")
+                .field("prompt_len", &prompt.len())
+                .finish(),
+        }
+    }
+}
+
+/// One process-local environment mutation applied before child spawn.
+pub enum EnvironmentChange {
+    /// Remove an inherited environment variable.
+    Remove(&'static str),
+    /// Set an environment variable for only the spawned child.
+    Set {
+        /// Environment variable name.
+        name: &'static str,
+        /// Environment variable value, excluded from diagnostics.
+        value: String,
+    },
+}
+
+/// Typed child-process configuration for one JSONL backend invocation.
+pub struct ProcessSpec {
+    /// Backend executable name or path.
+    pub executable: String,
+    /// Backend-specific arguments excluding a delimited prompt.
+    pub args: Vec<String>,
+    /// Validated working directory.
+    pub cwd: PathBuf,
+    /// Process-local environment changes.
+    pub environment: Vec<EnvironmentChange>,
+    /// Backend-specific prompt transport.
+    pub prompt: PromptTransport,
+    /// Privacy-safe tracing method name.
+    pub trace_method: &'static str,
+    /// Privacy-safe backend name.
+    pub backend_name: &'static str,
+    /// Total wall-clock budget, including reply-channel backpressure.
+    pub total_timeout: Duration,
+    /// Maximum silence between stdout reads and through the final child wait.
+    pub idle_timeout: Duration,
+}
+
+impl fmt::Debug for ProcessSpec {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProcessSpec")
+            .field("argument_count", &self.args.len())
+            .field("environment_change_count", &self.environment.len())
+            .field("prompt", &self.prompt)
+            .field("trace_method", &self.trace_method)
+            .field("backend_name", &self.backend_name)
+            .field("total_timeout", &self.total_timeout)
+            .field("idle_timeout", &self.idle_timeout)
+            .finish_non_exhaustive()
+    }
+}
+
+/// One strictly decoded backend JSONL event understood by the shared runner.
+#[derive(PartialEq, Eq)]
+pub enum ParsedEvent {
+    /// A durable backend session id was observed.
+    Session(String),
+    /// One completed assistant-text item is ready for forwarding.
+    Text(String),
+    /// A sanitized backend failure classification was observed.
+    Error {
+        /// Optional session id carried by the backend's error event.
+        session_id: Option<String>,
+        /// Sanitized error classification; never a raw backend message.
+        summary: String,
+    },
+    /// A valid event that has no durable connector effect.
+    Ignored,
+}
+
+impl fmt::Debug for ParsedEvent {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Session(_) => formatter
+                .debug_struct("Session")
+                .field("session_present", &true)
+                .finish(),
+            Self::Text(text) => formatter
+                .debug_struct("Text")
+                .field("text_len", &text.len())
+                .finish(),
+            Self::Error {
+                session_id,
+                summary,
+            } => formatter
+                .debug_struct("Error")
+                .field("session_present", &session_id.is_some())
+                .field("summary_len", &summary.len())
+                .finish(),
+            Self::Ignored => formatter.write_str("Ignored"),
+        }
+    }
+}
+
+/// Runs one JSONL child process while keeping event decoding backend-specific.
+pub async fn run_jsonl_process<Parse, ParseError>(
+    spec: ProcessSpec,
+    tx: mpsc::Sender<RunnerEvent>,
+    mut parse_event: Parse,
+) -> std::result::Result<Outcome, RunFailure>
+where
+    Parse: FnMut(&str) -> std::result::Result<ParsedEvent, ParseError>,
+{
+    let ProcessSpec {
+        executable,
+        args,
+        cwd,
+        environment,
+        prompt,
+        trace_method,
+        backend_name,
+        total_timeout,
+        idle_timeout,
+    } = spec;
+    let mut command = Command::new(executable);
+    command
+        .args(args)
+        .current_dir(cwd)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    for change in environment {
+        match change {
+            EnvironmentChange::Remove(name) => {
+                command.env_remove(name);
+            }
+            EnvironmentChange::Set { name, value } => {
+                command.env(name, value);
+            }
+        }
+    }
+    match &prompt {
+        PromptTransport::Stdin(_) => {
+            command.stdin(Stdio::piped());
+        }
+        PromptTransport::DelimitedArgument { delimiter, prompt } => {
+            command.arg(delimiter).arg(prompt).stdin(Stdio::null());
+        }
+    }
+
+    let mut child = command.spawn().map_err(|_| RunFailure {
+        error: HarnessError::BackendSpawn,
+        observed_session: None,
+    })?;
+    let total_deadline = Instant::now() + total_timeout;
+    let mut writer_task = match prompt {
+        PromptTransport::Stdin(prompt) => match child.stdin.take() {
+            Some(stdin) => Some(write_stdin(stdin, prompt)),
+            None => {
+                kill_and_reap(&mut child).await;
+                return Err(spawn_failure());
+            }
+        },
+        PromptTransport::DelimitedArgument { .. } => None,
+    };
+    let stdout = match child.stdout.take() {
+        Some(stdout) => stdout,
+        None => {
+            cleanup_missing_pipe(&mut child, writer_task.as_mut()).await;
+            return Err(spawn_failure());
+        }
+    };
+    let stderr = match child.stderr.take() {
+        Some(stderr) => stderr,
+        None => {
+            cleanup_missing_pipe(&mut child, writer_task.as_mut()).await;
+            return Err(spawn_failure());
+        }
+    };
+    let mut stderr_task = tokio::spawn(capture_stderr(stderr));
+    let started = StdInstant::now();
+    let mut observed_session = None;
+    let mut error_summary = None;
+    let mut idle_deadline = Instant::now() + idle_timeout;
+
+    let lifecycle_result = timeout_at(total_deadline, async {
+        let mut lines = BufReader::new(stdout).lines();
+        loop {
+            let Some(line) = next_stdout_line(&mut lines, idle_deadline).await? else {
+                break;
+            };
+            if !line.is_empty() {
+                match parse_event(&line) {
+                    Ok(ParsedEvent::Session(session_id)) => {
+                        if observed_session.is_none() && !session_id.is_empty() {
+                            observed_session = Some(session_id);
+                        }
+                    }
+                    Ok(ParsedEvent::Text(text)) => {
+                        if !text.trim().is_empty() {
+                            // Reset below only after bounded backpressure clears. The total
+                            // deadline, not the idle deadline, covers intentional send waits.
+                            tx.send(RunnerEvent::Text(text))
+                                .await
+                                .map_err(|_| HarnessError::BackendStream)?;
+                        }
+                    }
+                    Ok(ParsedEvent::Error {
+                        session_id,
+                        summary,
+                    }) => {
+                        if observed_session.is_none()
+                            && let Some(session_id) = session_id.filter(|id| !id.is_empty())
+                        {
+                            observed_session = Some(session_id);
+                        }
+                        if error_summary.is_none() {
+                            error_summary = Some(summary);
+                        }
+                    }
+                    Ok(ParsedEvent::Ignored) => {}
+                    Err(_) => debug!(
+                        target: TRACE_TARGET,
+                        method = trace_method,
+                        backend = backend_name,
+                        error_kind = "json",
+                        "dropping undecodable backend event"
+                    ),
+                }
+            }
+            idle_deadline = Instant::now() + idle_timeout;
+        }
+
+        let (status, stderr) = match timeout_at(idle_deadline, async {
+            let writer = async {
+                match writer_task.as_mut() {
+                    Some(task) => Some(task.await),
+                    None => None,
+                }
+            };
+            let (writer, status, stderr) = tokio::join!(writer, child.wait(), &mut stderr_task);
+            let status = status.map_err(HarnessError::from)?;
+            let stderr = stderr.map_err(HarnessError::from)?;
+            if let Some(writer) = writer {
+                match writer.map_err(HarnessError::from)? {
+                    Ok(()) => {}
+                    Err(err) if err.kind() == std::io::ErrorKind::BrokenPipe => debug!(
+                        target: TRACE_TARGET,
+                        method = trace_method,
+                        backend = backend_name,
+                        error_kind = "stdin_closed",
+                        "backend closed stdin before draining the prompt"
+                    ),
+                    Err(_) => return Err(HarnessError::BackendStream),
+                }
+            }
+            Ok::<_, HarnessError>((status, stderr))
+        })
+        .await
+        {
+            Err(_) => return Err(HarnessError::BackendIdle),
+            Ok(result) => result?,
+        };
+        Ok::<_, HarnessError>(Outcome {
+            observed_session: observed_session.clone(),
+            exit_code: status.code(),
+            error_summary,
+            stderr: strip_ansi(stderr.trim()),
+            elapsed_ms: started.elapsed().as_millis(),
+        })
+    })
+    .await;
+
+    match lifecycle_result {
+        Ok(Ok(outcome)) => Ok(outcome),
+        Ok(Err(error)) => {
+            cleanup_failed_run(&mut child, &mut stderr_task, writer_task.as_mut()).await;
+            Err(RunFailure {
+                error,
+                observed_session,
+            })
+        }
+        Err(_) => {
+            cleanup_failed_run(&mut child, &mut stderr_task, writer_task.as_mut()).await;
+            Err(RunFailure {
+                error: HarnessError::BackendTimedOut,
+                observed_session,
+            })
+        }
+    }
+}
+
+fn spawn_failure() -> RunFailure {
+    RunFailure {
+        error: HarnessError::BackendSpawn,
+        observed_session: None,
+    }
+}
+
+async fn cleanup_missing_pipe(
+    child: &mut Child,
+    writer_task: Option<&mut JoinHandle<std::io::Result<()>>>,
+) {
+    if let Some(task) = writer_task {
+        task.abort();
+    }
+    kill_and_reap(child).await;
+}
+
 /// Reads one stdout line before the current idle deadline.
-pub async fn next_stdout_line(
+async fn next_stdout_line(
     lines: &mut tokio::io::Lines<impl tokio::io::AsyncBufRead + Unpin>,
     idle_deadline: Instant,
 ) -> Result<Option<String>> {
@@ -20,7 +352,7 @@ pub async fn next_stdout_line(
 }
 
 /// Writes and closes backend stdin concurrently with stdout consumption.
-pub fn write_stdin(stdin: ChildStdin, prompt: String) -> JoinHandle<std::io::Result<()>> {
+fn write_stdin(stdin: ChildStdin, prompt: String) -> JoinHandle<std::io::Result<()>> {
     tokio::spawn(async move {
         let mut stdin = stdin;
         stdin.write_all(prompt.as_bytes()).await?;
@@ -29,7 +361,7 @@ pub fn write_stdin(stdin: ChildStdin, prompt: String) -> JoinHandle<std::io::Res
 }
 
 /// Captures a bounded prefix of backend stderr.
-pub async fn capture_stderr(stderr: ChildStderr) -> String {
+async fn capture_stderr(stderr: ChildStderr) -> String {
     capture_bounded(stderr).await
 }
 
@@ -50,7 +382,7 @@ async fn capture_bounded(mut reader: impl AsyncRead + Unpin) -> String {
 }
 
 /// Aborts auxiliary tasks, terminates the child, and reaps it after failure.
-pub async fn cleanup_failed_run(
+async fn cleanup_failed_run(
     child: &mut Child,
     stderr_task: &mut JoinHandle<String>,
     writer_task: Option<&mut JoinHandle<std::io::Result<()>>>,
@@ -66,13 +398,13 @@ pub async fn cleanup_failed_run(
 }
 
 /// Best-effort terminates and reaps a backend child.
-pub async fn kill_and_reap(child: &mut Child) {
+async fn kill_and_reap(child: &mut Child) {
     let _ = child.start_kill();
     let _ = child.wait().await;
 }
 
 /// Removes ANSI CSI control sequences from bounded stderr.
-pub fn strip_ansi(value: &str) -> String {
+fn strip_ansi(value: &str) -> String {
     let mut out = String::with_capacity(value.len());
     let mut chars = value.chars().peekable();
     while let Some(ch) = chars.next() {

--- a/integrations/terminal-harness/tests/jsonl_process.rs
+++ b/integrations/terminal-harness/tests/jsonl_process.rs
@@ -203,6 +203,8 @@ printf '%s\n' '{"type":"text","text":"completed"}'
 
 #[tokio::test]
 async fn stdout_reads_reset_the_idle_deadline() {
+    const IDLE_TIMEOUT: Duration = Duration::from_millis(600);
+
     let _permit = process_test_permit().await;
     let root = tempfile::tempdir().unwrap();
     let script = executable_script(
@@ -210,17 +212,21 @@ async fn stdout_reads_reset_the_idle_deadline() {
         "progress-backend",
         r#"#!/bin/sh
 printf '%s\n' '{"type":"session","id":"progress"}'
-sleep 0.1
+sleep 0.25
 printf '%s\n' '{"type":"progress"}'
-sleep 0.1
+sleep 0.25
+printf '%s\n' '{"type":"progress"}'
+sleep 0.25
 printf '%s\n' '{"type":"text","text":"done"}'
 "#,
     );
     let (tx, mut rx) = mpsc::channel(2);
     let mut spec = process_spec(&script, root.path(), PromptTransport::Stdin(String::new()));
-    spec.idle_timeout = Duration::from_millis(500);
+    spec.idle_timeout = IDLE_TIMEOUT;
+    let started = std::time::Instant::now();
     let outcome = run_jsonl_process(spec, tx, parse_event).await.unwrap();
 
+    assert!(started.elapsed() > IDLE_TIMEOUT);
     assert_eq!(outcome.observed_session.as_deref(), Some("progress"));
     assert_eq!(rx.recv().await, Some(RunnerEvent::Text("done".to_owned())));
 }

--- a/integrations/terminal-harness/tests/jsonl_process.rs
+++ b/integrations/terminal-harness/tests/jsonl_process.rs
@@ -1,0 +1,442 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+
+use marmot_terminal_harness::{
+    ParsedEvent, PromptTransport, RunnerEvent,
+    process::{EnvironmentChange, ProcessSpec, run_jsonl_process},
+};
+use serde_json::Value;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore, mpsc};
+
+async fn process_test_permit() -> OwnedSemaphorePermit {
+    static PROCESS_TESTS: OnceLock<Arc<Semaphore>> = OnceLock::new();
+    PROCESS_TESTS
+        .get_or_init(|| Arc::new(Semaphore::new(1)))
+        .clone()
+        .acquire_owned()
+        .await
+        .unwrap()
+}
+
+fn executable_script(root: &std::path::Path, name: &str, body: &str) -> std::path::PathBuf {
+    let path = root.join(name);
+    fs::write(&path, body).unwrap();
+    let mut permissions = fs::metadata(&path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&path, permissions).unwrap();
+    path
+}
+
+fn parse_event(line: &str) -> serde_json::Result<ParsedEvent> {
+    let value: Value = serde_json::from_str(line)?;
+    Ok(match value.get("type").and_then(Value::as_str) {
+        Some("session") => value["id"]
+            .as_str()
+            .map(|id| ParsedEvent::Session(id.to_owned()))
+            .unwrap_or(ParsedEvent::Ignored),
+        Some("text") => value["text"]
+            .as_str()
+            .map(|text| ParsedEvent::Text(text.to_owned()))
+            .unwrap_or(ParsedEvent::Ignored),
+        Some("error") => ParsedEvent::Error {
+            session_id: value["session_id"].as_str().map(str::to_owned),
+            summary: value["class"]
+                .as_str()
+                .unwrap_or("classified_error")
+                .to_owned(),
+        },
+        _ => ParsedEvent::Ignored,
+    })
+}
+
+fn process_spec(
+    executable: &std::path::Path,
+    cwd: &std::path::Path,
+    prompt: PromptTransport,
+) -> ProcessSpec {
+    ProcessSpec {
+        executable: executable.to_string_lossy().into_owned(),
+        args: Vec::new(),
+        cwd: cwd.to_path_buf(),
+        environment: Vec::new(),
+        prompt,
+        trace_method: "test_backend_run",
+        backend_name: "test",
+        total_timeout: Duration::from_secs(5),
+        idle_timeout: Duration::from_secs(2),
+    }
+}
+
+#[tokio::test]
+async fn shared_runner_supports_stdin_and_delimited_argument_prompts() {
+    let _permit = process_test_permit().await;
+    let root = tempfile::tempdir().unwrap();
+    let stdin_script = executable_script(
+        root.path(),
+        "stdin-backend",
+        r#"#!/bin/sh
+prompt="$(cat)"
+printf '%s\n' '{"type":"session","id":"first"}'
+printf '{"type":"text","text":"stdin:%s"}\n' "$prompt"
+"#,
+    );
+    let argument_script = executable_script(
+        root.path(),
+        "argument-backend",
+        r#"#!/bin/sh
+if [ "$1" != "--json" ] || [ "$2" != "--" ]; then exit 64; fi
+printf '{"type":"text","text":"argument:%s"}\n' "$3"
+"#,
+    );
+
+    for (executable, prompt, expected) in [
+        (
+            stdin_script,
+            PromptTransport::Stdin("--stdin-prompt".to_owned()),
+            "stdin:--stdin-prompt",
+        ),
+        (
+            argument_script,
+            PromptTransport::DelimitedArgument {
+                delimiter: "--",
+                prompt: "--argument-prompt".to_owned(),
+            },
+            "argument:--argument-prompt",
+        ),
+    ] {
+        let (tx, mut rx) = mpsc::channel(2);
+        let mut spec = process_spec(&executable, root.path(), prompt);
+        spec.args = vec!["--json".to_owned()];
+        let outcome = run_jsonl_process(spec, tx, parse_event).await.unwrap();
+
+        assert_eq!(outcome.exit_code, Some(0));
+        assert_eq!(
+            rx.recv().await,
+            Some(RunnerEvent::Text(expected.to_owned()))
+        );
+        assert!(rx.recv().await.is_none());
+    }
+}
+
+#[tokio::test]
+async fn shared_runner_applies_process_local_environment_changes() {
+    let _permit = process_test_permit().await;
+    let root = tempfile::tempdir().unwrap();
+    let script = executable_script(
+        root.path(),
+        "environment-backend",
+        r#"#!/bin/sh
+if [ "${MARMOT_TEST_SET:-}" != "expected" ] || [ -n "${MARMOT_TEST_REMOVED:-}" ]; then
+  exit 64
+fi
+printf '%s\n' '{"type":"text","text":"environment-ok"}'
+"#,
+    );
+    let (tx, mut rx) = mpsc::channel(1);
+    let mut spec = process_spec(&script, root.path(), PromptTransport::Stdin(String::new()));
+    spec.environment = vec![
+        EnvironmentChange::Set {
+            name: "MARMOT_TEST_SET",
+            value: "expected".to_owned(),
+        },
+        EnvironmentChange::Set {
+            name: "MARMOT_TEST_REMOVED",
+            value: "unexpected".to_owned(),
+        },
+        EnvironmentChange::Remove("MARMOT_TEST_REMOVED"),
+    ];
+
+    let outcome = run_jsonl_process(spec, tx, parse_event).await.unwrap();
+
+    assert_eq!(outcome.exit_code, Some(0));
+    assert_eq!(
+        rx.recv().await,
+        Some(RunnerEvent::Text("environment-ok".to_owned()))
+    );
+}
+
+#[tokio::test]
+async fn shared_runner_drops_malformed_and_ignored_events_and_keeps_first_session() {
+    let _permit = process_test_permit().await;
+    let root = tempfile::tempdir().unwrap();
+    let script = executable_script(
+        root.path(),
+        "event-backend",
+        r#"#!/bin/sh
+printf '%s\n' 'not-json'
+printf '%s\n' '{"type":"progress","detail":"private"}'
+printf '%s\n' '{"type":"session","id":""}'
+printf '%s\n' '{"type":"session","id":"first"}'
+printf '%s\n' '{"type":"session","id":"second"}'
+printf '%s\n' '{"type":"error","session_id":"error-session","class":"first_error","message":"private"}'
+printf '%s\n' '{"type":"error","class":"second_error","message":"also private"}'
+printf '%s\n' '{"type":"text","text":"completed"}'
+"#,
+    );
+    let (tx, mut rx) = mpsc::channel(2);
+    let outcome = run_jsonl_process(
+        process_spec(
+            &script,
+            root.path(),
+            PromptTransport::DelimitedArgument {
+                delimiter: "--",
+                prompt: "prompt".to_owned(),
+            },
+        ),
+        tx,
+        parse_event,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(outcome.observed_session.as_deref(), Some("first"));
+    assert_eq!(outcome.error_summary.as_deref(), Some("first_error"));
+    assert_eq!(
+        rx.recv().await,
+        Some(RunnerEvent::Text("completed".to_owned()))
+    );
+}
+
+#[tokio::test]
+async fn stdout_reads_reset_the_idle_deadline() {
+    let _permit = process_test_permit().await;
+    let root = tempfile::tempdir().unwrap();
+    let script = executable_script(
+        root.path(),
+        "progress-backend",
+        r#"#!/bin/sh
+printf '%s\n' '{"type":"session","id":"progress"}'
+sleep 0.1
+printf '%s\n' '{"type":"progress"}'
+sleep 0.1
+printf '%s\n' '{"type":"text","text":"done"}'
+"#,
+    );
+    let (tx, mut rx) = mpsc::channel(2);
+    let mut spec = process_spec(&script, root.path(), PromptTransport::Stdin(String::new()));
+    spec.idle_timeout = Duration::from_millis(500);
+    let outcome = run_jsonl_process(spec, tx, parse_event).await.unwrap();
+
+    assert_eq!(outcome.observed_session.as_deref(), Some("progress"));
+    assert_eq!(rx.recv().await, Some(RunnerEvent::Text("done".to_owned())));
+}
+
+#[tokio::test]
+async fn channel_backpressure_is_bounded_by_total_not_idle_timeout() {
+    let _permit = process_test_permit().await;
+    let root = tempfile::tempdir().unwrap();
+    let script = executable_script(
+        root.path(),
+        "backpressure-backend",
+        r#"#!/bin/sh
+printf '%s\n' '{"type":"session","id":"backpressure"}'
+printf '%s\n' '{"type":"text","text":"first"}'
+printf '%s\n' '{"type":"text","text":"second"}'
+"#,
+    );
+    let (tx, _rx) = mpsc::channel(1);
+    let mut spec = process_spec(&script, root.path(), PromptTransport::Stdin(String::new()));
+    spec.total_timeout = Duration::from_secs(2);
+    spec.idle_timeout = Duration::from_secs(10);
+    let failure = run_jsonl_process(spec, tx, parse_event).await.unwrap_err();
+
+    assert!(matches!(
+        failure.error,
+        marmot_terminal_harness::HarnessError::BackendTimedOut
+    ));
+    assert_eq!(failure.observed_session.as_deref(), Some("backpressure"));
+}
+
+#[tokio::test]
+async fn total_timeout_covers_the_whole_lifecycle() {
+    let _permit = process_test_permit().await;
+    let root = tempfile::tempdir().unwrap();
+    let script = executable_script(
+        root.path(),
+        "total-timeout-backend",
+        r#"#!/bin/sh
+printf '%s\n' '{"type":"session","id":"total"}'
+exec sleep 30
+"#,
+    );
+    let (tx, _rx) = mpsc::channel(1);
+    let mut spec = process_spec(&script, root.path(), PromptTransport::Stdin(String::new()));
+    spec.total_timeout = Duration::from_secs(2);
+    spec.idle_timeout = Duration::from_secs(5);
+    let failure = run_jsonl_process(spec, tx, parse_event).await.unwrap_err();
+
+    assert!(matches!(
+        failure.error,
+        marmot_terminal_harness::HarnessError::BackendTimedOut
+    ));
+    assert_eq!(failure.observed_session.as_deref(), Some("total"));
+}
+
+#[tokio::test]
+async fn idle_timeout_applies_while_reading_output() {
+    let _permit = process_test_permit().await;
+    let root = tempfile::tempdir().unwrap();
+    let script = executable_script(
+        root.path(),
+        "output-idle-backend",
+        r#"#!/bin/sh
+printf '%s\n' '{"type":"session","id":"output-idle"}'
+exec sleep 30
+"#,
+    );
+    let (tx, _rx) = mpsc::channel(1);
+    let mut spec = process_spec(&script, root.path(), PromptTransport::Stdin(String::new()));
+    spec.idle_timeout = Duration::from_secs(2);
+    let failure = run_jsonl_process(spec, tx, parse_event).await.unwrap_err();
+
+    assert!(matches!(
+        failure.error,
+        marmot_terminal_harness::HarnessError::BackendIdle
+    ));
+    assert_eq!(failure.observed_session.as_deref(), Some("output-idle"));
+}
+
+#[tokio::test]
+async fn idle_timeout_applies_after_stdout_eof_during_final_wait() {
+    let _permit = process_test_permit().await;
+    let root = tempfile::tempdir().unwrap();
+    let script = executable_script(
+        root.path(),
+        "wait-idle-backend",
+        r#"#!/bin/sh
+printf '%s\n' '{"type":"session","id":"wait-idle"}'
+exec 1>&-
+sleep 30
+"#,
+    );
+    let (tx, _rx) = mpsc::channel(1);
+    let mut spec = process_spec(
+        &script,
+        root.path(),
+        PromptTransport::DelimitedArgument {
+            delimiter: "--",
+            prompt: "prompt".to_owned(),
+        },
+    );
+    spec.idle_timeout = Duration::from_secs(2);
+    let failure = run_jsonl_process(spec, tx, parse_event).await.unwrap_err();
+
+    assert!(matches!(
+        failure.error,
+        marmot_terminal_harness::HarnessError::BackendIdle
+    ));
+    assert_eq!(failure.observed_session.as_deref(), Some("wait-idle"));
+}
+
+#[tokio::test]
+async fn early_stdin_closure_preserves_exit_and_bounded_sanitized_stderr() {
+    let _permit = process_test_permit().await;
+    let root = tempfile::tempdir().unwrap();
+    let script = executable_script(
+        root.path(),
+        "early-closure-backend",
+        r#"#!/bin/sh
+printf '\033[31m' >&2
+i=0
+while [ "$i" -lt 5000 ]; do printf x >&2; i=$((i + 1)); done
+printf '\033[0m' >&2
+exit 64
+"#,
+    );
+    let (tx, _rx) = mpsc::channel(1);
+    let outcome = run_jsonl_process(
+        process_spec(
+            &script,
+            root.path(),
+            PromptTransport::Stdin("p".repeat(60_000)),
+        ),
+        tx,
+        parse_event,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(outcome.exit_code, Some(64));
+    assert_eq!(outcome.stderr.len(), 4091);
+    assert!(!outcome.stderr.contains('\u{1b}'));
+}
+
+#[tokio::test]
+async fn timeout_terminates_and_reaps_the_child() {
+    let _permit = process_test_permit().await;
+    let root = tempfile::tempdir().unwrap();
+    let pid_path = root.path().join("child.pid");
+    let script = executable_script(
+        root.path(),
+        "reap-backend",
+        r#"#!/bin/sh
+printf '%s' "$$" > "$1"
+exec sleep 30
+"#,
+    );
+    let (tx, _rx) = mpsc::channel(1);
+    let mut spec = process_spec(
+        &script,
+        root.path(),
+        PromptTransport::DelimitedArgument {
+            delimiter: "--",
+            prompt: "prompt".to_owned(),
+        },
+    );
+    spec.args = vec![pid_path.to_string_lossy().into_owned()];
+    spec.total_timeout = Duration::from_secs(2);
+    spec.idle_timeout = Duration::from_secs(5);
+    let failure = run_jsonl_process(spec, tx, parse_event).await.unwrap_err();
+    assert!(matches!(
+        failure.error,
+        marmot_terminal_harness::HarnessError::BackendTimedOut
+    ));
+
+    let pid = fs::read_to_string(pid_path).unwrap();
+    let output = std::process::Command::new("kill")
+        .args(["-0", pid.trim()])
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "child process {pid} was not reaped"
+    );
+}
+
+#[test]
+fn process_debug_output_redacts_paths_arguments_prompts_and_events() {
+    let spec = ProcessSpec {
+        executable: "/secret/backend".to_owned(),
+        args: vec!["secret-argument".to_owned()],
+        cwd: "/secret/worktree".into(),
+        environment: vec![EnvironmentChange::Set {
+            name: "SECRET_ENVIRONMENT_NAME",
+            value: "secret-environment-value".to_owned(),
+        }],
+        prompt: PromptTransport::Stdin("secret prompt".to_owned()),
+        trace_method: "safe_method",
+        backend_name: "safe_backend",
+        total_timeout: Duration::from_secs(5),
+        idle_timeout: Duration::from_secs(2),
+    };
+    let debug = format!("{spec:?}");
+    for secret in [
+        "/secret/backend",
+        "secret-argument",
+        "/secret/worktree",
+        "secret prompt",
+        "SECRET_ENVIRONMENT_NAME",
+        "secret-environment-value",
+    ] {
+        assert!(!debug.contains(secret));
+    }
+    assert!(
+        !format!("{:?}", ParsedEvent::Session("secret-session".to_owned()))
+            .contains("secret-session")
+    );
+    assert!(!format!("{:?}", ParsedEvent::Text("secret text".to_owned())).contains("secret text"));
+}


### PR DESCRIPTION
## Summary
- add a typed shared process specification, prompt transports, and parsed-event vocabulary
- centralize JSONL spawn, deadlines, backpressure, bounded stderr, session/error capture, and child cleanup
- keep Pi, OpenCode, and Codex argv construction and strict event decoding backend-local
- preserve the Codex resume coverage and review fixes merged in #1501

## Test plan
- [x] New shared-runner test failed before the API existed and passes after the fix
- [x] `cargo test -p marmot-terminal-harness -p wn-opencode -p wn-pi -p wn-codex`
- [x] `just codex-dev-e2e-connector opencode-dev-e2e-connector pi-dev-e2e-connector`
- [x] `just fast-ci`
- [ ] Real Codex and Pi contract tests remain ignored because they require authenticated model requests

Fixes #1503