### PR TITLE
Add explicit harness session reset and pipe OpenCode prompts

### DIFF
--- a/integrations/codex/marmot/README.md
+++ b/integrations/codex/marmot/README.md
@@ -101,6 +101,12 @@ starting Codex. Subsequent prompts resume that group's Codex thread. Without a
 picker, the shared harness uses `$HOME`; Codex rejects a non-Git working
 directory by default, so select a repository before sending the first prompt.
 
+Send exactly `/reset-session` to clear the current group's Codex thread id while
+preserving its selected workdir and Codex-owned transcript files. The next
+normal prompt starts and records a new Codex thread; a failed resumed prompt is
+never retried automatically. Send `//reset-session` to pass the literal
+`/reset-session` text to Codex instead of invoking the harness command.
+
 ## Configuration
 
 | Environment variable | Default | Meaning |

--- a/integrations/opencode/marmot/AGENTS.md
+++ b/integrations/opencode/marmot/AGENTS.md
@@ -31,7 +31,9 @@ Read `README.md`, `../../AGENTS.md`, and `../../terminal-harness/AGENTS.md` firs
 - Keep shared control, queueing, chunking, workdir, session-map, and process lifecycle behavior in
   `integrations/terminal-harness`; keep only OpenCode command/event behavior here.
 - Keep state files restrictive-by-construction through `fs-private` or an equivalent mode-tested path.
-- Keep opencode prompts after a `--` delimiter so prompt text cannot be parsed as `opencode run` flags.
+- Keep opencode prompts on stdin and out of process arguments. The supported
+  minimum OpenCode version is 1.18.18, whose non-interactive `run` path consumes
+  piped stdin when no message argument is present.
 
 ## Verification
 

--- a/integrations/opencode/marmot/README.md
+++ b/integrations/opencode/marmot/README.md
@@ -18,8 +18,8 @@ GitHub pre-releases.
 
 Prerequisites:
 
-- OpenCode installed locally and runnable on `PATH`, or an executable path set
-  with `WN_OPENCODE_BIN` / `--opencode-bin`
+- OpenCode 1.18.18 or newer installed locally and runnable on `PATH`, or an
+  executable path set with `WN_OPENCODE_BIN` / `--opencode-bin`
 - White Noise phone app pointed at the same public relay set
 - Linux x86_64, Linux arm64, macOS Apple Silicon, or macOS Intel
 
@@ -128,6 +128,40 @@ for the next prompt. Symlinks that resolve outside `$HOME` are rejected after
 canonicalization. Picker-looking messages with invalid segments are rejected
 and are not forwarded to OpenCode as prompts.
 
+## Session Reset
+
+Send exactly `/reset-session` to clear the current Marmot group's OpenCode
+session id. The harness intercepts the command, preserves the group's validated
+workdir, does not delete OpenCode-owned transcripts, and confirms the result.
+The next normal prompt creates and records a new OpenCode session in that
+workdir. A failed resumed prompt is never retried automatically because the
+original invocation may already have produced side effects.
+
+The command name is reserved. Send `//reset-session` when the literal
+`/reset-session` text should reach OpenCode; messages such as
+`/reset-session please` are ordinary prompts.
+
+## OpenCode Transport Contract
+
+The minimum supported OpenCode version is 1.18.18. The harness retains the
+process-per-message [`opencode run --format json`](https://opencode.ai/docs/cli/)
+integration, including `--session` resume and the existing completed-text event
+filter. It supplies the prompt only through the child's stdin. OpenCode 1.18.18
+explicitly reads piped stdin when no message argument is present in its
+[tagged `run` implementation](https://github.com/anomalyco/opencode/blob/v1.18.18/packages/opencode/src/cli/cmd/run.ts#L416-L422).
+
+The bounded transport comparison was:
+
+| Candidate | Contract fit | Decision |
+| --- | --- | --- |
+| `opencode run --format json` with stdin | Preserves durable session ids, process isolation, completed-event filtering, timeouts, cancellation, cleanup, and future `run` permission flags while removing prompt argv exposure. | Selected. |
+| [`opencode acp`](https://opencode.ai/docs/acp/) | Moves prompts to stdio, but adds a stateful JSON-RPC connection, initialize/load/prompt/cancel framing, and permission-request replies. | Not selected; no benefit over `run` stdin for this harness. |
+| [`opencode serve`](https://opencode.ai/docs/server/) | Provides a local OpenAPI HTTP interface, but adds server startup/readiness, authentication, port ownership, event-stream, and crash-recovery obligations. | Not selected; it weakens the current process-per-message boundary. |
+
+This ACP decision concerns only the OpenCode backend below the shared `Backend`
+trait. It does not change `marmot.agent-control.v2` and does not imply an ACP
+migration for other terminal harnesses.
+
 ## Security Notes
 
 - The control socket is local Unix-domain only. Use the normal `wn-agent`
@@ -143,9 +177,8 @@ and are not forwarded to OpenCode as prompts.
 - Logs are structured and privacy-safe: no account ids, group ids, message ids,
   local paths, prompt text, OpenCode output, relay URLs, pubkeys, ciphertext, or
   key material.
-- Prompt text is passed to `opencode run` as a process argument. Run this
-  harness only on trusted single-user hosts or hosts with equivalent local
-  process isolation.
+- Prompt text is written to `opencode run` over stdin and is absent from spawned
+  process arguments and privacy-safe logs.
 - The session map is written through `fs-private` with owner-only file and
   directory modes.
 

--- a/integrations/opencode/marmot/src/opencode.rs
+++ b/integrations/opencode/marmot/src/opencode.rs
@@ -4,7 +4,10 @@ use std::time::Instant;
 use async_trait::async_trait;
 use marmot_terminal_harness::{
     Backend, HarnessError, Invocation, Outcome, Result, RunFailure, RunnerEvent, TRACE_TARGET,
-    process::{capture_stderr, cleanup_failed_run, kill_and_reap, next_stdout_line, strip_ansi},
+    process::{
+        capture_stderr, cleanup_failed_run, kill_and_reap, next_stdout_line, strip_ansi,
+        write_stdin,
+    },
 };
 use serde::Deserialize;
 use tokio::io::{AsyncBufReadExt, BufReader};
@@ -73,12 +76,9 @@ async fn run_with_bin(
 ) -> std::result::Result<Outcome, RunFailure> {
     let mut command = Command::new(bin);
     command
-        .args(build_run_args(
-            invocation.session_id.as_deref(),
-            &invocation.prompt,
-        ))
+        .args(build_run_args(invocation.session_id.as_deref()))
         .current_dir(&invocation.cwd)
-        .stdin(Stdio::null())
+        .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true);
@@ -88,6 +88,16 @@ async fn run_with_bin(
         observed_session: None,
     })?;
     let total_deadline = tokio::time::Instant::now() + invocation.timeout;
+    let stdin = match child.stdin.take() {
+        Some(stdin) => stdin,
+        None => {
+            kill_and_reap(&mut child).await;
+            return Err(RunFailure {
+                error: HarnessError::BackendSpawn,
+                observed_session: None,
+            });
+        }
+    };
     let stdout = match child.stdout.take() {
         Some(stdout) => stdout,
         None => {
@@ -110,6 +120,7 @@ async fn run_with_bin(
     };
     let mut lines = BufReader::new(stdout).lines();
     let mut stderr_task = tokio::spawn(capture_stderr(stderr));
+    let mut writer_task = write_stdin(stdin, invocation.prompt);
     let start = Instant::now();
     let mut observed_session: Option<String> = None;
     let mut error_summary: Option<String> = None;
@@ -168,8 +179,20 @@ async fn run_with_bin(
         }
 
         let (status, stderr) = match timeout_at(idle_deadline, async {
-            let status = child.wait().await.map_err(HarnessError::from)?;
-            let stderr = (&mut stderr_task).await.map_err(HarnessError::from)?;
+            let (writer, status, stderr) =
+                tokio::join!(&mut writer_task, child.wait(), &mut stderr_task);
+            let status = status.map_err(HarnessError::from)?;
+            let stderr = stderr.map_err(HarnessError::from)?;
+            match writer.map_err(HarnessError::from)? {
+                Ok(()) => {}
+                Err(err) if err.kind() == std::io::ErrorKind::BrokenPipe => debug!(
+                    target: TRACE_TARGET,
+                    method = "opencode_run",
+                    error_kind = "stdin_closed",
+                    "backend closed stdin before draining the prompt"
+                ),
+                Err(_) => return Err(HarnessError::BackendStream),
+            }
             Ok::<_, HarnessError>((status, stderr))
         })
         .await
@@ -190,14 +213,14 @@ async fn run_with_bin(
     match lifecycle_result {
         Ok(Ok(outcome)) => Ok(outcome),
         Ok(Err(error)) => {
-            cleanup_failed_run(&mut child, &mut stderr_task, None).await;
+            cleanup_failed_run(&mut child, &mut stderr_task, Some(&mut writer_task)).await;
             Err(RunFailure {
                 error,
                 observed_session,
             })
         }
         Err(_) => {
-            cleanup_failed_run(&mut child, &mut stderr_task, None).await;
+            cleanup_failed_run(&mut child, &mut stderr_task, Some(&mut writer_task)).await;
             Err(RunFailure {
                 error: HarnessError::BackendTimedOut,
                 observed_session,
@@ -206,7 +229,7 @@ async fn run_with_bin(
     }
 }
 
-pub(crate) fn build_run_args(session_id: Option<&str>, prompt: &str) -> Vec<String> {
+pub(crate) fn build_run_args(session_id: Option<&str>) -> Vec<String> {
     let mut args = vec!["run".to_owned(), "--format".to_owned(), "json".to_owned()];
     if let Some(session_id) = session_id
         && !session_id.is_empty()
@@ -214,8 +237,6 @@ pub(crate) fn build_run_args(session_id: Option<&str>, prompt: &str) -> Vec<Stri
         args.push("--session".to_owned());
         args.push(session_id.to_owned());
     }
-    args.push("--".to_owned());
-    args.push(prompt.to_owned());
     args
 }
 
@@ -287,18 +308,10 @@ mod tests {
     }
 
     #[test]
-    fn build_run_args_separates_prompt_from_flags() {
+    fn build_run_args_keeps_prompt_out_of_process_arguments() {
         assert_eq!(
-            build_run_args(Some("ses_123"), "--auto"),
-            vec![
-                "run",
-                "--format",
-                "json",
-                "--session",
-                "ses_123",
-                "--",
-                "--auto"
-            ]
+            build_run_args(Some("ses_123")),
+            vec!["run", "--format", "json", "--session", "ses_123"]
         );
     }
 

--- a/integrations/opencode/marmot/tests/e2e_connector.rs
+++ b/integrations/opencode/marmot/tests/e2e_connector.rs
@@ -44,21 +44,12 @@ if [ "${1:-}" != "run" ] || [ "${2:-}" != "--format" ] || [ "${3:-}" != "json" ]
   echo "unexpected opencode args: $*" >&2
   exit 64
 fi
-found_delimiter=0
-prompt=""
-while [ "$#" -gt 0 ]; do
-  if [ "$1" = "--" ]; then
-    found_delimiter=1
-    shift
-    prompt="${1:-}"
-    break
-  fi
-  shift
-done
-if [ "$found_delimiter" -ne 1 ]; then
-  echo "missing prompt delimiter" >&2
+shift 3
+if [ "$#" -ne 0 ]; then
+  echo "prompt or unexpected option exposed in opencode args: $*" >&2
   exit 64
 fi
+prompt="$(cat)"
 tail=""
 for _ in $(seq 1 40); do
   tail="${tail}chunk "

--- a/integrations/opencode/marmot/tests/fixtures/mock-opencode.sh
+++ b/integrations/opencode/marmot/tests/fixtures/mock-opencode.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-scenario="${!#}"
+scenario="$(cat)"
 case "$scenario" in
     stream-text)
         printf '%s\n' '{"type":"step_start","sessionID":"ses_mock"}'

--- a/integrations/terminal-harness/README.md
+++ b/integrations/terminal-harness/README.md
@@ -28,9 +28,8 @@ Connector crates are responsible for:
 - exposing only completed assistant output, never thinking or tool output;
 - preserving or reporting the backend session id needed for the next prompt.
 
-OpenCode keeps prompt text after its command's `--` delimiter. Codex and Pi
-write prompt text to stdin. Backend-specific behavior belongs in those connector crates, not
-in this shared runtime.
+Codex, OpenCode, and Pi write prompt text to stdin. Backend-specific behavior
+belongs in those connector crates, not in this shared runtime.
 
 ## Shared Behavior
 
@@ -43,10 +42,18 @@ All connectors:
 - use `/<path>` on the first group message to select a canonical working
   directory beneath `$HOME`;
 - persist private per-group working-directory and session mappings;
+- intercept an exact `/reset-session` message before backend invocation, clear
+  only that group's backend session id, and retain its selected workdir;
 - split durable replies on UTF-8 boundaries with a 30,000-byte default and a
   60,000-byte hard ceiling;
 - enforce bounded per-group queues plus idle and total backend timeouts;
 - keep diagnostics free of identifiers, paths, prompts, and backend output.
+
+`/reset-session` is reserved as a harness control message. Send
+`//reset-session` to forward the literal `/reset-session` text to the backend.
+Reset never deletes backend-owned transcripts and never retries a failed resumed
+prompt automatically; the next distinct prompt starts a new logical backend
+session in the retained workdir.
 
 The connector READMEs document their environment variables, installer topology,
 and backend contracts:

--- a/integrations/terminal-harness/src/bridge.rs
+++ b/integrations/terminal-harness/src/bridge.rs
@@ -311,34 +311,75 @@ struct InboundPrompt {
     text: String,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+enum PromptDisposition {
+    ResetSession,
+    Forward {
+        prompt: String,
+        allow_workdir_picker: bool,
+    },
+}
+
+fn classify_prompt(text: &str) -> PromptDisposition {
+    match text.trim() {
+        "/reset-session" => PromptDisposition::ResetSession,
+        "//reset-session" => PromptDisposition::Forward {
+            prompt: "/reset-session".to_owned(),
+            allow_workdir_picker: false,
+        },
+        _ => PromptDisposition::Forward {
+            prompt: text.to_owned(),
+            allow_workdir_picker: true,
+        },
+    }
+}
+
 async fn handle_message(ctx: Arc<BridgeContext>, inbound: InboundPrompt, permit: GroupPermit) {
     let _serial = permit.serial.lock().await;
-    let known_session = ctx.sessions.get(&inbound.group_ref).await;
-    let (cwd, prompt) = match resolve_cwd_and_prompt(&ctx, &inbound, known_session.as_ref()).await {
-        Ok(Some(value)) => value,
-        Ok(None) => return,
-        Err(err) => {
-            warn!(
-                target: TRACE_TARGET,
-                method = "handle_message",
-                error_kind = err.privacy_safe_kind(),
-                "failed to prepare inbound prompt"
-            );
-            let _ = send_reply(
-                &ctx,
-                &inbound.account_ref,
-                &inbound.group_ref,
-                &inbound.message_ref,
-                &format!(
-                    "[{}] failed to prepare this prompt.",
-                    ctx.cfg.spec.reply_prefix
-                ),
-                0,
-            )
-            .await;
+    let mut inbound = inbound;
+    let allow_workdir_picker = match classify_prompt(&inbound.text) {
+        PromptDisposition::ResetSession => {
+            handle_session_reset(&ctx, &inbound).await;
             return;
         }
+        PromptDisposition::Forward {
+            prompt,
+            allow_workdir_picker,
+        } => {
+            inbound.text = prompt;
+            allow_workdir_picker
+        }
     };
+
+    let known_session = ctx.sessions.get(&inbound.group_ref).await;
+    let (cwd, prompt) =
+        match resolve_cwd_and_prompt(&ctx, &inbound, known_session.as_ref(), allow_workdir_picker)
+            .await
+        {
+            Ok(Some(value)) => value,
+            Ok(None) => return,
+            Err(err) => {
+                warn!(
+                    target: TRACE_TARGET,
+                    method = "handle_message",
+                    error_kind = err.privacy_safe_kind(),
+                    "failed to prepare inbound prompt"
+                );
+                let _ = send_reply(
+                    &ctx,
+                    &inbound.account_ref,
+                    &inbound.group_ref,
+                    &inbound.message_ref,
+                    &format!(
+                        "[{}] failed to prepare this prompt.",
+                        ctx.cfg.spec.reply_prefix
+                    ),
+                    0,
+                )
+                .await;
+                return;
+            }
+        };
 
     info!(
         target: TRACE_TARGET,
@@ -464,6 +505,48 @@ async fn handle_message(ctx: Arc<BridgeContext>, inbound: InboundPrompt, permit:
             )
             .await;
         }
+    }
+}
+
+async fn handle_session_reset(ctx: &BridgeContext, inbound: &InboundPrompt) {
+    let message = match ctx.sessions.reset_session(&inbound.group_ref).await {
+        Ok(true) => format!(
+            "[{}] Session reset. The next prompt will start a new {} session in the preserved workdir.",
+            ctx.cfg.spec.reply_prefix, ctx.cfg.spec.display_name
+        ),
+        Ok(false) => format!(
+            "[{}] No {} session is recorded for this group.",
+            ctx.cfg.spec.reply_prefix, ctx.cfg.spec.display_name
+        ),
+        Err(err) => {
+            warn!(
+                target: TRACE_TARGET,
+                method = "session_reset",
+                error_kind = err.privacy_safe_kind(),
+                "failed to reset backend session"
+            );
+            format!(
+                "[{}] Failed to reset the {} session.",
+                ctx.cfg.spec.reply_prefix, ctx.cfg.spec.display_name
+            )
+        }
+    };
+    if let Err(err) = send_reply(
+        ctx,
+        &inbound.account_ref,
+        &inbound.group_ref,
+        &inbound.message_ref,
+        &message,
+        0,
+    )
+    .await
+    {
+        warn!(
+            target: TRACE_TARGET,
+            method = "session_reset_reply",
+            error_kind = err.privacy_safe_kind(),
+            "failed to send session-reset reply"
+        );
     }
 }
 
@@ -632,10 +715,14 @@ async fn resolve_cwd_and_prompt(
     ctx: &BridgeContext,
     inbound: &InboundPrompt,
     known_session: Option<&SessionRecord>,
+    allow_workdir_picker: bool,
 ) -> Result<Option<(PathBuf, String)>> {
     if let Some(record) = known_session {
         let cwd = validate_session_cwd(&record.cwd, &ctx.home).await?;
         return Ok(Some((cwd, inbound.text.clone())));
+    }
+    if !allow_workdir_picker {
+        return Ok(Some((ctx.home.clone(), inbound.text.clone())));
     }
 
     let (name, rest) = match parse_repo_picker(&inbound.text) {
@@ -920,6 +1007,32 @@ mod tests {
     }
 
     #[test]
+    fn reset_command_is_exact_and_has_a_literal_escape() {
+        assert_eq!(
+            classify_prompt("/reset-session"),
+            PromptDisposition::ResetSession
+        );
+        assert_eq!(
+            classify_prompt("  /reset-session\n"),
+            PromptDisposition::ResetSession
+        );
+        assert_eq!(
+            classify_prompt("//reset-session"),
+            PromptDisposition::Forward {
+                prompt: "/reset-session".to_owned(),
+                allow_workdir_picker: false,
+            }
+        );
+        assert_eq!(
+            classify_prompt("/reset-session please"),
+            PromptDisposition::Forward {
+                prompt: "/reset-session please".to_owned(),
+                allow_workdir_picker: true,
+            }
+        );
+    }
+
+    #[test]
     fn find_account_ref_matches_case_insensitively() {
         let account = AgentControlAccount {
             account_id_hex: "AA".repeat(32),
@@ -964,6 +1077,41 @@ mod tests {
         .unwrap();
         let record = store.get("group1").await.unwrap();
         assert_eq!(record.session_id, "ses_new");
+    }
+
+    #[tokio::test]
+    async fn post_reset_observation_records_a_new_session_in_the_preserved_workdir() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sessions.json");
+        let home = dir.path().to_path_buf();
+        let cwd = home.join("proj");
+        let store = SessionStore::load(path, &home).unwrap();
+        store
+            .set(
+                "group1",
+                SessionRecord {
+                    session_id: "ses_old".to_owned(),
+                    cwd: cwd.clone(),
+                },
+            )
+            .await
+            .unwrap();
+        assert!(store.reset_session("group1").await.unwrap());
+
+        let reset_record = store.get("group1").await.unwrap();
+        persist_observed_session_if_unset(
+            &store,
+            "group1",
+            Some(&reset_record),
+            reset_record.cwd.clone(),
+            Some("ses_new".to_owned()),
+        )
+        .await
+        .unwrap();
+
+        let current = store.get("group1").await.unwrap();
+        assert_eq!(current.session_id, "ses_new");
+        assert_eq!(current.cwd, cwd);
     }
 
     #[tokio::test]

--- a/integrations/terminal-harness/src/store.rs
+++ b/integrations/terminal-harness/src/store.rs
@@ -72,6 +72,27 @@ impl SessionStore {
         *map = next;
         Ok(())
     }
+
+    pub(crate) async fn reset_session(&self, group_key: &str) -> Result<bool> {
+        let mut map = self.map.lock().await;
+        let Some(record) = map.get(group_key) else {
+            return Ok(false);
+        };
+        if record.session_id.is_empty() {
+            return Ok(false);
+        }
+
+        let mut next = map.clone();
+        next.get_mut(group_key)
+            .expect("record exists in cloned session map")
+            .session_id
+            .clear();
+        let path = self.path.clone();
+        let snapshot = next.clone();
+        tokio::task::spawn_blocking(move || write_snapshot(&path, &snapshot)).await??;
+        *map = next;
+        Ok(true)
+    }
 }
 
 fn write_snapshot(path: &Path, snapshot: &HashMap<String, SessionRecord>) -> Result<()> {
@@ -112,6 +133,80 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn session_store_resets_only_one_session_and_preserves_its_workdir() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state").join("sessions.json");
+        let home = dir.path().to_path_buf();
+        let first_cwd = home.join("first");
+        let second_cwd = home.join("second");
+
+        {
+            let store = SessionStore::load(path.clone(), &home).unwrap();
+            store
+                .set(
+                    "group1",
+                    SessionRecord {
+                        session_id: "ses_first".to_owned(),
+                        cwd: first_cwd.clone(),
+                    },
+                )
+                .await
+                .unwrap();
+            store
+                .set(
+                    "group2",
+                    SessionRecord {
+                        session_id: "ses_second".to_owned(),
+                        cwd: second_cwd.clone(),
+                    },
+                )
+                .await
+                .unwrap();
+
+            assert!(store.reset_session("group1").await.unwrap());
+        }
+
+        let store = SessionStore::load(path, &home).unwrap();
+        let first = store.get("group1").await.expect("first group retained");
+        assert_eq!(first.session_id, "");
+        assert_eq!(first.cwd, first_cwd);
+        let second = store.get("group2").await.expect("second group retained");
+        assert_eq!(second.session_id, "ses_second");
+        assert_eq!(second.cwd, second_cwd);
+    }
+
+    #[tokio::test]
+    async fn failed_reset_keeps_the_memory_and_durable_snapshots_unchanged() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sessions.json");
+        let home = dir.path().to_path_buf();
+        let cwd = home.join("proj");
+        let store = SessionStore::load(path.clone(), &home).unwrap();
+        store
+            .set(
+                "group1",
+                SessionRecord {
+                    session_id: "ses_original".to_owned(),
+                    cwd: cwd.clone(),
+                },
+            )
+            .await
+            .unwrap();
+        std::fs::create_dir(path.with_extension("json.tmp")).unwrap();
+
+        assert!(store.reset_session("group1").await.is_err());
+        let current = store.get("group1").await.unwrap();
+        assert_eq!(current.session_id, "ses_original");
+        assert_eq!(current.cwd, cwd);
+        drop(store);
+
+        let reloaded = SessionStore::load(path, &home).unwrap();
+        let current = reloaded.get("group1").await.unwrap();
+        assert_eq!(current.session_id, "ses_original");
+        assert_eq!(current.cwd, cwd);
+    }
+
+    #[tokio::test]
     async fn session_store_accepts_bare_string_legacy_format() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("sessions.json");
@@ -144,6 +239,7 @@ mod tests {
             )
             .await
             .unwrap();
+        assert!(store.reset_session("group1").await.unwrap());
 
         let parent_mode = path
             .parent()


### PR DESCRIPTION
## Summary
- add an exact `/reset-session` harness command that atomically clears only the current group backend session id while preserving its validated workdir
- keep reset commands out of Codex, OpenCode, and Pi; preserve backend transcript files; and support `//reset-session` as the literal prompt escape
- retain `opencode run --format json`, but write prompts over stdin so plaintext is absent from spawned argv
- document the shared reset behavior, OpenCode 1.18.18 minimum, and bounded transport decision

## OpenCode transport decision

The selected contract is process-per-message `opencode run --format json` with `--session` for resume and prompt text on stdin. OpenCode 1.18.18 explicitly reads piped stdin when no message argument is present in its [tagged run implementation](https://github.com/anomalyco/opencode/blob/v1.18.18/packages/opencode/src/cli/cmd/run.ts#L416-L422). This preserves the existing completed-text filter, timeouts, cancellation, cleanup, crash isolation, and future `run` permission flags.

ACP was not selected. Although [`opencode acp`](https://opencode.ai/docs/acp/) moves prompts to stdio, it adds a stateful JSON-RPC lifecycle plus initialize/load/prompt/cancel and permission-request handling without improving this harness once `run` accepts stdin. [`opencode serve`](https://opencode.ai/docs/server/) was also not selected because its local OpenAPI interface adds HTTP readiness, authentication, port ownership, event-stream, and crash-recovery obligations.

This decision stays below the shared `Backend` trait and does not change `marmot.agent-control.v2`.

## Test plan
- [x] New argv regression test failed before the fix and passes after
- [x] Reset parser/store tests failed before the fix and pass after
- [x] `cargo test -p marmot-terminal-harness` (44 passed)
- [x] `cargo test -p wn-codex` (9 passed; authenticated live-model test ignored)
- [x] `cargo test -p wn-opencode` (14 passed; connector E2E ignored by default)
- [x] `cargo test -p wn-pi` (10 passed; authenticated live-model test ignored)
- [x] `just opencode-dev-e2e-connector`
- [x] `just fast-ci`

Fixes #1502