### PR TITLE
Add shared execution profiles for terminal harness connectors

### DIFF
--- a/docs/marmot-architecture/index.md
+++ b/docs/marmot-architecture/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Marmot Architecture — Index"
 created: 2026-04-15
-updated: 2026-08-13
+updated: 2026-08-19
 tags: [marmot, architecture, index]
 ---
 
@@ -88,6 +88,10 @@ Written to be readable in 5 minutes each, shareable as a package.
   - **What it covers:** Restrictive-by-construction creation of local files, sockets, and databases: the
     `fs-private` helpers, the one octal-mode parser, the DB sidecar/PRAGMA-at-open rules, and the close-before-host-
     suspension rules that release WAL and root-lease file locks.
+
+- **Doc:** [`overview/terminal-harness-execution-profiles.md`](./overview/terminal-harness-execution-profiles.md)
+  - **What it covers:** Typed execution intent across Pi, OpenCode, and Codex; backend mappings, installer
+    acknowledgement, and the remote-execution containment boundary.
 
 - **Doc:** [`overview/multi-step-state-changes.md`](./overview/multi-step-state-changes.md)
   - **What it covers:** The no-torn-writes convention for multi-step operations: validate-before-mutate, full

--- a/docs/marmot-architecture/overview/current-state.md
+++ b/docs/marmot-architecture/overview/current-state.md
@@ -69,6 +69,12 @@ uploaded founding metadata and performs no media transfer; the older all-in-one 
 uploaded-before-success semantics while also enforcing the new group-image byte, dimension, pixel, and format limits
 before canonical creation.
 
+The Codex, OpenCode, and Pi terminal harnesses share typed `inherit`,
+`autonomous`, and `unrestricted` execution intent while retaining
+backend-specific approval and sandbox semantics. Unrestricted installs require
+explicit acknowledgement and an external OS-user, container, or VM boundary;
+see [`terminal-harness-execution-profiles.md`](./terminal-harness-execution-profiles.md).
+
 ### Marmot-TS (TypeScript)
 
 Marmot-TS is an independent implementation. It is valuable because it catches spec ambiguity that a single reference

--- a/docs/marmot-architecture/overview/observability.md
+++ b/docs/marmot-architecture/overview/observability.md
@@ -1,7 +1,7 @@
 ---
 title: "Observability & Privacy"
 created: 2026-05-09
-updated: 2026-07-02
+updated: 2026-08-19
 tags: [marmot, overview, observability, tracing, privacy]
 status: overview
 ---
@@ -59,6 +59,12 @@ mdk#379).
 | Errors wrapping any of the above | n/a | Constructors keep `Display` free of URLs/ids/values | n/a | Log `error_kind = privacy_safe_kind()` (or `io::ErrorKind`, variant names) — never `{err}`/`error = %err` | `error_kind` strings only |
 
 ## Current enforcement
+
+Terminal harness startup tracing may include the selected execution profile and
+typed approval/isolation support states. These are fixed enum values only
+(`inherit`, `autonomous`, `unrestricted`, and capability states such as
+`preserve_denies` or `not_provided`); backend configuration values and paths
+remain prohibited.
 
 `crates/cgka-conformance-simulator/tests/tracing_audit.rs` scans production Rust source for qualified and imported
 tracing calls. It requires explicit `target` and `method` fields, rejects known-sensitive token names inside tracing

--- a/docs/marmot-architecture/overview/terminal-harness-execution-profiles.md
+++ b/docs/marmot-architecture/overview/terminal-harness-execution-profiles.md
@@ -32,7 +32,7 @@ permissions, process sandboxing, and network policy are different controls.
 | --- | --- | --- | --- |
 | Pi | Non-interactive execution is natively approval-free for every profile | No built-in OS sandbox | No profile-specific CLI feature is required |
 | OpenCode | `autonomous` uses `--auto`; `unrestricted` adds a process-local allow-all permission overlay | Logical permissions only; no OS sandbox | An unsupported `--auto` fails the invocation; no successful reply is sent |
-| Codex | `autonomous` sets `approval_policy="never"`; `unrestricted` bypasses approvals | Configured sandbox/network survive `autonomous`; `unrestricted` bypasses the sandbox | Strict config/unknown flags fail the invocation; no successful reply is sent |
+| Codex | `autonomous` sets `approval_policy="never"`; `unrestricted` bypasses approvals | Configured sandbox/network survive `autonomous`; `unrestricted` bypasses the sandbox | An unsupported invocation-local config override or flag fails the invocation; no successful reply is sent |
 
 The OpenCode overlay exists only in the child process environment. The Codex
 override exists only in that invocation. Connector setup never rewrites global

--- a/docs/marmot-architecture/overview/terminal-harness-execution-profiles.md
+++ b/docs/marmot-architecture/overview/terminal-harness-execution-profiles.md
@@ -45,7 +45,8 @@ file and same-user service definition. It requires
 `--acknowledge-unrestricted` before writing `unrestricted`; `--yes`, dry-run,
 or an environment-provided profile do not substitute for that acknowledgement.
 
-Startup tracing contains only the profile and fixed capability state names.
+Startup tracing contains the profile and fixed capability state names alongside
+coarse fields such as the harness name, sender count, and reply-size limit.
 Unsupported or malformed profiles fail configuration loading.
 
 ## Security Boundary

--- a/docs/marmot-architecture/overview/terminal-harness-execution-profiles.md
+++ b/docs/marmot-architecture/overview/terminal-harness-execution-profiles.md
@@ -1,0 +1,61 @@
+---
+title: "Terminal Harness Execution Profiles"
+created: 2026-08-19
+updated: 2026-08-19
+tags: [marmot, overview, terminal-harness, permissions, sandbox]
+status: overview
+---
+
+# Terminal Harness Execution Profiles
+
+Marmot terminal harnesses accept remote prompts from explicitly allowed
+senders, then invoke a local coding-agent backend. A shared profile expresses
+operator intent while backend adapters preserve the real differences between
+Pi, OpenCode, and Codex.
+
+## Shared Intent
+
+`MARMOT_HARNESS_EXECUTION_PROFILE` has three values:
+
+- `inherit`: add no connector-side policy overrides.
+- `autonomous`: do not wait for interactive approvals, while preserving hard
+  denies and isolation where supported.
+- `unrestricted`: request the broadest non-interactive backend mode. External
+  isolation is mandatory.
+
+This is deliberately not a `yolo` boolean. Approval prompts, logical tool
+permissions, process sandboxing, and network policy are different controls.
+
+## Capability Matrix
+
+| Backend | Approval mapping | Isolation mapping | Version failure behavior |
+| --- | --- | --- | --- |
+| Pi | Non-interactive execution is natively approval-free for every profile | No built-in OS sandbox | No profile-specific CLI feature is required |
+| OpenCode | `autonomous` uses `--auto`; `unrestricted` adds a process-local allow-all permission overlay | Logical permissions only; no OS sandbox | An unsupported `--auto` fails the invocation; no successful reply is sent |
+| Codex | `autonomous` sets `approval_policy="never"`; `unrestricted` bypasses approvals | Configured sandbox/network survive `autonomous`; `unrestricted` bypasses the sandbox | Strict config/unknown flags fail the invocation; no successful reply is sent |
+
+The OpenCode overlay exists only in the child process environment. The Codex
+override exists only in that invocation. Connector setup never rewrites global
+Pi, OpenCode, or Codex configuration.
+
+## Installer Contract
+
+The shared installer writes the selected profile into the private harness env
+file and same-user service definition. It requires
+`--acknowledge-unrestricted` before writing `unrestricted`; `--yes`, dry-run,
+or an environment-provided profile do not substitute for that acknowledgement.
+
+Startup tracing contains only the profile and fixed capability state names.
+Unsupported or malformed profiles fail configuration loading.
+
+## Security Boundary
+
+An allowed Marmot sender plus `unrestricted` is effectively remote code
+execution as the harness service user. Sender allowlisting authenticates who
+may request work; it does not constrain what an unrestricted backend may do.
+
+The `/<path>` picker selects a working directory beneath `$HOME`. It is not a
+filesystem, process, credential, or network containment boundary. Unrestricted
+deployments should use a dedicated OS user, container, or VM with narrowly
+scoped credentials and host access. Backend logical permission checks must not
+be described as an OS sandbox.

--- a/integrations/codex/marmot/AGENTS.md
+++ b/integrations/codex/marmot/AGENTS.md
@@ -32,9 +32,8 @@ Rust Codex harness for Marmot through the local `wn-agent` control socket. Read
 ## Rules
 
 - Keep prompts on stdin; do not move prompt text into process arguments.
-- Do not add `--full-auto`, `--dangerously-bypass-approvals-and-sandbox`, or
-  connector-specific sandbox/approval overrides until the shared connector
-  permission model is designed.
+- Keep permission argv derived from the shared typed execution profile. Do not
+  add free-form backend argument configuration or mutate global Codex config.
 - Split completed assistant text into byte-budgeted Marmot messages. Keep
   `WN_CODEX_MAX_REPLY_BYTES=30000` below the Marmot message cap.
 - Keep request/response and Codex event validation strict; malformed or

--- a/integrations/codex/marmot/README.md
+++ b/integrations/codex/marmot/README.md
@@ -117,6 +117,7 @@ never retried automatically. Send `//reset-session` to pass the literal
 | `WN_CODEX_ALLOWED_SENDERS_HEX` | required | Comma-separated authorized sender ids |
 | `WN_CODEX_ACCOUNT_ID_HEX` | sole local account | Explicit account selection |
 | `WN_CODEX_BIN` | `codex` | Codex executable |
+| `MARMOT_HARNESS_EXECUTION_PROFILE` | `inherit` | Shared `inherit`, `autonomous`, or `unrestricted` execution policy |
 | `WN_CODEX_IDLE_TIMEOUT_SECS` | `120` | Maximum silence per invocation |
 | `WN_CODEX_TIMEOUT_SECS` | `3600` | Total invocation cap |
 | `WN_CODEX_REQUEST_TIMEOUT_SECS` | `30` | Control request timeout |
@@ -125,11 +126,14 @@ never retried automatically. Send `//reset-session` to pass the literal
 | `WN_CODEX_STATE_PATH` | `$XDG_STATE_HOME/wn-codex/sessions.json` | Group thread/workdir map |
 | `WN_CODEX_ACTIVATION` | `always` | Only supported activation mode |
 
-Codex credentials, model, config, sandbox, approval policy, and project trust
-remain authoritative. This first connector version deliberately adds no
-permission-broadening flags; common permission/configuration controls will be
-designed across all terminal harnesses separately. Prompts are written to Codex
-over stdin, and only completed `agent_message` text is returned to Marmot.
+Codex credentials, model, config, and project trust remain authoritative.
+`autonomous` overrides only `approval_policy` to `never`, preserving configured
+sandbox and network policy. `unrestricted` passes
+`--dangerously-bypass-approvals-and-sandbox` for both new and resumed threads.
+See the shared
+[execution-profile capability matrix](../../terminal-harness/README.md#execution-profiles).
+Prompts are written to Codex over stdin, and only completed `agent_message`
+text is returned to Marmot.
 
 The optional bearer token grants the complete `wn-agent` control API for every
 account in its home; the sender allowlist does not narrow that authority. Use a

--- a/integrations/codex/marmot/src/codex.rs
+++ b/integrations/codex/marmot/src/codex.rs
@@ -3,7 +3,8 @@ use std::time::Instant;
 
 use async_trait::async_trait;
 use marmot_terminal_harness::{
-    Backend, HarnessError, Invocation, Outcome, RunFailure, RunnerEvent, TRACE_TARGET,
+    ApprovalSupport, Backend, ExecutionProfile, ExecutionSupport, HarnessError, Invocation,
+    IsolationSupport, Outcome, RunFailure, RunnerEvent, TRACE_TARGET,
     process::{capture_stderr, cleanup_failed_run, next_stdout_line, strip_ansi, write_stdin},
 };
 use serde_json::Value;
@@ -16,33 +17,57 @@ use tracing::debug;
 #[derive(Clone)]
 pub(crate) struct CodexBackend {
     bin: String,
+    execution_profile: ExecutionProfile,
 }
 
 impl CodexBackend {
-    pub(crate) fn new(bin: String) -> Self {
-        Self { bin }
+    pub(crate) fn new(bin: String, execution_profile: ExecutionProfile) -> Self {
+        Self {
+            bin,
+            execution_profile,
+        }
     }
 }
 
 #[async_trait]
 impl Backend for CodexBackend {
+    fn execution_support(&self) -> ExecutionSupport {
+        ExecutionSupport {
+            approvals: match self.execution_profile {
+                ExecutionProfile::Inherit => ApprovalSupport::Inherited,
+                ExecutionProfile::Autonomous => ApprovalSupport::PreserveDenies,
+                ExecutionProfile::Unrestricted => ApprovalSupport::Bypassed,
+            },
+            isolation: match self.execution_profile {
+                ExecutionProfile::Unrestricted => IsolationSupport::Bypassed,
+                ExecutionProfile::Inherit | ExecutionProfile::Autonomous => {
+                    IsolationSupport::Inherited
+                }
+            },
+        }
+    }
+
     async fn run(
         &self,
         invocation: Invocation,
         tx: mpsc::Sender<RunnerEvent>,
     ) -> std::result::Result<Outcome, RunFailure> {
-        run_with_bin(&self.bin, invocation, tx).await
+        run_with_bin(&self.bin, self.execution_profile, invocation, tx).await
     }
 }
 
 async fn run_with_bin(
     bin: &str,
+    execution_profile: ExecutionProfile,
     invocation: Invocation,
     tx: mpsc::Sender<RunnerEvent>,
 ) -> std::result::Result<Outcome, RunFailure> {
     let mut command = Command::new(bin);
     command
-        .args(build_exec_args(invocation.session_id.as_deref()))
+        .args(build_exec_args(
+            invocation.session_id.as_deref(),
+            execution_profile,
+        ))
         .current_dir(&invocation.cwd)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -163,17 +188,31 @@ async fn run_with_bin(
     }
 }
 
-fn build_exec_args(session_id: Option<&str>) -> Vec<String> {
-    match session_id.filter(|value| !value.is_empty()) {
-        Some(session_id) => vec![
-            "exec".to_owned(),
-            "resume".to_owned(),
-            "--json".to_owned(),
-            session_id.to_owned(),
-            "-".to_owned(),
-        ],
-        None => vec!["exec".to_owned(), "--json".to_owned(), "-".to_owned()],
+fn build_exec_args(session_id: Option<&str>, profile: ExecutionProfile) -> Vec<String> {
+    let session_id = session_id.filter(|value| !value.is_empty());
+    let mut args = vec!["exec".to_owned()];
+    if session_id.is_some() {
+        args.push("resume".to_owned());
     }
+    match profile {
+        ExecutionProfile::Inherit => {}
+        ExecutionProfile::Autonomous => {
+            args.extend([
+                "--strict-config".to_owned(),
+                "-c".to_owned(),
+                "approval_policy=\"never\"".to_owned(),
+            ]);
+        }
+        ExecutionProfile::Unrestricted => {
+            args.push("--dangerously-bypass-approvals-and-sandbox".to_owned());
+        }
+    }
+    args.push("--json".to_owned());
+    if let Some(session_id) = session_id {
+        args.push(session_id.to_owned());
+    }
+    args.push("-".to_owned());
+    args
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -219,15 +258,74 @@ mod tests {
     use std::time::Duration;
 
     use super::*;
+    use marmot_terminal_harness::ExecutionProfile;
 
     #[test]
     fn args_select_json_stdin_and_optional_resume() {
-        assert_eq!(build_exec_args(None), vec!["exec", "--json", "-"]);
         assert_eq!(
-            build_exec_args(Some("thread-123")),
+            build_exec_args(None, ExecutionProfile::Inherit),
+            vec!["exec", "--json", "-"]
+        );
+        assert_eq!(
+            build_exec_args(Some("thread-123"), ExecutionProfile::Inherit),
             vec!["exec", "resume", "--json", "thread-123", "-"]
         );
-        assert_eq!(build_exec_args(Some("")), vec!["exec", "--json", "-"]);
+        assert_eq!(
+            build_exec_args(Some(""), ExecutionProfile::Inherit),
+            vec!["exec", "--json", "-"]
+        );
+    }
+
+    #[test]
+    fn autonomous_preserves_configured_sandbox_and_network_for_new_and_resumed_threads() {
+        assert_eq!(
+            build_exec_args(None, ExecutionProfile::Autonomous),
+            vec![
+                "exec",
+                "--strict-config",
+                "-c",
+                "approval_policy=\"never\"",
+                "--json",
+                "-",
+            ]
+        );
+        assert_eq!(
+            build_exec_args(Some("thread-123"), ExecutionProfile::Autonomous),
+            vec![
+                "exec",
+                "resume",
+                "--strict-config",
+                "-c",
+                "approval_policy=\"never\"",
+                "--json",
+                "thread-123",
+                "-",
+            ]
+        );
+    }
+
+    #[test]
+    fn unrestricted_bypasses_approvals_and_sandbox_for_new_and_resumed_threads() {
+        assert_eq!(
+            build_exec_args(None, ExecutionProfile::Unrestricted),
+            vec![
+                "exec",
+                "--dangerously-bypass-approvals-and-sandbox",
+                "--json",
+                "-",
+            ]
+        );
+        assert_eq!(
+            build_exec_args(Some("thread-123"), ExecutionProfile::Unrestricted),
+            vec![
+                "exec",
+                "resume",
+                "--dangerously-bypass-approvals-and-sandbox",
+                "--json",
+                "thread-123",
+                "-",
+            ]
+        );
     }
 
     #[test]
@@ -288,6 +386,7 @@ printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens
         let (tx, mut rx) = mpsc::channel(4);
         let outcome = run_with_bin(
             script.to_str().unwrap(),
+            ExecutionProfile::Inherit,
             Invocation {
                 timeout: Duration::from_secs(5),
                 idle_timeout: Duration::from_secs(2),
@@ -336,6 +435,7 @@ printf '{"type":"item.completed","item":{"type":"agent_message","text":"received
         let (tx, mut rx) = mpsc::channel(4);
         let outcome = run_with_bin(
             script.to_str().unwrap(),
+            ExecutionProfile::Inherit,
             Invocation {
                 timeout: Duration::from_secs(5),
                 idle_timeout: Duration::from_secs(2),
@@ -374,6 +474,7 @@ exit 64
         let (tx, _rx) = mpsc::channel(1);
         let outcome = run_with_bin(
             script.to_str().unwrap(),
+            ExecutionProfile::Inherit,
             Invocation {
                 timeout: Duration::from_secs(5),
                 idle_timeout: Duration::from_secs(2),
@@ -406,6 +507,7 @@ exit 64
         let (tx, mut rx) = mpsc::channel(8);
         let outcome = run_with_bin(
             "codex",
+            ExecutionProfile::Inherit,
             Invocation {
                 timeout: Duration::from_secs(120),
                 idle_timeout: Duration::from_secs(30),
@@ -430,6 +532,7 @@ exit 64
         let (resume_tx, mut resume_rx) = mpsc::channel(8);
         let resumed = run_with_bin(
             "codex",
+            ExecutionProfile::Inherit,
             Invocation {
                 timeout: Duration::from_secs(120),
                 idle_timeout: Duration::from_secs(30),

--- a/integrations/codex/marmot/src/codex.rs
+++ b/integrations/codex/marmot/src/codex.rs
@@ -197,11 +197,7 @@ fn build_exec_args(session_id: Option<&str>, profile: ExecutionProfile) -> Vec<S
     match profile {
         ExecutionProfile::Inherit => {}
         ExecutionProfile::Autonomous => {
-            args.extend([
-                "--strict-config".to_owned(),
-                "-c".to_owned(),
-                "approval_policy=\"never\"".to_owned(),
-            ]);
+            args.extend(["-c".to_owned(), "approval_policy=\"never\"".to_owned()]);
         }
         ExecutionProfile::Unrestricted => {
             args.push("--dangerously-bypass-approvals-and-sandbox".to_owned());
@@ -280,21 +276,13 @@ mod tests {
     fn autonomous_preserves_configured_sandbox_and_network_for_new_and_resumed_threads() {
         assert_eq!(
             build_exec_args(None, ExecutionProfile::Autonomous),
-            vec![
-                "exec",
-                "--strict-config",
-                "-c",
-                "approval_policy=\"never\"",
-                "--json",
-                "-",
-            ]
+            vec!["exec", "-c", "approval_policy=\"never\"", "--json", "-",]
         );
         assert_eq!(
             build_exec_args(Some("thread-123"), ExecutionProfile::Autonomous),
             vec![
                 "exec",
                 "resume",
-                "--strict-config",
                 "-c",
                 "approval_policy=\"never\"",
                 "--json",

--- a/integrations/codex/marmot/src/config.rs
+++ b/integrations/codex/marmot/src/config.rs
@@ -40,7 +40,7 @@ impl Config {
     }
 
     pub(crate) fn into_harness(self) -> (marmot_terminal_harness::Config, CodexBackend) {
-        let backend = CodexBackend::new(self.shared.bin);
+        let backend = CodexBackend::new(self.shared.bin, self.shared.harness.execution_profile);
         (self.shared.harness, backend)
     }
 }

--- a/integrations/opencode/marmot/README.md
+++ b/integrations/opencode/marmot/README.md
@@ -108,7 +108,10 @@ home, socket, token, and account for a separate trust boundary.
 `autonomous` passes OpenCode's `--auto`, which auto-approves asks while
 preserving explicit denies. `unrestricted` also supplies a connector-owned,
 process-local allow-all permission overlay; it does not rewrite OpenCode's
-global or project configuration. See the shared
+global or project configuration, and it clears an inherited
+`OPENCODE_PERMISSION` in the child. Managed organization policy may still
+override the process-local setting. OpenCode provides no built-in OS isolation;
+use external OS isolation for unrestricted deployments. See the shared
 [execution-profile capability matrix](../../terminal-harness/README.md#execution-profiles).
 
 The reply limit is byte-based, not character-based. The default is 30KB, well

--- a/integrations/opencode/marmot/README.md
+++ b/integrations/opencode/marmot/README.md
@@ -90,6 +90,7 @@ Configure with environment variables:
 | `WN_OPENCODE_ADMIN_HEX` | unset | Legacy alias for `WN_OPENCODE_ALLOWED_SENDERS_HEX` |
 | `WN_OPENCODE_ACCOUNT_ID_HEX` | first local account | Specific `wn-agent` account to use |
 | `WN_OPENCODE_BIN` | `opencode` | OpenCode binary or executable path |
+| `MARMOT_HARNESS_EXECUTION_PROFILE` | `inherit` | Shared `inherit`, `autonomous`, or `unrestricted` execution policy |
 | `WN_OPENCODE_IDLE_TIMEOUT_SECS` | `120` | Kill the invocation when OpenCode produces no stdout line for this long |
 | `WN_OPENCODE_TIMEOUT_SECS` | `3600` | Generous total safety cap for wedge recovery; ongoing output resets only the idle timer |
 | `WN_OPENCODE_REQUEST_TIMEOUT_SECS` | `30` | Timeout for each control-socket request |
@@ -103,6 +104,12 @@ The optional bearer token grants the complete `wn-agent` control API for every
 account in its home; the harness sender allowlist does not narrow that token's
 authority. Do not give it to an untrusted harness. Use a separate connector
 home, socket, token, and account for a separate trust boundary.
+
+`autonomous` passes OpenCode's `--auto`, which auto-approves asks while
+preserving explicit denies. `unrestricted` also supplies a connector-owned,
+process-local allow-all permission overlay; it does not rewrite OpenCode's
+global or project configuration. See the shared
+[execution-profile capability matrix](../../terminal-harness/README.md#execution-profiles).
 
 The reply limit is byte-based, not character-based. The default is 30KB, well
 below Marmot's roughly 60KB message ceiling. Splitting prefers paragraph,

--- a/integrations/opencode/marmot/src/config.rs
+++ b/integrations/opencode/marmot/src/config.rs
@@ -36,7 +36,10 @@ impl Config {
     }
 
     pub(crate) fn into_harness(self) -> (marmot_terminal_harness::Config, OpencodeBackend) {
-        let backend = OpencodeBackend { bin: self.0.bin };
+        let backend = OpencodeBackend {
+            bin: self.0.bin,
+            execution_profile: self.0.harness.execution_profile,
+        };
         (self.0.harness, backend)
     }
 }

--- a/integrations/opencode/marmot/src/opencode.rs
+++ b/integrations/opencode/marmot/src/opencode.rs
@@ -99,8 +99,8 @@ async fn run_with_bin(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true);
-    if let Some((name, value)) = permission_overlay(execution_profile) {
-        command.env(name, value);
+    if let Some((remove, name, value)) = config_overlay(execution_profile) {
+        command.env_remove(remove).env(name, value);
     }
 
     let mut child = command.spawn().map_err(|_| RunFailure {
@@ -269,8 +269,12 @@ pub(crate) fn build_run_args(
     args
 }
 
-fn permission_overlay(profile: ExecutionProfile) -> Option<(&'static str, &'static str)> {
-    (profile == ExecutionProfile::Unrestricted).then_some(("OPENCODE_PERMISSION", r#""allow""#))
+fn config_overlay(profile: ExecutionProfile) -> Option<(&'static str, &'static str, &'static str)> {
+    (profile == ExecutionProfile::Unrestricted).then_some((
+        "OPENCODE_PERMISSION",
+        "OPENCODE_CONFIG_CONTENT",
+        r#"{"permission":"allow"}"#,
+    ))
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -584,12 +588,16 @@ mod tests {
     }
 
     #[test]
-    fn unrestricted_uses_a_process_local_permission_overlay_only() {
-        assert_eq!(permission_overlay(ExecutionProfile::Inherit), None);
-        assert_eq!(permission_overlay(ExecutionProfile::Autonomous), None);
+    fn unrestricted_uses_a_process_local_config_overlay_only() {
+        assert_eq!(config_overlay(ExecutionProfile::Inherit), None);
+        assert_eq!(config_overlay(ExecutionProfile::Autonomous), None);
         assert_eq!(
-            permission_overlay(ExecutionProfile::Unrestricted),
-            Some(("OPENCODE_PERMISSION", r#""allow""#))
+            config_overlay(ExecutionProfile::Unrestricted),
+            Some((
+                "OPENCODE_PERMISSION",
+                "OPENCODE_CONFIG_CONTENT",
+                r#"{"permission":"allow"}"#
+            ))
         );
     }
 }

--- a/integrations/opencode/marmot/src/opencode.rs
+++ b/integrations/opencode/marmot/src/opencode.rs
@@ -3,7 +3,8 @@ use std::time::Instant;
 
 use async_trait::async_trait;
 use marmot_terminal_harness::{
-    Backend, HarnessError, Invocation, Outcome, Result, RunFailure, RunnerEvent, TRACE_TARGET,
+    ApprovalSupport, Backend, ExecutionProfile, ExecutionSupport, HarnessError, Invocation,
+    IsolationSupport, Outcome, Result, RunFailure, RunnerEvent, TRACE_TARGET,
     process::{
         capture_stderr, cleanup_failed_run, kill_and_reap, next_stdout_line, strip_ansi,
         write_stdin,
@@ -19,16 +20,28 @@ use tracing::debug;
 #[derive(Clone)]
 pub(crate) struct OpencodeBackend {
     pub(crate) bin: String,
+    pub(crate) execution_profile: ExecutionProfile,
 }
 
 #[async_trait]
 impl Backend for OpencodeBackend {
+    fn execution_support(&self) -> ExecutionSupport {
+        ExecutionSupport {
+            approvals: match self.execution_profile {
+                ExecutionProfile::Inherit => ApprovalSupport::Inherited,
+                ExecutionProfile::Autonomous => ApprovalSupport::PreserveDenies,
+                ExecutionProfile::Unrestricted => ApprovalSupport::ForceAllow,
+            },
+            isolation: IsolationSupport::NotProvided,
+        }
+    }
+
     async fn run(
         &self,
         invocation: Invocation,
         tx: mpsc::Sender<RunnerEvent>,
     ) -> std::result::Result<Outcome, RunFailure> {
-        run_with_bin(&self.bin, invocation, tx).await
+        run_with_bin(&self.bin, self.execution_profile, invocation, tx).await
     }
 }
 
@@ -71,17 +84,24 @@ struct OpencodeErrorData {
 
 async fn run_with_bin(
     bin: &str,
+    execution_profile: ExecutionProfile,
     invocation: Invocation,
     tx: mpsc::Sender<RunnerEvent>,
 ) -> std::result::Result<Outcome, RunFailure> {
     let mut command = Command::new(bin);
     command
-        .args(build_run_args(invocation.session_id.as_deref()))
+        .args(build_run_args(
+            invocation.session_id.as_deref(),
+            execution_profile,
+        ))
         .current_dir(&invocation.cwd)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true);
+    if let Some((name, value)) = permission_overlay(execution_profile) {
+        command.env(name, value);
+    }
 
     let mut child = command.spawn().map_err(|_| RunFailure {
         error: HarnessError::BackendSpawn,
@@ -229,8 +249,17 @@ async fn run_with_bin(
     }
 }
 
-pub(crate) fn build_run_args(session_id: Option<&str>) -> Vec<String> {
+pub(crate) fn build_run_args(
+    session_id: Option<&str>,
+    execution_profile: ExecutionProfile,
+) -> Vec<String> {
     let mut args = vec!["run".to_owned(), "--format".to_owned(), "json".to_owned()];
+    if matches!(
+        execution_profile,
+        ExecutionProfile::Autonomous | ExecutionProfile::Unrestricted
+    ) {
+        args.push("--auto".to_owned());
+    }
     if let Some(session_id) = session_id
         && !session_id.is_empty()
     {
@@ -238,6 +267,11 @@ pub(crate) fn build_run_args(session_id: Option<&str>) -> Vec<String> {
         args.push(session_id.to_owned());
     }
     args
+}
+
+fn permission_overlay(profile: ExecutionProfile) -> Option<(&'static str, &'static str)> {
+    (profile == ExecutionProfile::Unrestricted)
+        .then_some(("OPENCODE_PERMISSION", r#"{"*":"allow"}"#))
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -279,6 +313,7 @@ impl OpencodeError {
 
 #[cfg(test)]
 mod tests {
+    use marmot_terminal_harness::ExecutionProfile;
     use std::time::Duration;
 
     use tokio::sync::mpsc;
@@ -294,7 +329,7 @@ mod tests {
         invocation: Invocation,
         tx: mpsc::Sender<RunnerEvent>,
     ) -> std::result::Result<Outcome, RunFailure> {
-        run_with_bin(MOCK_BIN, invocation, tx).await
+        run_with_bin(MOCK_BIN, ExecutionProfile::Inherit, invocation, tx).await
     }
 
     fn mock_invocation(dir: &tempfile::TempDir, scenario: &str) -> Invocation {
@@ -310,7 +345,7 @@ mod tests {
     #[test]
     fn build_run_args_keeps_prompt_out_of_process_arguments() {
         assert_eq!(
-            build_run_args(Some("ses_123")),
+            build_run_args(Some("ses_123"), ExecutionProfile::Inherit),
             vec!["run", "--format", "json", "--session", "ses_123"]
         );
     }
@@ -528,6 +563,34 @@ mod tests {
         assert_eq!(
             failure.observed_session.as_deref(),
             Some("ses_backpressure")
+        );
+    }
+
+    #[test]
+    fn args_apply_typed_permission_profiles_without_putting_prompt_in_args() {
+        for (profile, permission_args) in [
+            (ExecutionProfile::Inherit, Vec::<&str>::new()),
+            (ExecutionProfile::Autonomous, vec!["--auto"]),
+            (ExecutionProfile::Unrestricted, vec!["--auto"]),
+        ] {
+            let mut expected = vec!["run", "--format", "json"];
+            expected.extend(permission_args.iter().copied());
+            assert_eq!(build_run_args(None, profile), expected);
+
+            let mut resumed = vec!["run", "--format", "json"];
+            resumed.extend(permission_args.iter().copied());
+            resumed.extend(["--session", "session-123"]);
+            assert_eq!(build_run_args(Some("session-123"), profile), resumed);
+        }
+    }
+
+    #[test]
+    fn unrestricted_uses_a_process_local_permission_overlay_only() {
+        assert_eq!(permission_overlay(ExecutionProfile::Inherit), None);
+        assert_eq!(permission_overlay(ExecutionProfile::Autonomous), None);
+        assert_eq!(
+            permission_overlay(ExecutionProfile::Unrestricted),
+            Some(("OPENCODE_PERMISSION", r#"{"*":"allow"}"#))
         );
     }
 }

--- a/integrations/opencode/marmot/src/opencode.rs
+++ b/integrations/opencode/marmot/src/opencode.rs
@@ -270,8 +270,7 @@ pub(crate) fn build_run_args(
 }
 
 fn permission_overlay(profile: ExecutionProfile) -> Option<(&'static str, &'static str)> {
-    (profile == ExecutionProfile::Unrestricted)
-        .then_some(("OPENCODE_PERMISSION", r#"{"*":"allow"}"#))
+    (profile == ExecutionProfile::Unrestricted).then_some(("OPENCODE_PERMISSION", r#""allow""#))
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -590,7 +589,7 @@ mod tests {
         assert_eq!(permission_overlay(ExecutionProfile::Autonomous), None);
         assert_eq!(
             permission_overlay(ExecutionProfile::Unrestricted),
-            Some(("OPENCODE_PERMISSION", r#"{"*":"allow"}"#))
+            Some(("OPENCODE_PERMISSION", r#""allow""#))
         );
     }
 }

--- a/integrations/pi/marmot/README.md
+++ b/integrations/pi/marmot/README.md
@@ -79,6 +79,7 @@ resume that group's Pi session.
 | `WN_PI_ALLOWED_SENDERS_HEX` | required | Comma-separated authorized sender ids |
 | `WN_PI_ACCOUNT_ID_HEX` | sole local account | Explicit account selection |
 | `WN_PI_BIN` | `pi` | Pi executable |
+| `MARMOT_HARNESS_EXECUTION_PROFILE` | `inherit` | Shared `inherit`, `autonomous`, or `unrestricted` execution policy |
 | `WN_PI_SESSION_DIR` | `$MARMOT_HOME/dev/pi-sessions` | Private Pi session directory |
 | `WN_PI_IDLE_TIMEOUT_SECS` | `120` | Maximum silence per invocation |
 | `WN_PI_TIMEOUT_SECS` | `3600` | Total invocation cap |
@@ -91,6 +92,12 @@ resume that group's Pi session.
 Pi's global credentials, model, tools, extensions, settings, and normal
 noninteractive project-trust policy remain authoritative. Prompts are written
 to Pi over stdin; only completed assistant text is returned to Marmot.
+
+Pi has no built-in approval prompt or OS sandbox. Its normal non-interactive
+invocation is already approval-free, so all three profiles use the same Pi
+arguments; `autonomous` and `unrestricted` describe deployment intent rather
+than adding a containment mechanism. See the shared
+[execution-profile capability matrix](../../terminal-harness/README.md#execution-profiles).
 
 The optional bearer token grants the complete `wn-agent` control API for every
 account in its home; the sender allowlist does not narrow that authority. Use a

--- a/integrations/pi/marmot/src/config.rs
+++ b/integrations/pi/marmot/src/config.rs
@@ -47,7 +47,11 @@ impl Config {
     }
 
     pub(crate) fn into_harness(self) -> Result<(marmot_terminal_harness::Config, PiBackend)> {
-        let backend = PiBackend::new(self.shared.bin, self.pi_session_dir)?;
+        let backend = PiBackend::new(
+            self.shared.bin,
+            self.pi_session_dir,
+            self.shared.harness.execution_profile,
+        )?;
         Ok((self.shared.harness, backend))
     }
 }

--- a/integrations/pi/marmot/src/pi.rs
+++ b/integrations/pi/marmot/src/pi.rs
@@ -4,7 +4,8 @@ use std::time::Instant;
 
 use async_trait::async_trait;
 use marmot_terminal_harness::{
-    Backend, HarnessError, Invocation, Outcome, Result, RunFailure, RunnerEvent, TRACE_TARGET,
+    ApprovalSupport, Backend, ExecutionProfile, ExecutionSupport, HarnessError, Invocation,
+    IsolationSupport, Outcome, Result, RunFailure, RunnerEvent, TRACE_TARGET,
     process::{capture_stderr, cleanup_failed_run, next_stdout_line, strip_ansi, write_stdin},
 };
 use serde_json::Value;
@@ -18,29 +19,53 @@ use tracing::debug;
 pub(crate) struct PiBackend {
     pub(crate) bin: String,
     pub(crate) session_dir: std::path::PathBuf,
+    pub(crate) execution_profile: ExecutionProfile,
 }
 
 impl PiBackend {
-    pub(crate) fn new(bin: String, session_dir: std::path::PathBuf) -> Result<Self> {
+    pub(crate) fn new(
+        bin: String,
+        session_dir: std::path::PathBuf,
+        execution_profile: ExecutionProfile,
+    ) -> Result<Self> {
         fs_private::create_dir_all_private(&session_dir)?;
-        Ok(Self { bin, session_dir })
+        Ok(Self {
+            bin,
+            session_dir,
+            execution_profile,
+        })
     }
 }
 
 #[async_trait]
 impl Backend for PiBackend {
+    fn execution_support(&self) -> ExecutionSupport {
+        ExecutionSupport {
+            approvals: ApprovalSupport::NativeApprovalFree,
+            isolation: IsolationSupport::NotProvided,
+        }
+    }
+
     async fn run(
         &self,
         invocation: Invocation,
         tx: mpsc::Sender<RunnerEvent>,
     ) -> std::result::Result<Outcome, RunFailure> {
-        run_with_bin(&self.bin, &self.session_dir, invocation, tx).await
+        run_with_bin(
+            &self.bin,
+            &self.session_dir,
+            self.execution_profile,
+            invocation,
+            tx,
+        )
+        .await
     }
 }
 
 async fn run_with_bin(
     bin: &str,
     session_dir: &Path,
+    execution_profile: ExecutionProfile,
     invocation: Invocation,
     tx: mpsc::Sender<RunnerEvent>,
 ) -> std::result::Result<Outcome, RunFailure> {
@@ -49,6 +74,7 @@ async fn run_with_bin(
         .args(build_run_args(
             session_dir,
             invocation.session_id.as_deref(),
+            execution_profile,
         ))
         .current_dir(&invocation.cwd)
         .stdin(Stdio::piped())
@@ -170,7 +196,11 @@ async fn run_with_bin(
     }
 }
 
-fn build_run_args(session_dir: &Path, session_id: Option<&str>) -> Vec<String> {
+fn build_run_args(
+    session_dir: &Path,
+    session_id: Option<&str>,
+    _execution_profile: ExecutionProfile,
+) -> Vec<String> {
     let mut args = vec![
         "--mode".to_owned(),
         "json".to_owned(),
@@ -243,6 +273,7 @@ fn assistant_text(content: Option<&Value>) -> String {
 
 #[cfg(test)]
 mod tests {
+    use marmot_terminal_harness::ExecutionProfile;
     use std::fs;
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
@@ -253,7 +284,11 @@ mod tests {
     #[test]
     fn args_select_json_session_dir_and_optional_session() {
         assert_eq!(
-            build_run_args(Path::new("/private/sessions"), Some("abc-123")),
+            build_run_args(
+                Path::new("/private/sessions"),
+                Some("abc-123"),
+                ExecutionProfile::Inherit,
+            ),
             vec![
                 "--mode",
                 "json",
@@ -300,7 +335,12 @@ mod tests {
     fn backend_constructor_creates_private_session_dir_once() {
         let root = tempfile::tempdir().unwrap();
         let session_dir = root.path().join("sessions");
-        let backend = PiBackend::new("pi".to_owned(), session_dir.clone()).unwrap();
+        let backend = PiBackend::new(
+            "pi".to_owned(),
+            session_dir.clone(),
+            ExecutionProfile::Inherit,
+        )
+        .unwrap();
         assert_eq!(backend.session_dir, session_dir);
         assert_eq!(
             fs::metadata(&backend.session_dir)
@@ -340,6 +380,7 @@ printf '{"type":"message_end","message":{"role":"assistant","content":[{"type":"
         let outcome = run_with_bin(
             script.to_str().unwrap(),
             &session_dir,
+            ExecutionProfile::Inherit,
             Invocation {
                 timeout: Duration::from_secs(5),
                 idle_timeout: Duration::from_secs(2),
@@ -392,6 +433,7 @@ printf '{"type":"message_end","message":{"role":"assistant","content":[{"type":"
         let outcome = run_with_bin(
             script.to_str().unwrap(),
             &session_dir,
+            ExecutionProfile::Inherit,
             Invocation {
                 timeout: Duration::from_secs(5),
                 idle_timeout: Duration::from_secs(2),
@@ -433,6 +475,7 @@ exit 64
         let outcome = run_with_bin(
             script.to_str().unwrap(),
             &session_dir,
+            ExecutionProfile::Inherit,
             Invocation {
                 timeout: Duration::from_secs(5),
                 idle_timeout: Duration::from_secs(2),
@@ -465,6 +508,7 @@ exit 64
         let outcome = run_with_bin(
             "pi",
             &session_dir,
+            ExecutionProfile::Inherit,
             Invocation {
                 timeout: Duration::from_secs(120),
                 idle_timeout: Duration::from_secs(30),
@@ -486,5 +530,31 @@ exit 64
             reply.push_str(&text);
         }
         assert_eq!(reply.trim(), "PI_CONNECTOR_OK");
+    }
+
+    #[test]
+    fn every_profile_uses_pis_native_approval_free_command_contract() {
+        let session_dir = Path::new("/private/pi-sessions");
+        for profile in [
+            ExecutionProfile::Inherit,
+            ExecutionProfile::Autonomous,
+            ExecutionProfile::Unrestricted,
+        ] {
+            assert_eq!(
+                build_run_args(session_dir, None, profile),
+                vec!["--mode", "json", "--session-dir", "/private/pi-sessions"]
+            );
+            assert_eq!(
+                build_run_args(session_dir, Some("session-123"), profile),
+                vec![
+                    "--mode",
+                    "json",
+                    "--session-dir",
+                    "/private/pi-sessions",
+                    "--session-id",
+                    "session-123",
+                ]
+            );
+        }
     }
 }

--- a/integrations/terminal-harness/README.md
+++ b/integrations/terminal-harness/README.md
@@ -45,15 +45,18 @@ the backends have equivalent permission or sandbox systems:
 | Backend | `inherit` | `autonomous` | `unrestricted` | Built-in OS isolation |
 | --- | --- | --- | --- | --- |
 | Pi | Existing tool/config behavior | Same native approval-free invocation | Same native approval-free invocation | None |
-| OpenCode | Existing permission config | `--auto`; explicit denies remain | `--auto` plus process-local `OPENCODE_PERMISSION="allow"` | None |
+| OpenCode | Existing permission config | `--auto`; explicit denies remain | `--auto` plus process-local `OPENCODE_CONFIG_CONTENT={"permission":"allow"}` | None |
 | Codex | Existing approval, sandbox, and network config | `approval_policy="never"`; sandbox/network remain configured | `--dangerously-bypass-approvals-and-sandbox` | Configured for `inherit`/`autonomous`; bypassed for `unrestricted` |
 
 The OpenCode overlay is set only on the spawned process and never rewrites the
-operator's global or project configuration. Older backend versions that do not
-understand a required flag or invocation-local config override fail the
-invocation; the harness does not fall back to a broader or interactive mode and
-does not send a successful reply. Pi needs no version-dependent permission flag
-because its normal non-interactive mode is already approval-free.
+operator's global or project configuration. The child does not inherit a
+separate `OPENCODE_PERMISSION` override in this profile. Managed organization
+policy is loaded later and may still override the process-local configuration.
+Older backend versions that do not understand a required flag or
+invocation-local config override fail the invocation; the harness does not fall
+back to a broader or interactive mode and does not send a successful reply. Pi
+needs no version-dependent permission flag because its normal non-interactive
+mode is already approval-free.
 
 Installers accept `--execution-profile inherit|autonomous|unrestricted` and
 write the shared environment variable into the private env file and same-user
@@ -70,9 +73,10 @@ deployments as a dedicated OS user or inside a container/VM, and give that
 boundary only narrowly scoped credentials. Backend logical permissions are not
 equivalent to an OS sandbox.
 
-Startup diagnostics report only the selected profile and typed approval/isolation
-support state. They never include paths, identities, prompts, configuration
-contents, or backend output.
+Startup diagnostics report the selected profile and typed approval/isolation
+support state alongside coarse fields such as the harness name, sender count,
+and reply-size limit. They never include paths, identities, prompts,
+configuration contents, or backend output.
 
 ## Shared Behavior
 

--- a/integrations/terminal-harness/README.md
+++ b/integrations/terminal-harness/README.md
@@ -31,6 +31,50 @@ Connector crates are responsible for:
 Codex, OpenCode, and Pi write prompt text to stdin. Backend-specific behavior
 belongs in those connector crates, not in this shared runtime.
 
+## Execution Profiles
+
+`MARMOT_HARNESS_EXECUTION_PROFILE` expresses operator intent without pretending
+the backends have equivalent permission or sandbox systems:
+
+- `inherit` (default) adds no connector-owned execution-policy overrides.
+- `autonomous` avoids interactive approvals while preserving configured hard
+  denies and isolation where the backend supports them.
+- `unrestricted` requests the backend's broadest non-interactive mode. It
+  requires external isolation.
+
+| Backend | `inherit` | `autonomous` | `unrestricted` | Built-in OS isolation |
+| --- | --- | --- | --- | --- |
+| Pi | Existing tool/config behavior | Same native approval-free invocation | Same native approval-free invocation | None |
+| OpenCode | Existing permission config | `--auto`; explicit denies remain | `--auto` plus process-local `OPENCODE_PERMISSION={"*":"allow"}` | None |
+| Codex | Existing approval, sandbox, and network config | `approval_policy="never"`; sandbox/network remain configured | `--dangerously-bypass-approvals-and-sandbox` | Configured for `inherit`/`autonomous`; bypassed for `unrestricted` |
+
+The OpenCode overlay is set only on the spawned process and never rewrites the
+operator's global or project configuration. Codex uses `--strict-config` with
+the autonomous override. Older backend versions that do not understand a
+required flag or config key fail the invocation; the harness does not fall back
+to a broader or interactive mode and does not send a successful reply. Pi needs
+no version-dependent permission flag because its normal non-interactive mode is
+already approval-free.
+
+Installers accept `--execution-profile inherit|autonomous|unrestricted` and
+write the shared environment variable into the private env file and same-user
+service configuration. Writing `unrestricted` requires the separate
+`--acknowledge-unrestricted` flag, including in non-interactive and dry-run
+installs.
+
+### Security Boundary
+
+An allowed Marmot sender combined with `unrestricted` execution is effectively
+remote code execution as the harness service user. The `/<path>` picker chooses
+a working directory; it is not an OS containment boundary. Run unrestricted
+deployments as a dedicated OS user or inside a container/VM, and give that
+boundary only narrowly scoped credentials. Backend logical permissions are not
+equivalent to an OS sandbox.
+
+Startup diagnostics report only the selected profile and typed approval/isolation
+support state. They never include paths, identities, prompts, configuration
+contents, or backend output.
+
 ## Shared Behavior
 
 All connectors:

--- a/integrations/terminal-harness/README.md
+++ b/integrations/terminal-harness/README.md
@@ -45,16 +45,15 @@ the backends have equivalent permission or sandbox systems:
 | Backend | `inherit` | `autonomous` | `unrestricted` | Built-in OS isolation |
 | --- | --- | --- | --- | --- |
 | Pi | Existing tool/config behavior | Same native approval-free invocation | Same native approval-free invocation | None |
-| OpenCode | Existing permission config | `--auto`; explicit denies remain | `--auto` plus process-local `OPENCODE_PERMISSION={"*":"allow"}` | None |
+| OpenCode | Existing permission config | `--auto`; explicit denies remain | `--auto` plus process-local `OPENCODE_PERMISSION="allow"` | None |
 | Codex | Existing approval, sandbox, and network config | `approval_policy="never"`; sandbox/network remain configured | `--dangerously-bypass-approvals-and-sandbox` | Configured for `inherit`/`autonomous`; bypassed for `unrestricted` |
 
 The OpenCode overlay is set only on the spawned process and never rewrites the
-operator's global or project configuration. Codex uses `--strict-config` with
-the autonomous override. Older backend versions that do not understand a
-required flag or config key fail the invocation; the harness does not fall back
-to a broader or interactive mode and does not send a successful reply. Pi needs
-no version-dependent permission flag because its normal non-interactive mode is
-already approval-free.
+operator's global or project configuration. Older backend versions that do not
+understand a required flag or invocation-local config override fail the
+invocation; the harness does not fall back to a broader or interactive mode and
+does not send a successful reply. Pi needs no version-dependent permission flag
+because its normal non-interactive mode is already approval-free.
 
 Installers accept `--execution-profile inherit|autonomous|unrestricted` and
 write the shared environment variable into the private env file and same-user

--- a/integrations/terminal-harness/src/bridge.rs
+++ b/integrations/terminal-harness/src/bridge.rs
@@ -26,12 +26,16 @@ const SEND_RETRY_ATTEMPTS: usize = 3;
 
 /// Connects to `wn-agent`, subscribes to allowed prompts, and runs the backend.
 pub async fn run<B: Backend>(config: Config, backend: B) -> Result<()> {
+    let execution_support = backend.execution_support();
     info!(
         target: TRACE_TARGET,
         method = "startup",
         allowed_senders = config.allowed_senders.len(),
         max_reply_bytes = config.max_reply_bytes,
         harness = config.spec.display_name,
+        execution_profile = config.execution_profile.as_str(),
+        approval_support = execution_support.approvals.as_str(),
+        isolation_support = execution_support.isolation.as_str(),
         "terminal harness starting"
     );
 
@@ -975,6 +979,7 @@ mod tests {
             state_path: root.join("sessions.json"),
             backend_timeout: Duration::from_secs(60),
             backend_idle_timeout: Duration::from_secs(45),
+            execution_profile: crate::ExecutionProfile::Inherit,
             spec: crate::ConfigSpec {
                 env_prefix: "WN_OPENCODE",
                 default_home_name: "harnesses",

--- a/integrations/terminal-harness/src/config.rs
+++ b/integrations/terminal-harness/src/config.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::fmt;
 use std::fs;
 use std::path::PathBuf;
+use std::str::FromStr;
 use std::time::Duration;
 
 use crate::{Config, DEFAULT_MAX_REPLY_BYTES, HarnessError, MARMOT_MESSAGE_BYTES_CEILING, Result};
@@ -11,6 +12,50 @@ const DEFAULT_BACKEND_IDLE_TIMEOUT_SECS: u64 = 120;
 const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 30;
 const DEFAULT_MAX_PENDING_PER_GROUP: usize = 4;
 const MIN_REPLY_BYTES: usize = 4;
+
+/// Operator intent for backend approval and isolation behavior.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ExecutionProfile {
+    /// Add no connector-owned execution-policy overrides.
+    #[default]
+    Inherit,
+    /// Avoid interactive approvals while preserving hard denies and isolation.
+    Autonomous,
+    /// Request the backend's broadest non-interactive execution mode.
+    Unrestricted,
+}
+
+impl ExecutionProfile {
+    /// Stable environment and diagnostic value for this profile.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Inherit => "inherit",
+            Self::Autonomous => "autonomous",
+            Self::Unrestricted => "unrestricted",
+        }
+    }
+}
+
+impl fmt::Display for ExecutionProfile {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl FromStr for ExecutionProfile {
+    type Err = HarnessError;
+
+    fn from_str(raw: &str) -> Result<Self> {
+        match raw.trim() {
+            "inherit" => Ok(Self::Inherit),
+            "autonomous" => Ok(Self::Autonomous),
+            "unrestricted" => Ok(Self::Unrestricted),
+            _ => Err(config_error(
+                "MARMOT_HARNESS_EXECUTION_PROFILE must be `inherit`, `autonomous`, or `unrestricted`",
+            )),
+        }
+    }
+}
 
 /// Connector-specific names and defaults used by the shared environment parser.
 #[derive(Clone, Copy, Debug)]
@@ -121,6 +166,10 @@ pub fn load_config_with(
             spec.bin_env_name
         )));
     }
+    let execution_profile = lookup("MARMOT_HARNESS_EXECUTION_PROFILE")
+        .as_deref()
+        .unwrap_or("inherit")
+        .parse()?;
 
     let backend_timeout = parse_positive_duration(
         lookup,
@@ -181,6 +230,7 @@ pub fn load_config_with(
             state_path,
             backend_timeout,
             backend_idle_timeout,
+            execution_profile,
             spec,
         },
         home,
@@ -279,6 +329,40 @@ mod tests {
         assert_eq!(loaded.home, PathBuf::from("/home/test/.marmot-agents/test"));
         assert_eq!(loaded.harness.backend_timeout, Duration::from_secs(3600));
         assert_eq!(loaded.harness.max_reply_bytes, DEFAULT_MAX_REPLY_BYTES);
+        assert_eq!(loaded.harness.execution_profile, ExecutionProfile::Inherit);
+    }
+
+    #[test]
+    fn shared_config_parses_every_execution_profile() {
+        for (raw, expected) in [
+            ("inherit", ExecutionProfile::Inherit),
+            ("autonomous", ExecutionProfile::Autonomous),
+            ("unrestricted", ExecutionProfile::Unrestricted),
+        ] {
+            let loaded = load(&[
+                ("HOME", "/home/test"),
+                ("WN_TEST_ALLOWED_SENDERS_HEX", SENDER),
+                ("MARMOT_HARNESS_EXECUTION_PROFILE", raw),
+            ])
+            .unwrap();
+            assert_eq!(loaded.harness.execution_profile, expected);
+            assert_eq!(loaded.harness.execution_profile.as_str(), raw);
+        }
+    }
+
+    #[test]
+    fn shared_config_rejects_unknown_execution_profile() {
+        let error = load(&[
+            ("HOME", "/home/test"),
+            ("WN_TEST_ALLOWED_SENDERS_HEX", SENDER),
+            ("MARMOT_HARNESS_EXECUTION_PROFILE", "yolo"),
+        ])
+        .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("MARMOT_HARNESS_EXECUTION_PROFILE")
+        );
     }
 
     #[test]
@@ -332,5 +416,6 @@ mod tests {
         }
         assert!(debug.contains("auth_token_present: true"));
         assert!(debug.contains("account_id_present: true"));
+        assert!(debug.contains("execution_profile: Inherit"));
     }
 }

--- a/integrations/terminal-harness/src/lib.rs
+++ b/integrations/terminal-harness/src/lib.rs
@@ -19,7 +19,7 @@ use async_trait::async_trait;
 use tokio::sync::mpsc;
 
 pub use bridge::run;
-pub use config::{ConfigSpec, LoadedConfig, load_config_with};
+pub use config::{ConfigSpec, ExecutionProfile, LoadedConfig, load_config_with};
 pub use error::{HarnessError, Result};
 
 /// Default maximum byte length for one Marmot reply chunk.
@@ -52,6 +52,8 @@ pub struct Config {
     pub backend_timeout: Duration,
     /// Maximum backend stdout silence.
     pub backend_idle_timeout: Duration,
+    /// Connector execution-permission policy selected by the operator.
+    pub execution_profile: ExecutionProfile,
     /// Connector identity and naming.
     pub spec: ConfigSpec,
 }
@@ -68,6 +70,7 @@ impl fmt::Debug for Config {
             .field("max_pending_per_group", &self.max_pending_per_group)
             .field("backend_timeout", &self.backend_timeout)
             .field("backend_idle_timeout", &self.backend_idle_timeout)
+            .field("execution_profile", &self.execution_profile)
             .field("spec", &self.spec)
             .finish_non_exhaustive()
     }
@@ -167,12 +170,84 @@ impl fmt::Debug for RunnerEvent {
 /// Backend-specific command construction and event parsing boundary.
 #[async_trait]
 pub trait Backend: Send + Sync + 'static {
+    /// Privacy-safe capability state emitted when the harness starts.
+    fn execution_support(&self) -> ExecutionSupport {
+        ExecutionSupport::INHERITED
+    }
+
     /// Runs one prompt and streams completed assistant text to `tx`.
     async fn run(
         &self,
         invocation: Invocation,
         tx: mpsc::Sender<RunnerEvent>,
     ) -> std::result::Result<Outcome, RunFailure>;
+}
+
+/// Backend support state for the selected execution profile.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ExecutionSupport {
+    /// How approval requests are handled.
+    pub approvals: ApprovalSupport,
+    /// How process isolation is handled.
+    pub isolation: IsolationSupport,
+}
+
+impl ExecutionSupport {
+    /// Default state for backends that add no policy overrides.
+    pub const INHERITED: Self = Self {
+        approvals: ApprovalSupport::Inherited,
+        isolation: IsolationSupport::Inherited,
+    };
+}
+
+/// Typed, privacy-safe approval capability state.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ApprovalSupport {
+    /// The connector leaves backend approval configuration unchanged.
+    Inherited,
+    /// The backend is natively approval-free.
+    NativeApprovalFree,
+    /// Interactive asks are auto-approved while explicit denies remain.
+    PreserveDenies,
+    /// The connector requests allowance of every logical permission.
+    ForceAllow,
+    /// Approval checks are bypassed.
+    Bypassed,
+}
+
+impl ApprovalSupport {
+    /// Stable tracing field value.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Inherited => "inherited",
+            Self::NativeApprovalFree => "native_approval_free",
+            Self::PreserveDenies => "preserve_denies",
+            Self::ForceAllow => "force_allow",
+            Self::Bypassed => "bypassed",
+        }
+    }
+}
+
+/// Typed, privacy-safe isolation capability state.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum IsolationSupport {
+    /// The connector leaves backend isolation configuration unchanged.
+    Inherited,
+    /// The backend does not provide a built-in OS sandbox.
+    NotProvided,
+    /// Backend isolation is explicitly bypassed.
+    Bypassed,
+}
+
+impl IsolationSupport {
+    /// Stable tracing field value.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Inherited => "inherited",
+            Self::NotProvided => "not_provided",
+            Self::Bypassed => "bypassed",
+        }
+    }
 }
 
 /// Returns the current user's home directory or fails closed when it is unset.

--- a/integrations/terminal-harness/tests/test_installer.sh
+++ b/integrations/terminal-harness/tests/test_installer.sh
@@ -41,6 +41,7 @@ idle_timeout_env="${env_prefix}_IDLE_TIMEOUT_SECS"
 request_timeout_env="${env_prefix}_REQUEST_TIMEOUT_SECS"
 max_reply_env="${env_prefix}_MAX_REPLY_BYTES"
 max_pending_env="${env_prefix}_MAX_PENDING_PER_GROUP"
+profile_env="MARMOT_HARNESS_EXECUTION_PROFILE"
 export "$bin_env=/bin/echo"
 allow_hex="$(printf '11%.0s' {1..32})"
 fixture_version="9.9.9"
@@ -223,6 +224,22 @@ unit_dir="$fixture_root/home/.config/systemd/user"
 [ "$(stat_mode "$fixture_root/marmot-home/dev/$harness_binary.env")" = 600 ]
 grep -F "Environment=\"$timeout_env=3600\"" "$unit_dir/$harness_service" >/dev/null
 grep -F "Environment=\"$request_timeout_env=30\"" "$unit_dir/$harness_service" >/dev/null
+grep -F "Environment=\"$profile_env=inherit\"" "$unit_dir/$harness_service" >/dev/null
+grep -F "$profile_env=inherit" \
+    "$fixture_root/marmot-home/dev/$harness_binary.env" >/dev/null
+
+for profile in autonomous unrestricted; do
+    profile_log="$fixture_root/systemctl-profile-$profile.log"
+    profile_args=(--execution-profile "$profile")
+    if [ "$profile" = unrestricted ]; then
+        profile_args+=(--acknowledge-unrestricted)
+    fi
+    run_linux_service_case "$fixture_root" 1 "$profile_log" "${profile_args[@]}"
+    grep -F "Environment=\"$profile_env=$profile\"" \
+        "$unit_dir/$harness_service" >/dev/null
+    grep -F "$profile_env=$profile" \
+        "$fixture_root/marmot-home/dev/$harness_binary.env" >/dev/null
+done
 
 upgrade_log="$fixture_root/systemctl-upgrade.log"
 run_linux_service_case "$fixture_root" 1 "$upgrade_log"
@@ -306,6 +323,35 @@ installer_stdin_dry_run="$(
     MARMOT_TERMINAL_HARNESS="$kind" \
     bash -s -- --dry-run --yes --no-service --allow-welcomer "$allow_hex" < "$shared_installer"
 )"
+
+for profile in inherit autonomous unrestricted; do
+    profile_args=(--execution-profile "$profile")
+    if [ "$profile" = unrestricted ]; then
+        profile_args+=(--acknowledge-unrestricted)
+    fi
+    profile_dry_run="$(
+        env -u MARMOT_HOME -u MARMOT_AGENT_SOCKET \
+            WN_AGENT_SHA="$fixture_version" \
+            MARMOT_RELEASE_TAG="wn-agent-v$fixture_version-test" \
+        "$installer" --dry-run --yes --no-service --allow-welcomer "$allow_hex" \
+            "${profile_args[@]}"
+    )"
+    case "$profile_dry_run" in
+        *"$profile_env=$profile"*) ;;
+        *) echo "$kind installer dry-run omitted execution profile $profile" >&2; exit 1 ;;
+    esac
+done
+
+unacknowledged_status=0
+unacknowledged_stderr="$fixture_root/unacknowledged-unrestricted.err"
+env -u MARMOT_HOME -u MARMOT_AGENT_SOCKET \
+    WN_AGENT_SHA="$fixture_version" \
+    MARMOT_RELEASE_TAG="wn-agent-v$fixture_version-test" \
+    "$installer" --dry-run --yes --no-service --allow-welcomer "$allow_hex" \
+        --execution-profile unrestricted >/dev/null 2>"$unacknowledged_stderr" \
+    || unacknowledged_status=$?
+[ "$unacknowledged_status" -ne 0 ]
+grep -F -- "--acknowledge-unrestricted is required" "$unacknowledged_stderr" >/dev/null
 
 custom_root="$fixture_parent/custom"
 installer_custom_socket_dry_run="$(

--- a/scripts/install-terminal-harness-marmot.sh
+++ b/scripts/install-terminal-harness-marmot.sh
@@ -56,6 +56,7 @@ HARNESS_IDLE_TIMEOUT_ENV="${HARNESS_ENV_PREFIX}_IDLE_TIMEOUT_SECS"
 HARNESS_REQUEST_TIMEOUT_ENV="${HARNESS_ENV_PREFIX}_REQUEST_TIMEOUT_SECS"
 HARNESS_MAX_REPLY_ENV="${HARNESS_ENV_PREFIX}_MAX_REPLY_BYTES"
 HARNESS_MAX_PENDING_ENV="${HARNESS_ENV_PREFIX}_MAX_PENDING_PER_GROUP"
+HARNESS_EXECUTION_PROFILE_ENV="MARMOT_HARNESS_EXECUTION_PROFILE"
 
 env_or_default() {
     local name="$1" default_value="$2"
@@ -91,6 +92,7 @@ HARNESS_IDLE_TIMEOUT_SECS="$(env_or_default "$HARNESS_IDLE_TIMEOUT_ENV" 120)"
 HARNESS_REQUEST_TIMEOUT_SECS="$(env_or_default "$HARNESS_REQUEST_TIMEOUT_ENV" 30)"
 HARNESS_MAX_REPLY_BYTES="$(env_or_default "$HARNESS_MAX_REPLY_ENV" 30000)"
 HARNESS_MAX_PENDING_PER_GROUP="$(env_or_default "$HARNESS_MAX_PENDING_ENV" 4)"
+HARNESS_EXECUTION_PROFILE="$(env_or_default "$HARNESS_EXECUTION_PROFILE_ENV" inherit)"
 HARNESS_CONFIGURED_SENDERS_HEX="$(env_or_default "$HARNESS_ALLOWED_SENDERS_ENV" "")"
 
 ASSUME_YES=0
@@ -100,6 +102,7 @@ INTERACTIVE=0
 NO_START_WN_AGENT=0
 NO_START_HARNESS=0
 SYSTEM_INSTALL=0
+ACKNOWLEDGE_UNRESTRICTED=0
 WN_AGENT_TEMP_PID=""
 BOOTSTRAP_ACCOUNT_ID_HEX=""
 BOOTSTRAP_ALLOWED_SENDERS_HEX=""
@@ -127,6 +130,8 @@ Options:
   --allow-sender VALUE     Alias for --allow-welcomer
   --relay URL              Relay URL for wn-agent/bootstrap; may repeat
   --$HARNESS_KIND-bin PATH      $HARNESS_DISPLAY_NAME binary or command name (default: $HARNESS_DEFAULT_BIN)
+  --execution-profile PROFILE  inherit, autonomous, or unrestricted (default: inherit)
+  --acknowledge-unrestricted   Confirm that unrestricted requires external isolation
   --no-service             Do not install/start LaunchAgents or systemd user units
   --no-start-wn-agent      Install services but do not start wn-agent or the harness
   --no-start-$HARNESS_BINARY   Install the service but do not activate it
@@ -151,6 +156,7 @@ Environment:
   MARMOT_WELCOMER_ALLOWLIST Comma-separated npub or hex allowlist values
   $HARNESS_ALLOWED_SENDERS_ENV Comma-separated hex values for prompt senders
   $HARNESS_BIN_ENV          $HARNESS_DISPLAY_NAME binary or command name
+  MARMOT_HARNESS_EXECUTION_PROFILE Shared execution profile (default: inherit)
 
 Example:
   curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/$MARMOT_RELEASE_TAG/install-$HARNESS_KIND-marmot.sh | bash
@@ -261,6 +267,22 @@ validate_prompt_senders() {
             exit 1
         fi
     done < <(append_csv "$HARNESS_CONFIGURED_SENDERS_HEX")
+}
+
+validate_execution_profile() {
+    case "$HARNESS_EXECUTION_PROFILE" in
+        inherit | autonomous) ;;
+        unrestricted)
+            if [ "$ACKNOWLEDGE_UNRESTRICTED" -ne 1 ]; then
+                echo "error: --acknowledge-unrestricted is required before writing the unrestricted execution profile" >&2
+                exit 1
+            fi
+            ;;
+        *)
+            echo "error: --execution-profile must be inherit, autonomous, or unrestricted" >&2
+            exit 1
+            ;;
+    esac
 }
 
 detect_platform() {
@@ -518,7 +540,7 @@ install_macos_harness_service() {
         else
             log "would run: launchctl bootstrap gui/$UID $plist"
         fi
-        log "env: $HARNESS_TIMEOUT_ENV=$HARNESS_TIMEOUT_SECS $HARNESS_IDLE_TIMEOUT_ENV=$HARNESS_IDLE_TIMEOUT_SECS $HARNESS_REQUEST_TIMEOUT_ENV=$HARNESS_REQUEST_TIMEOUT_SECS $HARNESS_MAX_REPLY_ENV=$HARNESS_MAX_REPLY_BYTES $HARNESS_MAX_PENDING_ENV=$HARNESS_MAX_PENDING_PER_GROUP"
+        log "env: $HARNESS_EXECUTION_PROFILE_ENV=$HARNESS_EXECUTION_PROFILE $HARNESS_TIMEOUT_ENV=$HARNESS_TIMEOUT_SECS $HARNESS_IDLE_TIMEOUT_ENV=$HARNESS_IDLE_TIMEOUT_SECS $HARNESS_REQUEST_TIMEOUT_ENV=$HARNESS_REQUEST_TIMEOUT_SECS $HARNESS_MAX_REPLY_ENV=$HARNESS_MAX_REPLY_BYTES $HARNESS_MAX_PENDING_ENV=$HARNESS_MAX_PENDING_PER_GROUP"
         return 0
     fi
 
@@ -543,6 +565,7 @@ install_macos_harness_service() {
         plist_env_entry "$HARNESS_ACCOUNT_ID_ENV" "$BOOTSTRAP_ACCOUNT_ID_HEX"
         plist_env_entry "$HARNESS_ALLOWED_SENDERS_ENV" "$BOOTSTRAP_ALLOWED_SENDERS_HEX"
         plist_env_entry "$HARNESS_BIN_ENV" "$HARNESS_BIN"
+        plist_env_entry "$HARNESS_EXECUTION_PROFILE_ENV" "$HARNESS_EXECUTION_PROFILE"
         plist_env_entry "$HARNESS_TIMEOUT_ENV" "$HARNESS_TIMEOUT_SECS"
         plist_env_entry "$HARNESS_IDLE_TIMEOUT_ENV" "$HARNESS_IDLE_TIMEOUT_SECS"
         plist_env_entry "$HARNESS_REQUEST_TIMEOUT_ENV" "$HARNESS_REQUEST_TIMEOUT_SECS"
@@ -663,7 +686,7 @@ install_linux_harness_service() {
         else
             log "would restart $MARMOT_HARNESS_SERVICE_NAME.service when active; otherwise enable --now"
         fi
-        log "env: $HARNESS_TIMEOUT_ENV=$HARNESS_TIMEOUT_SECS $HARNESS_IDLE_TIMEOUT_ENV=$HARNESS_IDLE_TIMEOUT_SECS $HARNESS_REQUEST_TIMEOUT_ENV=$HARNESS_REQUEST_TIMEOUT_SECS $HARNESS_MAX_REPLY_ENV=$HARNESS_MAX_REPLY_BYTES $HARNESS_MAX_PENDING_ENV=$HARNESS_MAX_PENDING_PER_GROUP"
+        log "env: $HARNESS_EXECUTION_PROFILE_ENV=$HARNESS_EXECUTION_PROFILE $HARNESS_TIMEOUT_ENV=$HARNESS_TIMEOUT_SECS $HARNESS_IDLE_TIMEOUT_ENV=$HARNESS_IDLE_TIMEOUT_SECS $HARNESS_REQUEST_TIMEOUT_ENV=$HARNESS_REQUEST_TIMEOUT_SECS $HARNESS_MAX_REPLY_ENV=$HARNESS_MAX_REPLY_BYTES $HARNESS_MAX_PENDING_ENV=$HARNESS_MAX_PENDING_PER_GROUP"
         return 0
     fi
 
@@ -686,6 +709,7 @@ install_linux_harness_service() {
         printf 'Environment=%s\n' "$(systemd_quote "$HARNESS_ACCOUNT_ID_ENV=$BOOTSTRAP_ACCOUNT_ID_HEX")"
         printf 'Environment=%s\n' "$(systemd_quote "$HARNESS_ALLOWED_SENDERS_ENV=$BOOTSTRAP_ALLOWED_SENDERS_HEX")"
         printf 'Environment=%s\n' "$(systemd_quote "$HARNESS_BIN_ENV=$HARNESS_BIN")"
+        printf 'Environment=%s\n' "$(systemd_quote "$HARNESS_EXECUTION_PROFILE_ENV=$HARNESS_EXECUTION_PROFILE")"
         printf 'Environment=%s\n' "$(systemd_quote "$HARNESS_TIMEOUT_ENV=$HARNESS_TIMEOUT_SECS")"
         printf 'Environment=%s\n' "$(systemd_quote "$HARNESS_IDLE_TIMEOUT_ENV=$HARNESS_IDLE_TIMEOUT_SECS")"
         printf 'Environment=%s\n' "$(systemd_quote "$HARNESS_REQUEST_TIMEOUT_ENV=$HARNESS_REQUEST_TIMEOUT_SECS")"
@@ -832,7 +856,7 @@ write_harness_env() {
     local env_file="$MARMOT_HOME/dev/$HARNESS_BINARY.env"
     if [ "$DRY_RUN" -eq 1 ]; then
         log "would write private env file $env_file"
-        log "env: $HARNESS_TIMEOUT_ENV=$HARNESS_TIMEOUT_SECS $HARNESS_IDLE_TIMEOUT_ENV=$HARNESS_IDLE_TIMEOUT_SECS $HARNESS_REQUEST_TIMEOUT_ENV=$HARNESS_REQUEST_TIMEOUT_SECS $HARNESS_MAX_REPLY_ENV=$HARNESS_MAX_REPLY_BYTES $HARNESS_MAX_PENDING_ENV=$HARNESS_MAX_PENDING_PER_GROUP"
+        log "env: $HARNESS_EXECUTION_PROFILE_ENV=$HARNESS_EXECUTION_PROFILE $HARNESS_TIMEOUT_ENV=$HARNESS_TIMEOUT_SECS $HARNESS_IDLE_TIMEOUT_ENV=$HARNESS_IDLE_TIMEOUT_SECS $HARNESS_REQUEST_TIMEOUT_ENV=$HARNESS_REQUEST_TIMEOUT_SECS $HARNESS_MAX_REPLY_ENV=$HARNESS_MAX_REPLY_BYTES $HARNESS_MAX_PENDING_ENV=$HARNESS_MAX_PENDING_PER_GROUP"
         return 0
     fi
     run mkdir -p "$MARMOT_HOME/dev"
@@ -844,6 +868,7 @@ write_harness_env() {
             printf '%s=%q\n' "$HARNESS_ACCOUNT_ID_ENV" "$BOOTSTRAP_ACCOUNT_ID_HEX"
             printf '%s=%q\n' "$HARNESS_ALLOWED_SENDERS_ENV" "$BOOTSTRAP_ALLOWED_SENDERS_HEX"
             printf '%s=%q\n' "$HARNESS_BIN_ENV" "$HARNESS_BIN"
+            printf '%s=%q\n' "$HARNESS_EXECUTION_PROFILE_ENV" "$HARNESS_EXECUTION_PROFILE"
             printf '%s=%q\n' "$HARNESS_TIMEOUT_ENV" "$HARNESS_TIMEOUT_SECS"
             printf '%s=%q\n' "$HARNESS_IDLE_TIMEOUT_ENV" "$HARNESS_IDLE_TIMEOUT_SECS"
             printf '%s=%q\n' "$HARNESS_REQUEST_TIMEOUT_ENV" "$HARNESS_REQUEST_TIMEOUT_SECS"
@@ -917,6 +942,14 @@ while [ "$#" -gt 0 ]; do
             HARNESS_BIN="${2:?missing value for --$HARNESS_KIND-bin}"
             shift 2
             ;;
+        --execution-profile)
+            HARNESS_EXECUTION_PROFILE="${2:?missing value for --execution-profile}"
+            shift 2
+            ;;
+        --acknowledge-unrestricted)
+            ACKNOWLEDGE_UNRESTRICTED=1
+            shift
+            ;;
         --no-service)
             INSTALL_SERVICE=0
             shift
@@ -980,6 +1013,7 @@ fi
 
 validate_welcomer_inputs
 validate_prompt_senders
+validate_execution_profile
 need_cmd curl
 need_cmd tar
 if [ "$DRY_RUN" -eq 0 ]; then


### PR DESCRIPTION
Depends on #1501. The final commit in this branch implements #1504; the two prerequisite commits are the current #1501 head and will disappear from this PR diff when #1501 lands.

## Summary
- add typed `inherit`, `autonomous`, and `unrestricted` execution profiles with privacy-safe capability diagnostics
- map Pi, OpenCode, and Codex to their distinct approval and isolation controls without global config mutation
- add installer persistence, explicit unrestricted acknowledgement, backend/installer regressions, and security documentation

## Test plan
- [x] New tests failed before the fix and pass after
- [x] `cargo test -p marmot-terminal-harness`
- [x] `cargo test -p wn-codex`
- [x] `cargo test -p wn-opencode`
- [x] `cargo test -p wn-pi`
- [x] `just codex-installer-test`
- [x] `just opencode-installer-test`
- [x] `just pi-installer-test`
- [x] `just codex-dev-e2e-connector`
- [x] `just opencode-dev-e2e-connector`
- [x] `just pi-dev-e2e-connector`
- [x] `just fast-ci`

Fixes #1504

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable terminal execution profiles: inherit, autonomous, and unrestricted.
  - Profiles now provide consistent behavior across Codex, OpenCode, and Pi integrations.
  - Added installer options and environment configuration for selecting profiles.
  - Unrestricted mode requires explicit acknowledgement and an external OS isolation boundary.
  - Startup diagnostics report execution and capability states using safe, limited values.

- **Documentation**
  - Added architecture, configuration, capability, security, and troubleshooting guidance.

- **Tests**
  - Expanded coverage for profile validation, propagation, installer behavior, and acknowledgement requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->