### PR TITLE
docs: simplify agent connector onboarding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Campaign image toolchain gate
         run: ./scripts/check_campaign_toolchain.sh
 
+      - name: Agent install documentation gate
+        run: ./scripts/check_agent_install_docs.sh
+
   terminal-harness-installers:
     name: Terminal harness installer tests
     runs-on: ubuntu-latest

--- a/.github/workflows/wn-agent-binaries.yml
+++ b/.github/workflows/wn-agent-binaries.yml
@@ -478,16 +478,6 @@ jobs:
           cat > "$notes" <<EOF
           WN Agent \`$version\` from MDK commit \`$GITHUB_SHA\`.
 
-          Install the latest WN Agent release with:
-
-          \`\`\`sh
-          curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/wn-agent-latest/install-hermes-marmot.sh | bash
-          curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/wn-agent-latest/install-openclaw-marmot.sh | bash
-          curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/wn-agent-latest/install-codex-marmot.sh | bash
-          curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/wn-agent-latest/install-opencode-marmot.sh | bash
-          curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/wn-agent-latest/install-pi-marmot.sh | bash
-          \`\`\`
-
           Install this exact WN Agent release with:
 
           \`\`\`sh
@@ -629,11 +619,11 @@ jobs:
           Latest WN Agent installers. These scripts install WN Agent \`$version\` from immutable release \`$tag\`.
 
           \`\`\`sh
-          curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/$latest_tag/install-hermes-marmot.sh | bash
-          curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/$latest_tag/install-openclaw-marmot.sh | bash
-          curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/$latest_tag/install-codex-marmot.sh | bash
-          curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/$latest_tag/install-opencode-marmot.sh | bash
-          curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/$latest_tag/install-pi-marmot.sh | bash
+          curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/$tag/install-hermes-marmot.sh | bash
+          curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/$tag/install-openclaw-marmot.sh | bash
+          curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/$tag/install-codex-marmot.sh | bash
+          curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/$tag/install-opencode-marmot.sh | bash
+          curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/$tag/install-pi-marmot.sh | bash
           \`\`\`
 
           Use the versioned \`$tag\` release URLs when you need a pinned install.

--- a/Justfile
+++ b/Justfile
@@ -226,6 +226,9 @@ pi-installer-test:
 pi-dev-e2e-connector:
     cargo test -p wn-pi --test e2e_connector -- --ignored --nocapture
 
+agent-install-docs-gate:
+    scripts/check_agent_install_docs.sh
+
 openclaw-dev-smoke root="":
     #!/usr/bin/env bash
     set -euo pipefail
@@ -556,6 +559,6 @@ test-convergence-policy-pin:
 
 # Fast local pre-push gate: mechanical/static checks plus the release pin proof.
 # GitHub CI runs the full `just ci` suite (including the workspace test matrix).
-fast-ci: fmt-check naming-gate convergence-ledger-gate campaign-toolchain-gate check clippy test-convergence-policy-pin
+fast-ci: fmt-check naming-gate convergence-ledger-gate campaign-toolchain-gate agent-install-docs-gate check clippy test-convergence-policy-pin
 
 ci: fmt-check naming-gate convergence-ledger-gate campaign-toolchain-gate check clippy test-convergence-policy-pin test

--- a/Justfile
+++ b/Justfile
@@ -558,7 +558,7 @@ test-convergence-policy-pin:
     cargo test -p cgka-engine --test convergence_policy_pin --locked
 
 # Fast local pre-push gate: mechanical/static checks plus the release pin proof.
-# GitHub CI runs the full `just ci` suite (including the workspace test matrix).
+# GitHub CI invokes the static gates directly and runs the full test matrix.
 fast-ci: fmt-check naming-gate convergence-ledger-gate campaign-toolchain-gate agent-install-docs-gate check clippy test-convergence-policy-pin
 
-ci: fmt-check naming-gate convergence-ledger-gate campaign-toolchain-gate check clippy test-convergence-policy-pin test
+ci: fmt-check naming-gate convergence-ledger-gate campaign-toolchain-gate agent-install-docs-gate check clippy test-convergence-policy-pin test

--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ conformance, diagnostics, and release material.
 
 ## Start Here
 
-If you are landing in this repo for the first time, read these files in order:
+If you want to use White Noise with an existing agent runtime, start with the
+[White Noise + Agents quickstart](integrations/README.md#get-started-white-noise--agents). It covers Hermes,
+OpenClaw, Codex, OpenCode, and Pi from install through the first encrypted chat.
+
+If you are developing Marmot itself, read these files in order:
 
 1. [`crates/cgka-engine/README.md`](crates/cgka-engine/README.md) - what the engine owns and what it leaves out.
 2. [`crates/cgka-conformance-simulator/README.md`](crates/cgka-conformance-simulator/README.md) - how scenarios,

--- a/crates/agent-connector/README.md
+++ b/crates/agent-connector/README.md
@@ -100,120 +100,14 @@ users, make the gateway the directory owner and give the connector's shared grou
 are created `0640`. In split-container deployments, mount the same directory read-write in the gateway and read-only
 in the connector. Omitting `--media-allowed-root` deliberately leaves media sends disabled.
 
-## Hermes Install
+## Release Installs
 
-Versioned WN Agent builds publish the `wn-agent` binary, the Hermes Marmot plugin, and an installer script on GitHub
-Releases under `wn-agent-v*` tags. The `wn-agent-latest` release contains installer scripts that are refreshed to the
-newest WN Agent release. Hermes itself must already be installed.
+The canonical [White Noise + Agents quickstart](../../integrations/README.md#get-started-white-noise--agents) owns the
+current release URLs, runtime chooser, phone onboarding, and repeatable agent/CI example for Hermes, OpenClaw, Codex,
+OpenCode, and Pi. Keep install commands there instead of duplicating them in this crate-level implementation guide.
 
-```sh
-curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-hermes-marmot.sh" | bash
-```
-
-For repeatable noninteractive setup:
-
-```sh
-curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-hermes-marmot.sh" | \
-  bash -s -- --yes --allow-welcomer npub1...
-```
-
-Use a versioned `wn-agent-v<version>` release URL when you need a pinned install for reproducible testing.
-
-The installer puts `wn-agent` in `~/.local/bin`, extracts the Hermes plugin to `~/.hermes/plugins/marmot`, and enables
-the plugin when the `hermes` launcher is on `PATH`. It also starts a same-user connector service where supported,
-bootstraps or reuses `~/.marmot-agents/hermes`, and patches only Marmot-specific Hermes config entries so existing
-connectors continue to work. The default service identity is connector-specific:
-`wn-agent-hermes.service` on Linux or `org.marmot.wn-agent.hermes` on macOS.
-
-Hermes-specific setup, development helpers, and phone-test commands live in
-[`integrations/hermes/marmot/README.md`](../../integrations/hermes/marmot/README.md).
-
-## OpenClaw Install
-
-The same WN Agent release publishes the OpenClaw Marmot channel plugin and installer:
-
-```sh
-curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-openclaw-marmot.sh" | bash
-```
-
-For repeatable noninteractive setup:
-
-```sh
-curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-openclaw-marmot.sh" | \
-  bash -s -- --yes --allow-welcomer npub1...
-```
-
-The OpenClaw installer follows the same release flow, but uses its own default connector home and service identity:
-`~/.marmot-agents/openclaw`, `wn-agent-openclaw.service` on Linux, or `org.marmot.wn-agent.openclaw` on macOS. It
-installs/enables the OpenClaw plugin and updates only `channels.marmot` in OpenClaw config so existing channels
-continue to work.
-
-## Codex Harness Install
-
-The same WN Agent release publishes the `wn-codex` harness binary and installer. Codex itself must already be installed
-and authenticated.
-
-```sh
-curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-codex-marmot.sh" | bash
-```
-
-For repeatable noninteractive setup:
-
-```sh
-curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-codex-marmot.sh" | \
-  bash -s -- --yes --allow-welcomer npub1...
-```
-
-The Codex installer creates or reuses the isolated agent home at `~/.marmot-agents/codex`, writes a private
-`wn-codex.env`, and starts same-user `wn-agent` and `wn-codex` services where supported. Its connector service is
-`wn-agent-codex.service` on Linux or `org.marmot.wn-agent.codex` on macOS. Codex-specific configuration and
-development commands live in
-[`integrations/codex/marmot/README.md`](../../integrations/codex/marmot/README.md).
-
-## OpenCode Harness Install
-
-The same WN Agent release publishes the `wn-opencode` harness binary and installer. OpenCode itself must already be
-installed.
-
-```sh
-curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-opencode-marmot.sh" | bash
-```
-
-For repeatable noninteractive setup:
-
-```sh
-curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-opencode-marmot.sh" | \
-  bash -s -- --yes --allow-welcomer npub1...
-```
-
-The OpenCode installer creates or reuses the terminal-harness agent home at `~/.marmot-agents/harnesses`, writes a
-private `wn-opencode.env`, and starts a same-user `wn-opencode` service where supported. The backing `wn-agent` service
-uses `wn-agent-harnesses.service` on Linux or `org.marmot.wn-agent.harnesses` on macOS. `WN_OPENCODE_MAX_REPLY_BYTES`
-defaults to 30000 bytes per Marmot reply chunk.
-
-## Pi Harness Install
-
-The same WN Agent release publishes the `wn-pi` harness binary and installer. Pi itself must already be installed and
-authenticated.
-
-```sh
-curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-pi-marmot.sh" | bash
-```
-
-For repeatable noninteractive setup:
-
-```sh
-curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-pi-marmot.sh" | \
-  bash -s -- --yes --allow-welcomer npub1...
-```
-
-The Pi installer creates or reuses the isolated agent home at `~/.marmot-agents/pi`, writes a private `wn-pi.env`,
-and starts same-user `wn-agent` and `wn-pi` services where supported. Its connector service is `wn-agent-pi.service`
-on Linux or `org.marmot.wn-agent.pi` on macOS. Pi sessions default to
-`~/.marmot-agents/pi/dev/pi-sessions`, and `WN_PI_MAX_REPLY_BYTES` defaults to 30000 bytes per Marmot reply chunk.
-
-Pi-specific configuration and development commands live in
-[`integrations/pi/marmot/README.md`](../../integrations/pi/marmot/README.md).
+Connector-specific configuration, manual setup, security notes, and development workflows remain in each integration
+README under [`integrations/`](../../integrations/README.md).
 
 ## Cutting A WN Agent Release
 

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -1,7 +1,125 @@
 # Marmot Integrations
 
-This directory contains host integrations that let external agent runtimes talk
-to Marmot through the local `wn-agent` connector.
+This directory contains the connectors that let White Noise users chat with
+existing agent runtimes through the local `wn-agent` service.
+
+## Get Started: White Noise + Agents
+
+You need:
+
+- White Noise on your phone, with your account `npub` available;
+- one supported agent runtime already installed, authenticated, and working on
+  the same Mac or Linux machine where you will run the connector;
+- Linux x86_64, Linux arm64, macOS Apple Silicon, or macOS Intel.
+
+Choose the runtime you already use:
+
+| Runtime | Connector style | Best fit |
+| --- | --- | --- |
+| Hermes | Gateway plugin | Rich chat history, reactions, media, and live previews |
+| OpenClaw | Channel plugin | Rich gateway routing, media, and live previews |
+| Codex | Terminal harness | Repository and coding tasks through Codex |
+| OpenCode | Terminal harness | Repository and coding tasks through OpenCode |
+| Pi | Terminal harness | Repository and coding tasks through Pi |
+
+The guided installers prompt on the terminal for the White Noise account that
+may invite and message the agent. They install release `wn-agent-v0.9.14`, create
+an isolated White Noise identity for the selected connector, and start same-user
+services where supported.
+
+### Hermes
+
+Hermes 0.19.0 or newer must already be installed and working.
+
+```sh
+curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-hermes-marmot.sh | bash
+```
+
+### OpenClaw
+
+OpenClaw 2026.7.1 or newer and Node 22.19 or newer must already be installed.
+
+```sh
+curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-openclaw-marmot.sh | bash
+```
+
+### Codex
+
+Codex must already be installed, authenticated, and runnable as `codex`.
+
+```sh
+curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-codex-marmot.sh | bash
+```
+
+### OpenCode
+
+OpenCode 1.18.18 or newer must already be installed and runnable as `opencode`.
+
+```sh
+curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-opencode-marmot.sh | bash
+```
+
+### Pi
+
+Pi must already be installed, authenticated, and runnable as `pi`.
+
+```sh
+curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-pi-marmot.sh | bash
+```
+
+### Finish In White Noise
+
+Release 0.9.14 records the new agent's `npub` and `nprofile` in the
+`bootstrap.json` path printed at completion. Display them with:
+
+```sh
+python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); print(d["npub"]); print(d["nprofile"])' \
+  "$HOME/.marmot-agents/codex/bootstrap.json"
+```
+
+Use `hermes`, `openclaw`, `codex`, `harnesses` (OpenCode), or `pi` in that path.
+The updated source installers also show these values directly and render a
+terminal QR when `qrencode` is installed; that improvement will apply to the
+next immutable release.
+
+1. Add the displayed agent identity in White Noise.
+2. Invite it to a direct message or group from the account you authorized.
+3. Send a test message.
+
+Hermes and OpenClaw print one final gateway restart command because the installer
+does not restart an existing gateway. Codex, OpenCode, and Pi services are
+started by the default install. Their first group message can be `/<path>` to
+select a working directory under your home directory.
+
+### Repeatable Agent Or CI Setup
+
+Use the immutable release URL and provide the authorized White Noise account
+explicitly. Terminal harnesses and OpenClaw use the welcomer entry for both
+invitation and prompt authorization.
+
+```sh
+OWNER_NPUB=npub1...
+curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-codex-marmot.sh | \
+  bash -s -- --yes --allow-welcomer "$OWNER_NPUB"
+```
+
+Replace `codex` in the URL with `openclaw`, `opencode`, or `pi`. Hermes keeps
+invite acceptance and message-sender authorization explicit:
+
+```sh
+curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-hermes-marmot.sh | \
+  bash -s -- --yes --allow-welcomer "$OWNER_NPUB" --allow-user "$OWNER_NPUB"
+```
+
+Every installer verifies the downloaded binary and plugin assets against the
+checksums from the same immutable release. For independent
+verification of the installer itself, download its adjacent `.sha256` asset
+before running it.
+
+Use each connector's README for existing-identity imports, shared deployments,
+execution profiles, manual service control, and development workflows.
+
+## How The Connectors Fit Together
 
 Current integrations:
 

--- a/integrations/codex/marmot/README.md
+++ b/integrations/codex/marmot/README.md
@@ -22,41 +22,18 @@ Prerequisites:
 - White Noise phone app pointed at the same public relay set
 - Linux x86_64, Linux arm64, macOS Apple Silicon, or macOS Intel
 
-```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest"
-tmpdir="$(mktemp -d)"
-trap 'rm -rf "$tmpdir"' 0 HUP INT TERM
-curl -fsSL "$base_url/install-codex-marmot.sh" -o "$tmpdir/install-codex-marmot.sh"
-curl -fsSL "$base_url/install-codex-marmot.sh.sha256" -o "$tmpdir/install-codex-marmot.sh.sha256"
-if command -v shasum >/dev/null 2>&1; then
-  (cd "$tmpdir" && shasum -a 256 -c install-codex-marmot.sh.sha256)
-elif command -v sha256sum >/dev/null 2>&1; then
-  (cd "$tmpdir" && sha256sum -c install-codex-marmot.sh.sha256)
-else
-  echo "error: need shasum or sha256sum to verify the installer" >&2
-  exit 1
-fi
-bash "$tmpdir/install-codex-marmot.sh"
-```
+Use the canonical [White Noise + Agents quickstart](../../README.md#codex) for
+the current guided install command and the steps to finish in White Noise.
 
 For noninteractive setup, provide the allowed inviter and prompt sender:
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest"
-tmpdir="$(mktemp -d)"
-trap 'rm -rf "$tmpdir"' 0 HUP INT TERM
-curl -fsSL "$base_url/install-codex-marmot.sh" -o "$tmpdir/install-codex-marmot.sh"
-curl -fsSL "$base_url/install-codex-marmot.sh.sha256" -o "$tmpdir/install-codex-marmot.sh.sha256"
-if command -v shasum >/dev/null 2>&1; then
-  (cd "$tmpdir" && shasum -a 256 -c install-codex-marmot.sh.sha256)
-elif command -v sha256sum >/dev/null 2>&1; then
-  (cd "$tmpdir" && sha256sum -c install-codex-marmot.sh.sha256)
-else
-  echo "error: need shasum or sha256sum to verify the installer" >&2
-  exit 1
-fi
-bash "$tmpdir/install-codex-marmot.sh" --yes --allow-welcomer npub1...
+curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-codex-marmot.sh" | \
+  bash -s -- --yes --allow-welcomer npub1...
 ```
+
+The immutable release also publishes `install-codex-marmot.sh.sha256` for
+independent verification of the installer before execution.
 
 The default install uses its own `~/.marmot-agents/codex` identity and services,
 so it does not share prompts or replies with installed OpenCode or Pi harnesses.

--- a/integrations/hermes/marmot/README.md
+++ b/integrations/hermes/marmot/README.md
@@ -48,27 +48,24 @@ Prerequisites:
 - White Noise phone app pointed at the same public relay set
 - Linux x86_64, Linux arm64, macOS Apple Silicon, or macOS Intel
 
-One-line install:
-
-```sh
-curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-hermes-marmot.sh" | bash
-```
+Use the canonical [White Noise + Agents quickstart](../../README.md#hermes) for
+the current guided install command and the steps to finish in White Noise.
 
 In guided setup, the allowed-message-sender prompt accepts one or more `npub` or
 raw hex public keys separated by commas. Leaving that prompt blank explicitly
 opens Marmot messaging to every sender by writing
 `MARMOT_ALLOW_ALL_USERS=true`.
 
-For repeatable noninteractive setup, pass the allowed inviter/welcomer and allowed
-message sender as either an `npub` or raw hex public key. `--allow-user` may be
-repeated or given a comma-separated list to authorize multiple senders:
+For repeatable noninteractive setup, configure the allowed inviter and message
+sender explicitly:
 
 ```sh
-curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-hermes-marmot.sh" | \
-  bash -s -- --yes \
-    --allow-welcomer npub1... \
-    --allow-user npub1...,0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-hermes-marmot.sh" | \
+  bash -s -- --yes --allow-welcomer npub1... --allow-user npub1...
 ```
+
+Both options may be repeated. `--allow-user` may also contain a comma-separated
+list when the sender set differs from the inviter set.
 
 Generated-identity onboarding is the default (and can be selected explicitly
 with `--generate-identity`). To preserve an existing Nostr identity, place its
@@ -76,7 +73,7 @@ with `--generate-identity`). To preserve an existing Nostr identity, place its
 `0600`, then use a pinned release URL:
 
 ```sh
-curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.9/install-hermes-marmot.sh" | \
+curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-hermes-marmot.sh" | \
   bash -s -- \
     --yes \
     --existing-identity-file "$HOME/.config/example/hermes-agent.nsec" \
@@ -103,7 +100,7 @@ the installers never opt into shared home/socket state silently.
 To accept Marmot messages from any sender (explicit opt-in):
 
 ```sh
-curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-hermes-marmot.sh" | \
+curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-hermes-marmot.sh" | \
   bash -s -- --yes --allow-all-users
 ```
 

--- a/integrations/hermes/marmot/tests/test_installer_env.sh
+++ b/integrations/hermes/marmot/tests/test_installer_env.sh
@@ -69,7 +69,7 @@ case "$archive_name" in
         cat >"$output_dir/wn-agent" <<'SCRIPT'
 #!/usr/bin/env bash
 if [ "${1:-}" = bootstrap ]; then
-    printf '%s\n' '{"account_id_hex":"aa4fc8665f5696e33db7e1a572e3b0f5b3d615837b0f362dcb1c8068b098c7b4","welcomer_account_ids_hex":["bb"]}'
+    printf '%s\n' '{"account_id_hex":"aa4fc8665f5696e33db7e1a572e3b0f5b3d615837b0f362dcb1c8068b098c7b4","welcomer_account_ids_hex":["bb"],"npub":"npub-test","nprofile":"nprofile-test"}'
 fi
 SCRIPT
         chmod +x "$output_dir/wn-agent"

--- a/integrations/openclaw/marmot/README.md
+++ b/integrations/openclaw/marmot/README.md
@@ -46,9 +46,8 @@ Prerequisites:
 - Node ≥ 22.19
 - Linux x86_64, Linux arm64, macOS Apple Silicon, or macOS Intel
 
-```sh
-curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-openclaw-marmot.sh" | bash
-```
+Use the canonical [White Noise + Agents quickstart](../../README.md#openclaw)
+for the current guided install command and the steps to finish in White Noise.
 
 The installer puts `wn-agent` in `~/.local/bin`, downloads and verifies the plugin
 tarball, runs `openclaw plugins install`, enables the `marmot` channel, starts a
@@ -59,11 +58,11 @@ Set `MARMOT_RELEASE_REPO`, `MARMOT_RELEASE_TAG`, and `WN_AGENT_VERSION` (or the
 legacy `WN_AGENT_SHA` alias) to install a non-default release asset, matching
 the Hermes installer.
 
-For repeatable noninteractive setup, pass the allowed inviter/welcomer as either
-an `npub` or raw hex public key:
+For repeatable noninteractive setup, pass the White Noise owner as either an
+`npub` or raw hex public key:
 
 ```sh
-curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-openclaw-marmot.sh" | \
+curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-openclaw-marmot.sh" | \
   bash -s -- --yes --allow-welcomer npub1...
 ```
 
@@ -73,7 +72,7 @@ with `--generate-identity`). To preserve an existing Nostr identity, place its
 `0600`, then use a pinned release URL:
 
 ```sh
-curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.9/install-openclaw-marmot.sh" | \
+curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-openclaw-marmot.sh" | \
   bash -s -- \
     --yes \
     --existing-identity-file "$HOME/.config/example/openclaw-agent.nsec" \

--- a/integrations/opencode/marmot/README.md
+++ b/integrations/opencode/marmot/README.md
@@ -23,17 +23,14 @@ Prerequisites:
 - White Noise phone app pointed at the same public relay set
 - Linux x86_64, Linux arm64, macOS Apple Silicon, or macOS Intel
 
-One-line install:
-
-```sh
-curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-opencode-marmot.sh" | bash
-```
+Use the canonical [White Noise + Agents quickstart](../../README.md#opencode)
+for the current guided install command and the steps to finish in White Noise.
 
 For repeatable noninteractive setup, pass the allowed inviter and prompt sender
 as either an `npub` or raw hex public key:
 
 ```sh
-curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-opencode-marmot.sh" | \
+curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-opencode-marmot.sh" | \
   bash -s -- --yes --allow-welcomer npub1...
 ```
 

--- a/integrations/pi/marmot/README.md
+++ b/integrations/pi/marmot/README.md
@@ -17,14 +17,13 @@ Prerequisites:
 - White Noise phone app pointed at the same public relay set
 - Linux x86_64, Linux arm64, macOS Apple Silicon, or macOS Intel
 
-```sh
-curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-pi-marmot.sh" | bash
-```
+Use the canonical [White Noise + Agents quickstart](../../README.md#pi) for the
+current guided install command and the steps to finish in White Noise.
 
 For noninteractive setup, provide the allowed inviter and prompt sender:
 
 ```sh
-curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-pi-marmot.sh" | \
+curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-pi-marmot.sh" | \
   bash -s -- --yes --allow-welcomer npub1...
 ```
 

--- a/integrations/terminal-harness/tests/test_installer.sh
+++ b/integrations/terminal-harness/tests/test_installer.sh
@@ -93,6 +93,7 @@ run_linux_service_case() {
     : >"$log_file"
     SYSTEMCTL_ACTIVE="$active" \
     SYSTEMCTL_LOG="$log_file" \
+    TEST_LEGACY_BOOTSTRAP="${TEST_LEGACY_BOOTSTRAP:-0}" \
     TEST_HARNESS_BINARY="$harness_binary" \
     HOME="$fixture_root/home" \
     MARMOT_HOME="$fixture_root/marmot-home" \
@@ -205,8 +206,12 @@ cat >/dev/null
 case "$code" in
     *account_id_hex*) printf '%s\n' aa ;;
     *welcomer_account_ids_hex*) printf '%s\n' bb ;;
-    *'json.load(sys.stdin)["npub"]'*) printf '%s\n' npub-test ;;
-    *'json.load(sys.stdin)["nprofile"]'*) printf '%s\n' nprofile-test ;;
+    *'json.load(sys.stdin).get("npub", "")'*)
+        [ "${TEST_LEGACY_BOOTSTRAP:-0}" = 1 ] || printf '%s\n' npub-test
+        ;;
+    *'json.load(sys.stdin).get("nprofile", "")'*)
+        [ "${TEST_LEGACY_BOOTSTRAP:-0}" = 1 ] || printf '%s\n' nprofile-test
+        ;;
     *) exit 1 ;;
 esac
 EOF
@@ -222,6 +227,12 @@ if grep -Fq "To run it manually:" "$installer_output"; then
     echo "$kind installer printed manual-start steps after starting services" >&2
     exit 1
 fi
+
+legacy_log="$fixture_root/systemctl-legacy.log"
+TEST_LEGACY_BOOTSTRAP=1 run_linux_service_case "$fixture_root" 1 "$legacy_log" --no-service
+legacy_output="$fixture_root/installer-output.log"
+grep -F "White Noise agent identity was not returned by this wn-agent release." "$legacy_output" >/dev/null
+grep -F "Inspect the bootstrap response at: $fixture_root/marmot-home/bootstrap.json" "$legacy_output" >/dev/null
 assert_log_contains "$fresh_log" "--user enable --now $agent_service"
 assert_log_contains "$fresh_log" "--user enable --now $harness_service"
 assert_log_excludes "$fresh_log" "--user restart $agent_service"

--- a/integrations/terminal-harness/tests/test_installer.sh
+++ b/integrations/terminal-harness/tests/test_installer.sh
@@ -170,7 +170,7 @@ mkdir -p "$destination/$binary-$platform"
 cat >"$destination/$binary-$platform/$binary" <<'SCRIPT'
 #!/usr/bin/env bash
 if [ "${1:-}" = bootstrap ]; then
-    printf '%s\n' '{"account_id_hex":"aa","welcomer_account_ids_hex":["bb"]}'
+    printf '%s\n' '{"account_id_hex":"aa","welcomer_account_ids_hex":["bb"],"npub":"npub-test","nprofile":"nprofile-test"}'
 fi
 SCRIPT
 chmod +x "$destination/$binary-$platform/$binary"
@@ -205,6 +205,8 @@ cat >/dev/null
 case "$code" in
     *account_id_hex*) printf '%s\n' aa ;;
     *welcomer_account_ids_hex*) printf '%s\n' bb ;;
+    *'json.load(sys.stdin)["npub"]'*) printf '%s\n' npub-test ;;
+    *'json.load(sys.stdin)["nprofile"]'*) printf '%s\n' nprofile-test ;;
     *) exit 1 ;;
 esac
 EOF
@@ -212,6 +214,14 @@ chmod +x "$mock_bin"/*
 
 fresh_log="$fixture_root/systemctl-fresh.log"
 run_linux_service_case "$fixture_root" 0 "$fresh_log"
+installer_output="$fixture_root/installer-output.log"
+grep -F "npub: npub-test" "$installer_output" >/dev/null
+grep -F "nprofile: nprofile-test" "$installer_output" >/dev/null
+grep -F "Services were installed and started for the current user." "$installer_output" >/dev/null
+if grep -Fq "To run it manually:" "$installer_output"; then
+    echo "$kind installer printed manual-start steps after starting services" >&2
+    exit 1
+fi
 assert_log_contains "$fresh_log" "--user enable --now $agent_service"
 assert_log_contains "$fresh_log" "--user enable --now $harness_service"
 assert_log_excludes "$fresh_log" "--user restart $agent_service"
@@ -428,6 +438,10 @@ esac
 case "$installer_dry_run" in
     *"Terminal harness agent:"*"home: $default_home"* ) ;;
     *) echo "$kind installer dry-run did not use terminal harness Marmot home" >&2; exit 1;;
+esac
+case "$installer_dry_run" in
+    *"Dry run complete. No services were installed or started."* ) ;;
+    *) echo "$kind installer dry-run claimed that services were started" >&2; exit 1;;
 esac
 case "$installer_dry_run" in
     *"--socket $default_home/dev/wn-agent.sock"* ) ;;

--- a/integrations/test_installer_systemd_service.sh
+++ b/integrations/test_installer_systemd_service.sh
@@ -89,7 +89,11 @@ case "${1:-}" in
         printf '%s\n' '{"account_id_hex":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","label":"imported-agent","local_signing":true}'
         ;;
     bootstrap)
-        printf '%s\n' '{"account_id_hex":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","created":false,"welcomer_account_ids_hex":["bb"],"npub":"npub-test","nprofile":"nprofile-test"}'
+        if [ "${WN_AGENT_LEGACY_BOOTSTRAP:-0}" = 1 ]; then
+            printf '%s\n' '{"account_id_hex":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","created":false,"welcomer_account_ids_hex":["bb"]}'
+        else
+            printf '%s\n' '{"account_id_hex":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","created":false,"welcomer_account_ids_hex":["bb"],"npub":"npub-test","nprofile":"nprofile-test"}'
+        fi
         ;;
 esac
 SCRIPT
@@ -137,6 +141,7 @@ run_case() {
     local log_file="$3"
     shift 3
     local case_root="$fixture_root/$name"
+    local output_file="$case_root/installer-output.log"
 
     mkdir -p "$case_root"
     : >"$log_file"
@@ -144,6 +149,7 @@ run_case() {
     SYSTEMCTL_ACTIVE="$active" \
     SYSTEMCTL_LOG="$log_file" \
     WN_AGENT_LOG="$case_root/wn-agent.log" \
+    WN_AGENT_LEGACY_BOOTSTRAP="${WN_AGENT_LEGACY_BOOTSTRAP:-0}" \
     HOME="$case_root/home" \
     HERMES_HOME="$case_root/hermes-home" \
     OPENCLAW_HOME="$case_root/openclaw-home" \
@@ -152,7 +158,7 @@ run_case() {
     PATH="$mock_bin:/usr/bin:/bin" \
     WN_AGENT_SHA="9.9.9" \
     MARMOT_RELEASE_TAG="wn-agent-v9.9.9-test" \
-        "$installer" --yes "$configure_flag" --allow-welcomer "$allow_hex" "$@" >/dev/null 2>&1
+        "$installer" --yes "$configure_flag" --allow-welcomer "$allow_hex" "$@" >"$output_file" 2>&1
 }
 
 assert_log_equals() {
@@ -169,9 +175,18 @@ assert_log_equals() {
 
 fresh_log="$fixture_root/systemctl-fresh.log"
 run_case fresh 0 "$fresh_log"
+fresh_output="$fixture_root/fresh/installer-output.log"
+grep -F "npub: npub-test" "$fresh_output" >/dev/null
+grep -F "nprofile: nprofile-test" "$fresh_output" >/dev/null
 assert_log_equals "$fresh_log" "--user daemon-reload
 --user is-active --quiet $service
 --user enable --now $service"
+
+legacy_log="$fixture_root/systemctl-legacy.log"
+WN_AGENT_LEGACY_BOOTSTRAP=1 run_case legacy 0 "$legacy_log" --no-service
+legacy_output="$fixture_root/legacy/installer-output.log"
+grep -F "White Noise agent identity was not returned by this wn-agent release." "$legacy_output" >/dev/null
+grep -F "Inspect the bootstrap response at: $fixture_root/legacy/marmot-home/bootstrap.json" "$legacy_output" >/dev/null
 
 upgrade_log="$fixture_root/systemctl-upgrade.log"
 run_case upgrade 1 "$upgrade_log"

--- a/integrations/test_installer_systemd_service.sh
+++ b/integrations/test_installer_systemd_service.sh
@@ -89,7 +89,7 @@ case "${1:-}" in
         printf '%s\n' '{"account_id_hex":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","label":"imported-agent","local_signing":true}'
         ;;
     bootstrap)
-        printf '%s\n' '{"account_id_hex":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","created":false,"welcomer_account_ids_hex":["bb"]}'
+        printf '%s\n' '{"account_id_hex":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","created":false,"welcomer_account_ids_hex":["bb"],"npub":"npub-test","nprofile":"nprofile-test"}'
         ;;
 esac
 SCRIPT
@@ -207,6 +207,7 @@ case "$(cat "$wn_agent_log")" in
     *) echo "$flavor installer did not import then bootstrap the exact existing identity" >&2; exit 1 ;;
 esac
 bootstrap_json="$fixture_root/existing/marmot-home/bootstrap.json"
+[ "$(stat -c %a "$bootstrap_json")" = 600 ]
 python3 - "$bootstrap_json" <<'PY'
 import json
 import sys

--- a/release.md
+++ b/release.md
@@ -340,26 +340,25 @@ The release job creates these assets:
 Each binary/plugin tarball carries a `manifest.json` recording the release tag, artifact version, source commit, and
 workspace version (the OpenClaw tarball's `package.json` version is also stamped to the cohort version at release time).
 
-The installer assets are generated during the release and default to their own `wn-agent-v<version>` release tag and
-`<version>` asset suffix. When a non-draft WN Agent release completes, the workflow also refreshes a
-`wn-agent-latest` prerelease containing only installer scripts; those scripts are baked to the newest immutable
-`wn-agent-v<version>` assets. A latest-by-default install looks like:
+The installer assets are generated during the release and default to their own immutable `wn-agent-v<version>` release
+tag and `<version>` asset suffix. The historical `wn-agent-latest` release is immutable and is not an authoritative
+update channel. User-facing commands must name a versioned release. For the current release:
 
 ```sh
 # Hermes gateway
-curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-hermes-marmot.sh | bash
+curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-hermes-marmot.sh | bash
 # OpenClaw gateway
-curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-openclaw-marmot.sh | bash
+curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-openclaw-marmot.sh | bash
 # Codex terminal harness
-curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-codex-marmot.sh | bash
+curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-codex-marmot.sh | bash
 # OpenCode terminal harness
-curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-opencode-marmot.sh | bash
+curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-opencode-marmot.sh | bash
 # Pi terminal harness
-curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-pi-marmot.sh | bash
+curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-pi-marmot.sh | bash
 ```
 
-Use the versioned `wn-agent-v<version>` release URLs instead when you need a pinned install for repeatable testing or
-bug reports.
+Update this section as part of a deliberate release-version bump. Use the exact version from the installed connector
+when reporting bugs.
 
 These one-liners perform full setup by default: they install `wn-agent`, install/enable the matching gateway plugin or
 harness binary, start same-user services where supported, bootstrap or reuse the default connector-specific Marmot

--- a/scripts/check_agent_install_docs.sh
+++ b/scripts/check_agent_install_docs.sh
@@ -21,13 +21,26 @@ active_paths=(
     .github/workflows/wn-agent-binaries.yml
 )
 
-for connector in hermes openclaw codex opencode pi; do
-    expected="releases/download/wn-agent-v${workspace_version}/install-${connector}-marmot.sh"
-    if ! rg -F -q "$expected" integrations/README.md; then
-        echo "error: integrations/README.md is missing the current $connector installer URL ($expected)" >&2
-        exit 1
-    fi
-done
+python3 - "$workspace_version" <<'PY'
+from pathlib import Path
+import sys
+
+version = sys.argv[1]
+quickstart = Path("integrations/README.md").read_text(encoding="utf-8")
+for connector in ("hermes", "openclaw", "codex", "opencode", "pi"):
+    url = (
+        "https://github.com/marmot-protocol/mdk/releases/download/"
+        f"wn-agent-v{version}/install-{connector}-marmot.sh"
+    )
+    block = f"```sh\ncurl -fsSL {url} | bash\n```"
+    if quickstart.count(block) != 1:
+        print(
+            "error: integrations/README.md must contain exactly one copy-pasteable "
+            f"one-line sh block for the current {connector} installer ({url})",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+PY
 
 if rg -n 'releases/download/wn-agent-latest/install-' "${active_paths[@]}"; then
     echo "error: active agent install guidance must use an immutable versioned release" >&2

--- a/scripts/check_agent_install_docs.sh
+++ b/scripts/check_agent_install_docs.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+workspace_version="$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n 1)"
+[ -n "$workspace_version" ] || {
+    echo "error: could not read the workspace version" >&2
+    exit 1
+}
+
+active_paths=(
+    README.md
+    integrations
+    crates/agent-connector/README.md
+    release.md
+    scripts/install-hermes-marmot.sh
+    scripts/install-openclaw-marmot.sh
+    scripts/install-terminal-harness-marmot.sh
+    .github/workflows/wn-agent-binaries.yml
+)
+
+for connector in hermes openclaw codex opencode pi; do
+    expected="releases/download/wn-agent-v${workspace_version}/install-${connector}-marmot.sh"
+    if ! rg -F -q "$expected" integrations/README.md; then
+        echo "error: integrations/README.md is missing the current $connector installer URL ($expected)" >&2
+        exit 1
+    fi
+done
+
+if rg -n 'releases/download/wn-agent-latest/install-' "${active_paths[@]}"; then
+    echo "error: active agent install guidance must use an immutable versioned release" >&2
+    exit 1
+fi
+
+stale_versioned_urls="$(
+    rg -n -o 'wn-agent-v[0-9]+\.[0-9]+\.[0-9]+/install-(hermes|openclaw|codex|opencode|pi)-marmot\.sh' \
+        "${active_paths[@]}" |
+        grep -F -v "wn-agent-v${workspace_version}/" || true
+)"
+if [ -n "$stale_versioned_urls" ]; then
+    printf '%s\n' "$stale_versioned_urls" >&2
+    echo "error: agent install guidance does not match workspace version $workspace_version" >&2
+    exit 1
+fi
+
+if rg -n 'releases/download/\$latest_tag/install-' .github/workflows/wn-agent-binaries.yml; then
+    echo "error: generated release notes must link to the immutable release tag" >&2
+    exit 1
+fi
+
+echo "agent install documentation matches wn-agent-v$workspace_version"

--- a/scripts/cut-full-release.sh
+++ b/scripts/cut-full-release.sh
@@ -119,10 +119,8 @@ if [ -n "$(git status --porcelain)" ]; then
     fi
 fi
 
-# Fetch only the immutable release-track tags used below. The
-# `wn-agent-latest` installer alias intentionally moves after publication, and
-# a blanket `--tags` fetch rejects that normal movement as a clobber when a
-# caller has an older local copy.
+# Fetch only the immutable release-track tags used below. The historical
+# `wn-agent-latest` tag is not an authoritative update channel and is excluded.
 run git fetch --no-tags origin master \
     'refs/tags/v*:refs/tags/v*' \
     'refs/tags/wn-agent-v*:refs/tags/wn-agent-v*' \
@@ -358,14 +356,6 @@ if [ "$push" -eq 1 ] && [ "$wait" -eq 1 ]; then
 
     verify_release "$mdk_tag" "v$version - MDK" "$([ "$draft" -eq 1 ] && echo true || echo false)" false 0
     verify_release "$wn_tag" "v$version - wn-agent" "$([ "$draft" -eq 1 ] && echo true || echo false)" true 14
-    if [ "$draft" -eq 0 ]; then
-        latest_immutable="$(gh api "repos/$repo/releases/tags/wn-agent-latest" --jq '.immutable' 2>/dev/null || true)"
-        if [ "$latest_immutable" = "true" ]; then
-            echo "warning: wn-agent-latest is immutable; verified the versioned WN Agent release only"
-        else
-            verify_release "wn-agent-latest" "Latest WN Agent installers" false true 3
-        fi
-    fi
     verify_release "$marmotkit_tag" "v$version - MarmotKit" "$([ "$draft" -eq 1 ] && echo true || echo false)" false 4
 elif [ "$push" -eq 1 ]; then
     echo "pushed release tags; artifact workflows will finish asynchronously"

--- a/scripts/install-hermes-marmot.sh
+++ b/scripts/install-hermes-marmot.sh
@@ -1165,11 +1165,11 @@ bootstrap_agent() {
     )"
     BOOTSTRAP_NPUB="$(
         printf '%s\n' "$bootstrap_json" |
-            python3 -c 'import json, sys; print(json.load(sys.stdin)["npub"])'
+            python3 -c 'import json, sys; print(json.load(sys.stdin).get("npub", ""))'
     )"
     BOOTSTRAP_NPROFILE="$(
         printf '%s\n' "$bootstrap_json" |
-            python3 -c 'import json, sys; print(json.load(sys.stdin)["nprofile"])'
+            python3 -c 'import json, sys; print(json.load(sys.stdin).get("nprofile", ""))'
     )"
     log "bootstrap details -> $BOOTSTRAP_JSON_PATH"
 }
@@ -1232,14 +1232,22 @@ configure_hermes_gateway() {
 }
 
 print_phone_invite() {
-    cat <<EOF
+    if [ -n "$BOOTSTRAP_NPUB" ] && [ -n "$BOOTSTRAP_NPROFILE" ]; then
+        cat <<EOF
 
 White Noise agent identity:
   npub: $BOOTSTRAP_NPUB
   nprofile: $BOOTSTRAP_NPROFILE
 EOF
-    if [ "$DRY_RUN" -eq 0 ] && [ -t 1 ] && command -v qrencode >/dev/null 2>&1; then
-        printf '%s' "$BOOTSTRAP_NPROFILE" | qrencode -t ANSIUTF8
+        if [ "$DRY_RUN" -eq 0 ] && [ -t 1 ] && command -v qrencode >/dev/null 2>&1; then
+            printf '%s' "$BOOTSTRAP_NPROFILE" | qrencode -t ANSIUTF8
+        fi
+    else
+        cat <<EOF
+
+White Noise agent identity was not returned by this wn-agent release.
+Inspect the bootstrap response at: $BOOTSTRAP_JSON_PATH
+EOF
     fi
 }
 

--- a/scripts/install-hermes-marmot.sh
+++ b/scripts/install-hermes-marmot.sh
@@ -47,6 +47,8 @@ SYSTEM_INSTALL=0
 CLI_RELAYS=0
 BOOTSTRAP_ACCOUNT_ID_HEX=""
 BOOTSTRAP_JSON_PATH=""
+BOOTSTRAP_NPUB=""
+BOOTSTRAP_NPROFILE=""
 EXISTING_IDENTITY_FILE=""
 EXISTING_IDENTITY_PROMPT=0
 GENERATE_IDENTITY_EXPLICIT=0
@@ -115,13 +117,10 @@ through wn-agent. Message-sender allowlist entries control which Marmot senders
 Hermes accepts after gateway restart via $HERMES_HOME/.env.
 
 Example:
-  curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-hermes-marmot.sh | bash
+  curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-hermes-marmot.sh | bash
 
   curl -fsSL .../install-hermes-marmot.sh | bash -s -- --yes \
-    --existing-identity-file "$HOME/.config/example/hermes-agent.nsec" \
-    --allow-welcomer npub1... \
-    --expected-npub npub1... \
-    --allow-user npub1...
+    --allow-welcomer npub1... --allow-user npub1...
 
   curl -fsSL .../install-hermes-marmot.sh | bash -s -- --yes \
     --allow-all-users
@@ -1147,6 +1146,8 @@ bootstrap_agent() {
         printf '\n'
         BOOTSTRAP_ACCOUNT_ID_HEX="<account-id-from-bootstrap>"
         BOOTSTRAP_JSON_PATH="$MARMOT_HOME/bootstrap.json"
+        BOOTSTRAP_NPUB="<agent-npub-from-bootstrap>"
+        BOOTSTRAP_NPROFILE="<agent-nprofile-from-bootstrap>"
         return 0
     fi
 
@@ -1154,10 +1155,21 @@ bootstrap_agent() {
     local bootstrap_json
     bootstrap_json="$(wn-agent "${args[@]}")"
     BOOTSTRAP_JSON_PATH="$MARMOT_HOME/bootstrap.json"
-    printf '%s\n' "$bootstrap_json" >"$BOOTSTRAP_JSON_PATH"
+    (
+        umask 077
+        printf '%s\n' "$bootstrap_json" >"$BOOTSTRAP_JSON_PATH"
+    )
     BOOTSTRAP_ACCOUNT_ID_HEX="$(
         printf '%s\n' "$bootstrap_json" |
             python3 -c 'import json, sys; print(json.load(sys.stdin)["account_id_hex"])'
+    )"
+    BOOTSTRAP_NPUB="$(
+        printf '%s\n' "$bootstrap_json" |
+            python3 -c 'import json, sys; print(json.load(sys.stdin)["npub"])'
+    )"
+    BOOTSTRAP_NPROFILE="$(
+        printf '%s\n' "$bootstrap_json" |
+            python3 -c 'import json, sys; print(json.load(sys.stdin)["nprofile"])'
     )"
     log "bootstrap details -> $BOOTSTRAP_JSON_PATH"
 }
@@ -1219,9 +1231,22 @@ configure_hermes_gateway() {
     run python3 "${args[@]}"
 }
 
+print_phone_invite() {
+    cat <<EOF
+
+White Noise agent identity:
+  npub: $BOOTSTRAP_NPUB
+  nprofile: $BOOTSTRAP_NPROFILE
+EOF
+    if [ "$DRY_RUN" -eq 0 ] && [ -t 1 ] && command -v qrencode >/dev/null 2>&1; then
+        printf '%s' "$BOOTSTRAP_NPROFILE" | qrencode -t ANSIUTF8
+    fi
+}
+
 print_next_steps() {
-    # Account ids stay in the bootstrap/config files but are intentionally
-    # omitted here to keep installer diagnostics privacy-safe.
+    # Public onboarding identifiers are printed only in this explicit success
+    # summary; normal diagnostics remain identifier-free.
+    print_phone_invite
     cat <<EOF
 
 Install complete.
@@ -1246,6 +1271,9 @@ Hermes:
 
 Restart your existing Hermes gateway when you are ready for it to load the Marmot plugin/config:
   hermes gateway restart
+
+Then add the agent identity above in White Noise, invite it from an authorized
+account, and send a test message.
 
 Hermes loads sender authorization from $HERMES_HOME/.env at gateway startup.
 After changing MARMOT_ALLOWED_USERS or MARMOT_ALLOW_ALL_USERS, restart Hermes

--- a/scripts/install-openclaw-marmot.sh
+++ b/scripts/install-openclaw-marmot.sh
@@ -49,6 +49,8 @@ CLI_RELAYS=0
 BOOTSTRAP_ACCOUNT_ID_HEX=""
 BOOTSTRAP_JSON_PATH=""
 BOOTSTRAP_WELCOMER_ALLOWLIST_CSV=""
+BOOTSTRAP_NPUB=""
+BOOTSTRAP_NPROFILE=""
 EXISTING_IDENTITY_FILE=""
 EXISTING_IDENTITY_PROMPT=0
 GENERATE_IDENTITY_EXPLICIT=0
@@ -107,7 +109,7 @@ Environment:
   MARMOT_WELCOMER_ALLOWLIST Comma-separated npub or hex allowlist values
 
 Example:
-  curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-openclaw-marmot.sh | bash
+  curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-openclaw-marmot.sh | bash
 
   curl -fsSL .../install-openclaw-marmot.sh | bash -s -- --yes --allow-welcomer npub1...
 
@@ -627,6 +629,8 @@ bootstrap_agent() {
         BOOTSTRAP_ACCOUNT_ID_HEX="<account-id-from-bootstrap>"
         BOOTSTRAP_JSON_PATH="$MARMOT_HOME/bootstrap.json"
         BOOTSTRAP_WELCOMER_ALLOWLIST_CSV=""
+        BOOTSTRAP_NPUB="<agent-npub-from-bootstrap>"
+        BOOTSTRAP_NPROFILE="<agent-nprofile-from-bootstrap>"
         return 0
     fi
 
@@ -634,7 +638,10 @@ bootstrap_agent() {
     local bootstrap_json
     bootstrap_json="$(wn-agent "${args[@]}")"
     BOOTSTRAP_JSON_PATH="$MARMOT_HOME/bootstrap.json"
-    printf '%s\n' "$bootstrap_json" >"$BOOTSTRAP_JSON_PATH"
+    (
+        umask 077
+        printf '%s\n' "$bootstrap_json" >"$BOOTSTRAP_JSON_PATH"
+    )
     BOOTSTRAP_ACCOUNT_ID_HEX="$(
         printf '%s\n' "$bootstrap_json" |
             python3 -c 'import json, sys; print(json.load(sys.stdin)["account_id_hex"])'
@@ -642,6 +649,14 @@ bootstrap_agent() {
     BOOTSTRAP_WELCOMER_ALLOWLIST_CSV="$(
         printf '%s\n' "$bootstrap_json" |
             python3 -c 'import json, sys; print(",".join(json.load(sys.stdin).get("welcomer_account_ids_hex", [])))'
+    )"
+    BOOTSTRAP_NPUB="$(
+        printf '%s\n' "$bootstrap_json" |
+            python3 -c 'import json, sys; print(json.load(sys.stdin)["npub"])'
+    )"
+    BOOTSTRAP_NPROFILE="$(
+        printf '%s\n' "$bootstrap_json" |
+            python3 -c 'import json, sys; print(json.load(sys.stdin)["nprofile"])'
     )"
     log "bootstrap details -> $BOOTSTRAP_JSON_PATH"
 }
@@ -713,7 +728,20 @@ NODE
     log "patched OpenClaw Marmot channel config -> $config_path"
 }
 
+print_phone_invite() {
+    cat <<EOF
+
+White Noise agent identity:
+  npub: $BOOTSTRAP_NPUB
+  nprofile: $BOOTSTRAP_NPROFILE
+EOF
+    if [ "$DRY_RUN" -eq 0 ] && [ -t 1 ] && command -v qrencode >/dev/null 2>&1; then
+        printf '%s' "$BOOTSTRAP_NPROFILE" | qrencode -t ANSIUTF8
+    fi
+}
+
 print_next_steps() {
+    print_phone_invite
     cat <<EOF
 
 Install complete.
@@ -739,6 +767,9 @@ OpenClaw:
 
 Restart your existing OpenClaw gateway when you are ready for it to load the Marmot plugin/config:
   openclaw gateway run
+
+Then add the agent identity above in White Noise, invite it from an authorized
+account, and send a test message.
 
 Existing OpenClaw channels were not removed or disabled. The installer only installed the Marmot plugin and updated channels.marmot.
 

--- a/scripts/install-openclaw-marmot.sh
+++ b/scripts/install-openclaw-marmot.sh
@@ -652,11 +652,11 @@ bootstrap_agent() {
     )"
     BOOTSTRAP_NPUB="$(
         printf '%s\n' "$bootstrap_json" |
-            python3 -c 'import json, sys; print(json.load(sys.stdin)["npub"])'
+            python3 -c 'import json, sys; print(json.load(sys.stdin).get("npub", ""))'
     )"
     BOOTSTRAP_NPROFILE="$(
         printf '%s\n' "$bootstrap_json" |
-            python3 -c 'import json, sys; print(json.load(sys.stdin)["nprofile"])'
+            python3 -c 'import json, sys; print(json.load(sys.stdin).get("nprofile", ""))'
     )"
     log "bootstrap details -> $BOOTSTRAP_JSON_PATH"
 }
@@ -729,14 +729,22 @@ NODE
 }
 
 print_phone_invite() {
-    cat <<EOF
+    if [ -n "$BOOTSTRAP_NPUB" ] && [ -n "$BOOTSTRAP_NPROFILE" ]; then
+        cat <<EOF
 
 White Noise agent identity:
   npub: $BOOTSTRAP_NPUB
   nprofile: $BOOTSTRAP_NPROFILE
 EOF
-    if [ "$DRY_RUN" -eq 0 ] && [ -t 1 ] && command -v qrencode >/dev/null 2>&1; then
-        printf '%s' "$BOOTSTRAP_NPROFILE" | qrencode -t ANSIUTF8
+        if [ "$DRY_RUN" -eq 0 ] && [ -t 1 ] && command -v qrencode >/dev/null 2>&1; then
+            printf '%s' "$BOOTSTRAP_NPROFILE" | qrencode -t ANSIUTF8
+        fi
+    else
+        cat <<EOF
+
+White Noise agent identity was not returned by this wn-agent release.
+Inspect the bootstrap response at: $BOOTSTRAP_JSON_PATH
+EOF
     fi
 }
 

--- a/scripts/install-terminal-harness-marmot.sh
+++ b/scripts/install-terminal-harness-marmot.sh
@@ -106,6 +106,8 @@ ACKNOWLEDGE_UNRESTRICTED=0
 WN_AGENT_TEMP_PID=""
 BOOTSTRAP_ACCOUNT_ID_HEX=""
 BOOTSTRAP_ALLOWED_SENDERS_HEX=""
+BOOTSTRAP_NPUB=""
+BOOTSTRAP_NPROFILE=""
 MARMOT_AGENT_SOCKET_SET=0
 if [ -n "$MARMOT_AGENT_SOCKET_OVERRIDE" ]; then
     MARMOT_AGENT_SOCKET_SET=1
@@ -820,6 +822,8 @@ bootstrap_agent() {
         printf '\n'
         BOOTSTRAP_ACCOUNT_ID_HEX="<account-id-from-bootstrap>"
         BOOTSTRAP_ALLOWED_SENDERS_HEX="${HARNESS_CONFIGURED_SENDERS_HEX:-<allowlist-from-bootstrap>}"
+        BOOTSTRAP_NPUB="<agent-npub-from-bootstrap>"
+        BOOTSTRAP_NPROFILE="<agent-nprofile-from-bootstrap>"
         return 0
     fi
 
@@ -841,6 +845,14 @@ bootstrap_agent() {
             python3 -c 'import json, sys; print(",".join(json.load(sys.stdin).get("welcomer_account_ids_hex", [])))'
     )"
     BOOTSTRAP_ALLOWED_SENDERS_HEX="${HARNESS_CONFIGURED_SENDERS_HEX:-$bootstrap_welcomers_hex}"
+    BOOTSTRAP_NPUB="$(
+        printf '%s\n' "$bootstrap_json" |
+            python3 -c 'import json, sys; print(json.load(sys.stdin)["npub"])'
+    )"
+    BOOTSTRAP_NPROFILE="$(
+        printf '%s\n' "$bootstrap_json" |
+            python3 -c 'import json, sys; print(json.load(sys.stdin)["nprofile"])'
+    )"
     if [ -z "$BOOTSTRAP_ACCOUNT_ID_HEX" ]; then
         echo "error: bootstrap did not return an account id" >&2
         exit 1
@@ -850,6 +862,18 @@ bootstrap_agent() {
         exit 1
     fi
     log "bootstrap details -> $MARMOT_HOME/bootstrap.json"
+}
+
+print_phone_invite() {
+    cat <<EOF
+
+White Noise agent identity:
+  npub: $BOOTSTRAP_NPUB
+  nprofile: $BOOTSTRAP_NPROFILE
+EOF
+    if [ "$DRY_RUN" -eq 0 ] && [ -t 1 ] && command -v qrencode >/dev/null 2>&1; then
+        printf '%s' "$BOOTSTRAP_NPROFILE" | qrencode -t ANSIUTF8
+    fi
 }
 
 write_harness_env() {
@@ -880,6 +904,7 @@ write_harness_env() {
 }
 
 print_next_steps() {
+    print_phone_invite
     cat <<EOF
 
 Install complete.
@@ -890,14 +915,35 @@ Terminal harness agent:
   socket: $MARMOT_AGENT_SOCKET
   service: $MARMOT_AGENT_SERVICE_NAME.service (Linux) / $MARMOT_AGENT_LAUNCHD_LABEL (macOS)
 
+EOF
+    if [ "$DRY_RUN" -eq 1 ]; then
+        cat <<EOF
+Dry run complete. No services were installed or started.
+EOF
+    elif [ "$INSTALL_SERVICE" -eq 1 ] && [ "$NO_START_WN_AGENT" -eq 0 ] && [ "$NO_START_HARNESS" -eq 0 ]; then
+        cat <<EOF
+Services were installed and started for the current user.
+
 Next steps:
-  1. Ensure binaries are on your PATH ($(install_dir))
+  1. Add the agent identity above in White Noise.
+  2. Invite it from an authorized account.
+  3. Send a test message. Use /<path> first to select a working directory.
+EOF
+    else
+        cat <<EOF
+The connector or harness was left stopped by the selected install options.
+
+To run it manually:
+  1. Ensure binaries are on your PATH ($(install_dir)).
   2. Start wn-agent:
      wn-agent --home "$MARMOT_HOME" --socket "$MARMOT_AGENT_SOCKET"
-  3. Load the harness env:
+  3. In another shell, load the harness environment and start $HARNESS_BINARY:
      . "$MARMOT_HOME/dev/$HARNESS_BINARY.env"
-  4. Start $HARNESS_BINARY:
      $HARNESS_BINARY
+  4. Add the agent identity above in White Noise, invite it, and send a test message.
+EOF
+    fi
+    cat <<EOF
 
 Build: ${MARMOT_RELEASE_REPO}@${MARMOT_RELEASE_TAG} (${WN_AGENT_VERSION})
 EOF

--- a/scripts/install-terminal-harness-marmot.sh
+++ b/scripts/install-terminal-harness-marmot.sh
@@ -847,11 +847,11 @@ bootstrap_agent() {
     BOOTSTRAP_ALLOWED_SENDERS_HEX="${HARNESS_CONFIGURED_SENDERS_HEX:-$bootstrap_welcomers_hex}"
     BOOTSTRAP_NPUB="$(
         printf '%s\n' "$bootstrap_json" |
-            python3 -c 'import json, sys; print(json.load(sys.stdin)["npub"])'
+            python3 -c 'import json, sys; print(json.load(sys.stdin).get("npub", ""))'
     )"
     BOOTSTRAP_NPROFILE="$(
         printf '%s\n' "$bootstrap_json" |
-            python3 -c 'import json, sys; print(json.load(sys.stdin)["nprofile"])'
+            python3 -c 'import json, sys; print(json.load(sys.stdin).get("nprofile", ""))'
     )"
     if [ -z "$BOOTSTRAP_ACCOUNT_ID_HEX" ]; then
         echo "error: bootstrap did not return an account id" >&2
@@ -865,14 +865,22 @@ bootstrap_agent() {
 }
 
 print_phone_invite() {
-    cat <<EOF
+    if [ -n "$BOOTSTRAP_NPUB" ] && [ -n "$BOOTSTRAP_NPROFILE" ]; then
+        cat <<EOF
 
 White Noise agent identity:
   npub: $BOOTSTRAP_NPUB
   nprofile: $BOOTSTRAP_NPROFILE
 EOF
-    if [ "$DRY_RUN" -eq 0 ] && [ -t 1 ] && command -v qrencode >/dev/null 2>&1; then
-        printf '%s' "$BOOTSTRAP_NPROFILE" | qrencode -t ANSIUTF8
+        if [ "$DRY_RUN" -eq 0 ] && [ -t 1 ] && command -v qrencode >/dev/null 2>&1; then
+            printf '%s' "$BOOTSTRAP_NPROFILE" | qrencode -t ANSIUTF8
+        fi
+    else
+        cat <<EOF
+
+White Noise agent identity was not returned by this wn-agent release.
+Inspect the bootstrap response at: $MARMOT_HOME/bootstrap.json
+EOF
     fi
 }
 


### PR DESCRIPTION
## Summary

- add one canonical White Noise + Agents quickstart covering Hermes, OpenClaw, Codex, OpenCode, and Pi
- pin active install documentation and generated release-note examples to the immutable `wn-agent-v0.9.14` assets
- remove duplicated connector install sections and document the current `bootstrap.json` identity handoff
- improve source installer completion output with the agent `npub`, `nprofile`, optional terminal QR code, and accurate service status
- add an install-documentation gate to prevent stale, mismatched, or legacy latest-alias URLs

## Why

The install path had drifted across several READMEs, and the immutable historical `wn-agent-latest` release is not an authoritative current alias. That made some documented commands stale or broken and made the White Noise handoff harder to discover.

This gives humans and agents one short, explicit starting path while keeping each connector's advanced documentation available.

## User impact

Users can choose a connector from a single table, run one exact-version install command, and follow the same White Noise invitation flow. The already-published v0.9.14 installers continue to expose identity data through `bootstrap.json`; the enhanced identity and QR completion output will apply to the next immutable release.

No DNS-link behavior is introduced.

## Validation

- `just fast-ci`
- `just hermes-dev-script-test`
- `integrations/hermes/marmot/tests/test_installer_env.sh`
- `just openclaw-dev-script-test`
- `just codex-installer-test`
- `just opencode-installer-test`
- `just pi-installer-test`
- `git diff --check`
- verified HTTP 200 responses for all five v0.9.14 installer assets and their adjacent checksum files
