### PR TITLE
marmot-app: let an embedder supply the nostr-sdk client

### DIFF
--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -558,6 +558,10 @@ pub struct MarmotApp {
     /// pool instead of constructing another TCP/TLS/WebSocket stack.
     account_publish_clients: Arc<Mutex<HashMap<String, Arc<dyn NostrRelayClient>>>>,
     account_client_factory: Option<AccountClientFactory>,
+    /// Whether [`MarmotApp::relay_plane`] came from the embedder rather than from this crate.
+    ///
+    /// Decides both who the transport belongs to and who is responsible for winding it down.
+    embedder_relay_plane: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -1333,12 +1337,24 @@ impl MarmotApp {
         )
     }
 
-    /// Replaces the relay plane this app will use.
+    /// Replaces the relay plane this app will use, everywhere it uses one.
     ///
     /// Call it before any account work. Pairs with [`MarmotRelayPlane::from_sdk_client`] to
-    /// run the runtime over an embedder-supplied transport.
+    /// run the runtime over an embedder-supplied transport. From here on the supplied plane
+    /// also backs [`MarmotApp::client`], which would otherwise open over a default plane and
+    /// put shared relay traffic on a connection the embedder does not control.
     pub fn with_relay_plane(mut self, relay_plane: MarmotRelayPlane) -> Self {
-        self.relay_plane = relay_plane;
+        let replaced = std::mem::replace(&mut self.relay_plane, relay_plane);
+        let ours = !self.embedder_relay_plane;
+        self.embedder_relay_plane = true;
+        // Constructing the default plane inside a runtime already started its router and
+        // notification forwarder, and those keep the old transport alive after the plane
+        // itself is dropped. Wind down the one this crate built; never touch one the caller
+        // supplied, since the caller may still be holding it. Outside a runtime nothing was
+        // started and there is nothing to wind down.
+        if ours && let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(async move { replaced.shutdown().await });
+        }
         self
     }
 
@@ -1395,6 +1411,7 @@ impl MarmotApp {
             external_signers: Arc::new(Mutex::new(HashMap::new())),
             account_publish_clients: Arc::new(Mutex::new(HashMap::new())),
             account_client_factory: None,
+            embedder_relay_plane: false,
         }
     }
 
@@ -1469,6 +1486,7 @@ impl MarmotApp {
             external_signers: Arc::new(Mutex::new(HashMap::new())),
             account_publish_clients: Arc::new(Mutex::new(HashMap::new())),
             account_client_factory: None,
+            embedder_relay_plane: false,
         }
     }
 
@@ -1527,16 +1545,20 @@ impl MarmotApp {
     /// retrying.
     pub async fn client(&self, label: &str) -> Result<AppClient, AppError> {
         #[cfg(test)]
-        let relay_plane = self
-            .test_relay_client
-            .as_ref()
-            .map(|client| MarmotRelayPlane::new(None, client.clone()))
-            .unwrap_or_else(|| {
-                MarmotRelayPlane::full_history_with_loopback(
-                    self.config.allow_loopback_relay_endpoints,
-                )
-            });
-        #[cfg(not(test))]
+        if let Some(client) = &self.test_relay_client {
+            let relay_plane = MarmotRelayPlane::new(None, client.clone());
+            return self
+                .client_with_relay_plane(label, &relay_plane, None)
+                .await;
+        }
+        // An embedder that supplied a plane supplied the only transport this app may use.
+        // Its own lookback stands: the full-history default below is this crate's choice for
+        // a plane this crate built, not a property the caller's plane has to inherit.
+        if self.embedder_relay_plane {
+            return self
+                .client_with_relay_plane(label, &self.relay_plane, None)
+                .await;
+        }
         let relay_plane = MarmotRelayPlane::full_history_with_loopback(
             self.config.allow_loopback_relay_endpoints,
         );

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -499,6 +499,12 @@ type AppRuntime = AccountDeviceRuntime<
 #[cfg(test)]
 type LegacyProjectionOpenHook = Arc<dyn Fn() + Send + Sync>;
 
+/// Builds the `nostr-sdk` client an account publishes through, given its signer.
+///
+/// Supplied by an embedder that runs the runtime over a transport of its own.
+pub type AccountClientFactory =
+    Arc<dyn Fn(Arc<dyn nostr::NostrSigner>) -> NostrSdkClient + Send + Sync>;
+
 #[derive(Clone)]
 pub struct MarmotApp {
     root: PathBuf,
@@ -551,6 +557,7 @@ pub struct MarmotApp {
     /// account worker share this client so the worker can reuse the same relay
     /// pool instead of constructing another TCP/TLS/WebSocket stack.
     account_publish_clients: Arc<Mutex<HashMap<String, Arc<dyn NostrRelayClient>>>>,
+    account_client_factory: Option<AccountClientFactory>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -1326,6 +1333,15 @@ impl MarmotApp {
         )
     }
 
+    /// Replaces the relay plane this app will use.
+    ///
+    /// Call it before any account work. Pairs with [`MarmotRelayPlane::from_sdk_client`] to
+    /// run the runtime over an embedder-supplied transport.
+    pub fn with_relay_plane(mut self, relay_plane: MarmotRelayPlane) -> Self {
+        self.relay_plane = relay_plane;
+        self
+    }
+
     pub fn with_relays_and_config(
         root: impl AsRef<Path>,
         relay_urls: Vec<String>,
@@ -1378,6 +1394,7 @@ impl MarmotApp {
             audit_log_tracker_config: Arc::new(Mutex::new(AuditLogTrackerConfig::default())),
             external_signers: Arc::new(Mutex::new(HashMap::new())),
             account_publish_clients: Arc::new(Mutex::new(HashMap::new())),
+            account_client_factory: None,
         }
     }
 
@@ -1451,6 +1468,7 @@ impl MarmotApp {
             audit_log_tracker_config: Arc::new(Mutex::new(AuditLogTrackerConfig::default())),
             external_signers: Arc::new(Mutex::new(HashMap::new())),
             account_publish_clients: Arc::new(Mutex::new(HashMap::new())),
+            account_client_factory: None,
         }
     }
 
@@ -5417,6 +5435,16 @@ impl MarmotApp {
         Ok(shared.get_or_insert_with(|| storage.clone()).clone())
     }
 
+    /// Sets the factory used to build each account's publishing client.
+    ///
+    /// Without it an app that supplied its own relay plane still has every account publish
+    /// go out over the default transport, because the per-account publishing client is built
+    /// here rather than taken from the plane.
+    pub fn with_account_client_factory(mut self, factory: AccountClientFactory) -> Self {
+        self.account_client_factory = Some(factory);
+        self
+    }
+
     fn relay_client_for_account_id(
         &self,
         account_id_hex: &str,
@@ -5436,7 +5464,10 @@ impl MarmotApp {
         clients
             .entry(account_id_hex.to_owned())
             .or_insert_with(|| {
-                let client = NostrSdkClient::builder().signer(signer).build();
+                let client = match &self.account_client_factory {
+                    Some(build) => build(signer),
+                    None => NostrSdkClient::builder().signer(signer).build(),
+                };
                 Arc::new(NostrSdkRelayClient::new(client))
             })
             .clone()

--- a/crates/marmot-app/src/relay_plane/mod.rs
+++ b/crates/marmot-app/src/relay_plane/mod.rs
@@ -247,6 +247,18 @@ impl MarmotRelayPlane {
         )
     }
 
+    /// Whether both handles are the same plane, rather than two planes that look alike.
+    #[cfg(test)]
+    pub(crate) fn is_same_plane(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
+    }
+
+    /// Whether [`MarmotRelayPlane::shutdown`] has been entered on this plane.
+    #[cfg(test)]
+    pub(crate) fn is_shutting_down(&self) -> bool {
+        self.inner.transport.shutting_down.load(Ordering::SeqCst)
+    }
+
     fn from_sdk(subscription_rebuild_lookback: Option<Duration>, allow_loopback: bool) -> Self {
         let client = NostrSdkClient::builder().build();
         let relay_client = NostrSdkRelayClient::new(client.clone());

--- a/crates/marmot-app/src/relay_plane/mod.rs
+++ b/crates/marmot-app/src/relay_plane/mod.rs
@@ -223,6 +223,30 @@ impl MarmotRelayPlane {
         )
     }
 
+    /// Builds a relay plane over a caller-supplied `nostr-sdk` client.
+    ///
+    /// The client owns the transport, so an embedder can reach relays over something other
+    /// than the default TCP/TLS WebSocket stack without forking this crate. Everything above
+    /// the transport, including the directory fetcher used to look up KeyPackages, is built
+    /// from the same client, so there is no second path that silently falls back to the
+    /// default transport.
+    pub fn from_sdk_client(
+        client: NostrSdkClient,
+        subscription_rebuild_lookback: Option<Duration>,
+        allow_loopback: bool,
+    ) -> Self {
+        let relay_client = NostrSdkRelayClient::new(client.clone());
+        let adapter = NostrTransportAdapter::new(Arc::new(relay_client.clone()));
+        Self::from_adapter(
+            subscription_rebuild_lookback,
+            adapter,
+            Some(relay_client),
+            None,
+            Arc::new(NostrSdkDirectoryRelayFetcher::new(client)),
+            allow_loopback,
+        )
+    }
+
     fn from_sdk(subscription_rebuild_lookback: Option<Duration>, allow_loopback: bool) -> Self {
         let client = NostrSdkClient::builder().build();
         let relay_client = NostrSdkRelayClient::new(client.clone());

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -10337,3 +10337,68 @@ async fn reconcile_repairs_stale_two_member_count_on_three_member_group_body() {
     );
     runtime.shutdown().await;
 }
+
+#[test]
+fn client_opens_over_an_embedder_supplied_relay_plane() {
+    run_composed_app_runtime_test("embedder-relay-plane-client", || async {
+        let dir = tempfile::tempdir().unwrap();
+        AccountHome::open(dir.path())
+            .create_account("alice")
+            .unwrap();
+        let supplied =
+            MarmotRelayPlane::from_sdk_client(NostrSdkClient::builder().build(), None, true);
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+            .with_relay_plane(supplied.clone());
+
+        let client = app.client("alice").await.unwrap();
+
+        assert!(
+            client.relay_plane.is_same_plane(&supplied),
+            "client() opened over a plane of its own, so shared relay traffic would leave \
+             over a transport the embedder never supplied"
+        );
+    });
+}
+
+#[test]
+fn the_default_relay_plane_is_wound_down_when_it_is_replaced() {
+    run_composed_app_runtime_test("embedder-relay-plane-replace", || async {
+        let dir = tempfile::tempdir().unwrap();
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+        // Built by this crate, and already running its router and notification forwarder,
+        // because construction happened inside a runtime.
+        let default_plane = app.relay_plane.clone();
+        assert!(!default_plane.is_shutting_down());
+
+        let supplied =
+            MarmotRelayPlane::from_sdk_client(NostrSdkClient::builder().build(), None, true);
+        let app = app.with_relay_plane(supplied.clone());
+
+        // The wind-down is async, so it runs as its own task rather than in the builder.
+        let mut wound_down = false;
+        for _ in 0..200 {
+            if default_plane.is_shutting_down() {
+                wound_down = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(
+            wound_down,
+            "the replaced plane was dropped without being shut down, leaving its tasks on the \
+             old transport"
+        );
+
+        // A plane the caller supplied belongs to the caller, so a second replacement leaves
+        // it alone.
+        let second =
+            MarmotRelayPlane::from_sdk_client(NostrSdkClient::builder().build(), None, true);
+        let _app = app.with_relay_plane(second);
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(
+            !supplied.is_shutting_down(),
+            "a supplied plane was shut down by this crate, though the embedder may still be \
+             using it"
+        );
+    });
+}


### PR DESCRIPTION
### Problem

`marmot-app` constructs its own `nostr-sdk` client in two places:

- `MarmotRelayPlane::from_sdk` for the shared relay plane, and
- `MarmotApp::relay_client_for_account_id` for each account's publishing client.

Both are private, so an application embedding `marmot-app` cannot run the runtime over a transport of its own. `nostr-sdk` already supports substituting one through `ClientBuilder::websocket_transport`; there is just no way to reach it from outside this crate.

Closing only one of the two is worse than closing neither: the relay plane would use the supplied transport while every account publish — relay lists, KeyPackages, welcomes — still went out over the default one, and that is the half that decides whether anyone can invite you.

### Change

Three additions. Nothing changes for callers that do not use them.

- `MarmotRelayPlane::from_sdk_client(client, lookback, allow_loopback)` — mirrors the existing private `from_sdk` exactly, including building `NostrSdkDirectoryRelayFetcher` from the same client, so the KeyPackage lookup path cannot silently fall back to a different transport.
- `MarmotApp::with_relay_plane(plane)` — installs it before any account work.
- `MarmotApp::with_account_client_factory(factory)` — supplies the per-account publishing client, given the account's signer.

```rust
let client = Client::builder().websocket_transport(my_transport.clone()).build();
let plane = MarmotRelayPlane::from_sdk_client(client, Some(lookback), false);

let app = MarmotApp::try_with_relays_and_account_home_and_config(root, relays, home, config)?
    .with_relay_plane(plane)
    .with_account_client_factory(Arc::new(move |signer| {
        Client::builder()
            .signer(signer)
            .websocket_transport(my_transport.clone())
            .build()
    }));
```

### Notes

- `AccountClientFactory` is a type alias so the signature stays readable at the call site.
- I kept the factory optional rather than making it a constructor argument, to avoid touching the existing constructors.
- Happy to reshape this — for instance as a single `TransportProvider` trait covering both, if you would rather have one seam than two.

### Checks

`cargo fmt --check` and `cargo clippy --all-targets` clean, `cargo test -p marmot-app` passes (728 tests).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable account-specific Nostr client creation.
  - Added support for supplying a custom relay plane.
  - Added a way to build relay connections from an existing Nostr SDK client.
  - Existing default client and relay behavior remains available when no custom configuration is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->