### PR TITLE
marmot-app: permit a named loopback blob origin instead of all of them

### DIFF
--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -171,6 +171,7 @@ pub use ids::{
 /// Re-exported so FFI/CLI consumers can name the audit data mode without
 /// depending on `marmot-forensics` directly.
 pub use marmot_forensics::AuditDataMode;
+pub use media::permit_loopback_blob_origin;
 pub use media::{
     DEFAULT_BLOSSOM_SERVER_URL, DEFAULT_BLOSSOM_SERVER_URLS, ENCRYPTED_MEDIA_VERSION,
     EncryptedMediaVersion, MAX_ENCRYPTED_MEDIA_BLOB_BYTES, MAX_GROUP_IMAGE_BYTES,

--- a/crates/marmot-app/src/media/blossom.rs
+++ b/crates/marmot-app/src/media/blossom.rs
@@ -459,8 +459,11 @@ async fn media_http_client_for_url(
 ) -> Result<reqwest::Client, AppError> {
     validate_blossom_fetch_url(url, allow_loopback_http)
         .map_err(|err| AppError::BlobStore(format!("unsafe Blossom URL: {err}")))?;
+    // The resolved address is checked separately from the URL, so a permitted loopback origin
+    // has to be recognised here too: otherwise the scheme passes and the connection is refused
+    // a line later, which reads like a bug rather than a policy.
     let allow_loopback = url.scheme() == "http"
-        && allow_loopback_http
+        && (allow_loopback_http || crate::media::host_safety::is_permitted_loopback_url(url))
         && url.host().map(is_loopback_host).unwrap_or(false);
     let pin = resolve_media_host(url, allow_loopback).await?;
     build_pinned_media_http_client(pin)

--- a/crates/marmot-app/src/media/host_safety.rs
+++ b/crates/marmot-app/src/media/host_safety.rs
@@ -104,6 +104,57 @@ pub(crate) fn parse_profile_image_redirect_url(
     Ok(url)
 }
 
+/// Loopback blob origins this process serves itself.
+///
+/// A blob endpoint is group state, so a group admin chooses it, and
+/// `allow_loopback_blob_endpoints` makes that choice reach the local host of every member.
+/// This is the narrow alternative for an application that runs its own blob service on
+/// loopback: it names that exact origin, and every other loopback address stays refused no
+/// matter who put it in group state.
+static PERMITTED_LOOPBACK_ORIGINS: std::sync::OnceLock<std::sync::Mutex<Vec<String>>> =
+    std::sync::OnceLock::new();
+
+fn permitted_origins() -> &'static std::sync::Mutex<Vec<String>> {
+    PERMITTED_LOOPBACK_ORIGINS.get_or_init(|| std::sync::Mutex::new(Vec::new()))
+}
+
+/// Permits one loopback origin, given as `http://127.0.0.1:PORT`.
+///
+/// A property of the process rather than of an account or a group: it names a service this
+/// same program is running. Call it before opening an app.
+pub fn permit_loopback_blob_origin(origin: &str) {
+    if let Ok(url) = Url::parse(origin)
+        && let Some(origin) = loopback_origin(&url)
+        && let Ok(mut permitted) = permitted_origins().lock()
+        && !permitted.contains(&origin)
+    {
+        permitted.push(origin);
+    }
+}
+
+/// `scheme://host:port` for a loopback HTTP URL, or nothing if it is not one.
+fn loopback_origin(url: &Url) -> Option<String> {
+    let host = url.host_str()?.to_owned();
+    if url.scheme() != "http" || !is_loopback_host(url.host()?) {
+        return None;
+    }
+    Some(format!("http://{host}:{}", url.port_or_known_default()?))
+}
+
+pub(crate) fn is_permitted_loopback_url(url: &Url) -> bool {
+    let Some(origin) = loopback_origin(url) else {
+        return false;
+    };
+    permitted_origins()
+        .lock()
+        .map(|permitted| permitted.contains(&origin))
+        .unwrap_or(false)
+}
+
+pub(crate) fn is_permitted_loopback_endpoint(raw: &str) -> bool {
+    Url::parse(raw.trim()).is_ok_and(|url| is_permitted_loopback_url(&url))
+}
+
 pub(crate) fn validate_blossom_fetch_url(
     url: &Url,
     allow_loopback_http: bool,
@@ -122,7 +173,12 @@ pub(crate) fn validate_blossom_fetch_url(
     let host = url.host().ok_or("URL must include a host")?;
     match url.scheme() {
         "https" => validate_public_or_allowed_loopback_host(host, false),
-        "http" if allow_loopback_http && is_loopback_host(host) => Ok(()),
+        "http"
+            if is_loopback_host(host)
+                && (allow_loopback_http || is_permitted_loopback_url(url)) =>
+        {
+            Ok(())
+        }
         "http" => Err("URL scheme must be https".into()),
         _ => Err("URL scheme must be https".into()),
     }

--- a/crates/marmot-app/src/media/mod.rs
+++ b/crates/marmot-app/src/media/mod.rs
@@ -18,6 +18,7 @@ mod blossom;
 mod crypto;
 mod group_image;
 mod host_safety;
+pub use host_safety::permit_loopback_blob_origin;
 
 use blossom::{
     blossom_content_hash_from_url, upload_blossom_blob, upload_blossom_blob_with_content_type,
@@ -770,7 +771,11 @@ async fn fetch_encrypted_media_blob(
         // production build: skip it rather than GETting the local host. The
         // candidate may come from a remote-admin policy endpoint or a
         // sender-chosen locator, so the gate applies to both.
-        candidates.retain(|candidate| !is_loopback_http_endpoint(candidate));
+        // …except an origin this same process serves, named explicitly by the application.
+        candidates.retain(|candidate| {
+            !is_loopback_http_endpoint(candidate)
+                || host_safety::is_permitted_loopback_endpoint(candidate)
+        });
     }
     if candidates.is_empty() {
         return Err(AppError::InvalidEncryptedMedia(

--- a/crates/marmot-app/src/media/tests.rs
+++ b/crates/marmot-app/src/media/tests.rs
@@ -11,7 +11,9 @@ use url::Url;
 use super::blossom::{
     MAX_BLOSSOM_DESCRIPTOR_BYTES, MAX_ENCRYPTED_MEDIA_BLOB_BYTES, read_limited_blossom_body,
 };
-use super::host_safety::validate_blossom_fetch_url;
+use super::host_safety::{
+    is_permitted_loopback_endpoint, permit_loopback_blob_origin, validate_blossom_fetch_url,
+};
 
 #[test]
 fn encrypted_media_blob_limit_supports_large_application_artifacts() {
@@ -1687,4 +1689,64 @@ fn shared_golden_v1_fixtures_parse_validate_and_round_trip_exactly() {
 #[test]
 fn shared_golden_v2_fixtures_parse_validate_and_round_trip_exactly() {
     assert_shared_media_fixture_file("imeta-v2.json");
+}
+
+#[test]
+fn a_permitted_loopback_origin_is_accepted_and_no_other_loopback_address_is() {
+    // A blob endpoint is group state, so a group admin picks it. Permitting one origin must
+    // not permit the local host generally: the port next door is a different service, and
+    // it belongs to whoever is running this program, not to whoever administers the group.
+    permit_loopback_blob_origin("http://127.0.0.1:47821");
+
+    assert!(
+        validate_blossom_fetch_url(&Url::parse("http://127.0.0.1:47821/abc").unwrap(), false)
+            .is_ok()
+    );
+
+    for refused in [
+        "http://127.0.0.1:47822/abc",
+        "http://127.0.0.1/abc",
+        "http://localhost:47821/abc",
+        "http://[::1]:47821/abc",
+    ] {
+        assert!(
+            validate_blossom_fetch_url(&Url::parse(refused).unwrap(), false).is_err(),
+            "{refused} was accepted by an allowlist that never named it"
+        );
+    }
+
+    // And permitting a loopback origin says nothing about cleartext elsewhere.
+    assert!(
+        validate_blossom_fetch_url(&Url::parse("http://example.com/abc").unwrap(), false).is_err()
+    );
+}
+
+#[test]
+fn a_permitted_origin_is_recognised_from_a_raw_endpoint_string() {
+    permit_loopback_blob_origin("http://127.0.0.1:47823/");
+
+    assert!(is_permitted_loopback_endpoint(
+        "http://127.0.0.1:47823/blob"
+    ));
+    assert!(!is_permitted_loopback_endpoint(
+        "http://127.0.0.1:47824/blob"
+    ));
+    assert!(!is_permitted_loopback_endpoint(
+        "https://blossom.example/blob"
+    ));
+    assert!(!is_permitted_loopback_endpoint("not a url"));
+}
+
+#[test]
+fn permitting_an_origin_ignores_anything_that_is_not_a_loopback_http_url() {
+    // Silently ignored rather than accepted: a caller that names a public host has made a
+    // mistake, and the safest reading of that mistake is that nothing was permitted.
+    permit_loopback_blob_origin("https://blossom.example");
+    permit_loopback_blob_origin("http://192.168.1.10:47825");
+    permit_loopback_blob_origin("nonsense");
+
+    assert!(!is_permitted_loopback_endpoint("https://blossom.example/x"));
+    assert!(!is_permitted_loopback_endpoint(
+        "http://192.168.1.10:47825/x"
+    ));
 }


### PR DESCRIPTION
### Problem

`allow_loopback_blob_endpoints` is all-or-nothing, and blob endpoints are group state. With the flag on, an endpoint chosen by a group admin reaches the local host of every member, for both upload and fetch — `http://127.0.0.1:PORT/` in `default_blob_endpoints` is valid component state, and validity is deliberately independent of reachability.

That is the right trade for a test harness. It is an uncomfortable one for an application that runs its own blob service on loopback and wants to reach that and nothing else.

### Change

`permit_loopback_blob_origin("http://127.0.0.1:PORT")` names one origin. It is a property of the process — it describes a service this same program is running — rather than of an account or a group, and every other loopback address stays refused no matter who put it in group state. The existing flag is untouched.

```rust
marmot_app::permit_loopback_blob_origin("http://127.0.0.1:7871");
// http://127.0.0.1:7871/... is now fetchable and uploadable;
// http://127.0.0.1:7872/... and http://localhost:7871/... are not.
```

It needed both gates rather than one:

- `host_safety::validate_blossom_fetch_url` checks the scheme, and
- `blossom::media_http_client_for_url` separately checks the resolved address.

Patching only the first leaves the scheme accepted and the connection refused a line later, which reads like a bug rather than a policy.

### Tests

Added to `media/tests.rs`: the neighbouring port, a different loopback host (`localhost`, `[::1]`), cleartext to a public host, recognition from raw endpoint strings, and inputs that are not loopback HTTP URLs at all. The last case is ignored rather than accepted — a caller naming a public host has made a mistake, and the safe reading of that mistake is that nothing was permitted.

### Notes

- The allowlist is a process-global `OnceLock<Mutex<Vec<String>>>`, which matches the scope of the thing it describes but does mean tests that permit an origin affect the whole test binary. The added tests use distinctive ports for that reason. If you would rather carry it in `MarmotAppConfig` and thread it through, I am glad to redo it that way — it is a larger diff because the boolean is threaded through several call sites.

### Checks

`cargo fmt --check` and `cargo clippy --all-targets` clean, `cargo test -p marmot-app` passes (731 tests).
