### PR TITLE
Project membership and admin-role local notifications

### DIFF
--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -9,6 +9,14 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ## [Unreleased]
 
+### Added
+
+- Local notification projection and UniFFI `NotificationTrigger` now include
+  `RemovedFromGroup`, `MadeAdmin`, and `RemovedAsAdmin` for authenticated
+  self-affecting membership and admin-role changes. Kind 446 wake delivery
+  stays context-free.
+  ([#1240](https://github.com/marmot-protocol/mdk/issues/1240))
+
 ## [0.9.14] - 2026-08-19
 
 ### Added

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -2087,8 +2087,13 @@ impl AppClient {
             Vec::new(),
             Some(member_refs.len() as u64),
         );
+        let target_hexes = members
+            .iter()
+            .map(|member| hex::encode(member.as_slice()))
+            .collect::<Vec<_>>();
 
         self.sync_runtime_groups().await?;
+        let wake_snapshot = self.snapshot_group_push_tokens_for_members(group_id, &target_hexes);
         let effects = self
             .runtime
             .send_with_audit_context(
@@ -2106,6 +2111,12 @@ impl AppClient {
         self.cleanup_stale_push_tokens_best_effort(group_id);
         self.save_state_with_pending_local_group_deletion_frontier_clears()?;
         self.queue_own_group_system_projection_updates(&effects);
+        self.publish_targeted_group_state_wake_best_effort(
+            group_id,
+            wake_snapshot,
+            &effects.events,
+        )
+        .await;
         Ok(send_summary_from_effects(&effects))
     }
 
@@ -2553,17 +2564,17 @@ impl AppClient {
         member_ref: &str,
     ) -> Result<SendSummary, AppError> {
         self.ensure_group(group_id)?;
+        let member_id = self.app.member_id(member_ref)?;
         let mut admins = self.runtime.admin_pubkeys(group_id)?;
-        admins.push(admin_pubkey_from_member_id(
-            &self.app.member_id(member_ref)?,
-        )?);
+        admins.push(admin_pubkey_from_member_id(&member_id)?);
         let audit_context = Self::local_human_action_context(
             "promote_admin",
             vec!["admins"],
             vec![GROUP_ADMIN_POLICY_COMPONENT_ID],
             Some(1),
         );
-        self.update_admin_policy(group_id, admins, audit_context)
+        let target_hex = hex::encode(member_id.as_slice());
+        self.update_admin_policy(group_id, admins, audit_context, &[target_hex])
             .await
     }
 
@@ -2573,7 +2584,8 @@ impl AppClient {
         member_ref: &str,
     ) -> Result<SendSummary, AppError> {
         self.ensure_group(group_id)?;
-        let target = admin_pubkey_from_member_id(&self.app.member_id(member_ref)?)?;
+        let member_id = self.app.member_id(member_ref)?;
+        let target = admin_pubkey_from_member_id(&member_id)?;
         let mut admins = self.runtime.admin_pubkeys(group_id)?;
         admins.retain(|admin| admin != &target);
         let audit_context = Self::local_human_action_context(
@@ -2582,7 +2594,8 @@ impl AppClient {
             vec![GROUP_ADMIN_POLICY_COMPONENT_ID],
             Some(1),
         );
-        self.update_admin_policy(group_id, admins, audit_context)
+        let target_hex = hex::encode(member_id.as_slice());
+        self.update_admin_policy(group_id, admins, audit_context, &[target_hex])
             .await
     }
 
@@ -2598,8 +2611,13 @@ impl AppClient {
             vec![GROUP_ADMIN_POLICY_COMPONENT_ID],
             Some(1),
         );
-        self.update_admin_policy(group_id, admins, audit_context)
-            .await
+        self.update_admin_policy(
+            group_id,
+            admins,
+            audit_context,
+            std::slice::from_ref(&account.account_id_hex),
+        )
+        .await
     }
 
     async fn update_admin_policy(
@@ -2607,10 +2625,12 @@ impl AppClient {
         group_id: &GroupId,
         admins: Vec<[u8; 32]>,
         audit_context: AuditEventContext,
+        wake_targets: &[String],
     ) -> Result<SendSummary, AppError> {
         let component = AppGroupAdminPolicyComponent::new(admins).to_app_component_data()?;
 
         self.sync_runtime_groups().await?;
+        let wake_snapshot = self.snapshot_group_push_tokens_for_members(group_id, wake_targets);
         let effects = self
             .runtime
             .send_with_audit_context(
@@ -2627,6 +2647,12 @@ impl AppClient {
         self.refresh_group(group_id);
         self.save_state_with_pending_local_group_deletion_frontier_clears()?;
         self.queue_own_group_system_projection_updates(&effects);
+        self.publish_targeted_group_state_wake_best_effort(
+            group_id,
+            wake_snapshot,
+            &effects.events,
+        )
+        .await;
         Ok(send_summary_from_effects(&effects))
     }
 

--- a/crates/marmot-app/src/client/push.rs
+++ b/crates/marmot-app/src/client/push.rs
@@ -422,6 +422,41 @@ impl AppClient {
         self.share_push_registration().await
     }
 
+    pub(crate) fn snapshot_group_push_tokens_for_members(
+        &self,
+        group_id: &GroupId,
+        member_id_hexes: &[String],
+    ) -> Vec<notifications::GroupPushTokenRecord> {
+        let Ok(account) = self.app.account_home().account(&self.state.label) else {
+            return Vec::new();
+        };
+        let group_id_hex = hex::encode(group_id.as_slice());
+        let Ok(tokens) = self.app.group_push_tokens(&account.label, &group_id_hex) else {
+            return Vec::new();
+        };
+        notifications::tokens_for_member_ids(tokens, member_id_hexes.iter().map(String::as_str))
+    }
+
+    pub(crate) async fn publish_targeted_group_state_wake_best_effort(
+        &self,
+        _group_id: &GroupId,
+        snapshot: Vec<notifications::GroupPushTokenRecord>,
+        events: &[cgka_traits::engine::GroupEvent],
+    ) {
+        let Ok(account) = self.app.account_home().account(&self.state.label) else {
+            return;
+        };
+        let wake_ids =
+            notifications::wake_member_ids_from_group_events(&account.account_id_hex, events);
+        let tokens =
+            notifications::tokens_for_member_ids(snapshot, wake_ids.iter().map(String::as_str));
+        if tokens.is_empty() {
+            return;
+        }
+        self.publish_notification_trigger_tokens_best_effort(tokens)
+            .await;
+    }
+
     pub(crate) async fn publish_notification_trigger_best_effort(
         &self,
         group_id: &GroupId,
@@ -437,6 +472,20 @@ impl AppClient {
         }
     }
 
+    async fn publish_notification_trigger_tokens_best_effort(
+        &self,
+        tokens: Vec<notifications::GroupPushTokenRecord>,
+    ) {
+        if let Err(err) = self.publish_notification_trigger_tokens(tokens).await {
+            tracing::warn!(
+                target: "marmot_app::notifications",
+                method = "publish_notification_trigger_tokens_best_effort",
+                error_kind = err.privacy_safe_kind(),
+                "notification trigger publish failed",
+            );
+        }
+    }
+
     async fn publish_notification_trigger(
         &self,
         group_id: &GroupId,
@@ -445,6 +494,14 @@ impl AppClient {
         let account = self.app.account_home().account(&self.state.label)?;
         let group_id_hex = hex::encode(group_id.as_slice());
         let tokens = self.app.group_push_tokens(&account.label, &group_id_hex)?;
+        self.publish_notification_trigger_tokens(tokens).await
+    }
+
+    async fn publish_notification_trigger_tokens(
+        &self,
+        tokens: Vec<notifications::GroupPushTokenRecord>,
+    ) -> Result<(), AppError> {
+        let account = self.app.account_home().account(&self.state.label)?;
         let by_server = notifications::token_records_by_server(tokens, &account.account_id_hex);
         if by_server.is_empty() {
             return Ok(());

--- a/crates/marmot-app/src/notifications.rs
+++ b/crates/marmot-app/src/notifications.rs
@@ -25,15 +25,21 @@ use sha2::{Digest, Sha256};
 use transport_nostr_peeler::NostrTransportEvent;
 
 use cgka_traits::app_event::{
-    EVENT_REF_TAG, MARMOT_APP_EVENT_KIND_AGENT_ACTIVITY, MARMOT_APP_EVENT_KIND_AGENT_OPERATION,
-    MARMOT_APP_EVENT_KIND_CHAT, MARMOT_APP_EVENT_KIND_REACTION,
+    EVENT_REF_TAG, GROUP_SYSTEM_TYPE_ADMIN_ADDED, GROUP_SYSTEM_TYPE_ADMIN_REMOVED,
+    GROUP_SYSTEM_TYPE_MEMBER_REMOVED, MARMOT_APP_EVENT_KIND_AGENT_ACTIVITY,
+    MARMOT_APP_EVENT_KIND_AGENT_OPERATION, MARMOT_APP_EVENT_KIND_CHAT,
+    MARMOT_APP_EVENT_KIND_GROUP_SYSTEM, MARMOT_APP_EVENT_KIND_REACTION,
+    group_system_event_material,
 };
+use cgka_traits::engine::{GroupEvent, GroupStateChange};
 use cgka_traits::group::ProtocolProfile;
+use cgka_traits::{GroupId, MemberId};
 
 use crate::messages::{PUBKEY_REF_TAG, inline_mention_pubkey_hexes, mention_pubkey_hex};
 use crate::{
     AppError, AppGroupRecord, AppMessageQuery, AppMessageRecord, MarmotApp, MarmotAppEvent,
-    ReceivedMessage, RuntimeMessageReceived, tag_value,
+    ReceivedMessage, RuntimeGroupEvent, RuntimeMessageReceived, group_system_event_from_message,
+    tag_value,
 };
 use storage_sqlite::TimelineMessageTarget;
 
@@ -155,6 +161,9 @@ pub enum NotificationCollectionStatus {
 pub enum NotificationTrigger {
     NewMessage,
     GroupInvite,
+    RemovedFromGroup,
+    MadeAdmin,
+    RemovedAsAdmin,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -1488,35 +1497,46 @@ pub(crate) fn recover_notification_updates(
             },
         )?;
         for record in records {
-            if !notification_recovery_is_fresh(&record, min_observed_at) {
+            if !notification_recovery_should_project(&record, min_observed_at) {
                 continue;
             }
-            let Ok(group_id) = hex::decode(&record.group_id_hex) else {
-                continue;
+            let result = if record.kind == MARMOT_APP_EVENT_KIND_GROUP_SYSTEM {
+                notification_update_from_group_system_record(
+                    app,
+                    &mut resolver,
+                    &account.label,
+                    &account.account_id_hex,
+                    &record,
+                )
+            } else {
+                let Ok(group_id) = hex::decode(&record.group_id_hex) else {
+                    continue;
+                };
+                let sender_display_name = app
+                    .display_name_for_account_id(&record.sender)
+                    .ok()
+                    .flatten();
+                let event = MarmotAppEvent::MessageReceived(RuntimeMessageReceived {
+                    account_id_hex: account.account_id_hex.clone(),
+                    account_label: account.label.clone(),
+                    message: ReceivedMessage {
+                        message_id_hex: record.message_id_hex,
+                        source_message_id_hex: String::new(),
+                        sender: record.sender,
+                        sender_display_name,
+                        group_id: GroupId::new(group_id),
+                        source_epoch: record.source_epoch.unwrap_or(0),
+                        retention: record.retention,
+                        plaintext: record.plaintext,
+                        kind: record.kind,
+                        tags: record.tags,
+                        recorded_at: record.recorded_at,
+                        received_at: record.received_at,
+                    },
+                });
+                notification_update_from_event_cached(app, &mut resolver, &event)
             };
-            let sender_display_name = app
-                .display_name_for_account_id(&record.sender)
-                .ok()
-                .flatten();
-            let event = MarmotAppEvent::MessageReceived(RuntimeMessageReceived {
-                account_id_hex: account.account_id_hex.clone(),
-                account_label: account.label.clone(),
-                message: ReceivedMessage {
-                    message_id_hex: record.message_id_hex,
-                    source_message_id_hex: String::new(),
-                    sender: record.sender,
-                    sender_display_name,
-                    group_id: cgka_traits::GroupId::new(group_id),
-                    source_epoch: record.source_epoch.unwrap_or(0),
-                    retention: record.retention,
-                    plaintext: record.plaintext,
-                    kind: record.kind,
-                    tags: record.tags,
-                    recorded_at: record.recorded_at,
-                    received_at: record.received_at,
-                },
-            });
-            match notification_update_from_event_cached(app, &mut resolver, &event) {
+            match result {
                 Ok(Some(update)) => updates.push(update),
                 Ok(None) | Err(AppError::NotificationsDisabled) => {}
                 Err(_) => {
@@ -1543,6 +1563,13 @@ pub(crate) fn notification_recovery_is_fresh(
     min_observed_at.is_none_or(|min| record.received_at >= min)
 }
 
+pub(crate) fn notification_recovery_should_project(
+    record: &AppMessageRecord,
+    min_observed_at: Option<u64>,
+) -> bool {
+    !record.invalidated && notification_recovery_is_fresh(record, min_observed_at)
+}
+
 /// Build a notification for one event, reusing `resolver`'s memoized
 /// settings/group/user lookups across a batch of events (#639).
 pub(crate) fn notification_update_from_event_cached(
@@ -1566,14 +1593,250 @@ pub(crate) fn notification_update_from_event_cached(
             group_id,
         )
         .map(Some),
+        MarmotAppEvent::GroupEvent(group_event) => {
+            notification_update_from_runtime_group_event(app, resolver, group_event)
+        }
         MarmotAppEvent::GroupStateUpdated { .. }
         | MarmotAppEvent::ProjectionUpdated(_)
         | MarmotAppEvent::AgentStreamStarted(_)
-        | MarmotAppEvent::GroupEvent(_)
         | MarmotAppEvent::WelcomeDeliveryPending { .. }
         | MarmotAppEvent::EpochStallEscalated { .. }
         | MarmotAppEvent::AccountError(_) => Ok(None),
     }
+}
+
+/// Classify an authenticated group-state change for the receiving local
+/// account. Only self-affecting `MemberRemoved`, `AdminAdded`, and non-self
+/// `AdminRemoved` notify. Voluntary leave, self-demotion, unrelated subjects,
+/// and changes without a local subject are suppressed. Inbound admin-policy
+/// diffs are commonly unattributed; self-demotion is the case whose actor is
+/// the local account.
+pub(crate) fn classify_local_group_state_notification(
+    local_account_id_hex: &str,
+    actor_account_id_hex: Option<&str>,
+    system_type: &str,
+    subject_account_id_hex: Option<&str>,
+) -> Option<NotificationTrigger> {
+    let subject = subject_account_id_hex.filter(|value| !value.is_empty())?;
+    if !subject.eq_ignore_ascii_case(local_account_id_hex) {
+        return None;
+    }
+    match system_type {
+        GROUP_SYSTEM_TYPE_MEMBER_REMOVED => Some(NotificationTrigger::RemovedFromGroup),
+        GROUP_SYSTEM_TYPE_ADMIN_ADDED => Some(NotificationTrigger::MadeAdmin),
+        GROUP_SYSTEM_TYPE_ADMIN_REMOVED => {
+            let is_self_demotion = actor_account_id_hex
+                .filter(|value| !value.is_empty())
+                .is_some_and(|actor| actor.eq_ignore_ascii_case(local_account_id_hex));
+            if is_self_demotion {
+                None
+            } else {
+                Some(NotificationTrigger::RemovedAsAdmin)
+            }
+        }
+        _ => None,
+    }
+}
+
+pub(crate) fn classify_group_state_change(
+    local_account_id_hex: &str,
+    actor: Option<&MemberId>,
+    change: &GroupStateChange,
+) -> Option<NotificationTrigger> {
+    let actor_hex = actor.map(|id| hex::encode(id.as_slice()));
+    let (system_type, subject) = match change {
+        GroupStateChange::MemberRemoved { member } => (GROUP_SYSTEM_TYPE_MEMBER_REMOVED, member),
+        GroupStateChange::AdminAdded { member } => (GROUP_SYSTEM_TYPE_ADMIN_ADDED, member),
+        GroupStateChange::AdminRemoved { member } => (GROUP_SYSTEM_TYPE_ADMIN_REMOVED, member),
+        _ => return None,
+    };
+    classify_local_group_state_notification(
+        local_account_id_hex,
+        actor_hex.as_deref(),
+        system_type,
+        Some(&hex::encode(subject.as_slice())),
+    )
+}
+
+/// Subjects of successful non-self membership/admin effects that should receive
+/// a context-free kind-446 wake from the mutating device.
+pub(crate) fn wake_member_id_hex_from_group_event(
+    local_account_id_hex: &str,
+    event: &GroupEvent,
+) -> Option<String> {
+    let GroupEvent::GroupStateChanged { change, .. } = event else {
+        return None;
+    };
+    let member = match change {
+        GroupStateChange::MemberRemoved { member }
+        | GroupStateChange::AdminAdded { member }
+        | GroupStateChange::AdminRemoved { member } => member,
+        _ => return None,
+    };
+    let member_hex = hex::encode(member.as_slice());
+    (!member_hex.eq_ignore_ascii_case(local_account_id_hex)).then_some(member_hex)
+}
+
+pub(crate) fn wake_member_ids_from_group_events(
+    local_account_id_hex: &str,
+    events: &[GroupEvent],
+) -> HashSet<String> {
+    events
+        .iter()
+        .filter_map(|event| wake_member_id_hex_from_group_event(local_account_id_hex, event))
+        .collect()
+}
+
+pub(crate) fn tokens_for_member_ids(
+    tokens: Vec<GroupPushTokenRecord>,
+    member_id_hexes: impl IntoIterator<Item = impl AsRef<str>>,
+) -> Vec<GroupPushTokenRecord> {
+    let wanted = member_id_hexes
+        .into_iter()
+        .map(|id| id.as_ref().to_ascii_lowercase())
+        .collect::<HashSet<_>>();
+    tokens
+        .into_iter()
+        .filter(|token| wanted.contains(&token.member_id_hex.to_ascii_lowercase()))
+        .collect()
+}
+
+fn notification_update_from_runtime_group_event(
+    app: &MarmotApp,
+    resolver: &mut NotificationResolver,
+    event: &RuntimeGroupEvent,
+) -> Result<Option<NotificationUpdate>, AppError> {
+    let GroupEvent::GroupStateChanged {
+        group_id,
+        epoch,
+        actor,
+        change,
+        ..
+    } = &event.event
+    else {
+        return Ok(None);
+    };
+    let Some(trigger) = classify_group_state_change(&event.account_id_hex, actor.as_ref(), change)
+    else {
+        return Ok(None);
+    };
+    let material = match group_system_event_material(group_id, epoch.0, actor.as_ref(), change) {
+        Ok(material) => material,
+        Err(_) => return Ok(None),
+    };
+    let actor_hex = actor.as_ref().map(|id| hex::encode(id.as_slice()));
+    notification_update_from_classified_group_state(
+        app,
+        resolver,
+        &event.account_label,
+        &event.account_id_hex,
+        ClassifiedGroupStateNotice {
+            group_id_hex: &material.group_id_hex,
+            trigger,
+            message_id_hex: &material.message_id_hex,
+            actor_account_id_hex: actor_hex.as_deref(),
+        },
+    )
+}
+
+fn notification_update_from_group_system_record(
+    app: &MarmotApp,
+    resolver: &mut NotificationResolver,
+    account_label: &str,
+    account_id_hex: &str,
+    record: &AppMessageRecord,
+) -> Result<Option<NotificationUpdate>, AppError> {
+    let Some(event) = group_system_event_from_message(record.kind, &record.plaintext) else {
+        return Ok(None);
+    };
+    let Some(trigger) = classify_local_group_state_notification(
+        account_id_hex,
+        event.actor_account_id_hex.as_deref(),
+        &event.system_type,
+        event.subject_account_id_hex.as_deref(),
+    ) else {
+        return Ok(None);
+    };
+    notification_update_from_classified_group_state(
+        app,
+        resolver,
+        account_label,
+        account_id_hex,
+        ClassifiedGroupStateNotice {
+            group_id_hex: &record.group_id_hex,
+            trigger,
+            message_id_hex: &record.message_id_hex,
+            actor_account_id_hex: event.actor_account_id_hex.as_deref(),
+        },
+    )
+}
+
+struct ClassifiedGroupStateNotice<'a> {
+    group_id_hex: &'a str,
+    trigger: NotificationTrigger,
+    message_id_hex: &'a str,
+    actor_account_id_hex: Option<&'a str>,
+}
+
+fn notification_update_from_classified_group_state(
+    app: &MarmotApp,
+    resolver: &mut NotificationResolver,
+    account_label: &str,
+    account_id_hex: &str,
+    notice: ClassifiedGroupStateNotice<'_>,
+) -> Result<Option<NotificationUpdate>, AppError> {
+    let settings = resolver.settings(app, account_label)?;
+    if !settings.local_notifications_enabled {
+        return Err(AppError::NotificationsDisabled);
+    }
+    let group = match resolver.group(app, account_label, notice.group_id_hex) {
+        Ok(group) => group,
+        Err(AppError::UnknownGroup(_)) => None,
+        Err(err) => return Err(err),
+    };
+    let muted = match resolver.chat_muted(app, account_label, notice.group_id_hex) {
+        Ok(muted) => muted,
+        Err(AppError::UnknownGroup(_)) => false,
+        Err(err) => return Err(err),
+    };
+    if muted {
+        return Ok(None);
+    }
+    let receiver = resolver.user(app, account_id_hex)?;
+    let sender = match notice
+        .actor_account_id_hex
+        .filter(|value| !value.is_empty())
+    {
+        Some(actor_id) => resolver.user(app, actor_id)?,
+        None => NotificationUser {
+            account_id_hex: String::new(),
+            display_name: None,
+            picture_url: None,
+        },
+    };
+    let is_from_self = notice
+        .actor_account_id_hex
+        .is_some_and(|actor| !actor.is_empty() && actor.eq_ignore_ascii_case(account_id_hex));
+    Ok(Some(NotificationUpdate {
+        notification_key: format!("group-state:{account_id_hex}:{}", notice.message_id_hex),
+        conversation_key: conversation_key(account_id_hex, notice.group_id_hex),
+        trigger: notice.trigger,
+        traffic_class: NotificationTrafficClass::Standard,
+        account_ref: account_label.to_owned(),
+        account_id_hex: account_id_hex.to_owned(),
+        group_id_hex: notice.group_id_hex.to_owned(),
+        group_name: group_name(group.as_ref()),
+        is_dm: false,
+        is_mention: false,
+        message_id_hex: Some(notice.message_id_hex.to_owned()),
+        sender,
+        receiver,
+        preview_text: None,
+        reaction_emoji: None,
+        reacted_to_preview: None,
+        timestamp_ms: unix_now_ms(),
+        is_from_self,
+    }))
 }
 
 /// Classify every notification-eligible wire kind. Returning `None` for

--- a/crates/marmot-app/src/notifications/tests.rs
+++ b/crates/marmot-app/src/notifications/tests.rs
@@ -1751,3 +1751,464 @@ fn recovery_skips_rows_before_the_subscription_watermark() {
     record.received_at = 1;
     assert!(notification_recovery_is_fresh(&record, None));
 }
+
+fn member_id_from_hex(value: &str) -> cgka_traits::MemberId {
+    cgka_traits::MemberId::new(hex::decode(value).expect("member hex"))
+}
+
+fn group_state_event(
+    group_id: cgka_traits::GroupId,
+    actor: Option<&str>,
+    change: cgka_traits::engine::GroupStateChange,
+) -> cgka_traits::engine::GroupEvent {
+    cgka_traits::engine::GroupEvent::GroupStateChanged {
+        group_id,
+        epoch: cgka_traits::EpochId(3),
+        actor: actor.map(member_id_from_hex),
+        change,
+        origin_commit_id: Some(cgka_traits::MessageId::new(vec![0xAB; 32])),
+    }
+}
+
+fn seed_group_state_resolver(
+    resolver: &mut NotificationResolver,
+    account_label: &str,
+    account_id_hex: &str,
+    group_id_hex: &str,
+    actor_id_hex: Option<&str>,
+    local_enabled: bool,
+    muted: bool,
+) {
+    resolver.settings.insert(
+        account_label.to_owned(),
+        NotificationSettings {
+            account_ref: account_label.to_owned(),
+            account_id_hex: account_id_hex.to_owned(),
+            local_notifications_enabled: local_enabled,
+            native_push_enabled: true,
+        },
+    );
+    let conversation = (account_label.to_owned(), group_id_hex.to_owned());
+    resolver.groups.insert(conversation.clone(), None);
+    resolver.chat_muted.insert(conversation, muted);
+    let mut users = vec![account_id_hex];
+    if let Some(actor_id_hex) = actor_id_hex {
+        users.push(actor_id_hex);
+    }
+    for account_id in users {
+        resolver.users.insert(
+            account_id.to_owned(),
+            NotificationUser {
+                account_id_hex: account_id.to_owned(),
+                display_name: None,
+                picture_url: None,
+            },
+        );
+    }
+}
+
+#[test]
+fn group_state_classifier_notifies_only_local_self_affecting_changes() {
+    let local = "aa".repeat(32);
+    let actor = "bb".repeat(32);
+    let other = "cc".repeat(32);
+
+    assert!(matches!(
+        classify_local_group_state_notification(
+            &local,
+            Some(&actor),
+            cgka_traits::app_event::GROUP_SYSTEM_TYPE_MEMBER_REMOVED,
+            Some(&local),
+        ),
+        Some(NotificationTrigger::RemovedFromGroup)
+    ));
+    assert!(matches!(
+        classify_local_group_state_notification(
+            &local,
+            Some(&actor),
+            cgka_traits::app_event::GROUP_SYSTEM_TYPE_ADMIN_ADDED,
+            Some(&local),
+        ),
+        Some(NotificationTrigger::MadeAdmin)
+    ));
+    assert!(matches!(
+        classify_local_group_state_notification(
+            &local,
+            Some(&actor),
+            cgka_traits::app_event::GROUP_SYSTEM_TYPE_ADMIN_REMOVED,
+            Some(&local),
+        ),
+        Some(NotificationTrigger::RemovedAsAdmin)
+    ));
+
+    assert_eq!(
+        classify_local_group_state_notification(
+            &local,
+            Some(&actor),
+            cgka_traits::app_event::GROUP_SYSTEM_TYPE_MEMBER_LEFT,
+            Some(&local),
+        ),
+        None,
+        "voluntary leave must not notify"
+    );
+    assert_eq!(
+        classify_local_group_state_notification(
+            &local,
+            Some(&local),
+            cgka_traits::app_event::GROUP_SYSTEM_TYPE_ADMIN_REMOVED,
+            Some(&local),
+        ),
+        None,
+        "self-demotion must not notify"
+    );
+    assert_eq!(
+        classify_local_group_state_notification(
+            &local,
+            Some(&actor),
+            cgka_traits::app_event::GROUP_SYSTEM_TYPE_MEMBER_REMOVED,
+            Some(&other),
+        ),
+        None,
+        "unrelated subjects must not notify"
+    );
+    assert!(matches!(
+        classify_local_group_state_notification(
+            &local,
+            None,
+            cgka_traits::app_event::GROUP_SYSTEM_TYPE_ADMIN_REMOVED,
+            Some(&local),
+        ),
+        Some(NotificationTrigger::RemovedAsAdmin),
+    ));
+    assert_eq!(
+        classify_local_group_state_notification(
+            &local,
+            Some(&actor),
+            cgka_traits::app_event::GROUP_SYSTEM_TYPE_GROUP_RENAMED,
+            None,
+        ),
+        None
+    );
+}
+
+#[test]
+fn group_state_live_classification_respects_settings_and_mute() {
+    let dir = tempfile::tempdir().unwrap();
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+    let account_label = "alice";
+    let local = "aa".repeat(32);
+    let actor = "bb".repeat(32);
+    let group_id = cgka_traits::GroupId::new(vec![0xEE; 16]);
+    let group_id_hex = hex::encode(group_id.as_slice());
+    let event = MarmotAppEvent::GroupEvent(crate::RuntimeGroupEvent {
+        account_id_hex: local.clone(),
+        account_label: account_label.to_owned(),
+        event: group_state_event(
+            group_id.clone(),
+            Some(&actor),
+            cgka_traits::engine::GroupStateChange::MemberRemoved {
+                member: member_id_from_hex(&local),
+            },
+        ),
+    });
+
+    let mut resolver = NotificationResolver::default();
+    seed_group_state_resolver(
+        &mut resolver,
+        account_label,
+        &local,
+        &group_id_hex,
+        Some(&actor),
+        true,
+        false,
+    );
+    let update = notification_update_from_event_cached(&app, &mut resolver, &event)
+        .unwrap()
+        .expect("unmuted eviction of the local account should notify");
+    assert!(matches!(
+        update.trigger,
+        NotificationTrigger::RemovedFromGroup
+    ));
+    assert!(!update.is_mention);
+    assert!(!update.is_from_self);
+    assert!(update.notification_key.starts_with("group-state:"));
+
+    resolver
+        .chat_muted
+        .insert((account_label.to_owned(), group_id_hex.clone()), true);
+    assert_eq!(
+        notification_update_from_event_cached(&app, &mut resolver, &event).unwrap(),
+        None,
+        "muted groups must suppress membership notifications"
+    );
+
+    seed_group_state_resolver(
+        &mut resolver,
+        account_label,
+        &local,
+        &group_id_hex,
+        Some(&actor),
+        false,
+        false,
+    );
+    assert!(
+        matches!(
+            notification_update_from_event_cached(&app, &mut resolver, &event),
+            Err(crate::AppError::NotificationsDisabled)
+        ),
+        "disabled local notifications must suppress membership notifications"
+    );
+}
+
+#[test]
+fn group_state_live_and_recovery_share_a_deterministic_key() {
+    let dir = tempfile::tempdir().unwrap();
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+    let account_label = "alice";
+    let local = "aa".repeat(32);
+    let actor = "bb".repeat(32);
+    let group_id = cgka_traits::GroupId::new(vec![0xEE; 16]);
+    let group_id_hex = hex::encode(group_id.as_slice());
+    let change = cgka_traits::engine::GroupStateChange::AdminAdded {
+        member: member_id_from_hex(&local),
+    };
+    let actor_id = member_id_from_hex(&actor);
+    let material =
+        cgka_traits::app_event::group_system_event_material(&group_id, 3, Some(&actor_id), &change)
+            .unwrap();
+
+    let mut resolver = NotificationResolver::default();
+    seed_group_state_resolver(
+        &mut resolver,
+        account_label,
+        &local,
+        &group_id_hex,
+        Some(&actor),
+        true,
+        false,
+    );
+    let live = notification_update_from_event_cached(
+        &app,
+        &mut resolver,
+        &MarmotAppEvent::GroupEvent(crate::RuntimeGroupEvent {
+            account_id_hex: local.clone(),
+            account_label: account_label.to_owned(),
+            event: group_state_event(group_id, Some(&actor), change),
+        }),
+    )
+    .unwrap()
+    .expect("live admin grant should notify");
+
+    let recovered = notification_update_from_group_system_record(
+        &app,
+        &mut resolver,
+        account_label,
+        &local,
+        &AppMessageRecord {
+            message_id_hex: material.message_id_hex.clone(),
+            direction: "system".to_owned(),
+            group_id_hex,
+            sender: actor.clone(),
+            plaintext: material.content,
+            kind: cgka_traits::app_event::MARMOT_APP_EVENT_KIND_GROUP_SYSTEM,
+            tags: material.tags,
+            source_epoch: Some(3),
+            retention: None,
+            recorded_at: 30,
+            received_at: 30,
+            insert_order: 1,
+            invalidated: false,
+            moderation_grant: false,
+        },
+    )
+    .unwrap()
+    .expect("fresh kind-1210 recovery should notify");
+
+    assert_eq!(live.notification_key, recovered.notification_key);
+    assert!(matches!(live.trigger, NotificationTrigger::MadeAdmin));
+    assert!(matches!(recovered.trigger, NotificationTrigger::MadeAdmin));
+}
+
+#[test]
+fn recovery_skips_invalidated_group_system_rows() {
+    let mut record = AppMessageRecord {
+        message_id_hex: "11".repeat(32),
+        direction: "system".to_owned(),
+        group_id_hex: "22".repeat(16),
+        sender: "33".repeat(32),
+        plaintext: "system".to_owned(),
+        kind: cgka_traits::app_event::MARMOT_APP_EVENT_KIND_GROUP_SYSTEM,
+        tags: Vec::new(),
+        source_epoch: Some(1),
+        retention: None,
+        recorded_at: 20,
+        received_at: 20,
+        insert_order: 1,
+        invalidated: true,
+        moderation_grant: false,
+    };
+    assert!(!notification_recovery_should_project(&record, Some(10)));
+    record.invalidated = false;
+    assert!(notification_recovery_should_project(&record, Some(10)));
+    record.received_at = 9;
+    assert!(!notification_recovery_should_project(&record, Some(10)));
+}
+
+#[test]
+fn group_state_wake_targets_only_matching_non_self_effects() {
+    let local = "aa".repeat(32);
+    let bob = "bb".repeat(32);
+    let carol = "cc".repeat(32);
+    let group_id = cgka_traits::GroupId::new(vec![0xEE; 16]);
+    let events = vec![
+        group_state_event(
+            group_id.clone(),
+            Some(&local),
+            cgka_traits::engine::GroupStateChange::MemberRemoved {
+                member: member_id_from_hex(&bob),
+            },
+        ),
+        group_state_event(
+            group_id.clone(),
+            Some(&local),
+            cgka_traits::engine::GroupStateChange::MemberLeft {
+                member: member_id_from_hex(&local),
+            },
+        ),
+        group_state_event(
+            group_id.clone(),
+            Some(&local),
+            cgka_traits::engine::GroupStateChange::AdminRemoved {
+                member: member_id_from_hex(&local),
+            },
+        ),
+        group_state_event(
+            group_id,
+            Some(&local),
+            cgka_traits::engine::GroupStateChange::AdminAdded {
+                member: member_id_from_hex(&carol),
+            },
+        ),
+    ];
+    let targets = wake_member_ids_from_group_events(&local, &events);
+    assert!(targets.contains(&bob));
+    assert!(targets.contains(&carol));
+    assert!(!targets.contains(&local));
+}
+
+#[test]
+fn group_state_wake_uses_only_snapshotted_target_tokens() {
+    let bob = "bb".repeat(32);
+    let carol = "cc".repeat(32);
+    let group_id_hex = "ee".repeat(16);
+    let tokens = vec![
+        GroupPushTokenRecord {
+            group_id_hex: group_id_hex.clone(),
+            member_id_hex: bob.clone(),
+            leaf_index: 1,
+            platform: PushPlatform::Fcm,
+            token_fingerprint: "fp-bob".to_owned(),
+            server_pubkey_hex: "aa".repeat(32),
+            relay_hint: Some("wss://hint.example".to_owned()),
+            encrypted_token: vec![1; PUSH_ENCRYPTED_TOKEN_LEN],
+            owner_ts: 0,
+            owner_sig: String::new(),
+            updated_at_ms: 0,
+        },
+        GroupPushTokenRecord {
+            group_id_hex,
+            member_id_hex: carol,
+            leaf_index: 2,
+            platform: PushPlatform::Fcm,
+            token_fingerprint: "fp-carol".to_owned(),
+            server_pubkey_hex: "aa".repeat(32),
+            relay_hint: Some("wss://hint.example".to_owned()),
+            encrypted_token: vec![2; PUSH_ENCRYPTED_TOKEN_LEN],
+            owner_ts: 0,
+            owner_sig: String::new(),
+            updated_at_ms: 0,
+        },
+    ];
+    let filtered = tokens_for_member_ids(tokens, [bob.as_str()]);
+    assert_eq!(filtered.len(), 1);
+    assert_eq!(filtered[0].member_id_hex, bob);
+}
+
+#[tokio::test]
+async fn group_state_wake_keeps_kind_446_context_free() {
+    use nostr::nips::nip59::UnwrappedGift;
+
+    let secret = server_secret();
+    let server_pubkey_hex = server_pubkey_hex(&secret);
+    let token = vec![7_u8; PUSH_ENCRYPTED_TOKEN_LEN];
+    let wrap = build_notification_gift_wrap(&server_pubkey_hex, &[token])
+        .await
+        .unwrap();
+    let event = wrap.to_verified_nostr_event().unwrap();
+    let server_keys = Keys::new(nostr::SecretKey::from(secret));
+    let UnwrappedGift { rumor, .. } = UnwrappedGift::from_gift_wrap(&server_keys, &event)
+        .await
+        .unwrap();
+    let tag_slices: Vec<&[String]> = rumor.tags.iter().map(|tag| tag.as_slice()).collect();
+    assert_eq!(
+        tag_slices,
+        vec![[NOTIFICATION_VERSION_TAG.to_owned(), PUSH_VERSION.to_owned()].as_slice()],
+        "group-state wakes must reuse the context-free kind-446 rumor"
+    );
+}
+
+#[test]
+fn recover_notification_updates_rebuilds_fresh_kind_1210_rows() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = marmot_account::AccountHome::open(dir.path());
+    let account = home.create_account("alice").unwrap();
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+    app.notification_settings("alice").unwrap();
+    let local = account.account_id_hex.clone();
+    let actor = "bb".repeat(32);
+    let group_id = cgka_traits::GroupId::new(vec![0xEE; 16]);
+    let change = cgka_traits::engine::GroupStateChange::MemberRemoved {
+        member: member_id_from_hex(&local),
+    };
+    let actor_id = member_id_from_hex(&actor);
+    let material =
+        cgka_traits::app_event::group_system_event_material(&group_id, 4, Some(&actor_id), &change)
+            .unwrap();
+    app.record_account_app_event_at(
+        "alice",
+        &crate::AppMessageProjection {
+            message_id_hex: material.message_id_hex.clone(),
+            source_message_id_hex: None,
+            direction: "system".to_owned(),
+            group_id_hex: material.group_id_hex,
+            sender: actor,
+            plaintext: material.content,
+            kind: cgka_traits::app_event::MARMOT_APP_EVENT_KIND_GROUP_SYSTEM,
+            tags: material.tags,
+            source_epoch: Some(4),
+            retention: None,
+            recorded_at: Some(40),
+            origin_commit_id: Some("ab".repeat(32)),
+            moderation_grant: false,
+        },
+        40,
+    )
+    .unwrap();
+
+    let recovered = recover_notification_updates(&app, Some(40)).unwrap();
+    assert_eq!(recovered.len(), 1);
+    assert!(matches!(
+        recovered[0].trigger,
+        NotificationTrigger::RemovedFromGroup
+    ));
+    assert_eq!(
+        recovered[0].notification_key,
+        format!("group-state:{local}:{}", material.message_id_hex)
+    );
+
+    let stale = recover_notification_updates(&app, Some(41)).unwrap();
+    assert!(
+        stale.is_empty(),
+        "pre-watermark kind-1210 rows must stay history"
+    );
+}

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -18,9 +18,10 @@ use marmot_app::{
     AccountRelayListBootstrap, AccountSetupRequest, AccountSetupResult, AppError, AppMessageQuery,
     AuditDataMode, AuditLogSettings, AuditLogTrackerConfig, AuditLogUploadSource, MarmotApp,
     MarmotAppConfig, MarmotAppEvent, MarmotAppRuntime, MediaAttachmentReference, MediaLocator,
-    MediaUploadAttachmentRequest, MediaUploadRequest, MissingRelayListKind, NotificationWakeSource,
-    PushPlatform, RetentionSweepStatus, RuntimeMessageUpdate, SelfMembership, SignOutOptions,
-    TimelineMessageQuery, TimelinePagination, UserDirectorySearch, UserProfileMetadata, tag_value,
+    MediaUploadAttachmentRequest, MediaUploadRequest, MissingRelayListKind, NotificationTrigger,
+    NotificationWakeSource, PushPlatform, RetentionSweepStatus, RuntimeMessageUpdate,
+    RuntimeNotificationsSubscription, SelfMembership, SignOutOptions, TimelineMessageQuery,
+    TimelinePagination, UserDirectorySearch, UserProfileMetadata, tag_value,
 };
 use nostr::base64::Engine as _;
 use nostr::base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
@@ -364,6 +365,53 @@ impl WritePolicy for RejectGiftWrapsWhileArmed {
             }
         })
     }
+}
+
+#[derive(Clone, Debug)]
+struct CountGiftWraps {
+    count: Arc<AtomicUsize>,
+}
+
+impl CountGiftWraps {
+    fn new() -> Self {
+        Self {
+            count: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    fn count(&self) -> usize {
+        self.count.load(Ordering::SeqCst)
+    }
+}
+
+impl WritePolicy for CountGiftWraps {
+    fn admit_event<'a>(
+        &'a self,
+        event: &'a nostr::Event,
+        _addr: &'a SocketAddr,
+    ) -> BoxedFuture<'a, PolicyResult> {
+        Box::pin(async move {
+            if event.kind == Kind::GiftWrap {
+                self.count.fetch_add(1, Ordering::SeqCst);
+            }
+            PolicyResult::Accept
+        })
+    }
+}
+
+async fn gift_wrap_counting_app(
+    dir: &tempfile::TempDir,
+    gate: CountGiftWraps,
+) -> (LocalRelay, MarmotApp, String) {
+    let relay = LocalRelay::new(RelayBuilder::default().write_policy(gate));
+    relay.run().await.unwrap();
+    let url = relay.url().await.to_string();
+    let app = MarmotApp::with_relay_and_config(
+        dir.path(),
+        url.clone(),
+        MarmotAppConfig::default().with_allow_loopback_relay_endpoints(true),
+    );
+    (relay, app, url)
 }
 
 #[derive(Clone, Debug)]
@@ -3848,6 +3896,372 @@ async fn removed_member_triggers_local_push_token_cleanup() {
 }
 
 #[tokio::test]
+async fn eviction_projects_removed_from_group_notification() {
+    let dir = tempfile::tempdir().unwrap();
+    let (_relay, app, url) = mock_app(&dir).await;
+    let runtime = MarmotAppRuntime::new(app.clone());
+    let setup = AccountSetupRequest {
+        default_relays: vec![endpoint(&url)],
+        bootstrap_relays: vec![endpoint(&url)],
+        publish_initial_key_package: true,
+        ..AccountSetupRequest::default()
+    };
+    let alice = create_network_ready_identity(&runtime, setup.relay_options_only()).await;
+    let bob = create_network_ready_identity(&runtime, setup).await;
+    let group_id = runtime
+        .create_group(
+            &alice.account.account_id_hex,
+            "eviction notify",
+            std::slice::from_ref(&bob.account.account_id_hex),
+            None,
+        )
+        .await
+        .unwrap();
+    app.set_local_notifications_enabled(&bob.account.account_id_hex, true)
+        .unwrap();
+    runtime.catch_up_accounts().await.unwrap();
+
+    let mut subscription = runtime.subscribe_notifications().unwrap();
+    let bob_id = bob.account.account_id_hex.clone();
+    runtime
+        .remove_members(
+            &alice.account.account_id_hex,
+            &group_id,
+            std::slice::from_ref(&bob_id),
+        )
+        .await
+        .unwrap();
+    runtime.catch_up_accounts().await.unwrap();
+
+    let update = wait_for_notification(&mut subscription, |update| {
+        update.account_id_hex == bob_id
+            && matches!(update.trigger, NotificationTrigger::RemovedFromGroup)
+    })
+    .await;
+    assert!(
+        update.notification_key.starts_with("group-state:"),
+        "live eviction keys must be deterministic group-state ids"
+    );
+    assert!(!update.is_from_self);
+
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn admin_grant_projects_made_admin_notification() {
+    let dir = tempfile::tempdir().unwrap();
+    let (_relay, app, url) = mock_app(&dir).await;
+    let runtime = MarmotAppRuntime::new(app.clone());
+    let setup = AccountSetupRequest {
+        default_relays: vec![endpoint(&url)],
+        bootstrap_relays: vec![endpoint(&url)],
+        publish_initial_key_package: true,
+        ..AccountSetupRequest::default()
+    };
+    let alice = create_network_ready_identity(&runtime, setup.relay_options_only()).await;
+    let bob = create_network_ready_identity(&runtime, setup).await;
+    let group_id = runtime
+        .create_group(
+            &alice.account.account_id_hex,
+            "admin notify",
+            std::slice::from_ref(&bob.account.account_id_hex),
+            None,
+        )
+        .await
+        .unwrap();
+    app.set_local_notifications_enabled(&bob.account.account_id_hex, true)
+        .unwrap();
+    runtime.catch_up_accounts().await.unwrap();
+
+    let mut subscription = runtime.subscribe_notifications().unwrap();
+    let bob_id = bob.account.account_id_hex.clone();
+    runtime
+        .promote_admin(&alice.account.account_id_hex, &group_id, &bob_id)
+        .await
+        .unwrap();
+    runtime.catch_up_accounts().await.unwrap();
+
+    let update = wait_for_notification(&mut subscription, |update| {
+        update.account_id_hex == bob_id && matches!(update.trigger, NotificationTrigger::MadeAdmin)
+    })
+    .await;
+    assert!(matches!(update.trigger, NotificationTrigger::MadeAdmin));
+
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn admin_revoke_projects_removed_as_admin_notification() {
+    let dir = tempfile::tempdir().unwrap();
+    let (_relay, app, url) = mock_app(&dir).await;
+    let runtime = MarmotAppRuntime::new(app.clone());
+    let setup = AccountSetupRequest {
+        default_relays: vec![endpoint(&url)],
+        bootstrap_relays: vec![endpoint(&url)],
+        publish_initial_key_package: true,
+        ..AccountSetupRequest::default()
+    };
+    let alice = create_network_ready_identity(&runtime, setup.relay_options_only()).await;
+    let bob = create_network_ready_identity(&runtime, setup).await;
+    let group_id = runtime
+        .create_group(
+            &alice.account.account_id_hex,
+            "admin revoke notify",
+            std::slice::from_ref(&bob.account.account_id_hex),
+            None,
+        )
+        .await
+        .unwrap();
+    app.set_local_notifications_enabled(&bob.account.account_id_hex, true)
+        .unwrap();
+    runtime.catch_up_accounts().await.unwrap();
+
+    let mut subscription = runtime.subscribe_notifications().unwrap();
+    let bob_id = bob.account.account_id_hex.clone();
+    runtime
+        .promote_admin(&alice.account.account_id_hex, &group_id, &bob_id)
+        .await
+        .unwrap();
+    runtime.catch_up_accounts().await.unwrap();
+    wait_for_notification(&mut subscription, |update| {
+        update.account_id_hex == bob_id && matches!(update.trigger, NotificationTrigger::MadeAdmin)
+    })
+    .await;
+
+    runtime
+        .demote_admin(&alice.account.account_id_hex, &group_id, &bob_id)
+        .await
+        .unwrap();
+    runtime.catch_up_accounts().await.unwrap();
+
+    let update = wait_for_notification(&mut subscription, |update| {
+        update.account_id_hex == bob_id
+            && matches!(update.trigger, NotificationTrigger::RemovedAsAdmin)
+    })
+    .await;
+    assert!(
+        update.notification_key.starts_with("group-state:"),
+        "live admin-revoke keys must be deterministic group-state ids"
+    );
+    assert!(!update.is_from_self);
+
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn remove_members_sends_context_free_wake_from_snapshotted_tokens() {
+    let dir = tempfile::tempdir().unwrap();
+    let gate = CountGiftWraps::new();
+    let (_relay, app, url) = gift_wrap_counting_app(&dir, gate.clone()).await;
+    let runtime = MarmotAppRuntime::new(app.clone());
+    let setup = AccountSetupRequest {
+        default_relays: vec![endpoint(&url)],
+        bootstrap_relays: vec![endpoint(&url)],
+        publish_initial_key_package: true,
+        ..AccountSetupRequest::default()
+    };
+    let alice = create_network_ready_identity(&runtime, setup.relay_options_only()).await;
+    let bob = create_network_ready_identity(&runtime, setup.relay_options_only()).await;
+    let carol = create_network_ready_identity(&runtime, setup).await;
+    let group_id = runtime
+        .create_group(
+            &alice.account.account_id_hex,
+            "eviction wake",
+            &[
+                bob.account.account_id_hex.clone(),
+                carol.account.account_id_hex.clone(),
+            ],
+            None,
+        )
+        .await
+        .unwrap();
+    let server_pubkey = nostr::Keys::generate().public_key().to_hex();
+    app.set_native_push_enabled(&bob.account.account_id_hex, true)
+        .unwrap();
+    app.upsert_push_registration(
+        &bob.account.account_id_hex,
+        PushPlatform::Fcm,
+        "bob-wake-token",
+        &server_pubkey,
+        Some(url.clone()),
+    )
+    .unwrap();
+    runtime
+        .share_push_registration(&bob.account.account_id_hex)
+        .await
+        .unwrap();
+    runtime.catch_up_accounts().await.unwrap();
+    sleep(Duration::from_millis(300)).await;
+
+    let wraps_before = gate.count();
+    runtime
+        .remove_members(
+            &alice.account.account_id_hex,
+            &group_id,
+            std::slice::from_ref(&bob.account.account_id_hex),
+        )
+        .await
+        .unwrap();
+    assert!(
+        gate.count() > wraps_before,
+        "successful eviction must publish a context-free kind-446 gift wrap from the snapshot"
+    );
+
+    let wraps_after_remove = gate.count();
+    runtime
+        .leave_group(&carol.account.account_id_hex, &group_id)
+        .await
+        .unwrap();
+    assert_eq!(
+        gate.count(),
+        wraps_after_remove,
+        "voluntary leave must not publish a membership wake"
+    );
+
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn remove_members_succeeds_when_wake_publish_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    let (_relay, app, url) = mock_app(&dir).await;
+    let runtime = MarmotAppRuntime::new(app.clone());
+    let setup = AccountSetupRequest {
+        default_relays: vec![endpoint(&url)],
+        bootstrap_relays: vec![endpoint(&url)],
+        publish_initial_key_package: true,
+        ..AccountSetupRequest::default()
+    };
+    let alice = create_network_ready_identity(&runtime, setup.relay_options_only()).await;
+    let bob = create_network_ready_identity(&runtime, setup).await;
+    let group_id = runtime
+        .create_group(
+            &alice.account.account_id_hex,
+            "wake failure",
+            std::slice::from_ref(&bob.account.account_id_hex),
+            None,
+        )
+        .await
+        .unwrap();
+    let server_pubkey = nostr::Keys::generate().public_key().to_hex();
+    app.set_native_push_enabled(&bob.account.account_id_hex, true)
+        .unwrap();
+    app.upsert_push_registration(
+        &bob.account.account_id_hex,
+        PushPlatform::Fcm,
+        "failing-wake-token",
+        &server_pubkey,
+        Some("not-a-relay-url".to_owned()),
+    )
+    .unwrap();
+    runtime
+        .share_push_registration(&bob.account.account_id_hex)
+        .await
+        .unwrap();
+    runtime.catch_up_accounts().await.unwrap();
+
+    runtime
+        .remove_members(
+            &alice.account.account_id_hex,
+            &group_id,
+            std::slice::from_ref(&bob.account.account_id_hex),
+        )
+        .await
+        .expect("successful eviction must ignore best-effort wake failure");
+
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn unauthorized_remove_and_self_demotion_send_no_wake() {
+    let dir = tempfile::tempdir().unwrap();
+    let gate = CountGiftWraps::new();
+    let (_relay, app, url) = gift_wrap_counting_app(&dir, gate.clone()).await;
+    let runtime = MarmotAppRuntime::new(app.clone());
+    let setup = AccountSetupRequest {
+        default_relays: vec![endpoint(&url)],
+        bootstrap_relays: vec![endpoint(&url)],
+        publish_initial_key_package: true,
+        ..AccountSetupRequest::default()
+    };
+    let alice = create_network_ready_identity(&runtime, setup.relay_options_only()).await;
+    let bob = create_network_ready_identity(&runtime, setup).await;
+    let group_id = runtime
+        .create_group(
+            &alice.account.account_id_hex,
+            "no wake",
+            std::slice::from_ref(&bob.account.account_id_hex),
+            None,
+        )
+        .await
+        .unwrap();
+    runtime.catch_up_accounts().await.unwrap();
+    sleep(Duration::from_millis(300)).await;
+    let wraps_before = gate.count();
+    let unauthorized = runtime
+        .remove_members(
+            &bob.account.account_id_hex,
+            &group_id,
+            std::slice::from_ref(&alice.account.account_id_hex),
+        )
+        .await;
+    assert!(
+        unauthorized.is_err(),
+        "non-admin removal must fail before any wake"
+    );
+    assert_eq!(
+        gate.count(),
+        wraps_before,
+        "unauthorized removal must not publish a wake"
+    );
+
+    let server_pubkey = nostr::Keys::generate().public_key().to_hex();
+    app.set_native_push_enabled(&bob.account.account_id_hex, true)
+        .unwrap();
+    app.upsert_push_registration(
+        &bob.account.account_id_hex,
+        PushPlatform::Fcm,
+        "bob-admin-token",
+        &server_pubkey,
+        Some(url.clone()),
+    )
+    .unwrap();
+    runtime
+        .share_push_registration(&bob.account.account_id_hex)
+        .await
+        .unwrap();
+    runtime.catch_up_accounts().await.unwrap();
+
+    runtime
+        .promote_admin(
+            &alice.account.account_id_hex,
+            &group_id,
+            &bob.account.account_id_hex,
+        )
+        .await
+        .unwrap();
+    runtime.catch_up_accounts().await.unwrap();
+    sleep(Duration::from_millis(300)).await;
+    let wraps_after_promote = gate.count();
+    assert!(
+        wraps_after_promote > wraps_before,
+        "promoting another member must publish a context-free wake"
+    );
+
+    runtime
+        .self_demote_admin(&bob.account.account_id_hex, &group_id)
+        .await
+        .unwrap();
+    assert_eq!(
+        gate.count(),
+        wraps_after_promote,
+        "self-demotion must not publish a wake"
+    );
+
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
 async fn concurrent_wake_collection_and_foreground_subscription_share_notification_key() {
     let dir = tempfile::tempdir().unwrap();
     let (_relay, app, url) = mock_app(&dir).await;
@@ -4935,6 +5349,25 @@ where
     })
     .await
     .expect("runtime event")
+}
+
+async fn wait_for_notification<F>(
+    subscription: &mut RuntimeNotificationsSubscription,
+    mut matches_update: F,
+) -> marmot_app::NotificationUpdate
+where
+    F: FnMut(&marmot_app::NotificationUpdate) -> bool,
+{
+    timeout(Duration::from_secs(8), async {
+        loop {
+            let update = subscription.recv().await.expect("notification update");
+            if matches_update(&update) {
+                return update;
+            }
+        }
+    })
+    .await
+    .expect("notification update")
 }
 
 async fn wait_for_message_update<F>(

--- a/crates/marmot-uniffi/src/conversions/notification.rs
+++ b/crates/marmot-uniffi/src/conversions/notification.rs
@@ -74,6 +74,9 @@ impl From<NotificationCollectionStatus> for NotificationCollectionStatusFfi {
 pub enum NotificationTriggerFfi {
     NewMessage,
     GroupInvite,
+    RemovedFromGroup,
+    MadeAdmin,
+    RemovedAsAdmin,
 }
 
 impl From<NotificationTrigger> for NotificationTriggerFfi {
@@ -81,6 +84,9 @@ impl From<NotificationTrigger> for NotificationTriggerFfi {
         match value {
             NotificationTrigger::NewMessage => Self::NewMessage,
             NotificationTrigger::GroupInvite => Self::GroupInvite,
+            NotificationTrigger::RemovedFromGroup => Self::RemovedFromGroup,
+            NotificationTrigger::MadeAdmin => Self::MadeAdmin,
+            NotificationTrigger::RemovedAsAdmin => Self::RemovedAsAdmin,
         }
     }
 }
@@ -209,6 +215,30 @@ mod tests {
         assert!(matches!(
             NotificationTrafficClassFfi::from(marmot_app::NotificationTrafficClass::AgentActivity,),
             NotificationTrafficClassFfi::AgentActivity,
+        ));
+    }
+
+    #[test]
+    fn notification_trigger_ffi_covers_every_core_variant() {
+        assert!(matches!(
+            NotificationTriggerFfi::from(marmot_app::NotificationTrigger::NewMessage),
+            NotificationTriggerFfi::NewMessage
+        ));
+        assert!(matches!(
+            NotificationTriggerFfi::from(marmot_app::NotificationTrigger::GroupInvite),
+            NotificationTriggerFfi::GroupInvite
+        ));
+        assert!(matches!(
+            NotificationTriggerFfi::from(marmot_app::NotificationTrigger::RemovedFromGroup),
+            NotificationTriggerFfi::RemovedFromGroup
+        ));
+        assert!(matches!(
+            NotificationTriggerFfi::from(marmot_app::NotificationTrigger::MadeAdmin),
+            NotificationTriggerFfi::MadeAdmin
+        ));
+        assert!(matches!(
+            NotificationTriggerFfi::from(marmot_app::NotificationTrigger::RemovedAsAdmin),
+            NotificationTriggerFfi::RemovedAsAdmin
         ));
     }
 }


### PR DESCRIPTION
## Summary
- Add `RemovedFromGroup`, `MadeAdmin`, and `RemovedAsAdmin` to core and UniFFI `NotificationTrigger` so clients can project eviction and admin-role changes.
- Classify only self-affecting authenticated `MemberRemoved`, `AdminAdded`, and non-self `AdminRemoved` effects in live `GroupStateChanged` events and fresh local kind-1210 recovery rows, with the existing mute/disabled/dedup/watermark rules.
- Snapshot requested members' wake records before removal/admin mutation and send the existing context-free kind-446 wake only for matching successful non-self effects.

Fixes #1240

Kind 446 remains unchanged and context-free: wake delivery still publishes the existing version-tag-only rumor and does not add group, actor, subject, role, or membership context.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p marmot-app notifications`
- [x] Focused `relay_runtime` coverage for eviction, admin grant/revoke, snapshotted wake, wake-publish failure, unauthorized remove, and self-demotion
- [x] `cargo test -p marmot-uniffi`
- [x] `just fast-ci`
- [x] Full `cargo test -p marmot-app --test relay_runtime` executed locally: all six new tests pass; unrelated pre-existing/timing-sensitive tests fail under the loaded vault runner (five reproduced on base in the initial run, plus one transient initial-catch-up timing failure in the final run). Exact-head GitHub Relay runtime tests pass.

## Sensitive-path disclosure
No MLS/CGKA, cryptography, credentials, authorization, or kind-446 payload/format changes. Wrapper orchestration snapshots existing wake records and publishes the unchanged context-free wake after already-authorized successful mutations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added notifications for being removed from a group, being promoted to admin, and having admin privileges removed.
  * Added reliable notification delivery when group membership or admin settings change.
  * Added support for these notification triggers in UniFFI integrations.

* **Bug Fixes**
  * Improved notification recovery by excluding invalid or outdated records.
  * Prevented notifications for unrelated changes, voluntary departures, and self-demotion.
  * Preserved context-free wake delivery where applicable.

* **Tests**
  * Expanded coverage for group membership changes, admin updates, notification recovery, filtering, and delivery failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
