### PR TITLE
Fix/arm refusals before publish gate

### DIFF
--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -3695,6 +3695,9 @@ impl AppClient {
         group_id: &GroupId,
         effects: &marmot_account::AccountDeviceEffects,
     ) -> Result<SendSummary, AppError> {
+        // Arm before the publish gate, for the reason spelled out in
+        // `observe_drained_session_events`.
+        self.arm_recovery_from_effects(effects);
         fail_if_publish_failed(effects)?;
         self.remember_published_reports(effects);
         // This is the path that releases sends the engine had retained, so its

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -3685,8 +3685,18 @@ impl AppClient {
 
         self.sync_runtime_groups().await?;
         let effects = self.runtime.advance_convergence(group_id).await?;
-        fail_if_publish_failed(&effects)?;
-        self.remember_published_reports(&effects);
+        self.observe_convergence_retry_effects(group_id, &effects)
+    }
+
+    /// Project one convergence retry's effects, split from the advance itself so
+    /// the projection is exercisable against a given batch of effects.
+    pub(crate) fn observe_convergence_retry_effects(
+        &mut self,
+        group_id: &GroupId,
+        effects: &marmot_account::AccountDeviceEffects,
+    ) -> Result<SendSummary, AppError> {
+        fail_if_publish_failed(effects)?;
+        self.remember_published_reports(effects);
         // This is the path that releases sends the engine had retained, so its
         // finalize updates carry the pending -> delivered flip for each of them.
         // Unlike the send path — which drops the same updates because it
@@ -3694,13 +3704,13 @@ impl AppClient {
         // there is nothing here to re-emit them, so buffer them for the account
         // worker to broadcast. Dropping them leaves storage delivered while
         // every timeline and chat-list subscriber still shows pending.
-        let finalize_updates = self.finalize_published_app_message_source_retention(&effects)?;
+        let finalize_updates = self.finalize_published_app_message_source_retention(effects)?;
         self.pending_projection_updates.extend(finalize_updates);
         self.refresh_group(group_id);
         self.prune_plaintext_retention_for_group(group_id)?;
         self.save_state_with_pending_local_group_deletion_frontier_clears()?;
-        self.queue_own_group_system_projection_updates(&effects);
-        Ok(send_summary_from_effects(&effects))
+        self.queue_own_group_system_projection_updates(effects);
+        Ok(send_summary_from_effects(effects))
     }
 
     pub async fn update_group_profile(

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -1696,11 +1696,23 @@ impl AppClient {
         // The account worker refreshes transport groups once for the scheduled
         // convergence batch before calling this per-group path.
         let effects = self.runtime.advance_convergence(group_id).await?;
-        fail_if_publish_failed(&effects)?;
-        self.remember_pending_convergence_groups(&effects);
-        self.arm_recovery_from_effects(&effects);
-        self.remember_published_reports(&effects);
-        let finalize_updates = self.finalize_published_app_message_source_retention(&effects)?;
+        self.observe_scheduled_convergence_effects(group_id, &effects)
+            .await
+    }
+
+    /// Project one scheduled convergence batch's effects, split from the
+    /// advance itself so the projection is exercisable against a given batch of
+    /// effects.
+    pub(crate) async fn observe_scheduled_convergence_effects(
+        &mut self,
+        group_id: &cgka_traits::GroupId,
+        effects: &marmot_account::AccountDeviceEffects,
+    ) -> Result<SyncSummary, AppError> {
+        fail_if_publish_failed(effects)?;
+        self.remember_pending_convergence_groups(effects);
+        self.arm_recovery_from_effects(effects);
+        self.remember_published_reports(effects);
+        let finalize_updates = self.finalize_published_app_message_source_retention(effects)?;
         let publish_new_message_notification =
             effects.published_app_messages.iter().any(|published| {
                 let group_id_hex = hex::encode(published.group_id.as_slice());
@@ -1723,7 +1735,7 @@ impl AppClient {
         let source_received_at = unix_now_seconds();
         let routes_dirty = self
             .observe_account_device_effects(
-                &effects,
+                effects,
                 &display_names,
                 &mut summary,
                 &source_message_id_hex,

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -168,7 +168,10 @@ impl AppClient {
             .extend(effects.pending_convergence.iter().cloned());
     }
 
-    fn arm_recovery_from_effects(&mut self, effects: &marmot_account::AccountDeviceEffects) {
+    pub(crate) fn arm_recovery_from_effects(
+        &mut self,
+        effects: &marmot_account::AccountDeviceEffects,
+    ) {
         if self.app.cursor_persistence() != CursorPersistence::Advance {
             return;
         }
@@ -1708,9 +1711,11 @@ impl AppClient {
         group_id: &cgka_traits::GroupId,
         effects: &marmot_account::AccountDeviceEffects,
     ) -> Result<SyncSummary, AppError> {
-        fail_if_publish_failed(effects)?;
         self.remember_pending_convergence_groups(effects);
+        // Arm before the publish gate, for the reason spelled out in
+        // `observe_drained_session_events`.
         self.arm_recovery_from_effects(effects);
+        fail_if_publish_failed(effects)?;
         self.remember_published_reports(effects);
         let finalize_updates = self.finalize_published_app_message_source_retention(effects)?;
         let publish_new_message_notification =

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -9299,6 +9299,126 @@ async fn a_publish_failure_in_the_session_event_drain_still_arms_recovery() {
     );
 }
 
+/// One effects batch carrying both a resource refusal for `group_id` and a hard
+/// publish failure whose pending commit rolled back — the shape in which a
+/// refusal the pass does not arm on becomes unrecoverable.
+fn a_refusal_riding_a_rolled_back_publish(
+    group_id: &cgka_traits::GroupId,
+) -> marmot_account::AccountDeviceEffects {
+    let message_id = cgka_traits::MessageId::new(vec![0xab; 32]);
+    let mut effects = marmot_account::AccountDeviceEffects::default();
+    effects.events.push(
+        cgka_traits::engine::GroupEvent::TransportObjectResourceRefused {
+            group_id: group_id.clone(),
+            message_id: message_id.clone(),
+            resource: cgka_traits::ingest::InboundResourceLimit::TransportDeferredCapacity,
+        },
+    );
+    effects.failures.push(marmot_account::PublishFailure {
+        message_id,
+        reason: "injected publish failure".to_owned(),
+    });
+    effects
+        .pending
+        .push(marmot_account::PendingResolution::RolledBack {
+            pending: cgka_traits::engine_state::PendingStateRef::new(7),
+        });
+    effects
+}
+
+/// A resource refusal carried by the scheduled convergence batch must arm
+/// epoch-gap recovery even when that same pass's publish check fails it.
+///
+/// Same one-shot loss as the drained seam: this batch's events reach the app
+/// once, and the refusal was buffered only after its durable retention row was
+/// deleted. The account worker calls this seam per group, so a failing advance
+/// that returned before arming would drop the refusal for good.
+#[tokio::test]
+async fn a_publish_failure_after_scheduled_convergence_still_arms_recovery() {
+    let dir = tempfile::tempdir().unwrap();
+    AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relay(dir.path(), "wss://advance-arm.example")
+        .with_test_relay_client(relay.clone());
+    app.set_audit_log_settings(AuditLogSettings {
+        enabled: true,
+        ..Default::default()
+    })
+    .unwrap();
+    let mut client = app.client("alice").await.unwrap();
+    let group_id = client
+        .create_group("advance arm ordering", &[])
+        .await
+        .unwrap();
+    assert_eq!(audit_rows_of_kind(&app, "epoch_stall_backfill_armed"), 0);
+
+    let effects = a_refusal_riding_a_rolled_back_publish(&group_id);
+    let result = client
+        .observe_scheduled_convergence_effects(&group_id, &effects)
+        .await;
+
+    assert!(
+        result.is_err(),
+        "a rolled-back publish failure must still fail the scheduled convergence pass"
+    );
+    assert!(
+        client.has_pending_epoch_backfill(),
+        "the refusal rides this batch only once, so it must arm before the pass can fail"
+    );
+    assert_eq!(
+        audit_rows_of_kind(&app, "epoch_stall_backfill_armed"),
+        1,
+        "the arm must leave its durable forensic row even on a failing pass"
+    );
+}
+
+/// A resource refusal carried by a host-requested convergence retry must arm
+/// epoch-gap recovery even when that same pass's publish check fails it.
+///
+/// The retry seam folds and publishes exactly like the scheduled one, so it
+/// carries the same refusals under the same one-shot loss — and a host that
+/// retries a stuck group is the case where the recovery evidence matters most.
+#[tokio::test]
+async fn a_publish_failure_during_a_convergence_retry_still_arms_recovery() {
+    let dir = tempfile::tempdir().unwrap();
+    AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relay(dir.path(), "wss://retry-arm.example")
+        .with_test_relay_client(relay.clone());
+    app.set_audit_log_settings(AuditLogSettings {
+        enabled: true,
+        ..Default::default()
+    })
+    .unwrap();
+    let mut client = app.client("alice").await.unwrap();
+    let group_id = client
+        .create_group("retry arm ordering", &[])
+        .await
+        .unwrap();
+    assert_eq!(audit_rows_of_kind(&app, "epoch_stall_backfill_armed"), 0);
+
+    let effects = a_refusal_riding_a_rolled_back_publish(&group_id);
+    let result = client.observe_convergence_retry_effects(&group_id, &effects);
+
+    assert!(
+        result.is_err(),
+        "a rolled-back publish failure must still fail the convergence retry"
+    );
+    assert!(
+        client.has_pending_epoch_backfill(),
+        "the refusal rides this batch only once, so it must arm before the pass can fail"
+    );
+    assert_eq!(
+        audit_rows_of_kind(&app, "epoch_stall_backfill_armed"),
+        1,
+        "the arm must leave its durable forensic row even on a failing pass"
+    );
+}
+
 /// An escalation recorded while an inbound delivery is ingested must ride the
 /// summary that seam returns.
 ///


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery during scheduled and manually retried synchronization convergence.
  * Publish failures are now reported consistently while durable epoch backfill recovery is activated.
  * Helps restore synchronization after resource refusals or rolled-back updates without requiring repeated recovery actions.
  * Improved handling ensures pending group updates, projections, notifications, and system state remain consistent during recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->