### PR TITLE
marmot-app: invite KeyPackages the caller already holds

### DIFF
--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -1865,6 +1865,24 @@ impl AppClient {
         Ok(summary)
     }
 
+    /// The same, for the account worker: timed like every other invite, and leaving Welcome
+    /// delivery to the worker's own fanout rather than driving it inline.
+    pub(crate) async fn invite_key_packages_with_telemetry(
+        &mut self,
+        group_id: &GroupId,
+        key_packages: Vec<KeyPackage>,
+        telemetry: &AppPerformanceTelemetry,
+    ) -> Result<SendSummary, AppError> {
+        self.invite_members_with_optional_telemetry(
+            group_id,
+            &[],
+            &[],
+            Some(telemetry),
+            Some(key_packages),
+        )
+        .await
+    }
+
     async fn invite_members_with_optional_telemetry(
         &mut self,
         group_id: &GroupId,

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -1824,7 +1824,7 @@ impl AppClient {
         member_refs: &[&str],
     ) -> Result<SendSummary, AppError> {
         let summary = self
-            .invite_members_with_optional_telemetry(group_id, member_refs, &[], None)
+            .invite_members_with_optional_telemetry(group_id, member_refs, &[], None, None)
             .await?;
         self.drive_unpublished_welcome_delivery(None).await;
         Ok(summary)
@@ -1842,8 +1842,27 @@ impl AppClient {
             member_refs,
             initial_admin_refs,
             Some(telemetry),
+            None,
         )
         .await
+    }
+
+    /// Invites members whose KeyPackages the caller already holds.
+    ///
+    /// Resolution maps one account to one KeyPackage, which is the right answer only while an
+    /// account has one device. A caller that knows an account's devices — and which of them
+    /// still count — supplies their KeyPackages here instead. Group setup already defines the
+    /// resulting shape: admin policy applies per leaf when an account has more than one.
+    pub async fn invite_key_packages(
+        &mut self,
+        group_id: &GroupId,
+        key_packages: Vec<KeyPackage>,
+    ) -> Result<SendSummary, AppError> {
+        let summary = self
+            .invite_members_with_optional_telemetry(group_id, &[], &[], None, Some(key_packages))
+            .await?;
+        self.drive_unpublished_welcome_delivery(None).await;
+        Ok(summary)
     }
 
     async fn invite_members_with_optional_telemetry(
@@ -1852,18 +1871,24 @@ impl AppClient {
         member_refs: &[&str],
         initial_admin_refs: &[&str],
         telemetry: Option<&AppPerformanceTelemetry>,
+        supplied_key_packages: Option<Vec<KeyPackage>>,
     ) -> Result<SendSummary, AppError> {
         self.ensure_group(group_id)?;
 
-        let key_package_started_at = Instant::now();
-        let key_packages = self.app.resolve_member_key_packages(member_refs).await;
-        record_app_performance(
-            telemetry,
-            AppPerformanceOperation::GroupInviteKeyPackageLookup,
-            key_package_started_at.elapsed(),
-            key_packages.is_ok(),
-        );
-        let key_packages = key_packages?;
+        let key_packages = match supplied_key_packages {
+            Some(key_packages) => key_packages,
+            None => {
+                let key_package_started_at = Instant::now();
+                let key_packages = self.app.resolve_member_key_packages(member_refs).await;
+                record_app_performance(
+                    telemetry,
+                    AppPerformanceOperation::GroupInviteKeyPackageLookup,
+                    key_package_started_at.elapsed(),
+                    key_packages.is_ok(),
+                );
+                key_packages?
+            }
+        };
 
         let mut initial_admins = Vec::with_capacity(initial_admin_refs.len());
         for admin in initial_admin_refs {

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -3018,8 +3018,17 @@ async fn handle_account_worker_command(
             key_packages,
             respond,
         } => {
-            let result = client.invite_key_packages(&group_id, key_packages).await;
-            if result.is_ok() {
+            let telemetry = shared.app_performance_telemetry();
+            let result = client
+                .invite_key_packages_with_telemetry(&group_id, key_packages, &telemetry)
+                .await;
+            // A queued send returns `Ok` without having been published, and announcing group
+            // state for one would be announcing something that has not happened. The sibling
+            // arm below draws the line in the same place.
+            let canonical = result.as_ref().is_ok_and(|summary| {
+                summary.accept_disposition == cgka_traits::SendAcceptDisposition::Published
+            });
+            if canonical {
                 publish_client_pending_projection_updates(
                     client,
                     events,

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -196,6 +196,11 @@ pub(crate) enum AccountWorkerCommand {
         initial_admins: Vec<String>,
         respond: oneshot::Sender<Result<SendSummary, AppError>>,
     },
+    InviteKeyPackages {
+        group_id: GroupId,
+        key_packages: Vec<cgka_traits::engine::KeyPackage>,
+        respond: oneshot::Sender<Result<SendSummary, AppError>>,
+    },
     RemoveMembers {
         group_id: GroupId,
         members: Vec<String>,
@@ -3006,6 +3011,28 @@ async fn handle_account_worker_command(
             respond,
         } => {
             let result = client.exporter_secret(&group_id, &label, length);
+            let _ = respond.send(result);
+        }
+        AccountWorkerCommand::InviteKeyPackages {
+            group_id,
+            key_packages,
+            respond,
+        } => {
+            let result = client.invite_key_packages(&group_id, key_packages).await;
+            if result.is_ok() {
+                publish_client_pending_projection_updates(
+                    client,
+                    events,
+                    account_id_hex,
+                    account_label,
+                );
+                publish_app_runtime_group_state_updated(
+                    events,
+                    account_id_hex,
+                    account_label,
+                    &group_id,
+                );
+            }
             let _ = respond.send(result);
         }
         AccountWorkerCommand::InviteMembers {

--- a/crates/marmot-app/src/runtime/commands.rs
+++ b/crates/marmot-app/src/runtime/commands.rs
@@ -1629,8 +1629,9 @@ impl AccountManager {
             .await
             .map_err(|_| AppError::TransportClosed)?;
         let summary = account_worker_response(response).await?;
-        self.catch_up_after_committed_mutation("invite_key_packages")
-            .await;
+        // Detached, like the other invite: the caller has its answer, and the account-wide
+        // catch-up that follows an invite is not something to hold them for.
+        self.spawn_invite_catch_up();
         self.schedule_audit_log_tracker_update("invite_key_packages");
         Ok(summary)
     }

--- a/crates/marmot-app/src/runtime/commands.rs
+++ b/crates/marmot-app/src/runtime/commands.rs
@@ -1612,6 +1612,29 @@ impl AccountManager {
         Ok(result)
     }
 
+    pub async fn invite_key_packages(
+        &self,
+        account_ref: &str,
+        group_id: &GroupId,
+        key_packages: Vec<cgka_traits::engine::KeyPackage>,
+    ) -> Result<SendSummary, AppError> {
+        let command = self.worker_commands(account_ref).await?;
+        let (respond, response) = oneshot::channel();
+        command
+            .send(AccountWorkerCommand::InviteKeyPackages {
+                group_id: group_id.clone(),
+                key_packages,
+                respond,
+            })
+            .await
+            .map_err(|_| AppError::TransportClosed)?;
+        let summary = account_worker_response(response).await?;
+        self.catch_up_after_committed_mutation("invite_key_packages")
+            .await;
+        self.schedule_audit_log_tracker_update("invite_key_packages");
+        Ok(summary)
+    }
+
     pub async fn retry_group_convergence(
         &self,
         account_ref: &str,

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -2508,6 +2508,22 @@ impl MarmotAppRuntime {
             .await
     }
 
+    /// Invites devices whose KeyPackages the caller already holds.
+    ///
+    /// [`Self::invite_members`] resolves one account to one KeyPackage, so an account with a
+    /// laptop and a phone joins as whichever published last. A host that knows an account's
+    /// devices supplies their KeyPackages here and every one of them becomes a member.
+    pub async fn invite_key_packages(
+        &self,
+        account_ref: &str,
+        group_id: &GroupId,
+        key_packages: Vec<cgka_traits::engine::KeyPackage>,
+    ) -> Result<SendSummary, AppError> {
+        self.accounts
+            .invite_key_packages(account_ref, group_id, key_packages)
+            .await
+    }
+
     pub async fn retry_group_convergence(
         &self,
         account_ref: &str,

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -9999,3 +9999,103 @@ async fn convergence_settles_across_generations_with_mid_window_queued_sends() {
 
     runtime.shutdown().await;
 }
+
+#[tokio::test]
+async fn invite_key_packages_admits_two_leaves_of_one_account() {
+    // Member resolution answers "the account's KeyPackage", singular: the most recently
+    // published one. An account with two devices therefore joins as whichever of them
+    // published last, and the other never hears about the group. Group setup already says
+    // what more than one leaf per account means — admin policy applies to each — so the gap
+    // is in how a caller expresses it, not in what the protocol allows.
+    let dir = tempfile::tempdir().unwrap();
+    let second = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(dir.path());
+    home.create_account("alice").unwrap();
+    home.create_account("bob").unwrap();
+    let bob_id = home.account("bob").unwrap().account_id_hex;
+
+    let (_relay, app, url) = mock_app(&dir).await;
+
+    // Bob's first device publishes a KeyPackage, and Alice reads it.
+    let mut bob_one = app.client("bob").await.unwrap();
+    bob_one.publish_key_package().await.unwrap();
+    let first = app
+        .fetch_latest_key_package_for_account_id(&bob_id, vec![endpoint(&url)])
+        .await
+        .unwrap()
+        .key_package;
+
+    // Bob's second device: the same account, a separate store, its own MLS key material —
+    // which is what a second device is. Its KeyPackage replaces the first as "the latest".
+    let secret = home
+        .load_signing_keys("bob")
+        .unwrap()
+        .secret_key()
+        .to_secret_hex();
+    let second_home = AccountHome::open(second.path());
+    second_home.import_account("bob", &secret).unwrap();
+    let second_app = MarmotApp::with_relay(second.path(), url.clone());
+    let mut bob_two = second_app.client("bob").await.unwrap();
+    bob_two.publish_key_package().await.unwrap();
+    let latest = app
+        .fetch_latest_key_package_for_account_id(&bob_id, vec![endpoint(&url)])
+        .await
+        .unwrap()
+        .key_package;
+    assert_ne!(
+        first.bytes, latest.bytes,
+        "the second device published nothing of its own"
+    );
+
+    // Alice invites both, which naming the account once cannot express.
+    let mut alice = app.client("alice").await.unwrap();
+    let group_id = alice.create_group("both of bob", &[]).await.unwrap();
+    let summary = alice
+        .invite_key_packages(&group_id, vec![first, latest])
+        .await
+        .unwrap();
+    assert_eq!(
+        summary.published, 1,
+        "the invite did not publish its commit"
+    );
+    let members = alice.members(&group_id).unwrap();
+    assert_eq!(
+        members.len(),
+        3,
+        "membership is per leaf: alice, and bob twice"
+    );
+    assert_eq!(
+        members
+            .iter()
+            .filter(|member| member.member_id_hex == bob_id)
+            .count(),
+        2,
+        "bob's two devices are not both in the group under his one identity"
+    );
+
+    // Both devices find the group, which is the whole point.
+    let joined_one = bob_one.sync().await.unwrap();
+    assert_eq!(
+        joined_one.joined_groups,
+        vec![group_id.clone()],
+        "bob's first device did not join"
+    );
+    let joined_two = bob_two.sync().await.unwrap();
+    assert_eq!(
+        joined_two.joined_groups,
+        vec![group_id.clone()],
+        "bob's second device did not join"
+    );
+
+    // And a message reaches both of them, rather than whichever published last.
+    alice.send(&group_id, b"for both of you").await.unwrap();
+    for (name, bob) in [("first", &mut bob_one), ("second", &mut bob_two)] {
+        let received = bob.sync().await.unwrap();
+        assert_eq!(
+            received.messages.len(),
+            1,
+            "bob's {name} device received nothing"
+        );
+        assert_eq!(received.messages[0].plaintext, "for both of you");
+    }
+}


### PR DESCRIPTION
Member resolution maps one account to one KeyPackage — whichever it published last. An account with two devices therefore joins a group as one of them, decided by a race between their publishes, and the other never learns the group exists. Naming the account twice does not help: `resolve_member_key_packages_inner` deduplicates by account id, so the second mention resolves to the same package.

Group setup already says what the result should look like:

> Admin authority is based on Marmot account identity, not on MLS leaf id. If an account has multiple leaves in a group, the admin policy applies to each current leaf.

So more than one leaf per account is a shape the protocol describes. What is missing is a way for a caller to ask for it.

### The change

`AppClient::invite_key_packages` and `MarmotAppRuntime::invite_key_packages` take the packages rather than resolving them. Everything after that is the existing invite path — the same commit, the same Welcomes, the same delivery records — so the only new behaviour is which packages end up in `SendIntent::Invite`.

Resolution is untouched for every existing caller: `invite_members` still resolves as before, and the shared body simply skips the lookup when packages are supplied.

This is deliberately **not** the multi-device External Commit flow from `features/multi-device.md`, which is a draft and needs the signalling gate and an admin-authorization proof. This is an ordinary invitation of packages the caller found for itself, which is how somebody discovers a contact's devices today anyway.

### Test

`invite_key_packages_admits_two_leaves_of_one_account` in `crates/marmot-app/tests/relay_runtime.rs` puts one account on two stores — separate MLS key material in each, which is what a second device is — publishes a KeyPackage from both, and invites the two together. Three leaves result, two of them under one identity; both devices join; a message from the group reaches both.

Inviting the same account by name in that scenario gives two leaves instead of three, which is the behaviour this addresses.

### Caveats

- Finding the devices is left to the caller. This does not add a way to enumerate an account's published KeyPackages; the packages must carry their source event id, since a Welcome is addressed with it — one read from a relay does that, a package read out of local storage does not.
- I did not touch how many packages an account may reasonably have in one group, nor what should happen to leaves of a device that has been retired. Both feel like questions for the multi-device feature rather than for this seam.
- `cargo test -p marmot-app` on this branch: 850 passed, 5 failed. The same five fail on a clean `master` here (`encrypted_media_*`, `retained_media_rehydrates_*`, `relay_app_runtime_synthesizes_system_row_for_retention_change`, `self_removal_suppresses_*`), all with timeouts, so they look environmental rather than related.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for inviting multiple devices to a group using explicitly selected invitation credentials.
  - Added runtime and account-level options for sending invitations with supplied credentials.
  - Group state and pending updates now refresh after invitations are successfully published.

- **Bug Fixes**
  - Improved multi-device account support so each device can join groups and receive subsequent messages.

- **Tests**
  - Added coverage for multi-device invitations, synchronized group membership, and message delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->