### PR TITLE
fix(engine): classify an empty admin policy as admin depletion

### DIFF
--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -83,7 +83,8 @@ These are the scenarios another implementation should be able to load from JSON 
 - Setup: Alice creates a group with Bob as a non-admin, rejects Bob's first admin-policy edit, promotes Bob, lets Bob
   make an admin-gated group-data update, and then Bob removes himself from the admin set.
 - Pressure: admin-policy app-component validation, admin authorization, role convergence, and post-demotion denial.
-- Expected: empty admin policies fail, non-admin updates fail, both clients observe Bob's promotion and later
+- Expected: an empty admin policy is refused as admin depletion, non-admin updates fail, both clients observe
+  Bob's promotion and later
   self-demotion, and both clients converge at epoch 4 with Alice as the sole admin.
 
 ### `group-data-fork-recovery/v1`

--- a/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
@@ -57,7 +57,7 @@
         "type": "expect_update_admin_policy_error",
         "client": "alice",
         "admins": [],
-        "error": "invalid_admin_policy"
+        "error": "admin_policy"
       },
       {
         "type": "update_admin_policy",
@@ -178,7 +178,7 @@
       "step_index": 6,
       "client": "alice",
       "operation": "update_admin_policy",
-      "error": "invalid_admin_policy"
+      "error": "admin_policy"
     },
     {
       "type": "pending_resolution",

--- a/crates/cgka-conformance-simulator/vectors/manifest.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/manifest.v1.json
@@ -103,7 +103,7 @@
       "artifact": "admin-policy-update.v1.json",
       "coverage": [
         "non-admin admin-policy update rejection",
-        "invalid empty admin-policy rejection",
+        "sole-admin empty admin-policy refused as admin depletion",
         "admin promotion through app-component update",
         "promoted member group-data update",
         "admin self-demotion through app-component update",

--- a/crates/cgka-engine/src/app_components.rs
+++ b/crates/cgka-engine/src/app_components.rs
@@ -1504,6 +1504,15 @@ pub(crate) fn encode_admin_policy(admins: &[[u8; 32]]) -> Result<Vec<u8>, Engine
     Ok(out)
 }
 
+/// Whether an admin-policy payload names no admin at all.
+///
+/// Bytes this cannot parse are not empty, they are malformed, and that verdict
+/// belongs to [`decode_admin_policy`] — so an unparseable payload answers
+/// `false` here and is refused there.
+pub(crate) fn admin_policy_is_empty(bytes: &[u8]) -> bool {
+    decode_quic_varint(bytes).is_ok_and(|(len, prefix_len)| len == 0 && prefix_len == bytes.len())
+}
+
 pub(crate) fn decode_admin_policy(bytes: &[u8]) -> Result<Vec<[u8; 32]>, EngineError> {
     let (len, prefix_len) = decode_quic_varint(bytes)
         .map_err(|e| EngineError::Serialize(format!("admin policy length decode failed: {e}")))?;

--- a/crates/cgka-engine/src/update_group_data.rs
+++ b/crates/cgka-engine/src/update_group_data.rs
@@ -91,6 +91,16 @@ impl<S: StorageProvider> Engine<S> {
                     "UpdateAppComponents contains duplicate component ids".into(),
                 ));
             }
+            // MIP-03 §150, ordered ahead of the component validator: that
+            // validator refuses the same payload as a malformed encoding, which
+            // would hide the policy refusal behind a wire fault.
+            if update.component_id == GROUP_ADMIN_POLICY_COMPONENT_ID
+                && crate::app_components::admin_policy_is_empty(&update.data)
+            {
+                return Err(EngineError::AdminDepletion {
+                    group_id: group_id.clone(),
+                });
+            }
             crate::app_components::validate_app_component_update(update)?;
         }
 

--- a/crates/cgka-engine/tests/mip03_guards.rs
+++ b/crates/cgka-engine/tests/mip03_guards.rs
@@ -13,7 +13,10 @@ use cgka_engine::convergence::ConvergencePolicy;
 use cgka_engine::feature_registry::FeatureRegistry;
 use cgka_engine::provider::EngineOpenMlsProvider;
 use cgka_engine::{DEFAULT_CIPHERSUITE, Engine, EngineBuilder};
-use cgka_traits::app_components::{GROUP_PROFILE_COMPONENT_ID, encode_component_vectors};
+use cgka_traits::app_components::{
+    AppComponentData, GROUP_ADMIN_POLICY_COMPONENT_ID, GROUP_PROFILE_COMPONENT_ID,
+    encode_component_vectors, encode_quic_varint,
+};
 use cgka_traits::capabilities::{Capability, CapabilityRequirement, Feature, RequirementLevel};
 use cgka_traits::engine::{CgkaEngine, CreateGroupRequest, SendIntent, SendResult};
 use cgka_traits::error::PeelerError;
@@ -1492,6 +1495,54 @@ async fn admin_cannot_self_remove_when_only_admin() {
             assert_eq!(gid, group_id);
         }
         other => panic!("expected AdminCannotSelfRemove, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn sole_admin_emptying_the_admin_policy_is_refused_as_admin_depletion() {
+    // Self-demotion travels as an admin-policy component update, so MIP-03
+    // §150 has to hold on that route too: the sole admin's demotion leaves
+    // the group with no admin at all. The refusal is a policy verdict and must
+    // name itself as one, not as a malformed payload.
+    let mut alice = build(b"alice");
+    let mut bob = build(b"bob");
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "sole-admin-self-demote".into(),
+            description: "".into(),
+            members: vec![bob_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    match create {
+        SendResult::GroupCreated { pending, .. } => {
+            alice.confirm_published(pending).await.unwrap();
+        }
+        other => panic!("expected GroupCreated, got {other:?}"),
+    }
+
+    let mut empty_admin_policy = Vec::new();
+    encode_quic_varint(0, &mut empty_admin_policy);
+    let err = alice
+        .send(SendIntent::UpdateAppComponents {
+            group_id: group_id.clone(),
+            updates: vec![AppComponentData {
+                component_id: GROUP_ADMIN_POLICY_COMPONENT_ID,
+                data: empty_admin_policy,
+            }],
+        })
+        .await
+        .err()
+        .unwrap();
+    match err {
+        cgka_traits::EngineError::AdminDepletion { group_id: gid } => {
+            assert_eq!(gid, group_id);
+        }
+        other => panic!("expected AdminDepletion, got {other:?}"),
     }
 }
 

--- a/crates/cgka-engine/tests/update_group_data.rs
+++ b/crates/cgka-engine/tests/update_group_data.rs
@@ -1208,15 +1208,20 @@ async fn non_admin_cannot_update_admin_policy_component() {
 #[tokio::test]
 async fn invalid_admin_policy_component_is_rejected() {
     let (mut alice, _bob, gid) = create_pair().await;
-    let mut empty_admin_policy = Vec::new();
-    cgka_traits::app_components::encode_quic_varint(0, &mut empty_admin_policy);
+    // A key one byte short of 32: this payload is malformed, so the encoding
+    // verdict is the right one. An *empty* admin policy is well-formed and
+    // refused as MIP-03 §150 admin depletion instead — see
+    // `mip03_guards.rs::sole_admin_emptying_the_admin_policy_is_refused_as_admin_depletion`.
+    let mut short_key_admin_policy = Vec::new();
+    cgka_traits::app_components::encode_quic_varint(31, &mut short_key_admin_policy);
+    short_key_admin_policy.extend_from_slice(&[0u8; 31]);
 
     let err = alice
         .send(SendIntent::UpdateAppComponents {
             group_id: gid,
             updates: vec![AppComponentData {
                 component_id: GROUP_ADMIN_POLICY_COMPONENT_ID,
-                data: empty_admin_policy,
+                data: short_key_admin_policy,
             }],
         })
         .await

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -3236,6 +3236,32 @@ async fn failed_leave_push_compensation_body() {
 }
 
 #[test]
+fn sole_admin_self_demote_surfaces_the_admin_policy_refusal() {
+    run_composed_app_runtime_test("sole-admin-self-demote", || async {
+        let dir = tempfile::tempdir().unwrap();
+        AccountHome::open(dir.path())
+            .create_account("alice")
+            .unwrap();
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+            .with_test_relay_client(Arc::new(ScriptedPushRelayClient::default()));
+        let mut client = app.client("alice").await.unwrap();
+        let group_id = client.create_group("sole admin", &[]).await.unwrap();
+
+        // Alice is the only admin, so demoting herself would leave the group
+        // with none. The host must receive that as the admin-policy refusal it
+        // is, not as a payload-encoding fault.
+        let err = client.self_demote_admin(&group_id).await.err().unwrap();
+        match err {
+            AppError::Account(marmot_account::AccountError::Session(
+                cgka_session::SessionError::Engine(cgka_traits::EngineError::AdminDepletion {
+                    ..
+                }),
+            )) => {}
+            other => panic!("expected AdminDepletion, got {other:?}"),
+        }
+    });
+}
+#[test]
 fn push_registration_removal_retry_survives_clear_and_restart() {
     run_composed_app_runtime_test(
         "push-registration-removal-retry",


### PR DESCRIPTION
A sole admin self-demoting was refused, correctly, but the refusal came out of a wire decoder: self-demote travels as an admin-policy component update, and `decode_admin_policy` rejects a zero-key payload as `EngineError::Serialize`. `marmot-uniffi` has no arm for `Serialize`, so hosts saw a generic `Runtime` — a protocol refusal wearing a fault's clothes.

The outbound authoring loop in `do_send_update_app_components` now classifies a well-formed but empty admin policy as the existing `EngineError::AdminDepletion`, ahead of the component validator so the specific verdict wins. That variant is already wired through FFI (`WouldRemoveLastAdmin`), the CLI, the audit classifier, and the conformance simulator, so no error surface changes.

`decode_admin_policy` is untouched: an empty admin policy arriving from a peer genuinely is a malformed component, and `Serialize` stays the right inbound verdict. `admin_policy_is_empty` keeps the format knowledge in `app_components`, and answers `false` for bytes it cannot parse — those are malformed, not empty, and belong to the decoder.

`update_group_data.rs::invalid_admin_policy_component_is_rejected` asserted the `Serialize` verdict for the outbound path, so it encoded the bug. It now uses a genuinely malformed payload (a 31-byte key), keeping its stated intent while the new MIP-03 guard test owns the policy verdict.

Closes #1510

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented the sole group administrator from removing themselves through an empty admin-policy update.
  - Preserved the group when this operation is rejected.
  - Continued distinguishing malformed admin-policy data from valid but disallowed empty policies.

- **Tests**
  - Added regression coverage for administrator self-demotion and related validation behavior.

- **Documentation**
  - Clarified conformance expectations and error reporting for administrator-depleting policy updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->