### PR TITLE
fix(marmot-app): arm epoch-gap recovery before every publish gate

### DIFF
--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -1997,7 +1997,7 @@ impl AppClient {
             },
         });
 
-        let published = self
+        let published = match self
             .runtime
             .publish_prepared_session_effects_with_audit_context(
                 session_effects,
@@ -2005,10 +2005,15 @@ impl AppClient {
             )
             .await
             .map_err(AppError::from)
-            .and_then(|effects| {
-                fail_if_publish_failed(&effects)?;
-                Ok(effects)
-            });
+        {
+            // Matched rather than chained so the gate can arm first: it
+            // previously sat in a combinator closure that could not reach
+            // `&mut self`.
+            Ok(effects) => self
+                .arm_recovery_then_fail_if_publish_failed(&effects)
+                .map(|()| effects),
+            Err(error) => Err(error),
+        };
         record_app_performance(
             telemetry,
             AppPerformanceOperation::GroupInviteEnginePublish,
@@ -2099,7 +2104,7 @@ impl AppClient {
                 audit_context.clone(),
             )
             .await?;
-        fail_if_publish_failed(&effects)?;
+        self.arm_recovery_then_fail_if_publish_failed(&effects)?;
         self.record_human_action_succeeded(group_id, &audit_context, &effects);
         self.remember_published_reports(&effects);
         self.refresh_group(group_id);
@@ -2145,7 +2150,7 @@ impl AppClient {
                 audit_context.clone(),
             )
             .await?;
-        fail_if_publish_failed(&effects)?;
+        self.arm_recovery_then_fail_if_publish_failed(&effects)?;
         self.record_human_action_succeeded(group_id, &audit_context, &effects);
         self.remember_published_reports(&effects);
         self.refresh_group(group_id);
@@ -2345,7 +2350,7 @@ impl AppClient {
                     audit_context.clone(),
                 )
                 .await?;
-            fail_if_publish_failed(&effects)?;
+            self.arm_recovery_then_fail_if_publish_failed(&effects)?;
             Ok::<_, AppError>(effects)
         }
         .await
@@ -2621,7 +2626,7 @@ impl AppClient {
                 audit_context.clone(),
             )
             .await?;
-        fail_if_publish_failed(&effects)?;
+        self.arm_recovery_then_fail_if_publish_failed(&effects)?;
         self.record_human_action_succeeded(group_id, &audit_context, &effects);
         self.remember_published_reports(&effects);
         self.refresh_group(group_id);
@@ -2656,7 +2661,7 @@ impl AppClient {
                 audit_context.clone(),
             )
             .await?;
-        fail_if_publish_failed(&effects)?;
+        self.arm_recovery_then_fail_if_publish_failed(&effects)?;
         self.record_human_action_succeeded(group_id, &audit_context, &effects);
         self.remember_published_reports(&effects);
         self.refresh_group(group_id);
@@ -2727,7 +2732,7 @@ impl AppClient {
                 audit_context.clone(),
             )
             .await?;
-        fail_if_publish_failed(&effects)?;
+        self.arm_recovery_then_fail_if_publish_failed(&effects)?;
         self.record_human_action_succeeded(group_id, &audit_context, &effects);
         self.remember_published_reports(&effects);
         self.refresh_group(group_id);
@@ -2771,7 +2776,7 @@ impl AppClient {
                 audit_context.clone(),
             )
             .await?;
-        fail_if_publish_failed(&effects)?;
+        self.arm_recovery_then_fail_if_publish_failed(&effects)?;
         self.record_human_action_succeeded(group_id, &audit_context, &effects);
         self.remember_published_reports(&effects);
         self.refresh_group(group_id);
@@ -2925,23 +2930,7 @@ impl AppClient {
                 return Err(err);
             }
         };
-        if let Err(publish_err) = fail_if_publish_failed(&effects) {
-            // The send itself failed to reach anyone, but any peer commits it
-            // folded are durably applied — broadcast them before surfacing the
-            // publish failure, best-effort so a projection error cannot mask
-            // the primary error.
-            self.observe_send_applied_effects_best_effort(&effects)
-                .await;
-            if let Err(_save_err) =
-                self.save_state_with_pending_local_group_deletion_frontier_clears()
-            {
-                tracing::warn!(
-                    target: "marmot_app::messages",
-                    method = "send_app_event_with_local_projection",
-                    error_code = "send_applied_state_save_failed",
-                    "failed to persist state observed from a failed send"
-                );
-            }
+        if let Err(publish_err) = self.arm_recovery_then_gate_send_publish(&effects).await {
             self.retract_failed_local_projection(
                 should_project_locally,
                 &group_id_hex,
@@ -3016,6 +3005,39 @@ impl AppClient {
                 maintenance_disposition: effects.maintenance_disposition,
             },
         ))
+    }
+
+    /// Apply the publish gate to a completed send's effects — arming
+    /// epoch-gap recovery from the same batch first — and, when the gate
+    /// fails, broadcast the peer commits the send folded before the caller
+    /// surfaces the error.
+    ///
+    /// Split out of `send_app_event_with_local_projection` so the ordering is
+    /// exercisable against a given batch of effects. The caller keeps the
+    /// local-projection retraction, which needs that send's own locals.
+    pub(crate) async fn arm_recovery_then_gate_send_publish(
+        &mut self,
+        effects: &marmot_account::AccountDeviceEffects,
+    ) -> Result<(), AppError> {
+        let publish_err = match self.arm_recovery_then_fail_if_publish_failed(effects) {
+            Ok(()) => return Ok(()),
+            Err(publish_err) => publish_err,
+        };
+        // The send itself failed to reach anyone, but any peer commits it
+        // folded are durably applied — broadcast them before surfacing the
+        // publish failure, best-effort so a projection error cannot mask
+        // the primary error.
+        self.observe_send_applied_effects_best_effort(effects).await;
+        if let Err(_save_err) = self.save_state_with_pending_local_group_deletion_frontier_clears()
+        {
+            tracing::warn!(
+                target: "marmot_app::messages",
+                method = "send_app_event_with_local_projection",
+                error_code = "send_applied_state_save_failed",
+                "failed to persist state observed from a failed send"
+            );
+        }
+        Err(publish_err)
     }
 
     /// Retract the optimistic local timeline row for a send that failed. No
@@ -3475,7 +3497,7 @@ impl AppClient {
                 audit_context.clone(),
             )
             .await?;
-        fail_if_publish_failed(&effects)?;
+        self.arm_recovery_then_fail_if_publish_failed(&effects)?;
         self.record_human_action_succeeded(group_id, &audit_context, &effects);
         self.remember_published_reports(&effects);
         let summary = send_summary_from_effects(&effects);
@@ -3755,7 +3777,7 @@ impl AppClient {
                 audit_context.clone(),
             )
             .await?;
-        fail_if_publish_failed(&effects)?;
+        self.arm_recovery_then_fail_if_publish_failed(&effects)?;
         self.record_human_action_succeeded(group_id, &audit_context, &effects);
         self.remember_published_reports(&effects);
         let message_ids = effects
@@ -4470,9 +4492,12 @@ impl AppClient {
                     "clear_delivered_founding_welcome_intents",
                     self.clear_delivered_founding_welcome_intents(&welcome_intents, &effects),
                 );
+                // Non-fatal here: this classification only logs, so no
+                // refusal is lost to an early return. It still arms through the
+                // same gate, so no publishing seam reaches the bare check.
                 recover_post_canonical_result(
                     "classify_founding_welcome_publish",
-                    fail_if_publish_failed(&effects),
+                    self.arm_recovery_then_fail_if_publish_failed(&effects),
                 );
                 recover_post_canonical_result(
                     "record_founding_welcome_delivery_failures",

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -203,6 +203,33 @@ impl AppClient {
         }
     }
 
+    /// Apply the publish gate to `effects`, arming epoch-gap recovery from the
+    /// same batch first.
+    ///
+    /// Every publishing seam must reach the gate through this rather than
+    /// calling `fail_if_publish_failed` directly. A
+    /// `TransportObjectResourceRefused` is buffered only after its durable
+    /// retention row is already deleted, and an effects batch carries its
+    /// events to the app exactly once — so a refusal a pass does not arm on can
+    /// never be re-observed. Gating first returns early and drops it for good;
+    /// arming first survives the caller's `?` because it is a field mutation
+    /// plus a durable audit row, not summary state. The two conditions are
+    /// correlated rather than independent: these seams publish, so the failure
+    /// and the refusal ride the same effects.
+    ///
+    /// Arming only. `remember_pending_convergence_groups` is deliberately not
+    /// paired here the way it is at the convergence and inbound seams: the
+    /// callers of this gate do not remember pending convergence on their
+    /// success paths either, so recording it on the failure path alone would
+    /// invent a scheduling contract they do not otherwise hold.
+    pub(crate) fn arm_recovery_then_fail_if_publish_failed(
+        &mut self,
+        effects: &marmot_account::AccountDeviceEffects,
+    ) -> Result<(), AppError> {
+        self.arm_recovery_from_effects(effects);
+        fail_if_publish_failed(effects)
+    }
+
     pub(crate) async fn sync_runtime_groups(&mut self) -> Result<(), AppError> {
         let rebuild_since = self
             .relay_plane

--- a/crates/marmot-app/src/groups.rs
+++ b/crates/marmot-app/src/groups.rs
@@ -2210,6 +2210,11 @@ pub(crate) fn add_group(
 ///   independently retryable Welcome deliveries remain outstanding.
 /// - failures with no pending resolution at all (e.g. a plain application
 ///   message or proposal publish that never landed): hard error, as before.
+///
+/// Call this from `AppClient::arm_recovery_then_fail_if_publish_failed` rather
+/// than directly. Gating an effects batch without first arming epoch-gap
+/// recovery from it drops any one-shot `TransportObjectResourceRefused` the
+/// batch carries; the seams that already arm explicitly are the only exception.
 pub(crate) fn fail_if_publish_failed(
     effects: &marmot_account::AccountDeviceEffects,
 ) -> Result<(), AppError> {

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -9445,6 +9445,167 @@ async fn a_publish_failure_during_a_convergence_retry_still_arms_recovery() {
     );
 }
 
+/// One effects batch carrying a resource refusal for `group_id` alongside a
+/// confirmed-but-partial publish failure: the shape the gate passes as a soft
+/// warning (mdk#428).
+fn a_refusal_riding_a_confirmed_but_partial_publish(
+    group_id: &cgka_traits::GroupId,
+) -> marmot_account::AccountDeviceEffects {
+    let message_id = cgka_traits::MessageId::new(vec![0xcd; 32]);
+    let mut effects = marmot_account::AccountDeviceEffects::default();
+    effects.events.push(
+        cgka_traits::engine::GroupEvent::TransportObjectResourceRefused {
+            group_id: group_id.clone(),
+            message_id: message_id.clone(),
+            resource: cgka_traits::ingest::InboundResourceLimit::TransportDeferredCapacity,
+        },
+    );
+    effects.failures.push(marmot_account::PublishFailure {
+        message_id,
+        reason: "insufficient publish acknowledgements".to_owned(),
+    });
+    effects
+        .pending
+        .push(marmot_account::PendingResolution::Confirmed {
+            pending: cgka_traits::engine_state::PendingStateRef::new(7),
+        });
+    effects
+}
+
+/// A resource refusal carried by an ordinary send must arm epoch-gap recovery
+/// even when that send's publish gate fails it.
+///
+/// The engine releases deferred-peel rows in the foreground of `do_send` and of
+/// the queued-outbound drain, so a plain send's effects can carry a
+/// `TransportObjectResourceRefused` — buffered only after its durable retention
+/// row was deleted, and delivered to the app exactly once. A gate that returned
+/// before arming dropped it for good, and no send-path observer downstream of
+/// the gate arms.
+#[tokio::test]
+async fn a_publish_failure_on_the_send_path_still_arms_recovery() {
+    let dir = tempfile::tempdir().unwrap();
+    AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relay(dir.path(), "wss://send-arm.example")
+        .with_test_relay_client(relay.clone());
+    app.set_audit_log_settings(AuditLogSettings {
+        enabled: true,
+        ..Default::default()
+    })
+    .unwrap();
+    let mut client = app.client("alice").await.unwrap();
+    let group_id = client.create_group("send arm ordering", &[]).await.unwrap();
+    assert_eq!(audit_rows_of_kind(&app, "epoch_stall_backfill_armed"), 0);
+
+    let effects = a_refusal_riding_a_rolled_back_publish(&group_id);
+    let result = client.arm_recovery_then_gate_send_publish(&effects).await;
+
+    assert!(
+        result.is_err(),
+        "a rolled-back publish failure must still fail the send"
+    );
+    assert!(
+        client.has_pending_epoch_backfill(),
+        "the refusal rides this batch only once, so it must arm before the send can fail"
+    );
+    assert_eq!(
+        audit_rows_of_kind(&app, "epoch_stall_backfill_armed"),
+        1,
+        "the arm must leave its durable forensic row even on a failing send"
+    );
+}
+
+/// Arming ahead of the send gate must not change what the gate accepts: a
+/// confirmed-but-partial publish still passes (mdk#428), and the refusal riding
+/// it is observed all the same.
+#[tokio::test]
+async fn a_confirmed_but_partial_send_publish_still_passes_the_arming_gate() {
+    let dir = tempfile::tempdir().unwrap();
+    AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relay(dir.path(), "wss://send-soft-arm.example")
+        .with_test_relay_client(relay.clone());
+    app.set_audit_log_settings(AuditLogSettings {
+        enabled: true,
+        ..Default::default()
+    })
+    .unwrap();
+    let mut client = app.client("alice").await.unwrap();
+    let group_id = client
+        .create_group("send soft arm ordering", &[])
+        .await
+        .unwrap();
+
+    let effects = a_refusal_riding_a_confirmed_but_partial_publish(&group_id);
+    let result = client.arm_recovery_then_gate_send_publish(&effects).await;
+
+    assert!(
+        result.is_ok(),
+        "a confirmed-but-partial publish must stay a soft pass on the send path"
+    );
+    assert!(
+        client.has_pending_epoch_backfill(),
+        "a refusal riding a passing batch must arm too"
+    );
+    assert_eq!(
+        audit_rows_of_kind(&app, "epoch_stall_backfill_armed"),
+        1,
+        "the arm must leave exactly one durable forensic row"
+    );
+}
+
+/// The arming gate is observation plus the unchanged publish check: for every
+/// classification it must return exactly what the bare check returns, so no
+/// caller's error path is widened or narrowed by arming ahead of it.
+#[tokio::test]
+async fn the_arming_publish_gate_classifies_exactly_as_the_bare_publish_check() {
+    let dir = tempfile::tempdir().unwrap();
+    AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relay(dir.path(), "wss://gate-parity.example")
+        .with_test_relay_client(relay.clone());
+    let mut client = app.client("alice").await.unwrap();
+    let group_id = client.create_group("gate parity", &[]).await.unwrap();
+
+    let clean = marmot_account::AccountDeviceEffects::default();
+    let mut failure_without_pending = marmot_account::AccountDeviceEffects::default();
+    failure_without_pending
+        .failures
+        .push(marmot_account::PublishFailure {
+            message_id: cgka_traits::MessageId::new(vec![0xef; 32]),
+            reason: "relay rejected".to_owned(),
+        });
+    let batches = [
+        ("no failures", clean),
+        (
+            "rolled back",
+            a_refusal_riding_a_rolled_back_publish(&group_id),
+        ),
+        (
+            "confirmed but partial",
+            a_refusal_riding_a_confirmed_but_partial_publish(&group_id),
+        ),
+        ("failure without pending", failure_without_pending),
+    ];
+
+    for (label, effects) in batches {
+        let bare = crate::groups::fail_if_publish_failed(&effects).map_err(|err| err.to_string());
+        let armed = client
+            .arm_recovery_then_fail_if_publish_failed(&effects)
+            .map_err(|err| err.to_string());
+        assert_eq!(
+            armed, bare,
+            "arming must not change how the gate classifies a {label} publish"
+        );
+    }
+}
+
 /// An escalation recorded while an inbound delivery is ingested must ride the
 /// summary that seam returns.
 ///


### PR DESCRIPTION
#1519 fixed the three convergence seams, but the same one-shot loss it described reaches the ordinary send paths. `release_deferred_peel_row` deletes the durable retention row before buffering `TransportObjectResourceRefused`, and its callers run under `DeferredPeelExecution::Foreground` — reachable from `do_send` and from the queued-outbound drain. So a plain `send`, invite, leave, admin-policy update, retention update, avatar/image/profile update or endpoint replacement can carry a refusal, and `fail_if_publish_failed(&effects)?` returned before anything observed it. Nothing downstream re-observes: `observe_send_applied_effects` projects the batch but does not arm.

All twelve app-client gates now run through
`arm_recovery_then_fail_if_publish_failed`, a shared arm-then-gate helper next to `arm_recovery_from_effects`. A shared helper rather than twelve carved tails: eleven of the sites are the identical bare one-liner, and the ordering — not each site's projection — is what needs pinning. `fail_if_publish_failed`'s own doc now says to reach it through that helper, so the bare call reads as the exception it is. The three seams #1519 already fixed keep their explicit arms untouched.

Two sites needed more than a one-line swap:

- `invite_members` gated inside an `and_then` closure that cannot reach `&mut self`; it is a `match` now, with the same classification and the same `record_app_performance` outcome.
- `send_app_event_with_local_projection` pairs its gate with recovery work. That gate plus its recovery moved into `arm_recovery_then_gate_send_publish`, a `pub(crate)` tail in the #1519 style so the ordering is exercisable against a chosen batch of effects; the caller keeps the local-projection retraction, which needs that send's own locals.

`drive_unpublished_welcome_delivery`'s founding-welcome classification is non-fatal (`recover_post_canonical_result` logs and continues), so no refusal was being lost to an early return there; it moves to the same helper anyway so no publishing seam reaches the bare check.

Arming only. `remember_pending_convergence_groups` is deliberately not paired at these gates the way it is at the convergence and inbound seams: these callers do not remember pending convergence on their success paths either, so recording it on the failure path alone would invent a scheduling contract they do not otherwise hold.

No error path is widened or narrowed: the helper returns exactly what `fail_if_publish_failed` returns, and every call site keeps its existing return shape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery handling when message, group, invitation, and welcome publishing fails.
  * Preserves recovery information from partially completed sends, helping synchronization resume correctly.
  * Refines publish-failure classification so confirmed partial publishes can proceed while rolled-back failures still report errors.

* **Tests**
  * Added coverage for recovery behavior across send failures, partial publishes, and resource refusals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->