### PR TITLE
fix(marmot-app): let external-signer accounts sign out and wipe

### DIFF
--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -5510,6 +5510,19 @@ impl MarmotApp {
         Err(AccountHomeError::SecretNotFound(account.account_id_hex.clone()).into())
     }
 
+    /// Drop an account's registered external signer.
+    ///
+    /// Only account *removal* may call this. The registration is what makes an
+    /// external-signer account reconcilable (see `has_external_signer`), so a
+    /// reversible sign-out has to keep it or the account could never be signed
+    /// back in without the host re-attaching its signer.
+    pub(crate) fn forget_external_signer(&self, account_id_hex: &str) {
+        self.external_signers
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(account_id_hex);
+    }
+
     pub(crate) fn has_external_signer(&self, account_id_hex: &str) -> bool {
         self.external_signers
             .lock()

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -2786,6 +2786,8 @@ impl MarmotAppRuntime {
     ///   the account's live state; neither step depends on a running worker for
     ///   the publish itself.
     /// - The account ref stays valid after this returns (unlike a wipe).
+    /// - Every account that can sign — local or external-signer — can sign
+    ///   out. Only tracked-only (npub) accounts are rejected.
     ///
     /// [`sign_out_and_wipe`]: Self::sign_out_and_wipe
     pub async fn sign_out(
@@ -2795,12 +2797,13 @@ impl MarmotAppRuntime {
     ) -> Result<SignOutOutcome, AppError> {
         self.shared.lifecycle().ensure_running()?;
         let account = self.accounts.resolve(account_ref)?;
-        if !account.local_signing {
-            // Publishing kind:5 KeyPackage deletions requires signing with this
-            // account's key, which a tracked-only (npub) account cannot do.
-            // Surface the same error the worker path uses. (A tracked account
-            // also never published KeyPackages from this device, so there is
-            // nothing remote to clean up.)
+        if !account.can_sign() {
+            // Only a tracked-only (npub) account is rejected: it has no signing
+            // key of any kind, never published a KeyPackage from this device,
+            // and never joined a group, so there is nothing to sign out.
+            // External-signer accounts do all three and sign out like local
+            // ones — the kind:5 publish resolves its signer the same way every
+            // other publish does. Surface the same error the worker path uses.
             return Err(AccountHomeError::SecretNotFound(account.account_id_hex).into());
         }
 
@@ -2892,13 +2895,23 @@ impl MarmotAppRuntime {
     /// - Stages 1 and 2 are network-bound; their per-target failures are
     ///   surfaced for the app's partial-failure sheet and never block local
     ///   cleanup.
+    /// - Every account that can sign — local or external-signer — can be
+    ///   wiped. Only tracked-only (npub) accounts are rejected. An external
+    ///   signer that is unavailable at wipe time degrades stages 1 and 2 to
+    ///   recorded failures; the local wipe still completes, so a device is
+    ///   never stuck holding an account it cannot remove.
     pub async fn sign_out_and_wipe(&self, account_ref: &str) -> Result<WipeOutcome, AppError> {
         self.shared.lifecycle().ensure_running()?;
         let account = self.accounts.resolve(account_ref)?;
-        if !account.local_signing {
-            // A wipe must sign group-leave messages and KeyPackage deletions;
-            // a tracked-only (npub) account can do neither, so there is nothing
-            // remote to clean up. Surface the same error the worker path uses.
+        if !account.can_sign() {
+            // Only a tracked-only (npub) account is rejected: with no signing
+            // key of any kind it never joined a group or published a KeyPackage
+            // from this device, so there is nothing device-side to tear down.
+            // External-signer accounts have both and are wiped like local ones;
+            // stages 1 and 2 sign through the account's registered external
+            // signer, and an unavailable signer degrades to a recorded
+            // best-effort failure instead of blocking the local wipe. Surface
+            // the same error the worker path uses.
             return Err(AccountHomeError::SecretNotFound(account.account_id_hex).into());
         }
 

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -4518,6 +4518,12 @@ impl AccountManager {
             self.app
                 .remove_account_key_package_artifacts(&account.label)?;
             self.app.account_home().remove_account(&account.label)?;
+            // The account no longer exists on this device, so the host callback
+            // handle it registered must not outlive it. This runs only after
+            // the removal commit point: a removal that failed leaves the
+            // account live, and a live external-signer account still needs its
+            // signer to reconcile.
+            self.app.forget_external_signer(&account.account_id_hex);
             Ok(())
         }
         .await;

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -8347,6 +8347,121 @@ async fn app_runtime_sign_out_and_wipe_rejects_unknown_account() {
 }
 
 #[tokio::test]
+async fn app_runtime_sign_out_and_wipe_removes_external_signer_account() {
+    // mdk#1509: an external-signer account (Amber and friends) publishes
+    // KeyPackages and joins groups exactly like a local-signing one, so it has
+    // a real device footprint to wipe. The old `local_signing` gate rejected it
+    // outright, leaving field users unable to remove the account at all.
+    let dir = tempfile::tempdir().unwrap();
+    let (_relay, app, url) = mock_app(&dir).await;
+    let home = AccountHome::open(dir.path());
+    let runtime = MarmotAppRuntime::new(app);
+    let keys = Keys::generate();
+    let account_id = keys.public_key().to_hex();
+
+    let created = runtime
+        .login_external_signer(
+            account_id.clone(),
+            TestExternalAccountSigner { keys },
+            AccountSetupRequest {
+                default_relays: vec![endpoint(&url)],
+                bootstrap_relays: vec![endpoint(&url)],
+                discovery_relays: vec![endpoint(&url)],
+                publish_missing_relay_lists: true,
+                publish_initial_key_package: true,
+                ..AccountSetupRequest::default()
+            },
+        )
+        .await
+        .unwrap();
+    assert!(created.account.external_signing);
+    assert!(!created.account.local_signing);
+
+    let before = runtime
+        .account_key_packages(&account_id, vec![endpoint(&url)])
+        .await
+        .unwrap();
+    assert!(
+        before.iter().any(|pkg| pkg.relay),
+        "external-signer setup should leave a relay-published key package to delete"
+    );
+
+    let outcome = runtime.sign_out_and_wipe(&account_id).await.unwrap();
+
+    // No groups joined, so nothing to leave and no leave failures.
+    assert_eq!(outcome.groups_left, 0);
+    assert!(outcome.group_leave_failures.is_empty());
+    // Stage 2 signs the kind:5 deletions through the registered external
+    // signer, so the relay cleanup is as complete as it is for a local account.
+    assert!(
+        outcome.key_packages_deleted >= 1,
+        "expected at least one relay key package deleted, got {}",
+        outcome.key_packages_deleted
+    );
+    assert!(
+        outcome.key_package_failures.is_empty(),
+        "unexpected key package failures: {:?}",
+        outcome.key_package_failures
+    );
+    // The local wipe has no nsec to delete; a missing secret must not surface
+    // as a cleanup failure.
+    assert!(outcome.local_cleanup.completed);
+    assert!(outcome.local_cleanup.reason.is_none());
+
+    assert!(
+        runtime
+            .accounts()
+            .managed_accounts()
+            .unwrap()
+            .into_iter()
+            .all(|account| account.account_id_hex != account_id),
+        "wiped external-signer account must not remain managed"
+    );
+    assert!(
+        home.accounts()
+            .unwrap()
+            .into_iter()
+            .all(|account| account.account_id_hex != account_id),
+        "wiped external-signer account directory must be removed"
+    );
+    assert!(runtime.accounts().resolve(&account_id).is_err());
+
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn app_runtime_sign_out_and_wipe_rejects_tracked_only_account() {
+    // A tracked-only (npub) follow has no signing key of any kind, so it never
+    // joined a group or published a KeyPackage from this device. It must keep
+    // failing with exactly the `SecretNotFound` app clients already classify
+    // on, and the tracked record must survive the rejection.
+    let dir = tempfile::tempdir().unwrap();
+    let (_relay, app, _url) = mock_app(&dir).await;
+    let home = AccountHome::open(dir.path());
+    let runtime = MarmotAppRuntime::new(app);
+    let account_id = Keys::generate().public_key().to_hex();
+    home.add_public_account(&account_id).unwrap();
+
+    let error = runtime.sign_out_and_wipe(&account_id).await.unwrap_err();
+    assert!(
+        matches!(
+            &error,
+            AppError::AccountHome(AccountHomeError::SecretNotFound(id)) if *id == account_id
+        ),
+        "tracked-only wipe must keep returning SecretNotFound, got {error:?}"
+    );
+    assert!(
+        home.accounts()
+            .unwrap()
+            .into_iter()
+            .any(|account| account.account_id_hex == account_id),
+        "a rejected wipe must leave the tracked account record untouched"
+    );
+
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
 async fn app_runtime_sign_out_deletes_key_packages_but_keeps_local_state() {
     // mdk#477: a non-destructive sign-out must clean up the relay
     // KeyPackages (so strangers can't gift-wrap a Welcome while signed out)
@@ -8576,6 +8691,118 @@ async fn app_runtime_sign_out_rejects_unknown_account() {
             .sign_out(&missing, SignOutOptions::default())
             .await
             .is_err()
+    );
+
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn app_runtime_sign_out_succeeds_for_external_signer_account() {
+    // mdk#1509: reversible sign-out must work for an external-signer account.
+    // Its KeyPackages are real relay publications, so they are cleaned up with
+    // the external signer, and every byte of local state survives for the
+    // sign-back-in.
+    let dir = tempfile::tempdir().unwrap();
+    let (_relay, app, url) = mock_app(&dir).await;
+    let home = AccountHome::open(dir.path());
+    let runtime = MarmotAppRuntime::new(app);
+    let keys = Keys::generate();
+    let account_id = keys.public_key().to_hex();
+
+    runtime
+        .login_external_signer(
+            account_id.clone(),
+            TestExternalAccountSigner { keys },
+            AccountSetupRequest {
+                default_relays: vec![endpoint(&url)],
+                bootstrap_relays: vec![endpoint(&url)],
+                discovery_relays: vec![endpoint(&url)],
+                publish_missing_relay_lists: true,
+                publish_initial_key_package: true,
+                ..AccountSetupRequest::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    let before = runtime
+        .account_key_packages(&account_id, vec![endpoint(&url)])
+        .await
+        .unwrap();
+    assert!(
+        before.iter().any(|pkg| pkg.relay),
+        "external-signer setup should leave a relay-published key package to delete"
+    );
+
+    let outcome = runtime
+        .sign_out(&account_id, SignOutOptions::default())
+        .await
+        .unwrap();
+
+    assert!(
+        outcome.key_packages_deleted >= 1,
+        "expected at least one relay key package deleted, got {}",
+        outcome.key_packages_deleted
+    );
+    assert!(
+        outcome.key_package_failures.is_empty(),
+        "unexpected key package failures: {:?}",
+        outcome.key_package_failures
+    );
+    assert!(outcome.local_cleanup.completed);
+    assert!(outcome.local_cleanup.reason.is_none());
+
+    let signed_out_account = home.account(&account_id).unwrap();
+    assert!(signed_out_account.signed_out);
+    assert!(signed_out_account.external_signing);
+    let managed = runtime
+        .accounts()
+        .managed_accounts()
+        .unwrap()
+        .into_iter()
+        .find(|account| account.account_id_hex == account_id)
+        .expect("signed-out external-signer account should remain listed");
+    assert!(managed.signed_out);
+    assert!(
+        !managed.running,
+        "sign-out should stop the worker immediately"
+    );
+
+    // Reversible means reversible: the account is still a live on-disk record
+    // and signs back in with its registered signer.
+    let signed_in = runtime.sign_in_account(&account_id).await.unwrap();
+    assert!(!signed_in.signed_out);
+    assert!(signed_in.running);
+
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn app_runtime_sign_out_rejects_tracked_only_account() {
+    // The gate's real purpose: a tracked-only (npub) follow has nothing to sign
+    // out. It must keep failing with exactly the `SecretNotFound` app clients
+    // already classify on.
+    let dir = tempfile::tempdir().unwrap();
+    let (_relay, app, _url) = mock_app(&dir).await;
+    let home = AccountHome::open(dir.path());
+    let runtime = MarmotAppRuntime::new(app);
+    let account_id = Keys::generate().public_key().to_hex();
+    home.add_public_account(&account_id).unwrap();
+
+    let error = runtime
+        .sign_out(&account_id, SignOutOptions::default())
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(
+            &error,
+            AppError::AccountHome(AccountHomeError::SecretNotFound(id)) if *id == account_id
+        ),
+        "tracked-only sign-out must keep returning SecretNotFound, got {error:?}"
+    );
+    assert!(
+        !home.account(&account_id).unwrap().signed_out,
+        "a rejected sign-out must not persist a signed-out marker"
     );
 
     runtime.shutdown().await;

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -8462,6 +8462,100 @@ async fn app_runtime_sign_out_and_wipe_rejects_tracked_only_account() {
 }
 
 #[tokio::test]
+async fn app_runtime_wipe_drops_external_signer_registration() {
+    // A wipe removes the account's footprint from this device, and the host
+    // callback handle registered for its external signer is part of that
+    // footprint. If it outlived the wipe, a later record for the same npub
+    // would silently sign with the stale handle instead of reporting that no
+    // signer is attached.
+    let dir = tempfile::tempdir().unwrap();
+    let (_relay, app, url) = mock_app(&dir).await;
+    let home = AccountHome::open(dir.path());
+    let runtime = MarmotAppRuntime::new(app);
+    let keys = Keys::generate();
+    let account_id = keys.public_key().to_hex();
+
+    runtime
+        .login_external_signer(
+            account_id.clone(),
+            TestExternalAccountSigner { keys },
+            AccountSetupRequest {
+                default_relays: vec![endpoint(&url)],
+                bootstrap_relays: vec![endpoint(&url)],
+                discovery_relays: vec![endpoint(&url)],
+                publish_missing_relay_lists: true,
+                publish_initial_key_package: true,
+                ..AccountSetupRequest::default()
+            },
+        )
+        .await
+        .unwrap();
+    runtime.sign_out_and_wipe(&account_id).await.unwrap();
+
+    // Re-add the same npub as an external-signer record without re-attaching a
+    // signer. Work that needs a signature must now report the signer as
+    // unavailable rather than reuse the wiped account's handle.
+    home.add_external_signer_account(&account_id).unwrap();
+    let error = runtime
+        .delete_key_package(&account_id, &"11".repeat(32), vec![endpoint(&url)])
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(&error, AppError::ExternalSignerUnavailable(id) if *id == account_id),
+        "a wiped account's external signer registration must not survive, got {error:?}"
+    );
+
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn app_runtime_sign_out_keeps_external_signer_registration() {
+    // The other half of the wipe-side drop: a reversible sign-out keeps the
+    // registration. Reconcile only reactivates an external-signer account whose
+    // signer is still registered, so forgetting it here would strand the
+    // account signed out until the host re-attached its signer.
+    let dir = tempfile::tempdir().unwrap();
+    let (_relay, app, url) = mock_app(&dir).await;
+    let runtime = MarmotAppRuntime::new(app);
+    let keys = Keys::generate();
+    let account_id = keys.public_key().to_hex();
+
+    runtime
+        .login_external_signer(
+            account_id.clone(),
+            TestExternalAccountSigner { keys },
+            AccountSetupRequest {
+                default_relays: vec![endpoint(&url)],
+                bootstrap_relays: vec![endpoint(&url)],
+                discovery_relays: vec![endpoint(&url)],
+                publish_missing_relay_lists: true,
+                publish_initial_key_package: true,
+                ..AccountSetupRequest::default()
+            },
+        )
+        .await
+        .unwrap();
+    runtime
+        .sign_out(
+            &account_id,
+            SignOutOptions {
+                delete_key_packages: false,
+            },
+        )
+        .await
+        .unwrap();
+
+    let signed_in = runtime.sign_in_account(&account_id).await.unwrap();
+    assert!(!signed_in.signed_out);
+    assert!(
+        signed_in.running,
+        "sign-in must reactivate the worker with the signer registered by the original login"
+    );
+
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
 async fn app_runtime_sign_out_deletes_key_packages_but_keeps_local_state() {
     // mdk#477: a non-destructive sign-out must clean up the relay
     // KeyPackages (so strangers can't gift-wrap a Welcome while signed out)


### PR DESCRIPTION
Closes #1509.

## Problem

`sign_out` and `sign_out_and_wipe` gate on `local_signing`, so external-signer accounts
(e.g. GrapheneOS + Amber) can never sign out or wipe — the engine rejects them with a
misleading `SecretNotFound` before any teardown. The gate's real purpose is to reject
*tracked-only* accounts, which have no signing key of any kind.

## Fix

**Commit 1** — gate on `!account.can_sign()` instead. External-signer accounts sign their
relay cleanup (KeyPackage deletion, group leaves) through the normal signer resolution,
and an unavailable signer degrades to recorded per-item failures — never a blocked local
sign-out. A missing local nsec is not an error on the wipe path. Tracked-only accounts
keep the exact `SecretNotFound(id)` rejection (test-pinned), so existing client
classification (whitenoise-android #2153) is unaffected.

**Commit 2** — wiping an external-signer account now drops its in-memory signer
registration. Without this, a later re-added record for the same npub inherited the wiped
account's handle and could sign with it (reproduced in
`app_runtime_wipe_drops_external_signer_registration`). The clear lives in
`remove_account` only — clearing in `drop_account_caches` would break re-sign-in after a
reversible sign-out, which is also test-pinned.

## Tests

Six new behavioural tests: external-signer sign-out and wipe succeed end to end
(KeyPackage deletion actually published, clean local cleanup, re-sign-in works),
tracked-only rejection unchanged for both paths, wipe drops the signer registration,
reversible sign-out keeps it. Existing local-signing sign-out tests untouched and green.

Unblocks the on-device Amber verification step left open in whitenoise-android #2153.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sign-out and account wipe now support accounts authenticated with external signers.
  * Wipe operations continue local cleanup when network-related signing steps fail.
* **Bug Fixes**
  * Accounts without signing capability remain protected from sign-out and destructive wipe operations.
  * External-signer account data, including relay credentials, is removed during wipe.
  * Successfully deleted accounts no longer retain their registered external signer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->