### PR TITLE
fix(incident-replay): reject documents that are not agent-state exports

### DIFF
--- a/crates/incident-replay/AGENTS.md
+++ b/crates/incident-replay/AGENTS.md
@@ -14,7 +14,12 @@ incident becomes a vector only if the simulator reproduces the recorded outcome
     the fields the pipeline needs and ignores everything else, so it tolerates
     the export growing new fields. Deliberately decoupled from `marmot-forensics`:
     it tracks the stable `marmot-forensics-audit/v2` wire shape Goggles
-    serialises, not the engine's internal `AuditEventKind` enum.
+    serialises, not the engine's internal `AuditEventKind` enum. The leniency is
+    bounded by one positive check: every modelled field defaults, so `parse`
+    requires the object to carry at least one modelled top-level field
+    (`events`, `derived_projections`, `normalized_scenario_history`) and rejects
+    a foreign document — or `{}` — rather than adopting it as an empty, healthy
+    export.
 - **Module:** `src/ndjson.rs`
   - **Role:** `parse_stream` — the second parser: the streaming NDJSON group
     export into the same `AgentStateExport`. Enforces the stream's completeness

--- a/crates/incident-replay/src/export.rs
+++ b/crates/incident-replay/src/export.rs
@@ -10,6 +10,7 @@
 use std::collections::BTreeMap;
 
 use serde::Deserialize;
+use serde_json::error::Category;
 
 /// The epoch-machine state an engine enters when its group is blocked pending a
 /// verified repair. Goggles derives its error-severity `epoch_state_transition`
@@ -441,11 +442,44 @@ impl EventKind {
     }
 }
 
+/// The top-level fields of [`AgentStateExport`] — the document's recognized
+/// markers. Every modelled field defaults, and unknown fields are ignored, so
+/// without a marker any JSON object at all would deserialize into an empty
+/// export and classify `Healthy`. Requiring *one* keeps the leniency that
+/// matters (a sparse export, a future field, an export whose sections this
+/// adapter ignores) while refusing a document that shows no evidence of being an
+/// export. Keep in step with the struct.
+const EXPORT_MARKERS: [&str; 3] = [
+    "events",
+    "derived_projections",
+    "normalized_scenario_history",
+];
+
 /// Parse a Goggles `agent-state.json` export.
 pub fn parse(json: &str) -> Result<AgentStateExport, ParseError> {
-    let probe = serde_json::from_str::<BTreeMap<String, serde::de::IgnoredAny>>(json);
-    if probe.is_ok_and(|object| object.contains_key("t")) {
-        return Err(ParseError::StreamDiscriminator);
+    match serde_json::from_str::<BTreeMap<String, serde::de::IgnoredAny>>(json) {
+        Ok(object) => {
+            if object.contains_key("t") {
+                return Err(ParseError::StreamDiscriminator);
+            }
+            if !EXPORT_MARKERS
+                .into_iter()
+                .any(|marker| object.contains_key(marker))
+            {
+                return Err(ParseError::UnrecognizedDocument);
+            }
+        }
+        // Well-formed JSON that is not an object. The probe deserializes a map
+        // of ignored values, so this is the only data error it can produce, and
+        // it has to be rejected here: serde also accepts a struct in its
+        // *sequence* form, so a bare `[]` would otherwise deserialize into the
+        // same empty (healthy) export a bare `{}` does.
+        Err(error) if error.classify() == Category::Data => {
+            return Err(ParseError::UnrecognizedDocument);
+        }
+        // Malformed JSON — fall through so the reported error keeps the
+        // position of the syntax that broke.
+        Err(_) => {}
     }
     Ok(serde_json::from_str(json)?)
 }
@@ -457,4 +491,11 @@ pub enum ParseError {
     Json(#[from] serde_json::Error),
     #[error("input carries the streamed NDJSON `t` discriminator, not an agent-state document")]
     StreamDiscriminator,
+    /// Deliberately names only what was expected: the rejected document is
+    /// operator-supplied forensic input and none of it belongs in a log line.
+    #[error(
+        "input is not an agent-state document: expected a JSON object carrying at least one of {}",
+        EXPORT_MARKERS.join(", ")
+    )]
+    UnrecognizedDocument,
 }

--- a/crates/incident-replay/tests/cli.rs
+++ b/crates/incident-replay/tests/cli.rs
@@ -35,6 +35,22 @@ fn run(fixture: &str) -> (String, String, i32) {
     )
 }
 
+/// Run the CLI against an export written to a temporary file, returning
+/// `(stdout, stderr, exit code)`.
+fn run_on(export: &[u8]) -> (String, String, i32) {
+    let mut input = NamedTempFile::new().expect("create export");
+    input.write_all(export).expect("write export");
+    let output = Command::new(env!("CARGO_BIN_EXE_incident-replay"))
+        .arg(input.path())
+        .output()
+        .expect("run incident-replay");
+    (
+        String::from_utf8(output.stdout).expect("stdout is utf-8"),
+        String::from_utf8(output.stderr).expect("stderr is utf-8"),
+        output.status.code().expect("the CLI exited normally"),
+    )
+}
+
 #[test]
 fn a_healthy_export_prints_the_healthy_line_and_nothing_else() {
     // A cleared halt leaves nothing to report, so this is the whole of stdout:
@@ -90,17 +106,23 @@ fn an_accepted_export_prints_its_fidelity_not_a_bare_scenario_name() {
 }
 
 #[test]
-fn a_manifest_less_error_remnant_never_classifies_as_healthy() {
-    let mut input = NamedTempFile::new().expect("create export");
-    input
-        .write_all(br#"{"t":"error","complete":false}"#)
-        .expect("write export");
-    let output = Command::new(env!("CARGO_BIN_EXE_incident-replay"))
-        .arg(input.path())
-        .output()
-        .expect("run incident-replay");
-    let stdout = String::from_utf8(output.stdout).expect("stdout is utf-8");
+fn an_unrecognized_document_never_classifies_as_healthy() {
+    // A document that is not an export at all — here a `package.json` fragment —
+    // must reach the operator as a parse failure, not as a clean bill of health.
+    let (stdout, stderr, code) = run_on(br#"{"name":"mdk","version":"0.1.0","dependencies":{}}"#);
 
-    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(code, 2);
+    assert!(!stdout.contains("healthy:"), "got {stdout:?}");
+    assert!(
+        stderr.contains("not an agent-state document"),
+        "the operator needs to be told what the input was not, got {stderr:?}"
+    );
+}
+
+#[test]
+fn a_manifest_less_error_remnant_never_classifies_as_healthy() {
+    let (stdout, _stderr, code) = run_on(br#"{"t":"error","complete":false}"#);
+
+    assert_eq!(code, 2);
     assert!(!stdout.contains("healthy:"));
 }

--- a/crates/incident-replay/tests/parse.rs
+++ b/crates/incident-replay/tests/parse.rs
@@ -39,10 +39,94 @@ fn stream_shaped_lines_are_rejected_as_documents() {
         r#"{"t": {}}"#,
         r#"{"t": []}"#,
         r#"{"t": "error", "t": null}"#,
+        // The discriminator is decisive even beside recognized export fields:
+        // a stream line must never be read as a document.
+        r#"{"t": "event", "events": []}"#,
     ] {
         assert!(
             matches!(parse(input), Err(ParseError::StreamDiscriminator)),
             "stream-shaped input was not rejected: {input}"
+        );
+    }
+}
+
+#[test]
+fn documents_with_no_recognized_field_are_rejected() {
+    // Every modelled field defaults, so without this gate any JSON object at all
+    // would deserialize into an empty export and print a healthy verdict — the
+    // worst failure a forensic tool has, a clean bill of health for a document
+    // that was never an export.
+    for input in [
+        "{}",
+        r#"{"name": "mdk", "version": "0.1.0", "dependencies": {}}"#,
+        // A version string is not evidence of contents: an export that carries
+        // no modelled section carries nothing to classify.
+        r#"{"schema_version": "marmot-agent-state/v1"}"#,
+    ] {
+        assert!(
+            matches!(parse(input), Err(ParseError::UnrecognizedDocument)),
+            "unrecognized document was not rejected: {input}"
+        );
+    }
+}
+
+#[test]
+fn the_rejection_message_names_what_was_expected_and_quotes_nothing() {
+    // The rejected document is operator-supplied forensic input; the error tells
+    // the operator what an export looks like without echoing a byte of it.
+    let error = parse(r#"{"relay": "wss://relay.example"}"#)
+        .expect_err("an unrecognized document is rejected")
+        .to_string();
+
+    assert!(error.contains("events"), "unhelpful message: {error}");
+    assert!(
+        !error.contains("relay"),
+        "message echoed the document: {error}"
+    );
+}
+
+#[test]
+fn any_single_recognized_field_is_enough_to_parse() {
+    // Sparse exports are legitimate: the marker proves the document is an
+    // export, not that it is a complete one.
+    for input in [
+        r#"{"events": []}"#,
+        r#"{"derived_projections": {}}"#,
+        r#"{"normalized_scenario_history": null}"#,
+    ] {
+        let export = parse(input).unwrap_or_else(|err| panic!("sparse export {input}: {err}"));
+        assert_eq!(classify(&export), Verdict::Healthy);
+    }
+}
+
+#[test]
+fn unknown_top_level_fields_stay_tolerated() {
+    // Forward compatibility is the whole point of the lenient model: a newer
+    // Goggles export growing sections this adapter does not read must still
+    // parse, and the marker gate must not turn into a schema check.
+    let export = parse(
+        r#"{
+            "schema_version": "marmot-agent-state/v1",
+            "events": [],
+            "derived_projections": {},
+            "normalized_scenario_history": null,
+            "some_future_section": { "rows": [1, 2, 3] }
+        }"#,
+    )
+    .expect("an export with unknown extra fields parses");
+
+    assert_eq!(classify(&export), Verdict::Healthy);
+}
+
+#[test]
+fn documents_that_are_not_json_objects_are_rejected() {
+    // An export is an object. `[]` is the sharp case: serde accepts a struct in
+    // its sequence form too, so an empty array deserialized into exactly the
+    // same empty, healthy export an empty object did.
+    for input in ["[]", "[[], {}, null]", r#""agent-state""#, "7", "null"] {
+        assert!(
+            matches!(parse(input), Err(ParseError::UnrecognizedDocument)),
+            "non-object document was not rejected: {input}"
         );
     }
 }


### PR DESCRIPTION
Closes #1373.

`incident-replay` accepted any JSON document as an agent-state export: every top-level
field is `#[serde(default)]`, so `{}` — or a `package.json` fragment — parsed as an empty
export and classified **healthy, exit 0**. Worse, serde's sequence form meant `[]` did too.
A forensic tool returning a silent clean bill on a document that is not an export at all.

`parse()` now requires at least one recognized export marker (`events`,
`derived_projections`, `normalized_scenario_history`) on the probe it already builds, and
rejects everything else with `ParseError::UnrecognizedDocument` — exit 2, a message that
names what was expected, and no document content echoed. `schema_version` is deliberately
not a marker (unmodelled, and common enough in foreign documents to gut the gate — pinned
by test). Unknown extra fields alongside a marker still parse, so newer Goggles exports
keep working; the `t` stream-discriminator rejection keeps precedence; the NDJSON path is
untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved export validation to reject malformed, non-object, empty, or unrelated documents.
  * Prevented streamed data formats from being mistaken for valid exports.
  * Improved error messages for unrecognized documents.
  * CLI now correctly reports invalid or incomplete exports as failures.

* **Tests**
  * Added coverage for sparse valid exports, unknown fields, invalid documents, and stream-format inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->