### PR TITLE
fix(marmot-app): report epoch passages to the stall detector

### DIFF
--- a/crates/marmot-app/src/client/epoch_stall.rs
+++ b/crates/marmot-app/src/client/epoch_stall.rs
@@ -19,12 +19,18 @@
 //!
 //! What the detector counts is bounded by what it is told. Its only view of a
 //! group's local epoch is the epoch handed to its own `observe_*` calls, so an
-//! advance nobody reports leaves it believing the group never moved. Two known
-//! blind spots follow, both tracked for a follow-up rather than defended here: a
-//! run can outlive the condition that opened it, because an unreported advance
-//! cannot end one (see [`GroupStall::observe_epoch`]); and a group whose
-//! reported epoch never moves at all arms once and never escalates, because
-//! every arm after the first needs that epoch to change.
+//! advance nobody reports leaves it believing the group never moved. Movement
+//! reaches it as an epoch *passage*
+//! ([`EpochStallDetector::observe_epoch_passage`]) — the engine's own
+//! `EpochChanged` — so a device that recovers can end its own run even across
+//! epochs no delivery was ever read at. Only a convergence reorg spans more than
+//! one epoch in a single passage; a confirmed local publish and a folded peer
+//! commit each advance exactly one, which is why the adjacency rule in
+//! [`EpochStallDetector::observe_epoch_passage`] must stay a *delayed* reset and
+//! not no reset at all. One blind spot remains, tracked for a follow-up rather
+//! than defended here: a group whose reported epoch never moves at all arms once
+//! and never escalates, because every arm after the first needs that epoch to
+//! change.
 //!
 //! All detector state is process-local, like the stall counts it extends.
 //! `sync_with_partial_progress` moves a one-shot escalation into either its
@@ -167,23 +173,39 @@ impl GroupStall {
     /// group that stalls again much later is reported again.
     ///
     /// "Passed through" means *reported to this method*, which is narrower than
-    /// "the device advanced". `self.epoch` only moves when a caller reports an
-    /// epoch, and neither convergence-fold seam — `AppClient::retry_group_convergence`
-    /// nor `AppClient::advance_convergence_after_runtime_sync`, the mechanism by
-    /// which a trailing device usually catches up — reaches an `observe_*` call at
-    /// all. So a device armed at 10 and then folded cleanly through 11, 12 and 13
-    /// arrives at its next stall with `self.epoch` still 10, the epoch it armed
-    /// at, and the run continues: a healthy recovery is counted as arm two. That
-    /// makes the unreported advance a false-positive amplifier, not merely a
-    /// delayed reset, and closing the reporting gap on both seams is the tracked
-    /// follow-up. The rule is pinned by
-    /// `an_epoch_advance_the_detector_never_observed_does_not_end_the_arm_run`;
-    /// the escalation it costs a recovered device is pinned at the runtime by
-    /// `a_clean_recovery_the_runtime_never_reports_still_escalates`.
+    /// "the device advanced": `self.epoch` only moves when a caller reports an
+    /// epoch. A landing position — the epoch a delivery was read at — cannot be
+    /// the *first* such report after an arm, because it arrives at the epoch the
+    /// device already sits on, which leaves the armed epoch as the one being
+    /// left. A *second* landing, at a further epoch, does end the run
+    /// (`an_epoch_the_device_passes_through_cleanly_ends_the_arm_run` pins
+    /// exactly that), but only if traffic happens to be read at both — which is
+    /// accident, not design. The engine's `EpochChanged` passage makes the report
+    /// unconditional: fed here as `from + 1` and then `to` by
+    /// [`EpochStallDetector::observe_epoch_passage`], one passage supplies both
+    /// reports on its own.
+    ///
+    /// The app routes that passage from every effects batch whose events it
+    /// gates or projects (`AppClient::observe_recovery_evidence`) — the
+    /// convergence folds a trailing device usually catches up by, and the
+    /// maintenance tick's own confirmed evolution, included. One publishing seam
+    /// is a known exception: `AppClient::disband_group` neither gates nor
+    /// observes its batch, a pre-existing gap tracked separately rather than
+    /// widened here. Arming from an observed batch is conditional on it carrying
+    /// a `TransportObjectResourceRefused`; observing a passage is not.
+    ///
+    /// A batch that reports neither leaves the run exactly as it was: an advance
+    /// nobody reports is invisible here, as
+    /// `an_epoch_advance_the_detector_never_observed_does_not_end_the_arm_run`
+    /// pins, and the runtime side of the passage report is pinned by
+    /// `a_clean_recovery_reported_as_a_passage_ends_the_arm_run` in
+    /// `tests/epoch_stall_backfill_audit.rs`.
     ///
     /// How far the epoch jumped does not enter into it: the rule compares only
     /// the armed epoch against the epoch being left, so a reported advance of
-    /// five epochs decides exactly as one of a single epoch does.
+    /// five epochs decides exactly as one of a single epoch does. Span decides
+    /// one level up, in [`EpochStallDetector::observe_epoch_passage`], where a
+    /// passage becomes the two reports this rule then reads.
     ///
     /// Deliberately *not* "the device decrypted something": a replay that
     /// recovers old backlog the device can read has not caught it up, and
@@ -273,6 +295,61 @@ impl EpochStallDetector {
     pub(crate) fn observe_group_epoch(&mut self, group: &GroupId, epoch: EpochId) {
         if let Some(stall) = self.groups.get_mut(group) {
             stall.observe_epoch(epoch);
+        }
+    }
+
+    /// Note that an already-tracked `group` moved *through* the epochs between
+    /// `from` and `to`: the engine's own `EpochChanged` passage, as reported by a
+    /// convergence reorg, a folded peer commit, or a confirmed local publish.
+    ///
+    /// A passage carries strictly more than a landing position: it names an epoch
+    /// the device is no longer at. Every other `observe_*` call reports the epoch
+    /// a delivery was *read* at, which is where the device already sits, while
+    /// [`GroupStall::observe_epoch`] decides on the epoch being *left*. A device
+    /// armed at 10 and recovered to 13 that reports only 13 is therefore still
+    /// judged on leaving 10 — the epoch it armed at — and its run never ends.
+    /// Feeding `from + 1` first moves the detector off the armed epoch, and
+    /// feeding `to` then leaves an epoch nothing armed at, which is what ends the
+    /// run.
+    ///
+    /// An adjacent passage (`to == from + 1`) deliberately does not end a run by
+    /// itself: the second feed is the epoch the first already recorded, so it
+    /// returns early, and the run ends only on the device's next movement off
+    /// that epoch. One epoch of progress per arm is a device limping, not a
+    /// device recovered — exactly the field shape escalation exists to report —
+    /// while sustained movement resets. Adjacency is the common case, not the
+    /// exception: a confirmed local publish (`from` synthesized as
+    /// `new_epoch - 1`) and a folded peer commit (`before` -> `after`) always
+    /// advance exactly one epoch, and only a convergence reorg can span several.
+    /// So the rule has to be a *delayed* reset rather than none — a single-commit
+    /// catch-up resets on the movement after it, which is the next passage the
+    /// device reports. Pinned by
+    /// `a_device_limping_one_epoch_per_arm_still_escalates` and
+    /// `the_movement_after_an_adjacent_passage_ends_the_arm_run`.
+    ///
+    /// One accepted edge, from the rollback guard below: a backward passage is
+    /// dropped, so the detector can sit one epoch above the engine's tip, and the
+    /// next forward passage from that lower tip has `from + 1` equal to the epoch
+    /// the detector already holds — the first feed returns early, the second sees
+    /// the armed epoch again, and one reset is swallowed. It costs a delayed
+    /// reset in a case that must already have reorged backwards, never a false
+    /// arm, and it is strictly better than the pre-passage behavior it replaces.
+    /// Forking the reset rule into a span-aware variant to recover that one reset
+    /// is deliberately not done.
+    ///
+    /// `get_mut` like [`Self::observe_group_epoch`]: a passage is evidence about
+    /// a stall run, never the start of one, so a group with no stall history
+    /// stays untracked.
+    pub(crate) fn observe_epoch_passage(&mut self, group: &GroupId, from: EpochId, to: EpochId) {
+        // Only forward movement is evidence of progress. A reorg that rolls the
+        // tip back reports a passage too, and synthesizing its intermediate
+        // epoch would end an unrecovered run on a rollback.
+        if to <= from {
+            return;
+        }
+        if let Some(stall) = self.groups.get_mut(group) {
+            stall.observe_epoch(from.next());
+            stall.observe_epoch(to);
         }
     }
 
@@ -485,19 +562,17 @@ mod tests {
         );
     }
 
-    /// Pins the known blind spot named in [`GroupStall::observe_epoch`]: a run
-    /// ends on an *observation* at an epoch the device did not arm at, and an
-    /// epoch the detector is never told about cannot be that observation. This is
-    /// today's behavior, not the intended behavior — a device that recovers
-    /// cleanly through several epochs still has its next unrelated stall counted
-    /// as arm two, so a healthy device can be escalated.
+    /// Pins the reporting rule in [`GroupStall::observe_epoch`]: a run ends on an
+    /// *observation* at an epoch the device did not arm at, and an epoch the
+    /// detector is never told about cannot be that observation.
     ///
-    /// What it pins is the rule, not the field bug: the observation is omitted
-    /// here by hand, so this test keeps passing whether or not the runtime ever
-    /// learns to report a fold. The "before" side of closing the gap is
-    /// `a_clean_recovery_the_runtime_never_reports_still_escalates` in
-    /// `tests/epoch_stall_backfill_audit.rs`, which drives a real fold and flips
-    /// to asserting no escalation once the report lands.
+    /// The runtime now reports the epochs a fold carries a device through, as a
+    /// passage — so the field shape this rule used to punish is handled by
+    /// [`EpochStallDetector::observe_epoch_passage`] and pinned by
+    /// `a_spanning_passage_off_the_armed_epoch_ends_the_arm_run`. The rule below
+    /// is still the one the detector runs on, and it still decides any batch that
+    /// reports nothing: the observation is omitted here by hand, so this test
+    /// states what silence costs rather than what the runtime does.
     #[test]
     fn an_epoch_advance_the_detector_never_observed_does_not_end_the_arm_run() {
         let mut detector = EpochStallDetector::new(1, 3);
@@ -521,6 +596,132 @@ mod tests {
         assert_eq!(
             detector.observe_undecryptable(g.clone(), "m3".into(), EpochId(14)),
             BackfillDecision::ArmAndEscalate { arms: 3 },
+        );
+    }
+
+    /// A passage that leaves the armed epoch behind ends the run, and clears the
+    /// escalation latch with it, so a group that stalls again much later is
+    /// reported again.
+    #[test]
+    fn a_spanning_passage_off_the_armed_epoch_ends_the_arm_run() {
+        let mut detector = EpochStallDetector::new(1, 3);
+        let g = group(0x01);
+
+        // A full unrecovered run, reported.
+        let _ = detector.observe_undecryptable(g.clone(), "m1".into(), EpochId(10));
+        let _ = detector.observe_undecryptable(g.clone(), "m2".into(), EpochId(11));
+        assert_eq!(
+            detector.observe_undecryptable(g.clone(), "m3".into(), EpochId(12)),
+            BackfillDecision::ArmAndEscalate { arms: 3 }
+        );
+
+        // One convergence fold then carries the device from 12 to 15. It passed
+        // through 13 and 14 without arming at either, which is as close to
+        // "reached the tip" as this layer can observe.
+        detector.observe_epoch_passage(&g, EpochId(12), EpochId(15));
+
+        // So the stalls that follow are a new run, counted from one, and able to
+        // report again on their own third arm rather than staying latched shut.
+        assert_eq!(
+            detector.observe_undecryptable(g.clone(), "m4".into(), EpochId(15)),
+            BackfillDecision::Arm
+        );
+        assert_eq!(
+            detector.observe_undecryptable(g.clone(), "m5".into(), EpochId(16)),
+            BackfillDecision::Arm
+        );
+        assert_eq!(
+            detector.observe_undecryptable(g.clone(), "m6".into(), EpochId(17)),
+            BackfillDecision::ArmAndEscalate { arms: 3 },
+            "the passage must have cleared the escalation latch too"
+        );
+    }
+
+    /// One epoch of progress per arm is not recovery, so an adjacent passage
+    /// does not end the run by itself — the run keeps counting to escalation.
+    #[test]
+    fn a_device_limping_one_epoch_per_arm_still_escalates() {
+        let mut detector = EpochStallDetector::new(1, 3);
+        let g = group(0x01);
+
+        // Arm, limp forward exactly one epoch, stall again at it: the field
+        // shape, now with the advance actually reported.
+        let _ = detector.observe_undecryptable(g.clone(), "m1".into(), EpochId(10));
+        detector.observe_epoch_passage(&g, EpochId(10), EpochId(11));
+        assert_eq!(
+            detector.observe_undecryptable(g.clone(), "m2".into(), EpochId(11)),
+            BackfillDecision::Arm
+        );
+        detector.observe_epoch_passage(&g, EpochId(11), EpochId(12));
+        assert_eq!(
+            detector.observe_undecryptable(g.clone(), "m3".into(), EpochId(12)),
+            BackfillDecision::ArmAndEscalate { arms: 3 },
+            "a device that arms at every epoch it reaches is still failing to catch up"
+        );
+    }
+
+    /// The movement *after* an adjacent passage is what ends the run: it leaves
+    /// an epoch nothing armed at.
+    #[test]
+    fn the_movement_after_an_adjacent_passage_ends_the_arm_run() {
+        let mut detector = EpochStallDetector::new(1, 3);
+        let g = group(0x01);
+
+        // Two arms into a run, one epoch apart.
+        let _ = detector.observe_undecryptable(g.clone(), "m1".into(), EpochId(10));
+        detector.observe_epoch_passage(&g, EpochId(10), EpochId(11));
+        let _ = detector.observe_undecryptable(g.clone(), "m2".into(), EpochId(11));
+
+        // The device then keeps moving: it reaches 12, arms nothing there, and
+        // moves on to 13. Leaving 12 is the clean pass that ends the run.
+        detector.observe_epoch_passage(&g, EpochId(11), EpochId(12));
+        detector.observe_epoch_passage(&g, EpochId(12), EpochId(13));
+
+        assert_eq!(
+            detector.observe_undecryptable(g.clone(), "m3".into(), EpochId(13)),
+            BackfillDecision::Arm,
+            "sustained movement must restart the run, so this is its first arm"
+        );
+    }
+
+    #[test]
+    fn a_passage_for_a_group_with_no_stall_history_leaves_it_untracked() {
+        let mut detector = EpochStallDetector::new(1, 3);
+        let g = group(0x01);
+
+        // A passage is evidence *about* a stall run, never the start of one.
+        detector.observe_epoch_passage(&g, EpochId(10), EpochId(14));
+
+        // Storm-collapse suppression covers tracked groups only, so a first arm
+        // surviving it proves the passage created no entry to suppress.
+        detector.mark_replayed();
+        assert_eq!(
+            detector.observe_undecryptable(g.clone(), "m1".into(), EpochId(14)),
+            BackfillDecision::Arm,
+            "a passage must not enroll a group with no stall history"
+        );
+    }
+
+    #[test]
+    fn a_backward_passage_is_not_progress_and_leaves_the_run_open() {
+        let mut detector = EpochStallDetector::new(1, 3);
+        let g = group(0x01);
+
+        let _ = detector.observe_undecryptable(g.clone(), "m1".into(), EpochId(10));
+
+        // A reorg that rolls the tip back moves the device away from the group's
+        // history, not toward it. Synthesizing an intermediate epoch here would
+        // end an unrecovered run on a rollback.
+        detector.observe_epoch_passage(&g, EpochId(10), EpochId(9));
+
+        assert_eq!(
+            detector.observe_undecryptable(g.clone(), "m2".into(), EpochId(11)),
+            BackfillDecision::Arm
+        );
+        assert_eq!(
+            detector.observe_undecryptable(g.clone(), "m3".into(), EpochId(12)),
+            BackfillDecision::ArmAndEscalate { arms: 3 },
+            "the rollback must not have ended the run"
         );
     }
 

--- a/crates/marmot-app/src/client/epoch_stall.rs
+++ b/crates/marmot-app/src/client/epoch_stall.rs
@@ -327,15 +327,32 @@ impl EpochStallDetector {
     /// `a_device_limping_one_epoch_per_arm_still_escalates` and
     /// `the_movement_after_an_adjacent_passage_ends_the_arm_run`.
     ///
-    /// One accepted edge, from the rollback guard below: a backward passage is
-    /// dropped, so the detector can sit one epoch above the engine's tip, and the
-    /// next forward passage from that lower tip has `from + 1` equal to the epoch
-    /// the detector already holds — the first feed returns early, the second sees
-    /// the armed epoch again, and one reset is swallowed. It costs a delayed
-    /// reset in a case that must already have reorged backwards, never a false
-    /// arm, and it is strictly better than the pre-passage behavior it replaces.
-    /// Forking the reset rule into a span-aware variant to recover that one reset
-    /// is deliberately not done.
+    /// The observed epoch is monotone, and two guards keep it that way: a
+    /// passage the engine reports as backward (`to <= from`) is dropped, and so
+    /// is one ending at or behind the epoch already observed. Together they make
+    /// a rollback and the re-climb after it silent — the device must pass its own
+    /// previous high-water mark before anything is reported again, and then only
+    /// the part of the passage beyond that mark is. Without the second guard the
+    /// re-climb would walk `self.epoch` backwards, which resets the run and
+    /// clears `fired_at_epoch`, so a device that merely retraced ground would end
+    /// an unrecovered run *and* re-arm at an epoch it had already armed at. The
+    /// same guard is what makes observing one `EpochChanged` twice decide as
+    /// observing it once does. Pinned by
+    /// `re_climbing_the_epochs_a_rollback_dropped_does_not_end_the_arm_run`,
+    /// `a_passage_ending_at_or_behind_the_observed_epoch_changes_nothing`, and
+    /// `a_stale_passage_does_not_reopen_storm_collapse_suppression`.
+    ///
+    /// What a span of two or more proves is worth stating plainly, because the
+    /// reset turns on it. It is not proof the device reached the tip — this layer
+    /// can never learn a group's live epoch, for the reason
+    /// [`GroupStall::observe_epoch`] gives. It is proof that more than one commit
+    /// applied in one go, which is the signature of an ingest pipe that started
+    /// flowing again rather than one delivering a commit at a time. So the reset
+    /// means "stop counting this run", not "this device recovered", and it is
+    /// deliberately cheap to earn. A device still behind stalls again at its new
+    /// epoch, re-arms, and escalates off the fresh run: being wrong here delays
+    /// the report, it does not lose it, whereas the opposite default keeps
+    /// escalating devices that did heal.
     ///
     /// `get_mut` like [`Self::observe_group_epoch`]: a passage is evidence about
     /// a stall run, never the start of one, so a group with no stall history
@@ -347,10 +364,24 @@ impl EpochStallDetector {
         if to <= from {
             return;
         }
-        if let Some(stall) = self.groups.get_mut(group) {
-            stall.observe_epoch(from.next());
-            stall.observe_epoch(to);
+        let Some(stall) = self.groups.get_mut(group) else {
+            return;
+        };
+        // The observed epoch only ever moves forward. A passage ending at or
+        // behind it is ground already covered — a re-observed event, or the
+        // re-climb after a dropped rollback — and feeding it would walk
+        // `self.epoch` backwards, taking the fired-at suppression with it.
+        if to <= stall.epoch {
+            return;
         }
+        // Synthesize the intermediate epoch only when it is itself forward.
+        // Below the observed epoch it is not a step the device is taking now,
+        // and reporting it would make the next feed misread which epoch is
+        // being left.
+        if from.next() > stall.epoch {
+            stall.observe_epoch(from.next());
+        }
+        stall.observe_epoch(to);
     }
 
     /// Record one undecryptable message for `group` observed while the group is
@@ -722,6 +753,101 @@ mod tests {
             detector.observe_undecryptable(g.clone(), "m3".into(), EpochId(12)),
             BackfillDecision::ArmAndEscalate { arms: 3 },
             "the rollback must not have ended the run"
+        );
+    }
+
+    /// A dropped backward passage leaves the detector above the engine's tip.
+    /// The forward passages that re-climb that same ground are not new progress,
+    /// so they must not end the run, reopen the fired-at suppression, or let the
+    /// device re-arm at an epoch it already armed at.
+    #[test]
+    fn re_climbing_the_epochs_a_rollback_dropped_does_not_end_the_arm_run() {
+        let mut detector = EpochStallDetector::new(1, 3);
+        let g = group(0x01);
+
+        // Two arms into a run, one epoch apart, so the detector sits at 15.
+        let _ = detector.observe_undecryptable(g.clone(), "m1".into(), EpochId(14));
+        detector.observe_epoch_passage(&g, EpochId(14), EpochId(15));
+        let _ = detector.observe_undecryptable(g.clone(), "m2".into(), EpochId(15));
+
+        // A reorg rolls the tip back to 12. The passage is dropped, so the
+        // detector keeps believing 15 while the engine restarts from 12.
+        detector.observe_epoch_passage(&g, EpochId(15), EpochId(12));
+        detector.observe_epoch_passage(&g, EpochId(12), EpochId(13));
+        detector.observe_epoch_passage(&g, EpochId(13), EpochId(14));
+        detector.observe_epoch_passage(&g, EpochId(14), EpochId(15));
+
+        assert_eq!(
+            detector.observe_undecryptable(g.clone(), "m3".into(), EpochId(15)),
+            BackfillDecision::Skip,
+            "re-climbing to 15 must not reopen the backfill already fired there"
+        );
+
+        // And the run is intact: the next genuine advance is still arm three.
+        detector.observe_epoch_passage(&g, EpochId(15), EpochId(16));
+        assert_eq!(
+            detector.observe_undecryptable(g.clone(), "m4".into(), EpochId(16)),
+            BackfillDecision::ArmAndEscalate { arms: 3 },
+            "the re-climb must not have reset the run"
+        );
+    }
+
+    /// The detector's epoch only ever moves forward, so a passage that ends
+    /// at-or-behind where it already sits is not evidence of anything. Pins
+    /// idempotency: observing one `EpochChanged` twice decides as observing it
+    /// once does.
+    #[test]
+    fn a_passage_ending_at_or_behind_the_observed_epoch_changes_nothing() {
+        let mut detector = EpochStallDetector::new(1, 3);
+        let g = group(0x01);
+
+        // A spanning passage ends the first run, then two arms open a new one.
+        let _ = detector.observe_undecryptable(g.clone(), "m1".into(), EpochId(12));
+        detector.observe_epoch_passage(&g, EpochId(12), EpochId(15));
+        let _ = detector.observe_undecryptable(g.clone(), "m2".into(), EpochId(15));
+        detector.observe_epoch_passage(&g, EpochId(15), EpochId(16));
+        let _ = detector.observe_undecryptable(g.clone(), "m3".into(), EpochId(16));
+
+        // The very same passage observed a second time, now far behind the tip.
+        detector.observe_epoch_passage(&g, EpochId(12), EpochId(15));
+
+        assert_eq!(
+            detector.observe_undecryptable(g.clone(), "m4".into(), EpochId(16)),
+            BackfillDecision::Skip,
+            "a re-observed passage must not reopen the backfill fired at 16"
+        );
+
+        detector.observe_epoch_passage(&g, EpochId(16), EpochId(17));
+        assert_eq!(
+            detector.observe_undecryptable(g.clone(), "m5".into(), EpochId(17)),
+            BackfillDecision::ArmAndEscalate { arms: 3 },
+            "a re-observed passage must not reset the run either"
+        );
+    }
+
+    /// The same rule guarding the run also guards storm-collapse suppression: a
+    /// stale passage that lands back on the epoch a replay already covered must
+    /// not hand the group a second account-wide replay for free.
+    #[test]
+    fn a_stale_passage_does_not_reopen_storm_collapse_suppression() {
+        let mut detector = EpochStallDetector::new(2, 3);
+        let g = group(0x01);
+
+        // Tracked but never armed, then suppressed by someone else's replay.
+        assert_eq!(
+            detector.observe_undecryptable(g.clone(), "m1".into(), EpochId(10)),
+            BackfillDecision::Skip
+        );
+        detector.mark_replayed();
+
+        // A passage the device already made, re-reported: no movement at all.
+        detector.observe_epoch_passage(&g, EpochId(8), EpochId(10));
+
+        let _ = detector.observe_undecryptable(g.clone(), "m2".into(), EpochId(10));
+        assert_eq!(
+            detector.observe_undecryptable(g.clone(), "m3".into(), EpochId(10)),
+            BackfillDecision::Skip,
+            "the replay suppression at 10 must survive a stale passage"
         );
     }
 

--- a/crates/marmot-app/src/client/epoch_stall.rs
+++ b/crates/marmot-app/src/client/epoch_stall.rs
@@ -188,11 +188,17 @@ impl GroupStall {
     /// The app routes that passage from every effects batch whose events it
     /// gates or projects (`AppClient::observe_recovery_evidence`) — the
     /// convergence folds a trailing device usually catches up by, and the
-    /// maintenance tick's own confirmed evolution, included. One publishing seam
-    /// is a known exception: `AppClient::disband_group` neither gates nor
-    /// observes its batch, a pre-existing gap tracked separately rather than
-    /// widened here. Arming from an observed batch is conditional on it carrying
-    /// a `TransportObjectResourceRefused`; observing a passage is not.
+    /// maintenance tick's own confirmed evolution, included. Two publishing
+    /// seams stay outside that routing. `AppClient::redeliver_welcome` is an
+    /// empty exception: it re-publishes a stored envelope without re-committing
+    /// and never drains the engine, so its batch carries no events to observe.
+    /// `AppClient::disband_group` is a real one — the engine does emit an
+    /// `EpochChanged` when it confirms a disband — and it is accepted rather
+    /// than pre-existing: passage reporting is a new contract, and this is a new
+    /// hole in it, taken because a run whose group is being destroyed has
+    /// nothing left to recover. Arming from an observed batch is conditional on
+    /// it carrying a `TransportObjectResourceRefused`; observing a passage is
+    /// not.
     ///
     /// A batch that reports neither leaves the run exactly as it was: an advance
     /// nobody reports is invisible here, as

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -678,8 +678,25 @@ impl AppClient {
             return Ok(maintenance_run_summary_from_account(summary));
         }
         let effects = self.runtime.run_due_maintenance().await?;
-        self.queue_own_group_system_projection_updates(&effects);
-        let summary = self.runtime.maintenance_run_summary(&effects)?;
+        self.observe_maintenance_effects(&effects)
+    }
+
+    /// Project one maintenance tick's effects, split from the tick itself so the
+    /// projection is exercisable against a given batch of effects.
+    ///
+    /// A maintenance tick publishes: it drains a recovered staged evolution and
+    /// confirms it, so this batch can carry an `EpochChanged` for a group the
+    /// stall detector is tracking. That passage is one-shot in these effects and
+    /// reaches the detector nowhere else — a tick's own recovery is invisible to
+    /// every delivery-driven seam — so observe it here, ahead of the summary
+    /// build that can return early.
+    pub(crate) fn observe_maintenance_effects(
+        &mut self,
+        effects: &marmot_account::AccountDeviceEffects,
+    ) -> Result<crate::MaintenanceRunSummary, AppError> {
+        self.observe_recovery_evidence(effects);
+        self.queue_own_group_system_projection_updates(effects);
+        let summary = self.runtime.maintenance_run_summary(effects)?;
         Ok(maintenance_run_summary_from_account(summary))
     }
 
@@ -2010,7 +2027,7 @@ impl AppClient {
             // previously sat in a combinator closure that could not reach
             // `&mut self`.
             Ok(effects) => self
-                .arm_recovery_then_fail_if_publish_failed(&effects)
+                .observe_recovery_evidence_then_fail_if_publish_failed(&effects)
                 .map(|()| effects),
             Err(error) => Err(error),
         };
@@ -2104,7 +2121,7 @@ impl AppClient {
                 audit_context.clone(),
             )
             .await?;
-        self.arm_recovery_then_fail_if_publish_failed(&effects)?;
+        self.observe_recovery_evidence_then_fail_if_publish_failed(&effects)?;
         self.record_human_action_succeeded(group_id, &audit_context, &effects);
         self.remember_published_reports(&effects);
         self.refresh_group(group_id);
@@ -2150,7 +2167,7 @@ impl AppClient {
                 audit_context.clone(),
             )
             .await?;
-        self.arm_recovery_then_fail_if_publish_failed(&effects)?;
+        self.observe_recovery_evidence_then_fail_if_publish_failed(&effects)?;
         self.record_human_action_succeeded(group_id, &audit_context, &effects);
         self.remember_published_reports(&effects);
         self.refresh_group(group_id);
@@ -2350,7 +2367,7 @@ impl AppClient {
                     audit_context.clone(),
                 )
                 .await?;
-            self.arm_recovery_then_fail_if_publish_failed(&effects)?;
+            self.observe_recovery_evidence_then_fail_if_publish_failed(&effects)?;
             Ok::<_, AppError>(effects)
         }
         .await
@@ -2626,7 +2643,7 @@ impl AppClient {
                 audit_context.clone(),
             )
             .await?;
-        self.arm_recovery_then_fail_if_publish_failed(&effects)?;
+        self.observe_recovery_evidence_then_fail_if_publish_failed(&effects)?;
         self.record_human_action_succeeded(group_id, &audit_context, &effects);
         self.remember_published_reports(&effects);
         self.refresh_group(group_id);
@@ -2661,7 +2678,7 @@ impl AppClient {
                 audit_context.clone(),
             )
             .await?;
-        self.arm_recovery_then_fail_if_publish_failed(&effects)?;
+        self.observe_recovery_evidence_then_fail_if_publish_failed(&effects)?;
         self.record_human_action_succeeded(group_id, &audit_context, &effects);
         self.remember_published_reports(&effects);
         self.refresh_group(group_id);
@@ -2732,7 +2749,7 @@ impl AppClient {
                 audit_context.clone(),
             )
             .await?;
-        self.arm_recovery_then_fail_if_publish_failed(&effects)?;
+        self.observe_recovery_evidence_then_fail_if_publish_failed(&effects)?;
         self.record_human_action_succeeded(group_id, &audit_context, &effects);
         self.remember_published_reports(&effects);
         self.refresh_group(group_id);
@@ -2776,7 +2793,7 @@ impl AppClient {
                 audit_context.clone(),
             )
             .await?;
-        self.arm_recovery_then_fail_if_publish_failed(&effects)?;
+        self.observe_recovery_evidence_then_fail_if_publish_failed(&effects)?;
         self.record_human_action_succeeded(group_id, &audit_context, &effects);
         self.remember_published_reports(&effects);
         self.refresh_group(group_id);
@@ -2930,7 +2947,10 @@ impl AppClient {
                 return Err(err);
             }
         };
-        if let Err(publish_err) = self.arm_recovery_then_gate_send_publish(&effects).await {
+        if let Err(publish_err) = self
+            .observe_recovery_evidence_then_gate_send_publish(&effects)
+            .await
+        {
             self.retract_failed_local_projection(
                 should_project_locally,
                 &group_id_hex,
@@ -3007,19 +3027,20 @@ impl AppClient {
         ))
     }
 
-    /// Apply the publish gate to a completed send's effects — arming
-    /// epoch-gap recovery from the same batch first — and, when the gate
-    /// fails, broadcast the peer commits the send folded before the caller
-    /// surfaces the error.
+    /// Apply the publish gate to a completed send's effects — observing the same
+    /// batch's epoch-gap recovery evidence first — and, when the gate fails,
+    /// broadcast the peer commits the send folded before the caller surfaces the
+    /// error.
     ///
     /// Split out of `send_app_event_with_local_projection` so the ordering is
     /// exercisable against a given batch of effects. The caller keeps the
     /// local-projection retraction, which needs that send's own locals.
-    pub(crate) async fn arm_recovery_then_gate_send_publish(
+    pub(crate) async fn observe_recovery_evidence_then_gate_send_publish(
         &mut self,
         effects: &marmot_account::AccountDeviceEffects,
     ) -> Result<(), AppError> {
-        let publish_err = match self.arm_recovery_then_fail_if_publish_failed(effects) {
+        let publish_err = match self.observe_recovery_evidence_then_fail_if_publish_failed(effects)
+        {
             Ok(()) => return Ok(()),
             Err(publish_err) => publish_err,
         };
@@ -3497,7 +3518,7 @@ impl AppClient {
                 audit_context.clone(),
             )
             .await?;
-        self.arm_recovery_then_fail_if_publish_failed(&effects)?;
+        self.observe_recovery_evidence_then_fail_if_publish_failed(&effects)?;
         self.record_human_action_succeeded(group_id, &audit_context, &effects);
         self.remember_published_reports(&effects);
         let summary = send_summary_from_effects(&effects);
@@ -3717,9 +3738,9 @@ impl AppClient {
         group_id: &GroupId,
         effects: &marmot_account::AccountDeviceEffects,
     ) -> Result<SendSummary, AppError> {
-        // Arm before the publish gate, for the reason spelled out in
+        // Observe before the publish gate, for the reason spelled out in
         // `observe_drained_session_events`.
-        self.arm_recovery_from_effects(effects);
+        self.observe_recovery_evidence(effects);
         fail_if_publish_failed(effects)?;
         self.remember_published_reports(effects);
         // This is the path that releases sends the engine had retained, so its
@@ -3777,7 +3798,7 @@ impl AppClient {
                 audit_context.clone(),
             )
             .await?;
-        self.arm_recovery_then_fail_if_publish_failed(&effects)?;
+        self.observe_recovery_evidence_then_fail_if_publish_failed(&effects)?;
         self.record_human_action_succeeded(group_id, &audit_context, &effects);
         self.remember_published_reports(&effects);
         let message_ids = effects
@@ -4497,7 +4518,7 @@ impl AppClient {
                 // same gate, so no publishing seam reaches the bare check.
                 recover_post_canonical_result(
                     "classify_founding_welcome_publish",
-                    self.arm_recovery_then_fail_if_publish_failed(&effects),
+                    self.observe_recovery_evidence_then_fail_if_publish_failed(&effects),
                 );
                 recover_post_canonical_result(
                     "record_founding_welcome_delivery_failures",

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -678,19 +678,32 @@ impl AppClient {
             return Ok(maintenance_run_summary_from_account(summary));
         }
         let effects = self.runtime.run_due_maintenance().await?;
-        self.observe_maintenance_effects(&effects)
+        self.observe_recovery_evidence_then_summarize_maintenance(&effects)
     }
 
-    /// Project one maintenance tick's effects, split from the tick itself so the
-    /// projection is exercisable against a given batch of effects.
+    /// Observe one maintenance tick's recovery evidence, then summarize the
+    /// tick — split from the tick itself so the pair is exercisable against a
+    /// given batch of effects.
     ///
     /// A maintenance tick publishes: it drains a recovered staged evolution and
     /// confirms it, so this batch can carry an `EpochChanged` for a group the
     /// stall detector is tracking. That passage is one-shot in these effects and
     /// reaches the detector nowhere else — a tick's own recovery is invisible to
-    /// every delivery-driven seam — so observe it here, ahead of the summary
-    /// build that can return early.
-    pub(crate) fn observe_maintenance_effects(
+    /// every delivery-driven seam.
+    ///
+    /// Hence the order the name states, and the reason this is one function
+    /// rather than two calls at the seam: the summary build reads storage and so
+    /// can return early, and an `Err` reached before the observation would drop
+    /// that passage for good. It is the same hazard
+    /// [`Self::observe_recovery_evidence_then_fail_if_publish_failed`] exists
+    /// for, and it gets the same answer — a name that fixes the order.
+    ///
+    /// A tick can also *arm*, from a `TransportObjectResourceRefused` riding the
+    /// same batch. Nothing executes that arm here: the worker does not run the
+    /// pending backfill after a tick, so the intent waits for the next
+    /// delivery-driven seam to drain it. The arm and its audit row are durable
+    /// meanwhile, so the wait costs latency, not the recovery.
+    pub(crate) fn observe_recovery_evidence_then_summarize_maintenance(
         &mut self,
         effects: &marmot_account::AccountDeviceEffects,
     ) -> Result<crate::MaintenanceRunSummary, AppError> {

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -168,7 +168,28 @@ impl AppClient {
             .extend(effects.pending_convergence.iter().cloned());
     }
 
-    pub(crate) fn arm_recovery_from_effects(
+    /// Feed one effects batch's epoch-gap recovery evidence to the stall
+    /// detector: a resource refusal arms a replay, and an epoch passage reports
+    /// the movement that can end an unrecovered run.
+    ///
+    /// Both directions matter, and only this seam carries the second one. A
+    /// delivery reports the epoch it was *read* at, which is where the device
+    /// already sits; the epochs a fold, a confirmed publish, or a maintenance
+    /// tick's own evolution carried it *through* are read at by nothing, so
+    /// without the engine's own `EpochChanged` the detector cannot tell a device
+    /// that recovered from one that is still stuck (see
+    /// [`EpochStallDetector::observe_epoch_passage`](super::epoch_stall::EpochStallDetector::observe_epoch_passage)).
+    /// Of the three emitting sites only a convergence reorg spans more than one
+    /// epoch; publish-confirm and peer-commit ingest are always adjacent, which
+    /// is the case the passage rule is tuned for.
+    ///
+    /// Events are consumed in engine order, so a passage later in the same batch
+    /// supersedes an arm an earlier refusal just made: the durable
+    /// `epoch_stall_backfill_armed` row still records that the replay was armed,
+    /// while the detector's run counter starts over. That split is intended — the
+    /// arm happened and stays on the forensic record, and the run is what the
+    /// later evidence contradicts.
+    pub(crate) fn observe_recovery_evidence(
         &mut self,
         effects: &marmot_account::AccountDeviceEffects,
     ) {
@@ -176,35 +197,41 @@ impl AppClient {
             return;
         }
         for event in &effects.events {
-            let cgka_traits::engine::GroupEvent::TransportObjectResourceRefused {
-                group_id, ..
-            } = event
-            else {
-                continue;
-            };
-            let Ok(record) = self.runtime.group_record(group_id) else {
-                continue;
-            };
-            // Recording the recovery intent before the worker performs the
-            // external full-history replay, and recording an escalation this
-            // arm raises, are both the shared decision handler's job: a
-            // resource-refusal arm counts toward the same unrecovered run as a
-            // deferred-delivery arm, and the detector raises the run's
-            // escalation only once, at whichever path happens to arm third.
-            let decision = self
-                .epoch_stall
-                .observe_resource_refusal(group_id.clone(), record.epoch);
-            self.apply_backfill_decision(
-                group_id,
-                record.epoch.0,
-                decision,
-                EpochStallBackfillTrigger::ResourceRefusal,
-            );
+            match event {
+                cgka_traits::engine::GroupEvent::EpochChanged { group_id, from, to } => {
+                    self.epoch_stall.observe_epoch_passage(group_id, *from, *to);
+                }
+                cgka_traits::engine::GroupEvent::TransportObjectResourceRefused {
+                    group_id,
+                    ..
+                } => {
+                    let Ok(record) = self.runtime.group_record(group_id) else {
+                        continue;
+                    };
+                    // Recording the recovery intent before the worker performs
+                    // the external full-history replay, and recording an
+                    // escalation this arm raises, are both the shared decision
+                    // handler's job: a resource-refusal arm counts toward the
+                    // same unrecovered run as a deferred-delivery arm, and the
+                    // detector raises the run's escalation only once, at
+                    // whichever path happens to arm third.
+                    let decision = self
+                        .epoch_stall
+                        .observe_resource_refusal(group_id.clone(), record.epoch);
+                    self.apply_backfill_decision(
+                        group_id,
+                        record.epoch.0,
+                        decision,
+                        EpochStallBackfillTrigger::ResourceRefusal,
+                    );
+                }
+                _ => {}
+            }
         }
     }
 
-    /// Apply the publish gate to `effects`, arming epoch-gap recovery from the
-    /// same batch first.
+    /// Apply the publish gate to `effects`, observing the same batch's
+    /// epoch-gap recovery evidence first.
     ///
     /// Every publishing seam must reach the gate through this rather than
     /// calling `fail_if_publish_failed` directly. A
@@ -215,18 +242,21 @@ impl AppClient {
     /// arming first survives the caller's `?` because it is a field mutation
     /// plus a durable audit row, not summary state. The two conditions are
     /// correlated rather than independent: these seams publish, so the failure
-    /// and the refusal ride the same effects.
+    /// and the refusal ride the same effects. An `EpochChanged` passage is
+    /// one-shot in the same batch, and losing it costs the opposite mistake —
+    /// a device that recovered stays counted as stuck — so it is observed on the
+    /// same side of the gate.
     ///
-    /// Arming only. `remember_pending_convergence_groups` is deliberately not
-    /// paired here the way it is at the convergence and inbound seams: the
-    /// callers of this gate do not remember pending convergence on their
-    /// success paths either, so recording it on the failure path alone would
-    /// invent a scheduling contract they do not otherwise hold.
-    pub(crate) fn arm_recovery_then_fail_if_publish_failed(
+    /// Recovery evidence only. `remember_pending_convergence_groups` is
+    /// deliberately not paired here the way it is at the convergence and inbound
+    /// seams: the callers of this gate do not remember pending convergence on
+    /// their success paths either, so recording it on the failure path alone
+    /// would invent a scheduling contract they do not otherwise hold.
+    pub(crate) fn observe_recovery_evidence_then_fail_if_publish_failed(
         &mut self,
         effects: &marmot_account::AccountDeviceEffects,
     ) -> Result<(), AppError> {
-        self.arm_recovery_from_effects(effects);
+        self.observe_recovery_evidence(effects);
         fail_if_publish_failed(effects)
     }
 
@@ -485,15 +515,15 @@ impl AppClient {
         // Preserve that scheduling edge even when hydration emitted no app
         // events; the worker drains this set immediately after startup sync.
         self.remember_pending_convergence_groups(effects);
-        // Arm before the publish gate, not after. `drain()` empties the engine's
-        // in-memory event buffer one-shot and is these events' only source, and
-        // a `TransportObjectResourceRefused` is buffered only after its durable
-        // retention row is already deleted — so a refusal this pass does not arm
-        // on can never be re-observed. The arm survives the `?` because it is a
-        // field mutation plus a durable audit row, not summary state. The two
-        // conditions are correlated rather than independent: this drain
-        // publishes, so the failure and the refusal ride the same effects.
-        self.arm_recovery_from_effects(effects);
+        // Observe before the publish gate, not after. `drain()` empties the
+        // engine's in-memory event buffer one-shot and is these events' only
+        // source, and a `TransportObjectResourceRefused` is buffered only after
+        // its durable retention row is already deleted — so a refusal this pass
+        // does not arm on can never be re-observed. The arm survives the `?`
+        // because it is a field mutation plus a durable audit row, not summary
+        // state. The two conditions are correlated rather than independent: this
+        // drain publishes, so the failure and the refusal ride the same effects.
+        self.observe_recovery_evidence(effects);
         fail_if_publish_failed(effects)?;
         let mut summary = SyncSummary::default();
         if effects.events.is_empty() {
@@ -1106,7 +1136,7 @@ impl AppClient {
         let publish_error = fail_if_publish_failed(&effects.effects).err();
         self.remember_buffered_convergence_outcome(&effects.outcome);
         self.remember_pending_convergence_groups(&effects.effects);
-        self.arm_recovery_from_effects(&effects.effects);
+        self.observe_recovery_evidence(&effects.effects);
         self.remember_transport_cursor(outer_transport_at);
         self.detect_epoch_stall(group_id_hint, &source_message_id_hex, &effects.outcome);
         // A delivery can contain several application events. If projection
@@ -1203,9 +1233,15 @@ impl AppClient {
                 .epoch_stall
                 .observe_resource_refusal(group_id.clone(), record.epoch),
             // Any other outcome carries no stall evidence, but it does tell the
-            // detector where this device now sits: a tracked group that leaves an
-            // epoch without arming at it has stopped failing to catch up, which
-            // ends its escalation run.
+            // detector where this device now sits. This is a landing position
+            // only: the epochs a folded commit carried the device *through* reach
+            // the detector as an `EpochChanged` passage, from this same delivery's
+            // effects in `observe_recovery_evidence`. The landing report stays
+            // because it is the fallback for movement no passage covers — an
+            // engine seam that advances a group without emitting `EpochChanged`,
+            // or a batch this delivery never sees — and because two landings at
+            // different epochs can end a run on their own. Where both fire they
+            // agree, since observing an epoch already recorded is a no-op.
             _ => {
                 self.epoch_stall
                     .observe_group_epoch(&group_id, record.epoch);
@@ -1739,9 +1775,9 @@ impl AppClient {
         effects: &marmot_account::AccountDeviceEffects,
     ) -> Result<SyncSummary, AppError> {
         self.remember_pending_convergence_groups(effects);
-        // Arm before the publish gate, for the reason spelled out in
+        // Observe before the publish gate, for the reason spelled out in
         // `observe_drained_session_events`.
-        self.arm_recovery_from_effects(effects);
+        self.observe_recovery_evidence(effects);
         fail_if_publish_failed(effects)?;
         self.remember_published_reports(effects);
         let finalize_updates = self.finalize_published_app_message_source_retention(effects)?;

--- a/crates/marmot-app/src/groups.rs
+++ b/crates/marmot-app/src/groups.rs
@@ -2211,10 +2211,13 @@ pub(crate) fn add_group(
 /// - failures with no pending resolution at all (e.g. a plain application
 ///   message or proposal publish that never landed): hard error, as before.
 ///
-/// Call this from `AppClient::arm_recovery_then_fail_if_publish_failed` rather
-/// than directly. Gating an effects batch without first arming epoch-gap
-/// recovery from it drops any one-shot `TransportObjectResourceRefused` the
-/// batch carries; the seams that already arm explicitly are the only exception.
+/// Call this from
+/// `AppClient::observe_recovery_evidence_then_fail_if_publish_failed` rather
+/// than directly. Gating an effects batch without first observing its
+/// epoch-gap recovery evidence drops any one-shot
+/// `TransportObjectResourceRefused` the batch carries, and any `EpochChanged`
+/// passage that would have ended a stall run; the seams that already observe
+/// explicitly are the only exception.
 pub(crate) fn fail_if_publish_failed(
     effects: &marmot_account::AccountDeviceEffects,
 ) -> Result<(), AppError> {

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -9500,7 +9500,9 @@ async fn a_publish_failure_on_the_send_path_still_arms_recovery() {
     assert_eq!(audit_rows_of_kind(&app, "epoch_stall_backfill_armed"), 0);
 
     let effects = a_refusal_riding_a_rolled_back_publish(&group_id);
-    let result = client.arm_recovery_then_gate_send_publish(&effects).await;
+    let result = client
+        .observe_recovery_evidence_then_gate_send_publish(&effects)
+        .await;
 
     assert!(
         result.is_err(),
@@ -9541,7 +9543,9 @@ async fn a_confirmed_but_partial_send_publish_still_passes_the_arming_gate() {
         .unwrap();
 
     let effects = a_refusal_riding_a_confirmed_but_partial_publish(&group_id);
-    let result = client.arm_recovery_then_gate_send_publish(&effects).await;
+    let result = client
+        .observe_recovery_evidence_then_gate_send_publish(&effects)
+        .await;
 
     assert!(
         result.is_ok(),
@@ -9597,13 +9601,90 @@ async fn the_arming_publish_gate_classifies_exactly_as_the_bare_publish_check() 
     for (label, effects) in batches {
         let bare = crate::groups::fail_if_publish_failed(&effects).map_err(|err| err.to_string());
         let armed = client
-            .arm_recovery_then_fail_if_publish_failed(&effects)
+            .observe_recovery_evidence_then_fail_if_publish_failed(&effects)
             .map_err(|err| err.to_string());
         assert_eq!(
             armed, bare,
             "arming must not change how the gate classifies a {label} publish"
         );
     }
+}
+
+fn an_epoch_passage(
+    group_id: &cgka_traits::GroupId,
+    from: u64,
+    to: u64,
+) -> marmot_account::AccountDeviceEffects {
+    let mut effects = marmot_account::AccountDeviceEffects::default();
+    effects
+        .events
+        .push(cgka_traits::engine::GroupEvent::EpochChanged {
+            group_id: group_id.clone(),
+            from: cgka_traits::EpochId(from),
+            to: cgka_traits::EpochId(to),
+        });
+    effects
+}
+
+/// A maintenance tick's own epoch advance must reach the stall detector.
+///
+/// A tick drains a recovered staged evolution and confirms it, which emits
+/// `EpochChanged` into the batch this seam projects — and nowhere else. Miss it
+/// and the detector keeps believing the device sits at the epoch it armed at, so
+/// the *next* passage a peer fold reports cannot end the run either: its
+/// `from + 1` lands on the armed epoch and decides nothing. Two unrelated stalls
+/// later, a recovered device is escalated.
+#[tokio::test]
+async fn a_maintenance_tick_reports_its_own_epoch_passage_to_the_stall_detector() {
+    let dir = tempfile::tempdir().unwrap();
+    AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relay(dir.path(), "wss://maintenance-passage.example")
+        .with_test_relay_client(relay.clone());
+    let mut client = app.client("alice").await.unwrap();
+    let group_id = client
+        .create_group("maintenance passage", &[])
+        .await
+        .unwrap();
+
+    // The group is stuck and arms once, at epoch 10.
+    assert_eq!(
+        client
+            .epoch_stall
+            .observe_resource_refusal(group_id.clone(), cgka_traits::EpochId(10)),
+        crate::client::epoch_stall::BackfillDecision::Arm
+    );
+
+    // Maintenance then confirms a recovered evolution, 10 -> 11.
+    client
+        .observe_maintenance_effects(&an_epoch_passage(&group_id, 10, 11))
+        .expect("a maintenance batch carrying only an epoch passage summarizes cleanly");
+
+    // A peer fold carries the device on to 12. Only a detector that heard the
+    // maintenance passage is sitting at 11 to have this one leave it.
+    client.epoch_stall.observe_epoch_passage(
+        &group_id,
+        cgka_traits::EpochId(11),
+        cgka_traits::EpochId(12),
+    );
+
+    // So the stalls that follow are a new run: without the maintenance report
+    // the second of these is the run's escalating third arm.
+    assert_eq!(
+        client
+            .epoch_stall
+            .observe_resource_refusal(group_id.clone(), cgka_traits::EpochId(12)),
+        crate::client::epoch_stall::BackfillDecision::Arm
+    );
+    assert_eq!(
+        client
+            .epoch_stall
+            .observe_resource_refusal(group_id, cgka_traits::EpochId(13)),
+        crate::client::epoch_stall::BackfillDecision::Arm,
+        "the maintenance passage must have ended the run, so this is only its second arm"
+    );
 }
 
 /// An escalation recorded while an inbound delivery is ingested must ride the

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -9659,7 +9659,7 @@ async fn a_maintenance_tick_reports_its_own_epoch_passage_to_the_stall_detector(
 
     // Maintenance then confirms a recovered evolution, 10 -> 11.
     client
-        .observe_maintenance_effects(&an_epoch_passage(&group_id, 10, 11))
+        .observe_recovery_evidence_then_summarize_maintenance(&an_epoch_passage(&group_id, 10, 11))
         .expect("a maintenance batch carrying only an epoch passage summarizes cleanly");
 
     // A peer fold carries the device on to 12. Only a detector that heard the

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -9687,6 +9687,68 @@ async fn a_maintenance_tick_reports_its_own_epoch_passage_to_the_stall_detector(
     );
 }
 
+/// A confirmed local publish's epoch passage must reach the detector through the
+/// publish gate.
+///
+/// An own commit is the strongest recovery evidence this layer ever sees — MLS
+/// requires current-epoch state to commit, so the committer was at tip by
+/// construction — but the engine reports it as an ordinary adjacent passage,
+/// `from` synthesized as `new_epoch - 1`. So it takes two: the confirm moves the
+/// detector off the armed epoch, and the next movement is what leaves an epoch
+/// nothing armed at. This pins that both halves land, and that the publishing
+/// seams carry the first one — the delivery-driven seams never see an own
+/// confirm.
+#[tokio::test]
+async fn a_confirmed_local_publish_reports_its_epoch_passage_through_the_publish_gate() {
+    let dir = tempfile::tempdir().unwrap();
+    AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relay(dir.path(), "wss://own-publish-passage.example")
+        .with_test_relay_client(relay.clone());
+    let mut client = app.client("alice").await.unwrap();
+    let group_id = client
+        .create_group("own publish passage", &[])
+        .await
+        .unwrap();
+
+    // The group is stuck and arms once, at epoch 10.
+    assert_eq!(
+        client
+            .epoch_stall
+            .observe_resource_refusal(group_id.clone(), cgka_traits::EpochId(10)),
+        crate::client::epoch_stall::BackfillDecision::Arm
+    );
+
+    // The device then commits and the publish confirms, 10 -> 11.
+    client
+        .observe_recovery_evidence_then_fail_if_publish_failed(&an_epoch_passage(&group_id, 10, 11))
+        .expect("a batch carrying only an epoch passage clears the publish gate");
+
+    // One epoch per arm is a limp, so that confirm alone does not end the run —
+    // the movement after it does.
+    client.epoch_stall.observe_epoch_passage(
+        &group_id,
+        cgka_traits::EpochId(11),
+        cgka_traits::EpochId(12),
+    );
+
+    assert_eq!(
+        client
+            .epoch_stall
+            .observe_resource_refusal(group_id.clone(), cgka_traits::EpochId(12)),
+        crate::client::epoch_stall::BackfillDecision::Arm
+    );
+    assert_eq!(
+        client
+            .epoch_stall
+            .observe_resource_refusal(group_id, cgka_traits::EpochId(13)),
+        crate::client::epoch_stall::BackfillDecision::Arm,
+        "the confirm must have been observed, so this is only the new run's second arm"
+    );
+}
+
 /// An escalation recorded while an inbound delivery is ingested must ride the
 /// summary that seam returns.
 ///

--- a/crates/marmot-app/tests/epoch_stall_backfill_audit.rs
+++ b/crates/marmot-app/tests/epoch_stall_backfill_audit.rs
@@ -20,8 +20,9 @@
 //! `MarmotAppEvent::EpochStallEscalated`) plus one durable
 //! `epoch_stall_backfill_escalated` row. The escalation tests below pin that
 //! decision, its once-per-run latch, its reset when bob passes cleanly through
-//! an epoch, and the runtime reporting gap that costs him that reset when a
-//! convergence fold is what carried him through.
+//! an epoch, and that the reset also lands when a convergence fold is what
+//! carried him through — an epoch no delivery is ever read at, so only the
+//! engine's own epoch passage can report it.
 //!
 //! The arm is driven through `AppClient::next_event` exactly as
 //! `next_event_backfill.rs` does — the deterministic seam that avoids the full
@@ -93,12 +94,12 @@ const EPOCH_ADVANCE_POLL_INTERVAL: Duration = Duration::from_millis(50);
 /// through `wn-cli`. That difference is not cosmetic here. At 1 s a convergence
 /// pass stays open across a drain, so a device reads a burst of commits at the
 /// epoch it was already sitting at and folds afterwards; at 0 ms every commit
-/// folds inside its own ingest, so the runtime reports an epoch per delivery and
-/// no device can be carried *through* an epoch at all. The whole reporting gap
-/// that [`a_clean_recovery_the_runtime_never_reports_still_escalates`] exists to
-/// pin lives in the first regime, which is also the one real devices run in, so this
-/// file states the window it means instead of taking whichever one the feature
-/// resolution hands it.
+/// folds inside its own ingest, so the runtime lands on an epoch per delivery and
+/// no device can be carried *through* an epoch at all. The carry that
+/// [`a_clean_recovery_reported_as_a_passage_ends_the_arm_run`] needs — an epoch
+/// no landing report can cover — exists only in the first regime, which is also
+/// the one real devices run in, so this file states the window it means instead
+/// of taking whichever one the feature resolution hands it.
 const SETTLEMENT_QUIESCENCE_MS: u64 = 1_000;
 
 async fn mock_relay() -> (MockRelay, String) {
@@ -391,27 +392,26 @@ impl StalledGroup {
     /// Carry bob *through* an epoch instead of stopping at it: alice commits
     /// twice, bob retains *both* commits before he folds either, and the folds
     /// then take him past the middle epoch without a single delivery ever being
-    /// read while he is there. That is the whole shape of the reporting gap: the
-    /// only epoch the runtime reports to the detector is the one it read a
-    /// delivery at, and the folds that moved bob two epochs on report nothing.
+    /// read while he is there. That isolates the epoch *passage* as the only
+    /// report that can decide the run: a landing position always arrives at the
+    /// epoch bob sits on, and he never sits on the middle one.
     ///
     /// Ingesting and folding are two phases here, not one loop, and the split is
-    /// what makes the carry deterministic rather than a race. The epoch a
-    /// delivery is *read* at is the only epoch the runtime ever reports, so both
-    /// commits have to be read before either is folded. Neither half of that is
-    /// left to timing: [`SETTLEMENT_QUIESCENCE_MS`] keeps the convergence pass
-    /// open across the drain that reads them (bob retains the first commit as
+    /// what makes the carry deterministic rather than a race. Both commits have
+    /// to be read before either is folded. Neither half of that is left to
+    /// timing: [`SETTLEMENT_QUIESCENCE_MS`] keeps the convergence pass open
+    /// across the drain that reads them (bob retains the first commit as
     /// convergence input and cannot even peel the second from below its epoch),
     /// and the fold is driven explicitly, by `retry_group_convergence`, only
     /// once the ingest phase has both. Interleaving the two — drain, fold, drain
     /// — would instead let a slow relay hand bob the second commit after the
     /// first had already been folded: that delivery is then read at the middle
-    /// epoch, the runtime does report it, the arm run legitimately ends, and the
-    /// test's premise is deleted rather than failed. The ingest phase therefore
-    /// waits on the engine's own ingest outcomes for exactly alice's two commit
-    /// ids — the group's undecryptable probe traffic shares its `group_ref`, so
-    /// a count would not do — and the epoch assertion between the phases pins
-    /// that nothing folded early.
+    /// epoch, a landing report ends the run all by itself, and a test about
+    /// passages passes without one. The ingest phase therefore waits on the
+    /// engine's own ingest outcomes for exactly alice's two commit ids — the
+    /// group's undecryptable probe traffic shares its `group_ref`, so a count
+    /// would not do — and the epoch assertion between the phases pins that
+    /// nothing folded early.
     async fn carry_bob_through_an_epoch(&mut self, name: &str) {
         let before = self.bobs_epoch();
         let mut audit_rows = AuditRowTracker::default();
@@ -750,29 +750,29 @@ async fn repeated_arming_without_recovery_escalates_exactly_once() {
     );
 }
 
-/// A device that recovered cleanly is escalated anyway, because the runtime
-/// never tells the detector about the epochs a convergence fold carried it
-/// through.
+/// A device that recovers cleanly is not escalated, because the convergence fold
+/// that carried it reports the epochs it passed through.
 ///
-/// Bob arms, then one real fold takes him past an epoch he never stalled at.
-/// Under the detector's own rule that clean pass ends his unrecovered run — but
-/// no `observe_*` call on the fold path reports it, so the run stays open and his
-/// next two stalls are counted as its second and third arms. He is reported as a
-/// group full-history replay cannot repair on the strength of an epoch he sailed
-/// through.
+/// Bob arms, then one real fold takes him past an epoch he never stalled at. No
+/// delivery is ever read while he is there — the epoch a delivery is read at is
+/// a landing position, and he never lands on that one — so the only report that
+/// can end his unrecovered run is the engine's `EpochChanged` passage. The
+/// runtime feeds it to the detector, the run ends, and his next two stalls are a
+/// fresh run's first and second arms rather than the old run's second and third.
 ///
-/// This is today's behavior, not the intended behavior, and it is the "before"
-/// side of closing the reporting gap: once the convergence fold reports its
-/// epochs, the middle epoch ends the run, the last stall is only its second arm,
-/// and this test flips to asserting no escalation at all. The detector unit test
-/// `an_epoch_advance_the_detector_never_observed_does_not_end_the_arm_run`
-/// cannot pin this — it omits the observation by hand, so it keeps passing
-/// whether or not the runtime makes the call.
+/// This is the runtime half of the passage report, and the half the detector unit
+/// tests cannot pin: they hand the detector a passage directly, so they keep
+/// passing whether or not a real fold produces one. The rule the passage feeds is
+/// `GroupStall::observe_epoch`; the arithmetic that turns one passage into two
+/// reports is pinned by
+/// `a_spanning_passage_off_the_armed_epoch_ends_the_arm_run`.
 #[tokio::test]
-async fn a_clean_recovery_the_runtime_never_reports_still_escalates() {
+async fn a_clean_recovery_reported_as_a_passage_ends_the_arm_run() {
     let dir_bob = tempfile::tempdir().unwrap();
     let dir_alice = tempfile::tempdir().unwrap();
     let mut live = stalled_bob_in_a_live_group(&dir_bob, &dir_alice).await;
+    let mut audit_rows = AuditRowTracker::default();
+    let _setup_rows = audit_rows.new_rows(&live.app_bob, "bob");
 
     // Arm one: bob stalls at the epoch he starts on.
     assert!(
@@ -780,8 +780,8 @@ async fn a_clean_recovery_the_runtime_never_reports_still_escalates() {
         "the first arm of a run must not escalate",
     );
 
-    // He then recovers cleanly through an epoch — the one thing that should end
-    // the run — carried by a fold nobody reports.
+    // He then recovers cleanly through an epoch — the one thing that ends the
+    // run — carried by a fold that reports its passage and nothing else.
     let armed_epoch = live.bobs_epoch();
     live.carry_bob_through_an_epoch("recovered").await;
     assert!(
@@ -789,31 +789,30 @@ async fn a_clean_recovery_the_runtime_never_reports_still_escalates() {
         "the carry must take bob past an epoch, not stop at the next one",
     );
 
-    // The two stalls that follow are unrelated to the armed run, but the detector
-    // has heard nothing since the arm, so it counts them as its second and third.
+    // The two stalls that follow are unrelated to the armed run, and the detector
+    // now knows it: they open a new run instead of completing the old one.
     assert!(
         live.stall_bob_for_one_run(1).await.is_empty(),
         "a stall after a clean recovery must not escalate on its own",
     );
-    let stalled_epoch = live.bobs_epoch();
     live.advance_bobs_epoch("advanced").await;
     let escalations = live.stall_bob_for_one_run(2).await;
 
-    assert_eq!(
-        escalations.len(),
-        1,
-        "today's runtime escalates a recovered device: {escalations:?}",
+    assert!(
+        escalations.is_empty(),
+        "a recovery the runtime reported must not be counted as an arm: {escalations:?}",
     );
+    // Three arms did happen — the absence above is a decision, not a run that
+    // never armed — and none of them was reported.
+    let rows = audit_rows.new_rows(&live.app_bob, "bob");
     assert_eq!(
-        escalations[0].arms, ESCALATION_ARM_THRESHOLD as u32,
-        "the escalation counts the clean recovery as an arm of the same run: {:?}",
-        escalations[0],
+        rows_of_kind(&rows, "epoch_stall_backfill_armed").len(),
+        ESCALATION_ARM_THRESHOLD,
+        "each stalled epoch must still record its own arm row: {rows:?}"
     );
-    assert_eq!(
-        escalations[0].stalled_epoch,
-        stalled_epoch + 1,
-        "the escalating arm fired at the epoch the last commit left bob on: {:?}",
-        escalations[0],
+    assert!(
+        rows_of_kind(&rows, "epoch_stall_backfill_escalated").is_empty(),
+        "no escalation row may be recorded: {rows:?}"
     );
 }
 

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "Convergence Reliability And Simulation Plan"
 created: 2026-07-30
-updated: 2026-08-16
+updated: 2026-08-21
 tags: [marmot, cgka, convergence, simulation, verification, reliability]
 status: working-plan
 ---
@@ -335,7 +335,7 @@ future inventory revision should encode machine-checked expected values where th
 | A6 | `epoch_stall.rs`; threshold/debounce/reset tests; next-event and audit backfill tests | M3.1 retained-relay threshold sweep; additional production cohorts |
 | A7 | `marmot-app/lib.rs`; `cold_restart_since_floor_permanently_drops_backlog_below_it`; `stalled_epoch_backfill_recovers_below_floor_backlog_when_armed` | M2.3 long-offline retained-relay matrix |
 | A8 | `marmot-app/lib.rs`; since-floor malicious/future timestamp coverage | M3.1 explicit skew/cursor-reset Scenario IR family |
-| A9 | `epoch_stall.rs`; `escalates_when_arms_repeat_without_passing_cleanly_through_an_epoch`; `an_epoch_the_device_passes_through_cleanly_ends_the_arm_run`; `an_epoch_advance_the_detector_never_observed_does_not_end_the_arm_run`; `an_escalated_run_reports_once_however_long_it_keeps_arming`; `storm_collapse_suppression_is_not_an_arm`; `repeated_arming_without_recovery_escalates_exactly_once`; `an_epoch_passed_cleanly_between_arms_never_escalates`; `a_clean_recovery_the_runtime_never_reports_still_escalates`; `an_escalation_recorded_before_a_failing_sync_is_reported_by_the_next_sync`; `an_escalation_recorded_during_a_received_delivery_rides_that_seam` | M3.1 retained-relay arm-run sweep; production cohorts confirming the run length that warrants the stronger repair |
+| A9 | `epoch_stall.rs`; `escalates_when_arms_repeat_without_passing_cleanly_through_an_epoch`; `an_epoch_the_device_passes_through_cleanly_ends_the_arm_run`; `an_epoch_advance_the_detector_never_observed_does_not_end_the_arm_run`; `an_escalated_run_reports_once_however_long_it_keeps_arming`; `storm_collapse_suppression_is_not_an_arm`; `repeated_arming_without_recovery_escalates_exactly_once`; `an_epoch_passed_cleanly_between_arms_never_escalates`; `a_clean_recovery_reported_as_a_passage_ends_the_arm_run`; `a_spanning_passage_off_the_armed_epoch_ends_the_arm_run`; `a_device_limping_one_epoch_per_arm_still_escalates`; `the_movement_after_an_adjacent_passage_ends_the_arm_run`; `a_passage_for_a_group_with_no_stall_history_leaves_it_untracked`; `a_backward_passage_is_not_progress_and_leaves_the_run_open`; `re_climbing_the_epochs_a_rollback_dropped_does_not_end_the_arm_run`; `a_passage_ending_at_or_behind_the_observed_epoch_changes_nothing`; `a_stale_passage_does_not_reopen_storm_collapse_suppression`; `an_escalation_recorded_before_a_failing_sync_is_reported_by_the_next_sync`; `an_escalation_recorded_during_a_received_delivery_rides_that_seam` | M3.1 retained-relay arm-run sweep; production cohorts confirming the run length that warrants the stronger repair |
 
 Ledger work:
 


### PR DESCRIPTION
Closes #1477.

## Problem

The epoch-stall detector's reset rule decides on the epoch being *left*: `GroupStall::observe_epoch` ends an arm run only when the epoch it is told about differs from `armed_at_epoch`. Every caller, though, reported a landing position — the epoch a delivery was *read* at, which is where the device already sits. The first such report after an arm therefore always names the armed epoch as the one being left, so a device armed at 10 and carried to 13 by a convergence fold arrives at its next stall with the run still open, and two unrelated stalls later a recovered device is escalated as one a full-history replay cannot repair.

#1477's own proposed fix — have the fold report the epoch it landed on — is a no-op for exactly that reason: a landing report arrives at the epoch the device now sits on, and the epoch being left is still the armed one. Nothing resets. What is missing is not a report at the fold seam but a report that names an epoch the device is no longer at.

## Fix

Feed the engine's own `GroupEvent::EpochChanged { from, to }` as an epoch *passage*. `EpochStallDetector::observe_epoch_passage` reports `from + 1` and then `to`: the first moves the detector off the armed epoch, the second leaves an epoch nothing armed at, which is what ends the run. Passages at or behind the detector's observed epoch are dropped, and the synthesized intermediate epoch is fed only when it is itself forward — the detector's epoch is monotonic, so a rollback's re-climb, a stale replay, or a duplicate passage can neither end an unrecovered run nor re-arm a replay at an epoch that already fired. Lookup is `get_mut`, so a passage is evidence about a stall run and never the start of one; a healthy group allocates no state.

An adjacent passage (`to == from + 1`) deliberately does not reset on its own: the second feed is the epoch the first just recorded and returns early, so the run ends on the device's next movement instead. One epoch of progress per arm is a device limping, which is the field shape escalation exists to report. The reset has to be *delayed* rather than absent because adjacency is the common case — a confirmed local publish and a folded peer commit each advance exactly one epoch, and only a convergence reorg spans several — so a single-commit catch-up still resets, on the movement after it. A span of two or more is evidence the ingest pipe is flowing, not that the device reached tip; a device still behind stalls again, re-arms, and escalates off a fresh run, so a wrong reset delays the report rather than losing it.

`arm_recovery_from_effects` becomes `observe_recovery_evidence` and handles both events from one batch: a `TransportObjectResourceRefused` arms, an `EpochChanged` reports movement. Every seam that gates or projects an effects batch routes through it, including maintenance: `run_due_maintenance`'s projection is split into `observe_recovery_evidence_then_summarize_maintenance` so the tick's own drained-and-confirmed evolution reports its passage, ahead of a summary build that can return early. That passage is one-shot in those effects and reaches the detector nowhere else, because no delivery-driven seam sees a tick's own recovery. Maintenance thereby becomes a refusal-arming site; the armed intent executes at the next delivery-driven seam rather than in the tick itself. `disband_group` remains the one publishing seam that neither gates nor observes — a new hole in the new contract, accepted because the group is being destroyed.

The `arm_recovery_*` wrappers are renamed to `observe_recovery_evidence_*` because the seam now ends runs as well as arming them. #1524's invariant is untouched: the refusal arm still runs before every publish gate, in the same order, on the same side of the `?`; the renames wrap it and add the passage beside it.

## Tests

Detector unit tests pin both target behaviors: `a_spanning_passage_off_the_armed_epoch_ends_the_arm_run` ends the run and clears the escalation latch, and `a_device_limping_one_epoch_per_arm_still_escalates` keeps a one-epoch-per-arm device escalating. Three more pin the edges — the movement after an adjacent passage is what resets, a backward passage leaves the run open, and a passage for a group with no stall history enrolls nothing. Three regression tests pin the monotonic guard: re-climbing the epochs a rollback dropped does not end the arm run, a passage ending at or behind the observed epoch changes nothing, and a stale passage does not reopen storm-collapse suppression. At the runtime, `a_clean_recovery_reported_as_a_passage_ends_the_arm_run` (the former `a_clean_recovery_the_runtime_never_reports_still_escalates`) drives a real two-commit fold that carries bob through an epoch no delivery is read at, and flips from asserting one escalation to asserting three arm rows and no escalation row. `a_maintenance_tick_reports_its_own_epoch_passage_to_the_stall_detector` pins the tick seam, and `a_confirmed_local_publish_reports_its_epoch_passage_through_the_publish_gate` pins the own-commit passage at the publish-gate seam.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery tracking when groups advance across one or more epochs.
  * Recovery evidence is now captured consistently during maintenance, messaging, synchronization, convergence, and publish-failure handling.
  * Recovery runs end reliably after reported epoch progress, preventing unnecessary escalation and preserving replay-storm suppression.
  * Backward, stale, duplicate, or already-covered epoch movements are safely ignored.

* **Tests**
  * Expanded coverage for spanning passages, delayed resets, rollback behavior, maintenance-driven progress, and convergence recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->