### PR TITLE
Harden WN Agent installer verification and RustSec CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,11 @@ jobs:
       - name: Naming gate (retired legacy tokens)
         run: ./scripts/check_legacy_naming.sh
 
+      - name: Install example SHA-256 gate
+        run: |
+          python3 scripts/check_install_example_sha256.py
+          python3 scripts/test_install_example_sha256_gate.py
+
       - name: Campaign image toolchain gate
         run: ./scripts/check_campaign_toolchain.sh
 
@@ -66,6 +71,15 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
+
+      - name: Install Rust toolchain
+        run: |
+          set -euo pipefail
+          toolchain="$(sed -n 's/^channel = "\(.*\)"/\1/p' rust-toolchain.toml)"
+          rustup toolchain install "$toolchain" --profile minimal
+          rustup default "$toolchain"
+          rustc --version
+          cargo --version
 
       - name: Install cargo-audit
         uses: taiki-e/install-action@b18fb392e1a1b90971f7c7572c92790fa54f23d5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,9 @@ jobs:
           tool: cargo-audit@0.22.1
 
       - name: Audit Rust dependencies
-        run: cargo audit --locked
+        # Cargo consumes --locked before dispatching to cargo-audit; cargo-audit
+        # itself does not accept --locked after the subcommand.
+        run: cargo --locked audit
 
   terminal-harness-installers:
     name: Terminal harness installer tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,25 @@ jobs:
       - name: Agent install documentation gate
         run: ./scripts/check_agent_install_docs.sh
 
+  rust-audit:
+    name: Rust audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@b18fb392e1a1b90971f7c7572c92790fa54f23d5
+        with:
+          tool: cargo-audit@0.22.1
+
+      - name: Audit Rust dependencies
+        run: cargo audit --locked
+
   terminal-harness-installers:
     name: Terminal harness installer tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Agent install documentation gate
         run: ./scripts/check_agent_install_docs.sh
 
+      - name: Cargo audit workflow policy gate
+        run: python3 scripts/test_check_cargo_audit_ci.py
+
   rust-audit:
     name: Rust audit
     runs-on: ubuntu-latest

--- a/.github/workflows/wn-agent-binaries.yml
+++ b/.github/workflows/wn-agent-binaries.yml
@@ -684,7 +684,7 @@ jobs:
           fi
 
           cat > "$latest_notes" <<EOF
-          Latest WN Agent installers. These scripts install WN Agent \`$version\` from immutable release \`$tag\`.
+          Latest WN Agent installers. These scripts install whichever version the mutable \`$latest_tag\` alias currently references; use immutable release \`$tag\` for WN Agent \`$version\`.
 
           \`\`\`sh
           set -eu

--- a/.github/workflows/wn-agent-binaries.yml
+++ b/.github/workflows/wn-agent-binaries.yml
@@ -478,14 +478,82 @@ jobs:
           cat > "$notes" <<EOF
           WN Agent \`$version\` from MDK commit \`$GITHUB_SHA\`.
 
+          Install the latest WN Agent release with:
+
+          \`\`\`sh
+          set -eu
+          base_url="https://github.com/$GITHUB_REPOSITORY/releases/download/wn-agent-latest"
+
+          install_verified() (
+            set -eu
+            installer_url="\$1"
+            checksum_url="\$2"
+            shift 2
+            installer_script="\${installer_url##*/}"
+            tmpdir="\$(mktemp -d)"
+            trap 'rm -rf "\$tmpdir"' 0 HUP INT TERM
+            curl -fsSL "\$installer_url" -o "\$tmpdir/\$installer_script"
+            curl -fsSL "\$checksum_url" -o "\$tmpdir/\$installer_script.sha256"
+            if command -v shasum >/dev/null 2>&1; then
+              (cd "\$tmpdir" && shasum -a 256 -c "\$installer_script.sha256")
+            elif command -v sha256sum >/dev/null 2>&1; then
+              (cd "\$tmpdir" && sha256sum -c "\$installer_script.sha256")
+            else
+              echo "error: need shasum or sha256sum to verify the installer" >&2
+              exit 1
+            fi
+            bash "\$tmpdir/\$installer_script" "\$@"
+          )
+
+          # Hermes gateway
+          install_verified "\$base_url/install-hermes-marmot.sh" "\$base_url/install-hermes-marmot.sh.sha256"
+          # OpenClaw gateway
+          install_verified "\$base_url/install-openclaw-marmot.sh" "\$base_url/install-openclaw-marmot.sh.sha256"
+          # Codex terminal harness
+          install_verified "\$base_url/install-codex-marmot.sh" "\$base_url/install-codex-marmot.sh.sha256"
+          # OpenCode terminal harness
+          install_verified "\$base_url/install-opencode-marmot.sh" "\$base_url/install-opencode-marmot.sh.sha256"
+          # Pi terminal harness
+          install_verified "\$base_url/install-pi-marmot.sh" "\$base_url/install-pi-marmot.sh.sha256"
+          \`\`\`
+
           Install this exact WN Agent release with:
 
           \`\`\`sh
-          curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/$tag/install-hermes-marmot.sh | bash
-          curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/$tag/install-openclaw-marmot.sh | bash
-          curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/$tag/install-codex-marmot.sh | bash
-          curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/$tag/install-opencode-marmot.sh | bash
-          curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/$tag/install-pi-marmot.sh | bash
+          set -eu
+          base_url="https://github.com/$GITHUB_REPOSITORY/releases/download/$tag"
+
+          install_verified() (
+            set -eu
+            installer_url="\$1"
+            checksum_url="\$2"
+            shift 2
+            installer_script="\${installer_url##*/}"
+            tmpdir="\$(mktemp -d)"
+            trap 'rm -rf "\$tmpdir"' 0 HUP INT TERM
+            curl -fsSL "\$installer_url" -o "\$tmpdir/\$installer_script"
+            curl -fsSL "\$checksum_url" -o "\$tmpdir/\$installer_script.sha256"
+            if command -v shasum >/dev/null 2>&1; then
+              (cd "\$tmpdir" && shasum -a 256 -c "\$installer_script.sha256")
+            elif command -v sha256sum >/dev/null 2>&1; then
+              (cd "\$tmpdir" && sha256sum -c "\$installer_script.sha256")
+            else
+              echo "error: need shasum or sha256sum to verify the installer" >&2
+              exit 1
+            fi
+            bash "\$tmpdir/\$installer_script" "\$@"
+          )
+
+          # Hermes gateway
+          install_verified "\$base_url/install-hermes-marmot.sh" "\$base_url/install-hermes-marmot.sh.sha256"
+          # OpenClaw gateway
+          install_verified "\$base_url/install-openclaw-marmot.sh" "\$base_url/install-openclaw-marmot.sh.sha256"
+          # Codex terminal harness
+          install_verified "\$base_url/install-codex-marmot.sh" "\$base_url/install-codex-marmot.sh.sha256"
+          # OpenCode terminal harness
+          install_verified "\$base_url/install-opencode-marmot.sh" "\$base_url/install-opencode-marmot.sh.sha256"
+          # Pi terminal harness
+          install_verified "\$base_url/install-pi-marmot.sh" "\$base_url/install-pi-marmot.sh.sha256"
           \`\`\`
 
           Assets:
@@ -619,11 +687,40 @@ jobs:
           Latest WN Agent installers. These scripts install WN Agent \`$version\` from immutable release \`$tag\`.
 
           \`\`\`sh
-          curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/$tag/install-hermes-marmot.sh | bash
-          curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/$tag/install-openclaw-marmot.sh | bash
-          curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/$tag/install-codex-marmot.sh | bash
-          curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/$tag/install-opencode-marmot.sh | bash
-          curl -fsSL https://github.com/$GITHUB_REPOSITORY/releases/download/$tag/install-pi-marmot.sh | bash
+          set -eu
+          base_url="https://github.com/$GITHUB_REPOSITORY/releases/download/$latest_tag"
+
+          install_verified() (
+            set -eu
+            installer_url="\$1"
+            checksum_url="\$2"
+            shift 2
+            installer_script="\${installer_url##*/}"
+            tmpdir="\$(mktemp -d)"
+            trap 'rm -rf "\$tmpdir"' 0 HUP INT TERM
+            curl -fsSL "\$installer_url" -o "\$tmpdir/\$installer_script"
+            curl -fsSL "\$checksum_url" -o "\$tmpdir/\$installer_script.sha256"
+            if command -v shasum >/dev/null 2>&1; then
+              (cd "\$tmpdir" && shasum -a 256 -c "\$installer_script.sha256")
+            elif command -v sha256sum >/dev/null 2>&1; then
+              (cd "\$tmpdir" && sha256sum -c "\$installer_script.sha256")
+            else
+              echo "error: need shasum or sha256sum to verify the installer" >&2
+              exit 1
+            fi
+            bash "\$tmpdir/\$installer_script" "\$@"
+          )
+
+          # Hermes gateway
+          install_verified "\$base_url/install-hermes-marmot.sh" "\$base_url/install-hermes-marmot.sh.sha256"
+          # OpenClaw gateway
+          install_verified "\$base_url/install-openclaw-marmot.sh" "\$base_url/install-openclaw-marmot.sh.sha256"
+          # Codex terminal harness
+          install_verified "\$base_url/install-codex-marmot.sh" "\$base_url/install-codex-marmot.sh.sha256"
+          # OpenCode terminal harness
+          install_verified "\$base_url/install-opencode-marmot.sh" "\$base_url/install-opencode-marmot.sh.sha256"
+          # Pi terminal harness
+          install_verified "\$base_url/install-pi-marmot.sh" "\$base_url/install-pi-marmot.sh.sha256"
           \`\`\`
 
           Use the versioned \`$tag\` release URLs when you need a pinned install.

--- a/.github/workflows/wn-agent-binaries.yml
+++ b/.github/workflows/wn-agent-binaries.yml
@@ -478,7 +478,7 @@ jobs:
           cat > "$notes" <<EOF
           WN Agent \`$version\` from MDK commit \`$GITHUB_SHA\`.
 
-          Install the latest WN Agent release with:
+          Install whichever version the mutable \`wn-agent-latest\` alias currently references with:
 
           \`\`\`sh
           set -eu

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,13 @@ just fmt-check
 just check
 just clippy
 just test
+just install-example-sha256-gate
 ```
+
+The install-example gate renders all five installer `--help` surfaces and checks
+release guidance plus workflow-generated notes for download, sibling `.sha256`
+verification (`shasum` or `sha256sum`), then local execution. It also rejects
+new download-to-shell examples in tracked Markdown, shell, and workflow files.
 
 For formal-model changes:
 

--- a/Justfile
+++ b/Justfile
@@ -229,6 +229,14 @@ pi-dev-e2e-connector:
 agent-install-docs-gate:
     scripts/check_agent_install_docs.sh
 
+install-example-sha256-gate:
+    python3 scripts/check_install_example_sha256.py
+    python3 scripts/test_install_example_sha256_gate.py
+
+cargo-audit-policy-gate:
+    python3 scripts/check_cargo_audit_ci.py
+    python3 scripts/test_check_cargo_audit_ci.py
+
 openclaw-dev-smoke root="":
     #!/usr/bin/env bash
     set -euo pipefail
@@ -559,6 +567,6 @@ test-convergence-policy-pin:
 
 # Fast local pre-push gate: mechanical/static checks plus the release pin proof.
 # GitHub CI invokes the static gates directly and runs the full test matrix.
-fast-ci: fmt-check naming-gate convergence-ledger-gate campaign-toolchain-gate agent-install-docs-gate check clippy test-convergence-policy-pin
+fast-ci: fmt-check naming-gate convergence-ledger-gate campaign-toolchain-gate agent-install-docs-gate install-example-sha256-gate cargo-audit-policy-gate check clippy test-convergence-policy-pin
 
-ci: fmt-check naming-gate convergence-ledger-gate campaign-toolchain-gate agent-install-docs-gate check clippy test-convergence-policy-pin test
+ci: fmt-check naming-gate convergence-ledger-gate campaign-toolchain-gate agent-install-docs-gate install-example-sha256-gate cargo-audit-policy-gate check clippy test-convergence-policy-pin test

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -57,6 +57,8 @@ base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9
 
 Hermes 0.19.0 or newer must already be installed and working.
 
+Run this example in the same shell where `install_verified` above was defined.
+
 ```sh
 install_verified "$base_url/install-hermes-marmot.sh" \
   "$base_url/install-hermes-marmot.sh.sha256"
@@ -65,6 +67,8 @@ install_verified "$base_url/install-hermes-marmot.sh" \
 ### OpenClaw
 
 OpenClaw 2026.7.1 or newer and Node 22.19 or newer must already be installed.
+
+Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
 install_verified "$base_url/install-openclaw-marmot.sh" \
@@ -75,6 +79,8 @@ install_verified "$base_url/install-openclaw-marmot.sh" \
 
 Codex must already be installed, authenticated, and runnable as `codex`.
 
+Run this example in the same shell where `install_verified` above was defined.
+
 ```sh
 install_verified "$base_url/install-codex-marmot.sh" \
   "$base_url/install-codex-marmot.sh.sha256"
@@ -84,6 +90,8 @@ install_verified "$base_url/install-codex-marmot.sh" \
 
 OpenCode 1.18.18 or newer must already be installed and runnable as `opencode`.
 
+Run this example in the same shell where `install_verified` above was defined.
+
 ```sh
 install_verified "$base_url/install-opencode-marmot.sh" \
   "$base_url/install-opencode-marmot.sh.sha256"
@@ -92,6 +100,8 @@ install_verified "$base_url/install-opencode-marmot.sh" \
 ### Pi
 
 Pi must already be installed, authenticated, and runnable as `pi`.
+
+Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
 install_verified "$base_url/install-pi-marmot.sh" \
@@ -128,6 +138,8 @@ Use the immutable release URL and provide the authorized White Noise account
 explicitly. Terminal harnesses and OpenClaw use the welcomer entry for both
 invitation and prompt authorization.
 
+Run this example in the same shell where `install_verified` above was defined.
+
 ```sh
 OWNER_NPUB=npub1...
 install_verified "$base_url/install-codex-marmot.sh" \
@@ -137,6 +149,8 @@ install_verified "$base_url/install-codex-marmot.sh" \
 
 Replace `codex` in the URL with `openclaw`, `opencode`, or `pi`. Hermes keeps
 invite acceptance and message-sender authorization explicit:
+
+Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
 install_verified "$base_url/install-hermes-marmot.sh" \

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -25,14 +25,41 @@ Choose the runtime you already use:
 The guided installers prompt on the terminal for the White Noise account that
 may invite and message the agent. They install release `wn-agent-v0.9.14`, create
 an isolated White Noise identity for the selected connector, and start same-user
-services where supported.
+services where supported. Download each installer with its adjacent checksum,
+verify it, and only then execute the local file:
+
+```sh
+install_verified() (
+  set -eu
+  installer_url="$1"
+  checksum_url="$2"
+  shift 2
+  installer_script="${installer_url##*/}"
+  tmpdir="$(mktemp -d)"
+  trap 'rm -rf "$tmpdir"' 0 HUP INT TERM
+  curl -fsSL "$installer_url" -o "$tmpdir/$installer_script"
+  curl -fsSL "$checksum_url" -o "$tmpdir/$installer_script.sha256"
+  if command -v shasum >/dev/null 2>&1; then
+    (cd "$tmpdir" && shasum -a 256 -c "$installer_script.sha256")
+  elif command -v sha256sum >/dev/null 2>&1; then
+    (cd "$tmpdir" && sha256sum -c "$installer_script.sha256")
+  else
+    echo "error: need shasum or sha256sum to verify the installer" >&2
+    exit 1
+  fi
+  bash "$tmpdir/$installer_script" "$@"
+)
+
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14"
+```
 
 ### Hermes
 
 Hermes 0.19.0 or newer must already be installed and working.
 
 ```sh
-curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-hermes-marmot.sh | bash
+install_verified "$base_url/install-hermes-marmot.sh" \
+  "$base_url/install-hermes-marmot.sh.sha256"
 ```
 
 ### OpenClaw
@@ -40,7 +67,8 @@ curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.
 OpenClaw 2026.7.1 or newer and Node 22.19 or newer must already be installed.
 
 ```sh
-curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-openclaw-marmot.sh | bash
+install_verified "$base_url/install-openclaw-marmot.sh" \
+  "$base_url/install-openclaw-marmot.sh.sha256"
 ```
 
 ### Codex
@@ -48,7 +76,8 @@ curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.
 Codex must already be installed, authenticated, and runnable as `codex`.
 
 ```sh
-curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-codex-marmot.sh | bash
+install_verified "$base_url/install-codex-marmot.sh" \
+  "$base_url/install-codex-marmot.sh.sha256"
 ```
 
 ### OpenCode
@@ -56,7 +85,8 @@ curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.
 OpenCode 1.18.18 or newer must already be installed and runnable as `opencode`.
 
 ```sh
-curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-opencode-marmot.sh | bash
+install_verified "$base_url/install-opencode-marmot.sh" \
+  "$base_url/install-opencode-marmot.sh.sha256"
 ```
 
 ### Pi
@@ -64,7 +94,8 @@ curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.
 Pi must already be installed, authenticated, and runnable as `pi`.
 
 ```sh
-curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-pi-marmot.sh | bash
+install_verified "$base_url/install-pi-marmot.sh" \
+  "$base_url/install-pi-marmot.sh.sha256"
 ```
 
 ### Finish In White Noise
@@ -99,16 +130,18 @@ invitation and prompt authorization.
 
 ```sh
 OWNER_NPUB=npub1...
-curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-codex-marmot.sh | \
-  bash -s -- --yes --allow-welcomer "$OWNER_NPUB"
+install_verified "$base_url/install-codex-marmot.sh" \
+  "$base_url/install-codex-marmot.sh.sha256" \
+  --yes --allow-welcomer "$OWNER_NPUB"
 ```
 
 Replace `codex` in the URL with `openclaw`, `opencode`, or `pi`. Hermes keeps
 invite acceptance and message-sender authorization explicit:
 
 ```sh
-curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-hermes-marmot.sh | \
-  bash -s -- --yes --allow-welcomer "$OWNER_NPUB" --allow-user "$OWNER_NPUB"
+install_verified "$base_url/install-hermes-marmot.sh" \
+  "$base_url/install-hermes-marmot.sh.sha256" \
+  --yes --allow-welcomer "$OWNER_NPUB" --allow-user "$OWNER_NPUB"
 ```
 
 Every installer verifies the downloaded binary and plugin assets against the

--- a/integrations/codex/marmot/README.md
+++ b/integrations/codex/marmot/README.md
@@ -6,6 +6,9 @@ messages to [Codex](https://learn.chatgpt.com/) through the local
 activation, media handling, profile onboarding, live previews, MLS, or relay
 logic.
 
+For the current guided install, runtime chooser, and steps to finish in White Noise, use the canonical
+[White Noise + Agents quickstart](../../README.md#get-started-white-noise--agents).
+
 It uses Codex's documented non-interactive JSONL interface: a new group starts
 with `codex exec --json -`, and later messages resume the group's Codex thread
 with `codex exec resume --json <thread-id> -`.
@@ -28,8 +31,31 @@ the current guided install command and the steps to finish in White Noise.
 For noninteractive setup, provide the allowed inviter and prompt sender:
 
 ```sh
-curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-codex-marmot.sh" | \
-  bash -s -- --yes --allow-welcomer npub1...
+install_verified() (
+  set -eu
+  installer_url="$1"
+  checksum_url="$2"
+  shift 2
+  installer_script="${installer_url##*/}"
+  tmpdir="$(mktemp -d)"
+  trap 'rm -rf "$tmpdir"' 0 HUP INT TERM
+  curl -fsSL "$installer_url" -o "$tmpdir/$installer_script"
+  curl -fsSL "$checksum_url" -o "$tmpdir/$installer_script.sha256"
+  if command -v shasum >/dev/null 2>&1; then
+    (cd "$tmpdir" && shasum -a 256 -c "$installer_script.sha256")
+  elif command -v sha256sum >/dev/null 2>&1; then
+    (cd "$tmpdir" && sha256sum -c "$installer_script.sha256")
+  else
+    echo "error: need shasum or sha256sum to verify the installer" >&2
+    exit 1
+  fi
+  bash "$tmpdir/$installer_script" "$@"
+)
+
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14"
+install_verified "$base_url/install-codex-marmot.sh" \
+  "$base_url/install-codex-marmot.sh.sha256" \
+  --yes --allow-welcomer npub1...
 ```
 
 The immutable release also publishes `install-codex-marmot.sh.sha256` for

--- a/integrations/hermes/marmot/README.md
+++ b/integrations/hermes/marmot/README.md
@@ -89,6 +89,8 @@ For repeatable noninteractive setup, pass the allowed inviter/welcomer and allow
 message sender as either an `npub` or raw hex public key. `--allow-user` may be
 repeated or given a comma-separated list to authorize multiple senders:
 
+Run this example in the same shell where `install_verified` above was defined.
+
 ```sh
 base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14"
 install_verified "$base_url/install-hermes-marmot.sh" \
@@ -102,6 +104,8 @@ Generated-identity onboarding is the default (and can be selected explicitly
 with `--generate-identity`). To preserve an existing Nostr identity, place its
 `nsec` or raw secret hex in a regular file owned by the current user with mode
 `0600`, then use a pinned release URL:
+
+Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
 base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14"
@@ -130,6 +134,8 @@ another connector home, such as OpenClaw's, requires a separate explicit import;
 the installers never opt into shared home/socket state silently.
 
 To accept Marmot messages from any sender (explicit opt-in):
+
+Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
 base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14"

--- a/integrations/hermes/marmot/README.md
+++ b/integrations/hermes/marmot/README.md
@@ -4,6 +4,9 @@ This directory is a Hermes platform plugin for the local `wn-agent` connector.
 Hermes runs the agent and tools. `wn-agent` owns the Marmot account, MLS state,
 Nostr transport, final encrypted sends, and QUIC live-preview stream records.
 
+For the current guided install, runtime chooser, and steps to finish in White Noise, use the canonical
+[White Noise + Agents quickstart](../../README.md#get-started-white-noise--agents).
+
 For each activated inbound turn, the plugin asks `wn-agent` for a bounded recent
 materialized chat window and supplies Hermes with durable message ids, senders,
 timestamps, reply links, current reaction summaries, and
@@ -48,24 +51,52 @@ Prerequisites:
 - White Noise phone app pointed at the same public relay set
 - Linux x86_64, Linux arm64, macOS Apple Silicon, or macOS Intel
 
-Use the canonical [White Noise + Agents quickstart](../../README.md#hermes) for
-the current guided install command and the steps to finish in White Noise.
+Verified install (the helper also forwards any installer arguments after the two URLs):
+
+```sh
+install_verified() (
+  set -eu
+  installer_url="$1"
+  checksum_url="$2"
+  shift 2
+  installer_script="${installer_url##*/}"
+  tmpdir="$(mktemp -d)"
+  trap 'rm -rf "$tmpdir"' 0 HUP INT TERM
+  curl -fsSL "$installer_url" -o "$tmpdir/$installer_script"
+  curl -fsSL "$checksum_url" -o "$tmpdir/$installer_script.sha256"
+  if command -v shasum >/dev/null 2>&1; then
+    (cd "$tmpdir" && shasum -a 256 -c "$installer_script.sha256")
+  elif command -v sha256sum >/dev/null 2>&1; then
+    (cd "$tmpdir" && sha256sum -c "$installer_script.sha256")
+  else
+    echo "error: need shasum or sha256sum to verify the installer" >&2
+    exit 1
+  fi
+  bash "$tmpdir/$installer_script" "$@"
+)
+
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14"
+install_verified "$base_url/install-hermes-marmot.sh" \
+  "$base_url/install-hermes-marmot.sh.sha256"
+```
 
 In guided setup, the allowed-message-sender prompt accepts one or more `npub` or
 raw hex public keys separated by commas. Leaving that prompt blank explicitly
 opens Marmot messaging to every sender by writing
 `MARMOT_ALLOW_ALL_USERS=true`.
 
-For repeatable noninteractive setup, configure the allowed inviter and message
-sender explicitly:
+For repeatable noninteractive setup, pass the allowed inviter/welcomer and allowed
+message sender as either an `npub` or raw hex public key. `--allow-user` may be
+repeated or given a comma-separated list to authorize multiple senders:
 
 ```sh
-curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-hermes-marmot.sh" | \
-  bash -s -- --yes --allow-welcomer npub1... --allow-user npub1...
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14"
+install_verified "$base_url/install-hermes-marmot.sh" \
+  "$base_url/install-hermes-marmot.sh.sha256" \
+  --yes \
+    --allow-welcomer npub1... \
+    --allow-user npub1...,0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 ```
-
-Both options may be repeated. `--allow-user` may also contain a comma-separated
-list when the sender set differs from the inviter set.
 
 Generated-identity onboarding is the default (and can be selected explicitly
 with `--generate-identity`). To preserve an existing Nostr identity, place its
@@ -73,13 +104,14 @@ with `--generate-identity`). To preserve an existing Nostr identity, place its
 `0600`, then use a pinned release URL:
 
 ```sh
-curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-hermes-marmot.sh" | \
-  bash -s -- \
-    --yes \
-    --existing-identity-file "$HOME/.config/example/hermes-agent.nsec" \
-    --expected-npub npub1... \
-    --allow-welcomer npub1... \
-    --allow-user npub1...
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14"
+install_verified "$base_url/install-hermes-marmot.sh" \
+  "$base_url/install-hermes-marmot.sh.sha256" \
+  --yes \
+  --existing-identity-file "$HOME/.config/example/hermes-agent.nsec" \
+  --expected-npub npub1... \
+  --allow-welcomer npub1... \
+  --allow-user npub1...
 ```
 
 The installer passes only the file path, never the secret, in process arguments.
@@ -100,8 +132,10 @@ the installers never opt into shared home/socket state silently.
 To accept Marmot messages from any sender (explicit opt-in):
 
 ```sh
-curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-hermes-marmot.sh" | \
-  bash -s -- --yes --allow-all-users
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14"
+install_verified "$base_url/install-hermes-marmot.sh" \
+  "$base_url/install-hermes-marmot.sh.sha256" \
+  --yes --allow-all-users
 ```
 
 Welcomer allowlist entries control which accounts may invite the Marmot agent

--- a/integrations/hermes/marmot/tests/test_installer_env.sh
+++ b/integrations/hermes/marmot/tests/test_installer_env.sh
@@ -36,7 +36,7 @@ while [ "$#" -gt 0 ]; do
 done
 printf '%s\n' "$url" >>"${CURL_LOG:?}"
 if [[ "$url" == *.sha256 ]]; then
-    printf '%s\n' fixture-hash >"$destination"
+    printf '%s\n' aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa >"$destination"
 else
     : >"$destination"
 fi
@@ -44,7 +44,7 @@ EOF
 
 cat >"$mock_bin/shasum" <<'EOF'
 #!/usr/bin/env bash
-printf '%s\n' fixture-hash
+printf '%s\n' aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 EOF
 
 cat >"$mock_bin/tar" <<'EOF'

--- a/integrations/openclaw/marmot/README.md
+++ b/integrations/openclaw/marmot/README.md
@@ -88,6 +88,8 @@ the Hermes installer.
 For repeatable noninteractive setup, pass the allowed inviter/welcomer as either
 an `npub` or raw hex public key:
 
+Run this example in the same shell where `install_verified` above was defined.
+
 ```sh
 base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14"
 install_verified "$base_url/install-openclaw-marmot.sh" \
@@ -99,6 +101,8 @@ Generated-identity onboarding is the default (and can be selected explicitly
 with `--generate-identity`). To preserve an existing Nostr identity, place its
 `nsec` or raw secret hex in a regular file owned by the current user with mode
 `0600`, then use a pinned release URL:
+
+Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
 base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14"

--- a/integrations/openclaw/marmot/README.md
+++ b/integrations/openclaw/marmot/README.md
@@ -5,6 +5,9 @@ local `wn-agent` connector. OpenClaw runs the agent, model, tools, and channel
 routing. `wn-agent` owns the Marmot account, MLS group state, Nostr transport,
 durable encrypted sends, and QUIC live-preview stream records.
 
+For the current guided install, runtime chooser, and steps to finish in White Noise, use the canonical
+[White Noise + Agents quickstart](../../README.md#get-started-white-noise--agents).
+
 The plugin is intentionally thin and **control-plane only**: it speaks the
 `marmot.agent-control.v2` newline-delimited JSON protocol to `wn-agent` over a
 local Unix socket. It never opens a QUIC connection, encrypts a record, or talks
@@ -46,8 +49,32 @@ Prerequisites:
 - Node ≥ 22.19
 - Linux x86_64, Linux arm64, macOS Apple Silicon, or macOS Intel
 
-Use the canonical [White Noise + Agents quickstart](../../README.md#openclaw)
-for the current guided install command and the steps to finish in White Noise.
+```sh
+install_verified() (
+  set -eu
+  installer_url="$1"
+  checksum_url="$2"
+  shift 2
+  installer_script="${installer_url##*/}"
+  tmpdir="$(mktemp -d)"
+  trap 'rm -rf "$tmpdir"' 0 HUP INT TERM
+  curl -fsSL "$installer_url" -o "$tmpdir/$installer_script"
+  curl -fsSL "$checksum_url" -o "$tmpdir/$installer_script.sha256"
+  if command -v shasum >/dev/null 2>&1; then
+    (cd "$tmpdir" && shasum -a 256 -c "$installer_script.sha256")
+  elif command -v sha256sum >/dev/null 2>&1; then
+    (cd "$tmpdir" && sha256sum -c "$installer_script.sha256")
+  else
+    echo "error: need shasum or sha256sum to verify the installer" >&2
+    exit 1
+  fi
+  bash "$tmpdir/$installer_script" "$@"
+)
+
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14"
+install_verified "$base_url/install-openclaw-marmot.sh" \
+  "$base_url/install-openclaw-marmot.sh.sha256"
+```
 
 The installer puts `wn-agent` in `~/.local/bin`, downloads and verifies the plugin
 tarball, runs `openclaw plugins install`, enables the `marmot` channel, starts a
@@ -58,12 +85,14 @@ Set `MARMOT_RELEASE_REPO`, `MARMOT_RELEASE_TAG`, and `WN_AGENT_VERSION` (or the
 legacy `WN_AGENT_SHA` alias) to install a non-default release asset, matching
 the Hermes installer.
 
-For repeatable noninteractive setup, pass the White Noise owner as either an
-`npub` or raw hex public key:
+For repeatable noninteractive setup, pass the allowed inviter/welcomer as either
+an `npub` or raw hex public key:
 
 ```sh
-curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-openclaw-marmot.sh" | \
-  bash -s -- --yes --allow-welcomer npub1...
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14"
+install_verified "$base_url/install-openclaw-marmot.sh" \
+  "$base_url/install-openclaw-marmot.sh.sha256" \
+  --yes --allow-welcomer npub1...
 ```
 
 Generated-identity onboarding is the default (and can be selected explicitly
@@ -72,12 +101,13 @@ with `--generate-identity`). To preserve an existing Nostr identity, place its
 `0600`, then use a pinned release URL:
 
 ```sh
-curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-openclaw-marmot.sh" | \
-  bash -s -- \
-    --yes \
-    --existing-identity-file "$HOME/.config/example/openclaw-agent.nsec" \
-    --expected-npub npub1... \
-    --allow-welcomer npub1...
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14"
+install_verified "$base_url/install-openclaw-marmot.sh" \
+  "$base_url/install-openclaw-marmot.sh.sha256" \
+  --yes \
+  --existing-identity-file "$HOME/.config/example/openclaw-agent.nsec" \
+  --expected-npub npub1... \
+  --allow-welcomer npub1...
 ```
 
 The installer passes only the file path, never the secret, in process arguments.

--- a/integrations/opencode/marmot/README.md
+++ b/integrations/opencode/marmot/README.md
@@ -58,6 +58,8 @@ install_verified "$base_url/install-opencode-marmot.sh" \
 For repeatable noninteractive setup, pass the allowed inviter and prompt sender
 as either an `npub` or raw hex public key:
 
+Run this example in the same shell where `install_verified` above was defined.
+
 ```sh
 base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14"
 install_verified "$base_url/install-opencode-marmot.sh" \

--- a/integrations/opencode/marmot/README.md
+++ b/integrations/opencode/marmot/README.md
@@ -10,6 +10,9 @@ Hermes and OpenClaw gateway integrations: it has no mention activation, media
 handling, profile onboarding, or live previews. It is a pure harness for an
 authorized operator.
 
+For the current guided install, runtime chooser, and steps to finish in White Noise, use the canonical
+[White Noise + Agents quickstart](../../README.md#get-started-white-noise--agents).
+
 ## Install (OpenCode Already Installed)
 
 Versioned `wn-agent` builds publish the `wn-agent` binary, this harness binary,
@@ -23,15 +26,43 @@ Prerequisites:
 - White Noise phone app pointed at the same public relay set
 - Linux x86_64, Linux arm64, macOS Apple Silicon, or macOS Intel
 
-Use the canonical [White Noise + Agents quickstart](../../README.md#opencode)
-for the current guided install command and the steps to finish in White Noise.
+Verified install (the helper also forwards any installer arguments after the two URLs):
+
+```sh
+install_verified() (
+  set -eu
+  installer_url="$1"
+  checksum_url="$2"
+  shift 2
+  installer_script="${installer_url##*/}"
+  tmpdir="$(mktemp -d)"
+  trap 'rm -rf "$tmpdir"' 0 HUP INT TERM
+  curl -fsSL "$installer_url" -o "$tmpdir/$installer_script"
+  curl -fsSL "$checksum_url" -o "$tmpdir/$installer_script.sha256"
+  if command -v shasum >/dev/null 2>&1; then
+    (cd "$tmpdir" && shasum -a 256 -c "$installer_script.sha256")
+  elif command -v sha256sum >/dev/null 2>&1; then
+    (cd "$tmpdir" && sha256sum -c "$installer_script.sha256")
+  else
+    echo "error: need shasum or sha256sum to verify the installer" >&2
+    exit 1
+  fi
+  bash "$tmpdir/$installer_script" "$@"
+)
+
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14"
+install_verified "$base_url/install-opencode-marmot.sh" \
+  "$base_url/install-opencode-marmot.sh.sha256"
+```
 
 For repeatable noninteractive setup, pass the allowed inviter and prompt sender
 as either an `npub` or raw hex public key:
 
 ```sh
-curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-opencode-marmot.sh" | \
-  bash -s -- --yes --allow-welcomer npub1...
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14"
+install_verified "$base_url/install-opencode-marmot.sh" \
+  "$base_url/install-opencode-marmot.sh.sha256" \
+  --yes --allow-welcomer npub1...
 ```
 
 Use a versioned `wn-agent-v<version>` release URL when you need a pinned install.

--- a/integrations/pi/marmot/README.md
+++ b/integrations/pi/marmot/README.md
@@ -5,6 +5,9 @@ messages to [Pi](https://pi.dev) through the local `wn-agent` control socket.
 It is intentionally a thin harness: no mention activation, media handling,
 profile onboarding, live previews, MLS, or relay logic.
 
+For the current guided install, runtime chooser, and steps to finish in White Noise, use the canonical
+[White Noise + Agents quickstart](../../README.md#get-started-white-noise--agents).
+
 ## Install (Pi Already Installed)
 
 Versioned `wn-agent-v*` releases publish `wn-agent`, `wn-pi`, checksums, and a
@@ -17,14 +20,40 @@ Prerequisites:
 - White Noise phone app pointed at the same public relay set
 - Linux x86_64, Linux arm64, macOS Apple Silicon, or macOS Intel
 
-Use the canonical [White Noise + Agents quickstart](../../README.md#pi) for the
-current guided install command and the steps to finish in White Noise.
+```sh
+install_verified() (
+  set -eu
+  installer_url="$1"
+  checksum_url="$2"
+  shift 2
+  installer_script="${installer_url##*/}"
+  tmpdir="$(mktemp -d)"
+  trap 'rm -rf "$tmpdir"' 0 HUP INT TERM
+  curl -fsSL "$installer_url" -o "$tmpdir/$installer_script"
+  curl -fsSL "$checksum_url" -o "$tmpdir/$installer_script.sha256"
+  if command -v shasum >/dev/null 2>&1; then
+    (cd "$tmpdir" && shasum -a 256 -c "$installer_script.sha256")
+  elif command -v sha256sum >/dev/null 2>&1; then
+    (cd "$tmpdir" && sha256sum -c "$installer_script.sha256")
+  else
+    echo "error: need shasum or sha256sum to verify the installer" >&2
+    exit 1
+  fi
+  bash "$tmpdir/$installer_script" "$@"
+)
+
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14"
+install_verified "$base_url/install-pi-marmot.sh" \
+  "$base_url/install-pi-marmot.sh.sha256"
+```
 
 For noninteractive setup, provide the allowed inviter and prompt sender:
 
 ```sh
-curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-pi-marmot.sh" | \
-  bash -s -- --yes --allow-welcomer npub1...
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14"
+install_verified "$base_url/install-pi-marmot.sh" \
+  "$base_url/install-pi-marmot.sh.sha256" \
+  --yes --allow-welcomer npub1...
 ```
 
 The default install uses its own `~/.marmot-agents/pi` identity and services,

--- a/integrations/pi/marmot/README.md
+++ b/integrations/pi/marmot/README.md
@@ -49,6 +49,8 @@ install_verified "$base_url/install-pi-marmot.sh" \
 
 For noninteractive setup, provide the allowed inviter and prompt sender:
 
+Run this example in the same shell where `install_verified` above was defined.
+
 ```sh
 base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14"
 install_verified "$base_url/install-pi-marmot.sh" \

--- a/integrations/terminal-harness/tests/test_installer.sh
+++ b/integrations/terminal-harness/tests/test_installer.sh
@@ -128,7 +128,7 @@ while [ "$#" -gt 0 ]; do
     esac
 done
 if [[ "$url" == *.sha256 ]]; then
-    printf '%s\n' fixture-hash >"$destination"
+    printf '%s\n' aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa >"$destination"
 else
     : >"$destination"
 fi
@@ -136,7 +136,7 @@ EOF
 
 cat >"$mock_bin/shasum" <<'EOF'
 #!/usr/bin/env bash
-printf '%s\n' fixture-hash
+printf '%s\n' aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 EOF
 
 cat >"$mock_bin/tar" <<'EOF'

--- a/integrations/test_installer_systemd_service.sh
+++ b/integrations/test_installer_systemd_service.sh
@@ -49,7 +49,7 @@ while [ "$#" -gt 0 ]; do
     esac
 done
 if [[ "$url" == *.sha256 ]]; then
-    printf '%s\n' fixture-hash >"$destination"
+    printf '%s\n' aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa >"$destination"
 else
     : >"$destination"
 fi
@@ -57,7 +57,7 @@ EOF
 
 cat >"$mock_bin/shasum" <<'EOF'
 #!/usr/bin/env bash
-printf '%s\n' fixture-hash
+printf '%s\n' aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 EOF
 
 cat >"$mock_bin/tar" <<'EOF'

--- a/release.md
+++ b/release.md
@@ -341,9 +341,12 @@ Each binary/plugin tarball carries a `manifest.json` recording the release tag, 
 workspace version (the OpenClaw tarball's `package.json` version is also stamped to the cohort version at release time).
 
 The installer assets are generated during the release and default to their own immutable `wn-agent-v<version>` release
-tag and `<version>` asset suffix. A verified install for the current workspace release looks like:
+tag and `<version>` asset suffix. The mutable `wn-agent-latest` release is a rolling convenience alias, not an
+authoritative pin; repeatable installs use immutable `wn-agent-v<version>` tags. A verified install for the current
+workspace release looks like:
 
 ```sh
+(
 set -eu
 base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14"
 
@@ -378,6 +381,7 @@ install_verified "$base_url/install-codex-marmot.sh" "$base_url/install-codex-ma
 install_verified "$base_url/install-opencode-marmot.sh" "$base_url/install-opencode-marmot.sh.sha256"
 # Pi terminal harness
 install_verified "$base_url/install-pi-marmot.sh" "$base_url/install-pi-marmot.sh.sha256"
+)
 ```
 
 Change the immutable `wn-agent-v<version>` release URL when you need to pin a different release for repeatable testing or

--- a/release.md
+++ b/release.md
@@ -341,28 +341,51 @@ Each binary/plugin tarball carries a `manifest.json` recording the release tag, 
 workspace version (the OpenClaw tarball's `package.json` version is also stamped to the cohort version at release time).
 
 The installer assets are generated during the release and default to their own immutable `wn-agent-v<version>` release
-tag and `<version>` asset suffix. The historical `wn-agent-latest` release is immutable and is not an authoritative
-update channel. User-facing commands must name a versioned release. For the current release:
+tag and `<version>` asset suffix. A verified install for the current workspace release looks like:
 
 ```sh
+set -eu
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14"
+
+install_verified() (
+  set -eu
+  installer_url="$1"
+  checksum_url="$2"
+  shift 2
+  installer_script="${installer_url##*/}"
+  tmpdir="$(mktemp -d)"
+  trap 'rm -rf "$tmpdir"' 0 HUP INT TERM
+  curl -fsSL "$installer_url" -o "$tmpdir/$installer_script"
+  curl -fsSL "$checksum_url" -o "$tmpdir/$installer_script.sha256"
+  if command -v shasum >/dev/null 2>&1; then
+    (cd "$tmpdir" && shasum -a 256 -c "$installer_script.sha256")
+  elif command -v sha256sum >/dev/null 2>&1; then
+    (cd "$tmpdir" && sha256sum -c "$installer_script.sha256")
+  else
+    echo "error: need shasum or sha256sum to verify the installer" >&2
+    exit 1
+  fi
+  bash "$tmpdir/$installer_script" "$@"
+)
+
 # Hermes gateway
-curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-hermes-marmot.sh | bash
+install_verified "$base_url/install-hermes-marmot.sh" "$base_url/install-hermes-marmot.sh.sha256"
 # OpenClaw gateway
-curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-openclaw-marmot.sh | bash
+install_verified "$base_url/install-openclaw-marmot.sh" "$base_url/install-openclaw-marmot.sh.sha256"
 # Codex terminal harness
-curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-codex-marmot.sh | bash
+install_verified "$base_url/install-codex-marmot.sh" "$base_url/install-codex-marmot.sh.sha256"
 # OpenCode terminal harness
-curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-opencode-marmot.sh | bash
+install_verified "$base_url/install-opencode-marmot.sh" "$base_url/install-opencode-marmot.sh.sha256"
 # Pi terminal harness
-curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-pi-marmot.sh | bash
+install_verified "$base_url/install-pi-marmot.sh" "$base_url/install-pi-marmot.sh.sha256"
 ```
 
-Update this section as part of a deliberate release-version bump. Use the exact version from the installed connector
-when reporting bugs.
+Change the immutable `wn-agent-v<version>` release URL when you need to pin a different release for repeatable testing or
+bug reports. Keep each installer URL paired with its sibling `.sha256` URL and execute only the verified local copy.
 
-These one-liners perform full setup by default: they install `wn-agent`, install/enable the matching gateway plugin or
-harness binary, start same-user services where supported, bootstrap or reuse the default connector-specific Marmot
-agent home, and patch only the Marmot-specific gateway config when a gateway is involved. Use `--no-service`,
+These verified installers perform full setup by default: they install `wn-agent`, install/enable the matching gateway
+plugin or harness binary, start same-user services where supported, bootstrap or reuse the default connector-specific
+Marmot agent home, and patch only the Marmot-specific gateway config when a gateway is involved. Use `--no-service`,
 `--no-start-wn-agent`, `--no-configure-hermes`, `--no-configure-openclaw`, or `--no-start-wn-opencode` when you need a
 partial/manual install. Terminal-harness installers also accept the matching
 `--no-start-wn-codex` or `--no-start-wn-pi` option.

--- a/scripts/check_agent_install_docs.sh
+++ b/scripts/check_agent_install_docs.sh
@@ -80,9 +80,4 @@ if [ -n "$stale_versioned_urls" ]; then
     exit 1
 fi
 
-if rg -n 'releases/download/\$latest_tag/install-' .github/workflows/wn-agent-binaries.yml; then
-    echo "error: generated release notes must link to the immutable release tag" >&2
-    exit 1
-fi
-
 echo "agent install documentation matches wn-agent-v$workspace_version"

--- a/scripts/check_agent_install_docs.sh
+++ b/scripts/check_agent_install_docs.sh
@@ -27,16 +27,25 @@ import sys
 
 version = sys.argv[1]
 quickstart = Path("integrations/README.md").read_text(encoding="utf-8")
-for connector in ("hermes", "openclaw", "codex", "opencode", "pi"):
-    url = (
-        "https://github.com/marmot-protocol/mdk/releases/download/"
-        f"wn-agent-v{version}/install-{connector}-marmot.sh"
+base_url = (
+    "https://github.com/marmot-protocol/mdk/releases/download/"
+    f"wn-agent-v{version}"
+)
+if quickstart.count(f'base_url="{base_url}"') != 1:
+    print(
+        "error: integrations/README.md must define exactly one immutable current-release base_url "
+        f"({base_url})",
+        file=sys.stderr,
     )
-    block = f"```sh\ncurl -fsSL {url} | bash\n```"
-    if quickstart.count(block) != 1:
+    raise SystemExit(1)
+for connector in ("hermes", "openclaw", "codex", "opencode", "pi"):
+    installer = f"install-{connector}-marmot.sh"
+    call = f'install_verified "$base_url/{installer}"'
+    checksum = f'"$base_url/{installer}.sha256"'
+    if quickstart.count(call) < 1 or quickstart.count(checksum) < 1:
         print(
-            "error: integrations/README.md must contain exactly one copy-pasteable "
-            f"one-line sh block for the current {connector} installer ({url})",
+            "error: integrations/README.md must verify the current "
+            f"{connector} installer against its companion checksum before execution",
             file=sys.stderr,
         )
         raise SystemExit(1)

--- a/scripts/check_agent_install_docs.sh
+++ b/scripts/check_agent_install_docs.sh
@@ -46,17 +46,22 @@ if release_guide.count(f'base_url="{base_url}"') != 1:
         file=sys.stderr,
     )
     raise SystemExit(1)
-for connector in ("hermes", "openclaw", "codex", "opencode", "pi"):
+quickstart_expected_calls = {"hermes": 2, "openclaw": 1, "codex": 2, "opencode": 1, "pi": 1}
+for connector, quickstart_expected in quickstart_expected_calls.items():
     installer = f"install-{connector}-marmot.sh"
     call = f'install_verified "$base_url/{installer}"'
     checksum = f'"$base_url/{installer}.sha256"'
-    if quickstart.count(call) < 1 or quickstart.count(checksum) < 1:
-        print(
-            "error: integrations/README.md must verify the current "
-            f"{connector} installer against its companion checksum before execution",
-            file=sys.stderr,
-        )
-        raise SystemExit(1)
+    for label, text, expected in (
+        ("integrations/README.md", quickstart, quickstart_expected),
+        ("release.md", release_guide, 1),
+    ):
+        if text.count(call) != expected or text.count(checksum) != expected:
+            print(
+                f"error: {label} must contain exactly {expected} current {connector} installer call(s) "
+                "paired with companion checksums",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
 PY
 
 if rg -n 'releases/download/wn-agent-latest/install-' "${active_paths[@]}"; then

--- a/scripts/check_agent_install_docs.sh
+++ b/scripts/check_agent_install_docs.sh
@@ -27,6 +27,7 @@ import sys
 
 version = sys.argv[1]
 quickstart = Path("integrations/README.md").read_text(encoding="utf-8")
+release_guide = Path("release.md").read_text(encoding="utf-8")
 base_url = (
     "https://github.com/marmot-protocol/mdk/releases/download/"
     f"wn-agent-v{version}"
@@ -34,6 +35,13 @@ base_url = (
 if quickstart.count(f'base_url="{base_url}"') != 1:
     print(
         "error: integrations/README.md must define exactly one immutable current-release base_url "
+        f"({base_url})",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+if release_guide.count(f'base_url="{base_url}"') != 1:
+    print(
+        "error: release.md must define exactly one immutable current-release base_url "
         f"({base_url})",
         file=sys.stderr,
     )

--- a/scripts/check_cargo_audit_ci.py
+++ b/scripts/check_cargo_audit_ci.py
@@ -5,11 +5,15 @@ from __future__ import annotations
 
 import re
 import sys
+import tomllib
 from pathlib import Path
 
 
 class PolicyError(ValueError):
     """The workflow no longer satisfies the cargo-audit policy."""
+
+
+APPROVED_ADVISORY_IGNORES = ["RUSTSEC-2024-0384"]
 
 
 def _job_block(workflow: str, job_name: str) -> str:
@@ -32,12 +36,22 @@ def validate(workflow_path: Path, audit_config_path: Path) -> None:
     if not audit_config_path.is_file():
         raise PolicyError(f"missing repository audit.toml: {audit_config_path}")
 
-    audit_config = audit_config_path.read_text(encoding="utf-8")
-    if not re.search(r"(?m)^\[advisories\]\s*$", audit_config):
-        raise PolicyError("audit.toml must contain an [advisories] policy section")
+    try:
+        audit_config = tomllib.loads(audit_config_path.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as error:
+        raise PolicyError(f"invalid repository audit.toml: {error}") from error
+    advisory_ignores = audit_config.get("advisories", {}).get("ignore")
+    if advisory_ignores != APPROVED_ADVISORY_IGNORES:
+        raise PolicyError(
+            "audit.toml advisory ignore list must exactly match the approved policy: "
+            f"{APPROVED_ADVISORY_IGNORES}"
+        )
 
     workflow = workflow_path.read_text(encoding="utf-8")
     job = _job_block(workflow, "rust-audit")
+
+    if re.search(r"(?m)^    if:", job):
+        raise PolicyError("rust-audit job must not use a job-level if condition")
 
     if "uses: actions/checkout@" not in job:
         raise PolicyError("rust-audit job must check out the repository")

--- a/scripts/check_cargo_audit_ci.py
+++ b/scripts/check_cargo_audit_ci.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Fail closed when the CI cargo-audit gate no longer enforces repository policy."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+class PolicyError(ValueError):
+    """The workflow no longer satisfies the cargo-audit policy."""
+
+
+def _job_block(workflow: str, job_name: str) -> str:
+    marker = f"  {job_name}:"
+    lines = workflow.splitlines()
+    try:
+        start = lines.index(marker)
+    except ValueError as error:
+        raise PolicyError(f"missing required {job_name} job") from error
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if re.fullmatch(r"  [A-Za-z0-9_-]+:", lines[index]):
+            end = index
+            break
+    return "\n".join(lines[start:end])
+
+
+def validate(workflow_path: Path, audit_config_path: Path) -> None:
+    if not audit_config_path.is_file():
+        raise PolicyError(f"missing repository audit.toml: {audit_config_path}")
+
+    audit_config = audit_config_path.read_text(encoding="utf-8")
+    if not re.search(r"(?m)^\[advisories\]\s*$", audit_config):
+        raise PolicyError("audit.toml must contain an [advisories] policy section")
+
+    workflow = workflow_path.read_text(encoding="utf-8")
+    job = _job_block(workflow, "rust-audit")
+
+    if "uses: actions/checkout@" not in job:
+        raise PolicyError("rust-audit job must check out the repository")
+    if "tool: cargo-audit@" not in job:
+        raise PolicyError("rust-audit job must install a pinned cargo-audit release")
+    if re.search(r"(?m)^\s*continue-on-error:\s*true\s*$", job):
+        raise PolicyError("rust-audit job must not use continue-on-error")
+    if re.search(r"(?m)^\s*working-directory:", job):
+        raise PolicyError("rust-audit must run at the repository root so .cargo/audit.toml is loaded")
+
+    commands = re.findall(r"(?m)^\s*run:\s*(.*?)\s*$", job)
+    audit_commands = [command for command in commands if re.search(r"\bcargo\b.*\baudit\b", command)]
+    if audit_commands != ["cargo --locked audit"]:
+        raise PolicyError(
+            "rust-audit command must be exactly 'cargo --locked audit' so Cargo.lock is immutable, "
+            "repository-root .cargo/audit.toml is loaded, and an unignored advisory exits nonzero"
+        )
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    try:
+        validate(
+            repo_root / ".github" / "workflows" / "ci.yml",
+            repo_root / ".cargo" / "audit.toml",
+        )
+    except (OSError, PolicyError) as error:
+        print(f"cargo-audit CI policy check failed: {error}", file=sys.stderr)
+        return 1
+    print("cargo-audit CI policy check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_cargo_audit_ci.py
+++ b/scripts/check_cargo_audit_ci.py
@@ -41,8 +41,10 @@ def validate(workflow_path: Path, audit_config_path: Path) -> None:
 
     if "uses: actions/checkout@" not in job:
         raise PolicyError("rust-audit job must check out the repository")
-    if "tool: cargo-audit@" not in job:
-        raise PolicyError("rust-audit job must install a pinned cargo-audit release")
+    if "rustup toolchain install" not in job or "cargo --version" not in job:
+        raise PolicyError("rust-audit job must install and activate the repository Rust toolchain")
+    if "tool: cargo-audit@0.22.1" not in job:
+        raise PolicyError("rust-audit job must install cargo-audit@0.22.1")
     if re.search(r"(?m)^\s*continue-on-error:\s*true\s*$", job):
         raise PolicyError("rust-audit job must not use continue-on-error")
     if re.search(r"(?m)^\s*working-directory:", job):

--- a/scripts/check_cargo_audit_ci.py
+++ b/scripts/check_cargo_audit_ci.py
@@ -14,19 +14,28 @@ class PolicyError(ValueError):
 
 
 APPROVED_ADVISORY_IGNORES = ["RUSTSEC-2024-0384"]
+APPROVED_AUDIT_CONFIG = {"advisories": {"ignore": APPROVED_ADVISORY_IGNORES}}
+
+
+def _mapping_key(line: str, indent: int) -> str | None:
+    pattern = rf"^ {{{indent}}}(?P<key>[A-Za-z0-9_-]+|'[^']+'|\"[^\"]+\")\s*:\s*(?:#.*)?$"
+    match = re.match(pattern, line)
+    if match is None:
+        return None
+    return match.group("key").strip("'\"")
 
 
 def _job_block(workflow: str, job_name: str) -> str:
-    marker = f"  {job_name}:"
     lines = workflow.splitlines()
-    try:
-        start = lines.index(marker)
-    except ValueError as error:
-        raise PolicyError(f"missing required {job_name} job") from error
-
+    start = next(
+        (index for index, line in enumerate(lines) if _mapping_key(line, 2) == job_name),
+        None,
+    )
+    if start is None:
+        raise PolicyError(f"missing required {job_name} job")
     end = len(lines)
     for index in range(start + 1, len(lines)):
-        if re.fullmatch(r"  [A-Za-z0-9_-]+:", lines[index]):
+        if _mapping_key(lines[index], 2) is not None:
             end = index
             break
     return "\n".join(lines[start:end])
@@ -40,18 +49,17 @@ def validate(workflow_path: Path, audit_config_path: Path) -> None:
         audit_config = tomllib.loads(audit_config_path.read_text(encoding="utf-8"))
     except tomllib.TOMLDecodeError as error:
         raise PolicyError(f"invalid repository audit.toml: {error}") from error
-    advisory_ignores = audit_config.get("advisories", {}).get("ignore")
-    if advisory_ignores != APPROVED_ADVISORY_IGNORES:
+    if audit_config != APPROVED_AUDIT_CONFIG:
         raise PolicyError(
-            "audit.toml advisory ignore list must exactly match the approved policy: "
-            f"{APPROVED_ADVISORY_IGNORES}"
+            "audit.toml must exactly match the approved policy: "
+            f"{APPROVED_AUDIT_CONFIG}"
         )
 
     workflow = workflow_path.read_text(encoding="utf-8")
     job = _job_block(workflow, "rust-audit")
 
-    if re.search(r"(?m)^    if:", job):
-        raise PolicyError("rust-audit job must not use a job-level if condition")
+    if re.search(r"(?m)^\s+(?:if|'if'|\"if\")\s*:", job):
+        raise PolicyError("rust-audit job and steps must not have an if condition")
 
     if "uses: actions/checkout@" not in job:
         raise PolicyError("rust-audit job must check out the repository")

--- a/scripts/check_install_example_sha256.py
+++ b/scripts/check_install_example_sha256.py
@@ -43,17 +43,12 @@ DOCUMENTED_INSTALL_CALLS = {
     "integrations/opencode/marmot/README.md": {"install-opencode-marmot.sh": 2},
     "integrations/pi/marmot/README.md": {"install-pi-marmot.sh": 2},
 }
-SAME_SHELL_NOTICE_COUNTS = {
-    "integrations/README.md": 7,
-    "integrations/hermes/marmot/README.md": 3,
-    "integrations/openclaw/marmot/README.md": 2,
-    "integrations/opencode/marmot/README.md": 1,
-    "integrations/pi/marmot/README.md": 1,
-}
-SAME_SHELL_NOTICE = "Run this example in the same shell where `install_verified` above was defined."
-LATEST_ALIAS_CLAIMS = (
-    "Install whichever version the mutable \\`wn-agent-latest\\` alias currently references with:",
-    "Latest WN Agent installers. These scripts install whichever version the mutable \\`$latest_tag\\` alias currently references; use immutable release \\`$tag\\` for WN Agent \\`$version\\`.",
+SAME_SHELL_SURFACES = (
+    "integrations/README.md",
+    "integrations/hermes/marmot/README.md",
+    "integrations/openclaw/marmot/README.md",
+    "integrations/opencode/marmot/README.md",
+    "integrations/pi/marmot/README.md",
 )
 
 
@@ -126,19 +121,46 @@ def documented_surface_errors(
     return errors
 
 
-def same_shell_notice_errors(text: str, expected: int) -> list[str]:
-    count = text.count(SAME_SHELL_NOTICE)
-    if count == expected:
-        return []
-    return [f"expected exactly {expected} same-shell notices, found {count}"]
+def same_shell_notice_errors(text: str) -> list[str]:
+    errors: list[str] = []
+    for index, match in enumerate(re.finditer(r"```sh\n(.*?)\n```", text, re.DOTALL), start=1):
+        block = match.group(1)
+        if "install_verified " not in block or "install_verified() (" in block:
+            continue
+        prelude = text[max(0, match.start() - 240):match.start()].lower()
+        if "same shell" not in prelude or "install_verified" not in prelude:
+            errors.append(f"dependent install fence {index} must state its same-shell prerequisite")
+    return errors
+
+
+def _heredoc(text: str, variable: str) -> str:
+    match = re.search(
+        rf'cat > "\${re.escape(variable)}" <<EOF\n(?P<body>.*?)\n\s*EOF',
+        text,
+        re.DOTALL,
+    )
+    return match.group("body") if match else ""
 
 
 def workflow_release_note_claim_errors(text: str) -> list[str]:
-    return [
-        "generated notes must distinguish the mutable latest alias from immutable release tags"
-        for claim in LATEST_ALIAS_CLAIMS
-        if text.count(claim) != 1
-    ]
+    versioned = _heredoc(text, "notes")
+    rolling = _heredoc(text, "latest_notes")
+    errors: list[str] = []
+    if not (
+        "releases/download/wn-agent-latest" in versioned
+        and re.search(r"\bmutable\b", versioned, re.IGNORECASE)
+        and "releases/download/$tag" in versioned
+        and "exact" in versioned.lower()
+    ):
+        errors.append("versioned notes must distinguish the mutable latest alias from the exact release tag")
+    if not (
+        "releases/download/$latest_tag" in rolling
+        and re.search(r"\bmutable\b", rolling, re.IGNORECASE)
+        and "$tag" in rolling
+        and re.search(r"\bimmutable\b", rolling, re.IGNORECASE)
+    ):
+        errors.append("rolling notes must distinguish the mutable latest alias from the immutable release tag")
+    return errors
 
 
 def scan_paths(root: Path, paths: Iterable[Path]) -> list[str]:
@@ -198,9 +220,9 @@ def repository_errors(root: Path) -> list[str]:
         for error in documented_surface_errors(text, installers):
             errors.append(f"{relative}: {error}")
 
-    for relative, expected in SAME_SHELL_NOTICE_COUNTS.items():
+    for relative in SAME_SHELL_SURFACES:
         text = (root / relative).read_text(encoding="utf-8")
-        for error in same_shell_notice_errors(text, expected):
+        for error in same_shell_notice_errors(text):
             errors.append(f"{relative}: {error}")
 
     for installer in INSTALLERS:

--- a/scripts/check_install_example_sha256.py
+++ b/scripts/check_install_example_sha256.py
@@ -43,6 +43,8 @@ DOCUMENTED_INSTALL_CALLS = {
     "integrations/opencode/marmot/README.md": {"install-opencode-marmot.sh": 2},
     "integrations/pi/marmot/README.md": {"install-pi-marmot.sh": 2},
 }
+# Codex is intentionally absent: its helper definition and only invocation
+# share one fence, so it has no dependent copy-paste fence.
 SAME_SHELL_SURFACES = (
     "integrations/README.md",
     "integrations/hermes/marmot/README.md",

--- a/scripts/check_install_example_sha256.py
+++ b/scripts/check_install_example_sha256.py
@@ -44,12 +44,17 @@ DOCUMENTED_INSTALL_CALLS = {
     "integrations/pi/marmot/README.md": {"install-pi-marmot.sh": 2},
 }
 SAME_SHELL_NOTICE_COUNTS = {
+    "integrations/README.md": 7,
     "integrations/hermes/marmot/README.md": 3,
     "integrations/openclaw/marmot/README.md": 2,
     "integrations/opencode/marmot/README.md": 1,
     "integrations/pi/marmot/README.md": 1,
 }
 SAME_SHELL_NOTICE = "Run this example in the same shell where `install_verified` above was defined."
+LATEST_ALIAS_CLAIMS = (
+    "Install whichever version the mutable \\`wn-agent-latest\\` alias currently references with:",
+    "Latest WN Agent installers. These scripts install whichever version the mutable \\`$latest_tag\\` alias currently references; use immutable release \\`$tag\\` for WN Agent \\`$version\\`.",
+)
 
 
 def find_download_to_shell_pipelines(text: str) -> list[str]:
@@ -126,6 +131,14 @@ def same_shell_notice_errors(text: str, expected: int) -> list[str]:
     if count == expected:
         return []
     return [f"expected exactly {expected} same-shell notices, found {count}"]
+
+
+def workflow_release_note_claim_errors(text: str) -> list[str]:
+    return [
+        "generated notes must distinguish the mutable latest alias from immutable release tags"
+        for claim in LATEST_ALIAS_CLAIMS
+        if text.count(claim) != 1
+    ]
 
 
 def scan_paths(root: Path, paths: Iterable[Path]) -> list[str]:
@@ -207,15 +220,8 @@ def repository_errors(root: Path) -> list[str]:
     workflow_text = (root / ".github/workflows/wn-agent-binaries.yml").read_text(
         encoding="utf-8"
     )
-    latest_alias_claims = (
-        "Install whichever version the mutable \\`wn-agent-latest\\` alias currently references with:",
-        "Latest WN Agent installers. These scripts install whichever version the mutable \\`$latest_tag\\` alias currently references; use immutable release \\`$tag\\` for WN Agent \\`$version\\`.",
-    )
-    for claim in latest_alias_claims:
-        if workflow_text.count(claim) != 1:
-            errors.append(
-                ".github/workflows/wn-agent-binaries.yml: generated notes must distinguish the mutable latest alias from immutable release tags"
-            )
+    for error in workflow_release_note_claim_errors(workflow_text):
+        errors.append(f".github/workflows/wn-agent-binaries.yml: {error}")
     for installer in INSTALLERS:
         verified_call = re.compile(
             rf"install_verified[^\n]*{re.escape(installer)}[^\n]*"

--- a/scripts/check_install_example_sha256.py
+++ b/scripts/check_install_example_sha256.py
@@ -32,6 +32,7 @@ DOCUMENTED_INSTALL_CALLS = {
     # connector guide intentionally links there rather than duplicating them.
     "integrations/hermes/marmot/README.md": {"install-hermes-marmot.sh": 4},
     "integrations/openclaw/marmot/README.md": {"install-openclaw-marmot.sh": 3},
+    "integrations/codex/marmot/README.md": {"install-codex-marmot.sh": 1},
     "integrations/opencode/marmot/README.md": {"install-opencode-marmot.sh": 2},
     "integrations/pi/marmot/README.md": {"install-pi-marmot.sh": 2},
 }

--- a/scripts/check_install_example_sha256.py
+++ b/scripts/check_install_example_sha256.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Fail closed when install examples bypass published SHA-256 checks."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable
+
+INSTALLERS = (
+    "install-hermes-marmot.sh",
+    "install-openclaw-marmot.sh",
+    "install-codex-marmot.sh",
+    "install-opencode-marmot.sh",
+    "install-pi-marmot.sh",
+)
+SCAN_SUFFIXES = {".md", ".sh", ".yaml", ".yml"}
+SCAN_EXCLUDES = {
+    Path("scripts/check_install_example_sha256.py"),
+    Path("scripts/test_install_example_sha256_gate.py"),
+}
+# Existing debt outside this task's release/install-help scope. The gate scans
+# every tracked guidance surface and allows no increase above these counts.
+LEGACY_PIPELINE_BASELINE = {
+    "crates/cli/CHANGELOG.md": 1,
+    "scripts/hermes_marmot_dev_setup.sh": 1,
+}
+DOCUMENTED_INSTALL_CALLS = {
+    # The repository-level quickstart owns release commands. The crate-level
+    # connector guide intentionally links there rather than duplicating them.
+    "integrations/hermes/marmot/README.md": {"install-hermes-marmot.sh": 4},
+    "integrations/openclaw/marmot/README.md": {"install-openclaw-marmot.sh": 3},
+    "integrations/opencode/marmot/README.md": {"install-opencode-marmot.sh": 2},
+    "integrations/pi/marmot/README.md": {"install-pi-marmot.sh": 2},
+}
+
+
+def find_download_to_shell_pipelines(text: str) -> list[str]:
+    """Return curl/wget commands whose bytes are piped directly to a shell."""
+    logical_lines = text.replace("\\\n", " ").splitlines()
+    pattern = re.compile(r"\b(?:curl|wget)\b[^\n]*\|\s*(?:ba)?sh\b")
+    return [line.strip() for line in logical_lines if pattern.search(line)]
+
+
+def verify_then_execute_errors(text: str, installer: str) -> list[str]:
+    """Check the minimum download -> companion -> verify -> execute contract."""
+    errors: list[str] = []
+    script_pos = text.find(installer)
+    checksum_candidates = (
+        text.find(f"{installer}.sha256", max(script_pos, 0)),
+        text.find("$installer_script.sha256", max(script_pos, 0)),
+        text.find("${installer_script}.sha256", max(script_pos, 0)),
+    )
+    checksum_pos = min((pos for pos in checksum_candidates if pos >= 0), default=-1)
+    verify_match = re.search(r"(?:shasum\s+-a\s+256|sha256sum)(?:\s+-c)?", text)
+    execute_match = re.search(
+        rf"^[ \t]*(?:bash|sh)\b[^\n]*{re.escape(installer)}|"
+        r"^[ \t]*(?:bash|sh)\b[^\n]*installer_script",
+        text,
+        flags=re.MULTILINE,
+    )
+
+    if script_pos < 0:
+        errors.append("missing installer download")
+    if checksum_pos < 0:
+        errors.append("missing companion .sha256 download")
+    if verify_match is None:
+        errors.append("missing SHA-256 verification")
+    if execute_match is None:
+        errors.append("missing execution of the verified local installer")
+    if (
+        script_pos >= 0
+        and checksum_pos >= 0
+        and verify_match is not None
+        and execute_match is not None
+        and not (script_pos < checksum_pos < verify_match.start() < execute_match.start())
+    ):
+        errors.append("installer example does not verify before execution")
+    return errors
+
+
+def documented_surface_errors(
+    text: str, installers: dict[str, int]
+) -> list[str]:
+    """Require each documented path to use the verified installer helper."""
+    errors: list[str] = []
+    if "install_verified() (" not in text:
+        errors.append("missing verify-then-execute helper")
+    if not re.search(r"install_verified\(\) \(\s*\n\s*set -eu\b", text):
+        errors.append("verify-then-execute helper must fail closed with set -eu")
+    if "shasum -a 256 -c" not in text:
+        errors.append("missing shasum SHA-256 verification branch")
+    if "sha256sum -c" not in text:
+        errors.append("missing sha256sum verification branch")
+    for installer, minimum in installers.items():
+        call = f'install_verified "$base_url/{installer}"'
+        checksum = f'"$base_url/{installer}.sha256"'
+        if text.count(call) < minimum:
+            errors.append(f"expected at least {minimum} verified calls for {installer}")
+        if text.count(checksum) < minimum:
+            errors.append(
+                f"expected at least {minimum} companion checksums for {installer}"
+            )
+    return errors
+
+
+def scan_paths(root: Path, paths: Iterable[Path]) -> list[str]:
+    errors: list[str] = []
+    for relative in paths:
+        if relative in SCAN_EXCLUDES:
+            continue
+        path = root / relative
+        if not path.is_file() or path.suffix not in SCAN_SUFFIXES:
+            continue
+        text = path.read_text(encoding="utf-8")
+        for line in find_download_to_shell_pipelines(text):
+            errors.append(f"{relative}: download-to-shell pipeline: {line}")
+    return errors
+
+
+def tracked_paths(root: Path) -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=root,
+        check=True,
+        capture_output=True,
+    )
+    return [Path(raw.decode("utf-8")) for raw in result.stdout.split(b"\0") if raw]
+
+
+def render_installer_help(root: Path, installer: str) -> str:
+    result = subprocess.run(
+        ["bash", str(root / "scripts" / installer), "--help"],
+        cwd=root,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"{installer} --help failed ({result.returncode}): {result.stderr.strip()}"
+        )
+    return result.stdout
+
+
+def repository_errors(root: Path) -> list[str]:
+    pipeline_hits = scan_paths(root, tracked_paths(root))
+    hits_by_path: dict[str, list[str]] = {}
+    for hit in pipeline_hits:
+        path = hit.split(":", 1)[0]
+        hits_by_path.setdefault(path, []).append(hit)
+
+    errors: list[str] = []
+    for path, hits in sorted(hits_by_path.items()):
+        allowed = LEGACY_PIPELINE_BASELINE.get(path, 0)
+        if len(hits) > allowed:
+            errors.extend(hits[allowed:])
+
+    for relative, installers in DOCUMENTED_INSTALL_CALLS.items():
+        text = (root / relative).read_text(encoding="utf-8")
+        for error in documented_surface_errors(text, installers):
+            errors.append(f"{relative}: {error}")
+
+    for installer in INSTALLERS:
+        try:
+            help_text = render_installer_help(root, installer)
+        except RuntimeError as exc:
+            errors.append(str(exc))
+            continue
+        for error in verify_then_execute_errors(help_text, installer):
+            errors.append(f"{installer} --help: {error}")
+        if "shasum -a 256" not in help_text:
+            errors.append(f"{installer} --help: missing shasum fallback")
+        if "sha256sum" not in help_text:
+            errors.append(f"{installer} --help: missing sha256sum fallback")
+
+    release_text = (root / "release.md").read_text(encoding="utf-8")
+    workflow_text = (root / ".github/workflows/wn-agent-binaries.yml").read_text(
+        encoding="utf-8"
+    )
+    for installer in INSTALLERS:
+        verified_call = re.compile(
+            rf"install_verified[^\n]*{re.escape(installer)}[^\n]*"
+            rf"{re.escape(installer)}\.sha256"
+        )
+        if verified_call.search(release_text) is None:
+            errors.append(f"release.md: missing verified install call for {installer}")
+        if len(verified_call.findall(workflow_text)) < 2:
+            errors.append(
+                ".github/workflows/wn-agent-binaries.yml: expected latest and "
+                f"version-pinned verified calls for {installer}"
+            )
+
+    for label, text, minimum in (
+        ("release.md", release_text, 1),
+        (".github/workflows/wn-agent-binaries.yml", workflow_text, 2),
+    ):
+        if text.count("shasum -a 256 -c") < minimum:
+            errors.append(f"{label}: missing shasum SHA-256 verification branch")
+        if text.count("sha256sum -c") < minimum:
+            errors.append(f"{label}: missing sha256sum verification branch")
+        if text.count("install_verified() (") < minimum:
+            errors.append(f"{label}: missing verify-then-execute helper")
+
+    return errors
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parent.parent
+    errors = repository_errors(root)
+    if errors:
+        for error in errors:
+            print(f"error: {error}", file=sys.stderr)
+        return 1
+    print("install example SHA-256 gate: clean")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_install_example_sha256.py
+++ b/scripts/check_install_example_sha256.py
@@ -28,6 +28,13 @@ LEGACY_PIPELINE_BASELINE = {
     "scripts/hermes_marmot_dev_setup.sh": 1,
 }
 DOCUMENTED_INSTALL_CALLS = {
+    "integrations/README.md": {
+        "install-hermes-marmot.sh": 2,
+        "install-openclaw-marmot.sh": 1,
+        "install-codex-marmot.sh": 2,
+        "install-opencode-marmot.sh": 1,
+        "install-pi-marmot.sh": 1,
+    },
     # The repository-level quickstart owns release commands. The crate-level
     # connector guide intentionally links there rather than duplicating them.
     "integrations/hermes/marmot/README.md": {"install-hermes-marmot.sh": 4},
@@ -36,6 +43,13 @@ DOCUMENTED_INSTALL_CALLS = {
     "integrations/opencode/marmot/README.md": {"install-opencode-marmot.sh": 2},
     "integrations/pi/marmot/README.md": {"install-pi-marmot.sh": 2},
 }
+SAME_SHELL_NOTICE_COUNTS = {
+    "integrations/hermes/marmot/README.md": 3,
+    "integrations/openclaw/marmot/README.md": 2,
+    "integrations/opencode/marmot/README.md": 1,
+    "integrations/pi/marmot/README.md": 1,
+}
+SAME_SHELL_NOTICE = "Run this example in the same shell where `install_verified` above was defined."
 
 
 def find_download_to_shell_pipelines(text: str) -> list[str]:
@@ -107,6 +121,13 @@ def documented_surface_errors(
     return errors
 
 
+def same_shell_notice_errors(text: str, expected: int) -> list[str]:
+    count = text.count(SAME_SHELL_NOTICE)
+    if count == expected:
+        return []
+    return [f"expected exactly {expected} same-shell notices, found {count}"]
+
+
 def scan_paths(root: Path, paths: Iterable[Path]) -> list[str]:
     errors: list[str] = []
     for relative in paths:
@@ -164,6 +185,11 @@ def repository_errors(root: Path) -> list[str]:
         for error in documented_surface_errors(text, installers):
             errors.append(f"{relative}: {error}")
 
+    for relative, expected in SAME_SHELL_NOTICE_COUNTS.items():
+        text = (root / relative).read_text(encoding="utf-8")
+        for error in same_shell_notice_errors(text, expected):
+            errors.append(f"{relative}: {error}")
+
     for installer in INSTALLERS:
         try:
             help_text = render_installer_help(root, installer)
@@ -181,6 +207,15 @@ def repository_errors(root: Path) -> list[str]:
     workflow_text = (root / ".github/workflows/wn-agent-binaries.yml").read_text(
         encoding="utf-8"
     )
+    latest_alias_claims = (
+        "Install whichever version the mutable \\`wn-agent-latest\\` alias currently references with:",
+        "Latest WN Agent installers. These scripts install whichever version the mutable \\`$latest_tag\\` alias currently references; use immutable release \\`$tag\\` for WN Agent \\`$version\\`.",
+    )
+    for claim in latest_alias_claims:
+        if workflow_text.count(claim) != 1:
+            errors.append(
+                ".github/workflows/wn-agent-binaries.yml: generated notes must distinguish the mutable latest alias from immutable release tags"
+            )
     for installer in INSTALLERS:
         verified_call = re.compile(
             rf"install_verified[^\n]*{re.escape(installer)}[^\n]*"

--- a/scripts/install-hermes-marmot.sh
+++ b/scripts/install-hermes-marmot.sh
@@ -116,13 +116,48 @@ Welcomer allowlist entries control which accounts may invite the Marmot agent
 through wn-agent. Message-sender allowlist entries control which Marmot senders
 Hermes accepts after gateway restart via $HERMES_HOME/.env.
 
-Example:
-  curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-hermes-marmot.sh | bash
+Verified download (then choose one invocation below):
+  set -eu
+  base_url=https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14
+  tmpdir="$(mktemp -d)"
+  trap 'rm -rf "$tmpdir"' 0 HUP INT TERM
+  installer_script=install-hermes-marmot.sh
+  installer_url="$base_url/$installer_script"
+  checksum_url="$installer_url.sha256"
+  if ! curl -fsSL "$installer_url" -o "$tmpdir/$installer_script"; then
+    echo "error: failed to download installer $installer_url to $tmpdir/$installer_script" >&2
+    exit 1
+  fi
+  if ! curl -fsSL "$checksum_url" -o "$tmpdir/$installer_script.sha256"; then
+    echo "error: failed to download checksum $checksum_url for $installer_url" >&2
+    exit 1
+  fi
+  if ! expected="$(awk 'NR == 1 && length($1) == 64 && $1 !~ /[^[:xdigit:]]/ { print tolower($1); found = 1 } END { if (!found) exit 1 }' "$tmpdir/$installer_script.sha256")"; then
+    echo "error: could not parse SHA-256 checksum from $tmpdir/$installer_script.sha256 ($checksum_url) for $installer_url" >&2
+    exit 1
+  fi
+  if command -v shasum >/dev/null 2>&1; then
+    actual="$(shasum -a 256 "$tmpdir/$installer_script" | awk '{print $1}')"
+  elif command -v sha256sum >/dev/null 2>&1; then
+    actual="$(sha256sum "$tmpdir/$installer_script" | awk '{print $1}')"
+  else
+    echo "error: need shasum or sha256sum to verify the installer" >&2
+    exit 1
+  fi
+  if [ "$expected" != "$actual" ]; then
+    echo "error: checksum mismatch for $tmpdir/$installer_script ($installer_url): expected $expected, actual $actual" >&2
+    exit 1
+  fi
 
-  curl -fsSL .../install-hermes-marmot.sh | bash -s -- --yes \
-    --allow-welcomer npub1... --allow-user npub1...
+  bash "$tmpdir/$installer_script"
 
-  curl -fsSL .../install-hermes-marmot.sh | bash -s -- --yes \
+  bash "$tmpdir/$installer_script" --yes \
+    --existing-identity-file "$HOME/.config/example/hermes-agent.nsec" \
+    --allow-welcomer npub1... \
+    --expected-npub npub1... \
+    --allow-user npub1...
+
+  bash "$tmpdir/$installer_script" --yes \
     --allow-all-users
 USAGE
 }

--- a/scripts/install-openclaw-marmot.sh
+++ b/scripts/install-openclaw-marmot.sh
@@ -108,12 +108,44 @@ Environment:
   MARMOT_RELAYS            Relay CSV used by wn-agent and bootstrap
   MARMOT_WELCOMER_ALLOWLIST Comma-separated npub or hex allowlist values
 
-Example:
-  curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14/install-openclaw-marmot.sh | bash
+Verified download (then choose one invocation below):
+  set -eu
+  base_url=https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14
+  tmpdir="$(mktemp -d)"
+  trap 'rm -rf "$tmpdir"' 0 HUP INT TERM
+  installer_script=install-openclaw-marmot.sh
+  installer_url="$base_url/$installer_script"
+  checksum_url="$installer_url.sha256"
+  if ! curl -fsSL "$installer_url" -o "$tmpdir/$installer_script"; then
+    echo "error: failed to download installer $installer_url to $tmpdir/$installer_script" >&2
+    exit 1
+  fi
+  if ! curl -fsSL "$checksum_url" -o "$tmpdir/$installer_script.sha256"; then
+    echo "error: failed to download checksum $checksum_url for $installer_url" >&2
+    exit 1
+  fi
+  if ! expected="$(awk 'NR == 1 && length($1) == 64 && $1 !~ /[^[:xdigit:]]/ { print tolower($1); found = 1 } END { if (!found) exit 1 }' "$tmpdir/$installer_script.sha256")"; then
+    echo "error: could not parse SHA-256 checksum from $tmpdir/$installer_script.sha256 ($checksum_url) for $installer_url" >&2
+    exit 1
+  fi
+  if command -v shasum >/dev/null 2>&1; then
+    actual="$(shasum -a 256 "$tmpdir/$installer_script" | awk '{print $1}')"
+  elif command -v sha256sum >/dev/null 2>&1; then
+    actual="$(sha256sum "$tmpdir/$installer_script" | awk '{print $1}')"
+  else
+    echo "error: need shasum or sha256sum to verify the installer" >&2
+    exit 1
+  fi
+  if [ "$expected" != "$actual" ]; then
+    echo "error: checksum mismatch for $tmpdir/$installer_script ($installer_url): expected $expected, actual $actual" >&2
+    exit 1
+  fi
 
-  curl -fsSL .../install-openclaw-marmot.sh | bash -s -- --yes --allow-welcomer npub1...
+  bash "$tmpdir/$installer_script"
 
-  curl -fsSL .../install-openclaw-marmot.sh | bash -s -- --yes \
+  bash "$tmpdir/$installer_script" --yes --allow-welcomer npub1...
+
+  bash "$tmpdir/$installer_script" --yes \
     --existing-identity-file "$HOME/.config/example/openclaw-agent.nsec" \
     --expected-npub npub1... --allow-welcomer npub1...
 USAGE

--- a/scripts/install-opencode-marmot.sh
+++ b/scripts/install-opencode-marmot.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 export MARMOT_TERMINAL_HARNESS=opencode
 script_source="${BASH_SOURCE[0]:-}"
 if [ -z "$script_source" ] || [ ! -f "$script_source" ]; then
-    echo "error: this repository wrapper must be run from a checkout; use the self-contained release installer for curl | bash" >&2
+    echo "error: this repository wrapper must be run from a checkout; use the release installer only after verifying its published .sha256 companion" >&2
     exit 64
 fi
 script_dir="$(cd "$(dirname "$script_source")" && pwd)"

--- a/scripts/install-pi-marmot.sh
+++ b/scripts/install-pi-marmot.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 export MARMOT_TERMINAL_HARNESS=pi
 script_source="${BASH_SOURCE[0]:-}"
 if [ -z "$script_source" ] || [ ! -f "$script_source" ]; then
-    echo "error: this repository wrapper must be run from a checkout; use the self-contained release installer for curl | bash" >&2
+    echo "error: this repository wrapper must be run from a checkout; use the release installer only after verifying its published .sha256 companion" >&2
     exit 64
 fi
 script_dir="$(cd "$(dirname "$script_source")" && pwd)"

--- a/scripts/install-terminal-harness-marmot.sh
+++ b/scripts/install-terminal-harness-marmot.sh
@@ -160,10 +160,42 @@ Environment:
   $HARNESS_BIN_ENV          $HARNESS_DISPLAY_NAME binary or command name
   MARMOT_HARNESS_EXECUTION_PROFILE Shared execution profile (default: inherit)
 
-Example:
-  curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/$MARMOT_RELEASE_TAG/install-$HARNESS_KIND-marmot.sh | bash
+Verified download (then choose one invocation below):
+  set -eu
+  base_url=https://github.com/marmot-protocol/mdk/releases/download/$MARMOT_RELEASE_TAG
+  tmpdir="\$(mktemp -d)"
+  trap 'rm -rf "\$tmpdir"' 0 HUP INT TERM
+  installer_script=install-$HARNESS_KIND-marmot.sh
+  installer_url="\$base_url/\$installer_script"
+  checksum_url="\$installer_url.sha256"
+  if ! curl -fsSL "\$installer_url" -o "\$tmpdir/\$installer_script"; then
+    echo "error: failed to download installer \$installer_url to \$tmpdir/\$installer_script" >&2
+    exit 1
+  fi
+  if ! curl -fsSL "\$checksum_url" -o "\$tmpdir/\$installer_script.sha256"; then
+    echo "error: failed to download checksum \$checksum_url for \$installer_url" >&2
+    exit 1
+  fi
+  if ! expected="\$(awk 'NR == 1 && length(\$1) == 64 && \$1 !~ /[^[:xdigit:]]/ { print tolower(\$1); found = 1 } END { if (!found) exit 1 }' "\$tmpdir/\$installer_script.sha256")"; then
+    echo "error: could not parse SHA-256 checksum from \$tmpdir/\$installer_script.sha256 (\$checksum_url) for \$installer_url" >&2
+    exit 1
+  fi
+  if command -v shasum >/dev/null 2>&1; then
+    actual="\$(shasum -a 256 "\$tmpdir/\$installer_script" | awk '{print \$1}')"
+  elif command -v sha256sum >/dev/null 2>&1; then
+    actual="\$(sha256sum "\$tmpdir/\$installer_script" | awk '{print \$1}')"
+  else
+    echo "error: need shasum or sha256sum to verify the installer" >&2
+    exit 1
+  fi
+  if [ "\$expected" != "\$actual" ]; then
+    echo "error: checksum mismatch for \$tmpdir/\$installer_script (\$installer_url): expected \$expected, actual \$actual" >&2
+    exit 1
+  fi
 
-  curl -fsSL .../install-$HARNESS_KIND-marmot.sh | bash -s -- --yes --allow-welcomer npub1...
+  bash "\$tmpdir/\$installer_script"
+
+  bash "\$tmpdir/\$installer_script" --yes --allow-welcomer npub1...
 USAGE
 }
 
@@ -317,7 +349,11 @@ download_asset() {
         log "url: $url"
         return 0
     fi
-    curl -fsSL --connect-timeout 10 --max-time 120 "$url" -o "$dest"
+    if ! curl -fsSL --connect-timeout 10 --max-time 120 "$url" -o "$dest"; then
+        rm -f "$dest"
+        echo "error: failed to download $url to $dest" >&2
+        exit 1
+    fi
 }
 
 verify_sha256() {
@@ -326,18 +362,33 @@ verify_sha256() {
     if [ "$DRY_RUN" -eq 1 ]; then
         return 0
     fi
-    local expected actual
-    expected="$(awk '{print $1}' "$checksum_file")"
+    local expected actual asset_url checksum_url
+    asset_url="$(release_base_url)/$(basename "$asset")"
+    checksum_url="$(release_base_url)/$(basename "$checksum_file")"
+    if [ ! -f "$checksum_file" ] || [ ! -r "$checksum_file" ]; then
+        echo "error: missing or unreadable checksum $checksum_file ($checksum_url) for $asset ($asset_url)" >&2
+        exit 1
+    fi
+    if ! expected="$(awk 'NR == 1 && length($1) == 64 && $1 !~ /[^[:xdigit:]]/ { print tolower($1); found = 1 } END { if (!found) exit 1 }' "$checksum_file")"; then
+        echo "error: could not parse SHA-256 checksum from $checksum_file ($checksum_url) for $asset ($asset_url)" >&2
+        exit 1
+    fi
     if command -v shasum >/dev/null 2>&1; then
-        actual="$(shasum -a 256 "$asset" | awk '{print $1}')"
+        if ! actual="$(shasum -a 256 "$asset" | awk '{print $1}')"; then
+            echo "error: could not compute SHA-256 for $asset ($asset_url)" >&2
+            exit 1
+        fi
     elif command -v sha256sum >/dev/null 2>&1; then
-        actual="$(sha256sum "$asset" | awk '{print $1}')"
+        if ! actual="$(sha256sum "$asset" | awk '{print $1}')"; then
+            echo "error: could not compute SHA-256 for $asset ($asset_url)" >&2
+            exit 1
+        fi
     else
         echo "error: need shasum or sha256sum to verify downloads" >&2
         exit 1
     fi
     if [ "$expected" != "$actual" ]; then
-        echo "error: checksum mismatch for $(basename "$asset")" >&2
+        echo "error: checksum mismatch for $asset ($asset_url): expected $expected, actual $actual" >&2
         exit 1
     fi
 }

--- a/scripts/test_check_cargo_audit_ci.py
+++ b/scripts/test_check_cargo_audit_ci.py
@@ -28,6 +28,20 @@ class CargoAuditCiPolicyTests(unittest.TestCase):
             with self.assertRaisesRegex(PolicyError, message):
                 validate(mutated, AUDIT_CONFIG)
 
+    def test_rejects_missing_rust_toolchain_setup(self) -> None:
+        self.assert_mutation_rejected(
+            '          rustup toolchain install "$toolchain" --profile minimal\n',
+            "",
+            "repository Rust toolchain",
+        )
+
+    def test_rejects_changed_cargo_audit_pin(self) -> None:
+        self.assert_mutation_rejected(
+            "tool: cargo-audit@0.22.1",
+            "tool: cargo-audit@latest",
+            "cargo-audit@0.22.1",
+        )
+
     def test_rejects_unlocked_or_bypassed_audit_command(self) -> None:
         self.assert_mutation_rejected(
             "run: cargo --locked audit",

--- a/scripts/test_check_cargo_audit_ci.py
+++ b/scripts/test_check_cargo_audit_ci.py
@@ -28,6 +28,13 @@ class CargoAuditCiPolicyTests(unittest.TestCase):
             with self.assertRaisesRegex(PolicyError, message):
                 validate(mutated, AUDIT_CONFIG)
 
+    def assert_workflow_rejected(self, workflow: str, message: str) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            mutated = Path(directory) / "ci.yml"
+            mutated.write_text(workflow, encoding="utf-8")
+            with self.assertRaisesRegex(PolicyError, message):
+                validate(mutated, AUDIT_CONFIG)
+
     def assert_audit_config_mutation_rejected(
         self, old: str, new: str, message: str
     ) -> None:
@@ -78,8 +85,40 @@ class CargoAuditCiPolicyTests(unittest.TestCase):
         self.assert_mutation_rejected(
             "  rust-audit:\n    name: Rust audit\n    runs-on: ubuntu-latest\n    timeout-minutes: 15\n\n    steps:",
             "  rust-audit:\n    name: Rust audit\n    runs-on: ubuntu-latest\n    timeout-minutes: 15\n    if: ${{ false }}\n\n    steps:",
-            "job-level if condition",
+            "must not have an if condition",
         )
+
+    def test_rejects_step_level_condition(self) -> None:
+        self.assert_mutation_rejected(
+            "      - name: Audit Rust dependencies\n",
+            "      - name: Audit Rust dependencies\n        if: ${{ false }}\n",
+            "must not have an if condition",
+        )
+
+    def test_rejects_quoted_condition_key(self) -> None:
+        self.assert_mutation_rejected(
+            "  rust-audit:\n    name: Rust audit\n    runs-on: ubuntu-latest\n    timeout-minutes: 15\n",
+            '  rust-audit:\n    name: Rust audit\n    runs-on: ubuntu-latest\n    timeout-minutes: 15\n    "if": ${{ false }}\n',
+            "must not have an if condition",
+        )
+
+    def test_commented_next_job_boundary_does_not_supply_audit_command(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        workflow = workflow.replace(
+            "  terminal-harness-installers:\n",
+            "  terminal-harness-installers: # annotated boundary\n",
+            1,
+        ).replace("run: cargo --locked audit", "run: echo audit-disabled", 1)
+        marker = "      - name: Test Codex, Pi, and OpenCode installers\n"
+        self.assertIn(marker, workflow)
+        workflow = workflow.replace(
+            marker,
+            "      - name: Synthetic unrelated audit command\n"
+            "        run: cargo --locked audit\n\n"
+            + marker,
+            1,
+        )
+        self.assert_workflow_rejected(workflow, "exactly 'cargo --locked audit'")
 
     def test_rejects_non_root_working_directory(self) -> None:
         self.assert_mutation_rejected(
@@ -101,6 +140,7 @@ class CargoAuditCiPolicyTests(unittest.TestCase):
             'ignore = ["RUSTSEC-2099-0001"]',
             'ignore = []',
             'ignore = [',
+            'ignore = ["RUSTSEC-2024-0384"]\nseverity_threshold = "critical"',
         )
         for mutation in mutations:
             with self.subTest(mutation=mutation):

--- a/scripts/test_check_cargo_audit_ci.py
+++ b/scripts/test_check_cargo_audit_ci.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Regression tests for the cargo-audit workflow policy check."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from check_cargo_audit_ci import PolicyError, validate
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+AUDIT_CONFIG = REPO_ROOT / ".cargo" / "audit.toml"
+
+
+class CargoAuditCiPolicyTests(unittest.TestCase):
+    def test_repository_workflow_enforces_audit_policy(self) -> None:
+        validate(WORKFLOW, AUDIT_CONFIG)
+
+    def assert_mutation_rejected(self, old: str, new: str, message: str) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn(old, workflow)
+        with tempfile.TemporaryDirectory() as directory:
+            mutated = Path(directory) / "ci.yml"
+            mutated.write_text(workflow.replace(old, new, 1), encoding="utf-8")
+            with self.assertRaisesRegex(PolicyError, message):
+                validate(mutated, AUDIT_CONFIG)
+
+    def test_rejects_unlocked_or_bypassed_audit_command(self) -> None:
+        self.assert_mutation_rejected(
+            "run: cargo --locked audit",
+            "run: cargo audit || true",
+            "exactly 'cargo --locked audit'",
+        )
+
+    def test_rejects_removed_audit_job(self) -> None:
+        self.assert_mutation_rejected(
+            "  rust-audit:",
+            "  rust-audit-disabled:",
+            "rust-audit job",
+        )
+
+    def test_rejects_error_masking(self) -> None:
+        self.assert_mutation_rejected(
+            "  rust-audit:\n    name: Rust audit\n    runs-on: ubuntu-latest\n    timeout-minutes: 15\n\n    steps:",
+            "  rust-audit:\n    name: Rust audit\n    runs-on: ubuntu-latest\n    timeout-minutes: 15\n    continue-on-error: true\n\n    steps:",
+            "continue-on-error",
+        )
+
+    def test_rejects_non_root_working_directory(self) -> None:
+        self.assert_mutation_rejected(
+            "      - name: Audit Rust dependencies\n",
+            "      - name: Audit Rust dependencies\n        working-directory: crates/cli\n",
+            "repository root",
+        )
+
+    def test_rejects_missing_audit_configuration(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            missing = Path(directory) / "audit.toml"
+            with self.assertRaisesRegex(PolicyError, "audit.toml"):
+                validate(WORKFLOW, missing)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_check_cargo_audit_ci.py
+++ b/scripts/test_check_cargo_audit_ci.py
@@ -28,6 +28,17 @@ class CargoAuditCiPolicyTests(unittest.TestCase):
             with self.assertRaisesRegex(PolicyError, message):
                 validate(mutated, AUDIT_CONFIG)
 
+    def assert_audit_config_mutation_rejected(
+        self, old: str, new: str, message: str
+    ) -> None:
+        audit_config = AUDIT_CONFIG.read_text(encoding="utf-8")
+        self.assertIn(old, audit_config)
+        with tempfile.TemporaryDirectory() as directory:
+            mutated = Path(directory) / "audit.toml"
+            mutated.write_text(audit_config.replace(old, new, 1), encoding="utf-8")
+            with self.assertRaisesRegex(PolicyError, message):
+                validate(WORKFLOW, mutated)
+
     def test_rejects_missing_rust_toolchain_setup(self) -> None:
         self.assert_mutation_rejected(
             '          rustup toolchain install "$toolchain" --profile minimal\n',
@@ -63,6 +74,13 @@ class CargoAuditCiPolicyTests(unittest.TestCase):
             "continue-on-error",
         )
 
+    def test_rejects_job_level_condition(self) -> None:
+        self.assert_mutation_rejected(
+            "  rust-audit:\n    name: Rust audit\n    runs-on: ubuntu-latest\n    timeout-minutes: 15\n\n    steps:",
+            "  rust-audit:\n    name: Rust audit\n    runs-on: ubuntu-latest\n    timeout-minutes: 15\n    if: ${{ false }}\n\n    steps:",
+            "job-level if condition",
+        )
+
     def test_rejects_non_root_working_directory(self) -> None:
         self.assert_mutation_rejected(
             "      - name: Audit Rust dependencies\n",
@@ -75,6 +93,22 @@ class CargoAuditCiPolicyTests(unittest.TestCase):
             missing = Path(directory) / "audit.toml"
             with self.assertRaisesRegex(PolicyError, "audit.toml"):
                 validate(WORKFLOW, missing)
+
+    def test_rejects_changed_missing_or_invalid_advisory_policy(self) -> None:
+        approved = 'ignore = ["RUSTSEC-2024-0384"]'
+        mutations = (
+            'ignore = ["RUSTSEC-2024-0384", "RUSTSEC-2099-0001"]',
+            'ignore = ["RUSTSEC-2099-0001"]',
+            'ignore = []',
+            'ignore = [',
+        )
+        for mutation in mutations:
+            with self.subTest(mutation=mutation):
+                self.assert_audit_config_mutation_rejected(
+                    approved,
+                    mutation,
+                    "audit.toml|exactly match the approved policy",
+                )
 
 
 if __name__ == "__main__":

--- a/scripts/test_install_example_sha256_gate.py
+++ b/scripts/test_install_example_sha256_gate.py
@@ -57,6 +57,23 @@ install_verified "$base_url/install.sh"
         errors = gate.documented_surface_errors(text, {"install.sh": 1})
         self.assertIn("expected at least 1 companion checksums for install.sh", errors)
 
+    def test_codex_readme_is_a_documented_install_surface(self) -> None:
+        installers = gate.DOCUMENTED_INSTALL_CALLS["integrations/codex/marmot/README.md"]
+        self.assertEqual(installers, {"install-codex-marmot.sh": 1})
+        readme = (Path(__file__).resolve().parents[1] / "integrations/codex/marmot/README.md").read_text(
+            encoding="utf-8"
+        )
+        self.assertEqual(gate.documented_surface_errors(readme, installers), [])
+        mutated = readme.replace(
+            '"$base_url/install-codex-marmot.sh.sha256"',
+            '"$base_url/install-codex-marmot.sh.sig"',
+            1,
+        )
+        self.assertIn(
+            "expected at least 1 companion checksums for install-codex-marmot.sh",
+            gate.documented_surface_errors(mutated, installers),
+        )
+
     def test_repository_scan_rejects_new_unverified_example(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_install_example_sha256_gate.py
+++ b/scripts/test_install_example_sha256_gate.py
@@ -74,6 +74,25 @@ install_verified "$base_url/install.sh"
             gate.documented_surface_errors(mutated, installers),
         )
 
+    def test_release_guide_rejects_download_to_shell_mutation(self) -> None:
+        release = (Path(__file__).resolve().parents[1] / "release.md").read_text(encoding="utf-8")
+        installers = {installer: 1 for installer in gate.INSTALLERS}
+        self.assertEqual(gate.documented_surface_errors(release, installers), [])
+        verified = (
+            'install_verified "$base_url/install-hermes-marmot.sh" '
+            '"$base_url/install-hermes-marmot.sh.sha256"'
+        )
+        mutated = release.replace(
+            verified,
+            "curl -fsSL https://example.test/install-hermes-marmot.sh | bash",
+            1,
+        )
+        self.assertTrue(gate.find_download_to_shell_pipelines(mutated))
+        self.assertIn(
+            "expected at least 1 verified calls for install-hermes-marmot.sh",
+            gate.documented_surface_errors(mutated, installers),
+        )
+
     def test_repository_scan_rejects_new_unverified_example(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_install_example_sha256_gate.py
+++ b/scripts/test_install_example_sha256_gate.py
@@ -93,6 +93,17 @@ install_verified "$base_url/install.sh"
             gate.documented_surface_errors(mutated, installers),
         )
 
+    def test_same_shell_notice_regression_is_rejected(self) -> None:
+        readme = (Path(__file__).resolve().parents[1] / "integrations/hermes/marmot/README.md").read_text(
+            encoding="utf-8"
+        )
+        self.assertEqual(gate.same_shell_notice_errors(readme, 3), [])
+        mutated = readme.replace(gate.SAME_SHELL_NOTICE, "", 1)
+        self.assertIn(
+            "expected exactly 3 same-shell notices, found 2",
+            gate.same_shell_notice_errors(mutated, 3),
+        )
+
     def test_repository_scan_rejects_new_unverified_example(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_install_example_sha256_gate.py
+++ b/scripts/test_install_example_sha256_gate.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Regression tests for the install-example SHA-256 gate."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import check_install_example_sha256 as gate
+
+
+class InstallExampleSha256GateTests(unittest.TestCase):
+    def test_rejects_download_to_shell_pipeline(self) -> None:
+        text = "curl -fsSL https://example.test/install.sh | bash\n"
+        self.assertTrue(gate.find_download_to_shell_pipelines(text))
+
+    def test_rejects_local_execution_without_checksum_verification(self) -> None:
+        text = """\
+curl -fsSLo /tmp/install.sh https://example.test/install.sh
+bash /tmp/install.sh
+"""
+        errors = gate.verify_then_execute_errors(text, "install.sh")
+        self.assertIn("missing companion .sha256 download", errors)
+        self.assertIn("missing SHA-256 verification", errors)
+
+    def test_accepts_verify_then_execute_sequence(self) -> None:
+        text = """\
+curl -fsSLo /tmp/install.sh https://example.test/install.sh
+curl -fsSLo /tmp/install.sh.sha256 https://example.test/install.sh.sha256
+(cd /tmp && shasum -a 256 -c install.sh.sha256)
+bash /tmp/install.sh
+"""
+        self.assertEqual(gate.verify_then_execute_errors(text, "install.sh"), [])
+
+    def test_rejects_documented_helper_without_fail_closed_shell(self) -> None:
+        text = """\
+install_verified() (
+  installer_url="$1"
+  shasum -a 256 -c installer.sha256
+  sha256sum -c installer.sha256
+  bash "$installer_url"
+)
+install_verified "$base_url/install.sh" "$base_url/install.sh.sha256"
+"""
+        errors = gate.documented_surface_errors(text, {"install.sh": 1})
+        self.assertIn("verify-then-execute helper must fail closed with set -eu", errors)
+
+    def test_rejects_documented_call_without_companion_checksum(self) -> None:
+        text = """\
+install_verified() (
+  shasum -a 256 -c installer.sha256
+  sha256sum -c installer.sha256
+)
+install_verified "$base_url/install.sh"
+"""
+        errors = gate.documented_surface_errors(text, {"install.sh": 1})
+        self.assertIn("expected at least 1 companion checksums for install.sh", errors)
+
+    def test_repository_scan_rejects_new_unverified_example(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "release.md").write_text(
+                "curl -fsSL https://example.test/install-hermes-marmot.sh | bash\n",
+                encoding="utf-8",
+            )
+            errors = gate.scan_paths(root, [Path("release.md")])
+        self.assertTrue(any("download-to-shell" in error for error in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_install_example_sha256_gate.py
+++ b/scripts/test_install_example_sha256_gate.py
@@ -104,6 +104,27 @@ install_verified "$base_url/install.sh"
             gate.same_shell_notice_errors(mutated, 3),
         )
 
+    def test_quickstart_same_shell_notice_regression_is_rejected(self) -> None:
+        quickstart = (Path(__file__).resolve().parents[1] / "integrations/README.md").read_text(
+            encoding="utf-8"
+        )
+        self.assertEqual(gate.same_shell_notice_errors(quickstart, 7), [])
+        mutated = quickstart.replace(gate.SAME_SHELL_NOTICE, "", 1)
+        self.assertIn(
+            "expected exactly 7 same-shell notices, found 6",
+            gate.same_shell_notice_errors(mutated, 7),
+        )
+
+    def test_generated_note_claim_mutations_are_rejected(self) -> None:
+        workflow = (
+            Path(__file__).resolve().parents[1] / ".github/workflows/wn-agent-binaries.yml"
+        ).read_text(encoding="utf-8")
+        self.assertEqual(gate.workflow_release_note_claim_errors(workflow), [])
+        for claim in gate.LATEST_ALIAS_CLAIMS:
+            with self.subTest(claim=claim):
+                mutated = workflow.replace(claim, "regressed wording", 1)
+                self.assertTrue(gate.workflow_release_note_claim_errors(mutated))
+
     def test_repository_scan_rejects_new_unverified_example(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_install_example_sha256_gate.py
+++ b/scripts/test_install_example_sha256_gate.py
@@ -97,32 +97,42 @@ install_verified "$base_url/install.sh"
         readme = (Path(__file__).resolve().parents[1] / "integrations/hermes/marmot/README.md").read_text(
             encoding="utf-8"
         )
-        self.assertEqual(gate.same_shell_notice_errors(readme, 3), [])
-        mutated = readme.replace(gate.SAME_SHELL_NOTICE, "", 1)
-        self.assertIn(
-            "expected exactly 3 same-shell notices, found 2",
-            gate.same_shell_notice_errors(mutated, 3),
+        self.assertEqual(gate.same_shell_notice_errors(readme), [])
+        mutated = readme.replace(
+            "Run this example in the same shell where `install_verified` above was defined.",
+            "Prerequisite omitted.",
+            1,
         )
+        self.assertTrue(gate.same_shell_notice_errors(mutated))
 
     def test_quickstart_same_shell_notice_regression_is_rejected(self) -> None:
         quickstart = (Path(__file__).resolve().parents[1] / "integrations/README.md").read_text(
             encoding="utf-8"
         )
-        self.assertEqual(gate.same_shell_notice_errors(quickstart, 7), [])
-        mutated = quickstart.replace(gate.SAME_SHELL_NOTICE, "", 1)
-        self.assertIn(
-            "expected exactly 7 same-shell notices, found 6",
-            gate.same_shell_notice_errors(mutated, 7),
+        self.assertEqual(gate.same_shell_notice_errors(quickstart), [])
+        mutated = quickstart.replace(
+            "Run this example in the same shell where `install_verified` above was defined.",
+            "Prerequisite omitted.",
+            1,
         )
+        self.assertTrue(gate.same_shell_notice_errors(mutated))
 
     def test_generated_note_claim_mutations_are_rejected(self) -> None:
         workflow = (
             Path(__file__).resolve().parents[1] / ".github/workflows/wn-agent-binaries.yml"
         ).read_text(encoding="utf-8")
         self.assertEqual(gate.workflow_release_note_claim_errors(workflow), [])
-        for claim in gate.LATEST_ALIAS_CLAIMS:
-            with self.subTest(claim=claim):
-                mutated = workflow.replace(claim, "regressed wording", 1)
+        mutations = (
+            workflow.replace("mutable \\`wn-agent-latest\\`", "rolling \\`wn-agent-latest\\`", 1),
+            workflow.replace("mutable \\`$latest_tag\\`", "rolling \\`$latest_tag\\`", 1),
+            workflow.replace(
+                'base_url="https://github.com/$GITHUB_REPOSITORY/releases/download/wn-agent-latest"',
+                'base_url="https://github.com/$GITHUB_REPOSITORY/releases/latest"',
+                1,
+            ),
+        )
+        for index, mutated in enumerate(mutations):
+            with self.subTest(index=index):
                 self.assertTrue(gate.workflow_release_note_claim_errors(mutated))
 
     def test_repository_scan_rejects_new_unverified_example(self) -> None:


### PR DESCRIPTION
## Summary

- replace active WN Agent `curl | bash` guidance with fail-closed download, sibling `.sha256` verification, and execution of only the verified local installer
- preserve the canonical guided onboarding and finish-in-White-Noise path while covering Hermes, OpenClaw, Codex, OpenCode, and Pi release installs
- treat `wn-agent-latest` as an endorsed rolling convenience alias while keeping versioned release tags as the immutable install path
- add a pinned RustSec audit job that installs the repository Rust toolchain and `cargo-audit@0.22.1`, then runs exact `cargo --locked audit` at the repository root
- add policy and mutation tests so future documentation or workflow changes cannot silently bypass either gate

## Acceptance criteria

- [x] Active install paths download the installer and its published `.sha256` companion
- [x] Documented helpers fail closed on download or checksum failure before invoking `bash`
- [x] Installer `--help`, release guidance, and generated release notes use verify-then-execute examples
- [x] Current guided phone onboarding, bootstrap-file permissions, and canonical quickstart navigation are preserved
- [x] CI installs the repository Rust toolchain and pinned `cargo-audit@0.22.1`
- [x] CI runs exact `cargo --locked audit` at repository root with no error masking
- [x] New unignored RustSec advisories fail the audit job while `.cargo/audit.toml` remains authoritative

## Disposition evidence

- Dependabot coverage for Cargo, Actions, and the OpenClaw pnpm lockfile is intentionally not duplicated here; it remains in [#1516](https://github.com/marmot-protocol/mdk/pull/1516).
- A historical `curl | bash` mention in `crates/cli/CHANGELOG.md` and the unrelated uv bootstrap in `scripts/hermes_marmot_dev_setup.sh` are pre-existing, baseline-capped debt outside active WN Agent install guidance.
- No F2 or F3 implementation track was skipped: verified installer guidance and RustSec CI are both included.

## Verification

- `just fast-ci`
- install-example SHA-256 policy and 11 regression/mutation tests
- cargo-audit workflow policy and 13 regression/mutation tests
- current-release agent install documentation gate
- workspace checks and clippy, normal and OTLP feature sets
- convergence policy pin tests

The local worktree does not have `cargo-audit` installed, so the audit binary itself was not re-run after rebasing. `Cargo.lock` is unchanged from the previously audited target; the GitHub Rust audit job installed the exact audit binary and repository toolchain and passed against the locked dependency graph.

## Independent review

PASS on exact follow-up head `0e8dd011e6ebb5042e45e0bee79d0eef5127fc7e`. The bounded independent runner selected Cursor `grok-4.6`; this is **not Kimi-reviewed**. It confirmed the exact RustSec policy, always-running audit job, every documented installer surface, semantic rolling-alias checks, and structural same-shell guidance; its remaining findings were non-blocking hardening notes.

## CI

- [CI run](https://github.com/marmot-protocol/mdk/actions/runs/32828443502)
- [Rust audit job](https://github.com/marmot-protocol/mdk/actions/runs/32828443502/job/97741620570)
- [WN Agent binaries run](https://github.com/marmot-protocol/mdk/actions/runs/32828443504)

All required checks passed on exact head `0e8dd011e6ebb5042e45e0bee79d0eef5127fc7e`. Release publication was correctly skipped for this pull request.