### PR TITLE
Fix/openclaw allowlist fail closed

### DIFF
--- a/integrations/openclaw/marmot/README.md
+++ b/integrations/openclaw/marmot/README.md
@@ -335,7 +335,14 @@ for any plugin or tenant that is not in the same trust boundary.
   `channels.marmot.dm.allowFrom` (hex account ids) into `wn-agent`'s welcomer
   allowlist (a no-op when none is configured, so it never wipes an allowlist
   managed directly on `wn-agent`). `wn-agent` still performs welcomer-based
-  post-join accept/decline.
+  post-join accept/decline. With `allowFrom` set the mirror is *exact
+  reconciliation* of an account-scoped list: entries another integration added
+  to the same `wn-agent` account are removed. It runs fail-closed — revocations
+  before additions, every step attempted even when an earlier one fails, and the
+  effective list read back afterwards. `wn-agent` has no atomic replace, so a
+  partial control-plane failure is reported, not repaired: the connector logs
+  `welcomer allowlist revocation failed …` (entries still authorized) or
+  `welcomer allowlist not reconciled …`, and startup continues.
 - **Profile-name onboarding** (`src/profile-onboarding.ts`, on by default;
   disable with `profileNameOnboarding: false`): when the agent joins a group it
   asks, on its own, whether to publish a public Nostr profile (`kind:0`) name —

--- a/integrations/openclaw/marmot/src/inbound-runtime.ts
+++ b/integrations/openclaw/marmot/src/inbound-runtime.ts
@@ -476,6 +476,11 @@ export interface SyncAllowlistOptions {
  * Mirror the configured `dm.allowFrom` welcomers into wn-agent's allowlist for
  * the resolved account. No-op when no allow-from is configured, so a bare
  * deployment does not wipe an allowlist managed directly on wn-agent.
+ *
+ * Startup stays best-effort — a wn-agent that cannot be reconciled must not
+ * block inbound dispatch — so failures surface as warnings rather than a throw.
+ * A failed revocation gets its own warning: it is the one outcome that leaves
+ * the account more permissive than the operator asked for.
  */
 export async function syncMarmotAllowlist(
   api: InboundPluginApi,
@@ -489,8 +494,21 @@ export async function syncMarmotAllowlist(
     const client = (options.clientFactory ?? clientForAccount)(resolved);
     const accountIdHex = resolved.marmotAccountIdHex ?? (await resolveSingleAccount(client));
     const result = await syncAllowlist(client, accountIdHex, resolved.allowFrom);
-    api.logger.info(
-      `marmot: welcomer allowlist synced (added ${result.added.length}, removed ${result.removed.length})`,
+    if (result.failedRemovals.length > 0) {
+      // Fail-open risk: those welcomers stay authorized on the shared account
+      // until the next successful sync, so never let it read as a clean start.
+      api.logger.warn(
+        `marmot: welcomer allowlist revocation failed for ${result.failedRemovals.length} entries; they remain authorized on wn-agent`,
+      );
+    }
+    if (result.verified) {
+      api.logger.info(
+        `marmot: welcomer allowlist synced (added ${result.added.length}, removed ${result.removed.length})`,
+      );
+      return;
+    }
+    api.logger.warn(
+      `marmot: welcomer allowlist not reconciled (added ${result.added.length}, removed ${result.removed.length}, failed ${result.failedAdds.length + result.failedRemovals.length})`,
     );
   } catch {
     // Best-effort on startup: account/config resolution or the sync itself can

--- a/integrations/openclaw/marmot/src/security.ts
+++ b/integrations/openclaw/marmot/src/security.ts
@@ -20,43 +20,99 @@ export function normalizeWelcomerId(entry: string | number): string {
   return String(entry).trim().toLowerCase().replace(/^0x/, "");
 }
 
+function welcomerIdSet(entries: Array<string | number>): Set<string> {
+  return new Set(
+    entries.map(normalizeWelcomerId).filter((id) => MARMOT_ACCOUNT_ID_HEX.test(id)),
+  );
+}
+
 export interface AllowlistSyncResult {
+  /** Ids a successful `allowlist_add` confirmed. */
   added: string[];
+  /** Ids a successful `allowlist_remove` confirmed. */
   removed: string[];
+  /** Ids whose `allowlist_add` threw; they are not authorized. */
+  failedAdds: string[];
+  /** Ids whose `allowlist_remove` threw; they are still authorized. */
+  failedRemovals: string[];
+  /**
+   * True only when the allowlist was read back after reconciliation and the
+   * effective set equalled the desired set. False means the caller must treat
+   * the allowlist as unreconciled, including when the read-back itself failed.
+   */
+  verified: boolean;
+}
+
+async function effectiveWelcomers(
+  client: AllowlistClient,
+  accountIdHex: string,
+): Promise<Set<string>> {
+  const response = await client.allowlistList(accountIdHex);
+  return welcomerIdSet(response.welcomer_account_ids_hex ?? []);
 }
 
 /**
- * Reconcile wn-agent's welcomer allowlist for `accountIdHex` to exactly the
- * hex ids in `desired`. Returns the ids added and removed.
+ * Reconcile wn-agent's welcomer allowlist for `accountIdHex` to exactly the hex
+ * ids in `desired`, fail-closed:
+ *
+ * - revocations run first, so a security-critical shrink never waits behind a
+ *   grow that may fail;
+ * - every step is attempted even when an earlier one throws;
+ * - `added`/`removed` list only confirmed changes, failures land in
+ *   `failedAdds`/`failedRemovals`;
+ * - the effective set is read back and only an exact match sets `verified`.
+ *
+ * `wn-agent` exposes no atomic replace, so reconciliation is still a sequence of
+ * single-entry mutations: a caller that sees `verified: false` knows the
+ * authoritative set diverges but cannot assume any particular intermediate
+ * state. The read-back is also account-scoped, not connector-scoped, so a
+ * concurrent writer on a shared account reads as divergence.
  */
 export async function syncAllowlist(
   client: AllowlistClient,
   accountIdHex: string,
   desired: Array<string | number>,
 ): Promise<AllowlistSyncResult> {
-  const want = new Set(
-    desired.map(normalizeWelcomerId).filter((id) => MARMOT_ACCOUNT_ID_HEX.test(id)),
-  );
-  const current = await client.allowlistList(accountIdHex);
-  const have = new Set(
-    (current.welcomer_account_ids_hex ?? [])
-      .map(normalizeWelcomerId)
-      .filter((id) => MARMOT_ACCOUNT_ID_HEX.test(id)),
-  );
+  const want = welcomerIdSet(desired);
+  // Nothing has been mutated yet, so an unreadable current set is a plain throw.
+  const have = await effectiveWelcomers(client, accountIdHex);
 
-  const added: string[] = [];
-  const removed: string[] = [];
-  for (const id of want) {
-    if (!have.has(id)) {
-      await client.allowlistAdd(accountIdHex, id);
-      added.push(id);
-    }
-  }
+  const result: AllowlistSyncResult = {
+    added: [],
+    removed: [],
+    failedAdds: [],
+    failedRemovals: [],
+    verified: false,
+  };
+
   for (const id of have) {
-    if (!want.has(id)) {
+    if (want.has(id)) {
+      continue;
+    }
+    try {
       await client.allowlistRemove(accountIdHex, id);
-      removed.push(id);
+      result.removed.push(id);
+    } catch {
+      result.failedRemovals.push(id);
     }
   }
-  return { added, removed };
+  for (const id of want) {
+    if (have.has(id)) {
+      continue;
+    }
+    try {
+      await client.allowlistAdd(accountIdHex, id);
+      result.added.push(id);
+    } catch {
+      result.failedAdds.push(id);
+    }
+  }
+
+  try {
+    const effective = await effectiveWelcomers(client, accountIdHex);
+    result.verified = effective.size === want.size && [...want].every((id) => effective.has(id));
+  } catch {
+    result.verified = false;
+  }
+  return result;
 }

--- a/integrations/openclaw/marmot/test/inbound-runtime.test.ts
+++ b/integrations/openclaw/marmot/test/inbound-runtime.test.ts
@@ -705,4 +705,39 @@ describe("syncMarmotAllowlist", () => {
     });
     expect(used).toBe(false);
   });
+
+  it("warns when a welcomer revocation cannot be applied", async () => {
+    const stale = HEX32("99");
+    const warnings: string[] = [];
+    const client = {
+      async accountList() {
+        return {
+          type: "account_list",
+          accounts: [{ account_id_hex: HEX32("aa"), label: "agent", local_signing: true }],
+        };
+      },
+      async allowlistList() {
+        return {
+          type: "allowlist",
+          account_id_hex: HEX32("aa"),
+          welcomer_account_ids_hex: [stale],
+        };
+      },
+      async allowlistAdd() {
+        return { type: "ack" };
+      },
+      async allowlistRemove() {
+        throw new Error("allowlist_remove failed");
+      },
+    } as unknown as MarmotAgentControlClient;
+    const api: InboundPluginApi = {
+      config: { channels: { marmot: { dm: { allowFrom: [HEX32("11")] } } } },
+      logger: { info: () => {}, warn: (message: string) => warnings.push(message) },
+    };
+
+    await syncMarmotAllowlist(api, { clientFactory: () => client });
+
+    expect(warnings.some((message) => message.includes("revocation failed"))).toBe(true);
+    expect(warnings.join(" ")).not.toContain(stale);
+  });
 });

--- a/integrations/openclaw/marmot/test/security.test.ts
+++ b/integrations/openclaw/marmot/test/security.test.ts
@@ -4,32 +4,69 @@ import { normalizeWelcomerId, syncAllowlist, type AllowlistClient } from "../src
 
 const HEX32 = (b: string) => b.repeat(32);
 
-function stubAllowlist(current: string[]): {
+interface StubOptions {
+  /** Ids whose `allowlist_add` throws. */
+  failAdds?: string[];
+  /** Ids whose `allowlist_remove` throws. */
+  failRemoves?: string[];
+  /** Runs on every read-back (list call after the first); may mutate or throw. */
+  onReadBack?: (effective: Set<string>) => void;
+}
+
+/**
+ * Stub that models wn-agent's authoritative set, so tests can assert the
+ * effective final allowlist and not only the attempted calls.
+ */
+function stubAllowlist(
+  current: string[],
+  options: StubOptions = {},
+): {
   client: AllowlistClient;
   adds: string[];
   removes: string[];
+  effective: Set<string>;
 } {
+  const effective = new Set(current);
+  const failAdds = new Set(options.failAdds ?? []);
+  const failRemoves = new Set(options.failRemoves ?? []);
   const adds: string[] = [];
   const removes: string[] = [];
+  let listCalls = 0;
   const client = {
     async allowlistList() {
-      return { type: "allowlist", account_id_hex: HEX32("aa"), welcomer_account_ids_hex: current };
+      listCalls += 1;
+      if (listCalls > 1) {
+        options.onReadBack?.(effective);
+      }
+      return {
+        type: "allowlist",
+        account_id_hex: HEX32("aa"),
+        welcomer_account_ids_hex: [...effective],
+      };
     },
     async allowlistAdd(_account: string, id: string) {
       adds.push(id);
+      if (failAdds.has(id)) {
+        throw new Error("allowlist_add failed");
+      }
+      effective.add(id);
       return { type: "ack" };
     },
     async allowlistRemove(_account: string, id: string) {
       removes.push(id);
+      if (failRemoves.has(id)) {
+        throw new Error("allowlist_remove failed");
+      }
+      effective.delete(id);
       return { type: "ack" };
     },
   } as unknown as AllowlistClient;
-  return { client, adds, removes };
+  return { client, adds, removes, effective };
 }
 
 describe("syncAllowlist", () => {
   it("adds missing hex welcomers and removes extras", async () => {
-    const { client, adds, removes } = stubAllowlist([HEX32("11"), HEX32("22")]);
+    const { client, adds, removes, effective } = stubAllowlist([HEX32("11"), HEX32("22")]);
     const result = await syncAllowlist(client, HEX32("aa"), [
       `0x${HEX32("22")}`,
       HEX32("33"),
@@ -37,14 +74,111 @@ describe("syncAllowlist", () => {
     ]);
     expect(adds).toEqual([HEX32("33")]);
     expect(removes).toEqual([HEX32("11")]);
-    expect(result).toEqual({ added: [HEX32("33")], removed: [HEX32("11")] });
+    expect(result).toEqual({
+      added: [HEX32("33")],
+      removed: [HEX32("11")],
+      failedAdds: [],
+      failedRemovals: [],
+      verified: true,
+    });
+    expect([...effective].sort()).toEqual([HEX32("22"), HEX32("33")].sort());
   });
 
   it("ignores non-hex allow entries", async () => {
     const { client, adds, removes } = stubAllowlist([]);
-    await syncAllowlist(client, HEX32("aa"), ["alice", "bob"]);
+    const result = await syncAllowlist(client, HEX32("aa"), ["alice", "bob"]);
     expect(adds).toEqual([]);
     expect(removes).toEqual([]);
+    expect(result.verified).toBe(true);
+  });
+
+  it("revokes before adding, so a failed addition cannot skip a revocation", async () => {
+    const stale = HEX32("11");
+    const fresh = HEX32("33");
+    const { client, removes, effective } = stubAllowlist([stale], { failAdds: [fresh] });
+
+    const result = await syncAllowlist(client, HEX32("aa"), [fresh]);
+
+    expect(removes).toEqual([stale]);
+    expect(effective.has(stale)).toBe(false);
+    expect(result.removed).toEqual([stale]);
+    expect(result.failedAdds).toEqual([fresh]);
+  });
+
+  it("keeps revoking after a failed revocation and still applies additions", async () => {
+    const stuck = HEX32("11");
+    const later = HEX32("22");
+    const fresh = HEX32("33");
+    const { client, removes, effective } = stubAllowlist([stuck, later], {
+      failRemoves: [stuck],
+    });
+
+    const result = await syncAllowlist(client, HEX32("aa"), [fresh]);
+
+    expect(removes).toEqual([stuck, later]);
+    expect(result.removed).toEqual([later]);
+    expect(result.failedRemovals).toEqual([stuck]);
+    expect(result.added).toEqual([fresh]);
+    expect([...effective].sort()).toEqual([stuck, fresh].sort());
+    expect(result.verified).toBe(false);
+  });
+
+  it("never reports an entry whose control-plane call failed", async () => {
+    const stuck = HEX32("11");
+    const fresh = HEX32("33");
+    const { client } = stubAllowlist([stuck], { failRemoves: [stuck], failAdds: [fresh] });
+
+    const result = await syncAllowlist(client, HEX32("aa"), [fresh]);
+
+    expect(result.removed).not.toContain(stuck);
+    expect(result.added).not.toContain(fresh);
+    expect(result.failedRemovals).toEqual([stuck]);
+    expect(result.failedAdds).toEqual([fresh]);
+    expect(result.verified).toBe(false);
+  });
+
+  it("reports read-back divergence as unverified even when every call succeeded", async () => {
+    const rogue = HEX32("44");
+    const { client } = stubAllowlist([], {
+      onReadBack: (effective) => {
+        effective.add(rogue); // another writer on the shared account
+      },
+    });
+
+    const result = await syncAllowlist(client, HEX32("aa"), [HEX32("33")]);
+
+    expect(result.added).toEqual([HEX32("33")]);
+    expect(result.failedAdds).toEqual([]);
+    expect(result.verified).toBe(false);
+  });
+
+  it("reports an unreadable effective set as unverified", async () => {
+    const { client } = stubAllowlist([], {
+      onReadBack: () => {
+        throw new Error("allowlist_list failed");
+      },
+    });
+
+    const result = await syncAllowlist(client, HEX32("aa"), [HEX32("33")]);
+
+    expect(result.added).toEqual([HEX32("33")]);
+    expect(result.verified).toBe(false);
+  });
+
+  it("propagates a failure to read the current allowlist before mutating anything", async () => {
+    const client = {
+      async allowlistList() {
+        throw new Error("allowlist_list failed");
+      },
+      async allowlistAdd() {
+        throw new Error("must not be called");
+      },
+      async allowlistRemove() {
+        throw new Error("must not be called");
+      },
+    } as unknown as AllowlistClient;
+
+    await expect(syncAllowlist(client, HEX32("aa"), [HEX32("33")])).rejects.toThrow();
   });
 });
 


### PR DESCRIPTION
Closes #1353.

## Problem

`syncAllowlist` ran additions before removals with every `await` unguarded, so one thrown addition aborted reconciliation before any revocation ran — a revoked welcomer stayed authorized on the shared `wn-agent` account while the function returned `{added, removed}` as if authoritative. Worse than the issue describes: the sole caller catches everything into one generic warning and starts inbound dispatch anyway, so a skipped revocation was indistinguishable from a config error.

## Fix

Removals run first, every entry is individually guarded, and the summary tells the truth: `added`/`removed` list only confirmed changes, `failedAdds`/`failedRemovals` carry the rest, and `verified` is true only when a read-back of the effective set (the existing `allowlist_list`, no new protocol surface) matches the desired set exactly. `syncAllowlist` no longer throws on per-entry failures — in this caller's error posture a throw is *less* visible than a dedicated log line — and `syncMarmotAllowlist` now warns specifically when revocations fail (counts only, no welcomer ids) and logs `synced` only on a verified reconciliation. Startup stays non-fatal; gating readiness on the summary is #1259, and the summary is shaped for it. Atomic replace, retry, and a source-of-truth toggle from the issue's wishlist are deliberately out of scope.

## Tests

Fail-first: seven of nine security tests fail on the old code, the headline (`revokes before adding, so a failed addition cannot skip a revocation`) failing exactly at the unguarded `allowlist_add` throw. The rewritten stub models wn-agent's authoritative set, so tests assert the final allowlist, not call counts: revocations survive failed additions and failed siblings, no entry is reported that failed, read-back divergence and an unreadable effective set both report unverified, and the caller's revocation warning is pinned id-free.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Allowlist synchronization now removes unauthorized entries before adding approved ones.
  * Failed additions or removals are reported clearly, while other reconciliation actions continue.
  * Synchronization verifies the effective allowlist after updates and reports incomplete results.
  * Startup continues when reconciliation cannot fully complete, with warnings for potential risks.

* **Bug Fixes**
  * Improved handling and reporting of failed allowlist revocations without exposing account identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->