### PR TITLE
Fix/honest engine error labels

### DIFF
--- a/crates/cgka-conformance-simulator/src/subject.rs
+++ b/crates/cgka-conformance-simulator/src/subject.rs
@@ -2369,6 +2369,20 @@ mod tests {
     }
 
     #[test]
+    fn an_admin_key_without_a_member_leaf_names_the_orphaned_member() {
+        // admin-policy-v1.md "Validation" refusals used to arrive as
+        // `EngineError::Other`, which this classifier can only call `other`.
+        // The engine now names the orphaned admin key, so the refusal carries
+        // its own verdict instead of the unclassified bucket's.
+        let (category, code) = classify_engine_error(&EngineError::UnknownMember {
+            group_id: cgka_traits::GroupId::new(vec![0xA5; 32]),
+            member: cgka_traits::MemberId::new(vec![0x11; 32]),
+        });
+        assert_eq!(category, SubjectFailureCategory::ExpectedRefusal);
+        assert_eq!(code, "unknown_member");
+    }
+
+    #[test]
     fn implicit_topology_preserves_legacy_client_identity_seeds() {
         let labels = vec!["alice".to_owned(), "bob".to_owned()];
         let subject = EngineHarnessSubject::new_with_topology(

--- a/crates/cgka-conformance-simulator/src/subject.rs
+++ b/crates/cgka-conformance-simulator/src/subject.rs
@@ -2382,6 +2382,35 @@ mod tests {
         assert_eq!(code, "unknown_member");
     }
 
+    #[tokio::test]
+    async fn admin_policy_naming_a_non_member_surfaces_unknown_member() {
+        // The classification-table pin above cannot see the harness funnel,
+        // and no vector can: `ScenarioErrorObservation` carries no category
+        // field, so `ExpectedRefusal` is only assertable here. On master this
+        // refusal surfaced as `Protocol`/`other`.
+        let labels = vec!["alice".to_owned(), "bob".to_owned(), "carol".to_owned()];
+        let mut subject = EngineHarnessSubject::new(
+            &labels,
+            ProtocolProfile::Current,
+            HarnessStorageMode::InMemorySqlite,
+        )
+        .expect("engine subject constructs");
+        // carol stays out of the group.
+        create_current_group_and_join(&mut subject, "alice", &labels[1..2]).await;
+
+        let error = subject
+            .update_admin_policy(SubjectUpdateAdminPolicy {
+                action_id: None,
+                client: "alice",
+                admins: &[labels[0].clone(), labels[2].clone()],
+                pending: None,
+            })
+            .await
+            .expect_err("an admin policy naming a non-member must be refused");
+        assert_eq!(error.category, SubjectFailureCategory::ExpectedRefusal);
+        assert_eq!(error.code, "unknown_member");
+    }
+
     #[test]
     fn implicit_topology_preserves_legacy_client_identity_seeds() {
         let labels = vec!["alice".to_owned(), "bob".to_owned()];

--- a/crates/cgka-conformance-simulator/src/subject.rs
+++ b/crates/cgka-conformance-simulator/src/subject.rs
@@ -2209,7 +2209,9 @@ fn observe_engine_error(error: &EngineError) -> String {
             "admin_policy"
         }
         EngineError::LeaveAlreadyRequested { .. } => "leave_already_requested",
-        EngineError::Serialize(_) => "invalid_admin_policy",
+        // Every decode failure the engine can reach, not an admin-policy
+        // verdict: `audit_helpers::engine_error_kind` names it the same way.
+        EngineError::Serialize(_) => "serialize",
         EngineError::InvalidWelcome => "invalid_welcome",
         EngineError::WelcomeAlreadyProcessed => "welcome_already_processed",
         EngineError::InvalidTransition(_) => "invalid_transition",
@@ -2352,11 +2354,18 @@ mod tests {
     }
 
     #[test]
-    fn serialization_failures_are_not_classified_as_expected_refusals() {
+    fn serialization_failures_report_an_encoding_fault_not_an_admin_policy_refusal() {
+        // `EngineError::Serialize` covers every decode failure the engine can
+        // reach — MLS payloads, trailing bytes, oversize lengths — and only a
+        // fraction of them ever touch an admin policy. Labelling all of them
+        // `invalid_admin_policy` reported a policy refusal for a wire fault,
+        // the inverse of the mislabelling #1523 fixed one layer down.
+        // `serialize` is the name `audit_helpers::engine_error_kind` already
+        // gives this verdict, so the two classifiers stay greppable together.
         let (category, code) =
             classify_engine_error(&EngineError::Serialize("malformed internal state".into()));
         assert_eq!(category, SubjectFailureCategory::Protocol);
-        assert_eq!(code, "invalid_admin_policy");
+        assert_eq!(code, "serialize");
     }
 
     #[test]

--- a/crates/cgka-engine/src/app_components.rs
+++ b/crates/cgka-engine/src/app_components.rs
@@ -593,7 +593,7 @@ fn credential_account_pubkey(cred: openmls::prelude::Credential) -> Option<[u8; 
 /// storage provider now wraps `merge_staged_commit` in a backend transaction.
 pub(crate) fn validate_admin_leaf_coupling_for_staged_commit(
     mls_group: &MlsGroup,
-    _group_id: &GroupId,
+    group_id: &GroupId,
     staged: &StagedCommit,
 ) -> Result<(), EngineError> {
     // Resulting admins come from the staged (provisional) app_data_dictionary, so
@@ -661,14 +661,14 @@ pub(crate) fn validate_admin_leaf_coupling_for_staged_commit(
         }
     }
 
-    if resulting_admins
+    if let Some(orphaned) = resulting_admins
         .iter()
-        .any(|admin| !accounts.contains(admin))
+        .find(|admin| !accounts.contains(*admin))
     {
-        return Err(EngineError::Other(
-            "admin-policy update is invalid: an admin key has no member leaf in the resulting epoch"
-                .into(),
-        ));
+        return Err(EngineError::UnknownMember {
+            group_id: group_id.clone(),
+            member: MemberId::new(orphaned.to_vec()),
+        });
     }
     Ok(())
 }
@@ -1335,16 +1335,32 @@ pub(crate) fn member_account_pubkeys(mls_group: &MlsGroup) -> BTreeSet<[u8; 32]>
 /// add/commit ingest), so the tree cannot carry an unvalidated member leaf here.
 /// The admin set (`decode_admin_policy`) is likewise length-only, so both sides
 /// of the coupling comparison share a basis.
+///
+/// The refusal is [`EngineError::UnknownMember`], naming the orphaned admin key:
+/// the account it names has no leaf in this group, which is exactly what that
+/// variant says, and it is already wired through the FFI
+/// (`MemberNotInGroup`), the CLI, the audit classifier and the conformance
+/// simulator. It used to be [`EngineError::Other`] — the unclassified bucket —
+/// which reported a policy refusal as a generic fault and threw away which key
+/// was at fault. [`validate_admin_leaf_coupling_for_staged_commit`] answers the
+/// same way, so the rule reads identically whether it fires on the authoring
+/// side or on ingest.
 pub(crate) fn reject_admins_without_member_accounts(
     admins: &[[u8; 32]],
     member_accounts: &BTreeSet<[u8; 32]>,
-    _group_id: &GroupId,
+    group_id: &GroupId,
 ) -> Result<(), EngineError> {
     if admins.is_empty() {
         return Ok(());
     }
-    if admins.iter().any(|admin| !member_accounts.contains(admin)) {
-        return Err(EngineError::Other("admin key has no member leaf".into()));
+    if let Some(orphaned) = admins
+        .iter()
+        .find(|admin| !member_accounts.contains(*admin))
+    {
+        return Err(EngineError::UnknownMember {
+            group_id: group_id.clone(),
+            member: MemberId::new(orphaned.to_vec()),
+        });
     }
     Ok(())
 }
@@ -1485,6 +1501,18 @@ pub(crate) fn encode_group_profile(name: &str, description: &str) -> Result<Vec<
     .map_err(EngineError::Other)
 }
 
+/// Encode an admin set as admin-policy-v1 component bytes.
+///
+/// The empty-set guard below is an encoder invariant, not a live policy
+/// refusal: no call site can reach it. Creation seeds the set with the creator
+/// (`group_lifecycle::do_create_group`), invite only encodes inside the
+/// non-empty-grants branch, disband passes the committer, and remove is guarded
+/// by an explicit [`EngineError::AdminDepletion`] check before it gets here
+/// (`message_processor::send`). MIP-03 §150 depletion arriving through an
+/// author-supplied payload is likewise refused upstream as `AdminDepletion` by
+/// [`admin_policy_is_empty`] (#1523). So this stays [`EngineError::Other`]:
+/// reaching it would be an engine bug, and dressing it as a policy verdict
+/// would claim a refusal no caller can actually provoke.
 pub(crate) fn encode_admin_policy(admins: &[[u8; 32]]) -> Result<Vec<u8>, EngineError> {
     let mut admins = admins.to_vec();
     admins.sort();
@@ -2018,7 +2046,7 @@ mod tests {
     }
 
     #[test]
-    fn admin_policy_validation_error_does_not_display_group_id() {
+    fn admin_policy_validation_error_names_the_orphaned_admin_without_displaying_ids() {
         let secret_group_id = GroupId::new(vec![0xA5; 32]);
         let error = reject_admins_without_member_accounts(
             &[[0x11; 32]],
@@ -2027,7 +2055,18 @@ mod tests {
         )
         .unwrap_err();
 
+        // The typed refusal carries both ids for callers that need them...
+        match &error {
+            EngineError::UnknownMember { group_id, member } => {
+                assert_eq!(group_id, &secret_group_id);
+                assert_eq!(member.as_slice(), [0x11; 32]);
+            }
+            other => panic!("expected UnknownMember, got {other:?}"),
+        }
+        // ...while the display string, which the audit log records verbatim,
+        // stays free of them.
         assert!(!error.to_string().contains(&hex::encode([0xA5; 32])));
+        assert!(!error.to_string().contains(&hex::encode([0x11; 32])));
     }
 
     #[test]

--- a/crates/cgka-engine/tests/group_creation.rs
+++ b/crates/cgka-engine/tests/group_creation.rs
@@ -793,10 +793,15 @@ async fn create_group_rejects_uninvited_initial_admin() {
         })
         .await
         .expect_err("an uninvited initial admin must be rejected");
-    assert!(
-        matches!(err, EngineError::Other(ref msg) if msg.contains("no member leaf")),
-        "expected admin-leaf-coupling rejection, got {err:?}"
-    );
+    // The refusal names the phantom admin rather than landing in
+    // `EngineError::Other`, the unclassified bucket that gave this policy
+    // refusal a generic fault's shape at every surface downstream.
+    match err {
+        EngineError::UnknownMember { member, .. } => {
+            assert_eq!(member, mallory.self_id());
+        }
+        other => panic!("expected UnknownMember naming mallory, got {other:?}"),
+    }
 }
 
 /// mdk#737 review: an `initial_admins` entry that is 32 bytes but not a valid

--- a/crates/cgka-engine/tests/update_group_data.rs
+++ b/crates/cgka-engine/tests/update_group_data.rs
@@ -1242,16 +1242,26 @@ async fn admin_policy_update_listing_non_member_is_rejected() {
 
     let err = alice
         .send(SendIntent::UpdateAppComponents {
-            group_id: gid,
+            group_id: gid.clone(),
             updates: vec![AppComponentData {
                 component_id: GROUP_ADMIN_POLICY_COMPONENT_ID,
-                data: encode_admin_policy_for_test(&[alice_id, carol_non_member]),
+                data: encode_admin_policy_for_test(&[alice_id, carol_non_member.clone()]),
             }],
         })
         .await
         .expect_err("admin-policy listing a non-member must be rejected");
 
-    assert!(matches!(err, EngineError::Other(_)), "got {err:?}");
+    // The refusal names the orphaned admin key. `EngineError::Other` — the old
+    // verdict — is the unclassified bucket, so hosts, the CLI, the audit log
+    // and the conformance simulator all saw this policy refusal as a generic
+    // fault and could not say which key was at fault.
+    match err {
+        EngineError::UnknownMember { group_id, member } => {
+            assert_eq!(group_id, gid);
+            assert_eq!(member.as_slice(), carol_non_member.as_slice());
+        }
+        other => panic!("expected UnknownMember naming carol, got {other:?}"),
+    }
 }
 
 // ── Partial update ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

Two error paths reported fused verdicts — the same class #1523 fixed for the empty admin
policy. The conformance simulator labelled **every** `EngineError::Serialize` as
`invalid_admin_policy`, so MLS decode failures and torn bytes reported as admin-policy
refusals; its own test pinned the fusion under a name that said the opposite. And the
admin-leaf coupling rule ("admin key has no member leaf") returned `EngineError::Other`
at both of its seams, labelling a policy refusal `"other"` — indistinguishable from a
generic fault, at either of two message strings depending on which side of the wire fired.

## Fix

`Serialize` now labels `serialize`, the name the audit classifier already uses for this
variant, so the two classification tables grep together. The coupling refusal is typed
`EngineError::UnknownMember` at both seams — it displays "member is not in the group",
carries the offending key that `Other(String)` discarded, and is already wired through
FFI, CLI, audit, and simulator, so no error surface changes and no bindings regenerate.
`encode_admin_policy`'s "at least one admin" check turned out unreachable (every caller
guarantees a non-empty slice, one via #1523's `AdminDepletion` guard) and is documented as
an encoder invariant rather than typed as a refusal no caller can provoke.

No committed vector, manifest entry, or SCENARIOS.md line referenced the old labels —
`canonical_scenarios` passes unchanged, and no `conformance_version` moves.

## Tests

The fused pin is rewritten as
`serialization_failures_report_an_encoding_fault_not_an_admin_policy_refusal` (red on the
old code: `left: "invalid_admin_policy"`), both engine refusal tests now assert the typed
error naming the orphaned key (red: `got Other(...)`), and two new tests pin the
simulator label and the typed refusal end to end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved admin-policy validation by reporting orphaned or non-member administrators as `unknown_member` errors.
  * Error details now identify the affected group and administrator while protecting sensitive information.
  * Serialization failures are now correctly classified as `serialize` protocol errors.
* **Tests**
  * Expanded coverage for group creation, group updates, orphaned administrators, and serialization error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->