### PR TITLE
Separate directory discovery from operational relays

### DIFF
--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -9,6 +9,12 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ## [Unreleased]
 
+### Added
+
+- Daemon-hosted directory and KeyPackage reads now honor configured discovery
+  relays independently from the operational relay set used for message
+  delivery.
+
 ## [0.9.14] - 2026-08-19
 
 ### Added

--- a/crates/cli/src/daemon/runtime_host.rs
+++ b/crates/cli/src/daemon/runtime_host.rs
@@ -169,6 +169,7 @@ async fn dispatch_hosted_runtime_command(
     let app = match crate::app_for(
         defaults.home.clone(),
         defaults.relay.clone(),
+        defaults.discovery_relays.clone(),
         account_home.clone(),
     ) {
         Ok(app) => app,
@@ -563,7 +564,12 @@ pub(crate) fn open_app_runtime(
     let secret_store = crate::resolve_secret_store(defaults.secret_store)?;
     let keychain_service = crate::resolve_keychain_service(defaults.keychain_service.clone());
     let account_home = crate::open_account_home(&defaults.home, secret_store, &keychain_service)?;
-    let app = crate::app_for(defaults.home.clone(), defaults.relay.clone(), account_home)?;
+    let app = crate::app_for(
+        defaults.home.clone(),
+        defaults.relay.clone(),
+        defaults.discovery_relays.clone(),
+        account_home,
+    )?;
     Ok(app.runtime())
 }
 
@@ -721,6 +727,7 @@ pub(crate) async fn auto_watch_agent_stream_starts(
     let app = match crate::app_for(
         defaults.home.clone(),
         defaults.relay.clone(),
+        defaults.discovery_relays.clone(),
         account_home.clone(),
     ) {
         Ok(app) => app,

--- a/crates/cli/src/daemon/stream_workers.rs
+++ b/crates/cli/src/daemon/stream_workers.rs
@@ -117,6 +117,7 @@ pub(crate) async fn start_stream_watch(
     let app = match crate::app_for(
         defaults.home.clone(),
         defaults.relay.clone(),
+        defaults.discovery_relays.clone(),
         account_home.clone(),
     ) {
         Ok(app) => app,

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -493,6 +493,7 @@ async fn execute_inner(
             .clone()
             .or_else(|| cli.daemon_discovery_relays.first().cloned())
             .or_else(|| cli.daemon_default_account_relays.first().cloned()),
+        cli.daemon_discovery_relays.clone(),
         account_home.clone(),
     )?;
     match command {
@@ -1113,6 +1114,7 @@ pub(crate) fn relay_lists_json(status: AccountRelayListStatus) -> Value {
 fn app_for(
     home: PathBuf,
     relay: Option<String>,
+    directory_relays: Vec<String>,
     account_home: AccountHome,
 ) -> Result<MarmotApp, WnError> {
     // Loopback-HTTP blob endpoints are only acted on when explicitly enabled for
@@ -1121,7 +1123,8 @@ fn app_for(
     // installs leave it unset.
     let mut config = MarmotAppConfig::default()
         .with_allow_loopback_blob_endpoints(wn_allow_loopback_blob_endpoints())
-        .with_allow_loopback_relay_endpoints(wn_allow_loopback_relays());
+        .with_allow_loopback_relay_endpoints(wn_allow_loopback_relays())
+        .with_directory_relay_urls(directory_relays);
     // Explicit test builds only: WN_DEV_SETTLEMENT_QUIESCENCE_MS overrides the
     // pinned convergence settlement window (e.g. `0` for integration tests).
     if let Some(ms) = wn_dev_settlement_quiescence_ms()? {

--- a/crates/cli/tests/cli.rs
+++ b/crates/cli/tests/cli.rs
@@ -5564,6 +5564,64 @@ fn daemon_executes_cli_commands_over_socket() {
 }
 
 #[test]
+fn daemon_uses_discovery_relays_independently_from_operational_relays() {
+    let discovery_relay = TestRelay::new();
+    let operational_relay = TestRelay::new();
+    let bob_home = tempfile::tempdir().expect("bob tempdir");
+    let bob = create_account_with_real_relay(bob_home.path(), discovery_relay.url());
+    run_json_with_relay(
+        bob_home.path(),
+        discovery_relay.url(),
+        &["--account", &bob, "keys", "rotate"],
+    );
+
+    let alice_home = tempfile::tempdir().expect("alice tempdir");
+    let alice = create_account_with_real_relay(alice_home.path(), discovery_relay.url());
+    let socket = alice_home.path().join("dev").join("wnd.sock");
+    let mut child = Command::new(env!("CARGO_BIN_EXE_wnd"))
+        .arg("--home")
+        .arg(alice_home.path())
+        .arg("--socket")
+        .arg(&socket)
+        .arg("--relay")
+        .arg(operational_relay.url())
+        .arg("--discovery-relays")
+        .arg(discovery_relay.url())
+        .arg("--default-account-relays")
+        .arg(operational_relay.url())
+        .arg("--secret-store")
+        .arg("file")
+        .env("WN_ALLOW_LOOPBACK_RELAYS", "1")
+        .spawn()
+        .expect("wnd should start");
+    wait_for_daemon(&socket);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_wn"))
+        .arg("--socket")
+        .arg(&socket)
+        .arg("--account")
+        .arg(&alice)
+        .arg("--json")
+        .args(["keys", "fetch", &bob])
+        .output()
+        .expect("wn keys fetch should run through daemon");
+
+    stop_daemon(&socket, &mut child);
+    assert!(
+        output.status.success(),
+        "daemon-hosted discovery failed\n{}",
+        command_output_summary(&output)
+    );
+    let value: Value = serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
+    assert_eq!(value["result"]["account_id"], bob);
+    assert_eq!(
+        value["result"]["source_relays"],
+        serde_json::json!([discovery_relay.url()]),
+        "KeyPackage discovery must not fall back to the operational relay"
+    );
+}
+
+#[test]
 #[cfg(unix)]
 fn daemon_socket_path_is_private() {
     let home = tempfile::tempdir().expect("tempdir");

--- a/crates/marmot-app/src/config.rs
+++ b/crates/marmot-app/src/config.rs
@@ -50,6 +50,14 @@ pub enum CursorPersistence {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MarmotAppConfig {
     pub directory_max_future_skew: Duration,
+    /// Host-configured WebSocket relays used for Nostr directory reads such as
+    /// relay-list and KeyPackage discovery.
+    ///
+    /// These are deliberately separate from the app's operational relay URLs,
+    /// allowing a host to use different relay sets for discovery and message
+    /// delivery. Empty preserves the historical behavior of falling back to
+    /// the operational relay set.
+    pub directory_relay_urls: Vec<String>,
     pub service_endpoints: MarmotServiceEndpoints,
     /// Durable transport-cursor persistence policy. Defaults to
     /// [`CursorPersistence::Advance`]; wake-collection runtimes (NSE,
@@ -170,6 +178,7 @@ impl Default for MarmotAppConfig {
     fn default() -> Self {
         Self {
             directory_max_future_skew: DEFAULT_DIRECTORY_MAX_FUTURE_SKEW,
+            directory_relay_urls: Vec::new(),
             service_endpoints: MarmotServiceEndpoints::compiled(),
             cursor_persistence: CursorPersistence::Advance,
             allow_loopback_blob_endpoints: false,
@@ -192,6 +201,12 @@ impl Default for MarmotAppConfig {
 impl MarmotAppConfig {
     pub fn with_directory_max_future_skew(mut self, skew: Duration) -> Self {
         self.directory_max_future_skew = skew;
+        self
+    }
+
+    /// Configure relays used only for Nostr directory and KeyPackage reads.
+    pub fn with_directory_relay_urls(mut self, relay_urls: Vec<String>) -> Self {
+        self.directory_relay_urls = relay_urls;
         self
     }
 

--- a/crates/marmot-app/src/directory/methods.rs
+++ b/crates/marmot-app/src/directory/methods.rs
@@ -860,6 +860,15 @@ impl MarmotApp {
         if !source_relays.is_empty() {
             return source_relays.to_vec();
         }
+        if !self.config.directory_relay_urls.is_empty() {
+            return self
+                .config
+                .directory_relay_urls
+                .iter()
+                .cloned()
+                .map(TransportEndpoint)
+                .collect();
+        }
         self.relay_endpoints()
     }
 

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -4276,6 +4276,34 @@ async fn key_package_deletion_routes_endpoints_through_relay_safety_policy() {
     );
 }
 
+#[test]
+fn configured_directory_relays_stay_separate_from_operational_relays() {
+    let directory = tempfile::tempdir().unwrap();
+    let operational = "wss://operational.example";
+    let discovery = "wss://directory.example";
+    let explicit = TransportEndpoint("wss://explicit.example".into());
+    let app = MarmotApp::with_relays_and_config(
+        directory.path(),
+        vec![operational.into()],
+        MarmotAppConfig::default().with_directory_relay_urls(vec![discovery.into()]),
+    );
+
+    assert_eq!(
+        app.relay_endpoints(),
+        vec![TransportEndpoint(operational.into())],
+        "directory configuration must not widen operational publication fanout"
+    );
+    assert_eq!(
+        app.directory_source_relays(&[]),
+        vec![TransportEndpoint(discovery.into())]
+    );
+    assert_eq!(
+        app.directory_source_relays(std::slice::from_ref(&explicit)),
+        vec![explicit],
+        "per-operation discovery relays must retain precedence"
+    );
+}
+
 #[tokio::test]
 async fn key_package_cutover_retains_current_cache_without_scheduling_replacement() {
     let directory = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

- add host-configured directory relay URLs to `MarmotAppConfig`
- preserve explicit per-operation relay precedence, then use configured directory relays, then fall back to operational relays
- pass daemon discovery relays through every CLI-created `MarmotApp`
- cover the separation with app-level and two-relay daemon KeyPackage regressions

## Why

Directory and KeyPackage discovery currently fall back to the operational message-delivery relay set. Hosts that deliberately separate those planes can therefore create a daemon runtime with the right delivery relays while remote-member KeyPackage lookup uses the wrong relay. This makes the two relay roles independently configurable without changing the historical empty-config fallback.

## Verification

- `just fast-ci`
- `cargo test -p marmot-app configured_directory_relays_stay_separate_from_operational_relays`
- `cargo test -p wn-cli daemon_uses_discovery_relays_independently_from_operational_relays`

I also ran the complete `marmot-app` and `wn-cli` suites. They exposed existing failures outside this change. Representative failures were rerun individually and reproduced on an untouched `origin/master` worktree:

- `marmot-app`: `encrypted_media_endpoint_updates_are_full_replacement_and_admin_only`
- `wn-cli`: `daemon_defaults_create_identities_and_block_loopback_auto_watch_without_manual_sync_or_relay_env`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring dedicated discovery relays for directory and KeyPackage lookups.
  - Discovery relays can now be managed independently from operational message-delivery relays.
  - Explicitly provided discovery relays take precedence, with fallback to operational relays when none are configured.

- **Bug Fixes**
  - Daemon-hosted directory and KeyPackage reads now consistently use the configured discovery relays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->