### PR TITLE
chore: ignore LLVM coverage profraw files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ __pycache__/
 # Rust build outputs at any workspace depth
 target/
 
+# LLVM coverage instrumentation output (cargo llvm-cov, -Cinstrument-coverage)
+*.profraw
+
 plans/
 reviews/
 


### PR DESCRIPTION
Instrumented builds (e.g. `cargo llvm-cov`, `-Cinstrument-coverage`) drop `default.profraw` into the repo root when test binaries run, leaving an untracked artifact in `git status`. Delete the stray file and add `*.profraw` to `.gitignore`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project ignore rules to exclude LLVM coverage output files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->