### PR TITLE
fix(openclaw): use host-authorized reader for outbound media

### DIFF
--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -5121,7 +5121,10 @@ async fn app_runtime_starts_directory_subscriptions_for_known_users() {
         loop {
             let health = runtime.shared_services().relay_plane().relay_health().await;
             if health.directory_active_subscriptions == 1
-                && health.directory_completed_subscription_syncs == 1
+                // A relay recovery can legitimately complete another rebuild
+                // before this poll observes the initial one. This counter is
+                // monotonic, so waiting for exact equality races that recovery.
+                && health.directory_completed_subscription_syncs >= 1
             {
                 break health;
             }
@@ -5131,7 +5134,7 @@ async fn app_runtime_starts_directory_subscriptions_for_known_users() {
     .await
     .expect("directory subscriptions should complete asynchronously");
     assert_eq!(health.directory_active_subscriptions, 1);
-    assert_eq!(health.directory_completed_subscription_syncs, 1);
+    assert!(health.directory_completed_subscription_syncs >= 1);
     runtime.shutdown().await;
 }
 

--- a/integrations/openclaw/marmot/AGENTS.md
+++ b/integrations/openclaw/marmot/AGENTS.md
@@ -13,6 +13,12 @@ The OpenClaw counterpart of `integrations/hermes/marmot`. Read `README.md` first
 - No QUIC, crypto, relay, or MLS logic here.
 - Privacy-safe logging only: no account ids, group ids, message ids, pubkeys,
   relay URLs, payloads, ciphertext, plaintext, or key material.
+- Runtime agents send media through OpenClaw's normal `message` tool with
+  `media`/`attachments`, using files beneath the active workspace or an
+  OpenClaw-managed media store; data URLs are unsupported. Treat the host's
+  media reader as source authorization and `wn-agent --media-allowed-root` as
+  independent staging authorization. Direct control-client `sendMedia()` calls
+  are for connector tests and smoketests only.
 
 ## Key files
 

--- a/integrations/openclaw/marmot/README.md
+++ b/integrations/openclaw/marmot/README.md
@@ -21,6 +21,17 @@ Repeating a removal is idempotent. Reaction content follows the
 agent-control v2 bound: non-blank, control-free, and at most 64 Unicode scalar
 values.
 
+Agents send outbound media through OpenClaw's normal
+`message(action="send", channel="marmot", media=..., attachments=...)` interface.
+Generated files must be placed under the active agent workspace or an
+OpenClaw-managed media store; data URLs are not supported. OpenClaw's
+host-provided media reader is the source authorization boundary. The plugin
+stages the authorized bytes as a private, short-lived copy under
+`MARMOT_OUTBOUND_MEDIA_DIR`, while `wn-agent --media-allowed-root` independently
+authorizes that staging path before encrypting and uploading it. Direct
+`MarmotAgentControlClient.sendMedia()` calls are reserved for connector tests
+and smoketests, not runtime agents.
+
 For each activated inbound turn, the plugin asks `wn-agent` for a bounded recent
 materialized chat window and supplies it to OpenClaw with durable message ids,
 senders, timestamps, reply links, current reaction summaries, and
@@ -309,14 +320,15 @@ for any plugin or tenant that is not in the same trust boundary.
   a host-local decrypted path and passes it to the turn as an OpenClaw
   `InboundMediaFacts` (`{ path, contentType, kind }`), which OpenClaw
   base64-encodes for a vision model. Outbound — the message adapter declares
-  `media` and maps an agent reply's `mediaUrl` (resolved to a local path via
-  `mediaReadFile` when needed) onto `send_media`. The adapter retains OpenClaw's
-  local-root check, stages a short-lived copy under `MARMOT_OUTBOUND_MEDIA_DIR`,
-  and cleans it up after the response; `wn-agent` independently requires that
-  path beneath a startup `--media-allowed-root` and rejects symlinks and
-  non-regular files. `wn-agent` encrypts + uploads to Blossom; the content key
-  never leaves it. The vision model actually
-  receiving the image is confirmed on the docker harness.
+  `media` and maps an agent reply's `mediaUrl` onto `send_media`. It prefers the
+  running host's authorized `mediaReadFile` capability for every source,
+  including local paths, and uses connector-side local-root validation only as
+  a fallback when the host provides no reader. The adapter stages a short-lived
+  copy under `MARMOT_OUTBOUND_MEDIA_DIR` and cleans it up after success or
+  failure; `wn-agent` independently requires that path beneath a startup
+  `--media-allowed-root` and rejects symlinks and non-regular files. `wn-agent`
+  encrypts + uploads to Blossom; the content key never leaves it. The vision
+  model actually receiving the image is confirmed on the docker harness.
 - **Live QUIC previews** (`src/live.ts`) are temporarily not wired into inbound
   agent turns. Those turns are final-only so durable delivery has one owner: the
   registered OpenClaw message adapter. The transcript and preview primitives

--- a/integrations/openclaw/marmot/src/outbound.ts
+++ b/integrations/openclaw/marmot/src/outbound.ts
@@ -10,7 +10,7 @@
 import { randomUUID } from "node:crypto";
 import { chmod, mkdir, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { basename, extname, join } from "node:path";
+import { basename, extname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
@@ -25,6 +25,7 @@ import {
 // `latest` and `beta` OpenClaw channels. The `plugin-sdk/media-runtime` barrel
 // dropped `assertLocalMediaAllowed`/`getDefaultLocalRoots` in 2026.7.2-beta.
 import { readLocalFileFromRoots } from "openclaw/plugin-sdk/infra-runtime";
+import { extractOriginalFilename, getMediaDir } from "openclaw/plugin-sdk/media-runtime";
 import { getDefaultLocalRoots, LocalMediaAccessError } from "openclaw/plugin-sdk/web-media";
 
 import type { AgentControlMediaUpload, MarmotAgentControlClient } from "./client.js";
@@ -50,6 +51,8 @@ export interface MarmotMessageAdapterDeps {
   writeTempMedia?: (fileName: string, bytes: Buffer) => Promise<string>;
   /** Override the connector-shared outbound staging directory (tests/deployments). */
   outboundMediaDir?: string;
+  /** Override the staged-file permission adjustment (tests). */
+  chmodTempMedia?: (path: string, mode: number) => Promise<void>;
 }
 
 /** Build an OpenClaw `MessageReceipt` from wn-agent's durable message ids. */
@@ -169,6 +172,18 @@ function isLocalMediaUrl(mediaUrl: string): boolean {
   return !/^[a-z][a-z0-9+.-]*:\/\//i.test(mediaUrl);
 }
 
+/** Restore a caller-facing name when OpenClaw has staged a buffer in its media store. */
+function localMediaFileName(localPath: string): string {
+  const storedName = basename(localPath) || "attachment";
+  const mediaRelativePath = relative(resolve(getMediaDir()), resolve(localPath));
+  const isManagedMedia =
+    mediaRelativePath === "" ||
+    (mediaRelativePath !== ".." &&
+      !mediaRelativePath.startsWith(`..${sep}`) &&
+      !isAbsolute(mediaRelativePath));
+  return isManagedMedia ? extractOriginalFilename(storedName) : storedName;
+}
+
 /**
  * A resolved outbound media upload plus cleanup for the private copy staged in
  * the connector-shared outbound directory.
@@ -234,7 +249,7 @@ async function resolveOutboundMediaUpload(
   if (mediaReadFile) {
     const bytes = await mediaReadFile(mediaUrl);
     const fileName = localPath
-      ? basename(localPath) || "attachment"
+      ? localMediaFileName(localPath)
       : basename(new URL(mediaUrl).pathname) || "attachment";
     const path = await writeTempMedia(fileName, bytes);
     return {
@@ -263,7 +278,7 @@ async function resolveOutboundMediaUpload(
         "marmot: outbound media is not readable from the allowed local media roots",
       );
     }
-    const fileName = basename(localPath) || "attachment";
+    const fileName = localMediaFileName(localPath);
     const path = await writeTempMedia(fileName, read.buffer);
     return {
       upload: { path, media_type: mimeFromExtension(fileName), file_name: fileName },
@@ -285,12 +300,20 @@ async function defaultWriteTempMedia(
   fileName: string,
   bytes: Buffer,
   outboundMediaDir = defaultOutboundMediaDir(),
+  chmodTempMedia: (path: string, mode: number) => Promise<void> = chmod,
 ): Promise<string> {
   await mkdir(outboundMediaDir, { recursive: true, mode: 0o700 });
   const safeName = basename(fileName || "attachment") || "attachment";
   const path = join(outboundMediaDir, `${randomUUID()}-${safeName}`);
   await writeFile(path, bytes, { flag: "wx", mode: 0o640 });
-  await chmod(path, 0o640);
+  try {
+    await chmodTempMedia(path, 0o640);
+  } catch (error) {
+    // Do not strand plaintext if the split-user permission adjustment fails
+    // before resolution can return its normal cleanup callback.
+    await rm(path, { force: true }).catch(() => undefined);
+    throw error;
+  }
   return path;
 }
 
@@ -306,7 +329,7 @@ export function createMarmotMessageAdapter(deps: MarmotMessageAdapterDeps) {
   const writeTempMedia =
     deps.writeTempMedia ??
     ((fileName: string, bytes: Buffer) =>
-      defaultWriteTempMedia(fileName, bytes, deps.outboundMediaDir));
+      defaultWriteTempMedia(fileName, bytes, deps.outboundMediaDir, deps.chmodTempMedia));
   // Lives in the adapter closure: maps each durable message id we return back to
   // the account+group it was sent to, so an agent delete can be routed by id.
   const sentTargets = new SentMessageTargetCache();

--- a/integrations/openclaw/marmot/src/outbound.ts
+++ b/integrations/openclaw/marmot/src/outbound.ts
@@ -179,13 +179,13 @@ export interface ResolvedOutboundMediaUpload {
 }
 
 /**
- * Resolve the allowlist of local roots an outbound local-path send is confined
- * to. OpenClaw hands the channel the approved roots on the send ctx
- * (`mediaLocalRoots`, or `mediaAccess.localRoots`); when neither is present we
- * fall back to OpenClaw's default media-store roots. We never honor a `"any"`
- * sentinel here: the gateway reads and stages the source, so an unrestricted
- * source root would reintroduce the arbitrary-file-read this guard exists to
- * close. An empty configured allowlist means "nothing is allowed".
+ * Resolve the fallback allowlist used when an outbound local-path send has no
+ * host-provided reader. OpenClaw hands the channel the approved roots on the
+ * send ctx (`mediaLocalRoots`, or `mediaAccess.localRoots`); when neither is
+ * present we fall back to OpenClaw's default media-store roots. We never honor
+ * a `"any"` sentinel here: the gateway reads and stages the source, so an
+ * unrestricted source root would reintroduce the arbitrary-file-read this guard
+ * exists to close. An empty configured allowlist means "nothing is allowed".
  */
 function resolveAllowedMediaRoots(ctx: ChannelMessageSendMediaContext): readonly string[] {
   const configured = ctx.mediaLocalRoots ?? ctx.mediaAccess?.localRoots;
@@ -196,32 +196,53 @@ function resolveAllowedMediaRoots(ctx: ChannelMessageSendMediaContext): readonly
  * Resolve `ctx.mediaUrl` to a local `AgentControlMediaUpload` the connector can
  * read by path. Handles two cases the ctx can express with the real SDK types:
  *
- * 1. A local filesystem path or `file://` URL — read only through the send's
- *    allowlisted media roots (`readLocalFileFromRoots`), then copied to the
- *    connector-shared staging root. Without the source guard
+ * 1. Any source with a host-provided `mediaReadFile` accessor — read through
+ *    that already-authorized host capability and copied to the connector-
+ *    shared staging root. This includes local paths: the running host owns the
+ *    active agent's media policy, which may differ from this connector's pinned
+ *    SDK defaults.
+ * 2. A local filesystem path or `file://` URL with no host accessor — read only
+ *    through the send's allowlisted media roots (`readLocalFileFromRoots`), then
+ *    copied to the connector-shared staging root. Without the source guard
  *    an agent-influenced `mediaUrl` (e.g. `~/.ssh/id_rsa`) would let a prompt-
  *    injected agent exfiltrate any connector-host file into a group. This
  *    mirrors the inbound trust model, where downloaded media is re-staged under
  *    an allowlisted root before the agent's image tool can read it.
- * 2. A non-local URL with a `mediaReadFile` host accessor — the bytes are read
- *    through that already-authorized host reader and staged the same way.
  *
  * Returns `null` when the ctx provides only a remote URL and no buffer accessor;
  * the connector reads a path it cannot be given in that case (see Seam 2 note).
  *
- * Throws `LocalMediaAccessError` (from the SDK) when a local path cannot be read
- * from the allowlisted roots; the caller surfaces that as a failed send. A path
- * outside the roots is never opened — the allowlist check and the read are the
- * same operation — but the error does not distinguish that from an in-root read
- * failure, so treat it as "refused", not specifically "escaped the allowlist".
+ * When the host reader is absent, throws `LocalMediaAccessError` (from the SDK)
+ * if a local path cannot be read from the allowlisted roots; the caller surfaces
+ * that as a failed send. A path outside the roots is never opened — the allowlist
+ * check and the read are the same operation — but the error does not distinguish
+ * that from an in-root read failure, so treat it as "refused", not specifically
+ * "escaped the allowlist". Errors from a host reader propagate unchanged.
  */
 async function resolveOutboundMediaUpload(
   ctx: ChannelMessageSendMediaContext,
   writeTempMedia: (fileName: string, bytes: Buffer) => Promise<string>,
 ): Promise<ResolvedOutboundMediaUpload | null> {
   const { mediaUrl } = ctx;
-  if (isLocalMediaUrl(mediaUrl)) {
-    const localPath = mediaUrl.startsWith("file://") ? fileURLToPath(mediaUrl) : mediaUrl;
+  const local = isLocalMediaUrl(mediaUrl);
+  const localPath = local
+    ? mediaUrl.startsWith("file://")
+      ? fileURLToPath(mediaUrl)
+      : mediaUrl
+    : undefined;
+  const mediaReadFile = ctx.mediaReadFile ?? ctx.mediaAccess?.readFile;
+  if (mediaReadFile) {
+    const bytes = await mediaReadFile(mediaUrl);
+    const fileName = localPath
+      ? basename(localPath) || "attachment"
+      : basename(new URL(mediaUrl).pathname) || "attachment";
+    const path = await writeTempMedia(fileName, bytes);
+    return {
+      upload: { path, media_type: mimeFromExtension(fileName), file_name: fileName },
+      cleanup: () => rm(path, { force: true }),
+    };
+  }
+  if (localPath) {
     // Defense against exfiltration via a tool/prompt-influenced path: the read
     // itself is confined to the allowlisted roots, so a path outside them is
     // never opened. Keep OpenClaw's source policy as the first layer; wn-agent
@@ -244,16 +265,6 @@ async function resolveOutboundMediaUpload(
     }
     const fileName = basename(localPath) || "attachment";
     const path = await writeTempMedia(fileName, read.buffer);
-    return {
-      upload: { path, media_type: mimeFromExtension(fileName), file_name: fileName },
-      cleanup: () => rm(path, { force: true }),
-    };
-  }
-  const mediaReadFile = ctx.mediaReadFile;
-  if (mediaReadFile) {
-    const bytes = await mediaReadFile(mediaUrl);
-    const fileName = basename(new URL(mediaUrl).pathname) || "attachment";
-    const path = await writeTempMedia(fileName, bytes);
     return {
       upload: { path, media_type: mimeFromExtension(fileName), file_name: fileName },
       cleanup: () => rm(path, { force: true }),

--- a/integrations/openclaw/marmot/test/openclaw-host-compat.sh
+++ b/integrations/openclaw/marmot/test/openclaw-host-compat.sh
@@ -31,6 +31,7 @@ cp "$plugin_dir/tsconfig.build.json" "$compat_root/"
 cp "$plugin_dir/vitest.config.ts" "$compat_root/"
 cp "$plugin_dir/index.ts" "$compat_root/"
 cp "$plugin_dir/setup-entry.ts" "$compat_root/"
+cp "$plugin_dir/openclaw.plugin.json" "$compat_root/"
 cp -R "$plugin_dir/src" "$compat_root/"
 cp -R "$plugin_dir/test" "$compat_root/"
 

--- a/integrations/openclaw/marmot/test/openclaw-host-contract.test.ts
+++ b/integrations/openclaw/marmot/test/openclaw-host-contract.test.ts
@@ -1,4 +1,15 @@
+import { createServer, type Server, type Socket } from "node:net";
+import { access, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Deliberate test-only internal import: OpenClaw exposes neither its plugin
+// loader nor generic message-action runner through a supported SDK subpath.
+// Re-verify this stable loader entry whenever the pinned SDK is bumped.
+import * as openClawPluginLoader from "../node_modules/openclaw/dist/plugins/loader.js";
 
 import type { AgentControlEvent, MarmotAgentControlClient } from "../src/client.js";
 import { createMarmotChannelPlugin } from "../src/channel.js";
@@ -15,10 +26,189 @@ import type { MarmotInboundMessage } from "../src/inbound.js";
 import { resetMarmotInboundRuntimeForTests } from "../src/runtime-state.js";
 
 const HEX32 = (byte: string): string => byte.repeat(32);
+const PROTOCOL = "marmot.agent-control.v2";
+
+interface RecordedMediaSend {
+  request: Record<string, unknown>;
+  stagedPath: string;
+  stagedBytes: Buffer;
+}
+
+type RunMessageAction = (input: {
+  cfg: unknown;
+  action: "send";
+  params: Record<string, unknown>;
+  agentId: string;
+  senderIsOwner: boolean;
+}) => Promise<unknown>;
+
+/** Load the installed host's private action runner without pinning its hashed chunk name. */
+async function loadInstalledRunMessageAction(): Promise<RunMessageAction> {
+  const distDir = join(import.meta.dirname, "..", "node_modules", "openclaw", "dist");
+  const runnerFile = (await readdir(distDir)).find(
+    (entry) => entry.startsWith("message-action-runner-") && entry.endsWith(".js"),
+  );
+  if (!runnerFile) {
+    throw new Error("installed OpenClaw has no message-action runner chunk");
+  }
+  const module = (await import(pathToFileURL(join(distDir, runnerFile)).href)) as Record<
+    string,
+    unknown
+  >;
+  const runner = Object.values(module).find(
+    (value) => typeof value === "function" && value.name === "runMessageAction",
+  );
+  if (!runner) {
+    throw new Error("installed OpenClaw message-action runner export was not found");
+  }
+  return runner as RunMessageAction;
+}
+
+function sendControlResponse(
+  socket: Socket,
+  id: unknown,
+  payload: Record<string, unknown>,
+): void {
+  socket.write(`${JSON.stringify({ marmot_agent_control: PROTOCOL, id, ...payload })}\n`);
+}
+
+/** Minimal wn-agent socket that records the staged media while it still exists. */
+function startMediaControlServer(
+  socketPath: string,
+  recorded: RecordedMediaSend[],
+): Promise<Server> {
+  const server = createServer((socket) => {
+    let pending = Buffer.alloc(0);
+    socket.on("data", (chunk) => {
+      pending = Buffer.concat([pending, chunk]);
+      let newline = pending.indexOf(0x0a);
+      while (newline !== -1) {
+        const line = pending.subarray(0, newline);
+        pending = pending.subarray(newline + 1);
+        if (line.length > 0) {
+          const request = JSON.parse(line.toString("utf8")) as Record<string, unknown>;
+          void (async () => {
+            if (request.type !== "send_media") {
+              sendControlResponse(socket, request.id, {
+                type: "error",
+                code: "unexpected_request",
+                message: `unexpected request: ${String(request.type)}`,
+              });
+              return;
+            }
+            const attachment = (request.attachments as Array<Record<string, unknown>>)[0]!;
+            const stagedPath = String(attachment.path);
+            recorded.push({
+              request,
+              stagedPath,
+              stagedBytes: await readFile(stagedPath),
+            });
+            sendControlResponse(socket, request.id, {
+              type: "final_sent",
+              message_ids_hex: [HEX32("11")],
+            });
+          })().catch((error: unknown) => socket.destroy(error as Error));
+        }
+        newline = pending.indexOf(0x0a);
+      }
+    });
+    socket.on("error", () => undefined);
+  });
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, () => resolve(server));
+  });
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+/** Run the installed generic message action through the loaded Marmot plugin. */
+async function runPublicMediaSend(
+  buildParams: (workspaceDir: string) => Promise<Record<string, unknown>>,
+): Promise<RecordedMediaSend> {
+  const root = await mkdtemp(join(tmpdir(), "marmot-host-media-contract-"));
+  const workspaceDir = join(root, "workspace");
+  const outboundMediaDir = join(root, "outbound-media");
+  const socketPath = join(root, "wn-agent.sock");
+  const recorded: RecordedMediaSend[] = [];
+  const previousOutboundMediaDir = process.env.MARMOT_OUTBOUND_MEDIA_DIR;
+  let server: Server | undefined;
+  try {
+    await mkdir(workspaceDir, { recursive: true, mode: 0o700 });
+    process.env.MARMOT_OUTBOUND_MEDIA_DIR = outboundMediaDir;
+    server = await startMediaControlServer(socketPath, recorded);
+    const pluginRoot = join(import.meta.dirname, "..");
+    const cfg = {
+      plugins: {
+        allow: ["marmot"],
+        load: { paths: [pluginRoot] },
+        entries: { marmot: { enabled: true } },
+      },
+      agents: { list: [{ id: "main", workspace: workspaceDir }] },
+      tools: { fs: { workspaceOnly: false } },
+      channels: {
+        marmot: {
+          socketPath,
+          accountIdHex: HEX32("aa"),
+        },
+      },
+    };
+    // Import the runner before activation: older hosts initialize additional
+    // runtime projections while evaluating this private chunk.
+    const runMessageAction = await loadInstalledRunMessageAction();
+    const registry = openClawPluginLoader.loadOpenClawPlugins({
+      config: cfg as never,
+      activationSourceConfig: cfg as never,
+      workspaceDir,
+      onlyPluginIds: ["marmot"],
+      activate: true,
+      loadModules: true,
+      cache: false,
+      mode: "full",
+      throwOnLoadError: true,
+    });
+    expect(
+      registry.channels.map((entry) => entry.plugin.id),
+      JSON.stringify(registry.diagnostics),
+    ).toContain("marmot");
+    await runMessageAction({
+      cfg,
+      action: "send",
+      params: await buildParams(workspaceDir),
+      agentId: "main",
+      senderIsOwner: true,
+    });
+    expect(recorded).toHaveLength(1);
+    await expect(access(recorded[0]!.stagedPath)).rejects.toThrow();
+    return recorded[0]!;
+  } finally {
+    if (server) {
+      await closeServer(server);
+    }
+    if (previousOutboundMediaDir === undefined) {
+      delete process.env.MARMOT_OUTBOUND_MEDIA_DIR;
+    } else {
+      process.env.MARMOT_OUTBOUND_MEDIA_DIR = previousOutboundMediaDir;
+    }
+    await rm(root, { recursive: true, force: true });
+  }
+}
 
 afterEach(() => {
   resetMarmotInboundAccountsForTests();
   resetMarmotInboundRuntimeForTests();
+  openClawPluginLoader.clearActivatedPluginRuntimeState();
+  openClawPluginLoader.clearPluginRegistryLoadCache();
+  const clearPluginLoaderCache = (
+    openClawPluginLoader as typeof openClawPluginLoader & {
+      clearPluginLoaderCache?: () => void;
+    }
+  ).clearPluginLoaderCache;
+  clearPluginLoaderCache?.();
 });
 
 /**
@@ -26,6 +216,50 @@ afterEach(() => {
  * This file is also run by openclaw-host-compat.sh against the supported beta.
  */
 describe("installed OpenClaw inbound host contract", () => {
+  it("sends an authorized workspace image through the public message action", async () => {
+    const imageBytes = Buffer.from("workspace-image-bytes");
+    const sent = await runPublicMediaSend(async (workspaceDir) => {
+      const imagePath = join(workspaceDir, "generated.png");
+      await writeFile(imagePath, imageBytes);
+      return {
+        channel: "marmot",
+        target: HEX32("cc"),
+        message: "workspace image",
+        media: imagePath,
+      };
+    });
+
+    expect(sent.stagedBytes).toEqual(imageBytes);
+    expect(sent.request).toMatchObject({
+      type: "send_media",
+      account_id_hex: HEX32("aa"),
+      group_id_hex: HEX32("cc"),
+      caption: "workspace image",
+      attachments: [{ media_type: "image/png", file_name: "generated.png" }],
+    });
+  });
+
+  it("sends a buffer and filename through the public message action", async () => {
+    const imageBytes = Buffer.from("buffer-image-bytes");
+    const sent = await runPublicMediaSend(async () => ({
+      channel: "marmot",
+      target: HEX32("cc"),
+      message: "buffer image",
+      buffer: imageBytes.toString("base64"),
+      filename: "from-buffer.png",
+      contentType: "image/png",
+    }));
+
+    expect(sent.stagedBytes).toEqual(imageBytes);
+    expect(sent.request).toMatchObject({
+      type: "send_media",
+      account_id_hex: HEX32("aa"),
+      group_id_hex: HEX32("cc"),
+      caption: "buffer image",
+      attachments: [{ media_type: "image/png", file_name: "from-buffer.png" }],
+    });
+  });
+
   it("runs Marmot's real dispatcher through the installed turn kernel", async () => {
     const deliverInboundReply = vi.fn(async () => ({
       status: "handled_visible" as const,

--- a/integrations/openclaw/marmot/test/outbound.test.ts
+++ b/integrations/openclaw/marmot/test/outbound.test.ts
@@ -1,4 +1,4 @@
-import { access, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { access, mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -366,6 +366,35 @@ describe("createMarmotMessageAdapter", () => {
       const stagedPath = calls.sendMedia[0]!.attachments[0]!.path;
       expect(stagedPath).toContain(join(tmpRoot, "staging"));
       await expect(access(stagedPath)).rejects.toThrow();
+    } finally {
+      await rm(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("removes staged plaintext when the permission adjustment fails", async () => {
+    const tmpRoot = await mkdtemp(join(tmpdir(), "marmot-outbound-test-"));
+    const stagingDir = join(tmpRoot, "staging");
+    try {
+      const calls = emptyClientCalls();
+      const adapter = createMarmotMessageAdapter({
+        resolveTarget: () => ({ client: stubClient(calls), marmotAccountIdHex: HEX32("aa") }),
+        outboundMediaDir: stagingDir,
+        chmodTempMedia: async () => {
+          throw new Error("chmod failed");
+        },
+      });
+      const ctx = {
+        cfg: {},
+        to: HEX32("cc"),
+        text: "generated image",
+        mediaUrl: "/workspace/generated/photo.png",
+        mediaReadFile: async () => Buffer.from("host-authorized-bytes"),
+      } as unknown as ChannelMessageSendMediaContext;
+
+      await expect(adapter.send!.media!(ctx)).rejects.toThrow(/chmod failed/);
+
+      expect(calls.sendMedia).toHaveLength(0);
+      expect(await readdir(stagingDir)).toEqual([]);
     } finally {
       await rm(tmpRoot, { recursive: true, force: true });
     }

--- a/integrations/openclaw/marmot/test/outbound.test.ts
+++ b/integrations/openclaw/marmot/test/outbound.test.ts
@@ -1,8 +1,8 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { access, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   deriveDurableFinalDeliveryRequirements,
   type ChannelMessageSendMediaContext,
@@ -206,6 +206,7 @@ describe("createMarmotMessageAdapter", () => {
       });
       expect(calls.sendMedia[0]?.attachments[0]?.path).not.toBe(filePath);
       expect(calls.sendMedia[0]?.attachments[0]?.path).toContain(join(tmpRoot, "staging"));
+      await expect(access(calls.sendMedia[0]!.attachments[0]!.path)).rejects.toThrow();
       expect(result.receipt.parts[0]).toMatchObject({ kind: "media", index: 0 });
       expect(result.receipt.sentAt).toBe(5678);
       expect(marmotInboundRuntimeSnapshot("default").lastOutboundAt).toBe(5678);
@@ -273,6 +274,101 @@ describe("createMarmotMessageAdapter", () => {
       media_type: "image/jpeg",
       file_name: "photo.jpg",
     });
+  });
+
+  it("uses the host-authorized media reader for a local path", async () => {
+    const calls = emptyClientCalls();
+    const writes: { fileName: string; bytes: Buffer }[] = [];
+    const mediaReadFile = vi.fn(async () => Buffer.from("host-authorized-bytes"));
+    const adapter = createMarmotMessageAdapter({
+      resolveTarget: () => ({ client: stubClient(calls), marmotAccountIdHex: HEX32("aa") }),
+      writeTempMedia: async (fileName, bytes) => {
+        writes.push({ fileName, bytes });
+        return `/tmp/marmot-media/${fileName}`;
+      },
+    });
+    const ctx = {
+      cfg: {},
+      to: HEX32("cc"),
+      text: "generated image",
+      mediaUrl: "/workspace/generated/photo.png",
+      // The running host has already authorized the source through
+      // mediaReadFile. Its roots may differ from this pinned SDK's roots.
+      mediaAccess: {
+        readFile: mediaReadFile,
+        localRoots: ["/different-sdk-media-root"],
+      },
+    } as unknown as ChannelMessageSendMediaContext;
+
+    await adapter.send!.media!(ctx);
+
+    expect(mediaReadFile).toHaveBeenCalledWith("/workspace/generated/photo.png");
+    expect(writes).toEqual([
+      { fileName: "photo.png", bytes: Buffer.from("host-authorized-bytes") },
+    ]);
+    expect(calls.sendMedia[0]?.attachments[0]).toMatchObject({
+      path: "/tmp/marmot-media/photo.png",
+      media_type: "image/png",
+      file_name: "photo.png",
+    });
+  });
+
+  it("does not stage or send media rejected by the host-authorized reader", async () => {
+    const calls = emptyClientCalls();
+    const writeTempMedia = vi.fn(async () => "/tmp/marmot-media/secret.png");
+    const adapter = createMarmotMessageAdapter({
+      resolveTarget: () => ({ client: stubClient(calls), marmotAccountIdHex: HEX32("aa") }),
+      writeTempMedia,
+    });
+    const ctx = {
+      cfg: {},
+      to: HEX32("cc"),
+      text: "denied",
+      mediaUrl: "/outside/authorized/roots/secret.png",
+      mediaReadFile: vi.fn(async () => {
+        throw new Error("host media authorization denied");
+      }),
+    } as unknown as ChannelMessageSendMediaContext;
+
+    await expect(adapter.send!.media!(ctx)).rejects.toThrow(/host media authorization denied/);
+
+    expect(writeTempMedia).not.toHaveBeenCalled();
+    expect(calls.sendMedia).toHaveLength(0);
+  });
+
+  it("removes host-authorized staged media when send_media fails", async () => {
+    const tmpRoot = await mkdtemp(join(tmpdir(), "marmot-outbound-test-"));
+    try {
+      const calls = emptyClientCalls();
+      const client = stubClient(calls);
+      client.sendMedia = async (_accountIdHex, _groupIdHex, attachments) => {
+        calls.sendMedia.push({
+          accountIdHex: HEX32("aa"),
+          groupIdHex: HEX32("cc"),
+          attachments,
+        });
+        throw new Error("wn-agent send failed");
+      };
+      const adapter = createMarmotMessageAdapter({
+        resolveTarget: () => ({ client, marmotAccountIdHex: HEX32("aa") }),
+        outboundMediaDir: join(tmpRoot, "staging"),
+      });
+      const ctx = {
+        cfg: {},
+        to: HEX32("cc"),
+        text: "generated image",
+        mediaUrl: "/workspace/generated/photo.png",
+        mediaReadFile: async () => Buffer.from("host-authorized-bytes"),
+      } as unknown as ChannelMessageSendMediaContext;
+
+      await expect(adapter.send!.media!(ctx)).rejects.toThrow(/wn-agent send failed/);
+
+      const stagedPath = calls.sendMedia[0]!.attachments[0]!.path;
+      expect(stagedPath).toContain(join(tmpRoot, "staging"));
+      await expect(access(stagedPath)).rejects.toThrow();
+    } finally {
+      await rm(tmpRoot, { recursive: true, force: true });
+    }
   });
 
   it("rejects a remote media url with no local-path accessor", async () => {

--- a/integrations/openclaw/marmot/test/plugin-sdk-surface.test.ts
+++ b/integrations/openclaw/marmot/test/plugin-sdk-surface.test.ts
@@ -26,6 +26,7 @@ const RUNTIME_IMPORTS: ReadonlyArray<readonly [string, readonly string[]]> = [
   ],
   ["openclaw/plugin-sdk/core", ["createChatChannelPlugin", "jsonResult", "KeyedAsyncQueue"]],
   ["openclaw/plugin-sdk/infra-runtime", ["readLocalFileFromRoots"]],
+  ["openclaw/plugin-sdk/media-runtime", ["extractOriginalFilename", "getMediaDir"]],
   ["openclaw/plugin-sdk/media-store", ["saveMediaBuffer"]],
   [
     "openclaw/plugin-sdk/status-helpers",


### PR DESCRIPTION
## Summary
- prefer the running OpenClaw host media reader for local and remote outbound sources, avoiding a second version-skewed allowlist decision
- retain connector-side local-root validation when no host reader exists, stage only authorized bytes, and document the public message-tool contract
- cover host-reader precedence, denied reads, attachment metadata, and staged-file cleanup after success and failure

## Test plan
- [x] New local-path host-reader test failed before the fix and passes after
- [x] `pnpm typecheck`
- [x] `pnpm test` (245 passed, 2 skipped)
- [x] `just openclaw-host-compat-test` against OpenClaw 2026.7.2-beta.7 (80 passed)
- [x] `just fast-ci`

Fixes #1539

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved outbound media handling for local and remote files.
  * Added support for host-authorized media access and secure staging before sending.
  * Preserved original filenames for managed media attachments.
  * Added automatic cleanup of staged media after successful or failed sends.

* **Bug Fixes**
  * Prevented unauthorized media from being staged or sent.
  * Ensured staged files are removed when permission updates fail.

* **Documentation**
  * Updated runtime guidance for sending media and managing temporary files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->