### PR TITLE
Prioritize storage close during suspension shutdown

### DIFF
--- a/crates/marmot-app/AGENTS.md
+++ b/crates/marmot-app/AGENTS.md
@@ -81,8 +81,9 @@ App runtime bridge for the first real Marmot app surfaces.
   `src/runtime/agent_stream_watch.rs`, before any connect; both follow the one dial discipline in
   `docs/marmot-architecture/overview/dial-safety.md` (validate + pin, trust from config, loopback only under an explicit
   dev flag). Do not add an outbound relay/broker path that bypasses them.
-- Keep `MarmotAppRuntime::shutdown_and_close` the one sequenced teardown for hosts whose process can be suspended: it
-  drains workers, then closes every SQLite database and releases the root runtime lease. `shutdown` alone does not
+- Keep `MarmotAppRuntime::shutdown_and_close` the one terminal teardown for hosts whose process can be suspended: it
+  closes admission, closes every SQLite database and releases the root runtime lease first, then gives graceful worker
+  cleanup a bounded budget. The terminal operation must outlive cancellation of its caller. `shutdown` alone does not
   release file locks. Closing is terminal — do not add a path that transparently reopens a database afterwards, and
   put shutdown checks at engine-step boundaries (never inside a step, where a snapshot guard may be live). See
   `docs/marmot-architecture/overview/local-artifact-safety.md`.

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -510,10 +510,14 @@ pub struct MarmotApp {
     /// it counts against the same App Group suspension rule as the databases
     /// (see [`Self::close_storage`]).
     root_runtime_lease: Arc<Mutex<Option<MarmotRootRuntimeLease>>>,
-    /// Latched by [`Self::close_storage`]. Every database accessor checks it so
-    /// a late call cannot silently reopen a database — and re-lock a container
-    /// the host has just been told is lock-free.
+    /// Latched as soon as [`Self::close_storage`] starts. Every database
+    /// accessor checks it so a late call cannot silently reopen a database
+    /// while terminal close is in progress or after it completes.
     storage_closed: Arc<AtomicBool>,
+    /// Published only after every database close has been attempted and the
+    /// root lease has been released. This is the host-facing completion fact;
+    /// `storage_closed` above is the earlier admission latch.
+    storage_close_completed: Arc<AtomicBool>,
     /// Admission control that makes the close *atomic* rather than merely
     /// latched: database opens hold the read side across create-and-publish,
     /// [`Self::close_storage`] holds the write side across its whole teardown.
@@ -1349,6 +1353,7 @@ impl MarmotApp {
             root,
             root_runtime_lease: Arc::new(Mutex::new(None)),
             storage_closed: Arc::new(AtomicBool::new(false)),
+            storage_close_completed: Arc::new(AtomicBool::new(false)),
             storage_lifecycle: Arc::new(RwLock::new(())),
             relay_urls,
             relay_plane,
@@ -1421,6 +1426,7 @@ impl MarmotApp {
             root: root.as_ref().to_path_buf(),
             root_runtime_lease: Arc::new(Mutex::new(None)),
             storage_closed: Arc::new(AtomicBool::new(false)),
+            storage_close_completed: Arc::new(AtomicBool::new(false)),
             storage_lifecycle: Arc::new(RwLock::new(())),
             relay_urls,
             account_home,
@@ -4896,6 +4902,7 @@ impl MarmotApp {
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
                 .take(),
         );
+        self.storage_close_completed.store(true, Ordering::Release);
 
         tracing::debug!(
             target: "marmot_app::storage",
@@ -4911,16 +4918,17 @@ impl MarmotApp {
         }
     }
 
-    /// Whether [`Self::close_storage`] has run. Databases are unreachable from
-    /// this handle once it returns true.
+    /// Whether [`Self::close_storage`] has finished closing every database and
+    /// releasing the root lease. Databases are unreachable from this handle
+    /// once it returns true.
     #[must_use]
     pub fn storage_is_closed(&self) -> bool {
-        self.storage_closed.load(Ordering::Acquire)
+        self.storage_close_completed.load(Ordering::Acquire)
     }
 
     /// Fail rather than reopen a database after [`Self::close_storage`].
     fn ensure_storage_open(&self, database: &'static str) -> Result<(), AppError> {
-        if self.storage_is_closed() {
+        if self.storage_closed.load(Ordering::Acquire) {
             return Err(AppError::from(cgka_traits::StorageError::Closed(format!(
                 "{database} unavailable: app storage is closed"
             ))));

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -18,6 +18,8 @@ use marmot_account::{
     NostrAccountImport,
 };
 use serde::{Deserialize, Serialize};
+#[cfg(test)]
+use tokio::sync::Semaphore;
 use tokio::sync::{Mutex, Notify, broadcast, mpsc, oneshot, watch};
 use tokio::task::{JoinHandle, JoinSet};
 use tokio::time::timeout;
@@ -120,6 +122,55 @@ pub struct MarmotAppRuntime {
     follow_list_updates: Arc<Mutex<HashMap<String, Arc<Mutex<()>>>>>,
     directory_sync: Arc<Mutex<Option<DirectorySyncHandle>>>,
     initial_directory_sync: Arc<Mutex<Option<JoinHandle<()>>>>,
+    #[cfg(test)]
+    shutdown_test_hook: Arc<StdMutex<Option<ShutdownTestHook>>>,
+    #[cfg(test)]
+    shutdown_grace_wait_for_test: Arc<StdMutex<Duration>>,
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ShutdownTestPhase {
+    StorageClose,
+    DirectorySync,
+    InitialDirectorySync,
+    AccountWorkers,
+    RelayPlane,
+    AuditTracker,
+    AccountOpens,
+}
+
+#[cfg(test)]
+#[derive(Clone)]
+struct ShutdownTestHook {
+    phase: ShutdownTestPhase,
+    entered: Arc<Semaphore>,
+    release: Arc<Semaphore>,
+}
+
+#[cfg(test)]
+pub(crate) struct ShutdownTestStall {
+    entered: Arc<Semaphore>,
+    release: Arc<Semaphore>,
+}
+
+#[cfg(test)]
+impl ShutdownTestStall {
+    pub(crate) async fn wait_until_entered(&self) {
+        self.entered
+            .acquire()
+            .await
+            .expect("shutdown test hook semaphore must stay open")
+            .forget();
+    }
+
+    pub(crate) fn was_entered(&self) -> bool {
+        self.entered.available_permits() > 0
+    }
+
+    pub(crate) fn release(&self) {
+        self.release.add_permits(1);
+    }
 }
 
 #[derive(Clone)]
@@ -1067,6 +1118,12 @@ impl MarmotAppRuntime {
             follow_list_updates: Arc::new(Mutex::new(HashMap::new())),
             directory_sync: Arc::new(Mutex::new(None)),
             initial_directory_sync: Arc::new(Mutex::new(None)),
+            #[cfg(test)]
+            shutdown_test_hook: Arc::new(StdMutex::new(None)),
+            #[cfg(test)]
+            shutdown_grace_wait_for_test: Arc::new(StdMutex::new(
+                APP_RUNTIME_ACCOUNT_SHUTDOWN_WAIT,
+            )),
         }
     }
 
@@ -4302,21 +4359,98 @@ impl MarmotAppRuntime {
         self.accounts.drain_in_flight_work().await
     }
 
+    #[cfg(test)]
+    pub(crate) fn stall_shutdown_for_test(&self, phase: ShutdownTestPhase) -> ShutdownTestStall {
+        let entered = Arc::new(Semaphore::new(0));
+        let release = Arc::new(Semaphore::new(0));
+        *self
+            .shutdown_test_hook
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(ShutdownTestHook {
+            phase,
+            entered: entered.clone(),
+            release: release.clone(),
+        });
+        ShutdownTestStall { entered, release }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_shutdown_grace_wait_for_test(&self, wait: Duration) {
+        *self
+            .shutdown_grace_wait_for_test
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = wait;
+    }
+
+    fn shutdown_grace_wait(&self) -> Duration {
+        #[cfg(test)]
+        {
+            return *self
+                .shutdown_grace_wait_for_test
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+        }
+        #[cfg(not(test))]
+        {
+            APP_RUNTIME_ACCOUNT_SHUTDOWN_WAIT
+        }
+    }
+
+    #[cfg(test)]
+    async fn stall_shutdown_phase_for_test(&self, phase: ShutdownTestPhase) {
+        let hook = self
+            .shutdown_test_hook
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
+        let Some(hook) = hook.filter(|hook| hook.phase == phase) else {
+            return;
+        };
+        hook.entered.add_permits(1);
+        hook.release
+            .acquire()
+            .await
+            .expect("shutdown test hook semaphore must stay open")
+            .forget();
+    }
+
     pub async fn shutdown(&self) {
         let started_at = Instant::now();
         self.shared.lifecycle().begin_shutdown();
         self.shared.stop_relay_telemetry_exporter();
+        #[cfg(test)]
+        self.stall_shutdown_phase_for_test(ShutdownTestPhase::DirectorySync)
+            .await;
         if let Some(directory_sync) = self.directory_sync.lock().await.take() {
             directory_sync.shutdown().await;
         }
+        #[cfg(test)]
+        self.stall_shutdown_phase_for_test(ShutdownTestPhase::InitialDirectorySync)
+            .await;
         if let Some(initial_directory_sync) = self.initial_directory_sync.lock().await.take() {
             let _ = initial_directory_sync.await;
         }
         self.accounts.app.set_directory_sync_handle(None);
-        let accounts = self.accounts.shutdown();
-        let relay_plane = self.shared.relay_plane.shutdown();
+        let accounts = async {
+            #[cfg(test)]
+            self.stall_shutdown_phase_for_test(ShutdownTestPhase::AccountWorkers)
+                .await;
+            self.accounts.shutdown().await;
+        };
+        let relay_plane = async {
+            #[cfg(test)]
+            self.stall_shutdown_phase_for_test(ShutdownTestPhase::RelayPlane)
+                .await;
+            self.shared.relay_plane.shutdown().await;
+        };
         tokio::join!(accounts, relay_plane);
+        #[cfg(test)]
+        self.stall_shutdown_phase_for_test(ShutdownTestPhase::AuditTracker)
+            .await;
         self.shared.shutdown_audit_log_tracker_uploader().await;
+        #[cfg(test)]
+        self.stall_shutdown_phase_for_test(ShutdownTestPhase::AccountOpens)
+            .await;
         self.shared
             .lifecycle()
             .wait_for_account_opens_to_drain(
@@ -4331,9 +4465,10 @@ impl MarmotAppRuntime {
         );
     }
 
-    /// [`Self::shutdown`], then close every SQLite database and release the
-    /// root runtime lease — so when this returns, nothing this process owns
-    /// holds a file lock inside the Marmot root.
+    /// Stop admitting runtime work, close every SQLite database and release the
+    /// root runtime lease, then make a bounded attempt to drain graceful
+    /// shutdown work. When this returns, nothing this process owns holds a file
+    /// lock inside the Marmot root.
     ///
     /// This is the operation a host needs before its process can be suspended.
     /// [`Self::shutdown`] alone is not enough: it stops workers but takes
@@ -4345,9 +4480,14 @@ impl MarmotAppRuntime {
     /// suspension (`0xdead10cc`, raised for holding a lock in a shared App
     /// Group container).
     ///
-    /// Ordering is the point of this method: workers drain first, so the
-    /// databases close under quiesced state rather than out from under live
-    /// engine work.
+    /// Ordering is the point of this method: the lifecycle stop latch closes
+    /// admission first, then storage closure takes priority over graceful
+    /// draining. This is deliberately different from [`Self::shutdown`]. A
+    /// host suspension deadline cannot safely sit behind directory, worker,
+    /// relay, or audit cleanup that may be awaiting network or task progress.
+    /// SQLite completes the statement holding a connection guard and rolls an
+    /// uncommitted transaction back on close; later work sees `Closed` and
+    /// cannot reopen storage.
     ///
     /// **Terminal.** This runtime and the [`MarmotApp`] it came from are done:
     /// every later database access fails with
@@ -4356,14 +4496,43 @@ impl MarmotAppRuntime {
     /// host has just been told is clear. Build a fresh `MarmotApp` and runtime
     /// to use the root again — which is what a foregrounding app does anyway.
     ///
-    /// Safe to call twice, and safe to call with or without a preceding
-    /// [`Self::shutdown`]. Worker drain is bounded by
-    /// `APP_RUNTIME_ACCOUNT_SHUTDOWN_WAIT`; the close itself waits only for
-    /// whatever SQLite statement is executing.
+    /// Safe to call twice, safe to call concurrently, and safe to call with or
+    /// without a preceding [`Self::shutdown`]. The terminal operation runs in a
+    /// runtime-owned task, so cancelling the caller (including a host-side FFI
+    /// future) cannot cancel storage closure. Graceful draining is bounded by
+    /// `APP_RUNTIME_ACCOUNT_SHUTDOWN_WAIT`; the close itself waits only for an
+    /// already-admitted database open or SQLite statement.
     pub async fn shutdown_and_close(&self) -> Result<(), AppError> {
-        self.shutdown().await;
+        let runtime = self.clone();
+        tokio::spawn(async move { runtime.run_terminal_shutdown_and_close().await })
+            .await
+            .map_err(|err| {
+                AppError::BlockingTask(format!("terminal shutdown task failed: {err}"))
+            })?
+    }
+
+    async fn run_terminal_shutdown_and_close(self) -> Result<(), AppError> {
+        self.shared.lifecycle().begin_shutdown();
+        #[cfg(test)]
+        self.stall_shutdown_phase_for_test(ShutdownTestPhase::StorageClose)
+            .await;
+
+        // Close first. Every graceful subsystem is allowed to retain `MarmotApp`
+        // clones after its deadline, but terminal storage closure makes those
+        // clones inert and releases the suspension-sensitive root lease.
         let app = self.accounts.app.clone();
-        blocking_app_task(move || app.close_storage()).await
+        let close_result = blocking_app_task(move || app.close_storage()).await;
+
+        let graceful_wait = self.shutdown_grace_wait();
+        if timeout(graceful_wait, self.shutdown()).await.is_err() {
+            tracing::warn!(
+                target: "marmot_app::runtime",
+                method = "shutdown_and_close",
+                graceful_wait_ms = graceful_wait.as_millis() as u64,
+                "graceful runtime shutdown exceeded its budget after storage was closed",
+            );
+        }
+        close_result
     }
 
     /// Whether this runtime's storage has been closed by

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -10289,6 +10289,237 @@ async fn runtime_shutdown_and_close_is_idempotent_with_or_without_prior_shutdown
     runtime.shutdown_and_close().await.unwrap();
 }
 
+fn open_suspension_shutdown_fixture(
+    root: &std::path::Path,
+) -> (
+    MarmotApp,
+    MarmotAppRuntime,
+    SqliteAccountStorage,
+    SqliteSharedStorage,
+    DirectoryCache,
+    PathBuf,
+    PathBuf,
+) {
+    let home = AccountHome::open(root);
+    let account = home.create_account("suspension-close").unwrap();
+    let app = MarmotApp::try_with_relays_and_account_home_and_config(
+        root,
+        Vec::new(),
+        AccountHome::open(root),
+        MarmotAppConfig::default(),
+    )
+    .unwrap();
+    let session = app.account_storage(&account.label).unwrap();
+    session.app_message_count().unwrap();
+    let shared = app.shared_storage().unwrap();
+    shared
+        .set_relay_telemetry_settings(&StoredRelayTelemetrySettings {
+            export_enabled: true,
+            export_interval_seconds: 30,
+        })
+        .unwrap();
+    let directory = app.directory_cache_for_account(&account).unwrap();
+    directory.entries().unwrap();
+    let session_path = app.account_storage_path(&account.label);
+    let shared_path = app.shared_storage_path();
+    let runtime = app.runtime();
+    (
+        app,
+        runtime,
+        session,
+        shared,
+        directory,
+        session_path,
+        shared_path,
+    )
+}
+
+fn assert_suspension_storage_closed(
+    root: &std::path::Path,
+    app: &MarmotApp,
+    session: &SqliteAccountStorage,
+    shared: &SqliteSharedStorage,
+    directory: &DirectoryCache,
+    session_path: &std::path::Path,
+    shared_path: &std::path::Path,
+) {
+    assert!(app.storage_is_closed());
+    assert!(session.is_closed());
+    assert!(shared.is_closed());
+    assert!(matches!(
+        directory.entries(),
+        Err(AppError::Storage(error)) if error.is_closed()
+    ));
+    for database in [session_path, shared_path] {
+        for suffix in ["-wal", "-shm"] {
+            let sidecar = PathBuf::from(format!("{}{suffix}", database.display()));
+            assert!(
+                !sidecar.exists(),
+                "{} must be released by terminal shutdown",
+                sidecar.display()
+            );
+        }
+    }
+    drop(MarmotRootRuntimeLease::try_acquire(root).expect("root lease must be released"));
+    assert!(matches!(
+        app.shared_storage(),
+        Err(AppError::Storage(error)) if error.is_closed()
+    ));
+}
+
+/// Every graceful subsystem can stop making progress. Terminal suspension
+/// close must already have released SQLite and the root lease, and the outer
+/// graceful budget must still bound the call.
+#[tokio::test]
+async fn runtime_shutdown_and_close_bounds_every_graceful_shutdown_phase() {
+    use crate::runtime::ShutdownTestPhase;
+
+    for phase in [
+        ShutdownTestPhase::DirectorySync,
+        ShutdownTestPhase::InitialDirectorySync,
+        ShutdownTestPhase::AccountWorkers,
+        ShutdownTestPhase::RelayPlane,
+        ShutdownTestPhase::AuditTracker,
+        ShutdownTestPhase::AccountOpens,
+    ] {
+        let temp = tempfile::tempdir().unwrap();
+        let (app, runtime, session, shared, directory, session_path, shared_path) =
+            open_suspension_shutdown_fixture(temp.path());
+        runtime.set_shutdown_grace_wait_for_test(Duration::from_millis(50));
+        let stall = runtime.stall_shutdown_for_test(phase);
+
+        let started = Instant::now();
+        runtime.shutdown_and_close().await.unwrap();
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "{phase:?} stall exceeded the terminal shutdown bound"
+        );
+        assert!(stall.was_entered(), "{phase:?} stall was not exercised");
+        assert_suspension_storage_closed(
+            temp.path(),
+            &app,
+            &session,
+            &shared,
+            &directory,
+            &session_path,
+            &shared_path,
+        );
+
+        // A fresh runtime can acquire and use the same root immediately. The
+        // spent runtime remains alive, proving release is explicit rather than
+        // an incidental last-Arc drop.
+        let reopened = MarmotApp::try_with_relays_and_account_home_and_config(
+            temp.path(),
+            Vec::new(),
+            AccountHome::open(temp.path()),
+            MarmotAppConfig::default(),
+        )
+        .expect("fresh runtime should acquire the closed root");
+        reopened.shared_storage().unwrap();
+        reopened.close_storage().unwrap();
+    }
+}
+
+/// Dropping the awaiting future models a host/UniFFI owner being cancelled.
+/// The runtime-owned terminal task must continue and close storage anyway.
+#[tokio::test]
+async fn cancelling_shutdown_and_close_cannot_strand_storage_open() {
+    use crate::runtime::ShutdownTestPhase;
+
+    let temp = tempfile::tempdir().unwrap();
+    let (app, runtime, session, shared, directory, session_path, shared_path) =
+        open_suspension_shutdown_fixture(temp.path());
+    let stall = runtime.stall_shutdown_for_test(ShutdownTestPhase::StorageClose);
+    let closing_runtime = runtime.clone();
+    let host_future = tokio::spawn(async move { closing_runtime.shutdown_and_close().await });
+    stall.wait_until_entered().await;
+
+    host_future.abort();
+    assert!(host_future.await.unwrap_err().is_cancelled());
+    assert!(!runtime.storage_is_closed());
+    stall.release();
+
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while !runtime.storage_is_closed() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("runtime-owned terminal close must survive caller cancellation");
+    assert_suspension_storage_closed(
+        temp.path(),
+        &app,
+        &session,
+        &shared,
+        &directory,
+        &session_path,
+        &shared_path,
+    );
+}
+
+#[tokio::test]
+async fn concurrent_runtime_shutdown_and_close_calls_are_safe() {
+    let temp = tempfile::tempdir().unwrap();
+    let (app, runtime, session, shared, directory, session_path, shared_path) =
+        open_suspension_shutdown_fixture(temp.path());
+    let callers = (0..4)
+        .map(|_| {
+            let runtime = runtime.clone();
+            tokio::spawn(async move { runtime.shutdown_and_close().await })
+        })
+        .collect::<Vec<_>>();
+    for caller in callers {
+        caller.await.unwrap().unwrap();
+    }
+    assert_suspension_storage_closed(
+        temp.path(),
+        &app,
+        &session,
+        &shared,
+        &directory,
+        &session_path,
+        &shared_path,
+    );
+}
+
+const SUSPENSION_REOPEN_CHILD_ROOT: &str = "MARMOT_SUSPENSION_REOPEN_CHILD_ROOT";
+
+#[test]
+fn shutdown_and_close_allows_another_process_to_open_root_child() {
+    let Some(root) = std::env::var_os(SUSPENSION_REOPEN_CHILD_ROOT) else {
+        return;
+    };
+    let root = PathBuf::from(root);
+    let app = MarmotApp::try_with_relays_and_account_home_and_config(
+        &root,
+        Vec::new(),
+        AccountHome::open(&root),
+        MarmotAppConfig::default(),
+    )
+    .expect("child process must acquire the released root");
+    app.shared_storage().unwrap();
+    app.close_storage().unwrap();
+}
+
+#[tokio::test]
+async fn shutdown_and_close_allows_another_process_to_open_root() {
+    let temp = tempfile::tempdir().unwrap();
+    let (app, runtime, ..) = open_suspension_shutdown_fixture(temp.path());
+    runtime.shutdown_and_close().await.unwrap();
+    assert!(app.storage_is_closed());
+
+    let status = std::process::Command::new(std::env::current_exe().unwrap())
+        .args([
+            "--exact",
+            "tests::shutdown_and_close_allows_another_process_to_open_root_child",
+            "--nocapture",
+        ])
+        .env(SUSPENSION_REOPEN_CHILD_ROOT, temp.path())
+        .status()
+        .expect("run fresh-runtime child process");
+    assert!(status.success(), "fresh-runtime child process failed");
+}
+
 /// #1177: an accepted send whose intent the engine retained in the group's
 /// durable queue must say so. Reporting `published: 0` with no message ids
 /// forces the host to infer acceptance from an empty list, which is exactly

--- a/crates/marmot-uniffi/src/lib.rs
+++ b/crates/marmot-uniffi/src/lib.rs
@@ -232,8 +232,9 @@ impl Marmot {
         self.runtime.shutdown().await;
     }
 
-    /// [`Marmot::shutdown`], then close every SQLite database and release the
-    /// Marmot root's runtime lease.
+    /// Stop admitting runtime work, close every SQLite database and release the
+    /// Marmot root's runtime lease, then make a bounded attempt at graceful
+    /// worker cleanup.
     ///
     /// Await this before letting the process be suspended. When it returns,
     /// nothing this process owns holds a file lock inside the Marmot root —
@@ -250,9 +251,12 @@ impl Marmot {
     /// this method just cleared. Construct a new `Marmot` on resume — which is
     /// what a foregrounding app does anyway.
     ///
-    /// Safe to call twice, and safe to call with or without a preceding
-    /// [`Marmot::shutdown`]. Bounded: worker drain has a fixed budget and the
-    /// close itself waits only for the SQLite statement currently executing.
+    /// Storage closure runs in a runtime-owned task, so cancelling the host
+    /// future cannot cancel it. Safe to call twice or concurrently, and safe to
+    /// call with or without a preceding [`Marmot::shutdown`]. Graceful cleanup
+    /// has a fixed budget; the close itself waits only for an already-admitted
+    /// database open or SQLite statement. Begin this call early enough to cover
+    /// that close before the host's suspension assertion expires.
     /// An error means at least one database reported a problem while closing;
     /// every database is still attempted and left closed, so a failure is not
     /// a reason to retry or to keep the process alive.

--- a/docs/marmot-architecture/overview/local-artifact-safety.md
+++ b/docs/marmot-architecture/overview/local-artifact-safety.md
@@ -1,7 +1,7 @@
 ---
 title: "Local Artifact Safety"
 created: 2026-07-02
-updated: 2026-08-08
+updated: 2026-08-23
 tags: [marmot, overview, security, filesystem, permissions]
 status: overview
 ---
@@ -65,9 +65,19 @@ drop anything.
 - **Closing is terminal, and nothing reopens.** `MarmotApp::close_storage` latches, and every database accessor
   refuses afterwards. A late background read that transparently reopened would re-lock the container the host was just
   told is clear — the exact failure the close exists to prevent. Hosts construct a fresh runtime on resume.
-- **Drain, then close.** `MarmotAppRuntime::shutdown_and_close` is the sequenced entry point: workers stop first, so
-  databases close under quiesced state. Closing under live work stays *safe* — SQLite rolls back any open transaction
-  as part of closing, so a write is all-or-nothing across the cut — but it is not the intended path.
+- **Terminal close precedes best-effort drain.** `MarmotAppRuntime::shutdown_and_close` closes runtime admission, every
+  database, and the root lease before it gives graceful directory, account, relay, audit, and account-open cleanup a
+  bounded budget. Those subsystems can await network or task progress and therefore cannot sit ahead of the lock-release
+  boundary on a host suspension deadline. The terminal operation is runtime-owned and continues if its caller is
+  cancelled.
+- **The cut is transaction-safe, but not operation-transparent.** A statement that already owns a connection guard is
+  allowed to finish; closing rolls an uncommitted SQLite transaction back, and later work receives
+  `StorageError::Closed`. A higher-level operation composed of multiple transactions or an external side effect can be
+  cut between its steps and must rely on durable intent/reconciliation. This is the deliberate suspension tradeoff: a
+  forced process kill is at least as abrupt and also leaves the container lock held until RunningBoard terminates it.
+- **Completion means completion.** The early close latch rejects new work, but `storage_is_closed` becomes true only
+  after all database closes have been attempted and the root lease has been released. Repeated and concurrent terminal
+  closes are safe.
 - **Bail out at engine-step boundaries, not inside them.** Shutdown checks belong between whole engine operations
   (`RuntimeLifecycle::is_stopping()` in the account worker's per-group loops), where no snapshot guard is live.
   Interrupting *inside* a step can leave a `SnapshotRollbackGuard`'s window half-applied, which is worse than the kill.


### PR DESCRIPTION
## Summary

- close runtime admission, every SQLite connection, and the Marmot root lease before awaiting graceful shutdown work
- run terminal closure in a runtime-owned task so cancellation of the awaiting host/UniFFI future cannot strand storage open
- give directory, account, relay, audit, and account-open cleanup one bounded graceful budget after lock release
- publish `storage_is_closed` only after database closure and root-lease release actually complete
- add subsystem-stall, retained-handle, WAL/SHM, root-lease, same-root reopen, cross-process reopen, concurrency, idempotency, late-work, and caller-cancellation regressions

## Why

MarmotKit 0.9.14's `shutdown_and_close` awaited the full graceful `shutdown` sequence before invoking `close_storage`. Several waits ahead of closure can be unbounded or materially exceed iOS background execution time: directory command delivery and initial-sync join, invite catch-up and account worker draining, async mutex acquisition, and an active audit upload.

If iOS suspended the process during one of those waits, idle WAL connections and the root runtime lease were still live. A WAL connection holds a persistent lock on its `-shm` sidecar even when no SQLite statement is active, which can produce a RunningBoard `0xdead10cc` kill with idle/parked stacks.

The terminal operation now prioritizes the fact iOS requires: release suspension-sensitive locks first. Graceful cleanup remains best-effort and bounded afterward.

## Semantics and integrity

Closing remains terminal. An already-admitted database open or SQLite statement is allowed to reach its safe close boundary; an uncommitted SQLite transaction rolls back, and later work receives `StorageError::Closed` instead of reopening the root.

This is transaction-safe but can cut a higher-level operation between transactions or after an external side effect. Protocol-critical operations retain their existing durable intent, pending-state, exact-event retry, and reopen-reconciliation mechanisms. The architecture documentation records that tradeoff explicitly. This PR does not introduce a new public API, regenerate bindings, or bump/release any version.

## Validation

Passed:

- `just fast-ci`
- `cargo test -p storage-sqlite` — 402 passed, 4 ignored
- `cargo test -p marmot-uniffi` — 157 passed across unit, fixture, and smoke tests
- `cargo test -p marmot-app shutdown_and_close --lib -- --nocapture` — all 6 terminal-shutdown regressions passed
- complete `marmot-app` library tests — 758 passed, 1 ignored
- `git diff --check`

The full `cargo test -p marmot-app` run reached the unrelated `relay_runtime` integration binary, where 5 existing encrypted-media/retention/removal tests failed. A representative failure (`encrypted_media_endpoint_updates_are_full_replacement_and_admin_only`) reproduced in an untouched worktree at current `master` (`845ebae9`), with the same `left: 3, right: 1` assertion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved shutdown reliability by closing databases and releasing runtime resources before cleanup.
  - Shutdown now continues safely if the initiating call is cancelled.
  - Repeated and concurrent shutdown requests are handled safely.
  - Storage can be reopened reliably after shutdown, including from another process.

- **Documentation**
  - Clarified shutdown behavior, bounded cleanup timing, and completion requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->