### PR TITLE
Add account-scoped invite policies for direct bots

### DIFF
--- a/crates/agent-connector/AGENTS.md
+++ b/crates/agent-connector/AGENTS.md
@@ -46,7 +46,7 @@ several files in the same crate); methods shared across those files are `pub(cra
   `ReconcileSource` label used on per-pass tracing events (mdk#1380).
 - `src/error.rs` — `ConnectorError` and its `code`/`client_message`/`privacy_safe_code` projections.
 - `src/socket.rs` — socket path/bind/hardening (`default_socket_path`, `bind_connector_socket*`, stale-socket recovery).
-- `src/allowlist.rs` — `AllowlistStore`/`AllowlistRecord` per-account welcomer allowlist persistence.
+- `src/allowlist.rs` — `AllowlistStore`/`AllowlistRecord` per-account invite-policy and welcomer-allowlist persistence.
 - `src/stream_session.rs` — `StreamSessionStore`/`ActiveStreamSession`, the persisted
   `SendIdempotencyStore` (`$MARMOT_HOME/dev/send-idempotency.json`, 1024-entry FIFO,
   versioned SHA-256 request fingerprints, `stream_finalize_v2:` keys for durable finalized sends,

--- a/crates/agent-connector/README.md
+++ b/crates/agent-connector/README.md
@@ -81,8 +81,29 @@ wn-agent --version
 
 ## Invite Policy
 
-Production connectors accept pending group invites only when the MLS-authenticated welcomer is on the configured
-`--allow-welcomer` list. An empty allowlist rejects every invite.
+Invite policy is account-scoped and defaults to `allowlist`, preserving the existing behavior: a pending group invite
+is accepted only when its authenticated welcomer is on the account's configured `--allow-welcomer` list. An empty
+allowlist rejects every invite.
+
+Set a production invite policy while bootstrapping or reusing an account:
+
+```sh
+wn-agent bootstrap \
+  --home ~/.marmot-agent \
+  --invite-policy any-authenticated-direct
+```
+
+The available policies are:
+
+- `deny` — decline every invite while retaining any stored allowlist entries;
+- `allowlist` — accept only authenticated welcomers on the account allowlist;
+- `any-authenticated-direct` — accept any authenticated welcomer only when the resulting MLS group has exactly two
+  members (the agent and one peer);
+- `any-authenticated` — accept any authenticated welcomer, including invites to multi-party groups.
+
+Every policy fails closed when the Welcome has no authenticated welcomer. Invite policy controls group admission only;
+the Hermes, OpenClaw, or terminal-harness integration independently controls which admitted senders may invoke the
+agent and whether multi-party messages require activation.
 
 Local development may use `--dev-allow-any-invites` together with `--debug-controls`. The connector warns when this
 mode is active and accepts any authenticated welcomer, but it still rejects a welcome whose authenticated author is

--- a/crates/agent-connector/README.md
+++ b/crates/agent-connector/README.md
@@ -98,7 +98,8 @@ The available policies are:
 - `deny` — decline every invite while retaining any stored allowlist entries;
 - `allowlist` — accept only authenticated welcomers on the account allowlist;
 - `any-authenticated-direct` — accept any authenticated welcomer only when the resulting MLS group has exactly two
-  members (the agent and one peer);
+  members (the agent and one peer); the member count is checked once, when the invite is confirmed, and does not
+  prevent later membership changes;
 - `any-authenticated` — accept any authenticated welcomer, including invites to multi-party groups.
 
 Every policy fails closed when the Welcome has no authenticated welcomer. Invite policy controls group admission only;

--- a/crates/agent-connector/src/account.rs
+++ b/crates/agent-connector/src/account.rs
@@ -160,4 +160,29 @@ impl AgentConnector {
                 .remove(&account.account_id_hex, &welcomer_account_id_hex)?,
         })
     }
+
+    pub(crate) fn invite_policy_response(
+        &self,
+        account_id_hex: &str,
+    ) -> Result<AgentControlResponse, ConnectorError> {
+        let account = self.local_account_for_account_id(account_id_hex)?;
+        Ok(AgentControlResponse::InvitePolicy {
+            account_id_hex: account.account_id_hex.clone(),
+            policy: self.allowlists.policy(&account.account_id_hex)?,
+        })
+    }
+
+    pub(crate) fn invite_policy_set_response(
+        &self,
+        account_id_hex: &str,
+        policy: agent_control::AgentControlInvitePolicy,
+    ) -> Result<AgentControlResponse, ConnectorError> {
+        let account = self.local_account_for_account_id(account_id_hex)?;
+        Ok(AgentControlResponse::InvitePolicy {
+            account_id_hex: account.account_id_hex.clone(),
+            policy: self
+                .allowlists
+                .set_policy(&account.account_id_hex, policy)?,
+        })
+    }
 }

--- a/crates/agent-connector/src/allowlist.rs
+++ b/crates/agent-connector/src/allowlist.rs
@@ -7,6 +7,7 @@ use std::sync::{Arc, Mutex};
 
 use std::fs::{File, OpenOptions};
 
+use agent_control::AgentControlInvitePolicy;
 use serde::{Deserialize, Serialize};
 
 use crate::ALLOWLIST_DIR;
@@ -21,6 +22,8 @@ pub(crate) struct AllowlistStore {
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub(crate) struct AllowlistRecord {
     pub(crate) account_id_hex: String,
+    #[serde(default)]
+    pub(crate) invite_policy: AgentControlInvitePolicy,
     pub(crate) welcomer_account_ids_hex: Vec<String>,
 }
 
@@ -76,6 +79,26 @@ impl AllowlistStore {
             .list(account_id_hex)?
             .iter()
             .any(|existing| existing == welcomer_account_id_hex))
+    }
+
+    pub(crate) fn policy(
+        &self,
+        account_id_hex: &str,
+    ) -> Result<AgentControlInvitePolicy, ConnectorError> {
+        let _guard = crate::lock_recover(&self.lock);
+        Ok(self.read_record(account_id_hex)?.invite_policy)
+    }
+
+    pub(crate) fn set_policy(
+        &self,
+        account_id_hex: &str,
+        invite_policy: AgentControlInvitePolicy,
+    ) -> Result<AgentControlInvitePolicy, ConnectorError> {
+        let _guard = crate::lock_recover(&self.lock);
+        let mut record = self.read_record(account_id_hex)?;
+        record.invite_policy = invite_policy;
+        self.write_record(&record)?;
+        Ok(record.invite_policy)
     }
 
     pub(crate) fn read_record(
@@ -154,6 +177,7 @@ impl AllowlistStore {
     fn empty_record(account_id_hex: &str) -> AllowlistRecord {
         AllowlistRecord {
             account_id_hex: account_id_hex.to_owned(),
+            invite_policy: AgentControlInvitePolicy::default(),
             welcomer_account_ids_hex: Vec::new(),
         }
     }

--- a/crates/agent-connector/src/bin/wn-agent.rs
+++ b/crates/agent-connector/src/bin/wn-agent.rs
@@ -11,6 +11,7 @@ use agent_connector::{
     resolve_bootstrap_home, resolve_bootstrap_quic_candidates, resolve_bootstrap_relays,
     resolve_bootstrap_socket, run_bootstrap, serve_socket,
 };
+use agent_control::AgentControlInvitePolicy;
 use clap::{Args, Parser, Subcommand};
 use zeroize::Zeroizing;
 
@@ -169,6 +170,12 @@ struct BootstrapArgs {
         help = "Add this welcomer/inviter public key to the agent allowlist; may be repeated"
     )]
     allow_welcomer: Vec<String>,
+    #[arg(
+        long,
+        value_name = "POLICY",
+        help = "Set invite policy: deny, allowlist, any-authenticated-direct, or any-authenticated"
+    )]
+    invite_policy: Option<AgentControlInvitePolicy>,
     #[arg(long, help = "Render invite URI as a terminal QR code using qrencode")]
     qr: bool,
     #[arg(long, help = "Print machine-readable JSON only")]
@@ -545,6 +552,7 @@ async fn run_bootstrap_command(args: BootstrapArgs) -> ExitCode {
         relays,
         quic_candidates,
         allow_welcomers: args.allow_welcomer,
+        invite_policy: args.invite_policy,
         create_if_missing: !args.no_create,
         publish_key_package: !args.no_publish_key_package,
         wait_for_socket: Duration::from_secs_f64(args.wait_for_socket.max(0.0)),
@@ -600,6 +608,9 @@ fn write_bootstrap_output(
             "ies"
         }
     );
+    if let Some(invite_policy) = result.invite_policy {
+        println!("Invite policy: {invite_policy}");
+    }
     if result.key_package_published {
         println!("KeyPackage: published or repaired");
     } else {

--- a/crates/agent-connector/src/bootstrap.rs
+++ b/crates/agent-connector/src/bootstrap.rs
@@ -4,8 +4,8 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use agent_control::{
-    AgentControlAccount, AgentControlEnvelope, AgentControlError, AgentControlRequest,
-    AgentControlResponse, encode_frame, read_envelope,
+    AgentControlAccount, AgentControlEnvelope, AgentControlError, AgentControlInvitePolicy,
+    AgentControlRequest, AgentControlResponse, encode_frame, read_envelope,
 };
 use marmot_app::{
     account_id_hex_from_ref, nprofile_for_account_id, npub_for_account_id, validate_relay_urls,
@@ -34,6 +34,7 @@ pub struct BootstrapOptions {
     pub relays: Vec<String>,
     pub quic_candidates: Vec<String>,
     pub allow_welcomers: Vec<String>,
+    pub invite_policy: Option<AgentControlInvitePolicy>,
     pub create_if_missing: bool,
     pub publish_key_package: bool,
     pub wait_for_socket: Duration,
@@ -53,6 +54,8 @@ pub struct BootstrapResult {
     pub relays: Vec<String>,
     pub quic_candidates: Vec<String>,
     pub welcomer_account_ids_hex: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub invite_policy: Option<AgentControlInvitePolicy>,
     pub npub: String,
     pub nprofile: String,
     pub qr_payload: String,
@@ -89,6 +92,8 @@ pub enum BootstrapError {
     KeyPackageAccountMismatch { expected: String, actual: String },
     #[error("allowlist updated for unexpected account: expected {expected}, got {actual}")]
     AllowlistAccountMismatch { expected: String, actual: String },
+    #[error("invite policy updated for unexpected account: expected {expected}, got {actual}")]
+    InvitePolicyAccountMismatch { expected: String, actual: String },
     #[error("{code}: {message}")]
     ControlRejected { code: String, message: String },
     #[error(transparent)]
@@ -125,6 +130,12 @@ pub async fn run_bootstrap(options: BootstrapOptions) -> Result<BootstrapResult,
         options.allow_welcomers.clone(),
     )
     .await?;
+    let invite_policy = match options.invite_policy {
+        Some(policy) => {
+            Some(bootstrap_invite_policy(&client, &account_state.account_id_hex, policy).await?)
+        }
+        None => None,
+    };
 
     let npub = npub_for_account_id(&account_state.account_id_hex)?;
     let nprofile = nprofile_for_account_id(&account_state.account_id_hex, &options.relays)?;
@@ -139,12 +150,41 @@ pub async fn run_bootstrap(options: BootstrapOptions) -> Result<BootstrapResult,
         relays: options.relays.clone(),
         quic_candidates: options.quic_candidates.clone(),
         welcomer_account_ids_hex,
+        invite_policy,
         npub,
         nprofile: nprofile.clone(),
         qr_payload: nprofile,
     };
 
     Ok(result)
+}
+
+async fn bootstrap_invite_policy(
+    client: &ControlClient,
+    account_id_hex: &str,
+    policy: AgentControlInvitePolicy,
+) -> Result<AgentControlInvitePolicy, BootstrapError> {
+    let request = AgentControlRequest::InvitePolicySet {
+        account_id_hex: account_id_hex.to_owned(),
+        policy,
+    };
+    let response = client.request(request).await?;
+    ensure_response_type(&response, "invite_policy")?;
+    let (echoed_account_id_hex, policy) = match response.payload {
+        AgentControlResponse::InvitePolicy {
+            account_id_hex,
+            policy,
+        } => (account_id_hex, policy),
+        other => return Err(unexpected_response("invite_policy", &other)),
+    };
+    let echoed_account_id_hex = normalize_account_id_hex(&echoed_account_id_hex)?;
+    if echoed_account_id_hex != account_id_hex {
+        return Err(BootstrapError::InvitePolicyAccountMismatch {
+            expected: account_id_hex.to_owned(),
+            actual: echoed_account_id_hex,
+        });
+    }
+    Ok(policy)
 }
 
 #[derive(Clone, Debug)]
@@ -472,6 +512,7 @@ fn response_type_name(response: &AgentControlResponse) -> &'static str {
         AgentControlResponse::FinalSent { .. } => "final_sent",
         AgentControlResponse::AppEventSent { .. } => "app_event_sent",
         AgentControlResponse::Allowlist { .. } => "allowlist",
+        AgentControlResponse::InvitePolicy { .. } => "invite_policy",
         AgentControlResponse::GroupInfo { .. } => "group_info",
         AgentControlResponse::MaintenanceStatus { .. } => "maintenance_status",
         AgentControlResponse::KeyPackageMaintenanceStatus { .. } => {
@@ -998,6 +1039,7 @@ mod tests {
                 .collect(),
             quic_candidates: vec![DEFAULT_QUIC_CANDIDATE.to_owned()],
             allow_welcomers: Vec::new(),
+            invite_policy: None,
             create_if_missing: true,
             publish_key_package: true,
             wait_for_socket: Duration::from_millis(100),

--- a/crates/agent-connector/src/connection.rs
+++ b/crates/agent-connector/src/connection.rs
@@ -206,6 +206,13 @@ impl AgentConnector {
                 account_id_hex,
                 welcomer_account_id_hex,
             } => self.allowlist_remove_response(&account_id_hex, &welcomer_account_id_hex),
+            AgentControlRequest::InvitePolicyGet { account_id_hex } => {
+                self.invite_policy_response(&account_id_hex)
+            }
+            AgentControlRequest::InvitePolicySet {
+                account_id_hex,
+                policy,
+            } => self.invite_policy_set_response(&account_id_hex, policy),
             AgentControlRequest::GroupInfo {
                 account_id_hex,
                 group_id_hex,

--- a/crates/agent-connector/src/invite_policy.rs
+++ b/crates/agent-connector/src/invite_policy.rs
@@ -377,6 +377,9 @@ impl AgentConnector {
         };
         let is_direct =
             if policy == AgentControlInvitePolicy::AnyAuthenticatedDirect && welcomer.is_some() {
+                // This worker evaluates invites serially. Directness is an
+                // admission-time snapshot; later membership changes remain
+                // possible after the invite is accepted.
                 self.runtime
                     .group_mls_state(&account.label, group_id)
                     .await?

--- a/crates/agent-connector/src/invite_policy.rs
+++ b/crates/agent-connector/src/invite_policy.rs
@@ -11,6 +11,7 @@
 
 use std::collections::HashSet;
 
+use agent_control::AgentControlInvitePolicy;
 use cgka_traits::{GroupId, MemberId, engine::GroupEvent};
 use marmot_app::MarmotAppEvent;
 
@@ -361,24 +362,31 @@ impl AgentConnector {
         welcomer: Option<MemberId>,
     ) -> Result<(), ConnectorError> {
         let account = self.local_account_for_account_id(account_id_hex)?;
-        let (welcomer_present, welcomer_allowlisted) = match welcomer {
-            Some(welcomer) => {
-                let allowlisted = if self.dev_allow_any_invites {
-                    false
-                } else {
-                    let welcomer_account_id_hex = hex::encode(welcomer.as_slice());
-                    self.allowlists
-                        .contains(&account.account_id_hex, &welcomer_account_id_hex)?
-                };
-                (true, allowlisted)
-            }
-            None => (false, false),
+        let policy = if self.dev_allow_any_invites {
+            AgentControlInvitePolicy::AnyAuthenticated
+        } else {
+            self.allowlists.policy(&account.account_id_hex)?
         };
-        let allowed = invite_policy_allows(
-            self.dev_allow_any_invites,
-            welcomer_present,
-            welcomer_allowlisted,
-        );
+        let welcomer_allowlisted = match (policy, welcomer.as_ref()) {
+            (AgentControlInvitePolicy::Allowlist, Some(welcomer)) => {
+                let welcomer_account_id_hex = hex::encode(welcomer.as_slice());
+                self.allowlists
+                    .contains(&account.account_id_hex, &welcomer_account_id_hex)?
+            }
+            _ => false,
+        };
+        let is_direct =
+            if policy == AgentControlInvitePolicy::AnyAuthenticatedDirect && welcomer.is_some() {
+                self.runtime
+                    .group_mls_state(&account.label, group_id)
+                    .await?
+                    .member_count
+                    == 2
+            } else {
+                false
+            };
+        let allowed =
+            invite_policy_allows(policy, welcomer.is_some(), welcomer_allowlisted, is_direct);
         if allowed {
             // A catch-up-owned worker returns AccountWorkerBusy as a
             // definitely-not-started result. Propagating it here is
@@ -451,9 +459,16 @@ impl AgentConnector {
 }
 
 pub(crate) fn invite_policy_allows(
-    dev_allow_any_invites: bool,
+    policy: AgentControlInvitePolicy,
     welcomer_present: bool,
     welcomer_allowlisted: bool,
+    is_direct: bool,
 ) -> bool {
-    welcomer_present && (dev_allow_any_invites || welcomer_allowlisted)
+    welcomer_present
+        && match policy {
+            AgentControlInvitePolicy::Deny => false,
+            AgentControlInvitePolicy::Allowlist => welcomer_allowlisted,
+            AgentControlInvitePolicy::AnyAuthenticatedDirect => is_direct,
+            AgentControlInvitePolicy::AnyAuthenticated => true,
+        }
 }

--- a/crates/agent-connector/src/tests.rs
+++ b/crates/agent-connector/src/tests.rs
@@ -2,8 +2,8 @@
 
 use agent_control::{
     AGENT_CONTROL_STREAM_STATUS_STARTED, AgentControlEnvelope, AgentControlEvent,
-    AgentControlProfileLookupStatus, AgentControlRequest, AgentControlResponse,
-    AgentControlSendMaintenanceDisposition, read_envelope, write_frame,
+    AgentControlInvitePolicy, AgentControlProfileLookupStatus, AgentControlRequest,
+    AgentControlResponse, AgentControlSendMaintenanceDisposition, read_envelope, write_frame,
 };
 use cgka_traits::agent_text_stream::{
     AGENT_TEXT_STREAM_MAX_PLAINTEXT_FRAME_LEN, AGENT_TEXT_STREAM_RECORD_STATUS,
@@ -2080,6 +2080,7 @@ fn allowlist_store_atomic_write_replaces_stale_temp_file() {
     store
         .write_record(&AllowlistRecord {
             account_id_hex: account_id_hex.clone(),
+            invite_policy: AgentControlInvitePolicy::Allowlist,
             welcomer_account_ids_hex: vec![welcomer_account_id_hex.clone()],
         })
         .unwrap();
@@ -2117,6 +2118,7 @@ fn allowlist_store_ignores_record_whose_account_id_does_not_match_path() {
     // `account_id_hex` claims to belong to account #99 (tampered/relocated file).
     let forged = serde_json::to_vec(&AllowlistRecord {
         account_id_hex: other_account_id_hex.clone(),
+        invite_policy: AgentControlInvitePolicy::Allowlist,
         welcomer_account_ids_hex: vec![welcomer_account_id_hex.clone()],
     })
     .unwrap();
@@ -2150,6 +2152,41 @@ fn allowlist_store_ignores_record_whose_account_id_does_not_match_path() {
         vec![welcomer_account_id_hex]
     );
     assert!(!store.record_path(&other_account_id_hex).exists());
+}
+
+#[test]
+fn invite_policy_defaults_to_allowlist_for_legacy_records_and_preserves_entries() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = AllowlistStore::new(dir.path());
+    let account_id_hex = format!("{:064x}", 1);
+    let welcomer_account_id_hex = format!("{:064x}", 2);
+    std::fs::create_dir_all(&store.dir).unwrap();
+    std::fs::write(
+        store.record_path(&account_id_hex),
+        serde_json::to_vec(&serde_json::json!({
+            "account_id_hex": account_id_hex.clone(),
+            "welcomer_account_ids_hex": [welcomer_account_id_hex.clone()]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        store.policy(&account_id_hex).unwrap(),
+        AgentControlInvitePolicy::Allowlist
+    );
+    assert_eq!(
+        store
+            .set_policy(&account_id_hex, AgentControlInvitePolicy::Deny)
+            .unwrap(),
+        AgentControlInvitePolicy::Deny
+    );
+    let record = store.read_record(&account_id_hex).unwrap();
+    assert_eq!(record.invite_policy, AgentControlInvitePolicy::Deny);
+    assert_eq!(
+        record.welcomer_account_ids_hex,
+        vec![welcomer_account_id_hex]
+    );
 }
 
 #[tokio::test]
@@ -2482,7 +2519,7 @@ async fn connector_policy_declines_unlisted_welcomer() {
 }
 
 #[tokio::test]
-async fn connector_policy_dev_allow_any_accepts_unlisted_authenticated_welcomer() {
+async fn connector_policy_any_authenticated_direct_accepts_unlisted_direct_welcomer() {
     let agent_dir = tempfile::tempdir().unwrap();
     let human_dir = tempfile::tempdir().unwrap();
     let relay = MockRelay::run().await.unwrap();
@@ -2509,20 +2546,30 @@ async fn connector_policy_dev_allow_any_accepts_unlisted_authenticated_welcomer(
         agent_dir.path(),
         socket.clone(),
         vec![relay_url],
-        true,
-        true,
+        false,
+        false,
     )));
+    let policy = send_control_request(
+        &socket,
+        "req-direct-policy",
+        AgentControlRequest::InvitePolicySet {
+            account_id_hex: agent.account.account_id_hex.clone(),
+            policy: AgentControlInvitePolicy::AnyAuthenticatedDirect,
+        },
+    )
+    .await;
     assert!(matches!(
-        send_control_request(&socket, "req-ready", AgentControlRequest::AccountList)
-            .await
-            .payload,
-        AgentControlResponse::AccountList { .. }
+        policy.payload,
+        AgentControlResponse::InvitePolicy {
+            policy: AgentControlInvitePolicy::AnyAuthenticatedDirect,
+            ..
+        }
     ));
 
     let group_id = human_runtime
         .create_group(
             &human.account.account_id_hex,
-            "allow any invite",
+            "allow authenticated direct invite",
             std::slice::from_ref(&agent.account.account_id_hex),
             None,
         )
@@ -2539,13 +2586,121 @@ async fn connector_policy_dev_allow_any_accepts_unlisted_authenticated_welcomer(
     let _ = server.await;
 }
 
+#[tokio::test]
+async fn connector_policy_any_authenticated_direct_declines_multiparty_invite() {
+    let agent_dir = tempfile::tempdir().unwrap();
+    let human_dir = tempfile::tempdir().unwrap();
+    let relay = MockRelay::run().await.unwrap();
+    let relay_url = relay.url().await.to_string();
+    let agent_app = MarmotApp::with_relay(agent_dir.path(), relay_url.clone());
+    let human_app = MarmotApp::with_relay(human_dir.path(), relay_url.clone());
+    let agent_setup_runtime = MarmotAppRuntime::new(agent_app.clone());
+    let human_runtime = MarmotAppRuntime::new(human_app);
+    let setup = AccountSetupRequest {
+        default_relays: vec![crate::validation::endpoint(&relay_url)],
+        bootstrap_relays: vec![crate::validation::endpoint(&relay_url)],
+        publish_initial_key_package: true,
+        ..AccountSetupRequest::default()
+    };
+    let third_setup = AccountSetupRequest {
+        default_relays: vec![crate::validation::endpoint(&relay_url)],
+        bootstrap_relays: vec![crate::validation::endpoint(&relay_url)],
+        publish_initial_key_package: true,
+        ..AccountSetupRequest::default()
+    };
+    let agent = agent_setup_runtime
+        .create_identity(setup.relay_options_only())
+        .await
+        .unwrap();
+    let human = human_runtime.create_identity(setup).await.unwrap();
+    let third = human_runtime.create_identity(third_setup).await.unwrap();
+    agent_setup_runtime.shutdown().await;
+
+    let socket = agent_dir.path().join("dev").join("wn-agent.sock");
+    let server = tokio::spawn(serve_socket(test_config(
+        agent_dir.path(),
+        socket.clone(),
+        vec![relay_url],
+        false,
+        false,
+    )));
+    let policy = send_control_request(
+        &socket,
+        "req-direct-policy",
+        AgentControlRequest::InvitePolicySet {
+            account_id_hex: agent.account.account_id_hex.clone(),
+            policy: AgentControlInvitePolicy::AnyAuthenticatedDirect,
+        },
+    )
+    .await;
+    assert!(matches!(
+        policy.payload,
+        AgentControlResponse::InvitePolicy {
+            policy: AgentControlInvitePolicy::AnyAuthenticatedDirect,
+            ..
+        }
+    ));
+
+    let group_id = human_runtime
+        .create_group(
+            &human.account.account_id_hex,
+            "reject authenticated multiparty invite",
+            &[
+                agent.account.account_id_hex.clone(),
+                third.account.account_id_hex.clone(),
+            ],
+            None,
+        )
+        .await
+        .unwrap();
+    let group_id_hex = hex::encode(group_id.as_slice());
+    wait_for_group_state(&agent_app, &agent.account.label, &group_id_hex, |group| {
+        !group.pending_confirmation && group.archived
+    })
+    .await;
+
+    human_runtime.shutdown().await;
+    server.abort();
+    let _ = server.await;
+}
+
 #[test]
-fn dev_allow_any_invites_still_requires_an_authenticated_welcomer() {
+fn invite_policies_require_an_authenticated_welcomer_and_enforce_scope() {
     assert!(crate::invite_policy::invite_policy_allows(
-        true, true, false
+        AgentControlInvitePolicy::AnyAuthenticated,
+        true,
+        false,
+        false,
     ));
     assert!(!crate::invite_policy::invite_policy_allows(
-        true, false, false
+        AgentControlInvitePolicy::AnyAuthenticated,
+        false,
+        false,
+        false,
+    ));
+    assert!(crate::invite_policy::invite_policy_allows(
+        AgentControlInvitePolicy::AnyAuthenticatedDirect,
+        true,
+        false,
+        true,
+    ));
+    assert!(!crate::invite_policy::invite_policy_allows(
+        AgentControlInvitePolicy::AnyAuthenticatedDirect,
+        true,
+        false,
+        false,
+    ));
+    assert!(crate::invite_policy::invite_policy_allows(
+        AgentControlInvitePolicy::Allowlist,
+        true,
+        true,
+        false,
+    ));
+    assert!(!crate::invite_policy::invite_policy_allows(
+        AgentControlInvitePolicy::Deny,
+        true,
+        true,
+        true,
     ));
 }
 

--- a/crates/agent-connector/src/tests.rs
+++ b/crates/agent-connector/src/tests.rs
@@ -2549,7 +2549,7 @@ async fn connector_policy_any_authenticated_direct_accepts_unlisted_direct_welco
         false,
         false,
     )));
-    let policy = send_control_request(
+    let policy_response = send_control_request(
         &socket,
         "req-direct-policy",
         AgentControlRequest::InvitePolicySet {
@@ -2559,7 +2559,7 @@ async fn connector_policy_any_authenticated_direct_accepts_unlisted_direct_welco
     )
     .await;
     assert!(matches!(
-        policy.payload,
+        policy_response.payload,
         AgentControlResponse::InvitePolicy {
             policy: AgentControlInvitePolicy::AnyAuthenticatedDirect,
             ..
@@ -2586,8 +2586,7 @@ async fn connector_policy_any_authenticated_direct_accepts_unlisted_direct_welco
     let _ = server.await;
 }
 
-#[tokio::test]
-async fn connector_policy_any_authenticated_direct_declines_multiparty_invite() {
+async fn assert_multiparty_invite_policy(policy: AgentControlInvitePolicy, expect_archived: bool) {
     let agent_dir = tempfile::tempdir().unwrap();
     let human_dir = tempfile::tempdir().unwrap();
     let relay = MockRelay::run().await.unwrap();
@@ -2624,27 +2623,27 @@ async fn connector_policy_any_authenticated_direct_declines_multiparty_invite() 
         false,
         false,
     )));
-    let policy = send_control_request(
+    let policy_response = send_control_request(
         &socket,
-        "req-direct-policy",
+        "req-multiparty-policy",
         AgentControlRequest::InvitePolicySet {
             account_id_hex: agent.account.account_id_hex.clone(),
-            policy: AgentControlInvitePolicy::AnyAuthenticatedDirect,
+            policy,
         },
     )
     .await;
     assert!(matches!(
-        policy.payload,
+        policy_response.payload,
         AgentControlResponse::InvitePolicy {
-            policy: AgentControlInvitePolicy::AnyAuthenticatedDirect,
+            policy: applied_policy,
             ..
-        }
+        } if applied_policy == policy
     ));
 
     let group_id = human_runtime
         .create_group(
             &human.account.account_id_hex,
-            "reject authenticated multiparty invite",
+            "authenticated multiparty invite",
             &[
                 agent.account.account_id_hex.clone(),
                 third.account.account_id_hex.clone(),
@@ -2655,13 +2654,23 @@ async fn connector_policy_any_authenticated_direct_declines_multiparty_invite() 
         .unwrap();
     let group_id_hex = hex::encode(group_id.as_slice());
     wait_for_group_state(&agent_app, &agent.account.label, &group_id_hex, |group| {
-        !group.pending_confirmation && group.archived
+        !group.pending_confirmation && group.archived == expect_archived
     })
     .await;
 
     human_runtime.shutdown().await;
     server.abort();
     let _ = server.await;
+}
+
+#[tokio::test]
+async fn connector_policy_any_authenticated_direct_declines_multiparty_invite() {
+    assert_multiparty_invite_policy(AgentControlInvitePolicy::AnyAuthenticatedDirect, true).await;
+}
+
+#[tokio::test]
+async fn connector_policy_any_authenticated_accepts_multiparty_invite() {
+    assert_multiparty_invite_policy(AgentControlInvitePolicy::AnyAuthenticated, false).await;
 }
 
 #[test]

--- a/crates/agent-connector/src/validation.rs
+++ b/crates/agent-connector/src/validation.rs
@@ -174,6 +174,8 @@ pub(crate) fn agent_control_request_type(request: &AgentControlRequest) -> &'sta
         AgentControlRequest::AllowlistList { .. } => "allowlist_list",
         AgentControlRequest::AllowlistAdd { .. } => "allowlist_add",
         AgentControlRequest::AllowlistRemove { .. } => "allowlist_remove",
+        AgentControlRequest::InvitePolicyGet { .. } => "invite_policy_get",
+        AgentControlRequest::InvitePolicySet { .. } => "invite_policy_set",
         AgentControlRequest::DebugInjectInbound { .. } => "debug_inject_inbound",
         AgentControlRequest::DebugRecordedFinals => "debug_recorded_finals",
         AgentControlRequest::SendMedia { .. } => "send_media",

--- a/crates/agent-control/README.md
+++ b/crates/agent-control/README.md
@@ -22,7 +22,7 @@ begin inputs is an error, and trying to begin another active stream with an occu
 
 ## What this crate does
 
-- Owns `AgentControlEnvelope` and the typed control DTOs (bootstrap, send, subscribe, timeline history, stream compose,
+- Owns `AgentControlEnvelope` and the typed control DTOs (bootstrap, send, subscribe, timeline history, invite policy, stream compose,
   allowlists, etc.).
 - Provides newline-delimited JSON framing with a 1 MiB per-frame cap.
 - Stays dependency-light: `serde` and Tokio IO only.

--- a/crates/agent-control/README.md
+++ b/crates/agent-control/README.md
@@ -27,6 +27,10 @@ begin inputs is an error, and trying to begin another active stream with an occu
 - Provides newline-delimited JSON framing with a 1 MiB per-frame cap.
 - Stays dependency-light: `serde` and Tokio IO only.
 
+Invite-policy values serialize on the wire as `deny`, `allowlist`, `any_authenticated_direct`, and
+`any_authenticated`. Deserialization also accepts the CLI spellings `any-authenticated-direct` and
+`any-authenticated`.
+
 `send_reaction` adds arbitrary non-blank, control-free reaction content of at
 most 64 Unicode scalar values to a durable message. Repeating the same content
 from the same account on the same target is idempotent and returns the existing

--- a/crates/agent-control/src/lib.rs
+++ b/crates/agent-control/src/lib.rs
@@ -26,7 +26,9 @@ pub enum AgentControlInvitePolicy {
     Deny,
     #[default]
     Allowlist,
+    #[serde(alias = "any-authenticated-direct")]
     AnyAuthenticatedDirect,
+    #[serde(alias = "any-authenticated")]
     AnyAuthenticated,
 }
 
@@ -905,12 +907,29 @@ mod tests {
     use tokio::io::BufReader;
 
     use crate::{
-        AgentControlEnvelope, AgentControlError, AgentControlEvent, AgentControlMediaUpload,
-        AgentControlProfileLookupStatus, AgentControlRequest, AgentControlResponse,
-        AgentControlSendMaintenanceDisposition, AgentControlTimelineCursor,
+        AgentControlEnvelope, AgentControlError, AgentControlEvent, AgentControlInvitePolicy,
+        AgentControlMediaUpload, AgentControlProfileLookupStatus, AgentControlRequest,
+        AgentControlResponse, AgentControlSendMaintenanceDisposition, AgentControlTimelineCursor,
         MAX_AGENT_CONTROL_FRAME_BYTES, decode_envelope, encode_frame, read_envelope, read_frame,
         write_frame,
     };
+
+    #[test]
+    fn invite_policy_accepts_cli_aliases_without_changing_canonical_wire_values() {
+        assert_eq!(
+            serde_json::from_str::<AgentControlInvitePolicy>("\"any-authenticated-direct\"")
+                .unwrap(),
+            AgentControlInvitePolicy::AnyAuthenticatedDirect
+        );
+        assert_eq!(
+            serde_json::from_str::<AgentControlInvitePolicy>("\"any-authenticated\"").unwrap(),
+            AgentControlInvitePolicy::AnyAuthenticated
+        );
+        assert_eq!(
+            serde_json::to_string(&AgentControlInvitePolicy::AnyAuthenticatedDirect).unwrap(),
+            "\"any_authenticated_direct\""
+        );
+    }
 
     #[test]
     fn rich_context_golden_events_decode_and_deleted_targets_are_redacted() {

--- a/crates/agent-control/src/lib.rs
+++ b/crates/agent-control/src/lib.rs
@@ -15,6 +15,54 @@ pub const AGENT_CONTROL_TIMELINE_MAX_LIMIT: u32 = 50;
 pub const AGENT_CONTROL_TIMELINE_TEXT_MAX_CHARS: usize = 8_192;
 pub const AGENT_CONTROL_TIMELINE_REACTIONS_MAX: usize = 64;
 
+/// Account-scoped policy for confirming inbound Marmot group invites.
+///
+/// A policy never makes an unauthenticated Welcome acceptable. The
+/// `any_authenticated_direct` variant additionally requires the joined MLS
+/// group to contain exactly the local agent and one peer.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentControlInvitePolicy {
+    Deny,
+    #[default]
+    Allowlist,
+    AnyAuthenticatedDirect,
+    AnyAuthenticated,
+}
+
+impl AgentControlInvitePolicy {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Deny => "deny",
+            Self::Allowlist => "allowlist",
+            Self::AnyAuthenticatedDirect => "any-authenticated-direct",
+            Self::AnyAuthenticated => "any-authenticated",
+        }
+    }
+}
+
+impl std::fmt::Display for AgentControlInvitePolicy {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for AgentControlInvitePolicy {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "deny" => Ok(Self::Deny),
+            "allowlist" => Ok(Self::Allowlist),
+            "any-authenticated-direct" => Ok(Self::AnyAuthenticatedDirect),
+            "any-authenticated" => Ok(Self::AnyAuthenticated),
+            _ => Err(format!(
+                "invalid invite policy {value:?}; expected deny, allowlist, any-authenticated-direct, or any-authenticated"
+            )),
+        }
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum AgentControlError {
     #[error("agent control frame is empty")]
@@ -272,6 +320,13 @@ pub enum AgentControlRequest {
         account_id_hex: String,
         welcomer_account_id_hex: String,
     },
+    InvitePolicyGet {
+        account_id_hex: String,
+    },
+    InvitePolicySet {
+        account_id_hex: String,
+        policy: AgentControlInvitePolicy,
+    },
     DebugInjectInbound {
         account_id_hex: String,
         group_id_hex: String,
@@ -397,6 +452,10 @@ pub enum AgentControlResponse {
     Allowlist {
         account_id_hex: String,
         welcomer_account_ids_hex: Vec<String>,
+    },
+    InvitePolicy {
+        account_id_hex: String,
+        policy: AgentControlInvitePolicy,
     },
     GroupInfo {
         account_id_hex: String,
@@ -1543,6 +1602,19 @@ mod tests {
                     welcomer_account_id_hex: welcomer(),
                 },
                 "allowlist_remove",
+            ),
+            (
+                AgentControlRequest::InvitePolicyGet {
+                    account_id_hex: account(),
+                },
+                "invite_policy_get",
+            ),
+            (
+                AgentControlRequest::InvitePolicySet {
+                    account_id_hex: account(),
+                    policy: crate::AgentControlInvitePolicy::AnyAuthenticatedDirect,
+                },
+                "invite_policy_set",
             ),
             (
                 AgentControlRequest::DebugInjectInbound {

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -255,6 +255,14 @@ the default installer topology that means each connector has its own allowlist.
 It matters most when several integrations are intentionally configured to manage
 the same account.
 
+Invite admission defaults to `allowlist`. Public direct-message bots can opt in
+without enabling debug controls by rerunning bootstrap with
+`--invite-policy any-authenticated-direct`; this accepts an authenticated
+welcomer only when the resulting MLS group has exactly two members. The other
+explicit policies are `deny`, `allowlist`, and `any-authenticated` (which also
+admits multi-party groups). These account-scoped invite policies remain
+independent from each integration's sender and activation policy.
+
 Hermes and OpenClaw can mirror configured `allowFrom`/welcomer entries into
 `wn-agent`. Their sync path is config-driven and may reconcile the connector
 allowlist to the configured set. All terminal harnesses require at least one

--- a/integrations/terminal-harness/src/control.rs
+++ b/integrations/terminal-harness/src/control.rs
@@ -311,6 +311,7 @@ fn response_name(response: &AgentControlResponse) -> &'static str {
         AgentControlResponse::FinalSent { .. } => "final_sent",
         AgentControlResponse::AppEventSent { .. } => "app_event_sent",
         AgentControlResponse::Allowlist { .. } => "allowlist",
+        AgentControlResponse::InvitePolicy { .. } => "invite_policy",
         AgentControlResponse::GroupInfo { .. } => "group_info",
         AgentControlResponse::MaintenanceStatus { .. } => "maintenance_status",
         AgentControlResponse::KeyPackageMaintenanceStatus { .. } => {


### PR DESCRIPTION
## Summary

- add account-scoped `deny`, `allowlist`, `any_authenticated_direct`, and `any_authenticated` invite policies
- preserve `allowlist` as the default for existing records and keep authenticated-welcomer fail-closed behavior
- require exactly two MLS members for `any_authenticated_direct`, declining multiparty invites
- expose policy get/set through agent control and `wn-agent bootstrap --invite-policy`
- document that invite admission remains separate from sender and activation policy

## Testing

- `just fast-ci`
- `cargo test -p agent-control`
- `cargo test -p agent-connector`

The connector tests include real local-relay coverage proving that an unlisted authenticated direct invite is accepted while a three-member invite is declined and archived.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added account-scoped invite policies: deny, allowlist, authenticated direct, and any authenticated.
  * Added controls to view and update an account’s invite policy.
  * Bootstrap configuration now supports setting and reporting invite policies.
  * Policy settings persist across restarts, with legacy configurations defaulting to allowlist behavior.

* **Bug Fixes**
  * Clarified enforcement for direct and multi-party invites, including fail-closed handling for unauthenticated welcomes.

* **Documentation**
  * Documented policy behavior, defaults, group restrictions, bootstrap configuration, and separation from sender activation settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->