### PR TITLE
fix(marmot-app): give the drained seam the projection effects it skipped

### DIFF
--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -536,7 +536,9 @@ impl AppClient {
         // (`restore_disband_tombstone`), and that replay is the only reconciler
         // left for a disband whose live-session projection never completed — a
         // crash, or a batch that failed after the engine had already drained the
-        // event. So this seam owes the same terminal sweep as the inbound one.
+        // event. So this seam owes the same terminal sweep as the inbound one,
+        // which it discharges by running the shared
+        // `observe_event_projection_effects` below rather than a copy of it.
         let local_account_id_hex = self
             .app
             .account_home()
@@ -621,7 +623,8 @@ impl AppClient {
                 updated_group.as_ref(),
                 &source_message_id_hex,
             );
-            self.invalidate_terminal_pending_sends(event, &local_account_id_hex, &mut summary)?;
+            routes_dirty |=
+                self.observe_event_projection_effects(event, &local_account_id_hex, &mut summary)?;
             let can_ack_application_event = if crosses_frontier {
                 self.prepare_local_group_deletion_frontier_clear(
                     event,
@@ -2132,6 +2135,114 @@ impl AppClient {
         Ok(())
     }
 
+    /// The durable app-projection effects one observed [`GroupEvent`] implies,
+    /// beyond the in-memory state [`observe_event`] maintains.
+    ///
+    /// Every seam that observes engine events runs this: live delivery and
+    /// send-applied effects through [`Self::observe_account_device_effects`],
+    /// and session-history replay through
+    /// [`Self::observe_drained_session_events`]. Those seams legitimately differ
+    /// in how they build a group projection and in what recovery evidence they
+    /// arm, but not in what an event means for the timeline, for membership, or
+    /// for a terminal group's notification destinations — so that part lives
+    /// here once. It used to be copied into the live seam only, which is how a
+    /// crash-replayed departure kept a departed member's push records and left
+    /// the account unread aggregate stale.
+    ///
+    /// Replay-safe by construction, which is what lets the drained seam call it:
+    /// hydration re-emits a stored group's `GroupDisbanded` on every open, and a
+    /// crash replays pending application events the live seam may already have
+    /// projected. Token removal is a `DELETE` of rows that may be gone;
+    /// `set_group_self_membership` writes an absolute value and no-ops when the
+    /// group has no projection row; the queued registration removal is an upsert
+    /// keyed on the group; and both invalidation sweeps skip rows they already
+    /// withdrew.
+    ///
+    /// Returns whether the event forces a transport-route refresh.
+    fn observe_event_projection_effects(
+        &self,
+        event: &cgka_traits::engine::GroupEvent,
+        local_account_id_hex: &str,
+        summary: &mut SyncSummary,
+    ) -> Result<bool, AppError> {
+        let mut routes_dirty = false;
+        // Timeline invalidation dispatch: `AppMessageInvalidated` withdraws
+        // the delivered source row; `GroupStateInvalidated` withdraws every
+        // kind-1210 system row stamped with the superseded commit's
+        // `origin_commit_id`. The engine pairs `GroupStateInvalidated`
+        // with the commit-rollback seam (`CommitRolledBack` on the
+        // stored-convergence path), so that event no longer triggers
+        // tombstoning here — the explicit withdrawal event is the single
+        // authoritative signal and one rollback produces exactly one
+        // projection update.
+        if let Some(projection_update) = self
+            .app
+            .projection_update_for_invalidation_event(&self.state.label, event)?
+        {
+            summary.projection_updates.push(projection_update);
+        }
+        if let cgka_traits::engine::GroupEvent::GroupStateChanged {
+            group_id, change, ..
+        } = event
+            && let Some((member, membership)) = member_departure(change)
+        {
+            let group_id_hex = hex::encode(group_id.as_slice());
+            let member_id_hex = hex::encode(member.as_slice());
+            let _ = self.app.remove_group_push_tokens_for_member(
+                &self.state.label,
+                &group_id_hex,
+                &member_id_hex,
+            );
+            // Only the local account leaving / being removed suppresses our
+            // own unread aggregate for the group; a peer departure must not.
+            // The recorded membership distinguishes a voluntary `Left` from
+            // an involuntary `Removed` so the chat list can tell them apart.
+            // This projection write is the source of truth for the account
+            // unread aggregate, so propagate its error (matching the nearby
+            // timeline/message projection writes) instead of swallowing it:
+            // silently leaving the flag stale would keep
+            // `account_unread_total()` returning an inflated badge after a
+            // self-removal that sync otherwise reports as successful.
+            if member_id_hex.eq_ignore_ascii_case(local_account_id_hex) {
+                self.app
+                    .set_group_self_membership(&self.state.label, &group_id_hex, membership)?;
+            }
+        }
+        if let cgka_traits::engine::GroupEvent::GroupStateChanged {
+            group_id,
+            change: cgka_traits::engine::GroupStateChange::GroupDisbanded,
+            ..
+        } = event
+        {
+            routes_dirty = true;
+            let group_id_hex = hex::encode(group_id.as_slice());
+            // Terminal groups never advertise notification destinations
+            // again. Queue the current registration's removal and discard
+            // every cached peer token immediately; publishing the removal
+            // rumor remains restart-safe in the normal outbox.
+            let _ = self.queue_current_push_registration_removal_for_group(group_id);
+            let _ = self
+                .app
+                .remove_stale_group_push_tokens(&self.state.label, &group_id_hex, &[]);
+        }
+        self.invalidate_terminal_pending_sends(event, local_account_id_hex, summary)?;
+        // A (re-)join or create restores the local account's membership so a
+        // re-add after removal un-suppresses the group's unread count. Same
+        // source-of-truth write as the departure path above: propagate the
+        // error rather than swallow it.
+        if let cgka_traits::engine::GroupEvent::GroupJoined { group_id, .. }
+        | cgka_traits::engine::GroupEvent::GroupCreated { group_id } = event
+        {
+            let group_id_hex = hex::encode(group_id.as_slice());
+            self.app.set_group_self_membership(
+                &self.state.label,
+                &group_id_hex,
+                SelfMembership::Member,
+            )?;
+        }
+        Ok(routes_dirty)
+    }
+
     async fn observe_account_device_effects(
         &mut self,
         effects: &marmot_account::AccountDeviceEffects,
@@ -2231,85 +2342,10 @@ impl AppClient {
                 updated_group.as_ref(),
                 source_message_id_hex,
             );
-            // Timeline invalidation dispatch: `AppMessageInvalidated` withdraws
-            // the delivered source row; `GroupStateInvalidated` withdraws every
-            // kind-1210 system row stamped with the superseded commit's
-            // `origin_commit_id`. The engine pairs `GroupStateInvalidated`
-            // with the commit-rollback seam (`CommitRolledBack` on the
-            // stored-convergence path), so that event no longer triggers
-            // tombstoning here — the explicit withdrawal event is the single
-            // authoritative signal and one rollback produces exactly one
-            // projection update.
-            if let Some(projection_update) = self
-                .app
-                .projection_update_for_invalidation_event(&self.state.label, event)?
-            {
-                summary.projection_updates.push(projection_update);
-            }
+            routes_dirty |=
+                self.observe_event_projection_effects(event, &local_account_id_hex, summary)?;
             if self.state.groups.len() != before {
                 routes_dirty = true;
-            }
-            if let cgka_traits::engine::GroupEvent::GroupStateChanged {
-                group_id, change, ..
-            } = event
-                && let Some((member, membership)) = member_departure(change)
-            {
-                let group_id_hex = hex::encode(group_id.as_slice());
-                let member_id_hex = hex::encode(member.as_slice());
-                let _ = self.app.remove_group_push_tokens_for_member(
-                    &self.state.label,
-                    &group_id_hex,
-                    &member_id_hex,
-                );
-                // Only the local account leaving / being removed suppresses our
-                // own unread aggregate for the group; a peer departure must not.
-                // The recorded membership distinguishes a voluntary `Left` from
-                // an involuntary `Removed` so the chat list can tell them apart.
-                // This projection write is the source of truth for the account
-                // unread aggregate, so propagate its error (matching the nearby
-                // timeline/message projection writes) instead of swallowing it:
-                // silently leaving the flag stale would keep
-                // `account_unread_total()` returning an inflated badge after a
-                // self-removal that sync otherwise reports as successful.
-                if member_id_hex.eq_ignore_ascii_case(&local_account_id_hex) {
-                    self.app.set_group_self_membership(
-                        &self.state.label,
-                        &group_id_hex,
-                        membership,
-                    )?;
-                }
-            }
-            if let cgka_traits::engine::GroupEvent::GroupStateChanged {
-                group_id,
-                change: cgka_traits::engine::GroupStateChange::GroupDisbanded,
-                ..
-            } = event
-            {
-                routes_dirty = true;
-                let group_id_hex = hex::encode(group_id.as_slice());
-                // Terminal groups never advertise notification destinations
-                // again. Queue the current registration's removal and discard
-                // every cached peer token immediately; publishing the removal
-                // rumor remains restart-safe in the normal outbox.
-                let _ = self.queue_current_push_registration_removal_for_group(group_id);
-                let _ =
-                    self.app
-                        .remove_stale_group_push_tokens(&self.state.label, &group_id_hex, &[]);
-            }
-            self.invalidate_terminal_pending_sends(event, &local_account_id_hex, summary)?;
-            // A (re-)join or create restores the local account's membership so a
-            // re-add after removal un-suppresses the group's unread count. Same
-            // source-of-truth write as the departure path above: propagate the
-            // error rather than swallow it.
-            if let cgka_traits::engine::GroupEvent::GroupJoined { group_id, .. }
-            | cgka_traits::engine::GroupEvent::GroupCreated { group_id } = event
-            {
-                let group_id_hex = hex::encode(group_id.as_slice());
-                self.app.set_group_self_membership(
-                    &self.state.label,
-                    &group_id_hex,
-                    SelfMembership::Member,
-                )?;
             }
             let can_ack_application_event = if crosses_frontier {
                 self.prepare_local_group_deletion_frontier_clear(

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -8602,6 +8602,382 @@ async fn a_drained_disband_sweeps_the_held_send_its_first_pass_never_reached() {
     );
 }
 
+fn drained_seam_push_token(
+    group_id_hex: &str,
+    member_id_hex: &str,
+    leaf_index: u32,
+) -> GroupPushTokenRecord {
+    GroupPushTokenRecord {
+        group_id_hex: group_id_hex.to_owned(),
+        member_id_hex: member_id_hex.to_owned(),
+        leaf_index,
+        platform: PushPlatform::Apns,
+        token_fingerprint: format!("fingerprint-{member_id_hex}"),
+        server_pubkey_hex: "bb".repeat(32),
+        relay_hint: None,
+        encrypted_token: vec![1, 2, 3],
+        owner_ts: 1,
+        owner_sig: String::new(),
+        updated_at_ms: 1,
+    }
+}
+
+/// A departed member's cached push records can never verify against current
+/// membership again, so the inbound seam drops them the moment it observes the
+/// departure. A departure that only ever reaches the drained seam — the live
+/// projection crashed before it ran — owes the same cleanup, or the records
+/// survive the restart with nothing left to sweep them.
+#[tokio::test]
+async fn a_drained_member_departure_removes_that_members_group_push_tokens() {
+    let dir = tempfile::tempdir().unwrap();
+    AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relay(dir.path(), "wss://drained-departure.example")
+        .with_test_relay_client(relay);
+    let mut client = app.client("alice").await.unwrap();
+    let group_id = client.create_group("drained departure", &[]).await.unwrap();
+    let group_id_hex = hex::encode(group_id.as_slice());
+
+    let departing = nostr::Keys::generate().public_key().to_hex();
+    let staying = nostr::Keys::generate().public_key().to_hex();
+    app.upsert_group_push_token(
+        "alice",
+        &drained_seam_push_token(&group_id_hex, &departing, 1),
+    )
+    .unwrap();
+    app.upsert_group_push_token(
+        "alice",
+        &drained_seam_push_token(&group_id_hex, &staying, 2),
+    )
+    .unwrap();
+
+    let effects = marmot_account::AccountDeviceEffects {
+        events: vec![cgka_traits::engine::GroupEvent::GroupStateChanged {
+            group_id: group_id.clone(),
+            epoch: cgka_traits::EpochId(1),
+            actor: None,
+            change: cgka_traits::engine::GroupStateChange::MemberRemoved {
+                member: MemberId::new(hex::decode(&departing).unwrap()),
+            },
+            origin_commit_id: None,
+        }],
+        ..Default::default()
+    };
+    client
+        .observe_drained_session_events(&effects)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        app.group_push_tokens("alice", &group_id_hex)
+            .unwrap()
+            .into_iter()
+            .map(|token| token.member_id_hex)
+            .collect::<HashSet<_>>(),
+        HashSet::from([staying]),
+        "a drained departure must drop the departed member's push records and keep the rest"
+    );
+}
+
+/// `account_groups.self_membership` is the source of truth for the account
+/// unread aggregate. A self-departure observed only on the drained seam must
+/// move it, and a drained re-join must move it back — otherwise a crash during
+/// a leave leaves the badge inflated forever, and a crash during a re-add
+/// leaves a live group's unread permanently suppressed.
+#[tokio::test]
+async fn a_drained_self_departure_and_rejoin_move_stored_self_membership() {
+    let dir = tempfile::tempdir().unwrap();
+    let account = AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relay(dir.path(), "wss://drained-membership.example")
+        .with_test_relay_client(relay);
+    let mut client = app.client("alice").await.unwrap();
+    let group_id = client
+        .create_group("drained membership", &[])
+        .await
+        .unwrap();
+    let group_id_hex = hex::encode(group_id.as_slice());
+    assert_eq!(
+        app.stored_group_self_membership("alice", &group_id_hex)
+            .unwrap(),
+        Some(SelfMembership::Member),
+    );
+
+    let departure = marmot_account::AccountDeviceEffects {
+        events: vec![cgka_traits::engine::GroupEvent::GroupStateChanged {
+            group_id: group_id.clone(),
+            epoch: cgka_traits::EpochId(1),
+            actor: None,
+            change: cgka_traits::engine::GroupStateChange::MemberRemoved {
+                member: MemberId::new(hex::decode(&account.account_id_hex).unwrap()),
+            },
+            origin_commit_id: None,
+        }],
+        ..Default::default()
+    };
+    client
+        .observe_drained_session_events(&departure)
+        .await
+        .unwrap();
+    assert_eq!(
+        app.stored_group_self_membership("alice", &group_id_hex)
+            .unwrap(),
+        Some(SelfMembership::Removed),
+        "a drained self-eviction must record how the account left"
+    );
+
+    let rejoin = marmot_account::AccountDeviceEffects {
+        events: vec![cgka_traits::engine::GroupEvent::GroupJoined {
+            group_id: group_id.clone(),
+            via_welcome: MessageId::new(vec![0x7a; 32]),
+            welcomer: None,
+        }],
+        ..Default::default()
+    };
+    client
+        .observe_drained_session_events(&rejoin)
+        .await
+        .unwrap();
+    assert_eq!(
+        app.stored_group_self_membership("alice", &group_id_hex)
+            .unwrap(),
+        Some(SelfMembership::Member),
+        "a drained re-join must un-suppress the group's unread aggregate again"
+    );
+}
+
+/// A terminal group never advertises notification destinations again. The
+/// inbound seam queues the current registration's removal and discards every
+/// cached peer token; hydration re-emits a stored group's `GroupDisbanded`
+/// behind no delivery at all, and that replay is the only reconciler left when
+/// the live projection never ran.
+///
+/// The arm also sets `routes_dirty`, which is deliberately not asserted here: a
+/// disband leaves the group's transport route in place, so the forced
+/// `sync_runtime_groups` reconciles an unchanged subscription set and reaches
+/// the relay as nothing observable.
+#[tokio::test]
+async fn a_drained_disband_performs_the_terminal_push_sweep() {
+    let dir = tempfile::tempdir().unwrap();
+    AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relay(dir.path(), "wss://drained-sweep.example")
+        .with_test_relay_client(relay);
+    let mut client = app.client("alice").await.unwrap();
+    let group_id = client.create_group("drained sweep", &[]).await.unwrap();
+    let group_id_hex = hex::encode(group_id.as_slice());
+
+    app.upsert_push_registration(
+        "alice",
+        PushPlatform::Fcm,
+        "device-token",
+        &nostr::Keys::generate().public_key().to_hex(),
+        None,
+    )
+    .unwrap();
+    let peer = nostr::Keys::generate().public_key().to_hex();
+    app.upsert_group_push_token("alice", &drained_seam_push_token(&group_id_hex, &peer, 1))
+        .unwrap();
+
+    let effects = marmot_account::AccountDeviceEffects {
+        events: vec![cgka_traits::engine::GroupEvent::GroupStateChanged {
+            group_id: group_id.clone(),
+            epoch: cgka_traits::EpochId(1),
+            actor: None,
+            change: cgka_traits::engine::GroupStateChange::GroupDisbanded,
+            origin_commit_id: None,
+        }],
+        ..Default::default()
+    };
+    client
+        .observe_drained_session_events(&effects)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        app.pending_push_registration_removals("alice")
+            .unwrap()
+            .into_iter()
+            .map(|(group, _)| group)
+            .collect::<Vec<_>>(),
+        vec![group_id_hex.clone()],
+        "a drained disband must queue the current registration's removal"
+    );
+    assert!(
+        app.group_push_tokens("alice", &group_id_hex)
+            .unwrap()
+            .is_empty(),
+        "a drained disband must discard every cached peer token"
+    );
+}
+
+/// `AppMessageInvalidated` is the engine's explicit timeline withdrawal. The
+/// drained seam is where it lands after a crash, so skipping the dispatch
+/// leaves a message the canonical branch never carried rendered as live
+/// history.
+#[tokio::test]
+async fn a_drained_invalidation_event_withdraws_the_timeline_record() {
+    let dir = tempfile::tempdir().unwrap();
+    let account = AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relay(dir.path(), "wss://drained-invalidation.example")
+        .with_test_relay_client(relay);
+    let mut client = app.client("alice").await.unwrap();
+    let group_id = client
+        .create_group("drained invalidation", &[])
+        .await
+        .unwrap();
+    let group_id_hex = hex::encode(group_id.as_slice());
+    let source_message_id = MessageId::new(vec![0x5c; 32]);
+    let source_message_id_hex = hex::encode(source_message_id.as_slice());
+
+    app.record_account_app_event(
+        "alice",
+        &AppMessageProjection {
+            message_id_hex: "losing-branch-row".to_owned(),
+            source_message_id_hex: Some(source_message_id_hex),
+            direction: "received".to_owned(),
+            group_id_hex: group_id_hex.clone(),
+            sender: account.account_id_hex.clone(),
+            plaintext: "from the losing branch".to_owned(),
+            kind: MARMOT_APP_EVENT_KIND_CHAT,
+            tags: Vec::new(),
+            source_epoch: Some(1),
+            retention: None,
+            recorded_at: Some(11),
+            origin_commit_id: None,
+            moderation_grant: false,
+        },
+    )
+    .unwrap();
+
+    let effects = marmot_account::AccountDeviceEffects {
+        events: vec![cgka_traits::engine::GroupEvent::AppMessageInvalidated {
+            group_id: group_id.clone(),
+            message_id: source_message_id,
+            epoch: cgka_traits::EpochId(1),
+            reason: cgka_traits::engine::AppMessageInvalidationReason::LosingBranch,
+            decrypted_payload_ref: None,
+        }],
+        ..Default::default()
+    };
+    let summary = client
+        .observe_drained_session_events(&effects)
+        .await
+        .unwrap();
+
+    assert!(
+        !summary.projection_updates.is_empty(),
+        "a drained withdrawal must reach live timeline subscribers"
+    );
+    assert_eq!(
+        app.timeline_messages_with_query(
+            "alice",
+            storage_sqlite::TimelineMessageQuery {
+                group_id_hex: Some(group_id_hex),
+                ..storage_sqlite::TimelineMessageQuery::default()
+            },
+        )
+        .unwrap()
+        .messages
+        .into_iter()
+        .find(|row| row.message_id_hex == "losing-branch-row")
+        .expect("the withdrawn row must still be on the timeline as a tombstone")
+        .invalidation_status,
+        Some("LosingBranch".to_owned()),
+        "a drained withdrawal must tombstone the delivered row"
+    );
+}
+
+/// Drained replay is not exclusive with live delivery: a crash can leave the
+/// engine's durable outbox holding events the inbound seam already projected,
+/// and hydration re-emits a disband on every open. Every write both seams share
+/// must therefore be safe to apply twice — an absent push token, a membership
+/// already at its target value, and an already-queued registration removal all
+/// converge rather than accumulate.
+#[tokio::test]
+async fn replaying_a_drained_batch_the_seam_already_applied_is_a_no_op() {
+    let dir = tempfile::tempdir().unwrap();
+    let account = AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relay(dir.path(), "wss://drained-replay.example")
+        .with_test_relay_client(relay);
+    let mut client = app.client("alice").await.unwrap();
+    let group_id = client.create_group("drained replay", &[]).await.unwrap();
+    let group_id_hex = hex::encode(group_id.as_slice());
+
+    app.upsert_push_registration(
+        "alice",
+        PushPlatform::Fcm,
+        "device-token",
+        &nostr::Keys::generate().public_key().to_hex(),
+        None,
+    )
+    .unwrap();
+    let peer = nostr::Keys::generate().public_key().to_hex();
+    app.upsert_group_push_token("alice", &drained_seam_push_token(&group_id_hex, &peer, 1))
+        .unwrap();
+
+    let effects = marmot_account::AccountDeviceEffects {
+        events: vec![
+            cgka_traits::engine::GroupEvent::GroupStateChanged {
+                group_id: group_id.clone(),
+                epoch: cgka_traits::EpochId(1),
+                actor: None,
+                change: cgka_traits::engine::GroupStateChange::MemberRemoved {
+                    member: MemberId::new(hex::decode(&account.account_id_hex).unwrap()),
+                },
+                origin_commit_id: None,
+            },
+            cgka_traits::engine::GroupEvent::GroupStateChanged {
+                group_id: group_id.clone(),
+                epoch: cgka_traits::EpochId(2),
+                actor: None,
+                change: cgka_traits::engine::GroupStateChange::GroupDisbanded,
+                origin_commit_id: None,
+            },
+        ],
+        ..Default::default()
+    };
+    client
+        .observe_drained_session_events(&effects)
+        .await
+        .unwrap();
+    client
+        .observe_drained_session_events(&effects)
+        .await
+        .expect("re-observing a replayed batch must not error");
+
+    assert_eq!(
+        app.pending_push_registration_removals("alice")
+            .unwrap()
+            .len(),
+        1,
+        "a replayed disband must converge on one queued removal, not accumulate them"
+    );
+    assert!(
+        app.group_push_tokens("alice", &group_id_hex)
+            .unwrap()
+            .is_empty(),
+    );
+    assert_eq!(
+        app.stored_group_self_membership("alice", &group_id_hex)
+            .unwrap(),
+        Some(SelfMembership::Removed),
+        "a replayed self-departure must leave membership where the first pass put it"
+    );
+}
+
 #[test]
 fn transport_group_route_replacement_installs_current_and_prior_routes() {
     let routing = AppTransportRouting::new(AppRoutingState {


### PR DESCRIPTION
## Problem

Two seams consume the same engine events: `observe_account_device_effects` (live delivery) and `observe_drained_session_events` (session-history replay after a crash or restart). They drifted. On the same events the drained seam skipped member-departure push-token cleanup, the `set_group_self_membership` writes on self-departure and re-join (leaving the account unread aggregate stale), the entire `GroupDisbanded` terminal sweep — which its own doc comment promised — and the invalidation-event timeline withdrawal. A device that crashed and replayed its history healed its groups but kept stale push tokens, a stale unread count, and timeline records that should have been withdrawn.

## Fix

The shared per-event handling moves into one helper, `observe_event_projection_effects`, called by both seams at the same loop position — no mode flags, since every callee takes `&self`; the deliberate seam differences (quarantine-tolerant projection, recovery-evidence arming, system-row synthesis) stay where they were. This makes the drift that caused the defect structurally impossible for these writes. Every added operation is idempotent under replay — absolute UPDATEs, conflict-converging queues, filtered or no-change invalidation — so a batch the inbound seam already applied before the crash re-applies as a no-op, which a test pins. One known residue: the drained seam still skips `project_group_system_rows` (kind-1210 system rows), tracked separately because it changes the seam's `projection_updates` contract.

## Tests

Five, each red before the fix: drained departure removes the member's push tokens, drained self-departure and re-join move stored self-membership, drained disband performs the terminal push sweep (the first test to exercise that arm on either seam), drained invalidation withdraws the timeline record, and a replayed already-applied batch is a no-op.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved synchronization of session events and app state.
  - Push-token cleanup now works correctly when members leave or sessions are disbanded.
  - Membership changes, including leaving and rejoining, are reflected reliably.
  - Disbanded sessions now remove stale registrations and peer information.
  - Invalidated messages are consistently marked as unavailable.
  - Replayed events no longer create duplicate removals or inconsistent state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->