### PR TITLE
Select the newest valid KeyPackage for group invites

### DIFF
--- a/crates/marmot-app/src/key_package_records.rs
+++ b/crates/marmot-app/src/key_package_records.rs
@@ -96,17 +96,22 @@ fn latest_key_package_from_records(
     mut records: Vec<RelayEventRecord>,
 ) -> Result<FetchedKeyPackage, AppError> {
     sort_directory_records(&mut records);
-    let mut latest = None;
-    for record in records {
+    let mut newest_error = None;
+    for record in records.into_iter().rev() {
         if record.event.kind != KIND_MARMOT_KEY_PACKAGE || record.event.pubkey != account_id_hex {
             continue;
         }
-        let fetched = key_package_from_record(record)?;
-        if fetched.key_package.protocol_profile == ProtocolProfile::Current {
-            latest = Some(fetched);
+        match key_package_from_record(record) {
+            Ok(fetched) if fetched.key_package.protocol_profile == ProtocolProfile::Current => {
+                return Ok(fetched);
+            }
+            Ok(_) => {}
+            Err(error) => {
+                newest_error.get_or_insert(error);
+            }
         }
     }
-    latest.ok_or_else(|| AppError::MissingKeyPackage(account_id_hex.to_owned()))
+    Err(newest_error.unwrap_or_else(|| AppError::MissingKeyPackage(account_id_hex.to_owned())))
 }
 
 pub(crate) fn latest_fresh_key_package_from_records(

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -5055,6 +5055,60 @@ async fn malformed_batch_member_does_not_discard_valid_member_prewarm() {
 }
 
 #[tokio::test]
+async fn member_key_package_resolution_ignores_older_malformed_publication() {
+    let (_directory, app, accounts, fetcher) = member_resolution_fixture(1, false).await;
+    let account_id = accounts[0].account_id_hex.clone();
+    {
+        let mut events = fetcher.events.lock().unwrap();
+        let current = events
+            .iter()
+            .find(|event| event.kind == KIND_MARMOT_KEY_PACKAGE)
+            .expect("current KeyPackage event")
+            .clone();
+        let mut older_malformed = current.clone();
+        older_malformed.created_at = current.created_at.saturating_sub(1);
+        older_malformed.id = "00".repeat(32);
+        older_malformed.content = "not-base64".to_owned();
+        events.push(older_malformed);
+    }
+
+    let summary = app
+        .prewarm_group_member_key_packages(&[account_id.as_str()])
+        .await
+        .expect("the newest valid KeyPackage must win over an older malformed publication");
+
+    assert_eq!(summary.unique_members, 1);
+    assert_eq!(summary.network_resolved_members, 1);
+}
+
+#[tokio::test]
+async fn member_key_package_resolution_falls_back_from_newest_malformed_publication() {
+    let (_directory, app, accounts, fetcher) = member_resolution_fixture(1, false).await;
+    let account_id = accounts[0].account_id_hex.clone();
+    {
+        let mut events = fetcher.events.lock().unwrap();
+        let current = events
+            .iter()
+            .find(|event| event.kind == KIND_MARMOT_KEY_PACKAGE)
+            .expect("current KeyPackage event")
+            .clone();
+        let mut newer_malformed = current.clone();
+        newer_malformed.created_at = current.created_at.saturating_add(1);
+        newer_malformed.id = "ff".repeat(32);
+        newer_malformed.content = "not-base64".to_owned();
+        events.push(newer_malformed);
+    }
+
+    let summary = app
+        .prewarm_group_member_key_packages(&[account_id.as_str()])
+        .await
+        .expect("an invalid newest publication must not hide an older valid KeyPackage");
+
+    assert_eq!(summary.unique_members, 1);
+    assert_eq!(summary.network_resolved_members, 1);
+}
+
+#[tokio::test]
 async fn cancelled_member_prewarm_does_not_admit_or_reserve_results() {
     let (_directory, app, accounts, fetcher) = member_resolution_fixture(1, false).await;
     *fetcher.stalled_endpoint.lock().unwrap() = Some("wss://directory.example".to_owned());


### PR DESCRIPTION
## Summary

- evaluate relay-fetched KeyPackage publications newest-first
- return immediately on the newest valid current-profile package
- skip malformed candidates while retaining the newest validation error when no package is usable
- add regressions for older-malformed/newer-valid and newer-malformed/older-valid publication sets

## Context

A user could not invite a friend because the friend had an older incompatible kind-30443 KeyPackage in a separate slot alongside a newer valid current-profile package. The previous oldest-first traversal parsed the stale publication first and aborted before reaching the usable package.

## Validation

- `cargo test -p marmot-app member_key_package_resolution_ -- --nocapture`
- `just fast-ci`

A broader pre-rebase `cargo test -p marmot-app` run passed all 747 unit tests (1 ignored), but its relay-runtime integration binary had five failures outside the KeyPackage path. One of those unrelated encrypted-media failures reproduced in isolation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved KeyPackage resolution when publications are malformed or invalid.
  * Newer valid publications are now selected over older malformed ones.
  * Older valid publications are used when the latest publication cannot be processed.
  * Legacy-profile packages are excluded from current-profile resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->