### PR TITLE
fix: surface group membership activity in chat list

### DIFF
--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -5203,8 +5203,13 @@ impl MarmotApp {
         storage_update: TimelineProjectionUpdate,
     ) -> Result<AppProjectionUpdate, AppError> {
         let chat_list_row = self.refresh_chat_list_row(label, &storage_update.group_id_hex)?;
-        let chat_list_trigger =
-            ChatListUpdateTrigger::from_timeline_changes(&storage_update.changes);
+        let projects_group_system_activity = chat_list_row
+            .as_ref()
+            .is_some_and(|row| row.conversation_kind == ChatConversationKind::Group);
+        let chat_list_trigger = ChatListUpdateTrigger::from_timeline_changes(
+            &storage_update.changes,
+            projects_group_system_activity,
+        );
         Ok(AppProjectionUpdate {
             group_id_hex: storage_update.group_id_hex,
             timeline_messages: storage_update.messages,

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -38,7 +38,7 @@ use cgka_traits::app_components::{
     AGENT_TEXT_STREAM_QUIC_COMPONENT_ID, NostrRoutingV1, default_group_components,
 };
 pub use cgka_traits::app_event::AppMessageRetentionDecision;
-use cgka_traits::app_event::MARMOT_APP_EVENT_KIND_CHAT;
+use cgka_traits::app_event::{MARMOT_APP_EVENT_KIND_CHAT, MARMOT_APP_EVENT_KIND_GROUP_SYSTEM};
 use cgka_traits::capabilities::{Capability, CapabilityRequirement, Feature, RequirementLevel};
 use cgka_traits::engine::{GroupEvent, KeyPackage};
 use cgka_traits::storage::{DisbandTombstoneStorage, KeyPackageBundleStorage, MaintenanceStorage};
@@ -4459,13 +4459,23 @@ impl MarmotApp {
             .map(|account| account.label))
     }
 
+    /// Kind-1210 rows are locally synthesized state projections, not authored
+    /// Nostr events. Their sender is the authenticated MLS actor when one is
+    /// available and is intentionally empty otherwise, so it is not a stable
+    /// Nostr identity input. The chat-list preview renders the structured
+    /// group-system payload and never consumes a sender display name.
+    fn chat_list_sender_for_profile_hydration(message: &ChatListMessagePreview) -> Option<&str> {
+        (message.kind != MARMOT_APP_EVENT_KIND_GROUP_SYSTEM).then_some(message.sender.as_str())
+    }
+
     fn hydrate_chat_list_rows(&self, rows: &mut [ChatListRow]) -> Result<(), AppError> {
         let senders = rows
             .iter()
             .filter_map(|row| {
                 row.last_message
                     .as_ref()
-                    .map(|message| message.sender.clone())
+                    .and_then(Self::chat_list_sender_for_profile_hydration)
+                    .map(ToOwned::to_owned)
             })
             .collect::<HashSet<_>>();
         let senders = senders.into_iter().collect::<Vec<_>>();
@@ -4492,7 +4502,10 @@ impl MarmotApp {
         };
         (message.attachment_kind, message.attachment_count) =
             media::classify_chat_list_attachments(message.media_json.as_deref());
-        if let Some(name) = self.display_name_for_account_id(&message.sender)? {
+        let Some(sender) = Self::chat_list_sender_for_profile_hydration(message) else {
+            return Ok(());
+        };
+        if let Some(name) = self.display_name_for_account_id(sender)? {
             message.sender_display_name = Some(name);
         }
         Ok(())

--- a/crates/marmot-app/src/runtime/subscriptions.rs
+++ b/crates/marmot-app/src/runtime/subscriptions.rs
@@ -6,7 +6,11 @@ use std::future::pending;
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 
-use cgka_traits::app_event::MARMOT_APP_EVENT_KIND_AGENT_STREAM_START;
+use cgka_traits::app_event::{
+    GROUP_SYSTEM_TYPE_ADMIN_ADDED, GROUP_SYSTEM_TYPE_ADMIN_REMOVED, GROUP_SYSTEM_TYPE_MEMBER_ADDED,
+    GROUP_SYSTEM_TYPE_MEMBER_LEFT, GROUP_SYSTEM_TYPE_MEMBER_REMOVED, GROUP_SYSTEM_TYPE_TAG,
+    MARMOT_APP_EVENT_KIND_AGENT_STREAM_START,
+};
 use cgka_traits::{GroupId, MessageId, storage::StorageError};
 use serde::{Deserialize, Serialize};
 use storage_sqlite::AppEventReplayCursor;
@@ -661,20 +665,40 @@ impl ChatListUpdateTrigger {
         }) {
             return Self::LastMessageDeleted;
         }
-        if changes.iter().any(|change| {
-            matches!(
-                change,
-                TimelineMessageChange::Upsert {
-                    trigger: TimelineUpdateTrigger::NewMessage
-                        | TimelineUpdateTrigger::AgentStreamStarted
-                        | TimelineUpdateTrigger::AgentStreamFinished,
-                    ..
-                }
-            )
-        }) {
+        if changes.iter().any(change_advances_chat_list) {
             return Self::NewLastMessage;
         }
         Self::SnapshotRefresh
+    }
+}
+
+fn change_advances_chat_list(change: &TimelineMessageChange) -> bool {
+    match change {
+        TimelineMessageChange::Upsert {
+            trigger:
+                TimelineUpdateTrigger::NewMessage
+                | TimelineUpdateTrigger::AgentStreamStarted
+                | TimelineUpdateTrigger::AgentStreamFinished,
+            ..
+        } => true,
+        TimelineMessageChange::Upsert {
+            trigger: TimelineUpdateTrigger::GroupSystem,
+            message,
+        } => message.tags.iter().any(|tag| {
+            tag.first()
+                .is_some_and(|name| name == GROUP_SYSTEM_TYPE_TAG)
+                && tag.get(1).is_some_and(|system_type| {
+                    matches!(
+                        system_type.as_str(),
+                        GROUP_SYSTEM_TYPE_MEMBER_ADDED
+                            | GROUP_SYSTEM_TYPE_MEMBER_REMOVED
+                            | GROUP_SYSTEM_TYPE_MEMBER_LEFT
+                            | GROUP_SYSTEM_TYPE_ADMIN_ADDED
+                            | GROUP_SYSTEM_TYPE_ADMIN_REMOVED
+                    )
+                })
+        }),
+        _ => false,
     }
 }
 

--- a/crates/marmot-app/src/runtime/subscriptions.rs
+++ b/crates/marmot-app/src/runtime/subscriptions.rs
@@ -642,7 +642,10 @@ pub enum ChatListUpdateTrigger {
 }
 
 impl ChatListUpdateTrigger {
-    pub(crate) fn from_timeline_changes(changes: &[TimelineMessageChange]) -> Self {
+    pub(crate) fn from_timeline_changes(
+        changes: &[TimelineMessageChange],
+        projects_group_system_activity: bool,
+    ) -> Self {
         if changes.iter().any(|change| {
             matches!(
                 change,
@@ -665,14 +668,20 @@ impl ChatListUpdateTrigger {
         }) {
             return Self::LastMessageDeleted;
         }
-        if changes.iter().any(change_advances_chat_list) {
+        if changes
+            .iter()
+            .any(|change| change_advances_chat_list(change, projects_group_system_activity))
+        {
             return Self::NewLastMessage;
         }
         Self::SnapshotRefresh
     }
 }
 
-fn change_advances_chat_list(change: &TimelineMessageChange) -> bool {
+fn change_advances_chat_list(
+    change: &TimelineMessageChange,
+    projects_group_system_activity: bool,
+) -> bool {
     match change {
         TimelineMessageChange::Upsert {
             trigger:
@@ -684,20 +693,23 @@ fn change_advances_chat_list(change: &TimelineMessageChange) -> bool {
         TimelineMessageChange::Upsert {
             trigger: TimelineUpdateTrigger::GroupSystem,
             message,
-        } => message.tags.iter().any(|tag| {
-            tag.first()
-                .is_some_and(|name| name == GROUP_SYSTEM_TYPE_TAG)
-                && tag.get(1).is_some_and(|system_type| {
-                    matches!(
-                        system_type.as_str(),
-                        GROUP_SYSTEM_TYPE_MEMBER_ADDED
-                            | GROUP_SYSTEM_TYPE_MEMBER_REMOVED
-                            | GROUP_SYSTEM_TYPE_MEMBER_LEFT
-                            | GROUP_SYSTEM_TYPE_ADMIN_ADDED
-                            | GROUP_SYSTEM_TYPE_ADMIN_REMOVED
-                    )
+        } => {
+            projects_group_system_activity
+                && message.tags.iter().any(|tag| {
+                    tag.first()
+                        .is_some_and(|name| name == GROUP_SYSTEM_TYPE_TAG)
+                        && tag.get(1).is_some_and(|system_type| {
+                            matches!(
+                                system_type.as_str(),
+                                GROUP_SYSTEM_TYPE_MEMBER_ADDED
+                                    | GROUP_SYSTEM_TYPE_MEMBER_REMOVED
+                                    | GROUP_SYSTEM_TYPE_MEMBER_LEFT
+                                    | GROUP_SYSTEM_TYPE_ADMIN_ADDED
+                                    | GROUP_SYSTEM_TYPE_ADMIN_REMOVED
+                            )
+                        })
                 })
-        }),
+        }
         _ => false,
     }
 }

--- a/crates/marmot-app/src/runtime/tests.rs
+++ b/crates/marmot-app/src/runtime/tests.rs
@@ -554,8 +554,27 @@ fn group_system_projection_advances_the_chat_list_like_a_new_message() {
     };
 
     assert_eq!(
-        ChatListUpdateTrigger::from_timeline_changes(&[change]),
+        ChatListUpdateTrigger::from_timeline_changes(&[change], true),
         ChatListUpdateTrigger::NewLastMessage,
+    );
+}
+
+#[test]
+fn direct_conversation_group_system_projection_does_not_claim_new_chat_list_activity() {
+    let mut record = timeline_test_record("role-change", 10);
+    record.kind = cgka_traits::app_event::MARMOT_APP_EVENT_KIND_GROUP_SYSTEM;
+    record.tags = vec![vec![
+        cgka_traits::app_event::GROUP_SYSTEM_TYPE_TAG.to_owned(),
+        cgka_traits::app_event::GROUP_SYSTEM_TYPE_ADMIN_ADDED.to_owned(),
+    ]];
+    let change = TimelineMessageChange::Upsert {
+        trigger: crate::TimelineUpdateTrigger::GroupSystem,
+        message: Box::new(record),
+    };
+
+    assert_eq!(
+        ChatListUpdateTrigger::from_timeline_changes(&[change], false),
+        ChatListUpdateTrigger::SnapshotRefresh,
     );
 }
 
@@ -571,7 +590,7 @@ fn agent_stream_updates_still_advance_the_chat_list_like_new_messages() {
         };
 
         assert_eq!(
-            ChatListUpdateTrigger::from_timeline_changes(&[change]),
+            ChatListUpdateTrigger::from_timeline_changes(&[change], false),
             ChatListUpdateTrigger::NewLastMessage,
         );
     }
@@ -591,7 +610,7 @@ fn unrelated_group_system_projection_does_not_claim_new_chat_list_activity() {
     };
 
     assert_eq!(
-        ChatListUpdateTrigger::from_timeline_changes(&[change]),
+        ChatListUpdateTrigger::from_timeline_changes(&[change], true),
         ChatListUpdateTrigger::SnapshotRefresh,
     );
 }

--- a/crates/marmot-app/src/runtime/tests.rs
+++ b/crates/marmot-app/src/runtime/tests.rs
@@ -540,6 +540,62 @@ fn timeline_test_record(message_id_hex: &str, timeline_at: u64) -> TimelineMessa
     }
 }
 
+#[test]
+fn group_system_projection_advances_the_chat_list_like_a_new_message() {
+    let mut record = timeline_test_record("role-change", 10);
+    record.kind = cgka_traits::app_event::MARMOT_APP_EVENT_KIND_GROUP_SYSTEM;
+    record.tags = vec![vec![
+        cgka_traits::app_event::GROUP_SYSTEM_TYPE_TAG.to_owned(),
+        cgka_traits::app_event::GROUP_SYSTEM_TYPE_ADMIN_ADDED.to_owned(),
+    ]];
+    let change = TimelineMessageChange::Upsert {
+        trigger: crate::TimelineUpdateTrigger::GroupSystem,
+        message: Box::new(record),
+    };
+
+    assert_eq!(
+        ChatListUpdateTrigger::from_timeline_changes(&[change]),
+        ChatListUpdateTrigger::NewLastMessage,
+    );
+}
+
+#[test]
+fn agent_stream_updates_still_advance_the_chat_list_like_new_messages() {
+    for trigger in [
+        crate::TimelineUpdateTrigger::AgentStreamStarted,
+        crate::TimelineUpdateTrigger::AgentStreamFinished,
+    ] {
+        let change = TimelineMessageChange::Upsert {
+            trigger,
+            message: Box::new(timeline_test_record("agent-stream", 10)),
+        };
+
+        assert_eq!(
+            ChatListUpdateTrigger::from_timeline_changes(&[change]),
+            ChatListUpdateTrigger::NewLastMessage,
+        );
+    }
+}
+
+#[test]
+fn unrelated_group_system_projection_does_not_claim_new_chat_list_activity() {
+    let mut record = timeline_test_record("rename", 10);
+    record.kind = cgka_traits::app_event::MARMOT_APP_EVENT_KIND_GROUP_SYSTEM;
+    record.tags = vec![vec![
+        cgka_traits::app_event::GROUP_SYSTEM_TYPE_TAG.to_owned(),
+        cgka_traits::app_event::GROUP_SYSTEM_TYPE_GROUP_RENAMED.to_owned(),
+    ]];
+    let change = TimelineMessageChange::Upsert {
+        trigger: crate::TimelineUpdateTrigger::GroupSystem,
+        message: Box::new(record),
+    };
+
+    assert_eq!(
+        ChatListUpdateTrigger::from_timeline_changes(&[change]),
+        ChatListUpdateTrigger::SnapshotRefresh,
+    );
+}
+
 fn timeline_test_page(
     records: &[(&str, u64)],
     has_more_before: bool,

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -5984,6 +5984,38 @@ fn batch_display_name_lookup_opens_one_directory_cache_per_local_account() {
 }
 
 #[test]
+fn group_system_chat_preview_does_not_hydrate_its_optional_actor_as_a_nostr_sender() {
+    let preview = ChatListMessagePreview {
+        message_id_hex: "11".repeat(32),
+        sender: String::new(),
+        sender_display_name: None,
+        plaintext: r#"{"v":1,"system_type":"admin_added","text":"Admin added"}"#.to_owned(),
+        kind: MARMOT_APP_EVENT_KIND_GROUP_SYSTEM,
+        timeline_at: 1,
+        deleted: false,
+        attachment_kind: None,
+        attachment_count: 0,
+        delivery_state: ChatListMessageDeliveryState::NotApplicable,
+        media_json: None,
+    };
+
+    assert_eq!(
+        MarmotApp::chat_list_sender_for_profile_hydration(&preview),
+        None,
+    );
+
+    let ordinary = ChatListMessagePreview {
+        kind: MARMOT_APP_EVENT_KIND_CHAT,
+        sender: "22".repeat(32),
+        ..preview
+    };
+    assert_eq!(
+        MarmotApp::chat_list_sender_for_profile_hydration(&ordinary),
+        Some(ordinary.sender.as_str()),
+    );
+}
+
+#[test]
 fn cached_identity_page_is_order_stable_and_distinguishes_local_from_remote() {
     let dir = tempfile::tempdir().unwrap();
     let home = AccountHome::open(dir.path());

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -5951,10 +5951,10 @@ async fn relay_app_runtime_exchanges_messages_without_lab() {
 }
 
 #[tokio::test]
-async fn self_removal_suppresses_account_unread_while_peer_removal_preserves_it() {
-    // mdk#573: the projection-only account unread aggregate must exclude
-    // groups the local account left / was removed from, but a peer removal must
-    // leave the observer's own unread untouched.
+async fn self_removal_suppresses_account_unread_while_peer_removal_advances_it() {
+    // mdk#573: the projection-only account unread aggregate must exclude groups
+    // the local account left / was removed from. Issue #822 additionally makes
+    // a peer removal visible chat-list activity for observers who remain.
     let dir = tempfile::tempdir().unwrap();
     let home = AccountHome::open(dir.path());
     let alice_account = home.create_account("alice").unwrap();
@@ -6030,16 +6030,16 @@ async fn self_removal_suppresses_account_unread_while_peer_removal_preserves_it(
     loop {
         bob.sync().await.unwrap();
         carol.sync().await.unwrap();
-        // carol's self-removal must zero her summary; bob's peer-removal view must
-        // leave his own unread untouched.
+        // Carol's self-removal must zero her summary. Bob remains a member, so
+        // the peer-removal system row advances his existing unread count.
         if unread_for(&carol_account.account_id_hex) == 0
-            && unread_for(&bob_account.account_id_hex) == 1
+            && unread_for(&bob_account.account_id_hex) == 2
         {
             break;
         }
         assert!(
             std::time::Instant::now() < deadline,
-            "timed out waiting for carol's self-removal to suppress while bob's count is preserved"
+            "timed out waiting for carol's self-removal to suppress while bob sees peer-removal activity"
         );
         sleep(Duration::from_millis(50)).await;
     }
@@ -6051,8 +6051,8 @@ async fn self_removal_suppresses_account_unread_while_peer_removal_preserves_it(
     );
     assert_eq!(
         unread_for(&bob_account.account_id_hex),
-        1,
-        "a peer removal must not suppress bob's own account unread total"
+        2,
+        "a peer removal must advance bob's unread total while he remains a member"
     );
 }
 

--- a/crates/storage-sqlite/src/chat_list.rs
+++ b/crates/storage-sqlite/src/chat_list.rs
@@ -9,7 +9,11 @@ use crate::{
     i64_to_u64, optional_u64_to_i64, u64_to_i64, unix_now_ms, unix_now_seconds,
 };
 use cgka_traits::app_components::{GROUP_AVATAR_URL_COMPONENT_ID, decode_group_avatar_url_v1};
-use cgka_traits::app_event::MARMOT_APP_EVENT_KIND_CHAT;
+use cgka_traits::app_event::{
+    GROUP_SYSTEM_TYPE_ADMIN_ADDED, GROUP_SYSTEM_TYPE_ADMIN_REMOVED, GROUP_SYSTEM_TYPE_MEMBER_ADDED,
+    GROUP_SYSTEM_TYPE_MEMBER_LEFT, GROUP_SYSTEM_TYPE_MEMBER_REMOVED, GROUP_SYSTEM_TYPE_TAG,
+    MARMOT_APP_EVENT_KIND_CHAT, MARMOT_APP_EVENT_KIND_GROUP_SYSTEM,
+};
 use cgka_traits::storage::StorageResult;
 use rusqlite::{Connection, OptionalExtension, Params, params};
 use serde::{Deserialize, Serialize};
@@ -936,10 +940,9 @@ fn rebuild_all_chat_list_rows_tx(
         [],
     )
     .storage()?;
-    // #750: a full rebuild recomputes every mention count, so the projection is
-    // current — advance the marker so warm-up completeness checks skip the
-    // per-group recompute.
-    set_chat_list_mention_counts_version_tx(tx, CHAT_LIST_MENTION_COUNTS_VERSION)?;
+    // A full rebuild reconciles every derived field covered by the current
+    // projection contract, including mentions and kind-1210 activity.
+    set_chat_list_projection_version_tx(tx, CHAT_LIST_PROJECTION_VERSION)?;
     Ok(())
 }
 
@@ -961,12 +964,42 @@ fn refresh_chat_list_row_tx(
     chat_list_row_tx(tx, group_id_hex)
 }
 
-/// Current chat-list projection reconciliation version (#750). Once the stored
-/// marker reaches this value, the warm-up completeness check trusts the stored
-/// `unread_mention_count`s (kept current by incremental refresh) and skips the
-/// O(groups × unread) per-group recompute. Bump this if a future migration can
-/// again leave the counts stale.
-const CHAT_LIST_MENTION_COUNTS_VERSION: i64 = 1;
+/// Current chat-list projection reconciliation version.
+///
+/// Version 1 covered unread-mention counts (#750). Version 2 additionally
+/// projects kind-1210 group-system rows into preview, activity, and unread state
+/// (#822). The persisted column keeps its legacy `mention_counts_version` name
+/// for schema compatibility, but now gates the complete derived-row contract.
+const CHAT_LIST_PROJECTION_VERSION: i64 = 2;
+
+const CHAT_LIST_GROUP_ACTIVITY_TYPES: [&str; 5] = [
+    GROUP_SYSTEM_TYPE_MEMBER_ADDED,
+    GROUP_SYSTEM_TYPE_MEMBER_REMOVED,
+    GROUP_SYSTEM_TYPE_MEMBER_LEFT,
+    GROUP_SYSTEM_TYPE_ADMIN_ADDED,
+    GROUP_SYSTEM_TYPE_ADMIN_REMOVED,
+];
+
+/// SQL predicate for activity that should behave like a chat message in the
+/// chat list. Kind-1210 also carries metadata changes; #822 intentionally
+/// promotes only membership/admin rows, leaving unrelated system events alone.
+fn chat_list_activity_filter_sql(column_prefix: &str) -> String {
+    let group_activity_tags = CHAT_LIST_GROUP_ACTIVITY_TYPES
+        .iter()
+        .map(|system_type| format!(r#"'[["{GROUP_SYSTEM_TYPE_TAG}","{system_type}"]]'"#))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "({column_prefix}kind = {MARMOT_APP_EVENT_KIND_CHAT} OR \
+         ({column_prefix}kind = {MARMOT_APP_EVENT_KIND_GROUP_SYSTEM} AND \
+          {column_prefix}tags_json IN ({group_activity_tags}) AND \
+          EXISTS (SELECT 1 FROM account_groups AS activity_group \
+                  WHERE activity_group.group_id_hex = {column_prefix}group_id_hex \
+                    AND (trim(activity_group.profile_name) != '' OR \
+                         (activity_group.member_count IS NOT NULL AND \
+                          activity_group.member_count != 2)))))"
+    )
+}
 
 /// One authoritative latest-preview order for rebuild, completeness, and
 /// secure-prune repair. Failed local sends remain visible in the timeline but
@@ -987,7 +1020,7 @@ struct LatestChatListMessage {
     canonical_order_prefix: (u8, u64, u8, u64),
 }
 
-fn chat_list_mention_counts_version_tx(tx: &Connection) -> StorageResult<i64> {
+fn chat_list_projection_version_tx(tx: &Connection) -> StorageResult<i64> {
     Ok(tx
         .query_row(
             "SELECT mention_counts_version FROM chat_list_projection_meta WHERE id = 1",
@@ -999,7 +1032,7 @@ fn chat_list_mention_counts_version_tx(tx: &Connection) -> StorageResult<i64> {
         .unwrap_or(0))
 }
 
-fn set_chat_list_mention_counts_version_tx(tx: &Connection, version: i64) -> StorageResult<()> {
+fn set_chat_list_projection_version_tx(tx: &Connection, version: i64) -> StorageResult<()> {
     tx.execute(
         "UPDATE chat_list_projection_meta SET mention_counts_version = ?1 WHERE id = 1",
         params![version],
@@ -1017,6 +1050,7 @@ fn chat_list_projection_complete_tx(
     local_account_id_hex: &str,
     mention_classifier: &MentionClassifier<'_>,
 ) -> StorageResult<bool> {
+    let activity_filter = chat_list_activity_filter_sql("mt.");
     if projection_has_rows_tx(
         tx,
         "SELECT EXISTS(
@@ -1115,7 +1149,7 @@ fn chat_list_projection_complete_tx(
                         SELECT mt.message_id_hex
                         FROM message_timeline AS mt
                         WHERE mt.group_id_hex = ag.group_id_hex
-                          AND mt.kind = ?1
+                          AND {activity_filter}
                           AND (
                               mt.invalidation_status IS NULL
                               OR (
@@ -1130,7 +1164,7 @@ fn chat_list_projection_complete_tx(
                         SELECT mt.sender
                         FROM message_timeline AS mt
                         WHERE mt.group_id_hex = ag.group_id_hex
-                          AND mt.kind = ?1
+                          AND {activity_filter}
                           AND (
                               mt.invalidation_status IS NULL
                               OR (
@@ -1145,7 +1179,7 @@ fn chat_list_projection_complete_tx(
                         SELECT mt.plaintext
                         FROM message_timeline AS mt
                         WHERE mt.group_id_hex = ag.group_id_hex
-                          AND mt.kind = ?1
+                          AND {activity_filter}
                           AND (
                               mt.invalidation_status IS NULL
                               OR (
@@ -1160,7 +1194,7 @@ fn chat_list_projection_complete_tx(
                         SELECT mt.kind
                         FROM message_timeline AS mt
                         WHERE mt.group_id_hex = ag.group_id_hex
-                          AND mt.kind = ?1
+                          AND {activity_filter}
                           AND (
                               mt.invalidation_status IS NULL
                               OR (
@@ -1175,7 +1209,7 @@ fn chat_list_projection_complete_tx(
                         SELECT mt.timeline_at
                         FROM message_timeline AS mt
                         WHERE mt.group_id_hex = ag.group_id_hex
-                          AND mt.kind = ?1
+                          AND {activity_filter}
                           AND (
                               mt.invalidation_status IS NULL
                               OR (
@@ -1190,7 +1224,7 @@ fn chat_list_projection_complete_tx(
                         SELECT mt.deleted
                         FROM message_timeline AS mt
                         WHERE mt.group_id_hex = ag.group_id_hex
-                          AND mt.kind = ?1
+                          AND {activity_filter}
                           AND (
                               mt.invalidation_status IS NULL
                               OR (
@@ -1205,7 +1239,7 @@ fn chat_list_projection_complete_tx(
                         SELECT mt.media_json
                         FROM message_timeline AS mt
                         WHERE mt.group_id_hex = ag.group_id_hex
-                          AND mt.kind = ?1
+                          AND {activity_filter}
                           AND (
                               mt.invalidation_status IS NULL
                               OR (
@@ -1225,7 +1259,7 @@ fn chat_list_projection_complete_tx(
                         END
                         FROM message_timeline AS mt
                         WHERE mt.group_id_hex = ag.group_id_hex
-                          AND mt.kind = ?1
+                          AND {activity_filter}
                           AND (
                               mt.invalidation_status IS NULL
                               OR (
@@ -1242,7 +1276,7 @@ fn chat_list_projection_complete_tx(
                             SELECT mt.timeline_at
                             FROM message_timeline AS mt
                             WHERE mt.group_id_hex = ag.group_id_hex
-                              AND mt.kind = ?1
+                              AND {activity_filter}
                               AND (
                                   mt.invalidation_status IS NULL
                                   OR (
@@ -1262,53 +1296,66 @@ fn chat_list_projection_complete_tx(
                      )
              )"
         ),
-        params![u64_to_i64(MARMOT_APP_EVENT_KIND_CHAT)?],
+        [],
     )? {
         return Ok(false);
     }
-    // #750: once the mention counts have been reconciled to the current
-    // projection version, the per-group recompute below is redundant —
-    // incremental refresh keeps `unread_mention_count` current — so skip the
-    // O(groups × unread-per-group) scan (which materializes every unread
-    // plaintext). The cheap structural checks above still run every warm-up.
-    if chat_list_mention_counts_version_tx(tx)? >= CHAT_LIST_MENTION_COUNTS_VERSION {
+    if chat_list_projection_version_tx(tx)? >= CHAT_LIST_PROJECTION_VERSION {
         return Ok(true);
     }
-    // Mention classification needs the injected closure (not expressible in pure
-    // SQL), so the remaining checks recompute the unread-mention count per group
-    // and compare it to the stored value. This corrects rows upgraded via
-    // migration 0019 (which defaults the new column to 0) for groups that
-    // actually have unread mentions.
-    for (group_id_hex, stored_mention_count) in chat_list_stored_mention_counts_tx(tx)? {
+    // The version marker can lag behind rows that a targeted refresh already
+    // brought current. Re-derive the unread summary once and rebuild only when
+    // a row is actually stale; this preserves the cheap warm path after the
+    // marker advances without turning a metadata-only open into needless SQL.
+    for (group_id_hex, stored) in chat_list_stored_unread_summaries_tx(tx)? {
         let read_state = read_state_tx(tx, &group_id_hex)?;
-        let unread = unread_summary_tx(
+        let derived = unread_summary_tx(
             tx,
             local_account_id_hex,
             &group_id_hex,
             read_state.as_ref(),
             mention_classifier,
         )?;
-        if unread.mention_count != stored_mention_count {
+        if derived.count != stored.count
+            || derived.mention_count != stored.mention_count
+            || derived.first_message_id != stored.first_message_id
+        {
             return Ok(false);
         }
     }
-    // Counts verified current — record the version so future warm-ups skip the
-    // per-group recompute above.
-    set_chat_list_mention_counts_version_tx(tx, CHAT_LIST_MENTION_COUNTS_VERSION)?;
+    set_chat_list_projection_version_tx(tx, CHAT_LIST_PROJECTION_VERSION)?;
     Ok(true)
 }
 
-fn chat_list_stored_mention_counts_tx(tx: &Connection) -> StorageResult<Vec<(String, u64)>> {
+fn chat_list_stored_unread_summaries_tx(
+    tx: &Connection,
+) -> StorageResult<Vec<(String, UnreadSummary)>> {
     let mut stmt = tx
-        .prepare("SELECT group_id_hex, unread_mention_count FROM chat_list_rows")
+        .prepare(
+            "SELECT group_id_hex, unread_count, unread_mention_count,
+                    first_unread_message_id_hex
+             FROM chat_list_rows",
+        )
         .storage()?;
     stmt.query_map([], |row| {
-        Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, i64>(1)?,
+            row.get::<_, i64>(2)?,
+            row.get::<_, Option<String>>(3)?,
+        ))
     })
     .storage()?
     .map(|entry| {
-        let (group_id_hex, count) = entry.storage()?;
-        Ok((group_id_hex, i64_to_u64(count)?))
+        let (group_id_hex, count, mention_count, first_message_id) = entry.storage()?;
+        Ok((
+            group_id_hex,
+            UnreadSummary {
+                count: i64_to_u64(count)?,
+                mention_count: i64_to_u64(mention_count)?,
+                first_message_id,
+            },
+        ))
     })
     .collect()
 }
@@ -1328,7 +1375,7 @@ fn rebuild_chat_list_row_for_group_tx(
     group: AccountGroupRow,
     mention_classifier: &MentionClassifier<'_>,
 ) -> StorageResult<()> {
-    let latest = latest_kind9_message_tx(tx, &group.group_id_hex)?;
+    let latest = latest_chat_list_activity_tx(tx, &group.group_id_hex)?;
     let latest_message = latest.as_ref().map(|latest| &latest.preview);
     let read_state = read_state_tx(tx, &group.group_id_hex)?;
     let unread = unread_summary_tx(
@@ -1498,7 +1545,7 @@ fn unread_summary_tx(
               timeline_order_primary,
               timeline_order_phase,
               timeline_order_at,
-              message_id_hex) > (?4, ?5, ?6, ?7, ?8)",
+              message_id_hex) > (?3, ?4, ?5, ?6, ?7)",
                 vec![
                     rusqlite::types::Value::Integer(i64::from(class)),
                     rusqlite::types::Value::Integer(u64_to_i64(primary)?),
@@ -1515,7 +1562,7 @@ fn unread_summary_tx(
         } else if let Some(last_read_at) = read_state.last_read_timeline_at {
             let marker_id = read_state.last_read_message_id_hex.as_deref().unwrap_or("");
             (
-                "(timeline_at > ?4 OR (timeline_at = ?4 AND message_id_hex > ?5))",
+                "(timeline_at > ?3 OR (timeline_at = ?3 AND message_id_hex > ?4))",
                 vec![
                     rusqlite::types::Value::Integer(u64_to_i64(last_read_at)?),
                     rusqlite::types::Value::Text(marker_id.to_owned()),
@@ -1524,7 +1571,7 @@ fn unread_summary_tx(
             )
         } else {
             (
-                "timeline_at > ?4 AND (?5 = ?5)",
+                "timeline_at > ?3 AND (?4 = ?4)",
                 vec![
                     rusqlite::types::Value::Integer(u64_to_i64(read_state.initialized_at)?),
                     rusqlite::types::Value::Text(String::new()),
@@ -1536,20 +1583,20 @@ fn unread_summary_tx(
     // the unread window. Persisted canonical anchors use the same accepted-history
     // key as timeline pagination even after retention prunes the marker row.
     // Legacy states without a canonical anchor use wall-clock predicate + order.
+    let activity_filter = chat_list_activity_filter_sql("");
     let scan_sql = format!(
-        "SELECT message_id_hex, plaintext, tags_json
+        "SELECT message_id_hex, plaintext, tags_json, kind
          FROM message_timeline
          WHERE group_id_hex = ?1
-           AND kind = ?2
+           AND {activity_filter}
            AND deleted = 0
            AND invalidation_status IS NULL
-           AND sender != ?3
+           AND sender != ?2
            AND {where_sql}
          ORDER BY {order_sql}"
     );
     let mut query_params = vec![
         rusqlite::types::Value::Text(group_id_hex.to_owned()),
-        rusqlite::types::Value::Integer(u64_to_i64(MARMOT_APP_EVENT_KIND_CHAT)?),
         rusqlite::types::Value::Text(local_account_id_hex.to_owned()),
     ];
     query_params.extend(marker_params);
@@ -1564,12 +1611,13 @@ fn unread_summary_tx(
         let message_id_hex: String = row.get(0).storage()?;
         let plaintext: String = row.get(1).storage()?;
         let tags_json: String = row.get(2).storage()?;
+        let kind = i64_to_u64(row.get(3).storage()?)?;
         if first_message_id.is_none() {
             first_message_id = Some(message_id_hex);
         }
         count += 1;
         let tags = crate::tags_from_json(tags_json).unwrap_or_default();
-        if mention_classifier(&plaintext, &tags) {
+        if kind == MARMOT_APP_EVENT_KIND_CHAT && mention_classifier(&plaintext, &tags) {
             mention_count += 1;
         }
     }
@@ -1683,17 +1731,18 @@ fn account_group_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<AccountGr
     })
 }
 
-fn latest_kind9_message_tx(
+fn latest_chat_list_activity_tx(
     tx: &Connection,
     group_id_hex: &str,
 ) -> StorageResult<Option<LatestChatListMessage>> {
+    let activity_filter = chat_list_activity_filter_sql("");
     let sql = format!(
         "SELECT message_id_hex, sender, plaintext, kind, timeline_at, deleted,
                 media_json, direction, source_message_id_hex, invalidation_status,
                 timeline_order_class, timeline_order_primary,
                 timeline_order_phase, timeline_order_at
          FROM message_timeline
-         WHERE group_id_hex = ?1 AND kind = ?2
+         WHERE group_id_hex = ?1 AND {activity_filter}
            AND (
                invalidation_status IS NULL
                OR (direction = 'sent' AND invalidation_status = 'local_publish_failed')
@@ -1701,21 +1750,17 @@ fn latest_kind9_message_tx(
          ORDER BY {CHAT_LIST_PREVIEW_ORDER_DESC}
          LIMIT 1"
     );
-    tx.query_row(
-        &sql,
-        params![group_id_hex, u64_to_i64(MARMOT_APP_EVENT_KIND_CHAT)?],
-        |row| {
-            Ok(LatestChatListMessage {
-                preview: chat_list_message_from_row(row)?,
-                canonical_order_prefix: (
-                    row.get::<_, i64>(10)?.try_into().unwrap_or_default(),
-                    row.get::<_, i64>(11)?.try_into().unwrap_or_default(),
-                    row.get::<_, i64>(12)?.try_into().unwrap_or_default(),
-                    row.get::<_, i64>(13)?.try_into().unwrap_or_default(),
-                ),
-            })
-        },
-    )
+    tx.query_row(&sql, params![group_id_hex], |row| {
+        Ok(LatestChatListMessage {
+            preview: chat_list_message_from_row(row)?,
+            canonical_order_prefix: (
+                row.get::<_, i64>(10)?.try_into().unwrap_or_default(),
+                row.get::<_, i64>(11)?.try_into().unwrap_or_default(),
+                row.get::<_, i64>(12)?.try_into().unwrap_or_default(),
+                row.get::<_, i64>(13)?.try_into().unwrap_or_default(),
+            ),
+        })
+    })
     .optional()
     .storage()
 }
@@ -1725,16 +1770,17 @@ fn timeline_message_for_read_marker_tx(
     group_id_hex: &str,
     message_id_hex: &str,
 ) -> StorageResult<Option<TimelineReadMarker>> {
+    let activity_filter = chat_list_activity_filter_sql("");
     tx.query_row(
-        "SELECT message_id_hex, source_message_id_hex, source_epoch,
+        &format!(
+            "SELECT message_id_hex, source_message_id_hex, source_epoch,
                 invalidation_status, timeline_at
          FROM message_timeline
-         WHERE group_id_hex = ?1 AND message_id_hex = ?2 AND kind = ?3",
-        params![
-            group_id_hex,
-            message_id_hex,
-            u64_to_i64(MARMOT_APP_EVENT_KIND_CHAT)?
-        ],
+         WHERE group_id_hex = ?1
+           AND message_id_hex = ?2
+           AND {activity_filter}"
+        ),
+        params![group_id_hex, message_id_hex],
         |row| {
             Ok(TimelineReadMarker {
                 message_id_hex: row.get(0)?,
@@ -1784,7 +1830,7 @@ fn insert_initial_read_state_tx(
     group_id_hex: &str,
     manually_marked_unread: bool,
 ) -> StorageResult<()> {
-    let latest = latest_kind9_message_tx(tx, group_id_hex)?;
+    let latest = latest_chat_list_activity_tx(tx, group_id_hex)?;
     let (message_id, timeline_at, order_class, order_primary, order_phase, order_at) = match latest
     {
         Some(latest) => (
@@ -1797,9 +1843,9 @@ fn insert_initial_read_state_tx(
         ),
         None => (None, None, None, None, None, None),
     };
-    // Match first-open semantics: with no retained kind-9 history there is no
-    // read anchor yet, so a subsequently recorded message counts even when its
-    // sender timestamp predates this local interaction.
+    // Match first-open semantics: with no retained chat or group-system
+    // activity there is no read anchor yet, so a subsequently recorded row
+    // counts even when its sender timestamp predates this local interaction.
     let initialized_at = timeline_at.unwrap_or(0);
     tx.execute(
         "INSERT INTO conversation_read_state (

--- a/crates/storage-sqlite/src/chat_list.rs
+++ b/crates/storage-sqlite/src/chat_list.rs
@@ -400,6 +400,7 @@ struct TimelineReadMarker {
     source_message_id_hex: Option<String>,
     source_epoch: Option<u64>,
     invalidation_status: Option<String>,
+    kind: u64,
     timeline_at: u64,
 }
 
@@ -409,7 +410,7 @@ impl TimelineReadMarker {
             self.source_message_id_hex.as_deref(),
             self.source_epoch,
             self.invalidation_status.as_deref(),
-            MARMOT_APP_EVENT_KIND_CHAT,
+            self.kind,
             self.timeline_at,
             &self.message_id_hex,
         )
@@ -1774,7 +1775,7 @@ fn timeline_message_for_read_marker_tx(
     tx.query_row(
         &format!(
             "SELECT message_id_hex, source_message_id_hex, source_epoch,
-                invalidation_status, timeline_at
+                invalidation_status, kind, timeline_at
          FROM message_timeline
          WHERE group_id_hex = ?1
            AND message_id_hex = ?2
@@ -1789,7 +1790,8 @@ fn timeline_message_for_read_marker_tx(
                     .get::<_, Option<i64>>(2)?
                     .and_then(|value| value.try_into().ok()),
                 invalidation_status: row.get(3)?,
-                timeline_at: row.get::<_, i64>(4)?.try_into().unwrap_or_default(),
+                kind: row.get::<_, i64>(4)?.try_into().unwrap_or_default(),
+                timeline_at: row.get::<_, i64>(5)?.try_into().unwrap_or_default(),
             })
         },
     )

--- a/crates/storage-sqlite/src/chat_list.rs
+++ b/crates/storage-sqlite/src/chat_list.rs
@@ -983,7 +983,7 @@ const CHAT_LIST_GROUP_ACTIVITY_TYPES: [&str; 5] = [
 /// SQL predicate for activity that should behave like a chat message in the
 /// chat list. Kind-1210 also carries metadata changes; #822 intentionally
 /// promotes only membership/admin rows, leaving unrelated system events alone.
-fn chat_list_activity_filter_sql(column_prefix: &str) -> String {
+pub(crate) fn chat_list_activity_filter_sql(column_prefix: &str) -> String {
     let group_activity_tags = CHAT_LIST_GROUP_ACTIVITY_TYPES
         .iter()
         .map(|system_type| format!(r#"'[["{GROUP_SYSTEM_TYPE_TAG}","{system_type}"]]'"#))

--- a/crates/storage-sqlite/src/chat_list/tests.rs
+++ b/crates/storage-sqlite/src/chat_list/tests.rs
@@ -2385,6 +2385,50 @@ fn secure_prune_refreshes_unread_count_mentions_and_first_message_atomically() {
 }
 
 #[test]
+fn secure_prune_preserves_a_newer_group_system_preview() {
+    let store = setup_store();
+    store
+        .initialize_chat_read_state(LOCAL, GROUP, &no_mentions)
+        .unwrap();
+    store
+        .record_app_event(&chat("expiring-chat", REMOTE, 10, "old chat"))
+        .unwrap();
+    store
+        .record_app_event(&group_system(
+            "retained-role-change",
+            REMOTE,
+            20,
+            GROUP_SYSTEM_TYPE_ADMIN_ADDED,
+            r#"{"v":1,"system_type":"admin_added","text":"Admin added"}"#,
+        ))
+        .unwrap();
+
+    let before = store
+        .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+        .unwrap()
+        .expect("chat row");
+    assert_eq!(
+        before.last_message.expect("system preview").message_id_hex,
+        "retained-role-change"
+    );
+    assert_eq!(before.unread_count, 2);
+
+    store
+        .secure_prune_app_events_before(GROUP, 15, LOCAL, &no_mentions)
+        .unwrap();
+
+    let after = store.chat_list_row(GROUP).unwrap().expect("chat row");
+    let preview = after.last_message.expect("retained system preview");
+    assert_eq!(preview.message_id_hex, "retained-role-change");
+    assert_eq!(preview.kind, MARMOT_APP_EVENT_KIND_GROUP_SYSTEM);
+    assert_eq!(after.unread_count, 1);
+    assert_eq!(
+        after.first_unread_message_id_hex.as_deref(),
+        Some("retained-role-change")
+    );
+}
+
+#[test]
 fn invalidated_kind9_tombstones_do_not_count_as_unread() {
     // Repro for #418: a group exchanges chat plus a group-system commit; fork
     // recovery later invalidates some received kind:9 rows (losing branch). The

--- a/crates/storage-sqlite/src/chat_list/tests.rs
+++ b/crates/storage-sqlite/src/chat_list/tests.rs
@@ -2468,6 +2468,72 @@ fn secure_prune_preserves_a_newer_group_system_preview() {
 }
 
 #[test]
+fn secure_prune_retains_pruned_group_system_activity_as_the_sort_anchor() {
+    let store = setup_store();
+    {
+        let conn = store.lock().unwrap();
+        conn.execute(
+            "UPDATE account_groups SET conversation_created_at = 5 WHERE group_id_hex = ?1",
+            params![GROUP],
+        )
+        .unwrap();
+    }
+    store
+        .initialize_chat_read_state(LOCAL, GROUP, &no_mentions)
+        .unwrap();
+    store
+        .record_app_event(&chat("older-chat", REMOTE, 100, "older activity"))
+        .unwrap();
+    store
+        .record_app_event(&group_system(
+            "pruned-role-change",
+            REMOTE,
+            200,
+            GROUP_SYSTEM_TYPE_ADMIN_ADDED,
+            r#"{"v":1,"system_type":"admin_added","text":"Admin added"}"#,
+        ))
+        .unwrap();
+
+    let before = store
+        .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+        .unwrap()
+        .expect("chat row");
+    assert_eq!(before.activity_sort_at, 200);
+    assert_eq!(
+        before.last_message.expect("system preview").message_id_hex,
+        "pruned-role-change"
+    );
+
+    store
+        .secure_prune_app_events_before(GROUP, 201, LOCAL, &no_mentions)
+        .unwrap();
+
+    let after = store.chat_list_row(GROUP).unwrap().expect("chat row");
+    assert!(after.last_message.is_none());
+    assert_eq!(after.activity_sort_at, 200);
+    let retained_activity_sort_at = store
+        .lock()
+        .unwrap()
+        .query_row(
+            "SELECT retained_activity_sort_at FROM chat_list_rows WHERE group_id_hex = ?1",
+            params![GROUP],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap();
+    assert_eq!(retained_activity_sort_at, 200);
+
+    store.refresh_chat_list_rows(LOCAL, &no_mentions).unwrap();
+    assert_eq!(
+        store
+            .chat_list_row(GROUP)
+            .unwrap()
+            .expect("rebuilt chat row")
+            .activity_sort_at,
+        200
+    );
+}
+
+#[test]
 fn invalidated_kind9_tombstones_do_not_count_as_unread() {
     // Repro for #418: a group exchanges chat plus a group-system commit; fork
     // recovery later invalidates some received kind:9 rows (losing branch). The

--- a/crates/storage-sqlite/src/chat_list/tests.rs
+++ b/crates/storage-sqlite/src/chat_list/tests.rs
@@ -9,7 +9,10 @@ use cgka_traits::app_components::{
     encode_group_avatar_url_v1,
 };
 use cgka_traits::app_event::{
-    EVENT_REF_TAG, MARMOT_APP_EVENT_KIND_CHAT, MARMOT_APP_EVENT_KIND_REACTION,
+    EVENT_REF_TAG, GROUP_SYSTEM_TYPE_ADMIN_ADDED, GROUP_SYSTEM_TYPE_ADMIN_REMOVED,
+    GROUP_SYSTEM_TYPE_GROUP_RENAMED, GROUP_SYSTEM_TYPE_MEMBER_ADDED, GROUP_SYSTEM_TYPE_MEMBER_LEFT,
+    GROUP_SYSTEM_TYPE_MEMBER_REMOVED, GROUP_SYSTEM_TYPE_TAG, MARMOT_APP_EVENT_KIND_CHAT,
+    MARMOT_APP_EVENT_KIND_GROUP_SYSTEM, MARMOT_APP_EVENT_KIND_REACTION,
 };
 use cgka_traits::storage::{GroupStorage, LeaveRequest, LeaveRequestStorage};
 use cgka_traits::types::{EpochId, GroupId};
@@ -68,6 +71,33 @@ fn chat_with_tags(
         recorded_at: at,
         received_at: at,
         origin_commit_id: None,
+        moderation_grant: false,
+    }
+}
+
+fn group_system(
+    id: &str,
+    sender: &str,
+    at: u64,
+    system_type: &str,
+    plaintext: &str,
+) -> StoredAppEvent {
+    StoredAppEvent {
+        group_id_hex: GROUP.to_owned(),
+        message_id_hex: id.to_owned(),
+        source_message_id_hex: None,
+        source_epoch: Some(at),
+        direction: "system".to_owned(),
+        sender: sender.to_owned(),
+        plaintext: plaintext.to_owned(),
+        kind: MARMOT_APP_EVENT_KIND_GROUP_SYSTEM,
+        tags: vec![vec![
+            GROUP_SYSTEM_TYPE_TAG.to_owned(),
+            system_type.to_owned(),
+        ]],
+        recorded_at: at,
+        received_at: at,
+        origin_commit_id: Some(format!("commit-{id}")),
         moderation_grant: false,
     }
 }
@@ -2067,6 +2097,257 @@ fn unread_starts_after_first_open_and_advances_by_visible_kind9() {
 }
 
 #[test]
+fn remote_group_system_event_advances_preview_unread_and_read_marker() {
+    let store = setup_store();
+    store
+        .record_app_event(&chat("old", REMOTE, 10, "before role change"))
+        .unwrap();
+    store
+        .initialize_chat_read_state(LOCAL, GROUP, &no_mentions)
+        .unwrap();
+
+    let system_at = unix_now_seconds() + 1;
+    let payload = r#"{"v":1,"system_type":"admin_added","text":"Admin added"}"#;
+    store
+        .record_app_event(&group_system(
+            "made-admin",
+            REMOTE,
+            system_at,
+            GROUP_SYSTEM_TYPE_ADMIN_ADDED,
+            payload,
+        ))
+        .unwrap();
+    let row = store
+        .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+        .unwrap()
+        .expect("chat row");
+
+    let preview = row.last_message.expect("group-system preview");
+    assert_eq!(preview.message_id_hex, "made-admin");
+    assert_eq!(preview.kind, MARMOT_APP_EVENT_KIND_GROUP_SYSTEM);
+    assert_eq!(preview.plaintext, payload);
+    assert_eq!(row.activity_sort_at, system_at);
+    assert_eq!(row.unread_count, 1);
+    assert_eq!(
+        row.first_unread_message_id_hex.as_deref(),
+        Some("made-admin")
+    );
+
+    let read = store
+        .mark_timeline_message_read(LOCAL, GROUP, "made-admin", &no_mentions)
+        .unwrap()
+        .expect("chat row");
+    assert_eq!(read.unread_count, 0);
+    assert_eq!(read.last_read_message_id_hex.as_deref(), Some("made-admin"));
+}
+
+#[test]
+fn every_membership_and_admin_system_type_signals_activity() {
+    for system_type in [
+        GROUP_SYSTEM_TYPE_MEMBER_ADDED,
+        GROUP_SYSTEM_TYPE_MEMBER_REMOVED,
+        GROUP_SYSTEM_TYPE_MEMBER_LEFT,
+        GROUP_SYSTEM_TYPE_ADMIN_ADDED,
+        GROUP_SYSTEM_TYPE_ADMIN_REMOVED,
+    ] {
+        let store = setup_store();
+        store
+            .initialize_chat_read_state(LOCAL, GROUP, &no_mentions)
+            .unwrap();
+        store
+            .record_app_event(&group_system(
+                system_type,
+                REMOTE,
+                unix_now_seconds() + 1,
+                system_type,
+                &format!(r#"{{"v":1,"system_type":"{system_type}","text":"Changed"}}"#),
+            ))
+            .unwrap();
+
+        let row = store
+            .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+            .unwrap()
+            .expect("chat row");
+        assert_eq!(
+            row.last_message
+                .expect("group activity preview")
+                .message_id_hex,
+            system_type,
+        );
+        assert_eq!(row.unread_count, 1, "system type {system_type}");
+    }
+}
+
+#[test]
+fn own_group_system_event_advances_preview_without_becoming_unread() {
+    let store = setup_store();
+    store
+        .record_app_event(&chat("old", REMOTE, 10, "before role change"))
+        .unwrap();
+    store
+        .initialize_chat_read_state(LOCAL, GROUP, &no_mentions)
+        .unwrap();
+
+    let system_at = unix_now_seconds() + 1;
+    store
+        .record_app_event(&group_system(
+            "own-role-change",
+            LOCAL,
+            system_at,
+            GROUP_SYSTEM_TYPE_ADMIN_ADDED,
+            r#"{"v":1,"system_type":"admin_added","text":"Admin added"}"#,
+        ))
+        .unwrap();
+    let row = store
+        .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+        .unwrap()
+        .expect("chat row");
+
+    assert_eq!(
+        row.last_message
+            .expect("group-system preview")
+            .message_id_hex,
+        "own-role-change"
+    );
+    assert_eq!(row.activity_sort_at, system_at);
+    assert_eq!(row.unread_count, 0);
+}
+
+#[test]
+fn group_system_payload_does_not_increment_mentions() {
+    let store = setup_store();
+    store
+        .initialize_chat_read_state(LOCAL, GROUP, &mentions_local)
+        .unwrap();
+    store
+        .record_app_event(&group_system(
+            "role-change",
+            REMOTE,
+            20,
+            GROUP_SYSTEM_TYPE_ADMIN_ADDED,
+            r#"{"v":1,"system_type":"admin_added","text":"Admin added","data":{"subject":"aa"}}"#,
+        ))
+        .unwrap();
+
+    let row = store
+        .refresh_chat_list_row(LOCAL, GROUP, &mentions_local)
+        .unwrap()
+        .expect("chat row");
+    assert_eq!(row.unread_count, 1);
+    assert_eq!(row.unread_mention_count, 0);
+}
+
+#[test]
+fn unrelated_group_system_event_does_not_signal_chat_list_activity() {
+    let store = setup_store();
+    store
+        .record_app_event(&chat("old", REMOTE, 10, "existing preview"))
+        .unwrap();
+    store
+        .initialize_chat_read_state(LOCAL, GROUP, &no_mentions)
+        .unwrap();
+    let before = store
+        .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+        .unwrap()
+        .expect("chat row");
+
+    store
+        .record_app_event(&group_system(
+            "renamed",
+            REMOTE,
+            unix_now_seconds() + 1,
+            GROUP_SYSTEM_TYPE_GROUP_RENAMED,
+            r#"{"v":1,"system_type":"group_renamed","text":"Group renamed"}"#,
+        ))
+        .unwrap();
+    let after = store
+        .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+        .unwrap()
+        .expect("chat row");
+
+    assert_eq!(
+        after.last_message.expect("existing preview").message_id_hex,
+        "old"
+    );
+    assert_eq!(after.activity_sort_at, before.activity_sort_at);
+    assert_eq!(after.unread_count, 0);
+}
+
+#[test]
+fn invalidated_group_activity_is_removed_from_preview_and_unread() {
+    let store = setup_store();
+    store
+        .record_app_event(&chat("old", REMOTE, 10, "existing preview"))
+        .unwrap();
+    store
+        .initialize_chat_read_state(LOCAL, GROUP, &no_mentions)
+        .unwrap();
+    store
+        .record_app_event(&group_system(
+            "rolled-back-role",
+            REMOTE,
+            unix_now_seconds() + 1,
+            GROUP_SYSTEM_TYPE_ADMIN_ADDED,
+            r#"{"v":1,"system_type":"admin_added","text":"Admin added"}"#,
+        ))
+        .unwrap();
+    let signaled = store
+        .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+        .unwrap()
+        .expect("chat row");
+    assert_eq!(signaled.unread_count, 1);
+    assert_eq!(
+        signaled.last_message.expect("role preview").message_id_hex,
+        "rolled-back-role"
+    );
+
+    store
+        .invalidate_app_event_by_message_id(GROUP, "rolled-back-role", "LosingBranch")
+        .unwrap();
+    let reconciled = store
+        .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+        .unwrap()
+        .expect("chat row");
+    assert_eq!(reconciled.unread_count, 0);
+    assert_eq!(
+        reconciled
+            .last_message
+            .expect("restored preview")
+            .message_id_hex,
+        "old"
+    );
+}
+
+#[test]
+fn direct_conversation_does_not_project_admin_activity() {
+    let mut direct = group();
+    direct.profile_name.clear();
+    direct.member_count = Some(2);
+    let store = setup_store_with_group(direct);
+    store
+        .initialize_chat_read_state(LOCAL, GROUP, &no_mentions)
+        .unwrap();
+
+    store
+        .record_app_event(&group_system(
+            "direct-role-change",
+            REMOTE,
+            unix_now_seconds() + 1,
+            GROUP_SYSTEM_TYPE_ADMIN_ADDED,
+            r#"{"v":1,"system_type":"admin_added","text":"Admin added"}"#,
+        ))
+        .unwrap();
+    let row = store
+        .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+        .unwrap()
+        .expect("chat row");
+
+    assert_eq!(row.conversation_kind, ChatConversationKind::Direct);
+    assert!(row.last_message.is_none());
+    assert_eq!(row.unread_count, 0);
+}
+
+#[test]
 fn secure_prune_refreshes_unread_count_mentions_and_first_message_atomically() {
     let store = setup_store();
     let mentions = |plaintext: &str, _tags: &[Vec<String>]| plaintext.contains("@local");
@@ -2478,6 +2759,76 @@ fn ensure_chat_list_rows_corrects_stale_unread_mention_count() {
 
     assert_eq!(row.unread_mention_count, 1);
     assert!(row.has_unread_mention);
+}
+
+#[test]
+fn ensure_chat_list_rows_reconciles_pre_group_system_projection() {
+    let store = setup_store();
+    store
+        .record_app_event(&chat("old", REMOTE, 10, "before first open"))
+        .unwrap();
+    store
+        .initialize_chat_read_state(LOCAL, GROUP, &no_mentions)
+        .unwrap();
+
+    let system_at = unix_now_seconds() + 1;
+    store
+        .record_app_event(&group_system(
+            "role-change",
+            REMOTE,
+            system_at,
+            GROUP_SYSTEM_TYPE_ADMIN_ADDED,
+            r#"{"v":1,"system_type":"admin_added","text":"Admin added"}"#,
+        ))
+        .unwrap();
+    let mut newest_chat = chat(
+        "newest-chat",
+        REMOTE,
+        system_at + 1,
+        "newer visible preview",
+    );
+    newest_chat.source_epoch = Some(system_at + 1);
+    store.record_app_event(&newest_chat).unwrap();
+    let current = store
+        .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+        .unwrap()
+        .expect("chat row");
+    assert_eq!(current.unread_count, 2);
+    assert_eq!(
+        current.last_message.expect("latest preview").message_id_hex,
+        "newest-chat"
+    );
+
+    // Simulate a version-1 row: its latest preview is structurally correct,
+    // but it counted only the kind-9 message and silently omitted the older
+    // kind-1210 role event.
+    {
+        let conn = store.lock().unwrap();
+        conn.execute(
+            "UPDATE chat_list_rows SET unread_count = 1 WHERE group_id_hex = ?1",
+            params![GROUP],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE chat_list_projection_meta SET mention_counts_version = 1 WHERE id = 1",
+            [],
+        )
+        .unwrap();
+    }
+
+    store.ensure_chat_list_rows(LOCAL, &no_mentions).unwrap();
+    let reconciled = store.chat_list_row(GROUP).unwrap().expect("chat row");
+    assert_eq!(reconciled.unread_count, 2);
+    let projection_version: i64 = store
+        .lock()
+        .unwrap()
+        .query_row(
+            "SELECT mention_counts_version FROM chat_list_projection_meta WHERE id = 1",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(projection_version, CHAT_LIST_PROJECTION_VERSION);
 }
 
 #[test]

--- a/crates/storage-sqlite/src/chat_list/tests.rs
+++ b/crates/storage-sqlite/src/chat_list/tests.rs
@@ -1851,6 +1851,45 @@ fn chat_list_read_state_and_preview_follow_canonical_epoch_order() {
 }
 
 #[test]
+fn group_system_read_marker_preserves_same_epoch_canonical_phase() {
+    let store = setup_store();
+    store
+        .initialize_chat_read_state(LOCAL, GROUP, &no_mentions)
+        .unwrap();
+
+    let mut marker = group_system(
+        "system-marker",
+        REMOTE,
+        200,
+        GROUP_SYSTEM_TYPE_ADMIN_ADDED,
+        "role changed",
+    );
+    marker.source_epoch = Some(7);
+    store.record_app_event(&marker).unwrap();
+    store
+        .mark_timeline_message_read(LOCAL, GROUP, "system-marker", &no_mentions)
+        .unwrap();
+
+    let mut later_chat = chat("same-epoch-chat", REMOTE, 100, "later canonical phase");
+    later_chat.source_epoch = Some(7);
+    store.record_app_event(&later_chat).unwrap();
+
+    let row = store
+        .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+        .unwrap()
+        .expect("chat row");
+    assert_eq!(
+        row.last_read_message_id_hex.as_deref(),
+        Some("system-marker")
+    );
+    assert_eq!(row.unread_count, 1);
+    assert_eq!(
+        row.first_unread_message_id_hex.as_deref(),
+        Some("same-epoch-chat")
+    );
+}
+
+#[test]
 fn read_marker_follows_pending_send_into_authenticated_history() {
     let store = setup_store();
     let mut pending = chat("pending", LOCAL, 500, "optimistic send");

--- a/crates/storage-sqlite/src/timeline.rs
+++ b/crates/storage-sqlite/src/timeline.rs
@@ -1289,6 +1289,7 @@ fn refresh_chat_list_last_message_after_secure_prune_tx(
     tx: &Connection,
     group_id_hex: &str,
 ) -> StorageResult<()> {
+    let activity_filter = crate::chat_list::chat_list_activity_filter_sql("");
     let sql = format!(
         "SELECT message_id_hex, sender, plaintext, kind, timeline_at, deleted,
                 media_json,
@@ -1300,32 +1301,28 @@ fn refresh_chat_list_last_message_after_secure_prune_tx(
                 END
          FROM message_timeline
          WHERE group_id_hex = ?1
-           AND kind = ?2
+           AND {activity_filter}
            AND (
                invalidation_status IS NULL
                OR (direction = 'sent' AND invalidation_status = 'local_publish_failed')
            )
          ORDER BY {}
          LIMIT 1",
-        crate::chat_list::CHAT_LIST_PREVIEW_ORDER_DESC
+        crate::chat_list::CHAT_LIST_PREVIEW_ORDER_DESC,
     );
     let latest = tx
-        .query_row(
-            &sql,
-            params![group_id_hex, u64_to_i64(MARMOT_APP_EVENT_KIND_CHAT)?],
-            |row| {
-                Ok((
-                    row.get::<_, String>(0)?,
-                    row.get::<_, String>(1)?,
-                    row.get::<_, String>(2)?,
-                    row.get::<_, i64>(3)?,
-                    row.get::<_, i64>(4)?,
-                    row.get::<_, i64>(5)?,
-                    row.get::<_, Option<String>>(6)?,
-                    row.get::<_, String>(7)?,
-                ))
-            },
-        )
+        .query_row(&sql, params![group_id_hex], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, i64>(3)?,
+                row.get::<_, i64>(4)?,
+                row.get::<_, i64>(5)?,
+                row.get::<_, Option<String>>(6)?,
+                row.get::<_, String>(7)?,
+            ))
+        })
         .optional()
         .storage()?;
     let updated_at = u64_to_i64(unix_now_seconds())?;

--- a/crates/storage-sqlite/src/timeline.rs
+++ b/crates/storage-sqlite/src/timeline.rs
@@ -1244,30 +1244,25 @@ fn retain_pruned_chat_activity_tx(
     group_id_hex: &str,
     pruned_message_ids: &BTreeSet<String>,
 ) -> StorageResult<()> {
-    let mut statement = tx
-        .prepare(
-            "SELECT timeline_at
-             FROM message_timeline
-             WHERE group_id_hex = ?1
-               AND message_id_hex = ?2
-               AND kind = ?3
-               AND (
-                   invalidation_status IS NULL
-                   OR (direction = 'sent' AND invalidation_status = 'local_publish_failed')
-               )",
-        )
-        .storage()?;
+    let activity_filter = crate::chat_list::chat_list_activity_filter_sql("");
+    let sql = format!(
+        "SELECT timeline_at
+         FROM message_timeline
+         WHERE group_id_hex = ?1
+           AND message_id_hex = ?2
+           AND {activity_filter}
+           AND (
+               invalidation_status IS NULL
+               OR (direction = 'sent' AND invalidation_status = 'local_publish_failed')
+           )"
+    );
+    let mut statement = tx.prepare(&sql).storage()?;
     let mut latest_pruned_activity = None;
     for message_id_hex in pruned_message_ids {
         let timeline_at = statement
-            .query_row(
-                params![
-                    group_id_hex,
-                    message_id_hex,
-                    u64_to_i64(MARMOT_APP_EVENT_KIND_CHAT)?
-                ],
-                |row| row.get::<_, i64>(0),
-            )
+            .query_row(params![group_id_hex, message_id_hex], |row| {
+                row.get::<_, i64>(0)
+            })
             .optional()
             .storage()?;
         latest_pruned_activity = latest_pruned_activity.max(timeline_at);


### PR DESCRIPTION
## Summary
- project membership and admin group-system events into chat-list preview, activity ordering, unread state, and read markers
- emit new-last-message subscription updates only for the five membership/admin event types
- avoid treating locally synthesized group-system actors as Nostr profile identities
- preserve DM behavior, mention counts, invalidation, self-authored unread semantics, and agent-stream triggers

Supports marmot-protocol/whitenoise-android#822 and marmot-protocol/whitenoise-android#2249.

## Verification
- just fast-ci
- cargo test -p storage-sqlite group_system --lib
- cargo test -p storage-sqlite every_membership_and_admin_system_type_signals_activity --lib
- cargo test -p storage-sqlite direct_conversation_does_not_project_admin_activity --lib
- cargo test -p marmot-app group_system_projection_advances_the_chat_list_like_a_new_message --lib
- cargo test -p marmot-app unrelated_group_system_projection_does_not_claim_new_chat_list_activity --lib
- cargo test -p marmot-app group_system_chat_preview_does_not_hydrate_its_optional_actor_as_a_nostr_sender --lib
- cargo test -p marmot-app agent_stream_updates_still_advance_the_chat_list_like_new_messages --lib

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Group membership and administrator activity now appears in group chat previews, timestamps, unread counts, and read markers.
  - Relevant system activity updates chat lists in real time.
  - Local-authored system events update previews without increasing unread counts.
  - Legacy chat-list data is rebuilt to include eligible group activity.

- **Bug Fixes**
  - Prevented system messages from being treated as sender profiles or generating mentions.
  - Excluded unrelated rename events and direct-chat system activity from chat lists.
  - Improved unread activity handling after member removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->