### PR TITLE
chore(release): prepare 0.9.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agent-connector"
-version = "0.9.14"
+version = "0.9.15"
 dependencies = [
  "agent-control",
  "agent-stream-compose",
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "agent-control"
-version = "0.9.14"
+version = "0.9.15"
 dependencies = [
  "serde",
  "serde_json",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "agent-stream-compose"
-version = "0.9.14"
+version = "0.9.15"
 dependencies = [
  "cgka-traits",
  "hex",
@@ -864,7 +864,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cgka-conformance-simulator"
-version = "0.9.14"
+version = "0.9.15"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-engine"
-version = "0.9.14"
+version = "0.9.15"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-session"
-version = "0.9.14"
+version = "0.9.15"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-traits"
-version = "0.9.14"
+version = "0.9.15"
 dependencies = [
  "async-trait",
  "criterion",
@@ -1192,7 +1192,7 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "convergence-campaign-runner"
-version = "0.9.14"
+version = "0.9.15"
 dependencies = [
  "async-trait",
  "cgka-conformance-simulator",
@@ -1987,7 +1987,7 @@ dependencies = [
 
 [[package]]
 name = "fs-private"
-version = "0.9.14"
+version = "0.9.15"
 dependencies = [
  "libc",
  "tempfile",
@@ -2725,7 +2725,7 @@ dependencies = [
 
 [[package]]
 name = "incident-replay"
-version = "0.9.14"
+version = "0.9.15"
 dependencies = [
  "cgka-conformance-simulator",
  "fs-private",
@@ -3322,7 +3322,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-account"
-version = "0.9.14"
+version = "0.9.15"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-app"
-version = "0.9.14"
+version = "0.9.15"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3399,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-forensics"
-version = "0.9.14"
+version = "0.9.15"
 dependencies = [
  "fs-private",
  "serde",
@@ -3409,7 +3409,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-markdown"
-version = "0.9.14"
+version = "0.9.15"
 dependencies = [
  "serde",
  "serde_json",
@@ -3417,7 +3417,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-terminal-harness"
-version = "0.9.14"
+version = "0.9.15"
 dependencies = [
  "agent-control",
  "async-trait",
@@ -3432,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-uniffi"
-version = "0.9.14"
+version = "0.9.15"
 dependencies = [
  "cgka-engine",
  "cgka-traits",
@@ -5652,7 +5652,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-sqlite"
-version = "0.9.14"
+version = "0.9.15"
 dependencies = [
  "cgka-traits",
  "fs-private",
@@ -6269,7 +6269,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-adapter"
-version = "0.9.14"
+version = "0.9.15"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -6289,7 +6289,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-peeler"
-version = "0.9.14"
+version = "0.9.15"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -6306,7 +6306,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-broker"
-version = "0.9.14"
+version = "0.9.15"
 dependencies = [
  "cgka-traits",
  "clap",
@@ -6325,7 +6325,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-stream"
-version = "0.9.14"
+version = "0.9.15"
 dependencies = [
  "cgka-traits",
  "chacha20poly1305",
@@ -7392,7 +7392,7 @@ dependencies = [
 
 [[package]]
 name = "wn-cli"
-version = "0.9.14"
+version = "0.9.15"
 dependencies = [
  "agent-stream-compose",
  "cgka-session",
@@ -7426,7 +7426,7 @@ dependencies = [
 
 [[package]]
 name = "wn-codex"
-version = "0.9.14"
+version = "0.9.15"
 dependencies = [
  "async-trait",
  "clap",
@@ -7440,7 +7440,7 @@ dependencies = [
 
 [[package]]
 name = "wn-opencode"
-version = "0.9.14"
+version = "0.9.15"
 dependencies = [
  "async-trait",
  "clap",
@@ -7455,7 +7455,7 @@ dependencies = [
 
 [[package]]
 name = "wn-pi"
-version = "0.9.14"
+version = "0.9.15"
 dependencies = [
  "async-trait",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "0.9.14"
+version = "0.9.15"
 license = "MIT"
 publish = false
 

--- a/crates/cgka-conformance-simulator/vectors/admin-handover.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/admin-handover.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "admin-handover/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.14",
+  "conformance_version": "0.9.15",
   "seed": null,
   "scenario": {
     "name": "admin-handover/v1",

--- a/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "admin-policy-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.14",
+  "conformance_version": "0.9.15",
   "seed": null,
   "scenario": {
     "name": "admin-policy-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "concurrent-invite-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.14",
+  "conformance_version": "0.9.15",
   "seed": null,
   "scenario": {
     "name": "concurrent-invite-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-committer-selected/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.14",
+  "conformance_version": "0.9.15",
   "seed": null,
   "scenario": {
     "name": "convergence-committer-selected/v1",

--- a/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-witness-selected/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.14",
+  "conformance_version": "0.9.15",
   "seed": null,
   "scenario": {
     "name": "convergence-witness-selected/v1",

--- a/crates/cgka-conformance-simulator/vectors/conversation.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/conversation.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "conversation/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.14",
+  "conformance_version": "0.9.15",
   "seed": null,
   "scenario": {
     "name": "conversation/v1",

--- a/crates/cgka-conformance-simulator/vectors/cross-route-own-commit-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/cross-route-own-commit-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "cross-route-own-commit-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.14",
+  "conformance_version": "0.9.15",
   "seed": null,
   "scenario": {
     "name": "cross-route-own-commit-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/current-profile-required-set.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/current-profile-required-set.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "current-profile-required-set/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.14",
+  "conformance_version": "0.9.15",
   "seed": null,
   "application_profile": {
     "name": "current",

--- a/crates/cgka-conformance-simulator/vectors/deferred-tick-catchup.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/deferred-tick-catchup.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "deferred-tick-catchup/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.14",
+  "conformance_version": "0.9.15",
   "seed": null,
   "scenario": {
     "name": "deferred-tick-catchup/v1",

--- a/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "delayed-past-epoch-app-message/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.14",
+  "conformance_version": "0.9.15",
   "seed": null,
   "scenario": {
     "name": "delayed-past-epoch-app-message/v1",

--- a/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "drop-queued/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.14",
+  "conformance_version": "0.9.15",
   "seed": null,
   "scenario": {
     "name": "drop-queued/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.14",
+  "conformance_version": "0.9.15",
   "seed": null,
   "scenario": {
     "name": "group-data-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.14",
+  "conformance_version": "0.9.15",
   "seed": null,
   "scenario": {
     "name": "group-data-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-profile-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-profile-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-profile-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.14",
+  "conformance_version": "0.9.15",
   "seed": null,
   "scenario": {
     "name": "group-profile-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.14",
+  "conformance_version": "0.9.15",
   "seed": null,
   "scenario": {
     "name": "convergence-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "fork-recovery-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.14",
+  "conformance_version": "0.9.15",
   "seed": null,
   "scenario": {
     "name": "fork-recovery-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "membership-fork-recovery-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.14",
+  "conformance_version": "0.9.15",
   "seed": null,
   "scenario": {
     "name": "membership-fork-recovery-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incremental-growth.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incremental-growth.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "incremental-growth/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.14",
+  "conformance_version": "0.9.15",
   "seed": null,
   "scenario": {
     "name": "incremental-growth/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-member/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.14",
+  "conformance_version": "0.9.15",
   "seed": null,
   "scenario": {
     "name": "invite-member/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.14",
+  "conformance_version": "0.9.15",
   "seed": null,
   "scenario": {
     "name": "invite-publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/late-welcome-backfill.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/late-welcome-backfill.v1.json
@@ -1,7 +1,7 @@
 {
  "scenario_name": "late-welcome-backfill/v1",
  "vector_version": "1",
- "conformance_version": "0.9.14",
+ "conformance_version": "0.9.15",
  "seed": null,
  "scenario": {
   "name": "late-welcome-backfill/v1",

--- a/crates/cgka-conformance-simulator/vectors/latecomer-forward-secrecy.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/latecomer-forward-secrecy.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "latecomer-forward-secrecy/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.14",
+  "conformance_version": "0.9.15",
   "seed": null,
   "scenario": {
     "name": "latecomer-forward-secrecy/v1",

--- a/crates/cgka-conformance-simulator/vectors/leaver-removal-secrecy.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/leaver-removal-secrecy.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "leaver-removal-secrecy/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.14",
+  "conformance_version": "0.9.15",
   "seed": null,
   "scenario": {
     "name": "leaver-removal-secrecy/v1",

--- a/crates/cgka-conformance-simulator/vectors/multigroup-isolation.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/multigroup-isolation.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "multigroup-isolation/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.14",
+  "conformance_version": "0.9.15",
   "seed": null,
   "scenario": {
     "name": "multigroup-isolation/v1",

--- a/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "partition-clear-leave/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.14",
+  "conformance_version": "0.9.15",
   "seed": null,
   "scenario": {
     "name": "partition-clear-leave/v1",

--- a/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.14",
+  "conformance_version": "0.9.15",
   "seed": null,
   "scenario": {
     "name": "publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "queue-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.14",
+  "conformance_version": "0.9.15",
   "seed": null,
   "scenario": {
     "name": "queue-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/readd-after-eviction.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/readd-after-eviction.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "readd-after-eviction/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.14",
+  "conformance_version": "0.9.15",
   "seed": null,
   "scenario": {
     "name": "readd-after-eviction/v1",

--- a/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "restart-delivery-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.14",
+  "conformance_version": "0.9.15",
   "seed": null,
   "scenario": {
     "name": "restart-delivery-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/route-equivalence.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/route-equivalence.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "route-equivalence/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.14",
+  "conformance_version": "0.9.15",
   "seed": null,
   "scenario": {
     "name": "route-equivalence/v1",

--- a/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "three-client-message-exchange/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.14",
+  "conformance_version": "0.9.15",
   "seed": null,
   "scenario": {
     "name": "three-client-message-exchange/v1",

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -9,6 +9,8 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ## [Unreleased]
 
+## [0.9.15] - 2026-08-25
+
 ### Added
 
 - Local notification projection and UniFFI `NotificationTrigger` now include
@@ -16,9 +18,85 @@ versioning through the workspace version in the root `Cargo.toml`.
   self-affecting membership and admin-role changes. Kind 446 wake delivery
   stays context-free.
   ([#1240](https://github.com/marmot-protocol/mdk/issues/1240))
+
+- Membership and administrator activity now advances group chat previews,
+  ordering, unread state, and read markers without treating synthesized system
+  actors as Nostr profile identities.
+  ([#1551](https://github.com/marmot-protocol/mdk/pull/1551))
+
+- WN Agent adds persistent account-scoped invite policies for denying all
+  invites, allowing configured senders, allowing authenticated direct invites,
+  or allowing any authenticated invite. The policy is available through agent
+  control and `wn-agent bootstrap --invite-policy`.
+  ([#1542](https://github.com/marmot-protocol/mdk/pull/1542))
+
+- The conformance simulator adds a deterministic 54-case large-group pressure
+  catalog spanning 10–200 members, with versioned workload metadata and strict
+  convergence, pending-work, policy, profile, and decryptability oracles.
+  ([#1511](https://github.com/marmot-protocol/mdk/pull/1511))
+
+### Changed
+
 - Daemon-hosted directory and KeyPackage reads now honor configured discovery
   relays independently from the operational relay set used for message
   delivery.
+  ([#1537](https://github.com/marmot-protocol/mdk/pull/1537))
+
+- WN Agent installation guidance now downloads installers and their adjacent
+  SHA-256 files, verifies them before execution, and distinguishes the rolling
+  convenience alias from immutable versioned releases. Connector onboarding
+  also reports the bootstrapped agent identity and service status more clearly.
+  ([#1512](https://github.com/marmot-protocol/mdk/pull/1512),
+  [#1533](https://github.com/marmot-protocol/mdk/pull/1533))
+
+- `shutdown_and_close` now closes runtime admission, SQLite connections, and
+  the root lease before bounded graceful cleanup, and terminal closure remains
+  runtime-owned if the awaiting host call is cancelled.
+  ([#1541](https://github.com/marmot-protocol/mdk/pull/1541))
+
+### Fixed
+
+- Epoch-gap recovery now arms before every publish-failure gate, observes real
+  epoch passages, and drains full-history backfill to relay end-of-stored-events
+  with paced retries and an explicit quiescence fallback. Failed or incomplete
+  drains no longer claim a successful replay.
+  ([#1519](https://github.com/marmot-protocol/mdk/pull/1519),
+  [#1524](https://github.com/marmot-protocol/mdk/pull/1524),
+  [#1532](https://github.com/marmot-protocol/mdk/pull/1532),
+  [#1548](https://github.com/marmot-protocol/mdk/pull/1548))
+
+- Restart-time session-history replay now applies the same idempotent
+  membership, push-token, unread, disband, and timeline-invalidation projection
+  effects as live delivery.
+  ([#1543](https://github.com/marmot-protocol/mdk/pull/1543))
+
+- Group invites select the newest usable current-profile KeyPackage while
+  skipping malformed publications, so an older incompatible record cannot mask
+  a newer valid one.
+  ([#1550](https://github.com/marmot-protocol/mdk/pull/1550))
+
+- External-signer accounts can sign out or wipe without a local secret key;
+  wiping also removes the in-memory signer registration while reversible
+  sign-out preserves it.
+  ([#1528](https://github.com/marmot-protocol/mdk/pull/1528))
+
+- OpenClaw durable text retries now reuse deterministic connector idempotency
+  keys, profile onboarding persists ambiguous send and publication intent, and
+  outbound media uses the host-authorized reader with staged-file cleanup.
+  Allowlist reconciliation revokes first and verifies the effective set.
+  ([#1516](https://github.com/marmot-protocol/mdk/pull/1516),
+  [#1534](https://github.com/marmot-protocol/mdk/pull/1534),
+  [#1540](https://github.com/marmot-protocol/mdk/pull/1540))
+
+- Valid empty administrator policies now report the typed last-admin refusal,
+  orphaned administrators report `unknown_member`, and serialization failures
+  are no longer mislabeled as administrator-policy refusals.
+  ([#1523](https://github.com/marmot-protocol/mdk/pull/1523),
+  [#1536](https://github.com/marmot-protocol/mdk/pull/1536))
+
+- Incident replay rejects empty, non-object, or unrelated JSON documents
+  instead of classifying them as healthy agent-state exports.
+  ([#1530](https://github.com/marmot-protocol/mdk/pull/1530))
 
 ## [0.9.14] - 2026-08-19
 
@@ -1773,7 +1851,8 @@ Initial release of the `dm` command-line app, the `dmd` background daemon, and t
 - Local installation docs for `cargo install --path crates/cli --locked --bins`.
 - Homebrew release checklist and namespaced tap packaging path for `marmot-protocol/tap/darkmatter`.
 
-[Unreleased]: https://github.com/marmot-protocol/mdk/compare/v0.9.14...HEAD
+[Unreleased]: https://github.com/marmot-protocol/mdk/compare/v0.9.15...HEAD
+[0.9.15]: https://github.com/marmot-protocol/mdk/compare/v0.9.14...v0.9.15
 [0.9.14]: https://github.com/marmot-protocol/mdk/compare/v0.9.13...v0.9.14
 [0.9.13]: https://github.com/marmot-protocol/mdk/compare/v0.9.12...v0.9.13
 [0.9.12]: https://github.com/marmot-protocol/mdk/compare/v0.9.11...v0.9.12

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -23,7 +23,7 @@ Choose the runtime you already use:
 | Pi | Terminal harness | Repository and coding tasks through Pi |
 
 The guided installers prompt on the terminal for the White Noise account that
-may invite and message the agent. They install release `wn-agent-v0.9.14`, create
+may invite and message the agent. They install release `wn-agent-v0.9.15`, create
 an isolated White Noise identity for the selected connector, and start same-user
 services where supported. Download each installer with its adjacent checksum,
 verify it, and only then execute the local file:
@@ -50,7 +50,7 @@ install_verified() (
   bash "$tmpdir/$installer_script" "$@"
 )
 
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.15"
 ```
 
 ### Hermes
@@ -110,7 +110,7 @@ install_verified "$base_url/install-pi-marmot.sh" \
 
 ### Finish In White Noise
 
-Release 0.9.14 records the new agent's `npub` and `nprofile` in the
+Release 0.9.15 records the new agent's `npub` and `nprofile` in the
 `bootstrap.json` path printed at completion. Display them with:
 
 ```sh
@@ -119,9 +119,8 @@ python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); print(d["npub"]); p
 ```
 
 Use `hermes`, `openclaw`, `codex`, `harnesses` (OpenCode), or `pi` in that path.
-The updated source installers also show these values directly and render a
-terminal QR when `qrencode` is installed; that improvement will apply to the
-next immutable release.
+The installers also show these values directly and render a terminal QR when
+`qrencode` is installed.
 
 1. Add the displayed agent identity in White Noise.
 2. Invite it to a direct message or group from the account you authorized.

--- a/integrations/codex/marmot/README.md
+++ b/integrations/codex/marmot/README.md
@@ -52,7 +52,7 @@ install_verified() (
   bash "$tmpdir/$installer_script" "$@"
 )
 
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.15"
 install_verified "$base_url/install-codex-marmot.sh" \
   "$base_url/install-codex-marmot.sh.sha256" \
   --yes --allow-welcomer npub1...

--- a/integrations/hermes/marmot/README.md
+++ b/integrations/hermes/marmot/README.md
@@ -75,7 +75,7 @@ install_verified() (
   bash "$tmpdir/$installer_script" "$@"
 )
 
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.15"
 install_verified "$base_url/install-hermes-marmot.sh" \
   "$base_url/install-hermes-marmot.sh.sha256"
 ```
@@ -92,7 +92,7 @@ repeated or given a comma-separated list to authorize multiple senders:
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.15"
 install_verified "$base_url/install-hermes-marmot.sh" \
   "$base_url/install-hermes-marmot.sh.sha256" \
   --yes \
@@ -108,7 +108,7 @@ with `--generate-identity`). To preserve an existing Nostr identity, place its
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.15"
 install_verified "$base_url/install-hermes-marmot.sh" \
   "$base_url/install-hermes-marmot.sh.sha256" \
   --yes \
@@ -138,7 +138,7 @@ To accept Marmot messages from any sender (explicit opt-in):
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.15"
 install_verified "$base_url/install-hermes-marmot.sh" \
   "$base_url/install-hermes-marmot.sh.sha256" \
   --yes --allow-all-users

--- a/integrations/openclaw/marmot/README.md
+++ b/integrations/openclaw/marmot/README.md
@@ -82,7 +82,7 @@ install_verified() (
   bash "$tmpdir/$installer_script" "$@"
 )
 
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.15"
 install_verified "$base_url/install-openclaw-marmot.sh" \
   "$base_url/install-openclaw-marmot.sh.sha256"
 ```
@@ -102,7 +102,7 @@ an `npub` or raw hex public key:
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.15"
 install_verified "$base_url/install-openclaw-marmot.sh" \
   "$base_url/install-openclaw-marmot.sh.sha256" \
   --yes --allow-welcomer npub1...
@@ -116,7 +116,7 @@ with `--generate-identity`). To preserve an existing Nostr identity, place its
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.15"
 install_verified "$base_url/install-openclaw-marmot.sh" \
   "$base_url/install-openclaw-marmot.sh.sha256" \
   --yes \

--- a/integrations/opencode/marmot/README.md
+++ b/integrations/opencode/marmot/README.md
@@ -50,7 +50,7 @@ install_verified() (
   bash "$tmpdir/$installer_script" "$@"
 )
 
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.15"
 install_verified "$base_url/install-opencode-marmot.sh" \
   "$base_url/install-opencode-marmot.sh.sha256"
 ```
@@ -61,7 +61,7 @@ as either an `npub` or raw hex public key:
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.15"
 install_verified "$base_url/install-opencode-marmot.sh" \
   "$base_url/install-opencode-marmot.sh.sha256" \
   --yes --allow-welcomer npub1...

--- a/integrations/pi/marmot/README.md
+++ b/integrations/pi/marmot/README.md
@@ -42,7 +42,7 @@ install_verified() (
   bash "$tmpdir/$installer_script" "$@"
 )
 
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.15"
 install_verified "$base_url/install-pi-marmot.sh" \
   "$base_url/install-pi-marmot.sh.sha256"
 ```
@@ -52,7 +52,7 @@ For noninteractive setup, provide the allowed inviter and prompt sender:
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.15"
 install_verified "$base_url/install-pi-marmot.sh" \
   "$base_url/install-pi-marmot.sh.sha256" \
   --yes --allow-welcomer npub1...

--- a/release.md
+++ b/release.md
@@ -252,9 +252,9 @@ cargo test -p marmot-terminal-harness
 cargo test -p wn-codex
 cargo test -p wn-opencode
 cargo test -p wn-pi
-bash scripts/install-hermes-marmot.sh --dry-run --yes
-bash scripts/install-openclaw-marmot.sh --dry-run --yes
 sender_hex="$(awk 'BEGIN { for (i = 0; i < 32; i++) printf "11" }')"
+bash scripts/install-hermes-marmot.sh --dry-run --yes --allow-welcomer "$sender_hex" --allow-user "$sender_hex"
+bash scripts/install-openclaw-marmot.sh --dry-run --yes --allow-welcomer "$sender_hex"
 bash scripts/install-codex-marmot.sh --dry-run --yes --allow-welcomer "$sender_hex" --codex-bin /bin/echo
 bash scripts/install-opencode-marmot.sh --dry-run --yes --allow-welcomer "$sender_hex" --opencode-bin /bin/echo
 bash scripts/install-pi-marmot.sh --dry-run --yes --allow-welcomer "$sender_hex" --pi-bin /bin/echo
@@ -348,7 +348,7 @@ workspace release looks like:
 ```sh
 (
 set -eu
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.15"
 
 install_verified() (
   set -eu

--- a/scripts/install-hermes-marmot.sh
+++ b/scripts/install-hermes-marmot.sh
@@ -118,7 +118,7 @@ Hermes accepts after gateway restart via $HERMES_HOME/.env.
 
 Verified download (then choose one invocation below):
   set -eu
-  base_url=https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14
+  base_url=https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.15
   tmpdir="$(mktemp -d)"
   trap 'rm -rf "$tmpdir"' 0 HUP INT TERM
   installer_script=install-hermes-marmot.sh

--- a/scripts/install-openclaw-marmot.sh
+++ b/scripts/install-openclaw-marmot.sh
@@ -110,7 +110,7 @@ Environment:
 
 Verified download (then choose one invocation below):
   set -eu
-  base_url=https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.14
+  base_url=https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.15
   tmpdir="$(mktemp -d)"
   trap 'rm -rf "$tmpdir"' 0 HUP INT TERM
   installer_script=install-openclaw-marmot.sh


### PR DESCRIPTION
## Summary

- bump the MDK workspace and lockfile package cohort to 0.9.15
- finalize the 0.9.15 changelog and conformance fixture versions
- pin active WN Agent installer guidance to the immutable 0.9.15 release
- update the release checklist dry-runs for explicit Hermes/OpenClaw authorization

## Validation

- `just fast-ci`
- `cargo metadata --format-version 1 --locked --no-deps`
- `cargo test -p cgka-conformance-simulator canonical_vector_fixtures_match_generated_traces --locked`
- `cargo test -p marmot-uniffi --locked`
- `cargo test -p agent-connector --locked`
- `cargo test -p marmot-terminal-harness --locked`
- `cargo test -p wn-codex --locked`
- `cargo test -p wn-opencode --locked`
- `cargo test -p wn-pi --locked`
- all five WN Agent installer dry-runs
- `just release-all-dry-run 0.9.15`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Released version 0.9.15.
  * Updated installer examples and integration guides to reference the new release.
  * Preflight installer checks now verify sender authorization during dry runs.
  * Installers document identity display and optional terminal QR generation.

* **Documentation**
  * Added comprehensive 0.9.15 changelog entries covering notifications, membership, policies, recovery, replay, installer verification, and reliability improvements.
  * Updated conformance scenarios to the 0.9.15 version without changing their expected outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->