### PR TITLE
Measure epoch divergence from the current epoch, not the high-water mark

### DIFF
--- a/crates/incident-replay/AGENTS.md
+++ b/crates/incident-replay/AGENTS.md
@@ -224,11 +224,33 @@ Precedence, highest first:
    mode: **`went_dark`** (its events end before — or within one hour of — the
    group provably advancing past it: a dead device, stopped uploads, or a
    member who left; telling a departure apart needs a member↔engine linkage
-   the export does not carry yet) or **`active_while_behind`** (it kept
+   the export does not carry yet), **`active_while_behind`** (it kept
    recording events for over an hour after the group moved past it without
-   catching up: commits are not reaching it while its other traffic flows).
-   A real liveness incident, but not a branch contest, so there is nothing to
-   replay — the named engines are the triage starting point.
+   catching up: commits are not reaching it while its other traffic flows), or
+   **`rolled_back`** (its newest timed epoch is *below* one it already
+   reported). A real liveness incident, but not a branch contest, so there is
+   nothing to replay — the named engines are the triage starting point.
+
+   The lag is measured from each engine's **current** epoch — its newest timed
+   observation — not from its high-water mark. The two agree on every engine
+   that only ever moves forward, and diverge exactly on a rollback, where the
+   high-water reading reports a restored device at an epoch it no longer holds
+   and understates its lag. On the 2026-08-26 cohort that gap hid five epochs:
+   one device re-hydrated at epoch 8 having reached 13, and read as lag-4
+   against a tip of 17 instead of lag-9. Since a rollback only ever *widens*
+   the measured lag, reading the current epoch can add a finding but never mask
+   one — including engines the high-water reading kept under the ≥ 2 threshold
+   entirely (`quarantine-rolled-back-engine.json` is that case: `Healthy`
+   before, quarantined after). An engine whose epoch evidence carries no
+   timestamp cannot be ordered, so it keeps the high-water reading and
+   classifies exactly as before.
+
+   `rolled_back` outranks the other two modes, which a rolled-back engine also
+   satisfies by construction (it is necessarily either dark or active). Nothing
+   in the protocol walks an epoch backwards, so the rollback is a local-storage
+   event — a device restored from an older backup, a rolled-back database — and
+   it names a different remedy: no redelivery repairs it, because the device is
+   asking for commits the group has already retired. Re-invite, not re-pull.
 7. **`Healthy`** — none of the above.
 
 Rules 5 and 6 rank *below* the incident routes on purpose: a reproducible contest is

--- a/crates/incident-replay/AGENTS.md
+++ b/crates/incident-replay/AGENTS.md
@@ -241,16 +241,26 @@ Precedence, highest first:
    the measured lag, reading the current epoch can add a finding but never mask
    one — including engines the high-water reading kept under the ≥ 2 threshold
    entirely (`quarantine-rolled-back-engine.json` is that case: `Healthy`
-   before, quarantined after). An engine whose epoch evidence carries no
-   timestamp cannot be ordered, so it keeps the high-water reading and
+   before, quarantined after). **One untimed epoch row forfeits the current
+   reading for that whole engine**, the same way one untimed halt row makes
+   rule 5's halt side unorderable: an untimed row may be the engine's newest,
+   so preferring the newest *timed* row would invent a rollback out of forward
+   movement nobody stamped. Such an engine keeps the high-water reading and
    classifies exactly as before.
 
    `rolled_back` outranks the other two modes, which a rolled-back engine also
    satisfies by construction (it is necessarily either dark or active). Nothing
    in the protocol walks an epoch backwards, so the rollback is a local-storage
-   event — a device restored from an older backup, a rolled-back database — and
-   it names a different remedy: no redelivery repairs it, because the device is
-   asking for commits the group has already retired. Re-invite, not re-pull.
+   event: a device restored from an older backup, a rolled-back database.
+
+   The mode reports where the device is, not that it is beyond repair. A
+   restored device still holds valid state at the epoch it fell back to, so a
+   full-history replay reaching every commit from there forward can carry it up
+   again — mdk#1548 healed a device from epoch 13 to 16 that way. The rollback
+   changes the size of the ask rather than its possibility: the gap spans every
+   epoch since the restore, so it needs that replay rather than ordinary
+   redelivery, and re-invite only once relay retention no longer covers the
+   span. Whether it still does is not a question the export can answer.
 7. **`Healthy`** — none of the above.
 
 Rules 5 and 6 rank *below* the incident routes on purpose: a reproducible contest is

--- a/crates/incident-replay/src/classify.rs
+++ b/crates/incident-replay/src/classify.rs
@@ -162,7 +162,9 @@ impl fmt::Display for HaltedEngine {
 pub struct BehindEngine {
     /// The engine that fell behind.
     pub engine_id: String,
-    /// The highest epoch the engine's own events place it at.
+    /// The epoch the engine's own events currently place it at — its newest
+    /// timed position, not its high-water mark, so a rolled-back device is
+    /// reported where it actually sits.
     pub epoch: u64,
     /// How the engine was behaving once the group moved past it.
     pub mode: BehindMode,
@@ -198,6 +200,15 @@ pub enum BehindMode {
     /// catching up: commits are not reaching it even though its other traffic
     /// flows.
     ActiveWhileBehind,
+    /// The engine's newest timed epoch is *below* one it already reported: its
+    /// local state moved backwards. Nothing in the protocol walks an epoch
+    /// back, so this is a local-storage event — a device restored from an
+    /// older backup, a rolled-back database — and no amount of redelivery
+    /// repairs it, because the device is asking for commits the group has
+    /// already retired. It outranks the other two modes: an engine that rolled
+    /// back is also, necessarily, active or dark, and the rollback is the
+    /// diagnosis an operator acts on (re-invite, not re-pull).
+    RolledBack,
 }
 
 impl fmt::Display for BehindMode {
@@ -205,6 +216,7 @@ impl fmt::Display for BehindMode {
         f.write_str(match self {
             BehindMode::WentDark => "went dark",
             BehindMode::ActiveWhileBehind => "active while behind",
+            BehindMode::RolledBack => "rolled back",
         })
     }
 }
@@ -448,6 +460,12 @@ struct EngineActivity {
     last_seen_ms: Option<u64>,
     /// The highest epoch the engine reported itself at.
     high_water_epoch: Option<u64>,
+    /// The engine's newest *timed* epoch observation, as `(wall_time_ms,
+    /// epoch)`. Held beside the high-water mark because the two disagree
+    /// exactly when local state moved backwards, which is the whole signal
+    /// behind [`BehindMode::RolledBack`] — a max alone reports a restored
+    /// device at the epoch it used to hold and understates its lag.
+    current: Option<(u64, u64)>,
 }
 
 /// The weaker of the two gates between "no contested branch" and "healthy":
@@ -478,6 +496,14 @@ fn epoch_divergence(export: &AgentStateExport) -> Option<QuarantineReason> {
         let observed = event.kind.observed_epoch();
         activity.high_water_epoch = activity.high_water_epoch.max(observed);
         if let (Some(epoch), Some(ms)) = (observed, event.wall_time_ms) {
+            // Newest timed observation wins. A tie orders nothing, so it keeps
+            // the higher epoch rather than assert a regression the timestamps
+            // do not actually establish.
+            let candidate = (ms, epoch);
+            activity.current = Some(match activity.current {
+                Some(current) if current > candidate => current,
+                _ => candidate,
+            });
             epoch_first_seen
                 .entry(epoch)
                 .and_modify(|first| *first = (*first).min(ms))
@@ -492,7 +518,14 @@ fn epoch_divergence(export: &AgentStateExport) -> Option<QuarantineReason> {
     let behind: Vec<BehindEngine> = engines
         .iter()
         .filter_map(|(engine_id, activity)| {
-            let epoch = activity.high_water_epoch?;
+            let high_water = activity.high_water_epoch?;
+            // Lag is measured from where the engine is now, not from the best
+            // it ever managed. The two differ only on a rollback, and only
+            // ever widen the lag, so this can add a finding but never mask
+            // one. An engine whose epoch evidence is untimed keeps the
+            // high-water reading, exactly as before.
+            let epoch = activity.current.map_or(high_water, |(_, epoch)| epoch);
+            let rolled_back = epoch < high_water;
             if group_epoch - epoch < EPOCH_DIVERGENCE_MIN_LAG {
                 return None;
             }
@@ -505,7 +538,9 @@ fn epoch_divergence(export: &AgentStateExport) -> Option<QuarantineReason> {
                 .map(|(_, first_seen)| *first_seen)
                 .min()?;
             let catch_up_deadline = moved_past.saturating_add(CATCH_UP_GRACE_MS);
-            let mode = if last_seen > catch_up_deadline {
+            let mode = if rolled_back {
+                BehindMode::RolledBack
+            } else if last_seen > catch_up_deadline {
                 BehindMode::ActiveWhileBehind
             } else {
                 BehindMode::WentDark

--- a/crates/incident-replay/src/classify.rs
+++ b/crates/incident-replay/src/classify.rs
@@ -203,11 +203,19 @@ pub enum BehindMode {
     /// The engine's newest timed epoch is *below* one it already reported: its
     /// local state moved backwards. Nothing in the protocol walks an epoch
     /// back, so this is a local-storage event — a device restored from an
-    /// older backup, a rolled-back database — and no amount of redelivery
-    /// repairs it, because the device is asking for commits the group has
-    /// already retired. It outranks the other two modes: an engine that rolled
-    /// back is also, necessarily, active or dark, and the rollback is the
-    /// diagnosis an operator acts on (re-invite, not re-pull).
+    /// older backup, a rolled-back database. It outranks the other two modes:
+    /// an engine that rolled back is also, necessarily, active or dark, and
+    /// the rollback is the sharper of the two readings.
+    ///
+    /// The mode says where the device is, not that it is beyond repair. A
+    /// restored device still holds valid state at the epoch it fell back to,
+    /// so a full-history replay that reaches every commit from there forward
+    /// can carry it up again — mdk#1548 healed a device from epoch 13 to 16
+    /// exactly that way. What the rollback changes is the size of the ask: the
+    /// gap spans every epoch since the restore rather than a commit or two, so
+    /// it needs that replay rather than ordinary redelivery, and re-invite
+    /// only once relay retention no longer covers the span. Whether it still
+    /// does is not a question this export can answer.
     RolledBack,
 }
 
@@ -466,6 +474,13 @@ struct EngineActivity {
     /// behind [`BehindMode::RolledBack`] — a max alone reports a restored
     /// device at the epoch it used to hold and understates its lag.
     current: Option<(u64, u64)>,
+    /// Whether any epoch observation arrived without a timestamp. One such row
+    /// makes the engine's whole epoch sequence unorderable, exactly as one
+    /// untimed halt row does in [`unrecoverable_halt`]: an untimed epoch may
+    /// be the newest one, so a "newest timed" reading could sit behind the
+    /// engine's real position and invent a rollback. The fail-closed answer is
+    /// to keep the high-water reading, which claims no ordering at all.
+    has_untimed_epoch: bool,
 }
 
 /// The weaker of the two gates between "no contested branch" and "healthy":
@@ -508,6 +523,8 @@ fn epoch_divergence(export: &AgentStateExport) -> Option<QuarantineReason> {
                 .entry(epoch)
                 .and_modify(|first| *first = (*first).min(ms))
                 .or_insert(ms);
+        } else if observed.is_some() {
+            activity.has_untimed_epoch = true;
         }
     }
 
@@ -522,9 +539,14 @@ fn epoch_divergence(export: &AgentStateExport) -> Option<QuarantineReason> {
             // Lag is measured from where the engine is now, not from the best
             // it ever managed. The two differ only on a rollback, and only
             // ever widen the lag, so this can add a finding but never mask
-            // one. An engine whose epoch evidence is untimed keeps the
-            // high-water reading, exactly as before.
-            let epoch = activity.current.map_or(high_water, |(_, epoch)| epoch);
+            // one. Any untimed epoch row forfeits that reading for the whole
+            // engine: the untimed row may be its newest, and preferring the
+            // newest *timed* one would then invent a rollback out of ordinary
+            // forward movement nobody stamped.
+            let epoch = match activity.current {
+                Some((_, epoch)) if !activity.has_untimed_epoch => epoch,
+                _ => high_water,
+            };
             let rolled_back = epoch < high_water;
             if group_epoch - epoch < EPOCH_DIVERGENCE_MIN_LAG {
                 return None;

--- a/crates/incident-replay/tests/classify.rs
+++ b/crates/incident-replay/tests/classify.rs
@@ -617,7 +617,7 @@ fn an_engine_whose_local_state_moved_backwards_quarantines_as_rolled_back() {
     // sits at epoch 5, one behind the tip, *below* the divergence threshold and
     // therefore invisible; read from where it actually is, it is four behind.
     // This is the 2026-08-26 cohort's worst device in miniature: nine epochs
-    // behind, reported as four, and unreachable by any redelivery.
+    // behind and reported as four.
     assert_eq!(
         classify(&load("quarantine-rolled-back-engine.json")),
         Verdict::Quarantine {
@@ -646,4 +646,23 @@ fn a_rollback_outranks_the_active_while_behind_it_also_satisfies() {
     };
     assert_eq!(engines.len(), 1);
     assert_eq!(engines[0].mode, BehindMode::RolledBack);
+}
+
+#[test]
+fn an_untimed_epoch_newer_than_the_timed_one_is_not_a_rollback() {
+    // engine-b reports a timed epoch 5 and then an *untimed* epoch 9. The
+    // untimed row may well be its newest, so reading the newest timed row
+    // would place it at 5 and invent a rollback out of ordinary forward
+    // movement nobody stamped. One untimed epoch row forfeits the current
+    // reading for the whole engine, exactly as one untimed halt row makes
+    // rule 5's halt side unorderable, and the high-water reading puts
+    // engine-b at the tip.
+    assert_eq!(
+        classify(&load("healthy-untimed-epoch-after-timed.json")),
+        Verdict::Healthy
+    );
+    assert_eq!(
+        liveness_advisory(&load("healthy-untimed-epoch-after-timed.json")),
+        None
+    );
 }

--- a/crates/incident-replay/tests/classify.rs
+++ b/crates/incident-replay/tests/classify.rs
@@ -608,3 +608,42 @@ fn a_halt_outranks_the_epoch_divergence_it_explains() {
         Some(QuarantineReason::EpochDivergence { .. })
     ));
 }
+
+#[test]
+fn an_engine_whose_local_state_moved_backwards_quarantines_as_rolled_back() {
+    // engine-b reports epoch 5, then reports epoch 2 nearly three hours later:
+    // local state moved backwards, which no protocol step produces — a device
+    // restored from an older backup. Read from the high-water mark alone it
+    // sits at epoch 5, one behind the tip, *below* the divergence threshold and
+    // therefore invisible; read from where it actually is, it is four behind.
+    // This is the 2026-08-26 cohort's worst device in miniature: nine epochs
+    // behind, reported as four, and unreachable by any redelivery.
+    assert_eq!(
+        classify(&load("quarantine-rolled-back-engine.json")),
+        Verdict::Quarantine {
+            reason: QuarantineReason::EpochDivergence {
+                group_epoch: 6,
+                engines: vec![BehindEngine {
+                    engine_id: "engine-b".into(),
+                    epoch: 2,
+                    mode: BehindMode::RolledBack,
+                }],
+            }
+        }
+    );
+}
+
+#[test]
+fn a_rollback_outranks_the_active_while_behind_it_also_satisfies() {
+    // The rolled-back engine keeps recording well past the catch-up grace, so
+    // it qualifies as active-while-behind too. The rollback is the mode
+    // reported: it names a cause and a different remedy (re-invite, not
+    // re-pull) than "commits are not arriving".
+    let Some(QuarantineReason::EpochDivergence { engines, .. }) =
+        liveness_advisory(&load("quarantine-rolled-back-engine.json"))
+    else {
+        panic!("expected an epoch-divergence advisory");
+    };
+    assert_eq!(engines.len(), 1);
+    assert_eq!(engines[0].mode, BehindMode::RolledBack);
+}

--- a/crates/incident-replay/tests/fixtures/healthy-untimed-epoch-after-timed.json
+++ b/crates/incident-replay/tests/fixtures/healthy-untimed-epoch-after-timed.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": "marmot-agent-state/v1",
+  "events": [
+    {
+      "engine_id": "engine-a",
+      "wall_time_ms": 1000000000000,
+      "kind": { "type": "epoch_state_changed", "epoch": 9, "new_state": "stable" }
+    },
+    {
+      "engine_id": "engine-b",
+      "wall_time_ms": 1000000060000,
+      "kind": { "type": "epoch_state_changed", "epoch": 5, "new_state": "stable" }
+    },
+    {
+      "engine_id": "engine-b",
+      "kind": { "type": "epoch_state_changed", "epoch": 9, "new_state": "stable" }
+    }
+  ],
+  "derived_projections": {
+    "pagination": {
+      "convergence_runs": { "has_more": false, "limit": 500, "offset": 0, "returned": 0 }
+    }
+  }
+}

--- a/crates/incident-replay/tests/fixtures/quarantine-rolled-back-engine.json
+++ b/crates/incident-replay/tests/fixtures/quarantine-rolled-back-engine.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": "marmot-agent-state/v1",
+  "events": [
+    {
+      "engine_id": "engine-a",
+      "wall_time_ms": 1000000000000,
+      "kind": { "type": "epoch_state_changed", "epoch": 2, "new_state": "stable" }
+    },
+    {
+      "engine_id": "engine-b",
+      "wall_time_ms": 1000000060000,
+      "kind": { "type": "epoch_state_changed", "epoch": 5, "new_state": "stable" }
+    },
+    {
+      "engine_id": "engine-a",
+      "wall_time_ms": 1000000120000,
+      "kind": { "type": "epoch_state_changed", "epoch": 6, "new_state": "stable" }
+    },
+    {
+      "engine_id": "engine-b",
+      "wall_time_ms": 1000010000000,
+      "kind": { "type": "epoch_state_changed", "epoch": 2, "new_state": "stable" }
+    }
+  ],
+  "derived_projections": {
+    "pagination": {
+      "convergence_runs": { "has_more": false, "limit": 500, "offset": 0, "returned": 0 }
+    }
+  }
+}


### PR DESCRIPTION
Rule 6 (`epoch_divergence`) measured each engine's lag from its high-water epoch. A marmot that burrows backwards, restored from an older backup or a rolled-back database, then gets reported at an epoch it no longer holds.

Nothing in the protocol walks an epoch back, so a regression is always a local-storage event. It also understates lag exactly when the device is worst off.

I found this while diagnosing a real cohort. One device re-hydrated at epoch 8 having already reached 13, and read as lag-4 against a tip of 17 instead of lag-9. Understating lag can also push an engine under the `>= 2` threshold and hide it from the report entirely, which is what the new fixture pins: `Healthy` before, quarantined after.

## What changed

Lag now comes from the newest timed epoch observation. The two readings agree on any engine that only moves forward and diverge only on a regression, where the lag can only widen. This adds findings and masks none. Untimed epoch evidence cannot be ordered, so it keeps the high-water reading and classifies as before.

A third `BehindMode`, `rolled_back`, outranks `went_dark` and `active_while_behind`, which a regressed engine also satisfies by construction. It points at a different remedy: no redelivery repairs it, because the device is asking for commits the group already retired. Re-invite, not re-pull.

On the export that prompted this, one engine moved from `at epoch 13 (active while behind)` to `at epoch 8 (rolled back)`.

## Testing

The new fixture is synthetic and carries no real identifiers, matching the crate's fixture policy. I checked it against the old logic to confirm it fails there: the old code returns `Healthy`, the new code returns a `RolledBack` quarantine.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added rollback detection when an engine reports a lower epoch.
  - Added a distinct “rolled back” status that takes precedence over lag indicators.
  - Updated remediation guidance: full-history replay may restore devices when history is retained; re-invitation is needed only when it is unavailable.

- **Bug Fixes**
  - Prevented false rollback detection when epoch observations lack timing information.
  - Preserved accurate high-water epoch calculations.

- **Tests**
  - Added coverage for rollback classification and untimed epoch scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->