### PR TITLE
fix: scope replay rollback to canonical group state

### DIFF
--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -2188,7 +2188,7 @@ impl<S: StorageProvider> Engine<S> {
             hasher.update(record.id.as_slice());
             let digest = hasher.finalize();
             let probe_snapshot = format!("hydrate-selfremove-probe-{}", hex::encode(&digest[..8]));
-            let guard = crate::snapshot_guard::SnapshotRollbackGuard::create(
+            let guard = crate::snapshot_guard::SnapshotRollbackGuard::create_group_state(
                 &self.storage,
                 group_id.clone(),
                 probe_snapshot,

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -2531,8 +2531,11 @@ impl<S: StorageProvider> Engine<S> {
             // (panic, early error, async cancel) so the live group
             // state never leaks past this scope as the past-snapshot
             // state.
-            let guard =
-                SnapshotRollbackGuard::create(&self.storage, group_id.clone(), restore_snapshot)?;
+            let guard = SnapshotRollbackGuard::create_group_state(
+                &self.storage,
+                group_id.clone(),
+                restore_snapshot,
+            )?;
             let (ctx, message_retention_seconds) =
                 match self.context_from_group_snapshot(group_id, &snapshot_name) {
                     Ok(Some(context)) => context,
@@ -2613,10 +2616,14 @@ impl<S: StorageProvider> Engine<S> {
             current_epoch.0,
             hex::encode(&hasher.finalize()[..8])
         );
-        let guard = SnapshotRollbackGuard::create(&self.storage, group_id.clone(), restore_name)?;
+        let guard = SnapshotRollbackGuard::create_group_state(
+            &self.storage,
+            group_id.clone(),
+            restore_name,
+        )?;
         let resolved = match self
             .storage
-            .rollback_group_to_snapshot(group_id, &snapshot_name)
+            .rollback_group_state_to_snapshot(group_id, &snapshot_name)
         {
             Ok(()) => {
                 let provider =
@@ -2683,7 +2690,7 @@ impl<S: StorageProvider> Engine<S> {
         EngineError,
     > {
         self.storage
-            .rollback_group_to_snapshot(group_id, snapshot_name)?;
+            .rollback_group_state_to_snapshot(group_id, snapshot_name)?;
         let provider = EngineOpenMlsProvider::<S>::new(&self.crypto, self.storage.mls_storage());
         let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
         let mls_group = MlsGroup::load(

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -1406,6 +1406,12 @@ pub(crate) fn recover_interrupted_rewind_probe<S: StorageProvider>(
         ));
     }
 
+    // Deliberately recover the complete pre-probe image. A surviving probe
+    // snapshot may have been created by an older binary before guards became
+    // state-scoped. If that binary also rewound through a legacy full retained
+    // anchor, the probe snapshot is the only durable copy of the newer live
+    // message ledger and outbound queue. State-only recovery would leave the
+    // historical work rows stranded after upgrade.
     rollback_and_release_group_snapshot(storage, group_id, snapshot)
 }
 

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -835,7 +835,7 @@ fn replay_openmls_messages_prevalidated_output<S: StorageProvider>(
     // commit at the end. Pre-validated own-commit rollforwards inside the
     // replay land within this guard, so they are unwound with everything
     // else.
-    let guard = SnapshotRollbackGuard::create(storage, group_id.clone(), snapshot)
+    let guard = SnapshotRollbackGuard::create_group_state(storage, group_id.clone(), snapshot)
         .map_err(|e| OpenMlsProjectionError::Snapshot(format!("{e:?}")))?;
 
     let result =
@@ -1349,11 +1349,11 @@ fn canonicalize_stored_openmls_messages_from_retained_anchor<S: StorageProvider>
     use crate::snapshot_guard::SnapshotRollbackGuard;
 
     let live_snapshot = retained_anchor_probe_snapshot_name(group_id, work.replay_start_epoch);
-    let guard = SnapshotRollbackGuard::create(storage, group_id.clone(), live_snapshot)
+    let guard = SnapshotRollbackGuard::create_group_state(storage, group_id.clone(), live_snapshot)
         .map_err(|e| OpenMlsProjectionError::Snapshot(format!("{e:?}")))?;
 
     let anchor_snapshot = retained_anchor_snapshot_name(work.replay_start_epoch);
-    let result = match storage.rollback_group_to_snapshot(group_id, &anchor_snapshot) {
+    let result = match storage.rollback_group_state_to_snapshot(group_id, &anchor_snapshot) {
         Ok(()) => {
             crate::test_crash_hooks::pause_if_requested("retained-anchor-after-rewind");
             canonicalize_stored_openmls_messages_from_current(storage, group_id, work)
@@ -1689,18 +1689,22 @@ pub(crate) fn candidate_branch_peel<S: StorageProvider>(
     // `recover_interrupted_rewind_probe` exactly as the pass's is — under this
     // sweep's own probe name, so two interrupted probes stay distinguishable.
     let probe_snapshot = candidate_branch_probe_snapshot_name(group_id, inputs.replay_start_epoch);
-    let guard = SnapshotRollbackGuard::create(storage, group_id.clone(), probe_snapshot)
-        .map_err(|e| OpenMlsProjectionError::Snapshot(format!("{e:?}")))?;
+    let guard =
+        SnapshotRollbackGuard::create_group_state(storage, group_id.clone(), probe_snapshot)
+            .map_err(|e| OpenMlsProjectionError::Snapshot(format!("{e:?}")))?;
     let anchor_snapshot = retained_anchor_snapshot_name(inputs.replay_start_epoch);
-    let contexts = match storage.rollback_group_to_snapshot(group_id, &anchor_snapshot) {
-        Ok(()) => candidate_branch_peel_contexts_from_current(
-            storage,
-            group_id,
-            inputs,
-            max_rewind_commits,
-            profile_policy,
-            max_contexts,
-        ),
+    let contexts = match storage.rollback_group_state_to_snapshot(group_id, &anchor_snapshot) {
+        Ok(()) => {
+            crate::test_crash_hooks::pause_if_requested("candidate-branch-after-rewind");
+            candidate_branch_peel_contexts_from_current(
+                storage,
+                group_id,
+                inputs,
+                max_rewind_commits,
+                profile_policy,
+                max_contexts,
+            )
+        }
         Err(StorageError::SnapshotMissing(_)) => Ok(Vec::new()),
         Err(e) => Err(OpenMlsProjectionError::Snapshot(format!("{e:?}"))),
     };
@@ -1878,7 +1882,7 @@ fn candidate_path_peel_context<S: StorageProvider>(
     budget.consume()?;
 
     let snapshot = replay_snapshot_name(group_id, &replay_path.messages);
-    let guard = SnapshotRollbackGuard::create(storage, group_id.clone(), snapshot)
+    let guard = SnapshotRollbackGuard::create_group_state(storage, group_id.clone(), snapshot)
         .map_err(|e| OpenMlsProjectionError::Snapshot(format!("{e:?}")))?;
     let captured = capture_candidate_tip_context(
         storage,
@@ -2268,6 +2272,9 @@ pub(crate) fn apply_openmls_canonicalization_result_with_profile_policy<S: Stora
             (Vec::new(), Vec::new())
         };
     let snapshot = apply_snapshot_name(group_id, result);
+    // Deliberately full. Unlike temporary replay/probe guards, canonical apply
+    // changes message dispositions and outbound work; error recovery needs the
+    // complete pre-apply image, not only canonical group/OpenMLS state.
     storage
         .create_group_snapshot(group_id, &snapshot)
         .map_err(|e| OpenMlsProjectionError::Snapshot(format!("{e:?}")))?;

--- a/crates/cgka-engine/src/snapshot_guard.rs
+++ b/crates/cgka-engine/src/snapshot_guard.rs
@@ -62,7 +62,7 @@ impl<'a, S: StorageProvider> SnapshotRollbackGuard<'a, S> {
     /// consumed.
     pub(crate) fn commit(mut self) -> StorageResult<()> {
         self.storage
-            .rollback_group_to_snapshot(&self.group_id, &self.name)?;
+            .rollback_group_state_to_snapshot(&self.group_id, &self.name)?;
         match self
             .storage
             .release_group_snapshot(&self.group_id, &self.name)
@@ -87,7 +87,7 @@ impl<'a, S: StorageProvider> Drop for SnapshotRollbackGuard<'a, S> {
         // privacy-safe trace so the failure is visible.
         if let Err(_e) = self
             .storage
-            .rollback_group_to_snapshot(&self.group_id, &self.name)
+            .rollback_group_state_to_snapshot(&self.group_id, &self.name)
         {
             tracing::warn!(
                 target: TRACE_TARGET,

--- a/crates/cgka-engine/src/snapshot_guard.rs
+++ b/crates/cgka-engine/src/snapshot_guard.rs
@@ -2,7 +2,7 @@
 //!
 //! The engine creates short-lived snapshots in several places to safely
 //! probe past state (peeling against retained epoch contexts; replaying
-//! candidate paths; canonicalize-and-apply windows). The pattern is:
+//! candidate paths; reading historical group state). The pattern is:
 //!
 //! 1. Create a snapshot of the live group state.
 //! 2. Mutate storage (rollback to a different snapshot, replay messages).
@@ -27,10 +27,10 @@ use cgka_traits::types::GroupId;
 
 const TRACE_TARGET: &str = "cgka_engine::snapshot_guard";
 
-/// Owns a freshly-created snapshot. Drop rolls back to the snapshot and
-/// releases it. Call [`Self::commit`] on the happy path to perform the
-/// rollback + release explicitly; that disarms the guard so Drop is a
-/// no-op afterwards.
+/// Owns a freshly-created canonical-group-state snapshot. Drop rolls back to
+/// the snapshot and releases it. Call [`Self::commit`] on the happy path to
+/// perform the rollback + release explicitly; that disarms the guard so Drop
+/// is a no-op afterwards.
 pub(crate) struct SnapshotRollbackGuard<'a, S: StorageProvider> {
     storage: &'a S,
     group_id: GroupId,
@@ -39,9 +39,16 @@ pub(crate) struct SnapshotRollbackGuard<'a, S: StorageProvider> {
 }
 
 impl<'a, S: StorageProvider> SnapshotRollbackGuard<'a, S> {
-    /// Create a snapshot named `name` for `group_id` and return a guard.
-    pub(crate) fn create(storage: &'a S, group_id: GroupId, name: String) -> StorageResult<Self> {
-        storage.create_group_snapshot(&group_id, &name)?;
+    /// Create a canonical-group-state snapshot named `name` for `group_id` and
+    /// return a guard. The message ledger and outbound queue are deliberately
+    /// excluded: callers use this guard only around temporary canonical-state
+    /// mutations and must leave live input/work collections untouched.
+    pub(crate) fn create_group_state(
+        storage: &'a S,
+        group_id: GroupId,
+        name: String,
+    ) -> StorageResult<Self> {
+        storage.create_group_state_snapshot(&group_id, &name)?;
         Ok(Self {
             storage,
             group_id,
@@ -98,5 +105,110 @@ impl<'a, S: StorageProvider> Drop for SnapshotRollbackGuard<'a, S> {
                 "snapshot release on panic-unwind failed"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SnapshotRollbackGuard;
+    use cgka_traits::capabilities::GroupCapabilities;
+    use cgka_traits::engine::SendIntent;
+    use cgka_traits::group::{Group, ProtocolProfile};
+    use cgka_traits::message::{MessageRecord, MessageState};
+    use cgka_traits::storage::{
+        GroupStorage, MessageStorage, OutboundIntentStorage, QueuedOutboundIntent,
+    };
+    use cgka_traits::types::{EpochId, GroupId, MessageId};
+    use storage_sqlite::SqliteAccountStorage;
+
+    fn group(group_id: &GroupId, epoch: u64, name: &str) -> Group {
+        Group {
+            id: group_id.clone(),
+            name: name.into(),
+            description: String::new(),
+            epoch: EpochId(epoch),
+            members: Vec::new(),
+            required_capabilities: GroupCapabilities::default(),
+            protocol_profile: ProtocolProfile::Legacy,
+            removed: false,
+            unrecoverable: false,
+            disbanded: None,
+            join_epoch: EpochId(0),
+        }
+    }
+
+    fn message(group_id: &GroupId, id: u8, epoch: u64) -> MessageRecord {
+        MessageRecord {
+            id: MessageId::new(vec![id]),
+            group_id: group_id.clone(),
+            epoch: EpochId(epoch),
+            state: MessageState::Processed,
+            payload: vec![id],
+            deferred_peel: None,
+        }
+    }
+
+    fn queued(group_id: &GroupId, id: u8) -> QueuedOutboundIntent {
+        QueuedOutboundIntent {
+            id: MessageId::new(vec![id]),
+            group_id: group_id.clone(),
+            intent: SendIntent::AppMessage {
+                group_id: group_id.clone(),
+                payload: vec![id],
+            },
+            created_at_ms: u64::from(id),
+        }
+    }
+
+    #[test]
+    fn group_state_guard_does_not_rewrite_live_message_or_queue_rows() {
+        let storage = SqliteAccountStorage::in_memory().expect("storage");
+        let group_id = GroupId::new(vec![7; 16]);
+        let live_group = group(&group_id, 3, "live");
+        let original_message = message(&group_id, 1, 2);
+        let original_queued = queued(&group_id, 11);
+        storage.put_group(&live_group).expect("put live group");
+        storage
+            .put_message(&original_message)
+            .expect("put original message");
+        storage
+            .put_queued_outbound_intent(&original_queued)
+            .expect("put original queued intent");
+
+        let guard = SnapshotRollbackGuard::create_group_state(
+            &storage,
+            group_id.clone(),
+            "temporary-probe".into(),
+        )
+        .expect("capture live state");
+
+        storage
+            .put_group(&group(&group_id, 2, "temporary"))
+            .expect("mutate canonical group state");
+        let live_message = message(&group_id, 2, 3);
+        storage
+            .put_message(&live_message)
+            .expect("put message while probe is active");
+        storage
+            .delete_queued_outbound_intent(&original_queued.id)
+            .expect("delete original queued intent");
+        let live_queued = queued(&group_id, 12);
+        storage
+            .put_queued_outbound_intent(&live_queued)
+            .expect("put live queued intent");
+
+        guard.commit().expect("restore canonical group state");
+
+        assert_eq!(storage.get_group(&group_id).unwrap(), live_group);
+        assert_eq!(
+            storage.list_messages(&group_id, EpochId(0)).unwrap(),
+            vec![original_message, live_message],
+            "temporary group-state replay must not restore a captured ledger image"
+        );
+        assert_eq!(
+            storage.list_queued_outbound_intents(&group_id).unwrap(),
+            vec![live_queued],
+            "temporary group-state replay must not restore a captured queue image"
+        );
     }
 }

--- a/crates/cgka-engine/tests/crash_recovery_sqlite.rs
+++ b/crates/cgka-engine/tests/crash_recovery_sqlite.rs
@@ -2,10 +2,10 @@
 
 //! Process-kill coverage for convergence rewrite durability (#1025).
 //!
-//! The ignored child test drives the real retained-anchor late-commit path over
-//! encrypted file-backed SQLite. Parent tests stop it at fixed debug-only crash
-//! points, then reopen and hydrate the database without running child
-//! destructors.
+//! The ignored child test drives the real retained-anchor late-commit and
+//! deferred candidate-branch paths over encrypted file-backed SQLite. Parent
+//! tests stop it at fixed debug-only crash points, then reopen and hydrate the
+//! database without running child destructors.
 
 use std::collections::BTreeSet;
 use std::hash::{Hash, Hasher};
@@ -28,7 +28,7 @@ use cgka_traits::engine::{CgkaEngine, CreateGroupRequest, SendIntent, SendResult
 use cgka_traits::error::PeelerError;
 use cgka_traits::group_context::GroupContextSnapshot;
 use cgka_traits::ingest::{PeeledContent, PeeledMessage};
-use cgka_traits::message::MessageState;
+use cgka_traits::message::{MessageRecord, MessageState, StoredMessagePayload};
 use cgka_traits::peeler::TransportPeeler;
 use cgka_traits::storage::{
     ConvergencePassStorage, GroupStorage, MessageStorage, OutboundIntentStorage,
@@ -52,6 +52,7 @@ const DATABASE_KEY: &str = "cgka convergence crash recovery key";
 const READY_PREFIX: &str = "MDK_CGKA_TEST_CRASH_READY:";
 const H5_POINT: &str = "historical-apply-before-commit";
 const H6_POINT: &str = "retained-anchor-after-rewind";
+const CANDIDATE_BRANCH_POINT: &str = "candidate-branch-after-rewind";
 const DURABLE_TRANSITION_POINTS: &[&str] = &[
     "convergence-pass-collecting-durable",
     "convergence-pass-frozen-durable",
@@ -136,6 +137,11 @@ fn h5_kill_before_historical_apply_commit_preserves_live_inputs() {
 #[test]
 fn h6_kill_after_retained_anchor_rewind_recovers_live_snapshot() {
     run_parent_case(H6_POINT, EpochId(1), "openmls-retained-probe-");
+}
+
+#[test]
+fn candidate_branch_kill_after_rewind_recovers_live_state_and_work_rows() {
+    run_parent_case(CANDIDATE_BRANCH_POINT, EpochId(1), "openmls-branch-probe-");
 }
 
 #[test]
@@ -243,7 +249,7 @@ fn run_parent_case(point: &str, stranded_epoch: EpochId, snapshot_prefix: &str) 
     let group_id = group_ids[0].clone();
     let stranded_group = storage.get_group(&group_id).expect("stranded group");
     assert_eq!(stranded_group.epoch, stranded_epoch);
-    if point == H6_POINT {
+    if matches!(point, H6_POINT | CANDIDATE_BRANCH_POINT) {
         assert!(
             !stranded_group
                 .members
@@ -260,7 +266,7 @@ fn run_parent_case(point: &str, stranded_epoch: EpochId, snapshot_prefix: &str) 
             .any(|name| name.starts_with(snapshot_prefix)),
         "expected stranded snapshot prefix {snapshot_prefix}"
     );
-    if point == H5_POINT {
+    if matches!(point, H5_POINT | CANDIDATE_BRANCH_POINT) {
         assert_eq!(
             storage
                 .list_queued_outbound_intents(&group_id)
@@ -606,7 +612,8 @@ async fn run_child_case(database: &Path) {
         .expect("buffer late competing commit");
 
     let _ = alice_seed;
-    if std::env::var(CRASH_POINT_ENV).as_deref() == Ok(H5_POINT) {
+    let crash_point = std::env::var(CRASH_POINT_ENV).ok();
+    if crash_point.as_deref() == Some(H5_POINT) {
         let policy = CanonicalizationPolicy::default();
         let state = CanonicalizationState {
             current_tip_epoch: 2,
@@ -630,6 +637,37 @@ async fn run_child_case(database: &Path) {
             policy.convergence.max_rewind_commits,
         )
         .expect("historical apply reaches selected crash point");
+    } else if crash_point.as_deref() == Some(CANDIDATE_BRANCH_POINT) {
+        let deferred = TransportMessage {
+            id: MessageId::new(b"candidate-branch-deferred".to_vec()),
+            payload: b"opaque candidate-branch traffic".to_vec(),
+            timestamp: Timestamp(2_200),
+            causal_deps: Vec::new(),
+            source: TransportSource("crash-test".into()),
+            envelope: TransportEnvelope::GroupMessage {
+                transport_group_id: group_id.as_slice().to_vec(),
+            },
+        };
+        carol_storage
+            .put_message(&MessageRecord {
+                id: deferred.id.clone(),
+                group_id: group_id.clone(),
+                epoch: EpochId(2),
+                state: MessageState::PeelDeferred,
+                payload: StoredMessagePayload::raw_transport(deferred)
+                    .encode()
+                    .expect("encode deferred crash input"),
+                deferred_peel: None,
+            })
+            .expect("persist deferred crash input");
+        carol
+            .retry_deferred_peels(&group_id)
+            .await
+            .expect("normalize deferred crash input");
+        carol
+            .retry_deferred_peels(&group_id)
+            .await
+            .expect("candidate branch probe reaches selected crash point");
     } else {
         carol
             .converge_stored_openmls_messages_at(&group_id, 3_000_000)

--- a/crates/cgka-engine/tests/hydration_quarantine.rs
+++ b/crates/cgka-engine/tests/hydration_quarantine.rs
@@ -192,6 +192,54 @@ fn insert_marmot_group_without_openmls_state(
         .expect("insert marmot group record without openmls state");
 }
 
+fn seed_probe_work_rows(
+    storage: &SqliteAccountStorage,
+    group_id: &GroupId,
+    suffix: u8,
+) -> (MessageRecord, QueuedOutboundIntent) {
+    let message = MessageRecord {
+        id: MessageId::new(vec![0x70, suffix]),
+        group_id: group_id.clone(),
+        epoch: storage.get_group(group_id).expect("group").epoch,
+        state: MessageState::Processed,
+        payload: vec![0x71, suffix],
+        deferred_peel: None,
+    };
+    storage.put_message(&message).expect("put probe message");
+    let queued = QueuedOutboundIntent {
+        id: MessageId::new(vec![0x72, suffix]),
+        group_id: group_id.clone(),
+        intent: SendIntent::AppMessage {
+            group_id: group_id.clone(),
+            payload: vec![0x73, suffix],
+        },
+        created_at_ms: u64::from(suffix),
+    };
+    storage
+        .put_queued_outbound_intent(&queued)
+        .expect("put probe queued intent");
+    (message, queued)
+}
+
+fn assert_probe_work_rows(
+    storage: &SqliteAccountStorage,
+    message: &MessageRecord,
+    queued: &QueuedOutboundIntent,
+) {
+    assert_eq!(
+        storage.get_message(&message.id).expect("probe message"),
+        *message,
+        "interrupted canonical-state probe recovery must preserve the live message ledger"
+    );
+    assert!(
+        storage
+            .list_queued_outbound_intents(&queued.group_id)
+            .expect("queued intents")
+            .contains(queued),
+        "interrupted canonical-state probe recovery must preserve the live outbound queue"
+    );
+}
+
 #[tokio::test]
 async fn hydration_quarantines_bad_group_and_keeps_healthy_groups_available() {
     let storage = SqliteAccountStorage::in_memory().expect("storage");
@@ -1631,6 +1679,7 @@ async fn hydration_recovers_interrupted_retained_anchor_probe() {
     let mut initial = build_engine(storage.clone());
     let group_id = create_confirmed_group(&mut initial).await;
     let live_group = storage.get_group(&group_id).expect("live group");
+    let (live_message, live_queued) = seed_probe_work_rows(&storage, &group_id, 1);
 
     let mut historical_group = live_group.clone();
     historical_group.name = "historical anchor".into();
@@ -1639,15 +1688,15 @@ async fn hydration_recovers_interrupted_retained_anchor_probe() {
         .put_group(&historical_group)
         .expect("plant historical group record");
     storage
-        .create_group_snapshot(&group_id, "test-historical-anchor")
+        .create_group_state_snapshot(&group_id, "test-historical-anchor")
         .expect("capture historical anchor");
 
     storage.put_group(&live_group).expect("restore live record");
     storage
-        .create_group_snapshot(&group_id, "openmls-retained-probe-test-crash")
+        .create_group_state_snapshot(&group_id, "openmls-retained-probe-test-crash")
         .expect("capture pre-probe live state");
     storage
-        .rollback_group_to_snapshot(&group_id, "test-historical-anchor")
+        .rollback_group_state_to_snapshot(&group_id, "test-historical-anchor")
         .expect("simulate committed probe rewind");
     drop(initial);
 
@@ -1671,6 +1720,7 @@ async fn hydration_recovers_interrupted_retained_anchor_probe() {
         reopened.epoch(&group_id).expect("hydrated epoch"),
         live_group.epoch
     );
+    assert_probe_work_rows(&storage, &live_message, &live_queued);
     assert!(
         !storage
             .list_group_snapshots(&group_id)
@@ -1690,6 +1740,7 @@ async fn hydration_recovers_interrupted_candidate_branch_probe() {
     let mut initial = build_engine(storage.clone());
     let group_id = create_confirmed_group(&mut initial).await;
     let live_group = storage.get_group(&group_id).expect("live group");
+    let (live_message, live_queued) = seed_probe_work_rows(&storage, &group_id, 2);
 
     let mut historical_group = live_group.clone();
     historical_group.name = "historical anchor".into();
@@ -1699,14 +1750,14 @@ async fn hydration_recovers_interrupted_candidate_branch_probe() {
         .expect("plant historical group record");
     storage
         .create_group_snapshot(&group_id, "test-historical-anchor")
-        .expect("capture historical anchor");
+        .expect("capture legacy full historical anchor");
 
     storage.put_group(&live_group).expect("restore live record");
     storage
-        .create_group_snapshot(&group_id, "openmls-branch-probe-test-crash")
+        .create_group_state_snapshot(&group_id, "openmls-branch-probe-test-crash")
         .expect("capture pre-probe live state");
     storage
-        .rollback_group_to_snapshot(&group_id, "test-historical-anchor")
+        .rollback_group_state_to_snapshot(&group_id, "test-historical-anchor")
         .expect("simulate committed probe rewind");
     drop(initial);
 
@@ -1720,6 +1771,7 @@ async fn hydration_recovers_interrupted_candidate_branch_probe() {
         live_group,
         "hydrate must restore the pre-probe live state"
     );
+    assert_probe_work_rows(&storage, &live_message, &live_queued);
     assert!(
         !storage
             .list_group_snapshots(&group_id)

--- a/crates/cgka-engine/tests/hydration_quarantine.rs
+++ b/crates/cgka-engine/tests/hydration_quarantine.rs
@@ -1740,7 +1740,6 @@ async fn hydration_recovers_interrupted_candidate_branch_probe() {
     let mut initial = build_engine(storage.clone());
     let group_id = create_confirmed_group(&mut initial).await;
     let live_group = storage.get_group(&group_id).expect("live group");
-    let (live_message, live_queued) = seed_probe_work_rows(&storage, &group_id, 2);
 
     let mut historical_group = live_group.clone();
     historical_group.name = "historical anchor".into();
@@ -1753,13 +1752,29 @@ async fn hydration_recovers_interrupted_candidate_branch_probe() {
         .expect("capture legacy full historical anchor");
 
     storage.put_group(&live_group).expect("restore live record");
+    let (live_message, live_queued) = seed_probe_work_rows(&storage, &group_id, 2);
     storage
-        .create_group_state_snapshot(&group_id, "openmls-branch-probe-test-crash")
-        .expect("capture pre-probe live state");
+        .create_group_snapshot(&group_id, "openmls-branch-probe-test-crash")
+        .expect("capture legacy full pre-probe live state");
     storage
-        .rollback_group_state_to_snapshot(&group_id, "test-historical-anchor")
-        .expect("simulate committed probe rewind");
+        .rollback_group_to_snapshot(&group_id, "test-historical-anchor")
+        .expect("simulate legacy full probe rewind");
     drop(initial);
+
+    assert!(
+        matches!(
+            storage.get_message(&live_message.id),
+            Err(StorageError::NotFound)
+        ),
+        "legacy full rewind must strand the historical message image before recovery"
+    );
+    assert!(
+        storage
+            .list_queued_outbound_intents(&group_id)
+            .expect("stranded queued intents")
+            .is_empty(),
+        "legacy full rewind must strand the historical queue image before recovery"
+    );
 
     let mut reopened = build_engine(storage.clone());
     reopened

--- a/crates/storage-sqlite/src/storage/messages.rs
+++ b/crates/storage-sqlite/src/storage/messages.rs
@@ -480,6 +480,14 @@ impl MessageStorage for SqliteAccountStorage {
         snapshots::rollback(self, group_id, name)
     }
 
+    fn rollback_group_state_to_snapshot(
+        &self,
+        group_id: &GroupId,
+        name: &str,
+    ) -> StorageResult<()> {
+        snapshots::rollback_group_state(self, group_id, name)
+    }
+
     fn release_group_snapshot(&self, group_id: &GroupId, name: &str) -> StorageResult<()> {
         snapshots::release(self, group_id, name)
     }

--- a/crates/storage-sqlite/src/storage/snapshots.rs
+++ b/crates/storage-sqlite/src/storage/snapshots.rs
@@ -37,6 +37,14 @@ pub(super) fn rollback(
     restore::rollback(store, group_id, name)
 }
 
+pub(super) fn rollback_group_state(
+    store: &SqliteAccountStorage,
+    group_id: &GroupId,
+    name: &str,
+) -> StorageResult<()> {
+    restore::rollback_group_state(store, group_id, name)
+}
+
 pub(super) fn release(
     store: &SqliteAccountStorage,
     group_id: &GroupId,
@@ -281,6 +289,44 @@ mod tests {
             .map(|m| m.id)
             .collect();
         assert_eq!(ids, vec![mid(1), mid(2)]);
+        assert_eq!(
+            store.list_queued_outbound_intents(&g0.id).unwrap(),
+            vec![live_queued]
+        );
+    }
+
+    #[test]
+    fn group_state_rollback_ignores_work_rows_captured_by_a_full_snapshot() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let g0 = sample_group(gid(1), 0, 1);
+        let original_message = sample_message(mid(1), g0.id.clone(), 0);
+        let original_queued = sample_queued_intent(mid(10), g0.id.clone());
+        store.put_group(&g0).unwrap();
+        store.put_message(&original_message).unwrap();
+        store.put_queued_outbound_intent(&original_queued).unwrap();
+        store
+            .create_group_snapshot(&g0.id, "legacy-full-anchor")
+            .unwrap();
+
+        let g1 = sample_group(gid(1), 1, 2);
+        let live_message = sample_message(mid(2), g0.id.clone(), 1);
+        let live_queued = sample_queued_intent(mid(11), g0.id.clone());
+        store.put_group(&g1).unwrap();
+        store.put_message(&live_message).unwrap();
+        store
+            .delete_queued_outbound_intent(&original_queued.id)
+            .unwrap();
+        store.put_queued_outbound_intent(&live_queued).unwrap();
+
+        store
+            .rollback_group_state_to_snapshot(&g0.id, "legacy-full-anchor")
+            .unwrap();
+
+        assert_eq!(store.get_group(&g0.id).unwrap(), g0);
+        assert_eq!(
+            store.list_messages(&g0.id, EpochId(0)).unwrap(),
+            vec![original_message, live_message]
+        );
         assert_eq!(
             store.list_queued_outbound_intents(&g0.id).unwrap(),
             vec![live_queued]

--- a/crates/storage-sqlite/src/storage/snapshots/restore.rs
+++ b/crates/storage-sqlite/src/storage/snapshots/restore.rs
@@ -18,14 +18,37 @@ use cgka_traits::storage::{StorageError, StorageResult};
 use cgka_traits::types::GroupId;
 use rusqlite::{OptionalExtension, TransactionBehavior, params};
 
+#[derive(Clone, Copy)]
+enum RestoreScope {
+    Full,
+    GroupState,
+}
+
 pub(super) fn rollback(
     store: &SqliteAccountStorage,
     group_id: &GroupId,
     name: &str,
 ) -> StorageResult<()> {
+    rollback_with_scope(store, group_id, name, RestoreScope::Full)
+}
+
+pub(super) fn rollback_group_state(
+    store: &SqliteAccountStorage,
+    group_id: &GroupId,
+    name: &str,
+) -> StorageResult<()> {
+    rollback_with_scope(store, group_id, name, RestoreScope::GroupState)
+}
+
+fn rollback_with_scope(
+    store: &SqliteAccountStorage,
+    group_id: &GroupId,
+    name: &str,
+    scope: RestoreScope,
+) -> StorageResult<()> {
     if store.connection.is_current_thread_transaction_owner() {
         let conn = store.lock()?;
-        return rollback_on_connection(&conn, group_id, name);
+        return rollback_on_connection(&conn, group_id, name, scope);
     }
 
     retry_on_busy(|| {
@@ -34,7 +57,7 @@ pub(super) fn rollback(
         let tx = conn
             .transaction_with_behavior(TransactionBehavior::Immediate)
             .storage()?;
-        rollback_snapshot(&tx, group_id, name, &mls_group_key)?;
+        rollback_snapshot(&tx, group_id, name, &mls_group_key, scope)?;
         tx.commit().storage()?;
         Ok(())
     })
@@ -44,9 +67,10 @@ fn rollback_on_connection(
     conn: &rusqlite::Connection,
     group_id: &GroupId,
     name: &str,
+    scope: RestoreScope,
 ) -> StorageResult<()> {
     let mls_group_key = mls_group_key(group_id)?;
-    rollback_snapshot(conn, group_id, name, &mls_group_key)
+    rollback_snapshot(conn, group_id, name, &mls_group_key, scope)
 }
 
 fn rollback_snapshot(
@@ -54,6 +78,7 @@ fn rollback_snapshot(
     group_id: &GroupId,
     name: &str,
     mls_group_key: &[u8],
+    scope: RestoreScope,
 ) -> StorageResult<()> {
     let snapshot_blob = SensitiveBytes::new(
         conn.query_row(
@@ -67,7 +92,7 @@ fn rollback_snapshot(
         .ok_or_else(|| StorageError::SnapshotMissing(name.to_string()))?,
     );
     let snapshot = snapshot_format::decode(snapshot_blob.as_slice())?;
-    restore_snapshot(conn, group_id, &snapshot, mls_group_key)
+    restore_snapshot(conn, group_id, &snapshot, mls_group_key, scope)
 }
 
 #[cfg(feature = "test-conformance-replay")]
@@ -94,7 +119,13 @@ pub(super) fn import(
         let tx = conn
             .transaction_with_behavior(TransactionBehavior::Immediate)
             .storage()?;
-        restore_snapshot(&tx, group_id, &snapshot.group, &mls_group_key)?;
+        restore_snapshot(
+            &tx,
+            group_id,
+            &snapshot.group,
+            &mls_group_key,
+            RestoreScope::Full,
+        )?;
         convergence_pass(&tx, group_id, snapshot.convergence_pass.as_ref())?;
         tx.commit().storage()?;
         Ok(())
@@ -127,16 +158,19 @@ fn restore_snapshot(
     group_id: &GroupId,
     snapshot: &Snapshot,
     mls_group_key: &[u8],
+    scope: RestoreScope,
 ) -> StorageResult<()> {
     group(conn, group_id, &snapshot.group)?;
-    // A state-scoped snapshot (`None`) never captured the message ledger or
-    // outbound queue, so rollback must leave the live rows alone rather than
-    // restore an empty image.
-    if let Some(snapshot_messages) = &snapshot.messages {
-        messages(conn, group_id, snapshot_messages)?;
-    }
-    if let Some(snapshot_queued) = &snapshot.queued_outbound {
-        queued_outbound(conn, group_id, snapshot_queued)?;
+    if matches!(scope, RestoreScope::Full) {
+        // A state-scoped snapshot (`None`) never captured the message ledger
+        // or outbound queue, so even full rollback leaves those live rows
+        // alone rather than restoring an empty image.
+        if let Some(snapshot_messages) = &snapshot.messages {
+            messages(conn, group_id, snapshot_messages)?;
+        }
+        if let Some(snapshot_queued) = &snapshot.queued_outbound {
+            queued_outbound(conn, group_id, snapshot_queued)?;
+        }
     }
     member_capabilities(conn, group_id, &snapshot.member_caps)?;
     convergence_policy(conn, group_id, snapshot.convergence_policy.as_deref())?;

--- a/crates/traits/src/storage.rs
+++ b/crates/traits/src/storage.rs
@@ -296,6 +296,26 @@ pub trait MessageStorage {
 
     fn list_group_snapshots(&self, group_id: &GroupId) -> StorageResult<Vec<String>>;
     fn rollback_group_to_snapshot(&self, group_id: &GroupId, name: &str) -> StorageResult<()>;
+
+    /// Restore only canonical group state from a named snapshot, ignoring any
+    /// message-ledger or outbound-queue image the snapshot may contain. This is
+    /// the restore counterpart to [`Self::create_group_state_snapshot`] and is
+    /// required when a temporary probe reads a legacy full snapshot: the probe
+    /// must not rewrite live input/work rows merely because the persisted
+    /// anchor predates state-scoped capture.
+    ///
+    /// Backends that cannot distinguish snapshot fields may restore the full
+    /// image. Callers pair this with a live group-state guard; the default
+    /// state-snapshot implementation is also full, so the fallback remains
+    /// correct even though it forfeits the narrower write bound.
+    fn rollback_group_state_to_snapshot(
+        &self,
+        group_id: &GroupId,
+        name: &str,
+    ) -> StorageResult<()> {
+        self.rollback_group_to_snapshot(group_id, name)
+    }
+
     fn release_group_snapshot(&self, group_id: &GroupId, name: &str) -> StorageResult<()>;
 
     /// Capture only canonical group state: the Marmot group projection,

--- a/docs/marmot-architecture/storage-format-v2.md
+++ b/docs/marmot-architecture/storage-format-v2.md
@@ -148,6 +148,11 @@ arrays. The exact encoded length is computed before allocating the zeroizing
 output buffer; the encoder cannot grow it. Temporary list bodies that can
 contain secret material also use zeroizing ownership.
 
+Temporary replay and branch probes use a canonical-state-only restore even when
+their retained anchor predates state-scoped capture and contains full message
+and queue images. This keeps legacy anchors readable without letting a probe
+rewrite live input or outbound-work rows.
+
 A blob without `MDKS` is decoded as the corresponding unversioned JSON v1
 snapshot or checkpoint. A blob with `MDKS` never falls back following a v2
 error. Full snapshots, state-scoped snapshots, and branch-addressed checkpoints


### PR DESCRIPTION
## Summary

- make every temporary replay, branch-probe, and historical-read guard capture canonical group/OpenMLS state instead of the full message ledger and outbound queue
- add canonical-state-only restore semantics so pre-upgrade full retained anchors remain usable without rewriting live input/work rows
- keep canonical apply and interrupted-apply recovery deliberately full, with semantic and encrypted process-kill regressions covering live message/queue survival

This addresses the urgent write-amplification portion of #1560. Candidate-context reuse, replay-count bounds, and observability remain separate follow-up work, so this PR intentionally does not close the issue.

## Test plan

- [x] New guard regression failed before the fix and passes after it
- [x] New legacy-full-anchor restore regression failed before the fix and passes after it
- [x] `cargo test -p storage-sqlite` (414 passed, 4 ignored)
- [x] `cargo test -p cgka-engine --features test-policy-overrides,test-crash-hooks`
- [x] `just fast-ci`

Refs #1560

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved crash recovery and hydration handling when rewinding or replaying group state.
  * Preserved live messages and queued outbound work during recovery probes and rollback operations.
  * Added support for recovering deferred candidate-branch work after interruptions.

* **Documentation**
  * Clarified snapshot and replay behavior, including preservation of live work during temporary recovery operations.

* **Tests**
  * Expanded coverage for crash recovery, hydration, rollback behavior, retained anchors, and candidate branches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->