### PR TITLE
perf(cgka-engine): reuse deferred peel candidates

### DIFF
--- a/crates/cgka-conformance-simulator/src/client.rs
+++ b/crates/cgka-conformance-simulator/src/client.rs
@@ -149,6 +149,35 @@ pub(crate) fn merge_engine_metrics(
         &mut target.foreground_deferred_budget_overrun_ms,
         &source.foreground_deferred_budget_overrun_ms,
     );
+    target.deferred_peel_sweeps = target
+        .deferred_peel_sweeps
+        .saturating_add(source.deferred_peel_sweeps);
+    target.deferred_peel_candidate_enumerations = target
+        .deferred_peel_candidate_enumerations
+        .saturating_add(source.deferred_peel_candidate_enumerations);
+    target.deferred_peel_candidate_contexts = target
+        .deferred_peel_candidate_contexts
+        .saturating_add(source.deferred_peel_candidate_contexts);
+    merge_histogram(
+        &mut target.deferred_peel_candidate_context_depth,
+        &source.deferred_peel_candidate_context_depth,
+    );
+    target.deferred_peel_candidate_replay_probes = target
+        .deferred_peel_candidate_replay_probes
+        .saturating_add(source.deferred_peel_candidate_replay_probes);
+    target.deferred_peel_candidate_cache_hits = target
+        .deferred_peel_candidate_cache_hits
+        .saturating_add(source.deferred_peel_candidate_cache_hits);
+    target.deferred_peel_candidate_cache_misses = target
+        .deferred_peel_candidate_cache_misses
+        .saturating_add(source.deferred_peel_candidate_cache_misses);
+    target.deferred_peel_candidate_cache_invalidations = target
+        .deferred_peel_candidate_cache_invalidations
+        .saturating_add(source.deferred_peel_candidate_cache_invalidations);
+    merge_histogram(
+        &mut target.deferred_peel_candidate_enumeration_ms,
+        &source.deferred_peel_candidate_enumeration_ms,
+    );
     merge_histogram(
         &mut target.queued_outbound_wait_ms,
         &source.queued_outbound_wait_ms,
@@ -208,7 +237,16 @@ mod metric_tests {
             foreground_deferred_unchanged: 42,
             foreground_deferred_errors: 43,
             foreground_deferred_budget_overrun_ms: histogram(44, 45, 46),
-            queued_outbound_wait_ms: histogram(47, 48, 49),
+            deferred_peel_sweeps: 47,
+            deferred_peel_candidate_enumerations: 48,
+            deferred_peel_candidate_contexts: 49,
+            deferred_peel_candidate_context_depth: histogram(50, 51, 52),
+            deferred_peel_candidate_replay_probes: 53,
+            deferred_peel_candidate_cache_hits: 54,
+            deferred_peel_candidate_cache_misses: 55,
+            deferred_peel_candidate_cache_invalidations: 56,
+            deferred_peel_candidate_enumeration_ms: histogram(57, 58, 59),
+            queued_outbound_wait_ms: histogram(60, 61, 62),
         };
         let mut target = EngineMetricsSnapshot::default();
 

--- a/crates/cgka-engine/src/disband.rs
+++ b/crates/cgka-engine/src/disband.rs
@@ -442,6 +442,7 @@ impl<S: StorageProvider> Engine<S> {
 
         let target_epoch = EpochId(source_epoch.0.saturating_add(1));
         let pending = self.epoch_manager.next_pending_ref();
+        self.invalidate_deferred_peel_candidate_cache(group_id);
         self.epoch_manager.begin_pending(
             group_id.clone(),
             source_epoch,
@@ -603,6 +604,7 @@ impl<S: StorageProvider> Engine<S> {
             .delete_transport_group_routes_for_group(group_id);
         self.route_backfill_pending.remove(group_id);
         self.pending_convergence_groups.remove(group_id);
+        self.invalidate_deferred_peel_candidate_cache(group_id);
         self.engine_metrics.forget_group(group_id);
         self.leaving_groups.remove(group_id);
         self.drop_self_remove_auto_commit_schedules_for_group(group_id);

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -257,6 +257,7 @@ impl<S: StorageProvider> Engine<S> {
         self.storage
             .put_convergence_policy(group_id, &encode_convergence_policy(&policy)?)
             .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
+        self.invalidate_deferred_peel_candidate_cache(group_id);
         let mut context = self
             .audit_group_context_snapshot(group_id)
             .unwrap_or_default();

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -1462,6 +1462,7 @@ impl<S: StorageProvider> Engine<S> {
 
         let terminalized = if let Some(selected_tip) = result.selected_tip {
             let selected_tip = EpochId(selected_tip);
+            self.invalidate_deferred_peel_candidate_cache(group_id);
             self.epoch_manager
                 .set_stable(group_id.clone(), selected_tip);
             // Diagnostic only: classify this applied selection as a forward

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -1483,6 +1483,10 @@ impl<S: StorageProvider> Engine<S> {
         &mut self,
         group_id: &GroupId,
     ) -> Result<EpochId, GroupHydrationQuarantineReason> {
+        // Hydration and repair replace the live OpenMLS projection. Any
+        // exporter-bearing candidate contexts from the prior projection are
+        // stale even when the durable fingerprint later compares equal.
+        self.invalidate_deferred_peel_candidate_cache(group_id);
         // A convergence rewind probe — the pass's, or the deferred-peel sweep's
         // candidate-branch enumeration — durably rewinds the group while it
         // explores historical candidates. Process termination cannot run the
@@ -2214,6 +2218,7 @@ impl<S: StorageProvider> Engine<S> {
         group_id: &GroupId,
         reason: GroupHydrationQuarantineReason,
     ) {
+        self.invalidate_deferred_peel_candidate_cache(group_id);
         let reason_tag = hydration_quarantine_reason_tag(reason);
         let group_digest = hydration_quarantine_group_digest(group_id);
         tracing::warn!(

--- a/crates/cgka-engine/src/engine_metrics.rs
+++ b/crates/cgka-engine/src/engine_metrics.rs
@@ -234,6 +234,17 @@ pub struct EngineMetrics {
     foreground_deferred_unchanged: u64,
     foreground_deferred_errors: u64,
     foreground_deferred_budget_overrun_ms: BucketHistogram,
+    /// Deferred-peel work-shape observability. All values are aggregate and
+    /// candidate contexts themselves remain exclusively in engine memory.
+    deferred_peel_sweeps: u64,
+    deferred_peel_candidate_enumerations: u64,
+    deferred_peel_candidate_contexts: u64,
+    deferred_peel_candidate_context_depth: BucketHistogram,
+    deferred_peel_candidate_replay_probes: u64,
+    deferred_peel_candidate_cache_hits: u64,
+    deferred_peel_candidate_cache_misses: u64,
+    deferred_peel_candidate_cache_invalidations: u64,
+    deferred_peel_candidate_enumeration_ms: BucketHistogram,
     queued_outbound_wait_ms: BucketHistogram,
     /// Per-group completion time of the last applied pass, in-memory only
     /// (never snapshotted); feeds `generation_gap_ms`.
@@ -266,6 +277,17 @@ impl Default for EngineMetrics {
             foreground_deferred_unchanged: 0,
             foreground_deferred_errors: 0,
             foreground_deferred_budget_overrun_ms: BucketHistogram::new(&LATENESS_BUCKET_BOUNDS_MS),
+            deferred_peel_sweeps: 0,
+            deferred_peel_candidate_enumerations: 0,
+            deferred_peel_candidate_contexts: 0,
+            deferred_peel_candidate_context_depth: BucketHistogram::new(&WORK_COUNT_BUCKET_BOUNDS),
+            deferred_peel_candidate_replay_probes: 0,
+            deferred_peel_candidate_cache_hits: 0,
+            deferred_peel_candidate_cache_misses: 0,
+            deferred_peel_candidate_cache_invalidations: 0,
+            deferred_peel_candidate_enumeration_ms: BucketHistogram::new(
+                &LATENESS_BUCKET_BOUNDS_MS,
+            ),
             queued_outbound_wait_ms: BucketHistogram::new(&LATENESS_BUCKET_BOUNDS_MS),
             last_pass_completed_at_ms: HashMap::new(),
         }
@@ -406,6 +428,46 @@ impl EngineMetrics {
         self.outbound_queue_accept_ms.record(duration_ms);
     }
 
+    pub(crate) fn note_deferred_peel_sweep(&mut self) {
+        self.deferred_peel_sweeps = self.deferred_peel_sweeps.saturating_add(1);
+    }
+
+    pub(crate) fn note_deferred_peel_candidate_enumeration(
+        &mut self,
+        duration_ms: u64,
+        context_depths: impl IntoIterator<Item = u64>,
+        replay_probe_count: u64,
+    ) {
+        self.deferred_peel_candidate_enumerations =
+            self.deferred_peel_candidate_enumerations.saturating_add(1);
+        for depth in context_depths {
+            self.deferred_peel_candidate_contexts =
+                self.deferred_peel_candidate_contexts.saturating_add(1);
+            self.deferred_peel_candidate_context_depth.record(depth);
+        }
+        self.deferred_peel_candidate_replay_probes = self
+            .deferred_peel_candidate_replay_probes
+            .saturating_add(replay_probe_count);
+        self.deferred_peel_candidate_enumeration_ms
+            .record(duration_ms);
+    }
+
+    pub(crate) fn note_deferred_peel_candidate_cache_hit(&mut self) {
+        self.deferred_peel_candidate_cache_hits =
+            self.deferred_peel_candidate_cache_hits.saturating_add(1);
+    }
+
+    pub(crate) fn note_deferred_peel_candidate_cache_miss(&mut self) {
+        self.deferred_peel_candidate_cache_misses =
+            self.deferred_peel_candidate_cache_misses.saturating_add(1);
+    }
+
+    pub(crate) fn note_deferred_peel_candidate_cache_invalidation(&mut self) {
+        self.deferred_peel_candidate_cache_invalidations = self
+            .deferred_peel_candidate_cache_invalidations
+            .saturating_add(1);
+    }
+
     pub(crate) fn note_outbound_wire_prepare_ms(&mut self, duration_ms: u64) {
         self.outbound_wire_prepare_ms.record(duration_ms);
     }
@@ -450,6 +512,20 @@ impl EngineMetrics {
             foreground_deferred_errors: self.foreground_deferred_errors,
             foreground_deferred_budget_overrun_ms: self
                 .foreground_deferred_budget_overrun_ms
+                .snapshot(),
+            deferred_peel_sweeps: self.deferred_peel_sweeps,
+            deferred_peel_candidate_enumerations: self.deferred_peel_candidate_enumerations,
+            deferred_peel_candidate_contexts: self.deferred_peel_candidate_contexts,
+            deferred_peel_candidate_context_depth: self
+                .deferred_peel_candidate_context_depth
+                .snapshot(),
+            deferred_peel_candidate_replay_probes: self.deferred_peel_candidate_replay_probes,
+            deferred_peel_candidate_cache_hits: self.deferred_peel_candidate_cache_hits,
+            deferred_peel_candidate_cache_misses: self.deferred_peel_candidate_cache_misses,
+            deferred_peel_candidate_cache_invalidations: self
+                .deferred_peel_candidate_cache_invalidations,
+            deferred_peel_candidate_enumeration_ms: self
+                .deferred_peel_candidate_enumeration_ms
                 .snapshot(),
             queued_outbound_wait_ms: self.queued_outbound_wait_ms.snapshot(),
         }
@@ -518,6 +594,24 @@ pub struct EngineMetricsSnapshot {
     pub foreground_deferred_errors: u64,
     /// Elapsed foreground deferred time beyond the configured budget.
     pub foreground_deferred_budget_overrun_ms: HistogramSnapshot,
+    /// Deferred-peel retry sweeps invoked, including empty or gated sweeps.
+    pub deferred_peel_sweeps: u64,
+    /// Candidate-branch enumerations actually performed (cache misses).
+    pub deferred_peel_candidate_enumerations: u64,
+    /// Candidate contexts captured across all enumerations.
+    pub deferred_peel_candidate_contexts: u64,
+    /// Commit depth of each captured candidate context.
+    pub deferred_peel_candidate_context_depth: HistogramSnapshot,
+    /// OpenMLS replay probes consumed by candidate enumeration and capture.
+    pub deferred_peel_candidate_replay_probes: u64,
+    /// Exact-fingerprint candidate-context cache hits.
+    pub deferred_peel_candidate_cache_hits: u64,
+    /// Candidate-context cache misses.
+    pub deferred_peel_candidate_cache_misses: u64,
+    /// Cached generations discarded because their work became stale or ended.
+    pub deferred_peel_candidate_cache_invalidations: u64,
+    /// Candidate enumeration elapsed time in local monotonic milliseconds.
+    pub deferred_peel_candidate_enumeration_ms: HistogramSnapshot,
     /// Time from durable queue acceptance to a regeneration attempt.
     pub queued_outbound_wait_ms: HistogramSnapshot,
 }

--- a/crates/cgka-engine/src/group_lifecycle.rs
+++ b/crates/cgka-engine/src/group_lifecycle.rs
@@ -766,6 +766,7 @@ impl<S: StorageProvider> Engine<S> {
         let pending_ref = self.epoch_manager.next_pending_ref();
         let staged =
             cgka_traits::engine_state::StagedCommitHandle::from_bytes(group_id.as_slice().to_vec());
+        self.invalidate_deferred_peel_candidate_cache(&group_id);
         self.epoch_manager.begin_pending(
             group_id.clone(),
             EpochId(0),
@@ -1240,6 +1241,7 @@ impl<S: StorageProvider> Engine<S> {
         // blind `set_stable` overwrite (mdk#971). The group record written
         // above already clears the durable `unrecoverable` marker.
         let joined_epoch = EpochId(mls_group.epoch().as_u64());
+        self.invalidate_deferred_peel_candidate_cache(&group_id);
         let join_reason = if repaired_unrecoverable {
             if !self.epoch_manager.is_unrecoverable(&group_id) {
                 // Direct join callers are not required to run session-open

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -1486,6 +1486,7 @@ impl<S: StorageProvider> Engine<S> {
                 let after_avatar = avatar_component_snapshot(&mls_group);
 
                 // Update our per-group state machine.
+                self.invalidate_deferred_peel_candidate_cache(&group_id);
                 self.epoch_manager.set_stable(group_id.clone(), after);
                 self.drop_self_remove_auto_commit_schedules_for_group(&group_id);
                 // Proposal-arrival schedule signals are source-epoch
@@ -2022,6 +2023,7 @@ impl<S: StorageProvider> Engine<S> {
         let pending_ref = self.epoch_manager.next_pending_ref();
         let staged =
             cgka_traits::engine_state::StagedCommitHandle::from_bytes(group_id.as_slice().to_vec());
+        self.invalidate_deferred_peel_candidate_cache(group_id);
         self.epoch_manager.begin_pending(
             group_id.clone(),
             pre_commit_epoch,
@@ -2863,6 +2865,7 @@ mod tests {
         let halted = CandidateBranchPeel {
             contested: true,
             contexts: Vec::new(),
+            replay_probe_count: 0,
         };
 
         let sweep = DeferredPeelSweep::over_branches(&halted);
@@ -2886,6 +2889,7 @@ mod tests {
         let uncontested = CandidateBranchPeel {
             contested: false,
             contexts: Vec::new(),
+            replay_probe_count: 0,
         };
 
         for sweep in [

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -35,6 +35,7 @@ use cgka_traits::transport::{TransportEnvelope, TransportMessage};
 use cgka_traits::types::{EpochId, GroupId, MemberId, MessageId};
 use sha2::{Digest, Sha256};
 use std::collections::BTreeSet;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 pub(crate) const MAX_CONVERGENCE_REPROCESSING_PASSES: usize = 16;
@@ -166,6 +167,21 @@ pub(crate) struct DeferredPeelGroupState {
     /// per rejected message; this suppresses the repeats until the backlog
     /// drops back below the cap and re-arms.
     cap_rejection_audited: bool,
+    /// Candidate branch contexts for one exact process-local generation.
+    ///
+    /// These contexts contain exporter-derived secret material. The cache is
+    /// deliberately nested in engine memory: it is never serialized, audited,
+    /// logged, or copied into durable generation state, and process restart
+    /// drops it naturally.
+    candidate_cache: Option<DeferredPeelCandidateCacheEntry>,
+}
+
+struct DeferredPeelCandidateCacheEntry {
+    context_fingerprint: [u8; 32],
+    /// Exact durable barrier generation observed after enumeration. `None` is
+    /// also meaningful and must match on reuse.
+    durable_generation_fingerprint: Option<[u8; 32]>,
+    peel: Arc<crate::openmls_projection::CandidateBranchPeel>,
 }
 
 impl DeferredPeelGroupState {
@@ -1394,6 +1410,7 @@ impl<S: StorageProvider> Engine<S> {
         execution: &mut DeferredPeelExecution<'_>,
     ) -> Result<DeferredPeelWorkResult, EngineError> {
         let sweep_started = Instant::now();
+        self.engine_metrics.note_deferred_peel_sweep();
         let foreground_budget_ms = match execution {
             DeferredPeelExecution::Foreground(budget) => Some(budget.budget_ms),
             DeferredPeelExecution::Background => None,
@@ -1548,6 +1565,7 @@ impl<S: StorageProvider> Engine<S> {
             state.counted = true;
         }
         if total == 0 {
+            self.invalidate_deferred_peel_candidate_cache(group_id);
             if self.storage.deferred_peel_generation(group_id)?.is_some() {
                 self.storage.delete_deferred_peel_generation(group_id)?;
                 self.converge_stored_openmls_messages_with_time(group_id, now)
@@ -1577,6 +1595,7 @@ impl<S: StorageProvider> Engine<S> {
             .cloned()
             .collect::<Vec<_>>();
         if unattempted.is_empty() {
+            self.invalidate_deferred_peel_candidate_cache(group_id);
             if self.storage.deferred_peel_generation(group_id)?.is_some() {
                 self.storage.delete_deferred_peel_generation(group_id)?;
                 self.converge_stored_openmls_messages_with_time(group_id, now)
@@ -1631,35 +1650,127 @@ impl<S: StorageProvider> Engine<S> {
         // pays only the seeding scan. Nothing read here is trusted: the bytes
         // re-enter through ordinary ingest and only the next pass's OpenMLS
         // replay authenticates them. A peel that fails is silence.
-        let peel = match self.candidate_branch_peel(group_id) {
-            Ok(peel) => peel,
-            Err(error) => {
-                self.note_foreground_deferred_phase(
-                    sweep_started,
-                    foreground_budget_ms,
-                    0,
-                    total,
-                    crate::engine_metrics::DeferredPeelMetricOutcome::Error,
+        let durable_generation_fingerprint = self
+            .storage
+            .deferred_peel_generation(group_id)?
+            .map(|generation| generation.context_fingerprint);
+        let cached = self
+            .deferred_peel
+            .get(group_id)
+            .and_then(|state| state.candidate_cache.as_ref())
+            .filter(|cached| {
+                cached.context_fingerprint == fingerprint
+                    && cached.durable_generation_fingerprint == durable_generation_fingerprint
+            })
+            .map(|cached| Arc::clone(&cached.peel));
+        let (peel, candidate_cache_hit) = if let Some(cached) = cached {
+            self.engine_metrics.note_deferred_peel_candidate_cache_hit();
+            (cached, true)
+        } else {
+            self.invalidate_deferred_peel_candidate_cache(group_id);
+            self.engine_metrics
+                .note_deferred_peel_candidate_cache_miss();
+            let candidate_enumeration_started = Instant::now();
+            let enumerated = match self.candidate_branch_peel(group_id) {
+                Ok(peel) => peel,
+                Err(error) => {
+                    self.engine_metrics
+                        .note_deferred_peel_candidate_enumeration(
+                            candidate_enumeration_started
+                                .elapsed()
+                                .as_millis()
+                                .try_into()
+                                .unwrap_or(u64::MAX),
+                            std::iter::empty(),
+                            0,
+                        );
+                    self.note_foreground_deferred_phase(
+                        sweep_started,
+                        foreground_budget_ms,
+                        0,
+                        total,
+                        crate::engine_metrics::DeferredPeelMetricOutcome::Error,
+                    );
+                    return Err(error);
+                }
+            };
+            let candidate_enumeration_ms = candidate_enumeration_started
+                .elapsed()
+                .as_millis()
+                .try_into()
+                .unwrap_or(u64::MAX);
+            self.engine_metrics
+                .note_deferred_peel_candidate_enumeration(
+                    candidate_enumeration_ms,
+                    enumerated.contexts.iter().map(|context| context.depth),
+                    enumerated.replay_probe_count,
                 );
-                return Err(error);
+            tracing::info!(
+                target: "cgka_engine::message_processor",
+                method = "candidate_branch_peel",
+                candidate_contexts = enumerated.contexts.len() as u64,
+                max_candidate_context_depth = enumerated
+                    .contexts
+                    .iter()
+                    .map(|context| context.depth)
+                    .max()
+                    .unwrap_or(0),
+                replay_probes = enumerated.replay_probe_count,
+                candidate_enumeration_ms,
+                "deferred-peel candidate enumeration"
+            );
+            if enumerated.contested {
+                self.storage
+                    .put_deferred_peel_generation(&DeferredPeelGeneration {
+                        group_id: group_id.clone(),
+                        context_fingerprint: fingerprint,
+                    })?;
             }
+            let cached_generation_fingerprint = if enumerated.contested {
+                Some(fingerprint)
+            } else {
+                durable_generation_fingerprint
+            };
+            let enumerated = Arc::new(enumerated);
+            self.deferred_peel
+                .entry(group_id.clone())
+                .or_default()
+                .candidate_cache = Some(DeferredPeelCandidateCacheEntry {
+                context_fingerprint: fingerprint,
+                durable_generation_fingerprint: cached_generation_fingerprint,
+                peel: Arc::clone(&enumerated),
+            });
+            (enumerated, false)
         };
+        tracing::debug!(
+            target: "cgka_engine::message_processor",
+            method = "candidate_branch_peel_cache",
+            cache_hit = candidate_cache_hit,
+            "deferred-peel candidate cache lookup"
+        );
         let sweep = crate::message_processor::ingest::DeferredPeelSweep::over_branches(&peel);
-        if peel.contested {
-            self.storage
-                .put_deferred_peel_generation(&DeferredPeelGeneration {
-                    group_id: group_id.clone(),
-                    context_fingerprint: fingerprint,
-                })?;
-        }
 
         let mut progressed = 0usize;
         let mut terminal = 0usize;
         let mut attempted = 0usize;
         let mut timed_out = false;
+        let mut contexts_invalidated = false;
         for record in unattempted.into_iter().take(row_limit) {
             if execution.exhausted() {
                 timed_out = true;
+                break;
+            }
+            // A row can itself advance or replace canonical state. Those
+            // transition sites synchronously invalidate the map entry; do not
+            // keep offering the slice's local Arc to later rows after that.
+            // Their lifecycle remains untouched for the next fingerprint.
+            if !self
+                .deferred_peel
+                .get(group_id)
+                .and_then(|state| state.candidate_cache.as_ref())
+                .is_some_and(|cached| Arc::ptr_eq(&cached.peel, &peel))
+            {
+                contexts_invalidated = true;
                 break;
             }
             let lifecycle = record
@@ -1728,6 +1839,9 @@ impl<S: StorageProvider> Engine<S> {
         }
 
         let final_fingerprint = self.deferred_peel_context_fingerprint(group_id)?;
+        if final_fingerprint != fingerprint {
+            self.invalidate_deferred_peel_candidate_cache(group_id);
+        }
         let remaining = self
             .storage
             .list_messages_in_states(group_id, &[MessageState::PeelDeferred], EpochId(0))?
@@ -1748,6 +1862,7 @@ impl<S: StorageProvider> Engine<S> {
                 // content rows are durable, so a crash in between simply lets
                 // the next normal convergence wake process the complete set.
                 self.storage.delete_deferred_peel_generation(group_id)?;
+                self.invalidate_deferred_peel_candidate_cache(group_id);
                 self.converge_stored_openmls_messages_with_time(group_id, now)
                     .map_err(|error| {
                         EngineError::Backend(format!("converge swept batch: {error}"))
@@ -1797,9 +1912,11 @@ impl<S: StorageProvider> Engine<S> {
             terminal = terminal as u64,
             contested = peel.contested,
             branch_contexts = peel.contexts.len() as u64,
+            candidate_cache_hit,
             queue_depth,
             sweep_duration_ms = duration_ms,
             budget_exhausted = status == DeferredPeelWorkStatus::BudgetExhausted,
+            contexts_invalidated,
             "deferred-peel retry sweep"
         );
         Ok(DeferredPeelWorkResult { status, progressed })
@@ -2078,6 +2195,26 @@ impl<S: StorageProvider> Engine<S> {
             .note_row_persisted();
     }
 
+    /// Drop exporter-bearing candidate contexts for one group. The aggregate
+    /// metric deliberately records only that stale work was discarded; the
+    /// group, fingerprint, generation, and branch identities never leave
+    /// engine memory.
+    pub(crate) fn invalidate_deferred_peel_candidate_cache(&mut self, group_id: &GroupId) {
+        let invalidated = self
+            .deferred_peel
+            .get_mut(group_id)
+            .is_some_and(|state| state.candidate_cache.take().is_some());
+        if invalidated {
+            self.engine_metrics
+                .note_deferred_peel_candidate_cache_invalidation();
+            tracing::debug!(
+                target: "cgka_engine::message_processor",
+                method = "invalidate_deferred_peel_candidate_cache",
+                "invalidated deferred-peel candidate cache"
+            );
+        }
+    }
+
     /// Bookkeeping for a row leaving `PeelDeferred` (applied, reclassified,
     /// invalidated, or terminally failed): release its flood-cap slot and its
     /// attempt-tracking entry. Once the backlog drops back below the cap, the
@@ -2120,6 +2257,7 @@ impl<S: StorageProvider> Engine<S> {
         &mut self,
         group_id: &GroupId,
     ) -> Result<usize, EngineError> {
+        self.invalidate_deferred_peel_candidate_cache(group_id);
         self.storage.delete_deferred_peel_generation(group_id)?;
         let queued = self.storage.list_queued_outbound_intents(group_id)?;
         if queued.is_empty() {

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -181,7 +181,17 @@ struct DeferredPeelCandidateCacheEntry {
     /// Exact durable barrier generation observed after enumeration. `None` is
     /// also meaningful and must match on reuse.
     durable_generation_fingerprint: Option<[u8; 32]>,
+    /// Pending proposals may be folded into candidate replay paths, but merely
+    /// staging a proposal cannot change the epoch, exporter secret, or
+    /// transport route captured by `GroupContextSnapshot`. If that snapshot
+    /// ever gains proposal-dependent state, this cache key must gain the same
+    /// dependency.
     peel: Arc<crate::openmls_projection::CandidateBranchPeel>,
+}
+
+struct DeferredPeelCandidateEnumerationFailure {
+    error: EngineError,
+    replay_probe_count: u64,
 }
 
 impl DeferredPeelGroupState {
@@ -1673,7 +1683,7 @@ impl<S: StorageProvider> Engine<S> {
             let candidate_enumeration_started = Instant::now();
             let enumerated = match self.candidate_branch_peel(group_id) {
                 Ok(peel) => peel,
-                Err(error) => {
+                Err(failure) => {
                     self.engine_metrics
                         .note_deferred_peel_candidate_enumeration(
                             candidate_enumeration_started
@@ -1682,7 +1692,7 @@ impl<S: StorageProvider> Engine<S> {
                                 .try_into()
                                 .unwrap_or(u64::MAX),
                             std::iter::empty(),
-                            0,
+                            failure.replay_probe_count,
                         );
                     self.note_foreground_deferred_phase(
                         sweep_started,
@@ -1691,7 +1701,7 @@ impl<S: StorageProvider> Engine<S> {
                         total,
                         crate::engine_metrics::DeferredPeelMetricOutcome::Error,
                     );
-                    return Err(error);
+                    return Err(failure.error);
                 }
             };
             let candidate_enumeration_ms = candidate_enumeration_started
@@ -1927,11 +1937,22 @@ impl<S: StorageProvider> Engine<S> {
     fn candidate_branch_peel(
         &self,
         group_id: &GroupId,
-    ) -> Result<crate::openmls_projection::CandidateBranchPeel, EngineError> {
-        let group = self.storage.get_group(group_id)?;
+    ) -> Result<
+        crate::openmls_projection::CandidateBranchPeel,
+        DeferredPeelCandidateEnumerationFailure,
+    > {
+        let group = self.storage.get_group(group_id).map_err(|error| {
+            DeferredPeelCandidateEnumerationFailure {
+                error: error.into(),
+                replay_probe_count: 0,
+            }
+        })?;
         let policy = self
             .convergence_policy_for_group_ungated(group_id)
-            .map_err(|e| EngineError::Backend(format!("load convergence policy: {e}")))?;
+            .map_err(|error| DeferredPeelCandidateEnumerationFailure {
+                error: EngineError::Backend(format!("load convergence policy: {error}")),
+                replay_probe_count: 0,
+            })?;
         let max_rewind_commits = policy.convergence.max_rewind_commits;
         crate::openmls_projection::candidate_branch_peel(
             &self.storage,
@@ -1944,7 +1965,10 @@ impl<S: StorageProvider> Engine<S> {
             },
             MAX_CANDIDATE_BRANCH_PEEL_CONTEXTS,
         )
-        .map_err(|e| EngineError::Backend(format!("candidate branch peel: {e}")))
+        .map_err(|failure| DeferredPeelCandidateEnumerationFailure {
+            error: EngineError::Backend(format!("candidate branch peel: {}", failure.error)),
+            replay_probe_count: failure.replay_probe_count,
+        })
     }
 
     /// Re-ingest one retained raw-transport row and settle its retry lifecycle

--- a/crates/cgka-engine/src/message_processor/send.rs
+++ b/crates/cgka-engine/src/message_processor/send.rs
@@ -360,6 +360,7 @@ impl<S: StorageProvider> Engine<S> {
         let pending_ref = self.epoch_manager.next_pending_ref();
         let staged =
             cgka_traits::engine_state::StagedCommitHandle::from_bytes(group_id.as_slice().to_vec());
+        self.invalidate_deferred_peel_candidate_cache(&group_id);
         self.epoch_manager.begin_pending(
             group_id.clone(),
             prior_epoch,
@@ -613,6 +614,7 @@ impl<S: StorageProvider> Engine<S> {
         let pending_ref = self.epoch_manager.next_pending_ref();
         let staged =
             cgka_traits::engine_state::StagedCommitHandle::from_bytes(group_id.as_slice().to_vec());
+        self.invalidate_deferred_peel_candidate_cache(&group_id);
         self.epoch_manager.begin_pending(
             group_id.clone(),
             prior_epoch,

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -172,7 +172,6 @@ struct StoredOpenMlsCandidatePathResult {
 /// The pass fails closed (`ReplayBudgetExceeded`) rather than returning a partial result.
 struct ReplayBudget {
     remaining: u64,
-    #[cfg(feature = "test-conformance-snapshot")]
     consumed: u64,
 }
 
@@ -187,7 +186,6 @@ impl ReplayBudget {
     fn new(limit: u64) -> Self {
         Self {
             remaining: limit,
-            #[cfg(feature = "test-conformance-snapshot")]
             consumed: 0,
         }
     }
@@ -197,7 +195,6 @@ impl ReplayBudget {
     fn unlimited() -> Self {
         Self {
             remaining: u64::MAX,
-            #[cfg(feature = "test-conformance-snapshot")]
             consumed: 0,
         }
     }
@@ -217,10 +214,7 @@ impl ReplayBudget {
             return Err(OpenMlsProjectionError::ReplayBudgetExceeded);
         }
         self.remaining -= 1;
-        #[cfg(feature = "test-conformance-snapshot")]
-        {
-            self.consumed = self.consumed.saturating_add(1);
-        }
+        self.consumed = self.consumed.saturating_add(1);
         Ok(())
     }
 }
@@ -1612,6 +1606,10 @@ pub(crate) struct CandidateBranchPeelContext {
     /// admits only its frozen batch, the two need not enumerate the same set.
     pub(crate) branch_id: String,
     pub(crate) tip_epoch: u64,
+    /// Number of commit edges replayed from the retained base to capture this
+    /// tip. Exposed only through aggregate metrics; never logged alongside a
+    /// branch or group identifier.
+    pub(crate) depth: u64,
     pub(crate) context: cgka_traits::group_context::GroupContextSnapshot,
 }
 
@@ -1629,6 +1627,9 @@ pub(crate) struct CandidateBranchPeel {
     /// Tip contexts enumeration captured, at most `max_contexts` of them.
     /// Empty on every halt, and empty for an uncontested graph.
     pub(crate) contexts: Vec<CandidateBranchPeelContext>,
+    /// OpenMLS replay probes consumed while enumerating and capturing the
+    /// candidate contexts. Aggregate work accounting only.
+    pub(crate) replay_probe_count: u64,
 }
 
 impl CandidateBranchPeel {
@@ -1637,15 +1638,22 @@ impl CandidateBranchPeel {
     const UNCONTESTED: Self = Self {
         contested: false,
         contexts: Vec::new(),
+        replay_probe_count: 0,
     };
 
     /// Whatever enumeration captured from a graph already known to be split.
-    fn contested_over(contexts: Vec<CandidateBranchPeelContext>) -> Self {
+    fn contested_over(enumeration: CandidateBranchPeelEnumeration) -> Self {
         Self {
             contested: true,
-            contexts,
+            contexts: enumeration.contexts,
+            replay_probe_count: enumeration.replay_probe_count,
         }
     }
+}
+
+struct CandidateBranchPeelEnumeration {
+    contexts: Vec<CandidateBranchPeelContext>,
+    replay_probe_count: u64,
 }
 
 /// Survey the branches a convergence graph offers: whether it is contested, and
@@ -1711,7 +1719,10 @@ pub(crate) fn candidate_branch_peel<S: StorageProvider>(
                 max_contexts,
             )
         }
-        Err(StorageError::SnapshotMissing(_)) => Ok(Vec::new()),
+        Err(StorageError::SnapshotMissing(_)) => Ok(CandidateBranchPeelEnumeration {
+            contexts: Vec::new(),
+            replay_probe_count: 0,
+        }),
         Err(e) => Err(OpenMlsProjectionError::Snapshot(format!("{e:?}"))),
     };
     guard
@@ -1749,7 +1760,7 @@ fn candidate_branch_peel_contexts_from_current<S: StorageProvider>(
     max_rewind_commits: u64,
     profile_policy: ReplayProfilePolicy,
     max_contexts: usize,
-) -> Result<Vec<CandidateBranchPeelContext>, OpenMlsProjectionError> {
+) -> Result<CandidateBranchPeelEnumeration, OpenMlsProjectionError> {
     let mut budget = ReplayBudget::for_pass(inputs.commit_messages.len(), max_rewind_commits);
     let path_result = match build_stored_openmls_candidate_paths(
         storage,
@@ -1777,12 +1788,18 @@ fn candidate_branch_peel_contexts_from_current<S: StorageProvider>(
                 reason = candidate_branch_enumeration_halt_reason(&err),
                 "no candidate branch peel contexts: branch enumeration halted"
             );
-            return Ok(Vec::new());
+            return Ok(CandidateBranchPeelEnumeration {
+                contexts: Vec::new(),
+                replay_probe_count: budget.consumed,
+            });
         }
         Err(err) => return Err(err),
     };
     if path_result.candidate_paths.len() < 2 {
-        return Ok(Vec::new());
+        return Ok(CandidateBranchPeelEnumeration {
+            contexts: Vec::new(),
+            replay_probe_count: budget.consumed,
+        });
     }
 
     let pending_proposals = pending_proposal_messages(&inputs.pending_messages)?;
@@ -1819,7 +1836,10 @@ fn candidate_branch_peel_contexts_from_current<S: StorageProvider>(
             Err(err) => return Err(err),
         }
     }
-    Ok(contexts)
+    Ok(CandidateBranchPeelEnumeration {
+        contexts,
+        replay_probe_count: budget.consumed,
+    })
 }
 
 /// Order candidate paths by how much a peel context on each is worth, so the
@@ -1904,6 +1924,7 @@ fn candidate_path_peel_context<S: StorageProvider>(
     Ok(captured?.map(|tip| CandidateBranchPeelContext {
         branch_id: path.branch_id.clone(),
         tip_epoch: tip.epoch,
+        depth: path.messages.len().try_into().unwrap_or(u64::MAX),
         context: tip.context,
     }))
 }

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -1656,6 +1656,21 @@ struct CandidateBranchPeelEnumeration {
     replay_probe_count: u64,
 }
 
+#[derive(Debug)]
+pub(crate) struct CandidateBranchPeelFailure {
+    pub(crate) error: OpenMlsProjectionError,
+    pub(crate) replay_probe_count: u64,
+}
+
+impl CandidateBranchPeelFailure {
+    fn new(error: OpenMlsProjectionError, replay_probe_count: u64) -> Self {
+        Self {
+            error,
+            replay_probe_count,
+        }
+    }
+}
+
 /// Survey the branches a convergence graph offers: whether it is contested, and
 /// the peel context of each candidate branch tip that could be materialized.
 ///
@@ -1674,10 +1689,11 @@ pub(crate) fn candidate_branch_peel<S: StorageProvider>(
     max_rewind_commits: u64,
     profile_policy: ReplayProfilePolicy,
     max_contexts: usize,
-) -> Result<CandidateBranchPeel, OpenMlsProjectionError> {
+) -> Result<CandidateBranchPeel, CandidateBranchPeelFailure> {
     use crate::snapshot_guard::SnapshotRollbackGuard;
 
-    let inputs = seed_stored_openmls_graph_inputs(storage, group_id, retained_anchor_epoch, None)?;
+    let inputs = seed_stored_openmls_graph_inputs(storage, group_id, retained_anchor_epoch, None)
+        .map_err(|error| CandidateBranchPeelFailure::new(error, 0))?;
     // Cheap contested-graph gate ahead of any replay: competing branches exist
     // only where two commits share a source epoch. An uncontested graph pays
     // the seeding scan and nothing more. This is also the ONLY answer to
@@ -1705,7 +1721,12 @@ pub(crate) fn candidate_branch_peel<S: StorageProvider>(
     let probe_snapshot = candidate_branch_probe_snapshot_name(group_id, inputs.replay_start_epoch);
     let guard =
         SnapshotRollbackGuard::create_group_state(storage, group_id.clone(), probe_snapshot)
-            .map_err(|e| OpenMlsProjectionError::Snapshot(format!("{e:?}")))?;
+            .map_err(|error| {
+                CandidateBranchPeelFailure::new(
+                    OpenMlsProjectionError::Snapshot(format!("{error:?}")),
+                    0,
+                )
+            })?;
     let anchor_snapshot = retained_anchor_snapshot_name(inputs.replay_start_epoch);
     let contexts = match storage.rollback_group_state_to_snapshot(group_id, &anchor_snapshot) {
         Ok(()) => {
@@ -1723,11 +1744,21 @@ pub(crate) fn candidate_branch_peel<S: StorageProvider>(
             contexts: Vec::new(),
             replay_probe_count: 0,
         }),
-        Err(e) => Err(OpenMlsProjectionError::Snapshot(format!("{e:?}"))),
+        Err(error) => Err(CandidateBranchPeelFailure::new(
+            OpenMlsProjectionError::Snapshot(format!("{error:?}")),
+            0,
+        )),
     };
-    guard
-        .commit()
-        .map_err(|e| OpenMlsProjectionError::Snapshot(format!("{e:?}")))?;
+    let replay_probe_count = contexts.as_ref().map_or_else(
+        |failure| failure.replay_probe_count,
+        |enumeration| enumeration.replay_probe_count,
+    );
+    guard.commit().map_err(|error| {
+        CandidateBranchPeelFailure::new(
+            OpenMlsProjectionError::Snapshot(format!("{error:?}")),
+            replay_probe_count,
+        )
+    })?;
     contexts.map(CandidateBranchPeel::contested_over)
 }
 
@@ -1760,7 +1791,7 @@ fn candidate_branch_peel_contexts_from_current<S: StorageProvider>(
     max_rewind_commits: u64,
     profile_policy: ReplayProfilePolicy,
     max_contexts: usize,
-) -> Result<CandidateBranchPeelEnumeration, OpenMlsProjectionError> {
+) -> Result<CandidateBranchPeelEnumeration, CandidateBranchPeelFailure> {
     let mut budget = ReplayBudget::for_pass(inputs.commit_messages.len(), max_rewind_commits);
     let path_result = match build_stored_openmls_candidate_paths(
         storage,
@@ -1793,7 +1824,9 @@ fn candidate_branch_peel_contexts_from_current<S: StorageProvider>(
                 replay_probe_count: budget.consumed,
             });
         }
-        Err(err) => return Err(err),
+        Err(error) => {
+            return Err(CandidateBranchPeelFailure::new(error, budget.consumed));
+        }
     };
     if path_result.candidate_paths.len() < 2 {
         return Ok(CandidateBranchPeelEnumeration {
@@ -1802,7 +1835,8 @@ fn candidate_branch_peel_contexts_from_current<S: StorageProvider>(
         });
     }
 
-    let pending_proposals = pending_proposal_messages(&inputs.pending_messages)?;
+    let pending_proposals = pending_proposal_messages(&inputs.pending_messages)
+        .map_err(|error| CandidateBranchPeelFailure::new(error, budget.consumed))?;
     let ranked =
         candidate_paths_ranked_for_peel(&path_result.candidate_paths, &path_result.materialized);
     let mut contexts = Vec::with_capacity(max_contexts.min(ranked.len()));
@@ -1833,7 +1867,9 @@ fn candidate_branch_peel_contexts_from_current<S: StorageProvider>(
                 );
                 break;
             }
-            Err(err) => return Err(err),
+            Err(error) => {
+                return Err(CandidateBranchPeelFailure::new(error, budget.consumed));
+            }
         }
     }
     Ok(CandidateBranchPeelEnumeration {
@@ -3991,8 +4027,8 @@ fn tls_hex<T: TlsSerialize>(value: &T) -> Result<String, OpenMlsProjectionError>
 #[cfg(test)]
 mod replay_budget_tests {
     use super::{
-        CANDIDATE_REPLAY_BUDGET_FLOOR, CANDIDATE_REPLAY_BUDGET_SLACK, OpenMlsProjectionError,
-        ReplayBudget,
+        CANDIDATE_REPLAY_BUDGET_FLOOR, CANDIDATE_REPLAY_BUDGET_SLACK, CandidateBranchPeelFailure,
+        OpenMlsProjectionError, ReplayBudget,
     };
 
     #[test]
@@ -4032,6 +4068,20 @@ mod replay_budget_tests {
             budget.consume(),
             Err(OpenMlsProjectionError::ReplayBudgetExceeded)
         ));
+    }
+
+    #[test]
+    fn candidate_failure_preserves_consumed_replay_count() {
+        let mut budget = ReplayBudget::new(3);
+        budget.consume().expect("first probe");
+        budget.consume().expect("second probe");
+        let failure = CandidateBranchPeelFailure::new(
+            OpenMlsProjectionError::Storage("injected failure".into()),
+            budget.consumed,
+        );
+
+        assert_eq!(failure.replay_probe_count, 2);
+        assert!(matches!(failure.error, OpenMlsProjectionError::Storage(_)));
     }
 
     #[test]

--- a/crates/cgka-engine/src/publish.rs
+++ b/crates/cgka-engine/src/publish.rs
@@ -271,6 +271,7 @@ impl<S: StorageProvider> Engine<S> {
         // backend) plus best-effort cleanup. Kind discriminates create (always
         // `GroupCreated`) from evolution (always `EpochChanged`).
         let (group_id, new_epoch) = self.epoch_manager.confirm_publish(pending)?;
+        self.invalidate_deferred_peel_candidate_cache(&group_id);
         if let (Some(fanout), Some(confirmed)) = (fanout.take(), confirmed_fanout) {
             *fanout = confirmed;
         }
@@ -491,6 +492,7 @@ impl<S: StorageProvider> Engine<S> {
         let pending_epoch_pre = EpochId(mls_group.epoch().as_u64());
         let audit_context = self.epoch_manager.audit_context_for_pending(pending);
         let (group_id, prior_epoch) = self.epoch_manager.rollback_publish(pending)?;
+        self.invalidate_deferred_peel_candidate_cache(&group_id);
         self.audit_with_context(
             Some(&group_id),
             audit_context.clone(),

--- a/crates/cgka-engine/src/self_update.rs
+++ b/crates/cgka-engine/src/self_update.rs
@@ -200,6 +200,7 @@ impl<S: StorageProvider> Engine<S> {
         evolution.pending_ref = Some(pending_ref);
         self.maintenance_storage()?
             .put_group_evolution(&evolution)?;
+        self.invalidate_deferred_peel_candidate_cache(&group_id);
         self.epoch_manager.begin_pending(
             group_id.clone(),
             source_epoch,

--- a/crates/cgka-engine/src/update_group_data.rs
+++ b/crates/cgka-engine/src/update_group_data.rs
@@ -286,6 +286,7 @@ impl<S: StorageProvider> Engine<S> {
         }
         let pending_ref = self.epoch_manager.next_pending_ref();
         let staged = StagedCommitHandle::from_bytes(group_id.as_slice().to_vec());
+        self.invalidate_deferred_peel_candidate_cache(&group_id);
         self.epoch_manager.begin_pending(
             group_id.clone(),
             pre_commit_epoch,

--- a/crates/cgka-engine/src/upgrade.rs
+++ b/crates/cgka-engine/src/upgrade.rs
@@ -264,6 +264,7 @@ impl<S: StorageProvider> Engine<S> {
         }
         let pending_ref = self.epoch_manager.next_pending_ref();
         let staged = StagedCommitHandle::from_bytes(group_id.as_slice().to_vec());
+        self.invalidate_deferred_peel_candidate_cache(group_id);
         self.epoch_manager.begin_pending(
             group_id.clone(),
             pre_commit_epoch,

--- a/crates/cgka-engine/tests/deferred_peel_lifecycle.rs
+++ b/crates/cgka-engine/tests/deferred_peel_lifecycle.rs
@@ -641,8 +641,7 @@ where
     let (mut eve, _eve_storage) = build_epoch_sealed_client(b"candidate-cache-eve");
 
     let rival_kp = rival.fresh_key_package().await.unwrap();
-    let routing =
-        NostrRoutingV1::new([0x43; 32], vec!["wss://candidate-cache.example".into()]).unwrap();
+    let routing = NostrRoutingV1::new([0x43; 32], vec!["wss://relay.example".into()]).unwrap();
     let (group_id, create) = incumbent
         .create_group(CreateGroupRequest {
             name: "candidate-cache".into(),

--- a/crates/cgka-engine/tests/deferred_peel_lifecycle.rs
+++ b/crates/cgka-engine/tests/deferred_peel_lifecycle.rs
@@ -8,6 +8,10 @@ use cgka_engine::canonicalization::CanonicalizationPolicy;
 use cgka_engine::message_processor::MAX_PEEL_DEFERRED_ROWS_PER_GROUP;
 use cgka_engine::openmls_projection::project_mls_message;
 use cgka_engine::{Engine, EngineBuilder, ManualConvergenceClock};
+use cgka_traits::app_components::{
+    AppComponentData, NOSTR_ROUTING_COMPONENT_ID, NostrRoutingV1, default_group_components,
+    encode_nostr_routing_v1,
+};
 use cgka_traits::app_event::{MARMOT_APP_EVENT_KIND_CHAT, MarmotAppEvent};
 use cgka_traits::engine::{CgkaEngine, CreateGroupRequest, GroupEvent, SendIntent, SendResult};
 use cgka_traits::error::PeelerError;
@@ -423,10 +427,13 @@ fn build_epoch_sealed_client_with_storage_and_peeler<P>(
 where
     P: TransportPeeler + 'static,
 {
+    let mut supported_components: Vec<_> = default_group_components().into_iter().collect();
+    supported_components.push(NOSTR_ROUTING_COMPONENT_ID);
     let mut engine = EngineBuilder::new(storage)
         .legacy_compatibility_profile()
         .identity(pad32(name))
         .account_identity_proof_signer(proof_signer(name))
+        .supported_app_components(supported_components)
         .peeler(Box::new(peeler))
         .build()
         .unwrap();
@@ -634,13 +641,18 @@ where
     let (mut eve, _eve_storage) = build_epoch_sealed_client(b"candidate-cache-eve");
 
     let rival_kp = rival.fresh_key_package().await.unwrap();
+    let routing =
+        NostrRoutingV1::new([0x43; 32], vec!["wss://candidate-cache.example".into()]).unwrap();
     let (group_id, create) = incumbent
         .create_group(CreateGroupRequest {
             name: "candidate-cache".into(),
             description: String::new(),
             members: vec![rival_kp],
             required_features: vec![],
-            app_components: vec![],
+            app_components: vec![AppComponentData {
+                component_id: NOSTR_ROUTING_COMPONENT_ID,
+                data: encode_nostr_routing_v1(&routing).unwrap(),
+            }],
             initial_admins: vec![rival.self_id()],
         })
         .await
@@ -699,11 +711,19 @@ where
     // value too so the setup is explicit about both sides of the contested
     // graph and cannot be optimized into an unused local evolution.
     let _ = incumbent_commit;
+    let TransportEnvelope::GroupMessage {
+        transport_group_id: rival_route,
+    } = &rival_root.envelope
+    else {
+        panic!("rival root must be a routed group message");
+    };
+    assert_ne!(
+        rival_route.as_slice(),
+        group_id.as_slice(),
+        "transport routing id must stay distinct from the MLS group id"
+    );
     assert!(matches!(
-        incumbent
-            .ingest(route(rival_root, &group_id))
-            .await
-            .unwrap(),
+        incumbent.ingest(rival_root).await.unwrap(),
         IngestOutcome::Buffered { .. }
     ));
 
@@ -782,6 +802,36 @@ async fn unchanged_192_row_contested_backlog_enumerates_candidates_once() {
 }
 
 #[tokio::test]
+async fn group_policy_change_invalidates_cached_candidate_enumeration() {
+    let (mut incumbent, _storage, group_id, _same_branch_peer) =
+        contested_rival_app_backlog(192).await;
+
+    assert_eq!(incumbent.retry_deferred_peels(&group_id).await.unwrap(), 64);
+    let before_change = incumbent.engine_metrics();
+    assert_eq!(before_change.deferred_peel_candidate_enumerations, 1);
+    assert_eq!(before_change.deferred_peel_candidate_cache_misses, 1);
+
+    let mut policy = CanonicalizationPolicy {
+        settlement_quiescence_ms: 0,
+        ..CanonicalizationPolicy::default()
+    };
+    policy.convergence.max_rewind_commits = 1;
+    incumbent
+        .set_group_convergence_policy(&group_id, policy)
+        .expect("test policy override accepted");
+
+    assert_eq!(incumbent.retry_deferred_peels(&group_id).await.unwrap(), 64);
+    let after_change = incumbent.engine_metrics();
+    assert_eq!(
+        after_change.deferred_peel_candidate_enumerations, 2,
+        "a changed replay horizon must not reuse the prior enumeration"
+    );
+    assert_eq!(after_change.deferred_peel_candidate_cache_misses, 2);
+    assert_eq!(after_change.deferred_peel_candidate_cache_hits, 0);
+    assert_eq!(after_change.deferred_peel_candidate_cache_invalidations, 1);
+}
+
+#[tokio::test]
 async fn changed_fingerprint_enumerates_exactly_one_new_candidate_generation() {
     let (mut incumbent, storage, group_id, mut same_branch_peer) =
         contested_rival_app_backlog(256).await;
@@ -806,7 +856,7 @@ async fn changed_fingerprint_enumerates_exactly_one_new_candidate_generation() {
     );
     same_branch_peer.confirm_published(pending).await.unwrap();
     assert!(matches!(
-        incumbent.ingest(route(new_input, &group_id)).await.unwrap(),
+        incumbent.ingest(new_input).await.unwrap(),
         IngestOutcome::Buffered { .. }
     ));
 

--- a/crates/cgka-engine/tests/deferred_peel_lifecycle.rs
+++ b/crates/cgka-engine/tests/deferred_peel_lifecycle.rs
@@ -30,6 +30,7 @@ use std::sync::{Arc, Mutex};
 use storage_sqlite::SqliteAccountStorage;
 
 mod support;
+use support::epoch_sealed_peeler::EpochSealedPeeler;
 use support::proof_signer;
 
 fn pad32(name: &[u8]) -> Vec<u8> {
@@ -199,6 +200,72 @@ struct NotifyEpochGatePeeler {
     block_on_attempt: Arc<AtomicU64>,
 }
 
+/// Epoch-faithful peeler that can suspend before any supplied context is
+/// attempted. Used to cancel a sweep after candidate enumeration but before a
+/// deferred row receives a definitive result.
+#[derive(Clone)]
+struct CancellableEpochSealedPeeler {
+    blocked: Arc<AtomicBool>,
+    blocked_attempts: Arc<AtomicU64>,
+}
+
+impl CancellableEpochSealedPeeler {
+    fn new() -> Self {
+        Self {
+            blocked: Arc::new(AtomicBool::new(false)),
+            blocked_attempts: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    fn block(&self) {
+        self.blocked_attempts.store(0, Ordering::SeqCst);
+        self.blocked.store(true, Ordering::SeqCst);
+    }
+
+    fn unblock(&self) {
+        self.blocked.store(false, Ordering::SeqCst);
+    }
+
+    fn blocked_attempts(&self) -> u64 {
+        self.blocked_attempts.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl TransportPeeler for CancellableEpochSealedPeeler {
+    async fn peel_group_message(
+        &self,
+        msg: &TransportMessage,
+        ctx: &GroupContextSnapshot,
+    ) -> Result<PeeledMessage, PeelerError> {
+        if self.blocked.load(Ordering::SeqCst) {
+            self.blocked_attempts.fetch_add(1, Ordering::SeqCst);
+            std::future::pending::<()>().await;
+        }
+        EpochSealedPeeler.peel_group_message(msg, ctx).await
+    }
+
+    async fn peel_welcome(&self, msg: &TransportMessage) -> Result<PeeledMessage, PeelerError> {
+        EpochSealedPeeler.peel_welcome(msg).await
+    }
+
+    async fn wrap_group_message(
+        &self,
+        payload: &EncryptedPayload,
+        ctx: &GroupContextSnapshot,
+    ) -> Result<TransportMessage, PeelerError> {
+        EpochSealedPeeler.wrap_group_message(payload, ctx).await
+    }
+
+    async fn wrap_welcome(
+        &self,
+        payload: &EncryptedPayload,
+        recipient: &MemberId,
+    ) -> Result<TransportMessage, PeelerError> {
+        EpochSealedPeeler.wrap_welcome(payload, recipient).await
+    }
+}
+
 impl NotifyEpochGatePeeler {
     fn new() -> Self {
         Self {
@@ -339,6 +406,43 @@ fn build_notify_client(
 ) {
     let peeler = NotifyEpochGatePeeler::new();
     build_gated_client(name, peeler)
+}
+
+fn build_epoch_sealed_client_with_storage(
+    name: &[u8],
+    storage: SqliteAccountStorage,
+) -> Engine<SqliteAccountStorage> {
+    build_epoch_sealed_client_with_storage_and_peeler(name, storage, EpochSealedPeeler)
+}
+
+fn build_epoch_sealed_client_with_storage_and_peeler<P>(
+    name: &[u8],
+    storage: SqliteAccountStorage,
+    peeler: P,
+) -> Engine<SqliteAccountStorage>
+where
+    P: TransportPeeler + 'static,
+{
+    let mut engine = EngineBuilder::new(storage)
+        .legacy_compatibility_profile()
+        .identity(pad32(name))
+        .account_identity_proof_signer(proof_signer(name))
+        .peeler(Box::new(peeler))
+        .build()
+        .unwrap();
+    engine
+        .set_convergence_policy(CanonicalizationPolicy {
+            settlement_quiescence_ms: 0,
+            ..CanonicalizationPolicy::default()
+        })
+        .expect("convergence policy accepted");
+    engine
+}
+
+fn build_epoch_sealed_client(name: &[u8]) -> (Engine<SqliteAccountStorage>, SqliteAccountStorage) {
+    let storage = SqliteAccountStorage::in_memory().unwrap();
+    let engine = build_epoch_sealed_client_with_storage(name, storage.clone());
+    (engine, storage)
 }
 
 fn route(msg: TransportMessage, group_id: &GroupId) -> TransportMessage {
@@ -491,6 +595,320 @@ async fn carol_behind_two_epochs_with<P>(
         commit_to_epoch2,
         commit_to_epoch3,
     )
+}
+
+/// Build a deterministic two-branch graph and retain `backlog` wrappers of one
+/// rival-branch application message. Peeling any wrapper adds no commit digest,
+/// so every background slice observes the exact same context fingerprint.
+async fn contested_rival_app_backlog(
+    backlog: usize,
+) -> (
+    Engine<SqliteAccountStorage>,
+    SqliteAccountStorage,
+    GroupId,
+    Engine<SqliteAccountStorage>,
+) {
+    contested_rival_app_backlog_with_peeler(backlog, EpochSealedPeeler).await
+}
+
+async fn contested_rival_app_backlog_with_peeler<P>(
+    backlog: usize,
+    incumbent_peeler: P,
+) -> (
+    Engine<SqliteAccountStorage>,
+    SqliteAccountStorage,
+    GroupId,
+    Engine<SqliteAccountStorage>,
+)
+where
+    P: TransportPeeler + 'static,
+{
+    let incumbent_storage = SqliteAccountStorage::in_memory().unwrap();
+    let mut incumbent = build_epoch_sealed_client_with_storage_and_peeler(
+        b"candidate-cache-incumbent",
+        incumbent_storage.clone(),
+        incumbent_peeler,
+    );
+    let (mut rival, _rival_storage) = build_epoch_sealed_client(b"candidate-cache-rival");
+    let (mut david, _david_storage) = build_epoch_sealed_client(b"candidate-cache-david");
+    let (mut eve, _eve_storage) = build_epoch_sealed_client(b"candidate-cache-eve");
+
+    let rival_kp = rival.fresh_key_package().await.unwrap();
+    let (group_id, create) = incumbent
+        .create_group(CreateGroupRequest {
+            name: "candidate-cache".into(),
+            description: String::new(),
+            members: vec![rival_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![rival.self_id()],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    incumbent.confirm_published(pending).await.unwrap();
+    rival
+        .join_welcome(welcome_for(&welcomes, b"candidate-cache-rival"))
+        .await
+        .unwrap();
+
+    let david_kp = david.fresh_key_package().await.unwrap();
+    let (incumbent_commit, incumbent_pending, incumbent_welcomes) = match incumbent
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![david_kp],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap()
+    {
+        SendResult::GroupEvolution {
+            msg,
+            pending,
+            welcomes,
+            ..
+        } => (msg, pending, welcomes),
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    incumbent
+        .confirm_published(incumbent_pending)
+        .await
+        .unwrap();
+    david
+        .join_welcome(welcome_for(&incumbent_welcomes, b"candidate-cache-david"))
+        .await
+        .unwrap();
+
+    let eve_kp = eve.fresh_key_package().await.unwrap();
+    let (rival_root, rival_pending) = evolution(
+        rival
+            .send(SendIntent::Invite {
+                group_id: group_id.clone(),
+                key_packages: vec![eve_kp],
+                initial_admins: vec![],
+            })
+            .await
+            .unwrap(),
+    );
+    rival.confirm_published(rival_pending).await.unwrap();
+
+    // The own commit is already durably stamped by confirm. Retain its wire
+    // value too so the setup is explicit about both sides of the contested
+    // graph and cannot be optimized into an unused local evolution.
+    let _ = incumbent_commit;
+    assert!(matches!(
+        incumbent
+            .ingest(route(rival_root, &group_id))
+            .await
+            .unwrap(),
+        IngestOutcome::Buffered { .. }
+    ));
+
+    let rival_app = send_app(&mut rival, &group_id, "rival branch witness").await;
+    for index in 0..backlog {
+        let wrapper = TransportMessage {
+            id: MessageId::new(format!("candidate-cache-wrapper-{index}").into_bytes()),
+            ..rival_app.clone()
+        };
+        assert!(matches!(
+            incumbent.ingest(wrapper).await.unwrap(),
+            IngestOutcome::TransportDeferred { .. }
+        ));
+    }
+    assert_eq!(
+        incumbent_storage
+            .list_messages_in_states(&group_id, &[MessageState::PeelDeferred], EpochId(0),)
+            .unwrap()
+            .len(),
+        backlog
+    );
+
+    (incumbent, incumbent_storage, group_id, david)
+}
+
+#[tokio::test]
+async fn unchanged_192_row_contested_backlog_enumerates_candidates_once() {
+    let (mut incumbent, storage, group_id, _same_branch_peer) =
+        contested_rival_app_backlog(192).await;
+
+    let mut handled = 0usize;
+    for _ in 0..3 {
+        let progressed = incumbent.retry_deferred_peels(&group_id).await.unwrap();
+        assert_eq!(progressed, 64, "background work must stay slice-bounded");
+        handled += progressed;
+    }
+
+    assert_eq!(handled, 192);
+    assert!(
+        storage
+            .list_messages_in_states(&group_id, &[MessageState::PeelDeferred], EpochId(0),)
+            .unwrap()
+            .is_empty(),
+        "every raw wrapper must leave the deferred lifecycle"
+    );
+    let metrics = incumbent.engine_metrics();
+    assert_eq!(metrics.deferred_peel_candidate_enumerations, 1);
+    assert_eq!(metrics.deferred_peel_candidate_cache_misses, 1);
+    assert_eq!(metrics.deferred_peel_candidate_cache_hits, 2);
+    assert_eq!(metrics.deferred_peel_candidate_cache_invalidations, 1);
+    assert_eq!(metrics.deferred_peel_candidate_contexts, 2);
+    assert_eq!(
+        metrics.deferred_peel_candidate_context_depth.sample_count(),
+        2
+    );
+    assert_eq!(
+        metrics
+            .deferred_peel_candidate_context_depth
+            .approx_percentile(1.0),
+        Some(1)
+    );
+    assert_eq!(
+        metrics.deferred_peel_candidate_replay_probes, 4,
+        "candidate replay work must be independent of the number of slices"
+    );
+    assert_eq!(
+        metrics
+            .deferred_peel_candidate_enumeration_ms
+            .sample_count(),
+        1
+    );
+    assert_eq!(
+        metrics.deferred_peel_sweeps, 4,
+        "three work slices plus the generation-completion empty sweep"
+    );
+}
+
+#[tokio::test]
+async fn changed_fingerprint_enumerates_exactly_one_new_candidate_generation() {
+    let (mut incumbent, storage, group_id, mut same_branch_peer) =
+        contested_rival_app_backlog(256).await;
+
+    assert_eq!(incumbent.retry_deferred_peels(&group_id).await.unwrap(), 64);
+    assert_eq!(incumbent.retry_deferred_peels(&group_id).await.unwrap(), 64);
+    let before_change = incumbent.engine_metrics();
+    assert_eq!(before_change.deferred_peel_candidate_enumerations, 1);
+    assert_eq!(before_change.deferred_peel_candidate_cache_hits, 1);
+
+    // A valid commit on the incumbent lineage adds one stored convergence
+    // input without adopting the rival branch. The commit digest is part of
+    // the existing fingerprint semantics, so the remaining rows form one new
+    // exact generation.
+    let (new_input, pending) = evolution(
+        same_branch_peer
+            .send(SendIntent::SelfUpdate {
+                group_id: group_id.clone(),
+            })
+            .await
+            .unwrap(),
+    );
+    same_branch_peer.confirm_published(pending).await.unwrap();
+    assert!(matches!(
+        incumbent.ingest(route(new_input, &group_id)).await.unwrap(),
+        IngestOutcome::Buffered { .. }
+    ));
+
+    assert_eq!(incumbent.retry_deferred_peels(&group_id).await.unwrap(), 64);
+    assert_eq!(incumbent.retry_deferred_peels(&group_id).await.unwrap(), 64);
+    assert!(
+        storage
+            .list_messages_in_states(&group_id, &[MessageState::PeelDeferred], EpochId(0),)
+            .unwrap()
+            .is_empty()
+    );
+    let after_change = incumbent.engine_metrics();
+    assert_eq!(
+        after_change.deferred_peel_candidate_enumerations,
+        before_change.deferred_peel_candidate_enumerations + 1,
+        "one changed fingerprint must cause exactly one new enumeration"
+    );
+    assert_eq!(after_change.deferred_peel_candidate_cache_misses, 2);
+    assert_eq!(after_change.deferred_peel_candidate_cache_hits, 2);
+    assert!(after_change.deferred_peel_candidate_cache_invalidations >= 2);
+}
+
+#[tokio::test]
+async fn restart_discards_candidate_context_cache_and_recomputes_once() {
+    let (mut incumbent, storage, group_id, _same_branch_peer) =
+        contested_rival_app_backlog(192).await;
+    assert_eq!(incumbent.retry_deferred_peels(&group_id).await.unwrap(), 64);
+    assert_eq!(
+        incumbent
+            .engine_metrics()
+            .deferred_peel_candidate_enumerations,
+        1
+    );
+    drop(incumbent);
+
+    let mut restarted =
+        build_epoch_sealed_client_with_storage(b"candidate-cache-incumbent", storage.clone());
+    restarted.hydrate_all_stored_groups().unwrap();
+    let mut progressed = 0usize;
+    for _ in 0..3 {
+        progressed += restarted.retry_deferred_peels(&group_id).await.unwrap();
+        if restarted
+            .engine_metrics()
+            .deferred_peel_candidate_enumerations
+            > 0
+        {
+            break;
+        }
+    }
+    assert_eq!(progressed, 64);
+    let metrics = restarted.engine_metrics();
+    assert_eq!(
+        metrics.deferred_peel_candidate_enumerations, 1,
+        "a restarted engine must enumerate instead of loading secret contexts"
+    );
+    assert_eq!(metrics.deferred_peel_candidate_cache_misses, 1);
+    assert_eq!(metrics.deferred_peel_candidate_cache_hits, 0);
+}
+
+#[tokio::test]
+async fn cancelled_sweep_keeps_untried_rows_eligible_and_reuses_enumeration() {
+    let peeler = CancellableEpochSealedPeeler::new();
+    let (mut incumbent, storage, group_id, _same_branch_peer) =
+        contested_rival_app_backlog_with_peeler(192, peeler.clone()).await;
+
+    peeler.block();
+    let cancelled = tokio::time::timeout(
+        std::time::Duration::from_millis(25),
+        incumbent.retry_deferred_peels(&group_id),
+    )
+    .await;
+    assert!(
+        cancelled.is_err(),
+        "the blocked peel must exhaust the caller budget"
+    );
+    assert_eq!(peeler.blocked_attempts(), 1);
+    let deferred = storage
+        .list_messages_in_states(&group_id, &[MessageState::PeelDeferred], EpochId(0))
+        .unwrap();
+    assert_eq!(deferred.len(), 192);
+    assert!(deferred.iter().all(|record| {
+        record
+            .deferred_peel
+            .as_ref()
+            .and_then(|lifecycle| lifecycle.last_context_fingerprint)
+            .is_none()
+    }));
+    assert_eq!(
+        incumbent
+            .engine_metrics()
+            .deferred_peel_candidate_enumerations,
+        1
+    );
+
+    peeler.unblock();
+    assert_eq!(incumbent.retry_deferred_peels(&group_id).await.unwrap(), 64);
+    let metrics = incumbent.engine_metrics();
+    assert_eq!(
+        metrics.deferred_peel_candidate_enumerations, 1,
+        "cancellation retains the safe memory-only enumeration"
+    );
+    assert_eq!(metrics.deferred_peel_candidate_cache_hits, 1);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- reuse memory-only candidate-branch peel contexts only for the same group, exact deferred-peel fingerprint, and exact durable generation marker
- invalidate exporter-bearing contexts at fingerprint, generation, canonical-state, hydration, repair, quarantine, removal, disband, pending-publish, and rollback boundaries
- add privacy-safe aggregate sweep, enumeration, context count/depth, replay-probe, cache hit/miss/invalidation, and elapsed-time observability
- add deterministic 192-row and 256-row contested-graph regressions covering unchanged slices, fingerprint rollover, restart, cancellation, and the existing foreground/background work limits

## Before / after

For a 192-row contested backlog processed in three 64-row background slices under one unchanged fingerprint:

| Measurement | Before cache | After cache |
| --- | ---: | ---: |
| Candidate enumerations | 3 | 1 |
| Candidate context instances | 6 | 2 |
| Candidate replay probes | 12 | 4 |

The final regression asserts the four replay probes are independent of slice count for one fingerprint. In this graph each consumed replay probe owns one state-scoped replay snapshot, so the candidate replay snapshot work is bounded at four as well.

## Stacking and overlap

- #1563 merged to `master` as 18b63645bcda9eef6263b884687a2af72944278e
- rebased onto current `master`; `git range-diff` reports the phase-2 patch as equivalent
- the narrow overlap in `openmls_projection.rs` only exposes aggregate replay-probe count and context depth
- no changes to `snapshot_guard.rs`, storage snapshot encoding, rollback recovery, crash-recovery tests, snapshot-scope APIs, migrations, bindings, protocol behavior, or versions

## Test plan

- [x] TDD baseline reproduced the failure: expected one enumeration, observed three
- [x] `cargo test -p cgka-engine --features test-policy-overrides,test-crash-hooks`
- [x] `just fast-ci`

Refs #1560

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved deferred processing by reusing candidate results when group state is unchanged.
  * Added safeguards to refresh cached results after updates, publishing, membership changes, recovery, and restarts.

* **Reliability**
  * Improved handling of replay limits, interruptions, missing anchors, and candidate evaluation failures.
  * Preserved pending work more consistently during cancellations and retries.

* **Monitoring**
  * Added detailed metrics for deferred processing, cache usage, replay activity, processing depth, and timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->