### PR TITLE
Fix/refused ingest stays fetchable

### DIFF
--- a/crates/marmot-app/src/client/audit.rs
+++ b/crates/marmot-app/src/client/audit.rs
@@ -14,6 +14,7 @@ use crate::messages::AppMessageIntent;
 use crate::{AppError, AppGroupRecord};
 
 use super::ObservedHumanActionAudit;
+use super::sync::DrainCounts;
 
 use super::AppClient;
 
@@ -25,6 +26,7 @@ pub(crate) struct EpochBackfillTerminalAudit {
     pub error_kind: Option<String>,
     pub deliveries: u64,
     pub skipped: u64,
+    pub refused: u64,
     pub local_epoch_before: u64,
     pub local_epoch_after: u64,
     pub group_advanced: bool,
@@ -192,19 +194,20 @@ impl AppClient {
 
     /// Record a `sync_drain` forensic audit row at every drain-loop exit: how
     /// long the drain ran (`duration_ms`, wall-clock), how many deliveries it
-    /// ingested (`deliveries`), how many receives it dropped as an echo or an
-    /// already-seen duplicate (`skipped`), and the durable transport cursor
-    /// immediately before and after the drain (Nostr second-granular).
-    /// Account-scoped, so `group_ref` is `None`.
+    /// ingested (`deliveries`), how many of those the engine refused unpersisted
+    /// (`refused`), how many receives it dropped as an echo or an already-seen
+    /// duplicate (`skipped`), and the durable transport cursor immediately
+    /// before and after the drain (Nostr second-granular). Account-scoped, so
+    /// `group_ref` is `None`.
     ///
-    /// The two counts are recorded apart because `duration_ms` alone cannot
-    /// tell a long drain that was making progress from one a relay held open
-    /// with traffic carrying no new history.
+    /// The counts are recorded apart because `duration_ms` alone cannot tell a
+    /// long drain that was making progress from one a relay held open with
+    /// traffic carrying no new history — nor either of those from a drain that
+    /// fetched real history into a full retention cap and had to drop it.
     pub(crate) fn record_sync_drain(
         &self,
         duration_ms: u64,
-        deliveries: u64,
-        skipped: u64,
+        counts: DrainCounts,
         cursor_before_secs: Option<u64>,
         cursor_after_secs: Option<u64>,
     ) {
@@ -213,8 +216,9 @@ impl AppClient {
             None,
             AuditEventKind::SyncDrain {
                 duration_ms,
-                deliveries,
-                skipped: Some(skipped),
+                deliveries: counts.deliveries,
+                skipped: Some(counts.skipped),
+                refused: Some(counts.refused),
                 cursor_before_secs,
                 cursor_after_secs,
             },
@@ -277,6 +281,7 @@ impl AppClient {
                 completion_kind: terminal.completion_kind,
                 deliveries: terminal.deliveries,
                 skipped: Some(terminal.skipped),
+                refused: Some(terminal.refused),
                 local_epoch_before: terminal.local_epoch_before,
                 local_epoch_after: terminal.local_epoch_after,
                 group_advanced: terminal.group_advanced,
@@ -289,6 +294,7 @@ impl AppClient {
                 error_kind: terminal.error_kind,
                 deliveries: terminal.deliveries,
                 skipped: Some(terminal.skipped),
+                refused: Some(terminal.refused),
                 local_epoch_before: terminal.local_epoch_before,
                 local_epoch_after: terminal.local_epoch_after,
                 group_advanced: terminal.group_advanced,

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -138,6 +138,40 @@ impl DrainVerdict {
     }
 }
 
+/// What one delivery's ingest settled, for the two seams that decide whether the
+/// delivery may be dropped from the fetch path.
+struct DeliveryIngest {
+    /// Membership-changing effects landed, so the app projection and the route
+    /// table owe a save before anything else can fail.
+    routes_dirty: bool,
+    /// The engine kept no durable trace of this object, so transport
+    /// redelivery is the only path back to it. See
+    /// [`ingest_left_object_unpersisted`].
+    must_stay_fetchable: bool,
+}
+
+/// Whether the engine left this outcome's transport object unpersisted, so only
+/// relay redelivery can present it again.
+///
+/// This is the app-side half of the engine's `retryable_unpersisted_ingest_id`
+/// contract. `ResourceRefused` is the one `Ok` outcome the engine drops without
+/// a durable record *and* deliberately keeps out of its own seen cache, and the
+/// trait states the consequence directly: a resource refusal "must not make
+/// same-id redelivery a duplicate". Recording it in `seen_events` (which has no
+/// removal site short of ring overflow) or letting it carry the relay `since`
+/// floor past itself makes the object permanently unfetchable — across restarts
+/// and across `repair_full_history` alike.
+///
+/// Every other `Ok` outcome leaves the engine holding durable evidence of the
+/// object: `TransportDeferred` retains the raw transport row for later peel,
+/// `Buffered` retains it for convergence replay, and the terminal
+/// classifications (`Processed`, `Ignored`, `LocalState`, `Stale`, `Rejected`)
+/// are decisions the engine can reach again from storage. Forgetting those is
+/// correct dedupe, so they stay.
+fn ingest_left_object_unpersisted(outcome: &IngestOutcome) -> bool {
+    matches!(outcome, IngestOutcome::ResourceRefused { .. })
+}
+
 /// What one drain loop saw on the wire.
 ///
 /// `deliveries` counts receives the drain ingested; `skipped` counts those it
@@ -919,14 +953,18 @@ impl AppClient {
         let display_names = self.app.display_names_by_id()?;
         let mut summary = SyncSummary::default();
         let event_id = hex::encode(delivery.message.id.as_slice());
-        let routes_dirty = self
+        let ingested = self
             .ingest_delivery(delivery, &display_names, &mut summary)
             .await?;
         // Mark the delivery seen only after durable ingest succeeds, matching
         // the catch-up drain below. Marking at receive time would let a failed
         // ingest poison the index, so a reused client would silently skip the
-        // redelivered event.
-        self.remember_seen_event(event_id);
+        // redelivered event — and an `Ok` the engine refused unpersisted is
+        // just as much a not-durable ingest as an `Err` is.
+        if !ingested.must_stay_fetchable {
+            self.remember_seen_event(event_id);
+        }
+        let routes_dirty = ingested.routes_dirty;
         // A membership-changing ingest is already durable. Persist its app
         // projection before route reconciliation or subscription refresh can
         // fail, matching the catch-up checkpoint below.
@@ -1205,11 +1243,11 @@ impl AppClient {
                     .await);
             }
             let mut delivery_summary = SyncSummary::default();
-            let delivery_routes_dirty = match self
+            let ingested = match self
                 .ingest_delivery(delivery, &display_names, &mut delivery_summary)
                 .await
             {
-                Ok(routes_dirty) => routes_dirty,
+                Ok(ingested) => ingested,
                 Err(error) => {
                     return Err(self
                         .finish_failed_sync_drain(
@@ -1223,10 +1261,15 @@ impl AppClient {
                         .await);
                 }
             };
-            self.remember_seen_event(event_id);
+            // Same rule as the receive seam above: an object the engine refused
+            // unpersisted must stay fetchable, so the relay re-serves it on a
+            // later drain instead of this one skipping it as already seen.
+            if !ingested.must_stay_fetchable {
+                self.remember_seen_event(event_id);
+            }
             counts.deliveries = counts.deliveries.saturating_add(1);
             summary.merge(delivery_summary);
-            routes_dirty |= delivery_routes_dirty;
+            routes_dirty |= ingested.routes_dirty;
         };
 
         if let Err(error) = self
@@ -1373,17 +1416,24 @@ impl AppClient {
         delivery: cgka_traits::TransportDelivery,
         display_names: &HashMap<String, String>,
         summary: &mut SyncSummary,
-    ) -> Result<bool, AppError> {
+    ) -> Result<DeliveryIngest, AppError> {
         let source_message_id_hex = hex::encode(delivery.message.id.as_slice());
         let outer_transport_at = delivery.message.timestamp.0;
         let source_received_at = delivery.received_at.0;
         let group_id_hint = delivery.group_id_hint.clone();
         let effects = self.runtime.ingest_delivery(delivery).await?;
         let publish_error = fail_if_publish_failed(&effects.effects).err();
+        let must_stay_fetchable = ingest_left_object_unpersisted(&effects.outcome);
         self.remember_buffered_convergence_outcome(&effects.outcome);
         self.remember_pending_convergence_groups(&effects.effects);
         self.observe_recovery_evidence(&effects.effects);
-        self.remember_transport_cursor(outer_transport_at);
+        if !must_stay_fetchable {
+            // Scope fence: a `TransportDeferred` object *is* durably retained,
+            // so it advances the floor here. Whether a retained-but-unapplied
+            // object should instead hold the floor back until it converges is
+            // the separate since-floor design item, not this seam's call.
+            self.remember_transport_cursor(outer_transport_at);
+        }
         self.detect_epoch_stall(group_id_hint, &source_message_id_hex, &effects.outcome);
         // A delivery can contain several application events. If projection
         // fails after an earlier event staged its acknowledgement, keep that
@@ -1440,7 +1490,10 @@ impl AppClient {
                 "incidental auto-publish failed after inbound effects were projected"
             );
         }
-        Ok(routes_dirty)
+        Ok(DeliveryIngest {
+            routes_dirty,
+            must_stay_fetchable,
+        })
     }
 
     /// Feed an unavailable group delivery to the epoch-stall detector.

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -1735,6 +1735,27 @@ impl AppClient {
         );
     }
 
+    /// Complete an execution the way a served end-of-stored-events drain does,
+    /// with the delivery count whose effect on the disarm rule is under test.
+    #[cfg(test)]
+    pub(crate) fn test_complete_epoch_backfill_execution(
+        &mut self,
+        execution: EpochBackfillExecution,
+        deliveries: u64,
+    ) {
+        self.finish_epoch_backfill_execution(
+            execution,
+            EpochBackfillActivationOutcome::Succeeded,
+            None,
+            Some(EpochBackfillCompletionKind::EndOfStoredEvents),
+            DrainCounts {
+                deliveries,
+                skipped: 0,
+            },
+            true,
+        );
+    }
+
     fn local_epoch_for_group(&self, group_id: &cgka_traits::GroupId) -> Option<u64> {
         self.runtime
             .group_record(group_id)
@@ -1833,10 +1854,50 @@ impl AppClient {
             },
         );
         if succeeded {
-            self.epoch_stall.mark_replayed();
+            if Self::replay_recovered_something(&execution.epochs_before, &epochs_after, counts) {
+                self.epoch_stall.mark_replayed();
+            }
         } else {
             self.requeue_failed_epoch_backfill_intent(execution.pending);
         }
+    }
+
+    /// Whether a completed replay recovered anything, and has therefore earned
+    /// the account-wide disarm.
+    ///
+    /// [`mark_replayed`](super::epoch_stall::EpochStallDetector::mark_replayed)
+    /// latches `fired_at_epoch` for every
+    /// *tracked* group, not just the armed one — the right trade when one
+    /// full-history replay really did serve every group's history, and a silent
+    /// end to all automatic recovery when it served nothing. Two independent
+    /// proofs, either of which is enough:
+    ///
+    /// - the drain ingested at least one delivery. A delivery can convert into
+    ///   an epoch long after this call returns — one field run drained 376
+    ///   deliveries and moved its epoch a second *after* the terminal row was
+    ///   written — so `epochs_after`, read the moment the drain ends, must never
+    ///   second-guess a delivery count. Deliveries parked awaiting convergence
+    ///   are recovery in flight.
+    /// - a tracked group's local epoch advanced across the run, which is what a
+    ///   zero-delivery replay whose value was letting already-deferred rows
+    ///   converge looks like.
+    ///
+    /// A run that proves neither is fruitless. It is still recorded as the
+    /// completed end-of-stored-events attempt it was and still consumes its
+    /// intent — the pacing and intent-consumption rules are untouched. What it
+    /// must not do is stop the next refusal or undecryptable from arming a fresh
+    /// replay.
+    fn replay_recovered_something(
+        epochs_before: &HashMap<cgka_traits::GroupId, u64>,
+        epochs_after: &HashMap<cgka_traits::GroupId, u64>,
+        counts: DrainCounts,
+    ) -> bool {
+        counts.deliveries > 0
+            || epochs_after.iter().any(|(group_id, after)| {
+                epochs_before
+                    .get(group_id)
+                    .is_some_and(|before| after > before)
+            })
     }
 
     fn record_epoch_backfill_terminal_rows(

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -183,6 +183,22 @@ fn ingest_left_object_unpersisted(outcome: &IngestOutcome) -> bool {
 pub(crate) struct DrainCounts {
     pub(crate) deliveries: u64,
     pub(crate) skipped: u64,
+    /// The subset of `deliveries` the engine refused unpersisted. Nested inside
+    /// `deliveries` rather than beside it: the receive really was ingested, and
+    /// `deliveries` keeps the audit meaning the field exports already depend
+    /// on. [`DrainCounts::durable_deliveries`] is the count that answers "did
+    /// this drain recover anything".
+    pub(crate) refused: u64,
+}
+
+impl DrainCounts {
+    /// Deliveries this drain ingested *and* the engine kept. A drain whose
+    /// every delivery was refused fetched history it could not retain, which is
+    /// no recovery at all — the objects stay fetchable (they are neither marked
+    /// seen nor allowed past the cursor) but nothing durably landed.
+    fn durable_deliveries(self) -> u64 {
+        self.deliveries.saturating_sub(self.refused)
+    }
 }
 
 /// What the convergence scheduler should do next for a group, derived from
@@ -1263,8 +1279,11 @@ impl AppClient {
             };
             // Same rule as the receive seam above: an object the engine refused
             // unpersisted must stay fetchable, so the relay re-serves it on a
-            // later drain instead of this one skipping it as already seen.
-            if !ingested.must_stay_fetchable {
+            // later drain instead of this one skipping it as already seen. The
+            // same flag is the refusal count, so one rule decides both.
+            if ingested.must_stay_fetchable {
+                counts.refused = counts.refused.saturating_add(1);
+            } else {
                 self.remember_seen_event(event_id);
             }
             counts.deliveries = counts.deliveries.saturating_add(1);
@@ -1281,8 +1300,7 @@ impl AppClient {
             let (summary, source) = self.checkpoint_failure_summary(summary, error);
             self.record_sync_drain(
                 drain_started.elapsed().as_millis() as u64,
-                counts.deliveries,
-                counts.skipped,
+                *counts,
                 cursor_before_secs,
                 cursor_after_secs,
             );
@@ -1290,8 +1308,7 @@ impl AppClient {
         }
         self.record_sync_drain(
             drain_started.elapsed().as_millis() as u64,
-            counts.deliveries,
-            counts.skipped,
+            *counts,
             cursor_before_secs,
             self.state.last_transport_timestamp,
         );
@@ -1327,8 +1344,7 @@ impl AppClient {
         };
         self.record_sync_drain(
             drain_started.elapsed().as_millis() as u64,
-            counts.deliveries,
-            counts.skipped,
+            counts,
             cursor_before_secs,
             cursor_after_secs,
         );
@@ -1736,12 +1752,13 @@ impl AppClient {
     }
 
     /// Complete an execution the way a served end-of-stored-events drain does,
-    /// with the delivery count whose effect on the disarm rule is under test.
+    /// with the delivery counts whose effect on the disarm rule is under test.
     #[cfg(test)]
     pub(crate) fn test_complete_epoch_backfill_execution(
         &mut self,
         execution: EpochBackfillExecution,
         deliveries: u64,
+        refused: u64,
     ) {
         self.finish_epoch_backfill_execution(
             execution,
@@ -1751,6 +1768,7 @@ impl AppClient {
             DrainCounts {
                 deliveries,
                 skipped: 0,
+                refused,
             },
             true,
         );
@@ -1872,12 +1890,16 @@ impl AppClient {
     /// end to all automatic recovery when it served nothing. Two independent
     /// proofs, either of which is enough:
     ///
-    /// - the drain ingested at least one delivery. A delivery can convert into
-    ///   an epoch long after this call returns — one field run drained 376
+    /// - the drain ingested at least one delivery the engine *kept*
+    ///   ([`DrainCounts::durable_deliveries`]). A delivery can convert into an
+    ///   epoch long after this call returns — one field run drained 376
     ///   deliveries and moved its epoch a second *after* the terminal row was
     ///   written — so `epochs_after`, read the moment the drain ends, must never
     ///   second-guess a delivery count. Deliveries parked awaiting convergence
-    ///   are recovery in flight.
+    ///   are recovery in flight. Refused ones are not: the engine dropped them
+    ///   unpersisted, so a drain that refused everything it fetched recovered
+    ///   nothing and must not disarm anything. A mixed drain still counts —
+    ///   one kept delivery is progress.
     /// - a tracked group's local epoch advanced across the run, which is what a
     ///   zero-delivery replay whose value was letting already-deferred rows
     ///   converge looks like.
@@ -1892,7 +1914,7 @@ impl AppClient {
         epochs_after: &HashMap<cgka_traits::GroupId, u64>,
         counts: DrainCounts,
     ) -> bool {
-        counts.deliveries > 0
+        counts.durable_deliveries() > 0
             || epochs_after.iter().any(|(group_id, after)| {
                 epochs_before
                     .get(group_id)
@@ -1930,6 +1952,7 @@ impl AppClient {
                     completion_kind: outcome.completion_kind,
                     deliveries: outcome.counts.deliveries,
                     skipped: outcome.counts.skipped,
+                    refused: outcome.counts.refused,
                     local_epoch_before,
                     local_epoch_after,
                     group_advanced,

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -1685,6 +1685,163 @@ fn epoch_backfill_without_relay_end_of_stored_events_stays_pending() {
     });
 }
 
+/// A tracked group stalled below the arm threshold, so `mark_replayed` is the
+/// only thing that can stop it from arming when its next undecryptable lands.
+///
+/// Returned by the disarm tests below as the probe they read the detector
+/// through: the armed group's own `arm()` has already latched its epoch, so a
+/// bystander is the only place the disarm rule is observable.
+fn bystander_stalled_below_threshold(
+    client: &mut crate::AppClient,
+    stalled_epoch: u64,
+) -> cgka_traits::GroupId {
+    let bystander = cgka_traits::GroupId::new(vec![7_u8; 32]);
+    for probe in 0..EPOCH_STALL_BACKFILL_THRESHOLD - 1 {
+        assert_eq!(
+            client.epoch_stall.observe_undecryptable(
+                bystander.clone(),
+                format!("bystander-{probe}"),
+                cgka_traits::EpochId(stalled_epoch),
+            ),
+            BackfillDecision::Skip,
+        );
+    }
+    bystander
+}
+
+/// The threshold-crossing undecryptable for [`bystander_stalled_below_threshold`].
+fn bystander_crosses_threshold(
+    client: &mut crate::AppClient,
+    bystander: cgka_traits::GroupId,
+    stalled_epoch: u64,
+) -> BackfillDecision {
+    client.epoch_stall.observe_undecryptable(
+        bystander,
+        "bystander-threshold".to_owned(),
+        cgka_traits::EpochId(stalled_epoch),
+    )
+}
+
+/// A replay that completed but recovered nothing must not disarm the detector.
+///
+/// `mark_replayed` latches `fired_at_epoch` for *every* tracked group, which is
+/// the right trade when one account-wide replay really did serve every group's
+/// history. A drain that ended at end-of-stored-events having ingested nothing,
+/// with no tracked group's epoch moving, served nothing — so latching on it ends
+/// all automatic recovery for the process lifetime, silently. The run is still
+/// recorded honestly and still consumes its intent; only the disarm is withheld.
+#[test]
+fn a_completed_backfill_that_recovered_nothing_does_not_disarm_the_detector() {
+    run_composed_app_runtime_test("backfill-fruitless-no-disarm", || async {
+        let dir = tempfile::tempdir().unwrap();
+        let relay = Arc::new(ScriptedPushRelayClient::default());
+        let (app, mut client, group_id) =
+            armed_epoch_backfill(&dir, &relay, backfill_drain_test_config()).await;
+        let stalled_epoch = client.group_mls_state(&group_id).unwrap().epoch;
+        let bystander = bystander_stalled_below_threshold(&mut client, stalled_epoch);
+
+        let execution = client
+            .begin_epoch_backfill_execution(
+                marmot_forensics::EpochBackfillExecutionSeam::Maintenance,
+            )
+            .expect("the armed intent must begin execution");
+        client.test_complete_epoch_backfill_execution(execution, 0);
+
+        assert_eq!(
+            bystander_crosses_threshold(&mut client, bystander, stalled_epoch),
+            BackfillDecision::Arm,
+            "a replay that recovered nothing must not disarm a group it never recovered",
+        );
+        assert!(
+            !client.has_pending_epoch_backfill(),
+            "the completed run still consumes its intent; only the disarm is withheld",
+        );
+        drop(client);
+
+        let rows = recorded_audit_rows(&app);
+        let completed = recorded_rows_of_kind(&rows, "epoch_stall_backfill_completed");
+        assert_eq!(
+            completed.len(),
+            1,
+            "a fruitless run is still recorded as the completed attempt it was",
+        );
+        assert_eq!(completed[0]["kind"]["deliveries"], 0);
+        assert_eq!(
+            completed[0]["kind"]["completion_kind"].as_str(),
+            Some("end_of_stored_events"),
+        );
+    });
+}
+
+/// A zero-delivery replay after which a tracked group's epoch moved is genuine
+/// success: the value of the replay was letting already-deferred rows converge,
+/// and that is exactly what the epoch delta reports.
+#[test]
+fn a_backfill_whose_epoch_moved_still_disarms_the_detector() {
+    run_composed_app_runtime_test("backfill-epoch-moved-disarms", || async {
+        let dir = tempfile::tempdir().unwrap();
+        let relay = Arc::new(ScriptedPushRelayClient::default());
+        let (_app, mut client, group_id) =
+            armed_epoch_backfill(&dir, &relay, backfill_drain_test_config()).await;
+        let stalled_epoch = client.group_mls_state(&group_id).unwrap().epoch;
+        let bystander = bystander_stalled_below_threshold(&mut client, stalled_epoch);
+
+        let execution = client
+            .begin_epoch_backfill_execution(
+                marmot_forensics::EpochBackfillExecutionSeam::Maintenance,
+            )
+            .expect("the armed intent must begin execution");
+        client
+            .update_group_profile(&group_id, Some("moved during the replay"), None)
+            .await
+            .expect("a solo group's commit confirms locally");
+        assert!(
+            client.group_mls_state(&group_id).unwrap().epoch > stalled_epoch,
+            "the armed group's epoch must have moved across the run",
+        );
+        client.test_complete_epoch_backfill_execution(execution, 0);
+
+        assert_eq!(
+            bystander_crosses_threshold(&mut client, bystander, stalled_epoch),
+            BackfillDecision::Skip,
+            "a replay that moved a tracked group's epoch has earned the account-wide disarm",
+        );
+    });
+}
+
+/// A replay that ingested deliveries has earned the disarm even with every
+/// tracked epoch still where it started.
+///
+/// The epoch is read the moment the drain returns, and a delivery it ingested
+/// can convert into an epoch long after that — one field run drained 376
+/// deliveries and moved its epoch a second *after* the terminal row was written.
+/// So a delivery count is never second-guessed by an epoch read taken this
+/// early: the deliveries are parked awaiting convergence, not lost.
+#[test]
+fn a_backfill_that_ingested_deliveries_still_disarms_the_detector() {
+    run_composed_app_runtime_test("backfill-deliveries-disarm", || async {
+        let dir = tempfile::tempdir().unwrap();
+        let relay = Arc::new(ScriptedPushRelayClient::default());
+        let (_app, mut client, group_id) =
+            armed_epoch_backfill(&dir, &relay, backfill_drain_test_config()).await;
+        let stalled_epoch = client.group_mls_state(&group_id).unwrap().epoch;
+        let bystander = bystander_stalled_below_threshold(&mut client, stalled_epoch);
+
+        let execution = client
+            .begin_epoch_backfill_execution(
+                marmot_forensics::EpochBackfillExecutionSeam::Maintenance,
+            )
+            .expect("the armed intent must begin execution");
+        client.test_complete_epoch_backfill_execution(execution, 1);
+
+        assert_eq!(
+            bystander_crosses_threshold(&mut client, bystander, stalled_epoch),
+            BackfillDecision::Skip,
+            "an ingested delivery is recovery in flight, not a fruitless run",
+        );
+    });
+}
+
 #[test]
 fn epoch_backfill_drain_needs_every_subscription_to_report() {
     run_composed_app_runtime_test("backfill-drain-partial-eose", || async {

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -1745,7 +1745,7 @@ fn a_completed_backfill_that_recovered_nothing_does_not_disarm_the_detector() {
                 marmot_forensics::EpochBackfillExecutionSeam::Maintenance,
             )
             .expect("the armed intent must begin execution");
-        client.test_complete_epoch_backfill_execution(execution, 0);
+        client.test_complete_epoch_backfill_execution(execution, 0, 0);
 
         assert_eq!(
             bystander_crosses_threshold(&mut client, bystander, stalled_epoch),
@@ -1769,6 +1769,106 @@ fn a_completed_backfill_that_recovered_nothing_does_not_disarm_the_detector() {
         assert_eq!(
             completed[0]["kind"]["completion_kind"].as_str(),
             Some("end_of_stored_events"),
+        );
+    });
+}
+
+/// A replay whose every delivery was refused recovered nothing, and must not
+/// disarm the detector — the end-to-end shape of the review finding.
+///
+/// This is the drain that hurts most in the field: the relays serve the exact
+/// history the device is missing, the engine's retention cap is full, and every
+/// object is dropped unpersisted. `deliveries` counts them (a receive really was
+/// ingested, and #1553 pinned that meaning for the field exports), so keying the
+/// disarm on `deliveries` alone read a total loss as a productive replay.
+/// `deliveries - refused` is the count that answers "did anything land".
+#[test]
+fn a_backfill_whose_every_delivery_was_refused_does_not_disarm_the_detector() {
+    run_composed_app_runtime_test("backfill-all-refusals", || async {
+        let dir = tempfile::tempdir().unwrap();
+        let relay = Arc::new(ScriptedPushRelayClient::default());
+        let filled_through = crate::unix_now_seconds() - 1_000;
+        let (app, mut client, route) = group_at_the_undecryptable_retention_cap_with_config(
+            &dir,
+            &relay,
+            backfill_drain_test_config(),
+            filled_through,
+        )
+        .await;
+        let stalled_epoch = client.group_mls_state(&route.group_id).unwrap().epoch;
+        let bystander = bystander_stalled_below_threshold(&mut client, stalled_epoch);
+
+        client.apply_backfill_decision(
+            &route.group_id,
+            stalled_epoch,
+            BackfillDecision::Arm,
+            marmot_forensics::EpochStallBackfillTrigger::ResourceRefusal,
+        );
+        let attempt_id = client
+            .pending_epoch_backfill
+            .as_ref()
+            .expect("the refusal must arm one recovery intent")
+            .attempt_id
+            .clone();
+
+        // The relays have the history and serve it; the engine's retention cap
+        // is full, so the replay fetches it and cannot keep any of it.
+        inject_epoch_gap_probe(
+            &app,
+            epoch_gap_probe(
+                &route.nostr_group_id_hex,
+                filled_through + 500,
+                "refused-during-the-replay",
+            ),
+        )
+        .await;
+        let _eose = scripted_eose_pump(app.relay_plane.clone(), relay.clone(), every_subscription);
+        let outcome = client
+            .run_pending_epoch_backfill(marmot_forensics::EpochBackfillExecutionSeam::Maintenance)
+            .await
+            .expect("the armed replay must run");
+        assert!(
+            matches!(outcome, crate::EpochBackfillRunOutcome::Completed(_)),
+            "a served end-of-stored-events drain is a completed replay, fruitless or not",
+        );
+
+        assert_eq!(
+            bystander_crosses_threshold(&mut client, bystander, stalled_epoch),
+            BackfillDecision::Arm,
+            "a replay that kept none of what it fetched must not disarm a bystander group",
+        );
+        assert!(
+            !client
+                .queued_epoch_backfills
+                .iter()
+                .chain(client.pending_epoch_backfill.iter())
+                .any(|pending| pending.attempt_id == attempt_id),
+            "the completed run still consumes its own intent; only the disarm is withheld",
+        );
+
+        drop(client);
+        let rows = recorded_audit_rows(&app);
+        let completed = recorded_rows_of_kind(&rows, "epoch_stall_backfill_completed");
+        assert_eq!(completed.len(), 1, "the run records one terminal row");
+        assert_eq!(
+            completed[0]["kind"]["completion_kind"].as_str(),
+            Some("end_of_stored_events"),
+            "the row stays honest about how the drain ended",
+        );
+        let deliveries = completed[0]["kind"]["deliveries"].as_u64();
+        assert_eq!(
+            (deliveries, completed[0]["kind"]["refused"].as_u64()),
+            (Some(1), Some(1)),
+            "the row must self-report cap saturation: every delivery refused",
+        );
+        // And the ordinary drain rows carry the same evidence, so a field export
+        // can read per-drain saturation without reconstructing it from raw
+        // `ingest_outcome` rows.
+        assert!(
+            recorded_rows_of_kind(&rows, "sync_drain")
+                .iter()
+                .any(|row| row["kind"]["refused"].as_u64() == Some(1)),
+            "the drain row must carry the refusal count too",
         );
     });
 }
@@ -1799,7 +1899,7 @@ fn a_backfill_whose_epoch_moved_still_disarms_the_detector() {
             client.group_mls_state(&group_id).unwrap().epoch > stalled_epoch,
             "the armed group's epoch must have moved across the run",
         );
-        client.test_complete_epoch_backfill_execution(execution, 0);
+        client.test_complete_epoch_backfill_execution(execution, 0, 0);
 
         assert_eq!(
             bystander_crosses_threshold(&mut client, bystander, stalled_epoch),
@@ -1832,12 +1932,13 @@ fn a_backfill_that_ingested_deliveries_still_disarms_the_detector() {
                 marmot_forensics::EpochBackfillExecutionSeam::Maintenance,
             )
             .expect("the armed intent must begin execution");
-        client.test_complete_epoch_backfill_execution(execution, 1);
+        // One delivery, none of it refused: a delivery the engine kept.
+        client.test_complete_epoch_backfill_execution(execution, 1, 0);
 
         assert_eq!(
             bystander_crosses_threshold(&mut client, bystander, stalled_epoch),
             BackfillDecision::Skip,
-            "an ingested delivery is recovery in flight, not a fruitless run",
+            "a delivery the engine kept is recovery in flight, not a fruitless run",
         );
     });
 }
@@ -11673,13 +11774,29 @@ async fn group_at_the_undecryptable_retention_cap(
     dir: &tempfile::TempDir,
     filled_through: u64,
 ) -> (MarmotApp, crate::AppClient, UndecryptableProbeRoute) {
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    group_at_the_undecryptable_retention_cap_with_config(
+        dir,
+        &relay,
+        MarmotAppConfig::default(),
+        filled_through,
+    )
+    .await
+}
+
+async fn group_at_the_undecryptable_retention_cap_with_config(
+    dir: &tempfile::TempDir,
+    relay: &Arc<ScriptedPushRelayClient>,
+    config: MarmotAppConfig,
+    filled_through: u64,
+) -> (MarmotApp, crate::AppClient, UndecryptableProbeRoute) {
     let account_id_hex = AccountHome::open(dir.path())
         .create_account("alice")
         .unwrap()
         .account_id_hex;
-    let relay = Arc::new(ScriptedPushRelayClient::default());
-    let mut app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
-        .with_test_relay_client(relay.clone());
+    let mut app =
+        MarmotApp::with_relay_and_config(dir.path(), "wss://relay.example".to_owned(), config)
+            .with_test_relay_client(relay.clone());
     app.set_audit_log_settings(crate::AuditLogSettings {
         enabled: true,
         ..Default::default()

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -11470,6 +11470,282 @@ async fn a_failed_ingest_leaves_the_delivery_retryable_on_the_reused_client() {
         "the failed delivery's message must be durably projected exactly once",
     );
 }
+/// A group whose per-group retained-undecryptable backlog is exactly full, plus
+/// everything a test needs to mint one more undecryptable delivery for it.
+///
+/// `cgka_engine::message_processor::MAX_PEEL_DEFERRED_ROWS_PER_GROUP` is the
+/// only way to reach `IngestOutcome::ResourceRefused`: the engine offers no
+/// knob for the cap, so the backlog is filled for real. Below the cap an
+/// unpeelable object is *retained* (`TransportDeferred`); at it the engine drops
+/// the object unpersisted and keeps its id out of its own seen cache, so
+/// transport redelivery is the only path back to it.
+struct UndecryptableProbeRoute {
+    account_id_hex: String,
+    group_id: cgka_traits::GroupId,
+    nostr_group_id_hex: String,
+}
+
+impl UndecryptableProbeRoute {
+    /// One kind-445 delivery for this group's route whose body cannot peel.
+    fn probe(&self, created_at: u64, marker: &str) -> cgka_traits::TransportDelivery {
+        cgka_traits::TransportDelivery {
+            account_id: MemberId::new(hex::decode(&self.account_id_hex).unwrap()),
+            group_id_hint: Some(self.group_id.clone()),
+            message: epoch_gap_probe(&self.nostr_group_id_hex, created_at, marker)
+                .to_transport_message()
+                .expect("probe converts to a transport message"),
+            received_at: cgka_traits::transport::Timestamp(created_at),
+            source: cgka_traits::TransportDeliverySource {
+                transport: cgka_traits::transport::TransportSource("nostr".to_owned()),
+                plane: cgka_traits::TransportDeliveryPlane::Group,
+                endpoint: None,
+                subscription_id: None,
+                wire: None,
+            },
+        }
+    }
+}
+
+/// Build [`UndecryptableProbeRoute`]'s group and fill its retained-undecryptable
+/// backlog to the cap, on an app whose relay plane accepts injected events.
+///
+/// Every filling probe is dated `filled_through` so a later probe's effect on
+/// the transport cursor is unambiguous, and each is ingested through the receive
+/// seam because that is the cheapest way to reach the engine 256 times.
+async fn group_at_the_undecryptable_retention_cap(
+    dir: &tempfile::TempDir,
+    filled_through: u64,
+) -> (MarmotApp, crate::AppClient, UndecryptableProbeRoute) {
+    let account_id_hex = AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap()
+        .account_id_hex;
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let mut app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+        .with_test_relay_client(relay.clone());
+    app.set_audit_log_settings(crate::AuditLogSettings {
+        enabled: true,
+        ..Default::default()
+    })
+    .unwrap();
+    app.relay_plane =
+        MarmotRelayPlane::new_with_loopback(Some(Duration::from_secs(120)), relay.clone(), true);
+
+    let mut client = client_on_app_relay_plane(&app, "alice").await;
+    let group_id = client
+        .create_group("undecryptable retention cap", &[])
+        .await
+        .unwrap();
+    let nostr_group_id_hex = app
+        .group("alice", &hex::encode(group_id.as_slice()))
+        .unwrap()
+        .expect("local group projection")
+        .nostr_routing
+        .nostr_group_id_hex;
+    let route = UndecryptableProbeRoute {
+        account_id_hex,
+        group_id,
+        nostr_group_id_hex,
+    };
+
+    for row in 0..cgka_engine::message_processor::MAX_PEEL_DEFERRED_ROWS_PER_GROUP {
+        client
+            .ingest_received_delivery(route.probe(filled_through, &format!("cap-fill-{row}")))
+            .await
+            .expect("a retained undecryptable object completes its ingest pass");
+    }
+    assert_eq!(
+        client.state.last_transport_timestamp,
+        Some(filled_through),
+        "the retained probes must have advanced the cursor to their own timestamp",
+    );
+    (app, client, route)
+}
+
+/// Every `ingest_outcome` audit row the engine recorded for `msg_id`.
+fn recorded_ingest_outcomes(app: &MarmotApp, msg_id: &str) -> Vec<String> {
+    recorded_audit_rows(app)
+        .iter()
+        .filter(|row| row["kind"]["type"] == "ingest_outcome")
+        .filter(|row| row["kind"]["msg_id"].as_str() == Some(msg_id))
+        .filter_map(|row| row["kind"]["outcome_kind"].as_str().map(ToOwned::to_owned))
+        .collect()
+}
+
+/// A refused object must stay fetchable: the receive seam may neither mark it
+/// seen nor let it advance the relay `since` cursor.
+///
+/// `IngestOutcome::ResourceRefused` is an `Ok` the engine deliberately leaves
+/// unpersisted — it suppresses its own seen-cache insertion so "same-id
+/// redelivery is not a duplicate". Marking it seen here defeats that: the id is
+/// persisted in `seen_events` with no removal site short of ring overflow, and
+/// the advanced cursor puts the object below the next subscription's `since`
+/// floor, so the message becomes permanently unfetchable across restarts and
+/// even across `repair_full_history`.
+#[test]
+fn a_refused_delivery_is_neither_marked_seen_nor_allowed_to_advance_the_cursor() {
+    run_composed_app_runtime_test("refused-ingest-receive-seam", || async {
+        let dir = tempfile::tempdir().unwrap();
+        let filled_through = crate::unix_now_seconds() - 1_000;
+        let (app, mut client, route) =
+            group_at_the_undecryptable_retention_cap(&dir, filled_through).await;
+
+        // Minted once and cloned, so the redelivery below is byte-identical:
+        // a re-minted probe would carry a fresh ephemeral key and a fresh id.
+        let refused = route.probe(filled_through + 500, "refused-at-the-cap");
+        let refused_id = hex::encode(refused.message.id.as_slice());
+        client
+            .ingest_received_delivery(refused.clone())
+            .await
+            .expect("a refused object still completes its ingest pass");
+
+        assert_eq!(
+            recorded_ingest_outcomes(&app, &refused_id),
+            vec!["resource_refused".to_owned()],
+            "the backlog must be full, so this object is refused rather than retained",
+        );
+        assert!(
+            !client.seen_events_index.contains(&refused_id),
+            "a refused object is not durably ingested, so it must not be marked seen",
+        );
+        assert!(
+            !client.state.seen_events.contains(&refused_id),
+            "nor persisted into the durable seen-events ring",
+        );
+        assert_eq!(
+            client.state.last_transport_timestamp,
+            Some(filled_through),
+            "a refused object must not carry the relay `since` floor past itself",
+        );
+
+        // The unstick proof: the relay redelivers, and the reused client hands
+        // the object to the engine again instead of skipping it as seen. It is
+        // still refused — the backlog is still full — which is itself the
+        // evidence that the engine reclassified it rather than deduplicating it.
+        client
+            .ingest_received_delivery(refused)
+            .await
+            .expect("the redelivered object must reach the engine again");
+        assert_eq!(
+            recorded_ingest_outcomes(&app, &refused_id),
+            vec!["resource_refused".to_owned(), "resource_refused".to_owned()],
+            "the redelivery must be reclassified, never deduplicated away",
+        );
+        assert!(
+            !client.seen_events_index.contains(&refused_id),
+            "and it stays fetchable for as long as the engine keeps refusing it",
+        );
+    });
+}
+
+/// The fence: a `TransportDeferred` object *is* durably retained by the engine,
+/// so marking it seen is correct dedupe and stays. Only the unpersisted refusal
+/// is exempt.
+#[test]
+fn a_transport_deferred_delivery_is_still_marked_seen() {
+    run_composed_app_runtime_test("transport-deferred-marks-seen", || async {
+        let dir = tempfile::tempdir().unwrap();
+        let account_id_hex = AccountHome::open(dir.path())
+            .create_account("alice")
+            .unwrap()
+            .account_id_hex;
+        let relay = Arc::new(ScriptedPushRelayClient::default());
+        let mut app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+            .with_test_relay_client(relay.clone());
+        app.set_audit_log_settings(crate::AuditLogSettings {
+            enabled: true,
+            ..Default::default()
+        })
+        .unwrap();
+        app.relay_plane = MarmotRelayPlane::new_with_loopback(
+            Some(Duration::from_secs(120)),
+            relay.clone(),
+            true,
+        );
+        let mut client = client_on_app_relay_plane(&app, "alice").await;
+        let group_id = client.create_group("deferred fence", &[]).await.unwrap();
+        let route = UndecryptableProbeRoute {
+            account_id_hex,
+            nostr_group_id_hex: app
+                .group("alice", &hex::encode(group_id.as_slice()))
+                .unwrap()
+                .expect("local group projection")
+                .nostr_routing
+                .nostr_group_id_hex,
+            group_id,
+        };
+
+        let created_at = crate::unix_now_seconds() - 1_000;
+        let deferred = route.probe(created_at, "retained-below-the-cap");
+        let deferred_id = hex::encode(deferred.message.id.as_slice());
+        client
+            .ingest_received_delivery(deferred)
+            .await
+            .expect("a retained undecryptable object completes its ingest pass");
+
+        assert_eq!(
+            recorded_ingest_outcomes(&app, &deferred_id),
+            vec!["transport_deferred".to_owned()],
+            "below the cap the engine retains the object durably",
+        );
+        assert!(
+            client.seen_events_index.contains(&deferred_id),
+            "a durably retained object must still be deduplicated by the seen index",
+        );
+        assert_eq!(
+            client.state.last_transport_timestamp,
+            Some(created_at),
+            "and it still carries the relay `since` floor forward",
+        );
+    });
+}
+
+/// The same rule at the catch-up drain seam: a refused delivery must leave both
+/// the seen index and the transport cursor untouched there too, so the relay
+/// re-serves it on the next drain instead of the app skipping it.
+#[test]
+fn a_refused_delivery_stays_fetchable_through_the_catch_up_drain() {
+    run_composed_app_runtime_test("refused-ingest-drain-seam", || async {
+        let dir = tempfile::tempdir().unwrap();
+        let filled_through = crate::unix_now_seconds() - 1_000;
+        let (app, mut client, route) =
+            group_at_the_undecryptable_retention_cap(&dir, filled_through).await;
+
+        let refused = epoch_gap_probe(
+            &route.nostr_group_id_hex,
+            filled_through + 500,
+            "refused-in-the-drain",
+        );
+        let refused_id = refused.id.clone();
+        inject_epoch_gap_probe(&app, refused.clone()).await;
+        client.sync().await.expect("the drain must complete");
+
+        assert_eq!(
+            recorded_ingest_outcomes(&app, &refused_id),
+            vec!["resource_refused".to_owned()],
+            "the backlog must be full, so the drain's object is refused",
+        );
+        assert!(
+            !client.seen_events_index.contains(&refused_id),
+            "the drain must not mark a refused object seen",
+        );
+        assert_eq!(
+            client.state.last_transport_timestamp,
+            Some(filled_through),
+            "nor carry the relay `since` floor past it",
+        );
+
+        // The relay re-serves it on the next drain, and the drain ingests it
+        // again rather than counting it as an already-seen skip.
+        inject_epoch_gap_probe(&app, refused).await;
+        client.sync().await.expect("the second drain must complete");
+        assert_eq!(
+            recorded_ingest_outcomes(&app, &refused_id),
+            vec!["resource_refused".to_owned(), "resource_refused".to_owned()],
+            "the re-served object must reach the engine again",
+        );
+    });
+}
 
 /// Every SQLite database this app can open, plus the root runtime lease, must
 /// be released by one `close_storage` call — that is the whole contract iOS

--- a/crates/marmot-forensics/schema/audit-log-event.v2.schema.json
+++ b/crates/marmot-forensics/schema/audit-log-event.v2.schema.json
@@ -1661,6 +1661,9 @@
             "skipped": {
               "$ref": "#/$defs/u64"
             },
+            "refused": {
+              "$ref": "#/$defs/u64"
+            },
             "cursor_before_secs": {
               "$ref": "#/$defs/u64"
             },
@@ -1742,6 +1745,9 @@
             "skipped": {
               "$ref": "#/$defs/u64"
             },
+            "refused": {
+              "$ref": "#/$defs/u64"
+            },
             "local_epoch_before": {
               "$ref": "#/$defs/u64"
             },
@@ -1786,6 +1792,9 @@
               "$ref": "#/$defs/u64"
             },
             "skipped": {
+              "$ref": "#/$defs/u64"
+            },
+            "refused": {
               "$ref": "#/$defs/u64"
             },
             "local_epoch_before": {

--- a/crates/marmot-forensics/src/audit.rs
+++ b/crates/marmot-forensics/src/audit.rs
@@ -1070,6 +1070,18 @@ pub enum AuditEventKind {
         /// field existed stay readable; absent means "not recorded", not zero.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         skipped: Option<u64>,
+        /// The subset of `deliveries` the engine refused under a local resource
+        /// bound (`IngestOutcome::ResourceRefused`) and therefore did not
+        /// retain. Counted inside `deliveries`, not beside it: the delivery was
+        /// received and ingested, and `deliveries` keeps its established
+        /// meaning. `deliveries - refused` is what the drain durably recovered,
+        /// so a run where the two are equal fetched history it could not keep —
+        /// per-drain cap saturation, readable straight off the row instead of
+        /// reconstructed from raw `ingest_outcome` rows. Optional only so rows
+        /// written before this field existed stay readable; absent means "not
+        /// recorded", not zero.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        refused: Option<u64>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         cursor_before_secs: Option<u64>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1132,6 +1144,13 @@ pub enum AuditEventKind {
         /// field existed stay readable; absent means "not recorded", not zero.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         skipped: Option<u64>,
+        /// The subset of `deliveries` the engine refused under a local resource
+        /// bound and therefore did not retain; see
+        /// [`Self::SyncDrain::refused`]. `deliveries - refused` is what this
+        /// replay durably recovered, so a replay whose two counts are equal
+        /// re-fetched history it could not keep and recovered nothing.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        refused: Option<u64>,
         local_epoch_before: u64,
         local_epoch_after: u64,
         group_advanced: bool,
@@ -1155,6 +1174,13 @@ pub enum AuditEventKind {
         /// field existed stay readable; absent means "not recorded", not zero.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         skipped: Option<u64>,
+        /// The subset of `deliveries` the engine refused under a local resource
+        /// bound and therefore did not retain; see
+        /// [`Self::SyncDrain::refused`]. `deliveries - refused` is what this
+        /// replay durably recovered, so a replay whose two counts are equal
+        /// re-fetched history it could not keep and recovered nothing.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        refused: Option<u64>,
         local_epoch_before: u64,
         local_epoch_after: u64,
         group_advanced: bool,

--- a/crates/marmot-forensics/src/audit/tests.rs
+++ b/crates/marmot-forensics/src/audit/tests.rs
@@ -363,6 +363,7 @@ fn sync_drain_round_trips_through_serde() {
         duration_ms: 250,
         deliveries: 3,
         skipped: Some(17),
+        refused: Some(1),
         cursor_before_secs: Some(1_699_999_880),
         cursor_after_secs: Some(1_700_000_000),
     };
@@ -386,6 +387,7 @@ fn sync_drain_round_trips_through_serde() {
         duration_ms: 8,
         deliveries: 0,
         skipped: None,
+        refused: None,
         cursor_before_secs: None,
         cursor_after_secs: None,
     };
@@ -396,6 +398,9 @@ fn sync_drain_round_trips_through_serde() {
     // means "this build did not count", which is not the same claim as "no
     // receive was skipped".
     assert!(!empty_json.contains("skipped"));
+    // Same rule for `refused`: absent is "this build did not count", which is
+    // not the same claim as "no delivery was refused".
+    assert!(!empty_json.contains("refused"));
     assert_eq!(
         serde_json::from_str::<AuditEventKind>(&empty_json).unwrap(),
         empty
@@ -411,6 +416,24 @@ fn sync_drain_round_trips_through_serde() {
             duration_ms: 250,
             deliveries: 3,
             skipped: None,
+            refused: None,
+            cursor_before_secs: None,
+            cursor_after_secs: None,
+        }
+    );
+    // And a row from the build that had `skipped` but not yet `refused` parses
+    // with its recorded skip count intact.
+    let pre_refused: AuditEventKind = serde_json::from_str(
+        r#"{"type":"sync_drain","duration_ms":250,"deliveries":3,"skipped":17}"#,
+    )
+    .expect("a v2 sync_drain row predating `refused` must still parse");
+    assert_eq!(
+        pre_refused,
+        AuditEventKind::SyncDrain {
+            duration_ms: 250,
+            deliveries: 3,
+            skipped: Some(17),
+            refused: None,
             cursor_before_secs: None,
             cursor_after_secs: None,
         }
@@ -901,6 +924,7 @@ fn sample_audit_event_kinds() -> Vec<AuditEventKind> {
             duration_ms: 250,
             deliveries: 3,
             skipped: Some(17),
+            refused: Some(1),
             cursor_before_secs: Some(1_699_999_880),
             cursor_after_secs: Some(1_700_000_000),
         },
@@ -921,6 +945,7 @@ fn sample_audit_event_kinds() -> Vec<AuditEventKind> {
             completion_kind: Some(EpochBackfillCompletionKind::EndOfStoredEvents),
             deliveries: 4,
             skipped: Some(21),
+            refused: Some(0),
             local_epoch_before: 19,
             local_epoch_after: 20,
             group_advanced: true,
@@ -932,6 +957,7 @@ fn sample_audit_event_kinds() -> Vec<AuditEventKind> {
             error_kind: Some("account_transport".into()),
             deliveries: 0,
             skipped: Some(0),
+            refused: Some(0),
             local_epoch_before: 19,
             local_epoch_after: 19,
             group_advanced: false,


### PR DESCRIPTION
## Problem

The engine deliberately keeps a capacity-refused ingest fetchable: it drops the object unpersisted and suppresses its own seen-cache insertion so transport redelivery can recover it. The app layer defeats that one level up — both sync seams mark every Ok outcome seen (under a comment saying "only after durable ingest succeeds"), and the transport cursor advances before the outcome is inspected. A refused message is therefore marked already-seen and pushed below the relay since-floor: permanently unfetchable, and seen_events is persisted with no removal path. Field: in group ae192586 the epoch-15 commit was refused three seconds after the deferred cap filled — inside the recovery drain armed to fetch it — then marked seen; three devices are live-wedged this way (one run shows the relays serving 861 events and the app discarding all of them), while the group ran to epoch 20.

Second, compounding: a backfill that recovers nothing still records success and calls mark_replayed(), silently latching every tracked group's detector for the process lifetime.

## Fix

ingest_delivery now reports whether the engine left the object unpersisted (one rule, one free function, both seams): on ResourceRefused, neither remember_seen_event nor remember_transport_cursor runs, so the relays' natural redelivery heals the device — verified end to end by tests that fill the real 256-row cap and prove the same event is re-presented and re-classified rather than deduped. TransportDeferred (durably retained) still marks seen, pinned by test. Whether deferred ingests should advance the cursor stays with the tracked since-floor design item. One asymmetric case deliberately not exempted: Ignored{UnknownGroup} is non-durable on one engine path but durable on the other and indistinguishable from the app side — un-seeing it risks an unbounded cursor stall; tracked separately.

mark_replayed() is now gated on the replay having recovered something: deliveries ingested, or a tracked group's epoch moving across the run. A fruitless EOSE-confirmed drain still records its honest completed row and consumes its intent, but no longer disarms groups it never recovered. Epoch movement and nonzero deliveries each still disarm — both boundaries pinned, since the field's 121-second recovery drain moved its epoch one second after its terminal row was written.

## Tests

Six, fail-first on the defects: refused deliveries leave the seen index and cursor untouched at both seams and stay fetchable through redelivery; deferred deliveries still mark seen; a recovered-nothing backfill no longer disarms a bystander's arm; epoch-moved and deliveries-ingested runs still disarm. 952 marmot-app tests and the serial relay_runtime suite pass; engine, traits, and storage untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refused deliveries can now be redelivered instead of being incorrectly marked as processed.
  * Recovery remains active after an empty or fully refused replay and only completes when durable progress is made.
  * Consistent behavior is now applied to live receiving and catch-up synchronization.

* **Improvements**
  * Audit records now distinguish refused deliveries from successfully retained deliveries while remaining compatible with older records.

* **Tests**
  * Added coverage for retention, replay behavior, recovery completion, and audit reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->