### PR TITLE
fix(app): recover per-account relay queue overflow

### DIFF
--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -72,7 +72,9 @@ use push::notification_trigger_for_intent;
 // `client::is_own_relay_echo`; the function itself lives in `client::sync`.
 #[cfg(test)]
 pub(crate) use sync::is_own_relay_echo;
-pub(crate) use sync::{ConvergenceScheduleState, EpochBackfillRunOutcome};
+pub(crate) use sync::{
+    ConvergenceScheduleState, DeliveryOverflowRecoveryOutcome, EpochBackfillRunOutcome,
+};
 
 #[cfg(test)]
 const CREATE_GROUP_LOOKUP_CONCURRENCY: usize = 8;

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -349,6 +349,11 @@ pub struct AppClient {
     /// background retry instead of turning the already-applied ingest into an
     /// apparent receive failure.
     pub(crate) pending_runtime_group_subscription_refresh: bool,
+    /// Durable account-wide marker set when the bounded relay-plane queue
+    /// omits a delivery. While true, every subscription rebuild is unfloored
+    /// and EOSE-gated recovery must complete before the cursor is trusted.
+    pub(crate) delivery_overflow_recovery_pending: bool,
+    pub(crate) delivery_overflow_recovery_marker_token: Option<u64>,
     /// Unit-test fault injection for the account-open replay path. This keeps
     /// the live protocol group intact while exercising a missing best-effort
     /// app projection.

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -349,6 +349,11 @@ pub struct AppClient {
     /// background retry instead of turning the already-applied ingest into an
     /// apparent receive failure.
     pub(crate) pending_runtime_group_subscription_refresh: bool,
+    /// Last transport cursor promoted by a completed drain checkpoint. Live
+    /// one-at-a-time worker ingests may advance `state` for diagnostics, but
+    /// they persist this older safe floor until a drain has observed any
+    /// process-local overflow fence/control record.
+    pub(crate) checkpointed_transport_timestamp: Option<u64>,
     /// Durable account-wide marker set when the bounded relay-plane queue
     /// omits a delivery. While true, every subscription rebuild is unfloored
     /// and EOSE-gated recovery must complete before the cursor is trusted.

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -460,7 +460,7 @@ impl AppClient {
             None
         } else {
             self.relay_plane
-                .subscription_rebuild_since(self.state.last_transport_timestamp)
+                .subscription_rebuild_since(self.checkpointed_transport_timestamp)
         }
     }
 
@@ -468,9 +468,9 @@ impl AppClient {
         &mut self,
         overflow: crate::relay_plane::AccountDeliveryOverflow,
     ) -> Result<(), AppError> {
-        // This write precedes any checkpoint of the already-drained prefix.
-        // A crash can therefore leave a conservative recovery marker with an
-        // older cursor, but never a newer cursor without the marker.
+        // The router's process-local fence already froze cursor advancement at
+        // the omission. Re-observe the same token here so the queued signal is
+        // also an idempotent storage boundary before recovery starts.
         self.app
             .account_storage(&self.state.label)?
             .mark_account_delivery_recovery(
@@ -700,13 +700,8 @@ impl AppClient {
         let mut counts = DrainCounts::default();
         let (mut summary, drain_verdict) = self.sync_sdk_relay(&mut counts).await?;
         if drain_verdict == DrainVerdict::Overflow || self.delivery_overflow_recovery_pending {
-            match self.recover_delivery_overflow().await {
-                Ok(recovered) => summary.merge(recovered),
-                Err(mut failure) => {
-                    failure.partial_summary.merge(summary);
-                    return Err(failure);
-                }
-            }
+            self.recover_delivery_overflow_and_merge(&mut summary)
+                .await?;
         }
         // Surface engine events queued without an inbound delivery — most
         // importantly `GroupHydrationQuarantined`, queued during session
@@ -1019,8 +1014,9 @@ impl AppClient {
                     self.ingest_received_delivery(*delivery).await?
                 }
                 crate::relay_plane::AccountDeliveryReceive::Overflow(_) => {
-                    match self.recover_delivery_overflow().await {
-                        Ok(summary) => summary,
+                    let mut summary = SyncSummary::default();
+                    match self.recover_delivery_overflow_and_merge(&mut summary).await {
+                        Ok(()) => summary,
                         Err(failure) => {
                             self.pending_failed_sync_summary
                                 .merge(failure.partial_summary);
@@ -1097,12 +1093,21 @@ impl AppClient {
         &mut self,
         delivery: cgka_traits::TransportDelivery,
     ) -> Result<SyncSummary, AppError> {
+        let cursor_before_secs = self.state.last_transport_timestamp;
         let display_names = self.app.display_names_by_id()?;
         let mut summary = SyncSummary::default();
         let event_id = hex::encode(delivery.message.id.as_slice());
         let ingested = self
             .ingest_delivery(delivery, &display_names, &mut summary)
             .await?;
+        if self.adapter.pending_delivery_overflow().is_some() {
+            // `record_drop` publishes this process-local fence at the exact
+            // omission, before marker I/O or the reserved control record can
+            // complete. Keep this per-delivery checkpoint on its pre-ingest
+            // floor so slow SQLite cannot commit the newest-first prefix ahead
+            // of the marker that represents the omitted older delivery.
+            self.state.last_transport_timestamp = cursor_before_secs;
+        }
         // Mark the delivery seen only after durable ingest succeeds, matching
         // the catch-up drain below. Marking at receive time would let a failed
         // ingest poison the index, so a reused client would silently skip the
@@ -1223,7 +1228,7 @@ impl AppClient {
             .drain_sdk_relay(
                 &mut counts,
                 DrainCompletion::EndOfStoredEvents {
-                    silence_budget: self.epoch_backfill_eose_wait(),
+                    silence_budget: self.delivery_overflow_eose_wait(),
                     execution_quantum: self.epoch_backfill_execution_quantum(),
                 },
             )
@@ -1272,6 +1277,8 @@ impl AppClient {
                 elapsed_ms = started.elapsed().as_millis() as u64,
                 "account delivery overflow recovery completed",
             );
+            let mut summary = summary;
+            self.drain_epoch_stall_escalations(&mut summary);
             return Ok(summary);
         }
 
@@ -1297,6 +1304,22 @@ impl AppClient {
             )),
             SyncFailureStage::RelayReceive,
         ))
+    }
+
+    async fn recover_delivery_overflow_and_merge(
+        &mut self,
+        summary: &mut SyncSummary,
+    ) -> Result<(), ClassifiedSyncFailure> {
+        match self.recover_delivery_overflow().await {
+            Ok(recovered) => {
+                summary.merge(recovered);
+                Ok(())
+            }
+            Err(mut failure) => {
+                failure.partial_summary.merge(std::mem::take(summary));
+                Err(failure)
+            }
+        }
     }
 
     /// How long an unconfirmed replay must wait before an automatic seam may
@@ -1338,6 +1361,13 @@ impl AppClient {
             return Duration::from_millis(ms);
         }
         EPOCH_BACKFILL_EOSE_WAIT
+    }
+
+    /// The EOSE budget for durable account-delivery overflow repair. It shares
+    /// today's configured value with epoch backfill, but remains a distinct
+    /// policy seam so either recovery mechanism can be tuned independently.
+    fn delivery_overflow_eose_wait(&self) -> Duration {
+        self.epoch_backfill_eose_wait()
     }
 
     /// Maximum wall-clock quantum one backfill drain owns the account worker.
@@ -1435,7 +1465,7 @@ impl AppClient {
         // `SDK_DRAIN_WAIT`. Held at the same interval as that timeout.
         let mut gate_polled_at = silence_started;
 
-        let verdict = loop {
+        let mut verdict = loop {
             if completion
                 .execution_quantum()
                 .is_some_and(|quantum| drain_started.elapsed() >= quantum)
@@ -1600,6 +1630,28 @@ impl AppClient {
             routes_dirty |= ingested.routes_dirty;
         };
 
+        if verdict != DrainVerdict::Overflow
+            && let Some(overflow) = self.adapter.pending_delivery_overflow()
+        {
+            // The queue signal intentionally trails marker persistence, so a
+            // quiescence timeout can win while that signal is still pending.
+            // Consult the immediate process-local fence before checkpointing.
+            self.state.last_transport_timestamp = cursor_before_secs;
+            if let Err(error) = self.observe_delivery_overflow(overflow) {
+                return Err(self
+                    .finish_failed_sync_drain(
+                        summary,
+                        routes_dirty,
+                        *counts,
+                        StagedSyncError::new(error, SyncFailureStage::StatePersist),
+                        drain_started,
+                        cursor_before_secs,
+                    )
+                    .await);
+            }
+            verdict = DrainVerdict::Overflow;
+        }
+
         if let Err(error) = self
             .checkpoint_sync_prefix(&mut summary, routes_dirty, counts.deliveries)
             .await
@@ -1682,6 +1734,10 @@ impl AppClient {
         } else {
             false
         };
+        let checkpointed_before = self.checkpointed_transport_timestamp;
+        if self.adapter.pending_delivery_overflow().is_none() {
+            self.checkpointed_transport_timestamp = self.state.last_transport_timestamp;
+        }
         let checkpoint = if cfg!(feature = "test-policy-overrides")
             && self
                 .app
@@ -1696,6 +1752,7 @@ impl AppClient {
             self.save_state_with_pending_local_group_deletion_frontier_clears()
         };
         if let Err(error) = checkpoint {
+            self.checkpointed_transport_timestamp = checkpointed_before;
             return Err(SyncCheckpointError::BeforePersistence(error));
         }
 
@@ -2673,13 +2730,8 @@ impl AppClient {
         let mut counts = DrainCounts::default();
         let (mut summary, drain_verdict) = self.sync_sdk_relay(&mut counts).await?;
         if drain_verdict == DrainVerdict::Overflow || self.delivery_overflow_recovery_pending {
-            match self.recover_delivery_overflow().await {
-                Ok(recovered) => summary.merge(recovered),
-                Err(mut failure) => {
-                    failure.partial_summary.merge(summary);
-                    return Err(failure);
-                }
-            }
+            self.recover_delivery_overflow_and_merge(&mut summary)
+                .await?;
         }
         let drained = match self.drain_pending_session_events().await {
             Ok(drained) => drained,
@@ -3005,7 +3057,7 @@ impl AppClient {
         let delta = AccountState {
             label: self.state.label.clone(),
             seen_events: self.state.seen_events[seen_start..].to_vec(),
-            last_transport_timestamp: self.state.last_transport_timestamp,
+            last_transport_timestamp: self.checkpointed_transport_timestamp,
             groups: self
                 .state
                 .groups
@@ -3318,10 +3370,11 @@ impl AppClient {
         Ok(routes_dirty)
     }
 
-    /// Advance the persisted transport cursor from an inbound message —
-    /// unless this runtime was constructed with
+    /// Advance the persisted transport cursor from an inbound message unless
+    /// this runtime was constructed with
     /// [`CursorPersistence::Frozen`](crate::CursorPersistence), in which case
-    /// this is a no-op and the cursor stays at the value loaded from the store.
+    /// this is a no-op, or the account route has already recorded a queue
+    /// omission whose marker/control record is still in flight.
     ///
     /// `timestamp` is the sender-controlled Nostr `created_at` of the outer
     /// kind-445 event and is never validated upstream. The cursor is a
@@ -3332,6 +3385,9 @@ impl AppClient {
     /// wall-clock plus a bounded skew so a hostile or clock-skewed sender can
     /// move the cursor no further than `now + TRANSPORT_CURSOR_MAX_FUTURE_SKEW`.
     fn remember_transport_cursor(&mut self, timestamp: u64) {
+        if self.adapter.pending_delivery_overflow().is_some() {
+            return;
+        }
         self.state.last_transport_timestamp = next_transport_cursor(
             self.app.cursor_persistence(),
             self.state.last_transport_timestamp,

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -1501,7 +1501,7 @@ impl AppClient {
                             .finish_failed_sync_drain(
                                 summary,
                                 routes_dirty,
-                                *counts,
+                                counts.clone(),
                                 StagedSyncError::new(error, SyncFailureStage::StatePersist),
                                 drain_started,
                                 cursor_before_secs,
@@ -1642,7 +1642,7 @@ impl AppClient {
                     .finish_failed_sync_drain(
                         summary,
                         routes_dirty,
-                        *counts,
+                        counts.clone(),
                         StagedSyncError::new(error, SyncFailureStage::StatePersist),
                         drain_started,
                         cursor_before_secs,

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -1,9 +1,9 @@
 use std::collections::{HashMap, HashSet};
 use std::time::{Duration, Instant};
 
+use cgka_traits::GroupId;
 use cgka_traits::app_event::{MARMOT_APP_EVENT_KIND_CHAT, MARMOT_APP_EVENT_KIND_DELETE};
 use cgka_traits::ingest::IngestOutcome;
-use cgka_traits::{GroupId, TransportAdapter};
 use storage_sqlite::clamp_to_max_future_skew;
 use tokio::time::timeout;
 use transport_nostr_adapter::AccountSubscriptionEose;
@@ -130,6 +130,10 @@ enum DrainVerdict {
     /// The account-worker quantum ended without durable novel progress. This
     /// includes duplicate/echo-only and all-refused streams.
     NoProgressQuantumYield,
+    /// The per-account queue omitted at least one delivery. The durable marker
+    /// is armed, but this drain's (possibly floored) subscription cannot close
+    /// the gap; the caller must issue a fresh unfloored replay.
+    Overflow,
 }
 
 impl DrainVerdict {
@@ -141,6 +145,7 @@ impl DrainVerdict {
             Self::NoRelayEose => Some("backfill_drain_no_relay_eose"),
             Self::NovelProgressQuantumYield => Some("backfill_drain_novel_progress_quantum_yield"),
             Self::NoProgressQuantumYield => Some("backfill_drain_no_progress_quantum_yield"),
+            Self::Overflow => Some("account_delivery_queue_overflow"),
         }
     }
 
@@ -150,6 +155,7 @@ impl DrainVerdict {
             Self::Complete => Some(EpochBackfillCompletionKind::EndOfStoredEvents),
             Self::EoseTimeout
             | Self::NoRelayEose
+            | Self::Overflow
             | Self::NovelProgressQuantumYield
             | Self::NoProgressQuantumYield => None,
         }
@@ -435,13 +441,71 @@ impl AppClient {
     }
 
     pub(crate) async fn sync_runtime_groups(&mut self) -> Result<(), AppError> {
-        let rebuild_since = self
-            .relay_plane
-            .subscription_rebuild_since(self.state.last_transport_timestamp);
+        let rebuild_since = self.subscription_rebuild_since();
+        self.sync_runtime_groups_since(rebuild_since).await
+    }
+
+    async fn sync_runtime_groups_since(
+        &mut self,
+        rebuild_since: Option<cgka_traits::transport::Timestamp>,
+    ) -> Result<(), AppError> {
         self.warm_encrypted_media_epoch_secrets("pre_subscription_sync");
         self.runtime.sync_transport_groups(rebuild_since).await?;
         self.warm_encrypted_media_epoch_secrets("post_subscription_sync");
         Ok(())
+    }
+
+    pub(crate) fn subscription_rebuild_since(&self) -> Option<cgka_traits::transport::Timestamp> {
+        if self.delivery_overflow_recovery_pending {
+            None
+        } else {
+            self.relay_plane
+                .subscription_rebuild_since(self.state.last_transport_timestamp)
+        }
+    }
+
+    fn observe_delivery_overflow(
+        &mut self,
+        overflow: crate::relay_plane::AccountDeliveryOverflow,
+    ) -> Result<(), AppError> {
+        // This write precedes any checkpoint of the already-drained prefix.
+        // A crash can therefore leave a conservative recovery marker with an
+        // older cursor, but never a newer cursor without the marker.
+        self.app
+            .account_storage(&self.state.label)?
+            .mark_account_delivery_recovery(
+                &self.state.label,
+                overflow.marker_token,
+                overflow.dropped,
+            )?;
+        self.delivery_overflow_recovery_pending = true;
+        self.delivery_overflow_recovery_marker_token = Some(overflow.marker_token);
+        tracing::warn!(
+            target: "marmot_app::relay_plane",
+            method = "observe_delivery_overflow",
+            queue_depth = overflow.queue_depth,
+            dropped = overflow.dropped,
+            elapsed_ms = overflow.elapsed_ms,
+            "account delivery queue overflow requires unfloored recovery",
+        );
+        Ok(())
+    }
+
+    fn clear_delivery_overflow_recovery(&mut self, marker_token: u64) -> Result<bool, AppError> {
+        let storage = self.app.account_storage(&self.state.label)?;
+        let cleared = storage.clear_account_delivery_recovery(&self.state.label, marker_token)?;
+        if cleared {
+            self.delivery_overflow_recovery_pending = false;
+            self.delivery_overflow_recovery_marker_token = None;
+            return Ok(true);
+        }
+        // A newer process-local generation won the storage race. Keep its
+        // marker authoritative; this replay must not clear or report it.
+        let current = storage.account_delivery_recovery(&self.state.label)?;
+        self.delivery_overflow_recovery_pending = current.is_some();
+        self.delivery_overflow_recovery_marker_token =
+            current.map(|recovery| recovery.marker_token);
+        Ok(false)
     }
 
     /// Warm the encrypted-media epoch-secret cache around a subscription sync,
@@ -515,9 +579,7 @@ impl AppClient {
         self.relay_plane
             .set_transport_signer(self.transport_signer.clone())
             .await;
-        let rebuild_since = self
-            .relay_plane
-            .subscription_rebuild_since(self.state.last_transport_timestamp);
+        let rebuild_since = self.subscription_rebuild_since();
         let activation = self.runtime.activate_transport(rebuild_since).await;
         if let Some(telemetry) = telemetry {
             telemetry.record(
@@ -621,8 +683,7 @@ impl AppClient {
                 })?;
         }
         let rebuild_since_secs = self
-            .relay_plane
-            .subscription_rebuild_since(self.state.last_transport_timestamp)
+            .subscription_rebuild_since()
             .map(|timestamp| timestamp.0);
         self.prepare_transport_for_sync(telemetry)
             .await
@@ -637,7 +698,16 @@ impl AppClient {
         // drained registration log before draining inbound deliveries.
         self.record_subscription_rebuild(rebuild_since_secs).await;
         let mut counts = DrainCounts::default();
-        let mut summary = self.sync_sdk_relay(&mut counts).await?;
+        let (mut summary, drain_verdict) = self.sync_sdk_relay(&mut counts).await?;
+        if drain_verdict == DrainVerdict::Overflow || self.delivery_overflow_recovery_pending {
+            match self.recover_delivery_overflow().await {
+                Ok(recovered) => summary.merge(recovered),
+                Err(mut failure) => {
+                    failure.partial_summary.merge(summary);
+                    return Err(failure);
+                }
+            }
+        }
         // Surface engine events queued without an inbound delivery — most
         // importantly `GroupHydrationQuarantined`, queued during session
         // `open()` hydration (mdk#426). If no relay delivery arrived
@@ -944,8 +1014,21 @@ impl AppClient {
 
     pub async fn next_event(&mut self) -> Result<SyncSummary, AppError> {
         loop {
-            let delivery = self.receive_next_delivery().await?;
-            let summary = self.ingest_received_delivery(delivery).await?;
+            let summary = match self.receive_next_delivery().await? {
+                crate::relay_plane::AccountDeliveryReceive::Delivery(delivery) => {
+                    self.ingest_received_delivery(*delivery).await?
+                }
+                crate::relay_plane::AccountDeliveryReceive::Overflow(_) => {
+                    match self.recover_delivery_overflow().await {
+                        Ok(summary) => summary,
+                        Err(failure) => {
+                            self.pending_failed_sync_summary
+                                .merge(failure.partial_summary);
+                            return Err(failure.source);
+                        }
+                    }
+                }
+            };
             // A directly-owned AppClient has no account-worker scheduler to
             // perform the post-visibility retry. Preserve its historical
             // contract by completing the pending rebuild before handing the
@@ -975,7 +1058,7 @@ impl AppClient {
     /// halfway through when a command arrives.
     pub(crate) async fn receive_next_delivery(
         &mut self,
-    ) -> Result<cgka_traits::TransportDelivery, AppError> {
+    ) -> Result<crate::relay_plane::AccountDeliveryReceive, AppError> {
         let local_account_id_hex = self
             .app
             .account_home()
@@ -983,11 +1066,20 @@ impl AppClient {
             .account_id_hex;
 
         loop {
-            let delivery = self
+            let received = self
                 .adapter
-                .receive()
+                .receive_account_delivery()
                 .await?
                 .ok_or(AppError::TransportClosed)?;
+            let delivery = match received {
+                crate::relay_plane::AccountDeliveryReceive::Delivery(delivery) => delivery,
+                crate::relay_plane::AccountDeliveryReceive::Overflow(overflow) => {
+                    self.observe_delivery_overflow(overflow)?;
+                    return Ok(crate::relay_plane::AccountDeliveryReceive::Overflow(
+                        overflow,
+                    ));
+                }
+            };
             let event_id = hex::encode(delivery.message.id.as_slice());
             if is_own_relay_echo(&delivery, &local_account_id_hex, &self.seen_events_index) {
                 continue;
@@ -995,7 +1087,9 @@ impl AppClient {
             if self.seen_events_index.contains(&event_id) {
                 continue;
             }
-            return Ok(delivery);
+            return Ok(crate::relay_plane::AccountDeliveryReceive::Delivery(
+                delivery,
+            ));
         }
     }
 
@@ -1059,11 +1153,9 @@ impl AppClient {
     async fn sync_sdk_relay(
         &mut self,
         counts: &mut DrainCounts,
-    ) -> Result<SyncSummary, ClassifiedSyncFailure> {
-        let (summary, _) = self
-            .drain_sdk_relay(counts, DrainCompletion::Quiescence)
-            .await?;
-        Ok(summary)
+    ) -> Result<(SyncSummary, DrainVerdict), ClassifiedSyncFailure> {
+        self.drain_sdk_relay(counts, DrainCompletion::Quiescence)
+            .await
     }
 
     /// Drain the transport for an epoch-gap backfill: the same ingest, ended by
@@ -1080,6 +1172,131 @@ impl AppClient {
             execution_quantum,
         };
         self.drain_sdk_relay(counts, completion).await
+    }
+
+    /// Resolve a durable per-account delivery gap with a fresh, unfloored
+    /// account-wide replay. Only EOSE for subscriptions issued by this attempt
+    /// can clear the marker, and a second queue overflow during the replay
+    /// makes the compare-and-clear fail so another attempt remains required.
+    pub(crate) async fn recover_delivery_overflow(
+        &mut self,
+    ) -> Result<SyncSummary, ClassifiedSyncFailure> {
+        if !self.delivery_overflow_recovery_pending {
+            return Ok(SyncSummary::default());
+        }
+        let marker_token = self
+            .delivery_overflow_recovery_marker_token
+            .ok_or_else(|| {
+                ClassifiedSyncFailure::at_stage(
+                    SyncSummary::default(),
+                    AppError::Transport(cgka_traits::TransportAdapterError::Other(
+                        "account delivery overflow marker unavailable".to_owned(),
+                    )),
+                    SyncFailureStage::StatePersist,
+                )
+            })?;
+        let attempt = self.adapter.start_delivery_overflow_recovery(marker_token);
+        let started = Instant::now();
+        self.relay_plane
+            .set_transport_signer(self.transport_signer.clone())
+            .await;
+        if let Err(source) = self.runtime.activate_transport(None).await {
+            self.adapter.fail_delivery_overflow_recovery();
+            return Err(ClassifiedSyncFailure::at_stage(
+                SyncSummary::default(),
+                AppError::from(source),
+                SyncFailureStage::TransportActivation,
+            ));
+        }
+        if let Err(source) = self.sync_runtime_groups_since(None).await {
+            self.adapter.fail_delivery_overflow_recovery();
+            return Err(ClassifiedSyncFailure::at_stage(
+                SyncSummary::default(),
+                source,
+                SyncFailureStage::GroupSubscriptionSync,
+            ));
+        }
+        self.pending_runtime_group_subscription_refresh = false;
+        self.record_subscription_rebuild(None).await;
+        let mut counts = DrainCounts::default();
+        let (summary, verdict) = match self
+            .drain_sdk_relay(
+                &mut counts,
+                DrainCompletion::EndOfStoredEvents {
+                    silence_budget: self.epoch_backfill_eose_wait(),
+                    execution_quantum: self.epoch_backfill_execution_quantum(),
+                },
+            )
+            .await
+        {
+            Ok(result) => result,
+            Err(error) => {
+                self.adapter.fail_delivery_overflow_recovery();
+                return Err(error);
+            }
+        };
+        if verdict == DrainVerdict::Complete
+            && let Some(recovery_elapsed_ms) =
+                self.adapter.finish_delivery_overflow_recovery(attempt)
+        {
+            match self.clear_delivery_overflow_recovery(attempt.marker_token) {
+                Ok(true) => self
+                    .adapter
+                    .record_delivery_overflow_recovery_success(recovery_elapsed_ms),
+                Ok(false) => {
+                    self.adapter.fail_delivery_overflow_recovery();
+                    return Err(ClassifiedSyncFailure::at_stage(
+                        summary,
+                        AppError::Transport(cgka_traits::TransportAdapterError::Other(
+                            "account delivery overflow generation advanced".to_owned(),
+                        )),
+                        SyncFailureStage::RelayReceive,
+                    ));
+                }
+                Err(source) => {
+                    self.adapter.fail_delivery_overflow_recovery();
+                    return Err(ClassifiedSyncFailure::at_stage(
+                        summary,
+                        source,
+                        SyncFailureStage::StatePersist,
+                    ));
+                }
+            }
+            tracing::info!(
+                target: "marmot_app::relay_plane",
+                method = "recover_delivery_overflow",
+                queue_depth = attempt.queue_depth,
+                dropped = attempt.dropped,
+                deliveries = counts.deliveries,
+                skipped = counts.skipped,
+                elapsed_ms = started.elapsed().as_millis() as u64,
+                "account delivery overflow recovery completed",
+            );
+            return Ok(summary);
+        }
+
+        self.adapter.fail_delivery_overflow_recovery();
+        let error_kind = verdict
+            .error_kind()
+            .unwrap_or("overflow_generation_advanced");
+        tracing::warn!(
+            target: "marmot_app::relay_plane",
+            method = "recover_delivery_overflow",
+            error_kind,
+            queue_depth = attempt.queue_depth,
+            dropped = attempt.dropped,
+            deliveries = counts.deliveries,
+            skipped = counts.skipped,
+            elapsed_ms = started.elapsed().as_millis() as u64,
+            "account delivery overflow recovery remains incomplete",
+        );
+        Err(ClassifiedSyncFailure::at_stage(
+            summary,
+            AppError::Transport(cgka_traits::TransportAdapterError::Other(
+                "account delivery overflow recovery incomplete".to_owned(),
+            )),
+            SyncFailureStage::RelayReceive,
+        ))
     }
 
     /// How long an unconfirmed replay must wait before an automatic seam may
@@ -1239,8 +1456,30 @@ impl AppClient {
                 wait = wait.min(quantum.saturating_sub(drain_started.elapsed()));
             }
             first_wait = false;
-            let delivery = match timeout(wait, self.adapter.receive()).await {
-                Ok(Ok(Some(delivery))) => delivery,
+            let delivery = match timeout(wait, self.adapter.receive_account_delivery()).await {
+                Ok(Ok(Some(crate::relay_plane::AccountDeliveryReceive::Delivery(delivery)))) => {
+                    delivery
+                }
+                Ok(Ok(Some(crate::relay_plane::AccountDeliveryReceive::Overflow(overflow)))) => {
+                    if let Err(error) = self.observe_delivery_overflow(overflow) {
+                        // Never checkpoint a cursor learned from the incomplete
+                        // prefix unless the durable recovery marker landed
+                        // first. Engine/app projection work remains retryable;
+                        // the older floor is the safe subscription authority.
+                        self.state.last_transport_timestamp = cursor_before_secs;
+                        return Err(self
+                            .finish_failed_sync_drain(
+                                summary,
+                                routes_dirty,
+                                *counts,
+                                StagedSyncError::new(error, SyncFailureStage::StatePersist),
+                                drain_started,
+                                cursor_before_secs,
+                            )
+                            .await);
+                    }
+                    break DrainVerdict::Overflow;
+                }
                 Ok(Ok(None)) => {
                     break match completion {
                         DrainCompletion::Quiescence => DrainVerdict::Complete,
@@ -1322,7 +1561,7 @@ impl AppClient {
             }
             let mut delivery_summary = SyncSummary::default();
             let ingested = match self
-                .ingest_delivery(delivery, &display_names, &mut delivery_summary)
+                .ingest_delivery(*delivery, &display_names, &mut delivery_summary)
                 .await
             {
                 Ok(ingested) => ingested,
@@ -2432,7 +2671,16 @@ impl AppClient {
         self.pending_runtime_group_subscription_refresh = false;
         self.record_subscription_rebuild(None).await;
         let mut counts = DrainCounts::default();
-        let mut summary = self.sync_sdk_relay(&mut counts).await?;
+        let (mut summary, drain_verdict) = self.sync_sdk_relay(&mut counts).await?;
+        if drain_verdict == DrainVerdict::Overflow || self.delivery_overflow_recovery_pending {
+            match self.recover_delivery_overflow().await {
+                Ok(recovered) => summary.merge(recovered),
+                Err(mut failure) => {
+                    failure.partial_summary.merge(summary);
+                    return Err(failure);
+                }
+            }
+        }
         let drained = match self.drain_pending_session_events().await {
             Ok(drained) => drained,
             Err(error) => {

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -74,6 +74,18 @@ pub(crate) enum EpochBackfillRunOutcome {
     Incomplete(SyncSummary),
 }
 
+/// Result of one durable account-delivery overflow recovery attempt.
+///
+/// An incomplete replay is not a transport failure: its durable marker stays
+/// armed, its real summary remains publishable, and a later sync seam retries
+/// the unfloored replay. Activation, ingest, and persistence errors remain
+/// typed hard failures outside this outcome.
+#[derive(Debug)]
+pub(crate) enum DeliveryOverflowRecoveryOutcome {
+    Completed(SyncSummary),
+    Incomplete(SyncSummary),
+}
+
 /// What ends a transport drain.
 ///
 /// The two contracts differ only in what silence means, so they share one loop
@@ -1185,9 +1197,11 @@ impl AppClient {
     /// makes the compare-and-clear fail so another attempt remains required.
     pub(crate) async fn recover_delivery_overflow(
         &mut self,
-    ) -> Result<SyncSummary, ClassifiedSyncFailure> {
+    ) -> Result<DeliveryOverflowRecoveryOutcome, ClassifiedSyncFailure> {
         if !self.delivery_overflow_recovery_pending {
-            return Ok(SyncSummary::default());
+            return Ok(DeliveryOverflowRecoveryOutcome::Completed(
+                SyncSummary::default(),
+            ));
         }
         let marker_token = self
             .delivery_overflow_recovery_marker_token
@@ -1279,7 +1293,7 @@ impl AppClient {
             );
             let mut summary = summary;
             self.drain_epoch_stall_escalations(&mut summary);
-            return Ok(summary);
+            return Ok(DeliveryOverflowRecoveryOutcome::Completed(summary));
         }
 
         self.adapter.fail_delivery_overflow_recovery();
@@ -1297,13 +1311,7 @@ impl AppClient {
             elapsed_ms = started.elapsed().as_millis() as u64,
             "account delivery overflow recovery remains incomplete",
         );
-        Err(ClassifiedSyncFailure::at_stage(
-            summary,
-            AppError::Transport(cgka_traits::TransportAdapterError::Other(
-                "account delivery overflow recovery incomplete".to_owned(),
-            )),
-            SyncFailureStage::RelayReceive,
-        ))
+        Ok(DeliveryOverflowRecoveryOutcome::Incomplete(summary))
     }
 
     async fn recover_delivery_overflow_and_merge(
@@ -1311,7 +1319,10 @@ impl AppClient {
         summary: &mut SyncSummary,
     ) -> Result<(), ClassifiedSyncFailure> {
         match self.recover_delivery_overflow().await {
-            Ok(recovered) => {
+            Ok(
+                DeliveryOverflowRecoveryOutcome::Completed(recovered)
+                | DeliveryOverflowRecoveryOutcome::Incomplete(recovered),
+            ) => {
                 summary.merge(recovered);
                 Ok(())
             }

--- a/crates/marmot-app/src/config.rs
+++ b/crates/marmot-app/src/config.rs
@@ -22,7 +22,10 @@ pub(crate) const DEFAULT_OPEN_RANKING_PROFILE_RELAY: &str = "wss://relay.vertexl
 ///
 /// * [`Advance`](Self::Advance) — the default, normal posture: every ingested
 ///   kind-445 advances the in-memory cursor (clamp-then-monotonic-max, see
-///   `client/sync.rs`) and `save_state` persists the advance.
+///   `client/sync.rs`). A completed transport drain promotes that candidate to
+///   the durable floor; isolated live-delivery projection saves retain the last
+///   drain checkpoint so a later bounded-queue overflow cannot strand an older
+///   delivery below an already-persisted newest-first cursor.
 /// * [`Frozen`](Self::Frozen) — the wake-collection posture (iOS NSE,
 ///   notification reply/mark-read actions: full runtimes with a sub-second
 ///   drain budget on cold sockets). A `Frozen` pass still ingests, decrypts,

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -1667,6 +1667,7 @@ impl MarmotApp {
             .iter()
             .cloned()
             .collect::<std::collections::HashSet<_>>();
+        let checkpointed_transport_timestamp = open.state.last_transport_timestamp;
         let mut client = AppClient {
             app: self.clone(),
             runtime: open.runtime,
@@ -1687,6 +1688,7 @@ impl MarmotApp {
             pending_local_group_deletion_frontier_clears: std::collections::HashMap::new(),
             pending_application_event_acks: std::collections::HashSet::new(),
             pending_runtime_group_subscription_refresh: false,
+            checkpointed_transport_timestamp,
             delivery_overflow_recovery_pending: open.delivery_overflow_recovery_pending,
             delivery_overflow_recovery_marker_token: open.delivery_overflow_recovery_marker_token,
             #[cfg(test)]
@@ -3533,7 +3535,13 @@ impl MarmotApp {
             Arc::new(move |marker_token, dropped| {
                 recovery_storage
                     .mark_account_delivery_recovery(&recovery_label, marker_token, dropped)
-                    .map_err(|_| ())
+                    .map_err(|error| {
+                        if error.is_closed() {
+                            relay_plane::AccountDeliveryRecoveryMarkerError::Closed
+                        } else {
+                            relay_plane::AccountDeliveryRecoveryMarkerError::Retryable
+                        }
+                    })
             });
         let adapter = relay_plane.account_adapter_with_recovery_marker(
             account_id.clone(),

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -1266,6 +1266,8 @@ struct OpenAppAccount {
     adapter: MarmotRelayPlaneAccountAdapter,
     routing: AppTransportRouting,
     state: AccountState,
+    delivery_overflow_recovery_pending: bool,
+    delivery_overflow_recovery_marker_token: Option<u64>,
     signer: Arc<dyn nostr::NostrSigner>,
 }
 
@@ -1685,6 +1687,8 @@ impl MarmotApp {
             pending_local_group_deletion_frontier_clears: std::collections::HashMap::new(),
             pending_application_event_acks: std::collections::HashSet::new(),
             pending_runtime_group_subscription_refresh: false,
+            delivery_overflow_recovery_pending: open.delivery_overflow_recovery_pending,
+            delivery_overflow_recovery_marker_token: open.delivery_overflow_recovery_marker_token,
             #[cfg(test)]
             force_event_group_projection_unavailable: false,
             pending_welcome_delivery_events: Vec::new(),
@@ -3447,6 +3451,12 @@ impl MarmotApp {
         let label = account.label.as_str();
         let session_guard = self.acquire_account_session(label)?;
         let state = self.load_state(label)?;
+        let delivery_overflow_recovery = self
+            .account_storage(label)?
+            .account_delivery_recovery(label)?;
+        let delivery_overflow_recovery_pending = delivery_overflow_recovery.is_some();
+        let delivery_overflow_recovery_marker_token =
+            delivery_overflow_recovery.map(|recovery| recovery.marker_token);
         let signer = self.account_signer_for_summary(&account)?;
         let account_id = MemberId::new(hex::decode(&account.account_id_hex)?);
         let nostr_signer = signer.as_nostr_signer();
@@ -3517,7 +3527,19 @@ impl MarmotApp {
 
         let publish_client =
             self.relay_client_for_account_id(&account.account_id_hex, nostr_signer.clone());
-        let adapter = relay_plane.account_adapter(account_id.clone(), publish_client);
+        let recovery_storage = self.account_storage(label)?;
+        let recovery_label = label.to_owned();
+        let recovery_marker: relay_plane::AccountDeliveryRecoveryMarker =
+            Arc::new(move |marker_token, dropped| {
+                recovery_storage
+                    .mark_account_delivery_recovery(&recovery_label, marker_token, dropped)
+                    .map_err(|_| ())
+            });
+        let adapter = relay_plane.account_adapter_with_recovery_marker(
+            account_id.clone(),
+            publish_client,
+            Some(recovery_marker),
+        );
 
         let key_packages = AppKeyPackagePublisher {
             app: self.clone(),
@@ -3533,6 +3555,8 @@ impl MarmotApp {
             adapter,
             routing,
             state,
+            delivery_overflow_recovery_pending,
+            delivery_overflow_recovery_marker_token,
             signer: nostr_signer,
         })
     }

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -136,7 +136,9 @@ pub use audit_log::{
     AuditLogUploadResult,
 };
 pub use client::AppClient;
-pub(crate) use client::{ConvergenceScheduleState, EpochBackfillRunOutcome};
+pub(crate) use client::{
+    ConvergenceScheduleState, DeliveryOverflowRecoveryOutcome, EpochBackfillRunOutcome,
+};
 pub use config::{
     AuditLogTrackerConfig, AuditLogUploadSource, CursorPersistence, MarmotAppConfig,
     MarmotServiceEndpoints, RelayTelemetryExportConfig, RelayTelemetryResource,

--- a/crates/marmot-app/src/relay_plane/mod.rs
+++ b/crates/marmot-app/src/relay_plane/mod.rs
@@ -705,7 +705,11 @@ impl MarmotRelayPlane {
             .get(&delivery.account_id)
             .cloned();
         match sender {
-            Some(sender) => sender.send(delivery).await.is_ok(),
+            Some(route) => route
+                .sender
+                .send(AccountDeliveryEvent::Delivery(Box::new(delivery)))
+                .await
+                .is_ok(),
             None => false,
         }
     }

--- a/crates/marmot-app/src/relay_plane/mod.rs
+++ b/crates/marmot-app/src/relay_plane/mod.rs
@@ -59,7 +59,7 @@ pub(crate) use transport_nostr_adapter::{
     DurationHistogramSnapshot, NostrAdapterMetrics, RelayDeliverySpread, RelaySyncSnapshot,
 };
 
-const ACCOUNT_DELIVERY_BUFFER: usize = 1024;
+pub(crate) const ACCOUNT_DELIVERY_BUFFER: usize = 1024;
 const DIRECTORY_EVENT_BUFFER: usize = 1024;
 pub(crate) const DIRECTORY_RELAY_CONNECT_WAIT: Duration = Duration::from_secs(5);
 const RELAY_PLANE_SHUTDOWN_WAIT: Duration = Duration::from_secs(2);
@@ -136,7 +136,13 @@ struct AccountDeliveryRoute {
 }
 
 pub(crate) type AccountDeliveryRecoveryMarker =
-    Arc<dyn Fn(u64, u64) -> Result<(), ()> + Send + Sync + 'static>;
+    Arc<dyn Fn(u64, u64) -> Result<(), AccountDeliveryRecoveryMarkerError> + Send + Sync + 'static>;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum AccountDeliveryRecoveryMarkerError {
+    Retryable,
+    Closed,
+}
 
 #[derive(Debug)]
 enum AccountDeliveryEvent {
@@ -166,7 +172,6 @@ pub(crate) enum AccountDeliveryReceive {
 struct AccountDeliveryOverflowState {
     inner: std::sync::Mutex<AccountDeliveryOverflowInner>,
     metrics: Arc<AccountDeliveryMetrics>,
-    marker_notify: tokio::sync::Notify,
 }
 
 #[derive(Default)]
@@ -179,10 +184,10 @@ struct AccountDeliveryOverflowInner {
     queue_depth: usize,
     started_at: Option<Instant>,
     recovery_started_at: Option<Instant>,
-    marker_generation: u64,
     marker_token: u64,
     marker_in_progress: bool,
     marker_durable: bool,
+    marker_closed: bool,
 }
 
 #[derive(Default)]
@@ -252,10 +257,10 @@ impl AccountDeliveryOverflowState {
             state.pending = true;
             state.dropped = 0;
             state.started_at = Some(Instant::now());
-            state.marker_generation = state.generation;
             state.marker_token = rand::rngs::OsRng.next_u64() & i64::MAX as u64;
             state.marker_in_progress = false;
             state.marker_durable = false;
+            state.marker_closed = false;
         }
         state.dropped = state.dropped.saturating_add(1);
         state.queue_depth = state.queue_depth.max(queue_depth);
@@ -279,85 +284,104 @@ impl AccountDeliveryOverflowState {
         }
     }
 
-    /// Persist the generation marker on an account-local blocking worker while
-    /// the shared relay router continues serving every other route. Every
-    /// omitted delivery task holds its delivery until this barrier succeeds;
-    /// one owner retries the write and same-generation waiters share the
-    /// result.
+    /// Claim the one account-local marker worker for the current generation.
+    /// Once the marker is durable (or storage has closed), later omissions need
+    /// only update the bounded counter and reuse the existing control record.
+    fn start_marker_persistence(&self) -> bool {
+        let mut state = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if state.marker_durable || state.marker_closed || state.marker_in_progress {
+            return false;
+        }
+        state.marker_in_progress = true;
+        true
+    }
+
+    fn marker_barrier_complete(&self) -> bool {
+        let state = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.marker_durable || state.marker_closed
+    }
+
+    /// Persist the generation marker on one account-local blocking worker while
+    /// the shared relay router continues serving every other route. Retryable
+    /// failures retain only this task and aggregate later omissions into the
+    /// generation counter; terminal storage closure releases the task.
     async fn persist_marker_before_drop(&self, marker: AccountDeliveryRecoveryMarker) {
+        let generation = {
+            let state = self
+                .inner
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            state.generation
+        };
         loop {
-            let notified = self.marker_notify.notified();
-            let owns_write = {
-                let mut state = self
+            let (marker_token, dropped) = {
+                let state = self
                     .inner
                     .lock()
                     .unwrap_or_else(|poisoned| poisoned.into_inner());
-                if state.marker_durable {
-                    return;
-                }
-                if state.marker_in_progress {
-                    false
-                } else {
-                    state.marker_in_progress = true;
-                    true
-                }
+                (state.marker_token, state.dropped)
             };
-            if !owns_write {
-                notified.await;
-                continue;
-            }
-
-            // The owner retains ownership across failures. Same-generation
-            // waiters therefore do not stampede SQLite, and every omitted
-            // delivery remains held by its task until one durable marker write
-            // succeeds.
-            loop {
-                let (generation, marker_token, dropped) = {
-                    let state = self
-                        .inner
-                        .lock()
-                        .unwrap_or_else(|poisoned| poisoned.into_inner());
-                    (state.generation, state.marker_token, state.dropped)
-                };
-                let marker = marker.clone();
-                let persisted = tokio::task::spawn_blocking(move || marker(marker_token, dropped))
-                    .await
-                    .is_ok_and(|result| result.is_ok());
-                if persisted {
+            let marker = marker.clone();
+            match tokio::task::spawn_blocking(move || marker(marker_token, dropped)).await {
+                Ok(Ok(())) => {
                     let mut state = self
                         .inner
                         .lock()
                         .unwrap_or_else(|poisoned| poisoned.into_inner());
-                    if state.generation == generation && state.marker_generation == generation {
-                        state.marker_in_progress = false;
+                    state.marker_in_progress = false;
+                    if state.generation == generation {
                         state.marker_durable = true;
-                        self.marker_notify.notify_waiters();
-                        return;
                     }
-                    // A newer generation now owns the route. Release this
-                    // ownership and let the outer loop join or write its marker.
-                    state.marker_in_progress = false;
-                    self.marker_notify.notify_waiters();
-                    break;
+                    return;
                 }
-                tracing::warn!(
-                    target: "marmot_app::relay_plane",
-                    method = "persist_marker_before_drop",
-                    error_kind = "overflow_marker_persist_failed",
-                    "durable account delivery overflow marker write failed; retrying",
-                );
-                tokio::time::sleep(Duration::from_millis(100)).await;
-                let mut state = self
-                    .inner
-                    .lock()
-                    .unwrap_or_else(|poisoned| poisoned.into_inner());
-                if state.generation != generation {
+                Ok(Err(AccountDeliveryRecoveryMarkerError::Closed)) => {
+                    let mut state = self
+                        .inner
+                        .lock()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner());
                     state.marker_in_progress = false;
-                    self.marker_notify.notify_waiters();
-                    break;
+                    state.marker_closed = true;
+                    tracing::debug!(
+                        target: "marmot_app::relay_plane",
+                        method = "persist_marker_before_drop",
+                        error_kind = "storage_closed",
+                        "account delivery overflow marker worker stopped after storage closure",
+                    );
+                    return;
+                }
+                Ok(Err(AccountDeliveryRecoveryMarkerError::Retryable)) | Err(_) => {
+                    tracing::warn!(
+                        target: "marmot_app::relay_plane",
+                        method = "persist_marker_before_drop",
+                        error_kind = "overflow_marker_persist_failed",
+                        "durable account delivery overflow marker write failed; retrying",
+                    );
+                    tokio::time::sleep(Duration::from_millis(100)).await;
                 }
             }
+            let mut state = self
+                .inner
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if state.generation != generation {
+                state.marker_in_progress = false;
+                return;
+            }
         }
+    }
+
+    fn pending_snapshot(&self) -> Option<AccountDeliveryOverflow> {
+        let state = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        (state.pending && !state.recovery_in_progress).then(|| Self::snapshot(&state))
     }
 
     fn consume_signal(&self, generation: u64) -> AccountDeliveryOverflow {
@@ -388,9 +412,9 @@ impl AccountDeliveryOverflowState {
             // This path exists only because the durable database marker was
             // loaded after a restart; the process-local generation is already
             // covered before its first recovery subscription is issued.
-            state.marker_generation = state.generation;
             state.marker_token = durable_marker_token;
             state.marker_durable = true;
+            state.marker_closed = false;
         }
         state.recovery_in_progress = true;
         state.recovery_started_at = Some(Instant::now());
@@ -412,6 +436,7 @@ impl AccountDeliveryOverflowState {
             state.recovery_in_progress = false;
             state.marker_in_progress = false;
             state.marker_durable = false;
+            state.marker_closed = false;
             state.started_at = None;
             let elapsed_ms = state
                 .recovery_started_at
@@ -628,6 +653,11 @@ impl MarmotRelayPlane {
         this
     }
 
+    /// Build an account adapter without durable queue-overflow recovery.
+    ///
+    /// Production callers must use `account_adapter_with_recovery_marker` with
+    /// a marker. This compatibility constructor is retained for tests and
+    /// embedders that do not persist account projection state.
     pub fn account_adapter(
         &self,
         account_id: MemberId,
@@ -651,7 +681,6 @@ impl MarmotRelayPlane {
         let delivery_overflow = Arc::new(AccountDeliveryOverflowState {
             inner: std::sync::Mutex::new(AccountDeliveryOverflowInner::default()),
             metrics: self.inner.transport.account_delivery_metrics.clone(),
-            marker_notify: tokio::sync::Notify::new(),
         });
         account_deliveries_write(&self.inner.transport.account_deliveries).insert(
             account_id.clone(),
@@ -1131,30 +1160,38 @@ impl MarmotRelayPlane {
                     route.overflow.observe_queue_depth(queue_depth);
                     if route.sender.capacity() <= 1 {
                         let signal_generation = route.overflow.record_drop(queue_depth);
-                        if let Some(marker) = route.recovery_marker.clone() {
-                            // Account-local persistence runs independently of
-                            // the shared router. Hold this omitted delivery in
-                            // the task until the durable marker barrier returns;
-                            // other accounts, EOSE, and commands keep flowing.
-                            let sender = route.sender.clone();
-                            let overflow_state = route.overflow.clone();
-                            tokio::spawn(async move {
-                                overflow_state.persist_marker_before_drop(marker).await;
-                                drop(delivery);
-                                if let Some(generation) = signal_generation {
+                        if let Some(generation) = signal_generation {
+                            if let Some(marker) = route.recovery_marker.clone() {
+                                if route.overflow.marker_barrier_complete() {
                                     enqueue_account_delivery_overflow_signal(
-                                        &sender,
-                                        &overflow_state,
+                                        &route.sender,
+                                        &route.overflow,
                                         generation,
                                     );
+                                } else if route.overflow.start_marker_persistence() {
+                                    // One account-local task owns this generation's
+                                    // persistence. The omitted payload is dropped
+                                    // here; later omissions update only the bounded
+                                    // counter while the shared router keeps serving
+                                    // every other account.
+                                    let sender = route.sender.clone();
+                                    let overflow_state = route.overflow.clone();
+                                    tokio::spawn(async move {
+                                        overflow_state.persist_marker_before_drop(marker).await;
+                                        enqueue_account_delivery_overflow_signal(
+                                            &sender,
+                                            &overflow_state,
+                                            generation,
+                                        );
+                                    });
                                 }
-                            });
-                        } else if let Some(generation) = signal_generation {
-                            enqueue_account_delivery_overflow_signal(
-                                &route.sender,
-                                &route.overflow,
-                                generation,
-                            );
+                            } else {
+                                enqueue_account_delivery_overflow_signal(
+                                    &route.sender,
+                                    &route.overflow,
+                                    generation,
+                                );
+                            }
                         }
                         tracing::warn!(
                             target: "marmot_app::relay_plane",
@@ -1205,6 +1242,20 @@ impl MarmotRelayPlane {
             .adapter
             .handle_relay_event(relay_event)
             .await
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_account_delivery_recovery_marker_for_test(
+        &self,
+        account_id: &MemberId,
+        marker: AccountDeliveryRecoveryMarker,
+    ) -> bool {
+        let mut routes = account_deliveries_write(&self.inner.transport.account_deliveries);
+        let Some(route) = routes.get_mut(account_id) else {
+            return false;
+        };
+        route.recovery_marker = Some(marker);
+        true
     }
 
     /// Report end-of-stored-events for one subscription on one endpoint, the
@@ -1747,6 +1798,12 @@ impl MarmotRelayPlaneAccountAdapter {
                 AccountDeliveryReceive::Overflow(self.delivery_overflow.consume_signal(generation))
             }
         }))
+    }
+
+    /// Process-local overflow evidence becomes visible at the exact omission,
+    /// before marker I/O or the queued control record can complete.
+    pub(crate) fn pending_delivery_overflow(&self) -> Option<AccountDeliveryOverflow> {
+        self.delivery_overflow.pending_snapshot()
     }
 
     /// Begin (or resume after process restart) the unfloored replay required by

--- a/crates/marmot-app/src/relay_plane/mod.rs
+++ b/crates/marmot-app/src/relay_plane/mod.rs
@@ -16,6 +16,7 @@ use nostr_sdk::prelude::{
     Client as NostrSdkClient, Filter, Kind, PublicKey, RelayMessage, RelayPoolNotification,
     RelayUrl, SubscriptionId, Timestamp as NostrTimestamp,
 };
+use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, broadcast, mpsc};
 use tokio::task::JoinHandle;
@@ -84,7 +85,8 @@ struct RelayPlaneTransport {
     adapter: NostrTransportAdapter,
     sdk_relay_client: Option<NostrSdkRelayClient>,
     directory_events: broadcast::Sender<DirectoryRelayPlaneEvent>,
-    account_deliveries: RwLock<HashMap<MemberId, mpsc::Sender<TransportDelivery>>>,
+    account_deliveries: RwLock<HashMap<MemberId, AccountDeliveryRoute>>,
+    account_delivery_metrics: Arc<AccountDeliveryMetrics>,
     router: Mutex<Option<JoinHandle<()>>>,
     notification_forwarder: Mutex<Option<JoinHandle<()>>>,
     notification_forwarder_health: Arc<RelayNotificationForwarderHealth>,
@@ -122,7 +124,345 @@ pub struct MarmotRelayPlaneAccountAdapter {
     account_id: MemberId,
     relay_plane: MarmotRelayPlane,
     publish_client: Arc<dyn NostrRelayClient>,
-    delivery_rx: Arc<Mutex<mpsc::Receiver<TransportDelivery>>>,
+    delivery_rx: Arc<Mutex<mpsc::Receiver<AccountDeliveryEvent>>>,
+    delivery_overflow: Arc<AccountDeliveryOverflowState>,
+}
+
+#[derive(Clone)]
+struct AccountDeliveryRoute {
+    sender: mpsc::Sender<AccountDeliveryEvent>,
+    overflow: Arc<AccountDeliveryOverflowState>,
+    recovery_marker: Option<AccountDeliveryRecoveryMarker>,
+}
+
+pub(crate) type AccountDeliveryRecoveryMarker =
+    Arc<dyn Fn(u64, u64) -> Result<(), ()> + Send + Sync + 'static>;
+
+#[derive(Debug)]
+enum AccountDeliveryEvent {
+    Delivery(Box<TransportDelivery>),
+    Overflow { generation: u64 },
+}
+
+/// Aggregate, privacy-safe description of one unresolved per-account queue
+/// overflow generation. The account identity never leaves the private route
+/// registry; callers see only counts, queue depth, and elapsed time.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct AccountDeliveryOverflow {
+    pub(crate) generation: u64,
+    pub(crate) marker_token: u64,
+    pub(crate) dropped: u64,
+    pub(crate) queue_depth: usize,
+    pub(crate) elapsed_ms: u64,
+}
+
+#[derive(Debug)]
+pub(crate) enum AccountDeliveryReceive {
+    Delivery(Box<TransportDelivery>),
+    Overflow(AccountDeliveryOverflow),
+}
+
+#[derive(Default)]
+struct AccountDeliveryOverflowState {
+    inner: std::sync::Mutex<AccountDeliveryOverflowInner>,
+    metrics: Arc<AccountDeliveryMetrics>,
+    marker_notify: tokio::sync::Notify,
+}
+
+#[derive(Default)]
+struct AccountDeliveryOverflowInner {
+    generation: u64,
+    pending: bool,
+    signal_queued: bool,
+    recovery_in_progress: bool,
+    dropped: u64,
+    queue_depth: usize,
+    started_at: Option<Instant>,
+    recovery_started_at: Option<Instant>,
+    marker_generation: u64,
+    marker_token: u64,
+    marker_in_progress: bool,
+    marker_durable: bool,
+}
+
+#[derive(Default)]
+struct AccountDeliveryMetrics {
+    max_queue_depth: AtomicU64,
+    dropped: AtomicU64,
+    recovery_attempts: AtomicU64,
+    recovery_successes: AtomicU64,
+    recovery_failures: AtomicU64,
+    recovery_elapsed_ms: AtomicU64,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct AccountDeliveryMetricsSnapshot {
+    queue_depth: usize,
+    max_queue_depth: u64,
+    dropped: u64,
+    recovery_attempts: u64,
+    recovery_successes: u64,
+    recovery_failures: u64,
+    recovery_elapsed_ms: u64,
+}
+
+impl AccountDeliveryMetrics {
+    fn snapshot(
+        &self,
+        routes: &RwLock<HashMap<MemberId, AccountDeliveryRoute>>,
+    ) -> AccountDeliveryMetricsSnapshot {
+        let queue_depth = account_deliveries_read(routes)
+            .values()
+            .map(|route| {
+                route
+                    .sender
+                    .max_capacity()
+                    .saturating_sub(route.sender.capacity())
+            })
+            .fold(0_usize, usize::saturating_add);
+        AccountDeliveryMetricsSnapshot {
+            queue_depth,
+            max_queue_depth: self.max_queue_depth.load(Ordering::Relaxed),
+            dropped: self.dropped.load(Ordering::Relaxed),
+            recovery_attempts: self.recovery_attempts.load(Ordering::Relaxed),
+            recovery_successes: self.recovery_successes.load(Ordering::Relaxed),
+            recovery_failures: self.recovery_failures.load(Ordering::Relaxed),
+            recovery_elapsed_ms: self.recovery_elapsed_ms.load(Ordering::Relaxed),
+        }
+    }
+}
+
+impl AccountDeliveryOverflowState {
+    fn observe_queue_depth(&self, queue_depth: usize) {
+        let depth = u64::try_from(queue_depth).unwrap_or(u64::MAX);
+        self.metrics
+            .max_queue_depth
+            .fetch_max(depth, Ordering::Relaxed);
+    }
+
+    /// Record an omitted delivery and return the generation only when this
+    /// caller must enqueue the generation's control record.
+    fn record_drop(&self, queue_depth: usize) -> Option<u64> {
+        let mut state = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if !state.pending {
+            state.generation = state.generation.saturating_add(1);
+            state.pending = true;
+            state.dropped = 0;
+            state.started_at = Some(Instant::now());
+            state.marker_generation = state.generation;
+            state.marker_token = rand::rngs::OsRng.next_u64() & i64::MAX as u64;
+            state.marker_in_progress = false;
+            state.marker_durable = false;
+        }
+        state.dropped = state.dropped.saturating_add(1);
+        state.queue_depth = state.queue_depth.max(queue_depth);
+        RelayNotificationForwarderHealth::increment(&self.metrics.dropped, 1);
+        self.observe_queue_depth(queue_depth);
+        if state.signal_queued {
+            None
+        } else {
+            state.signal_queued = true;
+            Some(state.generation)
+        }
+    }
+
+    fn cancel_signal(&self, generation: u64) {
+        let mut state = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if state.generation == generation {
+            state.signal_queued = false;
+        }
+    }
+
+    /// Persist the generation marker on an account-local blocking worker while
+    /// the shared relay router continues serving every other route. Every
+    /// omitted delivery task holds its delivery until this barrier succeeds;
+    /// one owner retries the write and same-generation waiters share the
+    /// result.
+    async fn persist_marker_before_drop(&self, marker: AccountDeliveryRecoveryMarker) {
+        loop {
+            let notified = self.marker_notify.notified();
+            let owns_write = {
+                let mut state = self
+                    .inner
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                if state.marker_durable {
+                    return;
+                }
+                if state.marker_in_progress {
+                    false
+                } else {
+                    state.marker_in_progress = true;
+                    true
+                }
+            };
+            if !owns_write {
+                notified.await;
+                continue;
+            }
+
+            // The owner retains ownership across failures. Same-generation
+            // waiters therefore do not stampede SQLite, and every omitted
+            // delivery remains held by its task until one durable marker write
+            // succeeds.
+            loop {
+                let (generation, marker_token, dropped) = {
+                    let state = self
+                        .inner
+                        .lock()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner());
+                    (state.generation, state.marker_token, state.dropped)
+                };
+                let marker = marker.clone();
+                let persisted = tokio::task::spawn_blocking(move || marker(marker_token, dropped))
+                    .await
+                    .is_ok_and(|result| result.is_ok());
+                if persisted {
+                    let mut state = self
+                        .inner
+                        .lock()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner());
+                    if state.generation == generation && state.marker_generation == generation {
+                        state.marker_in_progress = false;
+                        state.marker_durable = true;
+                        self.marker_notify.notify_waiters();
+                        return;
+                    }
+                    // A newer generation now owns the route. Release this
+                    // ownership and let the outer loop join or write its marker.
+                    state.marker_in_progress = false;
+                    self.marker_notify.notify_waiters();
+                    break;
+                }
+                tracing::warn!(
+                    target: "marmot_app::relay_plane",
+                    method = "persist_marker_before_drop",
+                    error_kind = "overflow_marker_persist_failed",
+                    "durable account delivery overflow marker write failed; retrying",
+                );
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                let mut state = self
+                    .inner
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                if state.generation != generation {
+                    state.marker_in_progress = false;
+                    self.marker_notify.notify_waiters();
+                    break;
+                }
+            }
+        }
+    }
+
+    fn consume_signal(&self, generation: u64) -> AccountDeliveryOverflow {
+        let mut state = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if state.generation == generation {
+            state.signal_queued = false;
+        }
+        Self::snapshot(&state)
+    }
+
+    fn start_recovery(&self, durable_marker_token: u64) -> AccountDeliveryOverflow {
+        let mut state = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        // A durable marker can outlive the process-local route that detected
+        // it. Recreate a synthetic pending generation on reopen so completion
+        // still has a compare-and-clear guard against new local overflow.
+        if !state.pending {
+            state.generation = state.generation.saturating_add(1);
+            state.pending = true;
+            state.dropped = 0;
+            state.queue_depth = 0;
+            state.started_at = Some(Instant::now());
+            // This path exists only because the durable database marker was
+            // loaded after a restart; the process-local generation is already
+            // covered before its first recovery subscription is issued.
+            state.marker_generation = state.generation;
+            state.marker_token = durable_marker_token;
+            state.marker_durable = true;
+        }
+        state.recovery_in_progress = true;
+        state.recovery_started_at = Some(Instant::now());
+        RelayNotificationForwarderHealth::increment(&self.metrics.recovery_attempts, 1);
+        Self::snapshot(&state)
+    }
+
+    fn finish_recovery(&self, attempt: AccountDeliveryOverflow) -> Option<u64> {
+        let mut state = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let resolved = state.pending
+            && state.generation == attempt.generation
+            && state.dropped == attempt.dropped
+            && !state.signal_queued;
+        if resolved {
+            state.pending = false;
+            state.recovery_in_progress = false;
+            state.marker_in_progress = false;
+            state.marker_durable = false;
+            state.started_at = None;
+            let elapsed_ms = state
+                .recovery_started_at
+                .take()
+                .map(|started| started.elapsed().as_millis() as u64)
+                .unwrap_or_default();
+            return Some(elapsed_ms);
+        }
+        None
+    }
+
+    fn record_recovery_success(&self, elapsed_ms: u64) {
+        RelayNotificationForwarderHealth::increment(&self.metrics.recovery_successes, 1);
+        RelayNotificationForwarderHealth::increment(&self.metrics.recovery_elapsed_ms, elapsed_ms);
+    }
+
+    fn fail_recovery(&self) {
+        let mut state = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.recovery_in_progress = false;
+        let elapsed_ms = state
+            .recovery_started_at
+            .take()
+            .map(|started| started.elapsed().as_millis() as u64)
+            .unwrap_or_default();
+        RelayNotificationForwarderHealth::increment(&self.metrics.recovery_failures, 1);
+        RelayNotificationForwarderHealth::increment(&self.metrics.recovery_elapsed_ms, elapsed_ms);
+    }
+
+    fn blocks_ordinary_eose(&self) -> bool {
+        let state = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.pending && !state.recovery_in_progress
+    }
+
+    fn snapshot(state: &AccountDeliveryOverflowInner) -> AccountDeliveryOverflow {
+        AccountDeliveryOverflow {
+            generation: state.generation,
+            marker_token: state.marker_token,
+            dropped: state.dropped,
+            queue_depth: state.queue_depth,
+            elapsed_ms: state
+                .started_at
+                .map(|started| started.elapsed().as_millis() as u64)
+                .unwrap_or_default(),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -145,6 +485,25 @@ pub struct RelayPlaneHealth {
     pub notification_forwarder_lagged_notifications: u64,
     pub notification_forwarder_panics: u64,
     pub notification_forwarder_unexpected_exits: u64,
+    /// Current queued account-delivery records across active accounts.
+    #[serde(default)]
+    pub account_delivery_queue_depth: usize,
+    /// High-water queue depth for any account since this plane started.
+    #[serde(default)]
+    pub account_delivery_max_queue_depth: u64,
+    /// Deliveries omitted from full per-account queues and covered by an
+    /// explicit recovery generation.
+    #[serde(default)]
+    pub account_delivery_dropped: u64,
+    #[serde(default)]
+    pub account_delivery_recovery_attempts: u64,
+    #[serde(default)]
+    pub account_delivery_recovery_successes: u64,
+    #[serde(default)]
+    pub account_delivery_recovery_failures: u64,
+    /// Aggregate wall-clock time spent in completed/failed recovery attempts.
+    #[serde(default)]
+    pub account_delivery_recovery_elapsed_ms: u64,
     pub directory_inflight_fetches: usize,
     pub directory_active_subscriptions: usize,
     pub directory_completed_fetches: usize,
@@ -250,6 +609,7 @@ impl MarmotRelayPlane {
             sdk_relay_client,
             directory_events: broadcast::channel(DIRECTORY_EVENT_BUFFER).0,
             account_deliveries: RwLock::new(HashMap::new()),
+            account_delivery_metrics: Arc::new(AccountDeliveryMetrics::default()),
             router: Mutex::new(None),
             notification_forwarder: Mutex::new(notification_forwarder),
             notification_forwarder_health: Arc::new(RelayNotificationForwarderHealth::default()),
@@ -273,15 +633,40 @@ impl MarmotRelayPlane {
         account_id: MemberId,
         publish_client: Arc<dyn NostrRelayClient>,
     ) -> MarmotRelayPlaneAccountAdapter {
+        self.account_adapter_with_recovery_marker(account_id, publish_client, None)
+    }
+
+    pub(crate) fn account_adapter_with_recovery_marker(
+        &self,
+        account_id: MemberId,
+        publish_client: Arc<dyn NostrRelayClient>,
+        recovery_marker: Option<AccountDeliveryRecoveryMarker>,
+    ) -> MarmotRelayPlaneAccountAdapter {
         self.spawn_router();
-        let (delivery_tx, delivery_rx) = mpsc::channel(ACCOUNT_DELIVERY_BUFFER);
-        account_deliveries_write(&self.inner.transport.account_deliveries)
-            .insert(account_id.clone(), delivery_tx);
+        // Keep one slot reserved for the overflow control record. Ordinary
+        // deliveries stop at ACCOUNT_DELIVERY_BUFFER, so a full account queue
+        // can always carry the explicit recovery signal without awaiting the
+        // slow consumer or blocking the shared router.
+        let (delivery_tx, delivery_rx) = mpsc::channel(ACCOUNT_DELIVERY_BUFFER + 1);
+        let delivery_overflow = Arc::new(AccountDeliveryOverflowState {
+            inner: std::sync::Mutex::new(AccountDeliveryOverflowInner::default()),
+            metrics: self.inner.transport.account_delivery_metrics.clone(),
+            marker_notify: tokio::sync::Notify::new(),
+        });
+        account_deliveries_write(&self.inner.transport.account_deliveries).insert(
+            account_id.clone(),
+            AccountDeliveryRoute {
+                sender: delivery_tx,
+                overflow: delivery_overflow.clone(),
+                recovery_marker,
+            },
+        );
         MarmotRelayPlaneAccountAdapter {
             account_id,
             relay_plane: self.clone(),
             publish_client,
             delivery_rx: Arc::new(Mutex::new(delivery_rx)),
+            delivery_overflow,
         }
     }
 
@@ -405,14 +790,20 @@ impl MarmotRelayPlane {
             .transport
             .notification_forwarder_health
             .snapshot();
+        let account_delivery = self
+            .inner
+            .transport
+            .account_delivery_metrics
+            .snapshot(&self.inner.transport.account_deliveries);
         if let Some(sdk_relay_client) = &self.inner.transport.sdk_relay_client {
             return RelayPlaneHealth::from_sdk(
                 sdk_relay_client.relay_health().await,
                 directory,
                 forwarder,
+                account_delivery,
             );
         }
-        RelayPlaneHealth::from_directory(directory)
+        RelayPlaneHealth::from_directory(directory, account_delivery)
     }
 
     /// Snapshot the device-local relay telemetry for local inspection.
@@ -723,20 +1114,77 @@ impl MarmotRelayPlane {
                 let sender = account_deliveries_read(&transport.account_deliveries)
                     .get(&delivery.account_id)
                     .cloned();
-                if let Some(sender) = sender {
+                if let Some(route) = sender {
                     // Fan out without awaiting the per-account queue: a single
                     // account whose receiver has stalled (full buffer) must not
                     // block this shared router and back-pressure delivery for
                     // every other account (and, upstream, the relay notification
-                    // pipeline). Drop the delivery for the lagging account
-                    // instead; it recovers on the next subscription catch-up.
-                    match sender.try_send(delivery) {
-                        Ok(()) => {}
+                    // pipeline). The extra channel slot is reserved for one
+                    // overflow record. Once ordinary capacity is exhausted,
+                    // every omitted delivery belongs to that explicit recovery
+                    // generation; the account cannot trust EOSE or its cursor
+                    // again until an unfloored replay resolves the generation.
+                    let queue_depth = route
+                        .sender
+                        .max_capacity()
+                        .saturating_sub(route.sender.capacity());
+                    route.overflow.observe_queue_depth(queue_depth);
+                    if route.sender.capacity() <= 1 {
+                        let signal_generation = route.overflow.record_drop(queue_depth);
+                        if let Some(marker) = route.recovery_marker.clone() {
+                            // Account-local persistence runs independently of
+                            // the shared router. Hold this omitted delivery in
+                            // the task until the durable marker barrier returns;
+                            // other accounts, EOSE, and commands keep flowing.
+                            let sender = route.sender.clone();
+                            let overflow_state = route.overflow.clone();
+                            tokio::spawn(async move {
+                                overflow_state.persist_marker_before_drop(marker).await;
+                                drop(delivery);
+                                if let Some(generation) = signal_generation {
+                                    enqueue_account_delivery_overflow_signal(
+                                        &sender,
+                                        &overflow_state,
+                                        generation,
+                                    );
+                                }
+                            });
+                        } else if let Some(generation) = signal_generation {
+                            enqueue_account_delivery_overflow_signal(
+                                &route.sender,
+                                &route.overflow,
+                                generation,
+                            );
+                        }
+                        tracing::warn!(
+                            target: "marmot_app::relay_plane",
+                            method = "spawn_router",
+                            queue_depth,
+                            "omitting transport delivery: account delivery queue overflow recovery required",
+                        );
+                        continue;
+                    }
+                    match route
+                        .sender
+                        .try_send(AccountDeliveryEvent::Delivery(Box::new(delivery)))
+                    {
+                        Ok(()) => {
+                            let queue_depth = route
+                                .sender
+                                .max_capacity()
+                                .saturating_sub(route.sender.capacity());
+                            route.overflow.observe_queue_depth(queue_depth);
+                        }
                         Err(mpsc::error::TrySendError::Full(_)) => {
+                            // Only this router writes the route, and it reserves
+                            // one control slot above, so reaching Full here
+                            // indicates a violated queue invariant rather than
+                            // ordinary backpressure.
                             tracing::warn!(
                                 target: "marmot_app::relay_plane",
                                 method = "spawn_router",
-                                "dropping transport delivery: account delivery queue full",
+                                error_kind = "reserved_overflow_slot_unavailable",
+                                "account delivery queue invariant failed",
                             );
                         }
                         Err(mpsc::error::TrySendError::Closed(_)) => {}
@@ -792,6 +1240,7 @@ impl RelayPlaneHealth {
         health: NostrSdkRelayHealth,
         directory: DirectoryRelayStats,
         forwarder: RelayNotificationForwarderHealthSnapshot,
+        account_delivery: AccountDeliveryMetricsSnapshot,
     ) -> Self {
         Self {
             sdk_backed: true,
@@ -812,6 +1261,13 @@ impl RelayPlaneHealth {
             notification_forwarder_lagged_notifications: forwarder.lagged_notifications,
             notification_forwarder_panics: forwarder.panics,
             notification_forwarder_unexpected_exits: forwarder.unexpected_exits,
+            account_delivery_queue_depth: account_delivery.queue_depth,
+            account_delivery_max_queue_depth: account_delivery.max_queue_depth,
+            account_delivery_dropped: account_delivery.dropped,
+            account_delivery_recovery_attempts: account_delivery.recovery_attempts,
+            account_delivery_recovery_successes: account_delivery.recovery_successes,
+            account_delivery_recovery_failures: account_delivery.recovery_failures,
+            account_delivery_recovery_elapsed_ms: account_delivery.recovery_elapsed_ms,
             directory_inflight_fetches: directory.inflight_fetches,
             directory_active_subscriptions: directory.active_subscriptions,
             directory_completed_fetches: directory.completed_fetches,
@@ -823,8 +1279,18 @@ impl RelayPlaneHealth {
         }
     }
 
-    fn from_directory(directory: DirectoryRelayStats) -> Self {
+    fn from_directory(
+        directory: DirectoryRelayStats,
+        account_delivery: AccountDeliveryMetricsSnapshot,
+    ) -> Self {
         Self {
+            account_delivery_queue_depth: account_delivery.queue_depth,
+            account_delivery_max_queue_depth: account_delivery.max_queue_depth,
+            account_delivery_dropped: account_delivery.dropped,
+            account_delivery_recovery_attempts: account_delivery.recovery_attempts,
+            account_delivery_recovery_successes: account_delivery.recovery_successes,
+            account_delivery_recovery_failures: account_delivery.recovery_failures,
+            account_delivery_recovery_elapsed_ms: account_delivery.recovery_elapsed_ms,
             directory_inflight_fetches: directory.inflight_fetches,
             directory_active_subscriptions: directory.active_subscriptions,
             directory_completed_fetches: directory.completed_fetches,
@@ -1258,12 +1724,56 @@ impl MarmotRelayPlaneAccountAdapter {
     /// The epoch-gap backfill drain reads this to tell a relay that has
     /// finished replaying stored history from one that has simply gone quiet.
     pub(crate) async fn account_subscription_eose(&self) -> AccountSubscriptionEose {
-        self.relay_plane
+        let mut eose = self
+            .relay_plane
             .inner
             .transport
             .adapter
             .account_subscription_eose(&self.account_id)
-            .await
+            .await;
+        if self.delivery_overflow.blocks_ordinary_eose() {
+            eose.with_eose = 0;
+        }
+        eose
+    }
+
+    pub(crate) async fn receive_account_delivery(
+        &self,
+    ) -> Result<Option<AccountDeliveryReceive>, TransportAdapterError> {
+        let event = self.delivery_rx.lock().await.recv().await;
+        Ok(event.map(|event| match event {
+            AccountDeliveryEvent::Delivery(delivery) => AccountDeliveryReceive::Delivery(delivery),
+            AccountDeliveryEvent::Overflow { generation } => {
+                AccountDeliveryReceive::Overflow(self.delivery_overflow.consume_signal(generation))
+            }
+        }))
+    }
+
+    /// Begin (or resume after process restart) the unfloored replay required by
+    /// a durable account-delivery overflow marker.
+    pub(crate) fn start_delivery_overflow_recovery(
+        &self,
+        durable_marker_token: u64,
+    ) -> AccountDeliveryOverflow {
+        self.delivery_overflow.start_recovery(durable_marker_token)
+    }
+
+    /// Resolve only the exact overflow prefix the replay started against. A
+    /// newer omitted delivery keeps the generation pending and forces another
+    /// unfloored attempt.
+    pub(crate) fn finish_delivery_overflow_recovery(
+        &self,
+        attempt: AccountDeliveryOverflow,
+    ) -> Option<u64> {
+        self.delivery_overflow.finish_recovery(attempt)
+    }
+
+    pub(crate) fn record_delivery_overflow_recovery_success(&self, elapsed_ms: u64) {
+        self.delivery_overflow.record_recovery_success(elapsed_ms);
+    }
+
+    pub(crate) fn fail_delivery_overflow_recovery(&self) {
+        self.delivery_overflow.fail_recovery();
     }
 
     pub(crate) async fn remove_group_maintenance_subscription(
@@ -1406,21 +1916,49 @@ impl TransportAdapter for MarmotRelayPlaneAccountAdapter {
     }
 
     async fn receive(&self) -> Result<Option<TransportDelivery>, TransportAdapterError> {
-        Ok(self.delivery_rx.lock().await.recv().await)
+        match self.receive_account_delivery().await? {
+            Some(AccountDeliveryReceive::Delivery(delivery)) => Ok(Some(*delivery)),
+            Some(AccountDeliveryReceive::Overflow(_)) => Err(TransportAdapterError::Other(
+                "account delivery overflow recovery required".to_owned(),
+            )),
+            None => Ok(None),
+        }
+    }
+}
+
+fn enqueue_account_delivery_overflow_signal(
+    sender: &mpsc::Sender<AccountDeliveryEvent>,
+    overflow: &AccountDeliveryOverflowState,
+    generation: u64,
+) {
+    match sender.try_send(AccountDeliveryEvent::Overflow { generation }) {
+        Ok(()) => {}
+        Err(error) => {
+            overflow.cancel_signal(generation);
+            tracing::warn!(
+                target: "marmot_app::relay_plane",
+                method = "spawn_router",
+                error_kind = match error {
+                    mpsc::error::TrySendError::Full(_) => "queue_full",
+                    mpsc::error::TrySendError::Closed(_) => "queue_closed",
+                },
+                "could not enqueue account delivery overflow recovery signal",
+            );
+        }
     }
 }
 
 fn account_deliveries_read(
-    deliveries: &RwLock<HashMap<MemberId, mpsc::Sender<TransportDelivery>>>,
-) -> RwLockReadGuard<'_, HashMap<MemberId, mpsc::Sender<TransportDelivery>>> {
+    deliveries: &RwLock<HashMap<MemberId, AccountDeliveryRoute>>,
+) -> RwLockReadGuard<'_, HashMap<MemberId, AccountDeliveryRoute>> {
     deliveries
         .read()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
 fn account_deliveries_write(
-    deliveries: &RwLock<HashMap<MemberId, mpsc::Sender<TransportDelivery>>>,
-) -> RwLockWriteGuard<'_, HashMap<MemberId, mpsc::Sender<TransportDelivery>>> {
+    deliveries: &RwLock<HashMap<MemberId, AccountDeliveryRoute>>,
+) -> RwLockWriteGuard<'_, HashMap<MemberId, AccountDeliveryRoute>> {
     deliveries
         .write()
         .unwrap_or_else(|poisoned| poisoned.into_inner())

--- a/crates/marmot-app/src/relay_plane/mod.rs
+++ b/crates/marmot-app/src/relay_plane/mod.rs
@@ -334,8 +334,8 @@ impl AccountDeliveryOverflowState {
                         .inner
                         .lock()
                         .unwrap_or_else(|poisoned| poisoned.into_inner());
-                    state.marker_in_progress = false;
                     if state.generation == generation {
+                        state.marker_in_progress = false;
                         state.marker_durable = true;
                     }
                     return;
@@ -345,14 +345,16 @@ impl AccountDeliveryOverflowState {
                         .inner
                         .lock()
                         .unwrap_or_else(|poisoned| poisoned.into_inner());
-                    state.marker_in_progress = false;
-                    state.marker_closed = true;
-                    tracing::debug!(
-                        target: "marmot_app::relay_plane",
-                        method = "persist_marker_before_drop",
-                        error_kind = "storage_closed",
-                        "account delivery overflow marker worker stopped after storage closure",
-                    );
+                    if state.generation == generation {
+                        state.marker_in_progress = false;
+                        state.marker_closed = true;
+                        tracing::debug!(
+                            target: "marmot_app::relay_plane",
+                            method = "persist_marker_before_drop",
+                            error_kind = "storage_closed",
+                            "account delivery overflow marker worker stopped after storage closure",
+                        );
+                    }
                     return;
                 }
                 Ok(Err(AccountDeliveryRecoveryMarkerError::Retryable)) | Err(_) => {
@@ -365,12 +367,11 @@ impl AccountDeliveryOverflowState {
                     tokio::time::sleep(Duration::from_millis(100)).await;
                 }
             }
-            let mut state = self
+            let state = self
                 .inner
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
             if state.generation != generation {
-                state.marker_in_progress = false;
                 return;
             }
         }

--- a/crates/marmot-app/src/relay_plane/tests.rs
+++ b/crates/marmot-app/src/relay_plane/tests.rs
@@ -157,6 +157,37 @@ fn account_delivery_recovery_metrics_report_retry_outcomes_without_identity() {
     assert_eq!(overflow.metrics.dropped.load(Ordering::Relaxed), 3);
 }
 
+#[tokio::test]
+async fn overflow_marker_uses_one_worker_and_stops_when_storage_closes() {
+    let overflow = AccountDeliveryOverflowState::default();
+    assert!(overflow.record_drop(ACCOUNT_DELIVERY_BUFFER).is_some());
+    assert!(overflow.start_marker_persistence());
+    assert!(
+        !overflow.start_marker_persistence(),
+        "one generation must never own more than one marker worker"
+    );
+
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let observed_attempts = attempts.clone();
+    let marker: AccountDeliveryRecoveryMarker = Arc::new(move |_, _| {
+        observed_attempts.fetch_add(1, Ordering::SeqCst);
+        Err(AccountDeliveryRecoveryMarkerError::Closed)
+    });
+    timeout(
+        Duration::from_secs(1),
+        overflow.persist_marker_before_drop(marker),
+    )
+    .await
+    .expect("terminal storage closure must release the marker worker");
+
+    assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    assert!(overflow.marker_barrier_complete());
+    assert!(
+        !overflow.start_marker_persistence(),
+        "closed storage must not arm an immortal retry task"
+    );
+}
+
 #[test]
 fn notification_restart_backoff_caps_and_resets_after_healthy_runtime() {
     let mut backoff = RelayNotificationRestartBackoff::default();
@@ -1231,7 +1262,7 @@ async fn account_queue_overflow_invalidates_eose_without_blocking_other_accounts
     let attempts = marker_attempts.clone();
     let recovery_marker: AccountDeliveryRecoveryMarker = Arc::new(move |_, _| {
         if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
-            return Err(());
+            return Err(AccountDeliveryRecoveryMarkerError::Retryable);
         }
         marker_flag.store(true, Ordering::SeqCst);
         Ok(())
@@ -1372,7 +1403,7 @@ async fn account_queue_overflow_invalidates_eose_without_blocking_other_accounts
     );
     assert!(
         marker_attempts.load(Ordering::SeqCst) >= 2,
-        "a failed marker write must retry while holding the omitted delivery"
+        "the single marker worker must retry without retaining omitted deliveries"
     );
     assert!(overflow.dropped >= 1);
     assert!(overflow.queue_depth >= ACCOUNT_DELIVERY_BUFFER);

--- a/crates/marmot-app/src/relay_plane/tests.rs
+++ b/crates/marmot-app/src/relay_plane/tests.rs
@@ -188,6 +188,74 @@ async fn overflow_marker_uses_one_worker_and_stops_when_storage_closes() {
     );
 }
 
+async fn assert_stale_marker_worker_preserves_new_generation(
+    result: Result<(), AccountDeliveryRecoveryMarkerError>,
+) {
+    let overflow = Arc::new(AccountDeliveryOverflowState::default());
+    let old_generation = overflow.record_drop(ACCOUNT_DELIVERY_BUFFER).unwrap();
+    overflow.consume_signal(old_generation);
+    assert!(overflow.start_marker_persistence());
+    let old_attempt = overflow.start_recovery(1);
+
+    let entered = Arc::new(AtomicBool::new(false));
+    let release = Arc::new(AtomicBool::new(false));
+    let marker: AccountDeliveryRecoveryMarker = {
+        let entered = entered.clone();
+        let release = release.clone();
+        Arc::new(move |_, _| {
+            entered.store(true, Ordering::SeqCst);
+            while !release.load(Ordering::SeqCst) {
+                std::thread::yield_now();
+            }
+            result
+        })
+    };
+    let worker = {
+        let overflow = overflow.clone();
+        tokio::spawn(async move { overflow.persist_marker_before_drop(marker).await })
+    };
+    timeout(Duration::from_secs(1), async {
+        while !entered.load(Ordering::SeqCst) {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("the old generation marker worker must start");
+
+    assert!(overflow.finish_recovery(old_attempt).is_some());
+    let new_generation = overflow.record_drop(ACCOUNT_DELIVERY_BUFFER).unwrap();
+    overflow.consume_signal(new_generation);
+    assert!(overflow.start_marker_persistence());
+
+    release.store(true, Ordering::SeqCst);
+    timeout(Duration::from_secs(1), worker)
+        .await
+        .expect("the stale marker worker must stop")
+        .unwrap();
+
+    assert!(
+        !overflow.start_marker_persistence(),
+        "a stale worker must not release the newer generation's worker claim"
+    );
+    assert!(
+        !overflow.marker_barrier_complete(),
+        "a stale worker must not publish its outcome into the newer generation"
+    );
+}
+
+#[tokio::test]
+async fn stale_overflow_marker_workers_preserve_new_generation_claim() {
+    assert_stale_marker_worker_preserves_new_generation(Ok(())).await;
+    assert_stale_marker_worker_preserves_new_generation(Err(
+        AccountDeliveryRecoveryMarkerError::Closed,
+    ))
+    .await;
+    assert_stale_marker_worker_preserves_new_generation(Err(
+        AccountDeliveryRecoveryMarkerError::Retryable,
+    ))
+    .await;
+}
+
 #[test]
 fn notification_restart_backoff_caps_and_resets_after_healthy_runtime() {
     let mut backoff = RelayNotificationRestartBackoff::default();

--- a/crates/marmot-app/src/relay_plane/tests.rs
+++ b/crates/marmot-app/src/relay_plane/tests.rs
@@ -113,9 +113,48 @@ fn account_deliveries_lock_helpers_recover_from_poisoned_guard() {
     }));
 
     let (delivery_tx, _delivery_rx) = mpsc::channel(1);
-    account_deliveries_write(&deliveries).insert(MemberId::new(vec![0x01; 32]), delivery_tx);
+    account_deliveries_write(&deliveries).insert(
+        MemberId::new(vec![0x01; 32]),
+        AccountDeliveryRoute {
+            sender: delivery_tx,
+            overflow: Arc::new(AccountDeliveryOverflowState::default()),
+            recovery_marker: None,
+        },
+    );
 
     assert_eq!(account_deliveries_read(&deliveries).len(), 1);
+}
+
+#[test]
+fn account_delivery_recovery_metrics_report_retry_outcomes_without_identity() {
+    let overflow = AccountDeliveryOverflowState::default();
+    let generation = overflow.record_drop(ACCOUNT_DELIVERY_BUFFER).unwrap();
+    overflow.consume_signal(generation);
+    let first = overflow.start_recovery(1);
+    let elapsed_ms = overflow.finish_recovery(first).unwrap();
+    overflow.record_recovery_success(elapsed_ms);
+
+    let generation = overflow.record_drop(ACCOUNT_DELIVERY_BUFFER).unwrap();
+    overflow.consume_signal(generation);
+    let second = overflow.start_recovery(2);
+    // A new omission during the replay invalidates this attempt.
+    assert!(overflow.record_drop(ACCOUNT_DELIVERY_BUFFER).is_some());
+    assert!(overflow.finish_recovery(second).is_none());
+    overflow.fail_recovery();
+
+    assert_eq!(
+        overflow.metrics.recovery_attempts.load(Ordering::Relaxed),
+        2
+    );
+    assert_eq!(
+        overflow.metrics.recovery_successes.load(Ordering::Relaxed),
+        1
+    );
+    assert_eq!(
+        overflow.metrics.recovery_failures.load(Ordering::Relaxed),
+        1
+    );
+    assert_eq!(overflow.metrics.dropped.load(Ordering::Relaxed), 3);
 }
 
 #[test]
@@ -1173,6 +1212,170 @@ async fn shared_group_event_is_delivered_to_each_matching_account_receiver() {
     assert_eq!(bob_delivery.group_id_hint, Some(group_id));
     assert_eq!(alice_delivery.source.plane, TransportDeliveryPlane::Group);
     assert_eq!(bob_delivery.source.plane, TransportDeliveryPlane::Group);
+}
+
+#[tokio::test]
+async fn account_queue_overflow_invalidates_eose_without_blocking_other_accounts() {
+    let relay = Arc::new(RecordingRelayClient::default());
+    let relay_plane = MarmotRelayPlane::new(Some(Duration::from_secs(30)), relay.clone());
+    let alice = MemberId::new(vec![0xA1; 32]);
+    let bob = MemberId::new(vec![0xB2; 32]);
+    let alice_group_id = GroupId::new(vec![0xC3; 32]);
+    let bob_group_id = GroupId::new(vec![0xC4; 32]);
+    let alice_transport_group_id = vec![0xD3; 32];
+    let bob_transport_group_id = vec![0xD4; 32];
+    let endpoint = TransportEndpoint("wss://relay.example".into());
+    let marker_persisted = Arc::new(AtomicBool::new(false));
+    let marker_attempts = Arc::new(AtomicUsize::new(0));
+    let marker_flag = marker_persisted.clone();
+    let attempts = marker_attempts.clone();
+    let recovery_marker: AccountDeliveryRecoveryMarker = Arc::new(move |_, _| {
+        if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+            return Err(());
+        }
+        marker_flag.store(true, Ordering::SeqCst);
+        Ok(())
+    });
+    let alice_adapter = relay_plane.account_adapter_with_recovery_marker(
+        alice.clone(),
+        relay.clone(),
+        Some(recovery_marker),
+    );
+    let bob_adapter = relay_plane.account_adapter(bob.clone(), relay.clone());
+
+    for (adapter, account_id, group_id, transport_group_id) in [
+        (
+            &alice_adapter,
+            alice.clone(),
+            alice_group_id,
+            alice_transport_group_id.clone(),
+        ),
+        (
+            &bob_adapter,
+            bob.clone(),
+            bob_group_id.clone(),
+            bob_transport_group_id.clone(),
+        ),
+    ] {
+        adapter
+            .activate_account(TransportAccountActivation {
+                account_id,
+                inbox_endpoints: vec![endpoint.clone()],
+                group_subscriptions: vec![TransportGroupSubscription {
+                    group_id,
+                    transport_group_id,
+                    endpoints: vec![endpoint.clone()],
+                }],
+                since: Some(Timestamp(1_699_999_900)),
+            })
+            .await
+            .unwrap();
+    }
+
+    // Newest-first stored history fills Alice's deliberately undrained queue.
+    // At least one older delivery is then omitted from that queue while the
+    // shared router must remain available to Bob.
+    for index in 0..=ACCOUNT_DELIVERY_BUFFER {
+        let mut event = group_event(&format!("alice-{index}"), &alice_transport_group_id);
+        event.created_at = 1_700_100_000_u64.saturating_sub(index as u64);
+        event.id = event.computed_id();
+        relay_plane
+            .handle_relay_event_for_test(NostrRelayEvent {
+                endpoint: endpoint.clone(),
+                subscription_id: Some("alice-group".into()),
+                event,
+            })
+            .await
+            .unwrap();
+    }
+
+    relay_plane
+        .handle_relay_event_for_test(NostrRelayEvent {
+            endpoint: endpoint.clone(),
+            subscription_id: Some("bob-group".into()),
+            event: group_event("bob-after-alice-overflow", &bob_transport_group_id),
+        })
+        .await
+        .unwrap();
+    let bob_delivery = timeout(Duration::from_secs(1), bob_adapter.receive())
+        .await
+        .expect("Alice's full queue must not block Bob")
+        .unwrap()
+        .unwrap();
+    assert_eq!(bob_delivery.account_id, bob);
+    assert_eq!(bob_delivery.group_id_hint, Some(bob_group_id));
+
+    let bob_subscription_ids = relay
+        .subscriptions
+        .lock()
+        .unwrap()
+        .iter()
+        .filter(|subscription| subscription.account_id() == &bob)
+        .map(NostrSubscription::subscription_id)
+        .collect::<Vec<_>>();
+    assert!(!bob_subscription_ids.is_empty());
+    for subscription_id in bob_subscription_ids {
+        relay_plane
+            .handle_relay_eose_for_test(endpoint.clone(), subscription_id)
+            .await;
+    }
+    assert!(
+        bob_adapter.account_subscription_eose().await.complete(),
+        "Alice's full queue must not block Bob's EOSE"
+    );
+
+    let alice_subscription_ids = relay
+        .subscriptions
+        .lock()
+        .unwrap()
+        .iter()
+        .filter(|subscription| subscription.account_id() == &alice)
+        .map(NostrSubscription::subscription_id)
+        .collect::<Vec<_>>();
+    assert!(!alice_subscription_ids.is_empty());
+    for subscription_id in alice_subscription_ids {
+        relay_plane
+            .handle_relay_eose_for_test(endpoint.clone(), subscription_id)
+            .await;
+    }
+
+    assert!(
+        !alice_adapter.account_subscription_eose().await.complete(),
+        "EOSE must stay incomplete while Alice has an unresolved delivery gap"
+    );
+    let health = relay_plane.relay_health().await;
+    assert!(health.account_delivery_queue_depth >= ACCOUNT_DELIVERY_BUFFER);
+    assert!(health.account_delivery_max_queue_depth >= ACCOUNT_DELIVERY_BUFFER as u64);
+    assert!(health.account_delivery_dropped >= 1);
+    assert_eq!(health.account_delivery_recovery_attempts, 0);
+
+    let (retained, overflow) = timeout(Duration::from_secs(1), async {
+        let mut retained = 0_usize;
+        loop {
+            match alice_adapter
+                .receive_account_delivery()
+                .await
+                .unwrap()
+                .expect("Alice's route stays open")
+            {
+                AccountDeliveryReceive::Delivery(_) => retained += 1,
+                AccountDeliveryReceive::Overflow(overflow) => break (retained, overflow),
+            }
+        }
+    })
+    .await
+    .expect("the reserved overflow record must follow the retained prefix");
+    assert_eq!(retained, ACCOUNT_DELIVERY_BUFFER);
+    assert!(
+        marker_persisted.load(Ordering::SeqCst),
+        "the overflow control record is released only after durable marking"
+    );
+    assert!(
+        marker_attempts.load(Ordering::SeqCst) >= 2,
+        "a failed marker write must retry while holding the omitted delivery"
+    );
+    assert!(overflow.dropped >= 1);
+    assert!(overflow.queue_depth >= ACCOUNT_DELIVERY_BUFFER);
 }
 
 #[tokio::test]

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -1232,7 +1232,20 @@ async fn run_app_runtime_account_worker(
                 // publish + projection as one uncancelled worker operation;
                 // commands remain queued until that durable sequence lands.
                 let result = match received {
-                    Ok(delivery) => client.ingest_received_delivery(delivery).await,
+                    Ok(crate::relay_plane::AccountDeliveryReceive::Delivery(delivery)) => {
+                        client.ingest_received_delivery(*delivery).await
+                    }
+                    Ok(crate::relay_plane::AccountDeliveryReceive::Overflow(_)) => {
+                        match client.recover_delivery_overflow().await {
+                            Ok(summary) => Ok(summary),
+                            Err(failure) => {
+                                client
+                                    .pending_failed_sync_summary
+                                    .merge(failure.partial_summary);
+                                Err(failure.source)
+                            }
+                        }
+                    }
                     Err(err) => Err(err),
                 };
                 match result {
@@ -4310,7 +4323,7 @@ async fn run_pending_epoch_backfill_reporting_arm(
     seam: EpochBackfillExecutionSeam,
 ) -> Result<(), AccountCatchUpFailure> {
     let backfill_armed = client.has_pending_epoch_backfill();
-    let result = match client.run_pending_epoch_backfill(seam).await {
+    let mut result = match client.run_pending_epoch_backfill(seam).await {
         // An incomplete replay published the same real summary: it ingested
         // whatever it reached before the relays failed to confirm they had
         // served the account's stored history. Its intent stays pending, so the
@@ -4342,6 +4355,40 @@ async fn run_pending_epoch_backfill_reporting_arm(
     };
     if backfill_armed {
         shared.schedule_audit_log_tracker_update("epoch_backfill_armed");
+    }
+    // An epoch replay is itself a large relay burst and can discover the
+    // bounded account queue's overflow record. Resolve that distinct durable
+    // gap immediately instead of waiting for unrelated later traffic to wake
+    // another sync seam.
+    if result.is_ok() && client.delivery_overflow_recovery_pending {
+        result = match client.recover_delivery_overflow().await {
+            Ok(summary) => {
+                publish_app_runtime_summary(events, account_id_hex, account_label, &summary);
+                Ok(())
+            }
+            Err(failure) => {
+                publish_app_runtime_summary(
+                    events,
+                    account_id_hex,
+                    account_label,
+                    &failure.partial_summary,
+                );
+                let message = account_error_message(
+                    "account delivery overflow recovery failed",
+                    &failure.source,
+                );
+                publish_app_runtime_account_error(
+                    events,
+                    account_id_hex,
+                    account_label,
+                    message.clone(),
+                );
+                Err(AccountCatchUpFailure::new(
+                    message,
+                    failure.classification(),
+                ))
+            }
+        };
     }
     result
 }

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -36,11 +36,12 @@ use crate::{
     AppDisbandRequest, AppError, AppGroupMemberRecord, AppGroupMlsState, AppGroupRecord,
     AppPreparedGroupImageUpload, AppProjectionUpdate, AppQuarantinedGroup, CanonicalCreatedGroup,
     ChatListUpdateTrigger, ClassifiedSyncFailure, ConvergenceScheduleState,
-    EpochBackfillRunOutcome, GroupInviteDeclineResult, MaintenanceRunSummary, MarmotApp,
-    MarmotRelayPlane, MediaAttachmentReference, MediaDownloadResult, MediaUploadRequest,
-    MediaUploadResult, NotificationSettings, PendingWelcomeDelivery, PushPlatform,
-    PushRegistration, PushRegistrationShareOutcome, PushRegistrationSyncResult, ReceivedMessage,
-    RetentionSweepReport, SecureDeleteExpiredResult, SendSummary, SyncSummary,
+    DeliveryOverflowRecoveryOutcome, EpochBackfillRunOutcome, GroupInviteDeclineResult,
+    MaintenanceRunSummary, MarmotApp, MarmotRelayPlane, MediaAttachmentReference,
+    MediaDownloadResult, MediaUploadRequest, MediaUploadResult, NotificationSettings,
+    PendingWelcomeDelivery, PushPlatform, PushRegistration, PushRegistrationShareOutcome,
+    PushRegistrationSyncResult, ReceivedMessage, RetentionSweepReport, SecureDeleteExpiredResult,
+    SendSummary, SyncSummary,
 };
 use cgka_traits::app_event::MarmotAppEvent as MarmotInnerEvent;
 
@@ -1237,24 +1238,29 @@ async fn run_app_runtime_account_worker(
                     }
                     Ok(crate::relay_plane::AccountDeliveryReceive::Overflow(_)) => {
                         match client.recover_delivery_overflow().await {
-                            Ok(summary) => (Ok(summary), false),
-                            Err(failure) => {
+                            Ok(DeliveryOverflowRecoveryOutcome::Completed(summary)) => {
+                                (Ok(summary), false)
+                            }
+                            Ok(DeliveryOverflowRecoveryOutcome::Incomplete(summary)) => {
                                 publish_app_runtime_account_error(
                                     &events,
                                     &account_id_hex,
                                     &account_label,
-                                    account_error_message(
-                                        "account delivery overflow recovery incomplete",
-                                        &failure.source,
-                                    ),
+                                    "account delivery overflow recovery incomplete".to_owned(),
                                 );
-                                client
-                                    .pending_failed_sync_summary
-                                    .merge(failure.partial_summary);
                                 // The durable marker remains armed. Keep the
                                 // account session available and let the next
                                 // receive/catch-up seam retry the replay.
-                                (Ok(SyncSummary::default()), true)
+                                (Ok(summary), true)
+                            }
+                            Err(failure) => {
+                                publish_app_runtime_summary(
+                                    &events,
+                                    &account_id_hex,
+                                    &account_label,
+                                    &failure.partial_summary,
+                                );
+                                (Err(failure.source), false)
                             }
                         }
                     }
@@ -4376,7 +4382,10 @@ async fn run_pending_epoch_backfill_reporting_arm(
     // another sync seam.
     if result.is_ok() && client.delivery_overflow_recovery_pending {
         result = match client.recover_delivery_overflow().await {
-            Ok(summary) => {
+            Ok(
+                DeliveryOverflowRecoveryOutcome::Completed(summary)
+                | DeliveryOverflowRecoveryOutcome::Incomplete(summary),
+            ) => {
                 publish_app_runtime_summary(events, account_id_hex, account_label, &summary);
                 Ok(())
             }
@@ -5122,6 +5131,51 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(relay.subscription_count(), subscriptions_after_replay);
+    }
+
+    #[tokio::test]
+    async fn incomplete_delivery_overflow_recovery_does_not_fail_catch_up() {
+        let dir = tempfile::tempdir().unwrap();
+        AccountHome::open(dir.path())
+            .create_account("alice")
+            .unwrap();
+        let relay = Arc::new(ScriptedPushRelayClient::default());
+        let app = MarmotApp::with_relay_and_config(
+            dir.path(),
+            "wss://relay.example".to_owned(),
+            bounded_epoch_backfill_config().with_dev_epoch_backfill_eose_wait_ms(25),
+        )
+        .with_test_relay_client(relay);
+        let mut client = client_on_app_relay_plane(&app, "alice").await;
+        let marker_token = 7;
+        app.account_storage("alice")
+            .unwrap()
+            .mark_account_delivery_recovery("alice", marker_token, 1)
+            .unwrap();
+        client.delivery_overflow_recovery_pending = true;
+        client.delivery_overflow_recovery_marker_token = Some(marker_token);
+
+        let (events, _subscriber) = broadcast::channel(4);
+        run_pending_epoch_backfill_reporting_arm(
+            &mut client,
+            &events,
+            "account-id",
+            "alice",
+            &RuntimeSharedServices::default(),
+            EpochBackfillExecutionSeam::ExplicitCatchUp,
+        )
+        .await
+        .expect("missing relay EOSE is incomplete recovery, not a catch-up failure");
+
+        assert!(client.delivery_overflow_recovery_pending);
+        assert!(
+            app.account_storage("alice")
+                .unwrap()
+                .account_delivery_recovery("alice")
+                .unwrap()
+                .is_some(),
+            "incomplete recovery must retain its durable retry marker"
+        );
     }
 
     #[tokio::test]

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -1231,22 +1231,34 @@ async fn run_app_runtime_account_worker(
                 // delivery has been claimed, finish ingest + incidental
                 // publish + projection as one uncancelled worker operation;
                 // commands remain queued until that durable sequence lands.
-                let result = match received {
+                let (result, overflow_recovery_incomplete) = match received {
                     Ok(crate::relay_plane::AccountDeliveryReceive::Delivery(delivery)) => {
-                        client.ingest_received_delivery(*delivery).await
+                        (client.ingest_received_delivery(*delivery).await, false)
                     }
                     Ok(crate::relay_plane::AccountDeliveryReceive::Overflow(_)) => {
                         match client.recover_delivery_overflow().await {
-                            Ok(summary) => Ok(summary),
+                            Ok(summary) => (Ok(summary), false),
                             Err(failure) => {
+                                publish_app_runtime_account_error(
+                                    &events,
+                                    &account_id_hex,
+                                    &account_label,
+                                    account_error_message(
+                                        "account delivery overflow recovery incomplete",
+                                        &failure.source,
+                                    ),
+                                );
                                 client
                                     .pending_failed_sync_summary
                                     .merge(failure.partial_summary);
-                                Err(failure.source)
+                                // The durable marker remains armed. Keep the
+                                // account session available and let the next
+                                // receive/catch-up seam retry the replay.
+                                (Ok(SyncSummary::default()), true)
                             }
                         }
                     }
-                    Err(err) => Err(err),
+                    Err(err) => (Err(err), false),
                 };
                 match result {
                     Ok(summary) => {
@@ -1268,15 +1280,17 @@ async fn run_app_runtime_account_worker(
                             &mut scheduled_convergence,
                             &mut client,
                         );
-                        let _ = run_pending_epoch_backfill_reporting_arm(
-                            &mut client,
-                            &events,
-                            &account_id_hex,
-                            &account_label,
-                            &shared,
-                            EpochBackfillExecutionSeam::Receive,
-                        )
-                        .await;
+                        if !overflow_recovery_incomplete {
+                            let _ = run_pending_epoch_backfill_reporting_arm(
+                                &mut client,
+                                &events,
+                                &account_id_hex,
+                                &account_label,
+                                &shared,
+                                EpochBackfillExecutionSeam::Receive,
+                            )
+                            .await;
+                        }
                         if sync_summary_triggers_audit_tracker_update(&summary) {
                             shared.schedule_audit_log_tracker_update("receive");
                         }

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -9294,11 +9294,35 @@ fn durable_delivery_overflow_marker_forces_unfloored_account_reopen() {
             "account reopen must issue no cursor floor while overflow recovery is pending"
         );
 
+        let group_id = client
+            .create_group("overflow recovery target", &[])
+            .await
+            .unwrap();
+        let group = reopened
+            .group("alice", &hex::encode(group_id.as_slice()))
+            .unwrap()
+            .expect("recovery target group projection");
+        let omitted = epoch_gap_probe(
+            &group.nostr_routing.nostr_group_id_hex,
+            cursor.saturating_sub(600),
+            "overflow-redelivery",
+        );
+        let omitted_id = omitted.id.clone();
+        inject_epoch_gap_probe(&reopened, omitted).await;
+
         let _eose = scripted_eose_pump(reopened.relay_plane.clone(), relay, every_subscription);
         client
             .sync()
             .await
             .expect("an EOSE-confirmed unfloored replay resolves the durable gap");
+        assert!(
+            reopened
+                .load_state("alice")
+                .unwrap()
+                .seen_events
+                .contains(&omitted_id),
+            "the unfloored recovery must ingest the older event omitted below the ordinary cursor floor"
+        );
         assert!(!client.delivery_overflow_recovery_pending);
         assert!(
             reopened
@@ -9313,6 +9337,172 @@ fn durable_delivery_overflow_marker_forces_unfloored_account_reopen() {
         assert_eq!(health.account_delivery_recovery_attempts, 1);
         assert_eq!(health.account_delivery_recovery_successes, 1);
         assert_eq!(health.account_delivery_recovery_failures, 0);
+    });
+}
+
+#[test]
+fn process_local_overflow_fence_freezes_cursor_while_marker_write_retries() {
+    run_composed_app_runtime_test("delivery-overflow-cursor-fence", || async {
+        let dir = tempfile::tempdir().unwrap();
+        let account = AccountHome::open(dir.path())
+            .create_account("alice")
+            .unwrap();
+        let relay = Arc::new(ScriptedPushRelayClient::default());
+        let mut app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+            .with_test_relay_client(relay.clone());
+        app.relay_plane =
+            MarmotRelayPlane::new_with_loopback(Some(Duration::from_secs(120)), relay, true);
+        let cursor_before = crate::unix_now_seconds().saturating_sub(10_000);
+        app.ensure_account_state("alice").unwrap();
+        let mut seeded = app.load_state("alice").unwrap();
+        seeded.last_transport_timestamp = Some(cursor_before);
+        app.save_state(&seeded).unwrap();
+
+        let mut client = client_on_app_relay_plane(&app, "alice").await;
+        let group_id = client
+            .create_group("overflow cursor fence", &[])
+            .await
+            .unwrap();
+        let nostr_group_id_hex = app
+            .group("alice", &hex::encode(group_id.as_slice()))
+            .unwrap()
+            .expect("local group projection")
+            .nostr_routing
+            .nostr_group_id_hex;
+
+        let release_marker = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let marker_attempts = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let release = release_marker.clone();
+        let attempts = marker_attempts.clone();
+        let storage = app.account_storage("alice").unwrap();
+        let marker: crate::relay_plane::AccountDeliveryRecoveryMarker =
+            Arc::new(move |marker_token, dropped| {
+                attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                if !release.load(std::sync::atomic::Ordering::SeqCst) {
+                    return Err(crate::relay_plane::AccountDeliveryRecoveryMarkerError::Retryable);
+                }
+                storage
+                    .mark_account_delivery_recovery("alice", marker_token, dropped)
+                    .map_err(|error| {
+                        if error.is_closed() {
+                            crate::relay_plane::AccountDeliveryRecoveryMarkerError::Closed
+                        } else {
+                            crate::relay_plane::AccountDeliveryRecoveryMarkerError::Retryable
+                        }
+                    })
+            });
+        assert!(
+            app.relay_plane
+                .set_account_delivery_recovery_marker_for_test(
+                    &MemberId::new(hex::decode(&account.account_id_hex).unwrap()),
+                    marker,
+                )
+        );
+
+        // Model the dangerous lead-in: several newest events are processed by
+        // the live one-at-a-time worker seam before the later burst finally
+        // fills its queue. Their in-memory max is above the older event that
+        // will be omitted, but they must not promote the durable drain floor.
+        for index in 0..3_u64 {
+            inject_epoch_gap_probe(
+                &app,
+                epoch_gap_probe(
+                    &nostr_group_id_hex,
+                    cursor_before + 4_000 - index,
+                    &format!("pre-overflow-cursor-{index}"),
+                ),
+            )
+            .await;
+            let received = client.receive_next_delivery().await.unwrap();
+            let crate::relay_plane::AccountDeliveryReceive::Delivery(delivery) = received else {
+                panic!("the pre-overflow delivery must not produce a control record");
+            };
+            client
+                .ingest_received_delivery(*delivery)
+                .await
+                .expect("the pre-overflow delivery must checkpoint its projection");
+        }
+        assert!(
+            client.state.last_transport_timestamp > Some(cursor_before + 3_000),
+            "the regression needs a processed in-memory cursor above the later omitted event"
+        );
+
+        let newest = cursor_before + 2_000;
+        let mut omitted_timestamp = 0;
+        for index in 0..=crate::relay_plane::ACCOUNT_DELIVERY_BUFFER {
+            let created_at = newest.saturating_sub(index as u64);
+            if index == crate::relay_plane::ACCOUNT_DELIVERY_BUFFER {
+                omitted_timestamp = created_at;
+            }
+            inject_epoch_gap_probe(
+                &app,
+                epoch_gap_probe(
+                    &nostr_group_id_hex,
+                    created_at,
+                    &format!("overflow-cursor-{index}"),
+                ),
+            )
+            .await;
+        }
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while marker_attempts.load(std::sync::atomic::Ordering::SeqCst) == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("overflow must start its one marker worker");
+
+        let received = client.receive_next_delivery().await.unwrap();
+        let crate::relay_plane::AccountDeliveryReceive::Delivery(delivery) = received else {
+            panic!("the retained newest-first prefix must precede the overflow signal");
+        };
+        client
+            .ingest_received_delivery(*delivery)
+            .await
+            .expect("the retained prefix delivery must checkpoint");
+
+        let persisted = app
+            .account_storage("alice")
+            .unwrap()
+            .load_account_projection_state("alice", MAX_SEEN_EVENT_IDS)
+            .unwrap();
+        assert_eq!(
+            persisted.last_transport_timestamp,
+            Some(cursor_before),
+            "the process-local overflow fence must freeze the durable cursor before marker I/O completes"
+        );
+        assert!(
+            app.account_storage("alice")
+                .unwrap()
+                .account_delivery_recovery("alice")
+                .unwrap()
+                .is_none(),
+            "the regression must inspect the pre-marker crash window"
+        );
+        assert!(
+            app.relay_plane
+                .subscription_rebuild_since(persisted.last_transport_timestamp)
+                .is_some_and(|since| since.0 <= omitted_timestamp),
+            "without a marker, the frozen cursor must still request a range containing the omitted older event"
+        );
+
+        release_marker.store(true, std::sync::atomic::Ordering::SeqCst);
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if app
+                    .account_storage("alice")
+                    .unwrap()
+                    .account_delivery_recovery("alice")
+                    .unwrap()
+                    .is_some()
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("the single marker worker must persist after the retry clears");
     });
 }
 

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -9243,6 +9243,80 @@ fn legacy_account_projection_clamps_poisoned_transport_cursor_on_import() {
 }
 
 #[test]
+fn durable_delivery_overflow_marker_forces_unfloored_account_reopen() {
+    run_composed_app_runtime_test("delivery-overflow-reopen", || async {
+        let dir = tempfile::tempdir().unwrap();
+        AccountHome::open(dir.path())
+            .create_account("alice")
+            .unwrap();
+        let cursor = crate::unix_now_seconds() - 3_600;
+
+        {
+            let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+            app.ensure_account_state("alice").unwrap();
+            let mut state = app.load_state("alice").unwrap();
+            state.last_transport_timestamp = Some(cursor);
+            app.save_state(&state).unwrap();
+            app.account_storage("alice")
+                .unwrap()
+                .mark_account_delivery_recovery("alice", 17, 1)
+                .unwrap();
+        }
+
+        let relay = Arc::new(ScriptedPushRelayClient::default());
+        let mut reopened = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+            .with_test_relay_client(relay.clone());
+        reopened.relay_plane = MarmotRelayPlane::new_with_loopback(
+            Some(Duration::from_secs(120)),
+            relay.clone(),
+            true,
+        );
+        let mut client = client_on_app_relay_plane(&reopened, "alice").await;
+
+        assert!(client.delivery_overflow_recovery_pending);
+        assert_eq!(
+            client.state.last_transport_timestamp,
+            Some(cursor),
+            "the newer durable cursor remains diagnostic state"
+        );
+        assert!(
+            client.subscription_rebuild_since().is_none(),
+            "the pending gap must override the cursor with a full-history request"
+        );
+        let subscriptions = relay.accepted_subscriptions();
+        assert!(!subscriptions.is_empty());
+        assert!(
+            subscriptions.iter().all(|subscription| match subscription {
+                NostrSubscription::AccountInbox { since, .. }
+                | NostrSubscription::Group { since, .. } => since.is_none(),
+                NostrSubscription::GroupMaintenance { .. } => true,
+            }),
+            "account reopen must issue no cursor floor while overflow recovery is pending"
+        );
+
+        let _eose = scripted_eose_pump(reopened.relay_plane.clone(), relay, every_subscription);
+        client
+            .sync()
+            .await
+            .expect("an EOSE-confirmed unfloored replay resolves the durable gap");
+        assert!(!client.delivery_overflow_recovery_pending);
+        assert!(
+            reopened
+                .account_storage("alice")
+                .unwrap()
+                .account_delivery_recovery("alice")
+                .unwrap()
+                .is_none(),
+            "the durable marker clears only after the recovery replay reaches EOSE"
+        );
+        let health = reopened.relay_plane.relay_health().await;
+        assert_eq!(health.account_delivery_recovery_attempts, 1);
+        assert_eq!(health.account_delivery_recovery_successes, 1);
+        assert_eq!(health.account_delivery_recovery_failures, 0);
+    });
+}
+
+#[test]
 fn ingest_applies_owner_signed_transitive_448_and_drops_spoof() {
     use nostr::base64::Engine as _;
     use nostr::base64::engine::general_purpose::STANDARD as B64;
@@ -12557,6 +12631,10 @@ async fn a_failed_ingest_leaves_the_delivery_retryable_on_the_reused_client() {
         .await
         .expect("locally fanned-out application message")
         .unwrap();
+    let crate::relay_plane::AccountDeliveryReceive::Delivery(delivery) = delivery else {
+        panic!("the test did not overflow its account delivery queue");
+    };
+    let delivery = *delivery;
     let event_id = hex::encode(delivery.message.id.as_slice());
     assert_eq!(event_id, relay_event.id);
     bob_client
@@ -12583,6 +12661,10 @@ async fn a_failed_ingest_leaves_the_delivery_retryable_on_the_reused_client() {
             .await
             .expect("redelivered application message")
             .unwrap();
+    let crate::relay_plane::AccountDeliveryReceive::Delivery(redelivery) = redelivery else {
+        panic!("the test did not overflow its account delivery queue");
+    };
+    let redelivery = *redelivery;
     assert_eq!(hex::encode(redelivery.message.id.as_slice()), event_id);
     let summary = bob_client
         .ingest_received_delivery(redelivery)

--- a/crates/marmot-app/tests/since_floor.rs
+++ b/crates/marmot-app/tests/since_floor.rs
@@ -1,29 +1,20 @@
-//! Characterization test for the since-floor defect. In two sentences:
+//! Characterization tests for transport-cursor floor safety and epoch-gap
+//! recovery.
 //!
-//! > `last_transport_timestamp` is one account-wide durable cursor advanced
-//! > from the sender-controlled `created_at` of every ingested kind-445
-//! > (undecryptable included), and every subscription rebuild floors at
-//! > `since = cursor − 120s` — so any 445 not delivered while the cursor was
-//! > still low is permanently unfetchable, with no gap detection.
+//! `last_transport_timestamp` has two stages: every retained kind-445 may
+//! advance an in-memory candidate, but only a completed transport drain
+//! promotes that candidate to the durable subscription floor. Isolated live
+//! delivery saves retain the previous drain checkpoint. That separation keeps
+//! a later bounded-queue overflow from stranding an older newest-first event
+//! below a cursor committed by the retained prefix.
 //!
-//! This test PINS today's behavior on purpose: an event whose `created_at`
-//! falls below the rebuilt subscription's `since` floor is never delivered to
-//! the runtime, while a sibling event just above the floor is delivered —
-//! and the miss survives a cold restart because the floor is derived from a
-//! durable, monotonic cursor. It is deliberately independent of the other
-//! fixes: the frozen wake-collection cursor does not change this outcome (a
-//! `Frozen` wake between the two probe events still leaves the same floor in
-//! place), and EOSE-gated cursor completeness and epoch-gap backfill are the
-//! fixes that are expected to flip these assertions — when they land, the
-//! below-floor probe should start arriving (via backfill) and this file's
-//! expectations must be updated accordingly.
-//!
-//! Epoch-gap backfill has since landed, splitting this file in two:
-//! `cold_restart_since_floor_permanently_drops_backlog_below_it` still pins the
-//! UNARMED floor-drop (one undecryptable probe stays under the backfill
-//! threshold, so it stays dropped forever), while
-//! `stalled_epoch_backfill_recovers_below_floor_backlog_when_armed` pins the
-//! ARMED recovery of below-floor backlog through the full-history backfill.
+//! This file pins both consequences. The first test proves that an isolated
+//! live delivery cannot make below-candidate backlog permanently unfetchable:
+//! the first cold restart receives both probes, then its completed drain safely
+//! promotes the cursor, so the second restart may floor the older probe only
+//! after it is already durable. The second test independently pins unfloored
+//! epoch-gap recovery when a previously completed drain really did establish a
+//! floor below which new backlog appears.
 //!
 //! # Why one account per store
 //!
@@ -62,9 +53,10 @@
 //! runtime down for good, publishes the probe events while `bob` has no
 //! store-side app instance running at all, then opens a *brand new*
 //! `MarmotApp`/`MarmotAppRuntime` pair against the same on-disk store. That
-//! new pair's first subscription rebuild is a genuine cold boot, and doing it
-//! twice (independently) demonstrates the permanence property: the
-//! below-floor probe never arrives, not even on a second independent boot.
+//! new pair's first subscription rebuild is a genuine cold boot. Doing it
+//! twice demonstrates the cursor transition: the first drain recovers and
+//! checkpoints the older probe; only the later rebuild applies the newly safe
+//! floor.
 //!
 //! # Delivery observable
 //!
@@ -88,9 +80,10 @@
 //! group's real history (the welcome and the one ordinary message this test
 //! sends to advance the cursor), the test measures that legitimate count on
 //! the very first (still-live) boot rather than assuming it, then asserts
-//! each subsequent cold boot's delivered count is exactly
-//! `legitimate_count + 1` (the sibling, and only the sibling) — never
-//! `+ 2` (which would mean the below-floor probe leaked through).
+//! the first subsequent cold boot's delivered count is exactly
+//! `legitimate_count + 2` (both probes), while the following cold boot is
+//! exactly `legitimate_count + 1`: its newly promoted floor may exclude the
+//! older probe because the previous drain already retained it durably.
 
 use std::time::{Duration, Instant};
 
@@ -280,7 +273,7 @@ async fn publish_garbage_group_message_at(
 }
 
 #[tokio::test]
-async fn cold_restart_since_floor_permanently_drops_backlog_below_it() {
+async fn cold_restart_keeps_backlog_fetchable_until_a_drain_promotes_the_floor() {
     let (_relay, url) = mock_relay().await;
 
     // --- bob's store: the account whose since-floor we are pinning ---
@@ -321,8 +314,8 @@ async fn cold_restart_since_floor_permanently_drops_backlog_below_it() {
     })
     .await;
 
-    // Ordinary traffic: advances bob's durable transport cursor exactly the
-    // way the defect describes (every ingested kind-445 advances it).
+    // Ordinary live traffic advances bob's in-memory cursor candidate. Its
+    // isolated projection save must retain the prior completed-drain floor.
     alice_client
         .send(&group_id, b"ordinary traffic advances the cursor")
         .await
@@ -383,17 +376,15 @@ async fn cold_restart_since_floor_permanently_drops_backlog_below_it() {
     let delivered_after_boot2 = inbound_events_delivered(&app_bob_boot2).await;
     assert_eq!(
         delivered_after_boot2,
-        legitimate_delivery_count + 1,
-        "only the above-floor sibling should reach ingest on a cold boot; the \
-         below-floor probe must be silently dropped by the rebuilt \
-         subscription's since floor",
+        legitimate_delivery_count + 2,
+        "an isolated live-delivery cursor candidate must not become the durable \
+         floor: the first cold boot must still fetch both probe siblings",
     );
     runtime_bob_boot2.shutdown().await;
 
-    // --- boot 3: a second, independent cold restart — the permanence
-    // property. If the miss were a timing fluke rather than a permanent
-    // consequence of the durable cursor, a second independent rebuild could
-    // behave differently; it must not. ---
+    // --- boot 3: boot 2's completed drain has now durably retained both
+    // probes and promoted its cursor candidate. A later rebuild can safely
+    // floor the older probe without making it unfetchable. ---
     let app_bob_boot3 = open_store(&dir_bob, &url);
     let runtime_bob_boot3 = MarmotAppRuntime::new(app_bob_boot3.clone());
     start_with_maintenance_paused(&runtime_bob_boot3, "bob").await;
@@ -403,17 +394,16 @@ async fn cold_restart_since_floor_permanently_drops_backlog_below_it() {
     assert_eq!(
         delivered_after_boot3,
         legitimate_delivery_count + 1,
-        "a second, independent cold restart must still never deliver the \
-         below-floor probe: the miss is permanent, not a one-off timing \
-         fluke (the permanent-drop property)",
+        "after the first cold boot retained both probes, its completed drain \
+         may promote the cursor so the next rebuild delivers only the \
+         above-floor sibling",
     );
     runtime_bob_boot3.shutdown().await;
 }
 
-/// The armed counterpart to
-/// [`cold_restart_since_floor_permanently_drops_backlog_below_it`]: with enough
-/// undecryptable traffic at a stalled epoch, epoch-gap backfill recovers the
-/// backlog the rebuilt subscription's since floor would otherwise drop forever.
+/// Separate armed-recovery characterization: with enough undecryptable traffic
+/// at a stalled epoch, epoch-gap backfill recovers backlog below a floor already
+/// established by a completed drain.
 ///
 /// The probes play two distinct roles on either side of the floor:
 ///

--- a/crates/storage-sqlite/src/account_projection.rs
+++ b/crates/storage-sqlite/src/account_projection.rs
@@ -118,6 +118,16 @@ pub struct StoredEpochBackfillIntent {
     pub stalled_epoch: u64,
 }
 
+/// Durable evidence that the app relay plane omitted at least one delivery
+/// from a bounded per-account queue and must complete an unfloored replay
+/// before trusting the account's transport cursor again.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AccountDeliveryRecovery {
+    pub marker_token: u64,
+    pub pending_since: u64,
+    pub dropped_count: u64,
+}
+
 /// Minimal outline of a group still pending the local device's join
 /// confirmation, for invite-policy reconciliation. Deliberately carries no
 /// profile/component payload: the policy decision needs only the group id and
@@ -525,6 +535,83 @@ impl SqliteAccountStorage {
             }
             Ok(())
         })
+    }
+
+    pub fn account_delivery_recovery(
+        &self,
+        label: &str,
+    ) -> StorageResult<Option<AccountDeliveryRecovery>> {
+        let conn = self.lock()?;
+        conn.query_row(
+            "SELECT marker_token, pending_since, dropped_count
+             FROM account_delivery_recovery
+             WHERE account_label = ?1",
+            params![label],
+            |row| {
+                let marker_token = row.get::<_, i64>(0)?;
+                let pending_since = row.get::<_, i64>(1)?;
+                let dropped_count = row.get::<_, i64>(2)?;
+                Ok(AccountDeliveryRecovery {
+                    marker_token: u64::try_from(marker_token).unwrap_or_default(),
+                    pending_since: u64::try_from(pending_since).unwrap_or_default(),
+                    dropped_count: u64::try_from(dropped_count).unwrap_or_default(),
+                })
+            },
+        )
+        .optional()
+        .storage()
+    }
+
+    /// Persist incomplete recovery before the account may checkpoint a newer
+    /// cursor. Re-observing the same process-local generation raises the count
+    /// monotonically without moving its original detection time.
+    pub fn mark_account_delivery_recovery(
+        &self,
+        label: &str,
+        marker_token: u64,
+        dropped_count: u64,
+    ) -> StorageResult<()> {
+        let now = unix_now_seconds_i64();
+        let marker_token = i64::try_from(marker_token).unwrap_or(i64::MAX);
+        let dropped_count = i64::try_from(dropped_count).unwrap_or(i64::MAX);
+        let conn = self.lock()?;
+        conn.execute(
+            "INSERT INTO account_delivery_recovery (
+                account_label, marker_token, pending_since, dropped_count
+             ) VALUES (?1, ?2, ?3, ?4)
+             ON CONFLICT(account_label) DO UPDATE SET
+                marker_token = excluded.marker_token,
+                pending_since = CASE
+                    WHEN account_delivery_recovery.marker_token = excluded.marker_token
+                    THEN account_delivery_recovery.pending_since
+                    ELSE excluded.pending_since
+                END,
+                dropped_count = CASE
+                    WHEN account_delivery_recovery.marker_token = excluded.marker_token
+                    THEN max(account_delivery_recovery.dropped_count, excluded.dropped_count)
+                    ELSE excluded.dropped_count
+                END",
+            params![label, marker_token, now, dropped_count],
+        )
+        .storage()?;
+        Ok(())
+    }
+
+    pub fn clear_account_delivery_recovery(
+        &self,
+        label: &str,
+        marker_token: u64,
+    ) -> StorageResult<bool> {
+        let marker_token = i64::try_from(marker_token).unwrap_or(i64::MAX);
+        let conn = self.lock()?;
+        let cleared = conn
+            .execute(
+                "DELETE FROM account_delivery_recovery
+                 WHERE account_label = ?1 AND marker_token = ?2",
+                params![label, marker_token],
+            )
+            .storage()?;
+        Ok(cleared > 0)
     }
 
     /// Read only the pending-confirmation, non-archived group outlines.

--- a/crates/storage-sqlite/src/account_projection/tests.rs
+++ b/crates/storage-sqlite/src/account_projection/tests.rs
@@ -55,6 +55,21 @@ fn account_delivery_recovery_marker_survives_reopen_and_clears_explicitly() {
         let updated = store.account_delivery_recovery("alice").unwrap().unwrap();
         assert_eq!(updated.pending_since, first.pending_since);
         assert_eq!(updated.dropped_count, 7);
+
+        store
+            .mark_account_delivery_recovery("alice", 12, 1)
+            .unwrap();
+        let replaced = store.account_delivery_recovery("alice").unwrap().unwrap();
+        assert_eq!(replaced.marker_token, 12);
+        assert_eq!(replaced.dropped_count, 1);
+        assert_ne!(replaced.pending_since, 0);
+        assert!(!store.clear_account_delivery_recovery("alice", 11).unwrap());
+
+        // Restore the original token so the reopen half below still exercises
+        // its explicit compare-and-clear assertions.
+        store
+            .mark_account_delivery_recovery("alice", 11, 7)
+            .unwrap();
     }
 
     let reopened = SqliteAccountStorage::open_encrypted(&path, &key).unwrap();

--- a/crates/storage-sqlite/src/account_projection/tests.rs
+++ b/crates/storage-sqlite/src/account_projection/tests.rs
@@ -30,6 +30,57 @@ fn secure_delete_restore_failure_preserves_committed_outcome() {
 }
 
 #[test]
+fn account_delivery_recovery_marker_survives_reopen_and_clears_explicitly() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("delivery-recovery.sqlite");
+    let key = SqlCipherKey::new("delivery recovery marker test key").unwrap();
+
+    {
+        let store = SqliteAccountStorage::open_encrypted(&path, &key).unwrap();
+        store.ensure_account_projection("alice").unwrap();
+        assert_eq!(store.account_delivery_recovery("alice").unwrap(), None);
+        store
+            .mark_account_delivery_recovery("alice", 11, 3)
+            .unwrap();
+        let first = store
+            .account_delivery_recovery("alice")
+            .unwrap()
+            .expect("overflow must create a durable marker");
+        assert_eq!(first.marker_token, 11);
+        assert_eq!(first.dropped_count, 3);
+
+        store
+            .mark_account_delivery_recovery("alice", 11, 7)
+            .unwrap();
+        let updated = store.account_delivery_recovery("alice").unwrap().unwrap();
+        assert_eq!(updated.pending_since, first.pending_since);
+        assert_eq!(updated.dropped_count, 7);
+    }
+
+    let reopened = SqliteAccountStorage::open_encrypted(&path, &key).unwrap();
+    assert_eq!(
+        reopened
+            .account_delivery_recovery("alice")
+            .unwrap()
+            .unwrap()
+            .dropped_count,
+        7,
+        "restart must retain incomplete recovery"
+    );
+    assert!(
+        !reopened
+            .clear_account_delivery_recovery("alice", 10)
+            .unwrap()
+    );
+    assert!(
+        reopened
+            .clear_account_delivery_recovery("alice", 11)
+            .unwrap()
+    );
+    assert_eq!(reopened.account_delivery_recovery("alice").unwrap(), None);
+}
+
+#[test]
 fn source_epoch_retention_decisions_are_frozen_and_drive_expiry() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("retention.sqlite");

--- a/crates/storage-sqlite/src/lib.rs
+++ b/crates/storage-sqlite/src/lib.rs
@@ -21,11 +21,12 @@ mod storage;
 mod timeline;
 
 pub use account_projection::{
-    AccountChatNotificationSettings, AccountGroupPushToken, AccountNotificationSettings,
-    AccountPendingPushRegistrationRemoval, AccountPushRegistration, AccountStoredPushRegistration,
-    AppEventReplayCursor, DeleteLocalGroupDataResult, SelfMembership, StoredAccountGroup,
-    StoredAccountGroupComponent, StoredAccountState, StoredAppMessageQuery, StoredAppMessageRecord,
-    StoredEpochBackfillIntent, StoredNostrRoute, clamp_to_max_future_skew,
+    AccountChatNotificationSettings, AccountDeliveryRecovery, AccountGroupPushToken,
+    AccountNotificationSettings, AccountPendingPushRegistrationRemoval, AccountPushRegistration,
+    AccountStoredPushRegistration, AppEventReplayCursor, DeleteLocalGroupDataResult,
+    SelfMembership, StoredAccountGroup, StoredAccountGroupComponent, StoredAccountState,
+    StoredAppMessageQuery, StoredAppMessageRecord, StoredEpochBackfillIntent, StoredNostrRoute,
+    clamp_to_max_future_skew,
 };
 pub use chat_list::{
     AccountUnreadTotal, ChatConversationKind, ChatListAttachmentKind, ChatListAvatar,

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -102,6 +102,8 @@ mod migration_0050_direct_conversation_members;
 mod migration_0051_prepared_group_image_uploads;
 #[path = "migrations/0052_epoch_backfill_intents.rs"]
 mod migration_0052_epoch_backfill_intents;
+#[path = "migrations/0053_account_delivery_recovery.rs"]
+mod migration_0053_account_delivery_recovery;
 #[cfg(test)]
 #[path = "migrations/test_support.rs"]
 mod test_support;
@@ -376,6 +378,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 52,
         name: "0052_epoch_backfill_intents",
         apply: migration_0052_epoch_backfill_intents::apply,
+    },
+    Migration {
+        version: 53,
+        name: "0053_account_delivery_recovery",
+        apply: migration_0053_account_delivery_recovery::apply,
     },
 ];
 
@@ -904,7 +911,7 @@ mod tests {
         assert!(matches!(
             error,
             StorageError::UnsupportedSchemaVersion {
-                found: 52,
+                found: 53,
                 latest_supported: 46,
             }
         ));
@@ -960,7 +967,7 @@ mod tests {
         assert!(matches!(
             error,
             StorageError::UnsupportedSchemaVersion {
-                found: 52,
+                found: 53,
                 latest_supported: 46,
             }
         ));
@@ -1264,7 +1271,7 @@ mod tests {
         assert!(matches!(
             error,
             StorageError::UnsupportedSchemaVersion {
-                found: 52,
+                found: 53,
                 latest_supported: 46,
             }
         ));

--- a/crates/storage-sqlite/src/migrations/0053_account_delivery_recovery.rs
+++ b/crates/storage-sqlite/src/migrations/0053_account_delivery_recovery.rs
@@ -1,0 +1,20 @@
+//! Migration 0053: durable incomplete-recovery marker for app relay overflow.
+
+use crate::SqliteResultExt;
+use cgka_traits::storage::StorageResult;
+use rusqlite::Transaction;
+
+pub(crate) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
+    tx.execute_batch(
+        r#"
+CREATE TABLE account_delivery_recovery (
+    account_label TEXT PRIMARY KEY
+        REFERENCES account_state(label) ON DELETE CASCADE,
+    marker_token INTEGER NOT NULL CHECK (marker_token >= 0),
+    pending_since INTEGER NOT NULL CHECK (pending_since >= 0),
+    dropped_count INTEGER NOT NULL CHECK (dropped_count >= 0)
+);
+"#,
+    )
+    .storage()
+}


### PR DESCRIPTION
## Summary
- reserve an explicit per-account overflow control record and durably mark each incomplete recovery generation before releasing omitted deliveries
- invalidate ordinary EOSE and cursor floors until a fresh unfloored, EOSE-confirmed replay clears the exact durable generation
- preserve cross-account routing isolation while exposing aggregate queue, drop, retry outcome, and elapsed-time health metrics
- add restart-safe SQLite state plus deterministic newest-first overflow, marker retry, EOSE, and cross-account regression coverage

## Test plan
- [x] cargo test -p storage-sqlite
- [x] cargo test -p marmot-app --features test-policy-overrides
- [x] just fast-ci
- [x] New overflow regression failed before the fix and passes after it

Fixes #1561

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Reliability**
  - Added automatic recovery when incoming account deliveries overflow, preserving progress and retrying incomplete recovery safely.
  - Recovery state now persists across restarts and clears only after confirmed completion.

- **Synchronization**
  - Improved replay and backfill behavior when relays are unavailable or only partially synchronized.
  - Durable cursor advancement now avoids skipping unconfirmed deliveries.

- **Messaging**
  - Send results now report publication status for each message, including unresolved completion states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->