### PR TITLE
fix(terminal-harness): add liveness-aware durable recovery

### DIFF
--- a/integrations/codex/marmot/README.md
+++ b/integrations/codex/marmot/README.md
@@ -121,7 +121,7 @@ never retried automatically. Send `//reset-session` to pass the literal
 | `WN_CODEX_ACCOUNT_ID_HEX` | sole local account | Explicit account selection |
 | `WN_CODEX_BIN` | `codex` | Codex executable |
 | `MARMOT_HARNESS_EXECUTION_PROFILE` | `inherit` | Shared `inherit`, `autonomous`, or `unrestricted` execution policy |
-| `WN_CODEX_IDLE_TIMEOUT_SECS` | `120` | Maximum silence per invocation |
+| `WN_CODEX_IDLE_TIMEOUT_SECS` | `120` | Presentation-idle interval before liveness is reported as unknown; does not stop the invocation |
 | `WN_CODEX_TIMEOUT_SECS` | `3600` | Total invocation cap |
 | `WN_CODEX_REQUEST_TIMEOUT_SECS` | `30` | Control request timeout |
 | `WN_CODEX_MAX_REPLY_BYTES` | `30000` | Durable reply chunk limit |

--- a/integrations/opencode/marmot/README.md
+++ b/integrations/opencode/marmot/README.md
@@ -121,8 +121,8 @@ Configure with environment variables:
 | `WN_OPENCODE_ACCOUNT_ID_HEX` | first local account | Specific `wn-agent` account to use |
 | `WN_OPENCODE_BIN` | `opencode` | OpenCode binary or executable path |
 | `MARMOT_HARNESS_EXECUTION_PROFILE` | `inherit` | Shared `inherit`, `autonomous`, or `unrestricted` execution policy |
-| `WN_OPENCODE_IDLE_TIMEOUT_SECS` | `120` | Kill the invocation when OpenCode produces no stdout line for this long |
-| `WN_OPENCODE_TIMEOUT_SECS` | `3600` | Generous total safety cap for wedge recovery; ongoing output resets only the idle timer |
+| `WN_OPENCODE_IDLE_TIMEOUT_SECS` | `120` | Presentation-idle interval before liveness is reported as unknown; does not stop the invocation |
+| `WN_OPENCODE_TIMEOUT_SECS` | `3600` | Total invocation policy limit; ongoing output does not reset it |
 | `WN_OPENCODE_REQUEST_TIMEOUT_SECS` | `30` | Timeout for each control-socket request |
 | `WN_OPENCODE_MAX_REPLY_BYTES` | `30000` | UTF-8 byte limit for each durable Marmot reply chunk |
 | `WN_OPENCODE_MAX_PENDING_PER_GROUP` | `4` | Per-group in-flight/queued prompt cap |

--- a/integrations/opencode/marmot/src/opencode.rs
+++ b/integrations/opencode/marmot/src/opencode.rs
@@ -254,22 +254,23 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn run_idle_timeout_fires_after_silence() {
+    async fn run_presentation_idle_reports_unknown_and_waits_for_total_limit() {
         let dir = tempfile::tempdir().unwrap();
-        let (tx, _rx) = mpsc::channel(4);
+        let (tx, mut rx) = mpsc::channel(4);
         let failure = run(
             Invocation {
-                // The mock child sleeps longer than this idle budget after the
-                // session line so CI load cannot race idle timeout with normal exit.
-                idle_timeout: Duration::from_secs(2),
+                timeout: Duration::from_secs(1),
+                idle_timeout: Duration::from_millis(200),
                 ..mock_invocation(&dir, "idle")
             },
             tx,
         )
         .await
         .unwrap_err();
-        assert!(matches!(failure.error, HarnessError::BackendIdle));
+        assert!(matches!(failure.error, HarnessError::BackendTimedOut));
         assert_eq!(failure.observed_session.as_deref(), Some("ses_idle"));
+        assert_eq!(rx.recv().await, Some(RunnerEvent::LivenessUnknown));
+        assert!(rx.recv().await.is_none());
     }
 
     #[cfg(unix)]
@@ -295,13 +296,13 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn run_idle_timeout_fires_after_stdout_eof_with_live_child() {
+    async fn run_stdout_eof_reports_unknown_and_waits_for_total_limit() {
         let dir = tempfile::tempdir().unwrap();
-        let (tx, _rx) = mpsc::channel(4);
+        let (tx, mut rx) = mpsc::channel(4);
         let started = Instant::now();
         let failure = run(
             Invocation {
-                timeout: Duration::from_secs(10),
+                timeout: Duration::from_secs(1),
                 idle_timeout: Duration::from_millis(200),
                 ..mock_invocation(&dir, "stdout-close-live")
             },
@@ -309,19 +310,21 @@ mod tests {
         )
         .await
         .unwrap_err();
-        assert!(matches!(failure.error, HarnessError::BackendIdle));
-        assert!(started.elapsed() < Duration::from_secs(1));
+        assert!(matches!(failure.error, HarnessError::BackendTimedOut));
+        assert!(started.elapsed() >= Duration::from_millis(800));
+        assert_eq!(rx.recv().await, Some(RunnerEvent::LivenessUnknown));
+        assert!(rx.recv().await.is_none());
     }
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn run_eof_keeps_remaining_idle_budget() {
+    async fn run_eof_keeps_original_presentation_idle_deadline() {
         let dir = tempfile::tempdir().unwrap();
-        let (tx, _rx) = mpsc::channel(4);
+        let (tx, mut rx) = mpsc::channel(4);
         let started = Instant::now();
         let failure = run(
             Invocation {
-                timeout: Duration::from_secs(10),
+                timeout: Duration::from_millis(1_200),
                 idle_timeout: Duration::from_secs(1),
                 ..mock_invocation(&dir, "stdout-close-near-idle")
             },
@@ -329,11 +332,13 @@ mod tests {
         )
         .await
         .unwrap_err();
-        assert!(matches!(failure.error, HarnessError::BackendIdle));
+        assert!(matches!(failure.error, HarnessError::BackendTimedOut));
         assert!(
-            started.elapsed() < Duration::from_millis(1_350),
+            started.elapsed() >= Duration::from_secs(1),
             "stdout EOF must not reset the existing idle deadline"
         );
+        assert_eq!(rx.recv().await, Some(RunnerEvent::LivenessUnknown));
+        assert!(rx.recv().await.is_none());
     }
 
     #[cfg(unix)]

--- a/integrations/opencode/marmot/tests/fixtures/mock-opencode.sh
+++ b/integrations/opencode/marmot/tests/fixtures/mock-opencode.sh
@@ -9,8 +9,8 @@ case "$scenario" in
         ;;
     idle)
         printf '%s\n' '{"type":"step_start","sessionID":"ses_idle"}'
-        # Stay alive longer than the harness idle timeout so the test observes
-        # BackendIdle instead of racing normal exit at the same deadline.
+        # Stay alive across presentation idle so the harness reports unknown
+        # liveness and waits for the explicit total policy limit.
         exec sleep 3
         ;;
     streaming)

--- a/integrations/pi/marmot/README.md
+++ b/integrations/pi/marmot/README.md
@@ -111,7 +111,7 @@ resume that group's Pi session.
 | `WN_PI_BIN` | `pi` | Pi executable |
 | `MARMOT_HARNESS_EXECUTION_PROFILE` | `inherit` | Shared `inherit`, `autonomous`, or `unrestricted` execution policy |
 | `WN_PI_SESSION_DIR` | `$MARMOT_HOME/dev/pi-sessions` | Private Pi session directory |
-| `WN_PI_IDLE_TIMEOUT_SECS` | `120` | Maximum silence per invocation |
+| `WN_PI_IDLE_TIMEOUT_SECS` | `120` | Presentation-idle interval before liveness is reported as unknown; does not stop the invocation |
 | `WN_PI_TIMEOUT_SECS` | `3600` | Total invocation cap |
 | `WN_PI_REQUEST_TIMEOUT_SECS` | `30` | Control request timeout |
 | `WN_PI_MAX_REPLY_BYTES` | `30000` | Durable reply chunk limit |

--- a/integrations/terminal-harness/README.md
+++ b/integrations/terminal-harness/README.md
@@ -16,8 +16,8 @@ storage, QUIC previews, or backend-specific CLI semantics.
 
 A connector supplies a `Backend` implementation. For each authorized inbound
 prompt, the shared runtime passes an `Invocation` containing the selected
-working directory, optional prior session id, prompt, idle timeout, and total
-timeout. The backend may emit only completed assistant text as `RunnerEvent::Text`
+working directory, optional prior session id, prompt, presentation-idle interval,
+and total policy limit. The backend may emit only completed assistant text as `RunnerEvent::Text`
 and returns privacy-safe `Outcome` metadata.
 
 Connector crates are responsible for:
@@ -98,7 +98,13 @@ All connectors:
   only that group's backend session id, and retain its selected workdir;
 - split durable replies on UTF-8 boundaries with a 30,000-byte default and a
   60,000-byte hard ceiling;
-- enforce bounded per-group queues plus idle and total backend timeouts;
+- report presentation-idle liveness as unknown without killing an invocation and
+  enforce a separate total backend policy limit;
+- persist typed recovery obligations and require an exact `/retry-last` or
+  `/discard-last` command before uncertain or resumable work can leave its FIFO
+  barrier;
+- reconcile text-only final-delivery acknowledgements idempotently before later
+  FIFO work, without replaying the backend invocation;
 - keep diagnostics free of identifiers, paths, prompts, and backend output.
 
 `/reset-session` is reserved as a harness control message. Send
@@ -106,6 +112,12 @@ All connectors:
 Reset never deletes backend-owned transcripts and never retries a failed resumed
 prompt automatically; the next distinct prompt starts a new logical backend
 session in the retained workdir.
+
+`/retry-last` and `/discard-last` are available only while one matching durable
+recovery record blocks that group. Retry consumes that record once and runs ahead
+of queued prompts; discard removes it without replay. An uncertain outcome warns
+that retrying may repeat side effects. Recovery state is stored in private files
+and is never included in logs or diagnostics.
 
 The connector READMEs document their environment variables, installer topology,
 and backend contracts:

--- a/integrations/terminal-harness/src/bridge.rs
+++ b/integrations/terminal-harness/src/bridge.rs
@@ -28,6 +28,7 @@ const RECONNECT_MAX: Duration = Duration::from_secs(30);
 const SEND_RETRY_ATTEMPTS: usize = 3;
 const LIVENESS_UNKNOWN_TEXT: &str = "The backend is still running, but the connector cannot confirm progress. No action is needed; it will keep checking until the configured total limit.";
 const TEXT_FINAL_ACK_UNKNOWN_TEXT: &str = "The backend finished, but the connector could not confirm delivery of its final response. No action is needed; it is reconciling delivery.";
+const INCOMPLETE_FINAL_TEXT: &str = "The backend finished, but the connector could not persist the complete final response. Send `/retry-last` to retry it, or `/discard-last` to abandon it and continue queued work.";
 
 /// Connects to `wn-agent`, subscribes to allowed prompts, and runs the backend.
 pub async fn run<B: Backend>(config: Config, backend: B) -> Result<()> {
@@ -482,25 +483,35 @@ async fn handle_message(ctx: Arc<BridgeContext>, inbound: InboundPrompt, mut per
             return;
         }
         PromptDisposition::DiscardLast => {
-            let message = match ctx.recovery.discard(&inbound.group_ref).await {
-                Ok(true) => {
-                    permit
-                        .queue
-                        .recovery_changed
-                        .send_modify(|generation| *generation = generation.wrapping_add(1));
-                    format!(
-                        "[{}] The saved recovery was discarded; queued work can continue.",
-                        ctx.cfg.spec.reply_prefix
-                    )
-                }
-                Ok(false) => format!(
+            let recovery = ctx.recovery.discard(&inbound.group_ref).await;
+            let incomplete = ctx
+                .deliveries
+                .discard_incomplete_final(&inbound.group_ref)
+                .await;
+            if let Err(err) = &recovery {
+                warn!(target: TRACE_TARGET, method = "discard_recovery", error_kind = err.privacy_safe_kind(), "failed to discard recovery record");
+            }
+            if let Err(err) = &incomplete {
+                warn!(target: TRACE_TARGET, method = "discard_incomplete_final", error_kind = err.privacy_safe_kind(), "failed to discard incomplete-final barrier");
+            }
+            let message = match (recovery, incomplete) {
+                (Err(_), _) | (_, Err(_)) => format!(
+                    "[{}] Failed to discard the saved recovery.",
+                    ctx.cfg.spec.reply_prefix
+                ),
+                (Ok(false), Ok(false)) => format!(
                     "[{}] There is no saved recovery to discard.",
                     ctx.cfg.spec.reply_prefix
                 ),
-                Err(err) => {
-                    warn!(target: TRACE_TARGET, method = "discard_recovery", error_kind = err.privacy_safe_kind(), "failed to discard recovery record");
+                (Ok(recovery_cleared), Ok(_)) => {
+                    if recovery_cleared {
+                        permit
+                            .queue
+                            .recovery_changed
+                            .send_modify(|generation| *generation = generation.wrapping_add(1));
+                    }
                     format!(
-                        "[{}] Failed to discard the saved recovery.",
+                        "[{}] The saved recovery was discarded; queued work can continue.",
                         ctx.cfg.spec.reply_prefix
                     )
                 }
@@ -627,30 +638,34 @@ async fn handle_message(ctx: Arc<BridgeContext>, inbound: InboundPrompt, mut per
     let mut chunk_index = 0usize;
     let mut delivered_chunks = 0usize;
     let mut delivery_failed = false;
+    let mut persist_failed = false;
     while let Some(event) = rx.recv().await {
         match event {
             RunnerEvent::Text(text) => {
-                let mut staged = Vec::new();
-                for chunk in split_reply_chunks(&text, ctx.cfg.max_reply_bytes) {
-                    chunk_index += 1;
-                    match stage_backend_reply(
-                        &ctx,
-                        &inbound.account_ref,
-                        &inbound.group_ref,
-                        &inbound.message_ref,
-                        chunk,
-                        chunk_index,
-                    )
-                    .await
-                    {
-                        Ok(key) => staged.push((key, chunk.to_owned(), chunk_index)),
-                        Err(err) => {
-                            warn!(target: TRACE_TARGET, method = "stage_final", error_kind = err.privacy_safe_kind(), "failed to persist backend reply chunk");
-                            delivery_failed = true;
-                        }
+                let staged = match stage_text_chunks(
+                    &FinalReplyTarget {
+                        deliveries: &ctx.deliveries,
+                        account_ref: &inbound.account_ref,
+                        group_ref: &inbound.group_ref,
+                        reply_to_ref: &inbound.message_ref,
+                    },
+                    &text,
+                    ctx.cfg.max_reply_bytes,
+                    &mut chunk_index,
+                    &mut persist_failed,
+                )
+                .await
+                {
+                    Ok(staged) => staged,
+                    Err(err) => {
+                        warn!(target: TRACE_TARGET, method = "stage_final", error_kind = err.privacy_safe_kind(), "failed to persist incomplete-final barrier");
+                        Vec::new()
                     }
+                };
+                if persist_failed {
+                    delivery_failed = true;
                 }
-                if delivery_failed {
+                if persist_failed || delivery_failed {
                     continue;
                 }
                 for (key, chunk, index) in staged {
@@ -693,14 +708,28 @@ async fn handle_message(ctx: Arc<BridgeContext>, inbound: InboundPrompt, mut per
 
     match runner.await {
         Ok(Ok(outcome)) => {
-            if retrying
-                && outcome.exit_code == Some(0)
-                && ctx.recovery.discard(&inbound.group_ref).await.is_ok()
-            {
-                permit
-                    .queue
-                    .recovery_changed
-                    .send_modify(|generation| *generation = generation.wrapping_add(1));
+            if retrying && outcome.exit_code == Some(0) && !persist_failed {
+                match ctx.recovery.discard(&inbound.group_ref).await {
+                    Ok(_) => {
+                        permit
+                            .queue
+                            .recovery_changed
+                            .send_modify(|generation| *generation = generation.wrapping_add(1));
+                    }
+                    Err(err) => {
+                        warn!(target: TRACE_TARGET, method = "discard_recovery", error_kind = err.privacy_safe_kind(), "failed to discard completed recovery record");
+                        if let Err(reset_err) = ctx.recovery.reset_retry(&inbound.group_ref).await {
+                            warn!(target: TRACE_TARGET, method = "retry_recovery", error_kind = reset_err.privacy_safe_kind(), "failed to restore retryable recovery state");
+                        }
+                    }
+                }
+                if let Err(err) = ctx
+                    .deliveries
+                    .discard_incomplete_final(&inbound.group_ref)
+                    .await
+                {
+                    warn!(target: TRACE_TARGET, method = "discard_incomplete_final", error_kind = err.privacy_safe_kind(), "failed to discard incomplete-final barrier");
+                }
             }
             finish_success(
                 ctx,
@@ -712,6 +741,7 @@ async fn handle_message(ctx: Arc<BridgeContext>, inbound: InboundPrompt, mut per
                 DeliveryReport {
                     chunk_count: delivered_chunks,
                     failed: delivery_failed,
+                    persist_failed,
                     status_chunk_index: chunk_index + 1,
                 },
             )
@@ -807,7 +837,7 @@ async fn begin_validated_retry(
 }
 
 async fn fifo_is_blocked(ctx: &BridgeContext, group_ref: &str) -> bool {
-    ctx.recovery.get(group_ref).await.is_some() || ctx.deliveries.has_group(group_ref).await
+    ctx.recovery.get(group_ref).await.is_some() || ctx.deliveries.blocks_group(group_ref).await
 }
 
 async fn handle_session_reset(ctx: &BridgeContext, inbound: &InboundPrompt) {
@@ -941,6 +971,38 @@ async fn finish_success(
             delivery.status_chunk_index,
         )
         .await;
+    } else if completion_route == CompletionRoute::IncompleteFinal {
+        let session_id = outcome
+            .observed_session
+            .clone()
+            .or_else(|| {
+                known_session
+                    .as_ref()
+                    .map(|record| record.session_id.clone())
+            })
+            .filter(|value| !value.is_empty());
+        if let Some(session_id) = session_id
+            && let Err(err) = persist_recovery_record(
+                &ctx.recovery,
+                &inbound.group_ref,
+                recovery_prompt,
+                cwd,
+                session_id,
+                RecoveryKind::UncertainOutcome,
+            )
+            .await
+        {
+            warn!(target: TRACE_TARGET, method = "recovery_store", error_kind = err.privacy_safe_kind(), "failed to persist recovery record");
+        }
+        let _ = send_reply(
+            &ctx,
+            &inbound.account_ref,
+            &inbound.group_ref,
+            &inbound.message_ref,
+            &format!("[{}] {INCOMPLETE_FINAL_TEXT}", ctx.cfg.spec.reply_prefix),
+            delivery.status_chunk_index,
+        )
+        .await;
     } else if completion_route == CompletionRoute::TextFinalAckUnknown {
         let _ = send_reply(
             &ctx,
@@ -986,12 +1048,14 @@ async fn finish_success(
 struct DeliveryReport {
     chunk_count: usize,
     failed: bool,
+    persist_failed: bool,
     status_chunk_index: usize,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum CompletionRoute {
     NonzeroExit,
+    IncompleteFinal,
     TextFinalAckUnknown,
     NoText,
     Complete,
@@ -1000,6 +1064,8 @@ enum CompletionRoute {
 fn completion_route(outcome: &Outcome, delivery: &DeliveryReport) -> CompletionRoute {
     if outcome.exit_code != Some(0) {
         CompletionRoute::NonzeroExit
+    } else if delivery.persist_failed {
+        CompletionRoute::IncompleteFinal
     } else if delivery.failed {
         CompletionRoute::TextFinalAckUnknown
     } else if delivery.chunk_count == 0 {
@@ -1112,10 +1178,36 @@ async fn handle_backend_run_failure(
                 config.spec.reply_prefix, config.spec.display_name, config.spec.bin_env_name
             )
         }
-        _ => format!(
-            "[{}] {} failed while streaming its response.",
-            config.spec.reply_prefix, config.spec.display_name
-        ),
+        _ => {
+            if let Some(session_id) = resumable_session {
+                if let Err(err) = persist_recovery_record(
+                    recovery,
+                    group_ref,
+                    prompt,
+                    cwd,
+                    session_id,
+                    RecoveryKind::UncertainOutcome,
+                )
+                .await
+                {
+                    warn!(target: TRACE_TARGET, method = "recovery_store", error_kind = err.privacy_safe_kind(), "failed to persist recovery record");
+                    format!(
+                        "[{}] The backend exited and this attempt cannot be resumed. Send a new prompt or `/reset-session`.",
+                        config.spec.reply_prefix
+                    )
+                } else {
+                    recovery_resolution_message(
+                        config.spec.reply_prefix,
+                        RecoveryKind::UncertainOutcome,
+                    )
+                }
+            } else {
+                format!(
+                    "[{}] {} failed while streaming its response.",
+                    config.spec.reply_prefix, config.spec.display_name
+                )
+            }
+        }
     }
 }
 
@@ -1283,7 +1375,7 @@ async fn install_allowlist(
 }
 
 async fn reconcile_pending_deliveries(client: &ControlClient, store: &FinalDeliveryStore) {
-    for (key, record) in store.list().await {
+    for (key, record) in store.list_reconcilable().await {
         match send_final_with_retry(
             client,
             &record.account_ref,
@@ -1306,8 +1398,53 @@ async fn reconcile_pending_deliveries(client: &ControlClient, store: &FinalDeliv
     }
 }
 
-async fn stage_backend_reply(
-    ctx: &BridgeContext,
+struct FinalReplyTarget<'a> {
+    deliveries: &'a FinalDeliveryStore,
+    account_ref: &'a str,
+    group_ref: &'a str,
+    reply_to_ref: &'a str,
+}
+
+async fn stage_text_chunks(
+    target: &FinalReplyTarget<'_>,
+    text: &str,
+    max_reply_bytes: usize,
+    chunk_index: &mut usize,
+    persist_failed: &mut bool,
+) -> Result<Vec<(String, String, usize)>> {
+    if *persist_failed {
+        return Ok(Vec::new());
+    }
+    let mut staged = Vec::new();
+    for chunk in split_reply_chunks(text, max_reply_bytes) {
+        *chunk_index += 1;
+        match stage_delivery_record(
+            target.deliveries,
+            target.account_ref,
+            target.group_ref,
+            target.reply_to_ref,
+            chunk,
+            *chunk_index,
+        )
+        .await
+        {
+            Ok(key) => staged.push((key, chunk.to_owned(), *chunk_index)),
+            Err(err) => {
+                warn!(target: TRACE_TARGET, method = "stage_final", error_kind = err.privacy_safe_kind(), "failed to persist backend reply chunk");
+                *persist_failed = true;
+                target
+                    .deliveries
+                    .mark_incomplete_final(target.group_ref, target.reply_to_ref)
+                    .await?;
+                break;
+            }
+        }
+    }
+    Ok(staged)
+}
+
+async fn stage_delivery_record(
+    deliveries: &FinalDeliveryStore,
     account_ref: &str,
     group_ref: &str,
     reply_to_ref: &str,
@@ -1315,7 +1452,7 @@ async fn stage_backend_reply(
     chunk_index: usize,
 ) -> Result<String> {
     let key = format!("{group_ref}:{reply_to_ref}:{chunk_index}");
-    ctx.deliveries
+    deliveries
         .set(
             &key,
             FinalDeliveryRecord {
@@ -1668,6 +1805,7 @@ mod tests {
         let failed_delivery = DeliveryReport {
             chunk_count: 0,
             failed: true,
+            persist_failed: false,
             status_chunk_index: 2,
         };
         let uncertain = Outcome {
@@ -1716,6 +1854,27 @@ mod tests {
             completion_route(&completed, &failed_delivery),
             CompletionRoute::TextFinalAckUnknown
         );
+
+        let persist_failed = DeliveryReport {
+            persist_failed: true,
+            ..failed_delivery
+        };
+        assert_eq!(
+            completion_route(&completed, &persist_failed),
+            CompletionRoute::IncompleteFinal
+        );
+        let persist_failed_nonzero = Outcome {
+            no_side_effects_proven: false,
+            exit_code: Some(64),
+            observed_session: Some("session".to_owned()),
+            error_summary: Some("failed".to_owned()),
+            stderr: String::new(),
+            elapsed_ms: 1,
+        };
+        assert_eq!(
+            completion_route(&persist_failed_nonzero, &persist_failed),
+            CompletionRoute::NonzeroExit
+        );
     }
 
     #[tokio::test]
@@ -1748,6 +1907,14 @@ mod tests {
             TEXT_FINAL_ACK_UNKNOWN_TEXT,
             "The backend finished, but the connector could not confirm delivery of its final response. No action is needed; it is reconciling delivery."
         );
+        assert_eq!(
+            INCOMPLETE_FINAL_TEXT,
+            "The backend finished, but the connector could not persist the complete final response. Send `/retry-last` to retry it, or `/discard-last` to abandon it and continue queued work."
+        );
+        assert!(!INCOMPLETE_FINAL_TEXT.contains("No action is needed"));
+        assert!(!INCOMPLETE_FINAL_TEXT.contains("reconciling delivery"));
+        assert!(INCOMPLETE_FINAL_TEXT.contains("/retry-last"));
+        assert!(INCOMPLETE_FINAL_TEXT.contains("/discard-last"));
     }
 
     #[tokio::test]
@@ -1871,7 +2038,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(validated.cwd, home.join("repo"));
+        assert_eq!(validated.cwd, home.join("repo").canonicalize().unwrap());
         assert_eq!(validated.status, RecoveryStatus::Retrying);
 
         recovery
@@ -1932,5 +2099,237 @@ mod tests {
         let recovery = recovery.get("group1").await.unwrap();
         assert_eq!(recovery.kind, RecoveryKind::PolicyLimit);
         assert_eq!(recovery.status, RecoveryStatus::Pending);
+    }
+
+    struct UnusedBackend;
+
+    #[async_trait::async_trait]
+    impl Backend for UnusedBackend {
+        async fn run(
+            &self,
+            _invocation: Invocation,
+            _tx: mpsc::Sender<RunnerEvent>,
+        ) -> std::result::Result<Outcome, RunFailure> {
+            Err(RunFailure {
+                error: HarnessError::BackendStream,
+                observed_session: None,
+            })
+        }
+    }
+
+    fn test_bridge_context(root: &std::path::Path) -> BridgeContext {
+        let cfg = test_config(root);
+        BridgeContext {
+            cfg: Arc::new(cfg.clone()),
+            client: ControlClient::new(
+                cfg.socket.clone(),
+                None,
+                cfg.request_timeout,
+                cfg.spec.reply_prefix,
+            ),
+            account_ref: "account".to_owned(),
+            sessions: Arc::new(SessionStore::load(root.join("sessions.json"), root).unwrap()),
+            recovery: Arc::new(RecoveryStore::load(root.join("recovery.json")).unwrap()),
+            deliveries: Arc::new(FinalDeliveryStore::load(root.join("delivery.json")).unwrap()),
+            reconciliation_slot: ReconciliationSlot::new(),
+            queues: Arc::new(GroupQueues::new(4)),
+            dedupe: Arc::new(InboundDedupe::new(8)),
+            backend: Arc::new(UnusedBackend),
+            home: root.to_path_buf(),
+        }
+    }
+
+    #[tokio::test]
+    async fn incomplete_final_persist_failure_raises_discardable_barrier() {
+        let dir = tempfile::tempdir().unwrap();
+        let ctx = test_bridge_context(dir.path());
+        let mut chunk_index = 0usize;
+        let mut persist_failed = false;
+
+        let target = FinalReplyTarget {
+            deliveries: &ctx.deliveries,
+            account_ref: "account",
+            group_ref: "group",
+            reply_to_ref: "message",
+        };
+        let first = stage_text_chunks(&target, "aaaa", 4, &mut chunk_index, &mut persist_failed)
+            .await
+            .unwrap();
+        assert_eq!(first.len(), 1);
+        assert!(!persist_failed);
+
+        ctx.deliveries.fail_next_set();
+        let second = stage_text_chunks(
+            &target,
+            "bbbbcccc",
+            4,
+            &mut chunk_index,
+            &mut persist_failed,
+        )
+        .await
+        .unwrap();
+        assert!(persist_failed);
+        assert!(second.is_empty());
+
+        let later = stage_text_chunks(&target, "dddd", 4, &mut chunk_index, &mut persist_failed)
+            .await
+            .unwrap();
+        assert!(later.is_empty());
+
+        let records = ctx.deliveries.list().await;
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].1.chunk_index, 1);
+        assert_eq!(records[0].1.text, "aaaa");
+        assert!(ctx.deliveries.list_reconcilable().await.is_empty());
+        assert!(fifo_is_blocked(&ctx, "group").await);
+
+        ctx.deliveries.remove(&records[0].0).await.unwrap();
+        assert!(
+            !ctx.deliveries.has_group("group").await,
+            "barrier must outlive removed delivery records"
+        );
+        assert!(fifo_is_blocked(&ctx, "group").await);
+        assert!(ctx.deliveries.list_reconcilable().await.is_empty());
+
+        let copy = format!("[{}] {INCOMPLETE_FINAL_TEXT}", ctx.cfg.spec.reply_prefix);
+        assert!(!copy.contains(TEXT_FINAL_ACK_UNKNOWN_TEXT));
+        assert!(!copy.contains("No action is needed"));
+        assert!(copy.contains("/retry-last"));
+        assert!(copy.contains("/discard-last"));
+        assert_eq!(
+            completion_route(
+                &Outcome {
+                    observed_session: Some("session".to_owned()),
+                    exit_code: Some(0),
+                    error_summary: None,
+                    no_side_effects_proven: true,
+                    stderr: String::new(),
+                    elapsed_ms: 1,
+                },
+                &DeliveryReport {
+                    chunk_count: 1,
+                    failed: true,
+                    persist_failed: true,
+                    status_chunk_index: 3,
+                },
+            ),
+            CompletionRoute::IncompleteFinal
+        );
+
+        assert!(
+            ctx.deliveries
+                .discard_incomplete_final("group")
+                .await
+                .unwrap()
+        );
+        assert!(!fifo_is_blocked(&ctx, "group").await);
+        assert!(ctx.deliveries.list().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn post_spawn_stream_failure_persists_uncertain_recovery() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path().to_path_buf();
+        std::fs::create_dir_all(home.join("repo")).unwrap();
+        let store = SessionStore::load(home.join("sessions.json"), &home).unwrap();
+        let recovery = RecoveryStore::load(home.join("recovery.json")).unwrap();
+        store
+            .set(
+                "group1",
+                SessionRecord {
+                    session_id: "ses_stream".to_owned(),
+                    cwd: home.join("repo"),
+                },
+            )
+            .await
+            .unwrap();
+
+        let failure = RunFailure {
+            error: HarnessError::BackendStream,
+            observed_session: Some("ses_stream".to_owned()),
+        };
+        let config = test_config(&home);
+        let reply = handle_backend_run_failure(
+            FailureRecoveryContext {
+                config: &config,
+                sessions: &store,
+                recovery: &recovery,
+            },
+            "group1",
+            store.get("group1").await.as_ref(),
+            home.join("repo"),
+            "private prompt".to_owned(),
+            &failure,
+        )
+        .await;
+
+        assert_eq!(
+            reply,
+            recovery_resolution_message("wn-opencode", RecoveryKind::UncertainOutcome)
+        );
+        assert!(!reply.contains("failed while streaming"));
+        let record = recovery.get("group1").await.unwrap();
+        assert_eq!(record.kind, RecoveryKind::UncertainOutcome);
+        assert_eq!(record.status, RecoveryStatus::Pending);
+        assert_eq!(record.session_id, "ses_stream");
+
+        let retried = begin_validated_retry(&recovery, "group1", &home)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(retried.status, RecoveryStatus::Retrying);
+        assert_eq!(retried.session_id, "ses_stream");
+
+        let streaming = handle_backend_run_failure(
+            FailureRecoveryContext {
+                config: &config,
+                sessions: &store,
+                recovery: &recovery,
+            },
+            "group2",
+            None,
+            home.clone(),
+            "private prompt".to_owned(),
+            &RunFailure {
+                error: HarnessError::BackendStream,
+                observed_session: None,
+            },
+        )
+        .await;
+        assert!(streaming.contains("failed while streaming"));
+        assert!(recovery.get("group2").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn successful_retry_discard_failure_restores_pending() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = RecoveryStore::load(dir.path().join("recovery.json")).unwrap();
+        store
+            .set(
+                "group",
+                RecoveryRecord {
+                    prompt: "private prompt".to_owned(),
+                    cwd: dir.path().join("repo"),
+                    session_id: "session".to_owned(),
+                    kind: RecoveryKind::UncertainOutcome,
+                    status: RecoveryStatus::Retrying,
+                },
+            )
+            .await
+            .unwrap();
+        std::fs::create_dir(dir.path().join("recovery.json.tmp")).unwrap();
+
+        assert!(store.discard("group").await.is_err());
+        assert_eq!(
+            store.get("group").await.unwrap().status,
+            RecoveryStatus::Retrying
+        );
+        std::fs::remove_dir(dir.path().join("recovery.json.tmp")).unwrap();
+        assert!(store.reset_retry("group").await.unwrap());
+        assert_eq!(
+            store.get("group").await.unwrap().status,
+            RecoveryStatus::Pending
+        );
+        assert!(store.begin_retry("group").await.unwrap().is_some());
     }
 }

--- a/integrations/terminal-harness/src/bridge.rs
+++ b/integrations/terminal-harness/src/bridge.rs
@@ -161,6 +161,7 @@ async fn drain_events(
     let mut reconcile = interval(Duration::from_secs(30));
     reconcile.set_missed_tick_behavior(MissedTickBehavior::Delay);
     reconcile.tick().await;
+    let reconciliation_slot = Arc::new(Semaphore::new(1));
     loop {
         tokio::select! {
             result = &mut shutdown => {
@@ -196,7 +197,13 @@ async fn drain_events(
                 }
             }
             _ = reconcile.tick() => {
-                reconcile_pending_deliveries(&ctx.client, &ctx.deliveries).await;
+                if let Ok(permit) = reconciliation_slot.clone().try_acquire_owned() {
+                    let ctx = ctx.clone();
+                    tokio::spawn(async move {
+                        let _permit = permit;
+                        reconcile_pending_deliveries(&ctx.client, &ctx.deliveries).await;
+                    });
+                }
             }
         }
     }
@@ -488,7 +495,9 @@ async fn handle_message(ctx: Arc<BridgeContext>, inbound: InboundPrompt, mut per
             return;
         }
         PromptDisposition::RetryLast => {
-            let record = match ctx.recovery.begin_retry(&inbound.group_ref).await {
+            let record = match begin_validated_retry(&ctx.recovery, &inbound.group_ref, &ctx.home)
+                .await
+            {
                 Ok(Some(record)) => record,
                 Ok(None) => {
                     let _ = send_reply(
@@ -643,13 +652,14 @@ async fn handle_message(ctx: Arc<BridgeContext>, inbound: InboundPrompt, mut per
             }
             RunnerEvent::LivenessUnknown => {
                 let text = format!("[{}] {LIVENESS_UNKNOWN_TEXT}", ctx.cfg.spec.reply_prefix);
+                chunk_index += 1;
                 if let Err(err) = send_reply(
                     &ctx,
                     &inbound.account_ref,
                     &inbound.group_ref,
                     &inbound.message_ref,
                     &text,
-                    0,
+                    chunk_index,
                 )
                 .await
                 {
@@ -741,6 +751,35 @@ async fn handle_message(ctx: Arc<BridgeContext>, inbound: InboundPrompt, mut per
                 chunk_index + 1,
             )
             .await;
+        }
+    }
+}
+
+async fn begin_validated_retry(
+    recovery: &RecoveryStore,
+    group_ref: &str,
+    home: &std::path::Path,
+) -> Result<Option<RecoveryRecord>> {
+    let Some(mut record) = recovery.begin_retry(group_ref).await? else {
+        return Ok(None);
+    };
+    match validate_session_cwd(&record.cwd, home).await {
+        Ok(cwd) => {
+            record.cwd = cwd;
+            Ok(Some(record))
+        }
+        Err(err) => {
+            for attempt in 0..3 {
+                match recovery.reset_retry(group_ref).await {
+                    Ok(_) => return Err(err),
+                    Err(reset_err) if attempt < 2 => {
+                        warn!(target: TRACE_TARGET, method = "retry_recovery", error_kind = reset_err.privacy_safe_kind(), "retrying recovery-state restoration after workdir validation");
+                        sleep(Duration::from_millis(50 * (attempt + 1))).await;
+                    }
+                    Err(reset_err) => return Err(reset_err),
+                }
+            }
+            unreachable!("bounded retry loop always returns")
         }
     }
 }
@@ -1760,6 +1799,49 @@ mod tests {
         let current = store.get("group1").await.unwrap();
         assert_eq!(current.session_id, "ses_new");
         assert_eq!(current.cwd, cwd);
+    }
+
+    #[tokio::test]
+    async fn retry_validation_canonicalizes_inside_home_and_restores_invalid_record() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path().join("home");
+        std::fs::create_dir_all(home.join("repo")).unwrap();
+        let recovery = RecoveryStore::load(dir.path().join("recovery.json")).unwrap();
+        let record = RecoveryRecord {
+            prompt: "private prompt".to_owned(),
+            cwd: home.join("repo").join("..").join("repo"),
+            session_id: "session".to_owned(),
+            kind: RecoveryKind::PolicyLimit,
+            status: RecoveryStatus::Pending,
+        };
+        recovery.set("valid", record.clone()).await.unwrap();
+
+        let validated = begin_validated_retry(&recovery, "valid", &home)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(validated.cwd, home.join("repo"));
+        assert_eq!(validated.status, RecoveryStatus::Retrying);
+
+        recovery
+            .set(
+                "invalid",
+                RecoveryRecord {
+                    cwd: home.join("missing"),
+                    ..record
+                },
+            )
+            .await
+            .unwrap();
+        assert!(
+            begin_validated_retry(&recovery, "invalid", &home)
+                .await
+                .is_err()
+        );
+        assert_eq!(
+            recovery.get("invalid").await.unwrap().status,
+            RecoveryStatus::Pending
+        );
     }
 
     #[tokio::test]

--- a/integrations/terminal-harness/src/bridge.rs
+++ b/integrations/terminal-harness/src/bridge.rs
@@ -6,14 +6,17 @@ use std::time::Duration;
 
 use agent_control::{AgentControlAccount, AgentControlEvent};
 use tokio::sync::{Mutex, OwnedSemaphorePermit, Semaphore, mpsc};
-use tokio::time::sleep;
+use tokio::time::{MissedTickBehavior, interval, sleep};
 use tracing::{debug, info, warn};
 
 use crate::chunking::split_reply_chunks;
 use crate::control::ControlClient;
 use crate::error::{HarnessError, Result};
 use crate::repo_picker::{RepoPicker, parse_repo_picker, resolve_repo, validate_session_cwd};
-use crate::store::{SessionRecord, SessionStore};
+use crate::store::{
+    FinalDeliveryRecord, FinalDeliveryStore, RecoveryKind, RecoveryRecord, RecoveryStatus,
+    RecoveryStore, SessionRecord, SessionStore,
+};
 use crate::{
     Backend, Config, Invocation, Outcome, RunFailure, RunnerEvent, TRACE_TARGET, dirs_home,
 };
@@ -23,6 +26,8 @@ const GROUP_QUEUE_LIMIT: usize = 4096;
 const RECONNECT_INITIAL: Duration = Duration::from_secs(1);
 const RECONNECT_MAX: Duration = Duration::from_secs(30);
 const SEND_RETRY_ATTEMPTS: usize = 3;
+const LIVENESS_UNKNOWN_TEXT: &str = "The backend is still running, but the connector cannot confirm progress. No action is needed; it will keep checking until the configured total limit.";
+const TEXT_FINAL_ACK_UNKNOWN_TEXT: &str = "The backend finished, but the connector could not confirm delivery of its final response. No action is needed; it is reconciling delivery.";
 
 /// Connects to `wn-agent`, subscribes to allowed prompts, and runs the backend.
 pub async fn run<B: Backend>(config: Config, backend: B) -> Result<()> {
@@ -55,12 +60,21 @@ pub async fn run<B: Backend>(config: Config, backend: B) -> Result<()> {
     install_allowlist(&client, &account_ref, &config.allowed_senders).await?;
 
     let sessions = Arc::new(SessionStore::load(config.state_path.clone(), &home)?);
+    let recovery = Arc::new(RecoveryStore::load(
+        config.state_path.with_extension("recovery.json"),
+    )?);
+    let deliveries = Arc::new(FinalDeliveryStore::load(
+        config.state_path.with_extension("delivery.json"),
+    )?);
+    reconcile_pending_deliveries(&client, &deliveries).await;
     let queues = Arc::new(GroupQueues::new(config.max_pending_per_group));
     let ctx = Arc::new(BridgeContext {
         cfg: Arc::new(config),
         client,
         account_ref,
         sessions,
+        recovery,
+        deliveries,
         queues,
         dedupe: Arc::new(InboundDedupe::new(DEDUPE_LIMIT)),
         backend: Arc::new(backend),
@@ -75,6 +89,8 @@ struct BridgeContext {
     client: ControlClient,
     account_ref: String,
     sessions: Arc<SessionStore>,
+    recovery: Arc<RecoveryStore>,
+    deliveries: Arc<FinalDeliveryStore>,
     queues: Arc<GroupQueues>,
     dedupe: Arc<InboundDedupe>,
     backend: Arc<dyn Backend>,
@@ -142,6 +158,9 @@ async fn drain_events(
     events: &mut mpsc::Receiver<AgentControlEvent>,
 ) -> Result<DrainOutcome> {
     let mut shutdown = Box::pin(shutdown_signal());
+    let mut reconcile = interval(Duration::from_secs(30));
+    reconcile.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    reconcile.tick().await;
     loop {
         tokio::select! {
             result = &mut shutdown => {
@@ -175,6 +194,9 @@ async fn drain_events(
                     DispatchOutcome::Continue => {}
                     DispatchOutcome::Reconnect => return Ok(DrainOutcome::Reconnect),
                 }
+            }
+            _ = reconcile.tick() => {
+                reconcile_pending_deliveries(&ctx.client, &ctx.deliveries).await;
             }
         }
     }
@@ -229,7 +251,16 @@ async fn dispatch_event(ctx: Arc<BridgeContext>, event: AgentControlEvent) -> Di
                 );
                 return DispatchOutcome::Continue;
             }
-            let Some(permit) = ctx.queues.try_enter(&group_id_hex).await else {
+            let disposition = classify_prompt(&message.text);
+            let permit = if matches!(
+                disposition,
+                PromptDisposition::RetryLast | PromptDisposition::DiscardLast
+            ) {
+                ctx.queues.enter_recovery(&group_id_hex).await
+            } else {
+                ctx.queues.try_enter_waiter(&group_id_hex).await
+            };
+            let Some(permit) = permit else {
                 warn!(
                     target: TRACE_TARGET,
                     method = "dispatch_event",
@@ -318,6 +349,8 @@ struct InboundPrompt {
 #[derive(Debug, PartialEq, Eq)]
 enum PromptDisposition {
     ResetSession,
+    RetryLast,
+    DiscardLast,
     Forward {
         prompt: String,
         allow_workdir_picker: bool,
@@ -327,6 +360,8 @@ enum PromptDisposition {
 fn classify_prompt(text: &str) -> PromptDisposition {
     match text.trim() {
         "/reset-session" => PromptDisposition::ResetSession,
+        "/retry-last" => PromptDisposition::RetryLast,
+        "/discard-last" => PromptDisposition::DiscardLast,
         "//reset-session" => PromptDisposition::Forward {
             prompt: "/reset-session".to_owned(),
             allow_workdir_picker: false,
@@ -338,52 +373,204 @@ fn classify_prompt(text: &str) -> PromptDisposition {
     }
 }
 
-async fn handle_message(ctx: Arc<BridgeContext>, inbound: InboundPrompt, permit: GroupPermit) {
-    let _serial = permit.serial.lock().await;
+async fn handle_message(ctx: Arc<BridgeContext>, inbound: InboundPrompt, mut permit: GroupPermit) {
     let mut inbound = inbound;
-    let allow_workdir_picker = match classify_prompt(&inbound.text) {
-        PromptDisposition::ResetSession => {
-            handle_session_reset(&ctx, &inbound).await;
-            return;
-        }
-        PromptDisposition::Forward {
-            prompt,
-            allow_workdir_picker,
-        } => {
-            inbound.text = prompt;
-            allow_workdir_picker
-        }
-    };
+    let disposition = classify_prompt(&inbound.text);
+    let recovery_command = matches!(
+        disposition,
+        PromptDisposition::RetryLast | PromptDisposition::DiscardLast
+    );
 
-    let known_session = ctx.sessions.get(&inbound.group_ref).await;
-    let (cwd, prompt) =
-        match resolve_cwd_and_prompt(&ctx, &inbound, known_session.as_ref(), allow_workdir_picker)
-            .await
-        {
-            Ok(Some(value)) => value,
-            Ok(None) => return,
-            Err(err) => {
-                warn!(
-                    target: TRACE_TARGET,
-                    method = "handle_message",
-                    error_kind = err.privacy_safe_kind(),
-                    "failed to prepare inbound prompt"
+    let _serial = if recovery_command {
+        match permit.serial.try_lock() {
+            Ok(guard) => guard,
+            Err(_) => {
+                let text = format!(
+                    "[{}] Recovery commands are unavailable while a turn is active.",
+                    ctx.cfg.spec.reply_prefix
                 );
                 let _ = send_reply(
                     &ctx,
                     &inbound.account_ref,
                     &inbound.group_ref,
                     &inbound.message_ref,
-                    &format!(
-                        "[{}] failed to prepare this prompt.",
-                        ctx.cfg.spec.reply_prefix
-                    ),
+                    &text,
                     0,
                 )
                 .await;
                 return;
             }
-        };
+        }
+    } else {
+        let mut recovery_changes = permit.queue.recovery_changed.subscribe();
+        let mut delivery_changes = ctx.deliveries.subscribe();
+        loop {
+            while fifo_is_blocked(&ctx, &inbound.group_ref).await {
+                tokio::select! {
+                    result = recovery_changes.changed() => {
+                        if result.is_err() {
+                            return;
+                        }
+                    }
+                    result = delivery_changes.changed() => {
+                        if result.is_err() {
+                            return;
+                        }
+                    }
+                }
+            }
+            let Some(pending) = permit.queue.pending.clone().try_acquire_owned().ok() else {
+                let text = format!(
+                    "[{}] too many prompts are already queued for this group; try again shortly.",
+                    ctx.cfg.spec.reply_prefix
+                );
+                let _ = send_reply(
+                    &ctx,
+                    &inbound.account_ref,
+                    &inbound.group_ref,
+                    &inbound.message_ref,
+                    &text,
+                    0,
+                )
+                .await;
+                return;
+            };
+            let guard = permit.serial.lock().await;
+            if !fifo_is_blocked(&ctx, &inbound.group_ref).await {
+                permit._pending = Some(pending);
+                permit._waiting.take();
+                break guard;
+            }
+            drop(guard);
+            drop(pending);
+        }
+    };
+
+    let mut retrying = false;
+    let forced_run = match disposition {
+        PromptDisposition::ResetSession => {
+            handle_session_reset(&ctx, &inbound).await;
+            return;
+        }
+        PromptDisposition::DiscardLast => {
+            let message = match ctx.recovery.discard(&inbound.group_ref).await {
+                Ok(true) => {
+                    permit
+                        .queue
+                        .recovery_changed
+                        .send_modify(|generation| *generation = generation.wrapping_add(1));
+                    format!(
+                        "[{}] The saved recovery was discarded; queued work can continue.",
+                        ctx.cfg.spec.reply_prefix
+                    )
+                }
+                Ok(false) => format!(
+                    "[{}] There is no saved recovery to discard.",
+                    ctx.cfg.spec.reply_prefix
+                ),
+                Err(err) => {
+                    warn!(target: TRACE_TARGET, method = "discard_recovery", error_kind = err.privacy_safe_kind(), "failed to discard recovery record");
+                    format!(
+                        "[{}] Failed to discard the saved recovery.",
+                        ctx.cfg.spec.reply_prefix
+                    )
+                }
+            };
+            let _ = send_reply(
+                &ctx,
+                &inbound.account_ref,
+                &inbound.group_ref,
+                &inbound.message_ref,
+                &message,
+                0,
+            )
+            .await;
+            return;
+        }
+        PromptDisposition::RetryLast => {
+            let record = match ctx.recovery.begin_retry(&inbound.group_ref).await {
+                Ok(Some(record)) => record,
+                Ok(None) => {
+                    let _ = send_reply(
+                        &ctx,
+                        &inbound.account_ref,
+                        &inbound.group_ref,
+                        &inbound.message_ref,
+                        &format!(
+                            "[{}] There is no retryable saved recovery.",
+                            ctx.cfg.spec.reply_prefix
+                        ),
+                        0,
+                    )
+                    .await;
+                    return;
+                }
+                Err(err) => {
+                    warn!(target: TRACE_TARGET, method = "retry_recovery", error_kind = err.privacy_safe_kind(), "failed to consume recovery record");
+                    let _ = send_reply(
+                        &ctx,
+                        &inbound.account_ref,
+                        &inbound.group_ref,
+                        &inbound.message_ref,
+                        &format!(
+                            "[{}] Failed to start the saved recovery.",
+                            ctx.cfg.spec.reply_prefix
+                        ),
+                        0,
+                    )
+                    .await;
+                    return;
+                }
+            };
+            retrying = true;
+            Some((record.cwd, Some(record.session_id), record.prompt))
+        }
+        PromptDisposition::Forward {
+            prompt,
+            allow_workdir_picker,
+        } => {
+            inbound.text = prompt;
+            let known_session = ctx.sessions.get(&inbound.group_ref).await;
+            match resolve_cwd_and_prompt(
+                &ctx,
+                &inbound,
+                known_session.as_ref(),
+                allow_workdir_picker,
+            )
+            .await
+            {
+                Ok(Some((cwd, prompt))) => Some((
+                    cwd,
+                    known_session.as_ref().and_then(|record| {
+                        (!record.session_id.is_empty()).then(|| record.session_id.clone())
+                    }),
+                    prompt,
+                )),
+                Ok(None) => return,
+                Err(err) => {
+                    warn!(target: TRACE_TARGET, method = "handle_message", error_kind = err.privacy_safe_kind(), "failed to prepare inbound prompt");
+                    let _ = send_reply(
+                        &ctx,
+                        &inbound.account_ref,
+                        &inbound.group_ref,
+                        &inbound.message_ref,
+                        &format!(
+                            "[{}] failed to prepare this prompt.",
+                            ctx.cfg.spec.reply_prefix
+                        ),
+                        0,
+                    )
+                    .await;
+                    return;
+                }
+            }
+        }
+    };
+
+    let Some((cwd, session_id, prompt)) = forced_run else {
+        return;
+    };
+    let known_session = ctx.sessions.get(&inbound.group_ref).await;
 
     info!(
         target: TRACE_TARGET,
@@ -395,9 +582,7 @@ async fn handle_message(ctx: Arc<BridgeContext>, inbound: InboundPrompt, permit:
         "handling inbound prompt"
     );
 
-    let session_id = known_session
-        .as_ref()
-        .and_then(|record| (!record.session_id.is_empty()).then(|| record.session_id.clone()));
+    let recovery_prompt = prompt.clone();
     let invocation = Invocation {
         timeout: ctx.cfg.backend_timeout,
         idle_timeout: ctx.cfg.backend_idle_timeout,
@@ -414,12 +599,10 @@ async fn handle_message(ctx: Arc<BridgeContext>, inbound: InboundPrompt, permit:
     while let Some(event) = rx.recv().await {
         match event {
             RunnerEvent::Text(text) => {
-                if delivery_failed {
-                    continue;
-                }
+                let mut staged = Vec::new();
                 for chunk in split_reply_chunks(&text, ctx.cfg.max_reply_bytes) {
                     chunk_index += 1;
-                    if let Err(err) = send_reply(
+                    match stage_backend_reply(
                         &ctx,
                         &inbound.account_ref,
                         &inbound.group_ref,
@@ -429,17 +612,48 @@ async fn handle_message(ctx: Arc<BridgeContext>, inbound: InboundPrompt, permit:
                     )
                     .await
                     {
-                        warn!(
-                            target: TRACE_TARGET,
-                            method = "send_final",
-                            error_kind = err.privacy_safe_kind(),
-                            "failed to send backend reply chunk"
-                        );
+                        Ok(key) => staged.push((key, chunk.to_owned(), chunk_index)),
+                        Err(err) => {
+                            warn!(target: TRACE_TARGET, method = "stage_final", error_kind = err.privacy_safe_kind(), "failed to persist backend reply chunk");
+                            delivery_failed = true;
+                        }
+                    }
+                }
+                if delivery_failed {
+                    continue;
+                }
+                for (key, chunk, index) in staged {
+                    if let Err(err) = send_staged_backend_reply(
+                        &ctx,
+                        &key,
+                        &inbound.account_ref,
+                        &inbound.group_ref,
+                        &inbound.message_ref,
+                        &chunk,
+                        index,
+                    )
+                    .await
+                    {
+                        warn!(target: TRACE_TARGET, method = "send_final", error_kind = err.privacy_safe_kind(), "failed to send backend reply chunk");
                         delivery_failed = true;
                         break;
-                    } else {
-                        delivered_chunks += 1;
                     }
+                    delivered_chunks += 1;
+                }
+            }
+            RunnerEvent::LivenessUnknown => {
+                let text = format!("[{}] {LIVENESS_UNKNOWN_TEXT}", ctx.cfg.spec.reply_prefix);
+                if let Err(err) = send_reply(
+                    &ctx,
+                    &inbound.account_ref,
+                    &inbound.group_ref,
+                    &inbound.message_ref,
+                    &text,
+                    0,
+                )
+                .await
+                {
+                    warn!(target: TRACE_TARGET, method = "liveness_status", error_kind = err.privacy_safe_kind(), "failed to send liveness status");
                 }
             }
         }
@@ -447,16 +661,26 @@ async fn handle_message(ctx: Arc<BridgeContext>, inbound: InboundPrompt, permit:
 
     match runner.await {
         Ok(Ok(outcome)) => {
+            if retrying
+                && outcome.exit_code == Some(0)
+                && ctx.recovery.discard(&inbound.group_ref).await.is_ok()
+            {
+                permit
+                    .queue
+                    .recovery_changed
+                    .send_modify(|generation| *generation = generation.wrapping_add(1));
+            }
             finish_success(
                 ctx,
                 inbound,
                 known_session,
                 cwd,
+                recovery_prompt,
                 outcome,
                 DeliveryReport {
                     chunk_count: delivered_chunks,
                     failed: delivery_failed,
-                    failure_chunk_index: chunk_index + 1,
+                    status_chunk_index: chunk_index + 1,
                 },
             )
             .await;
@@ -468,14 +692,20 @@ async fn handle_message(ctx: Arc<BridgeContext>, inbound: InboundPrompt, permit:
                 error_kind = failure.error.privacy_safe_kind(),
                 "backend invocation failed"
             );
+            if retrying && let Err(err) = ctx.recovery.reset_retry(&inbound.group_ref).await {
+                warn!(target: TRACE_TARGET, method = "retry_recovery", error_kind = err.privacy_safe_kind(), "failed to restore retryable recovery state");
+            }
             let text = handle_backend_run_failure(
-                &ctx.cfg,
-                &ctx.sessions,
+                FailureRecoveryContext {
+                    config: &ctx.cfg,
+                    sessions: &ctx.sessions,
+                    recovery: &ctx.recovery,
+                },
                 &inbound.group_ref,
                 known_session.as_ref(),
                 cwd,
+                recovery_prompt,
                 &failure,
-                ctx.cfg.backend_idle_timeout,
             )
             .await;
             let _ = send_reply(
@@ -484,7 +714,7 @@ async fn handle_message(ctx: Arc<BridgeContext>, inbound: InboundPrompt, permit:
                 &inbound.group_ref,
                 &inbound.message_ref,
                 &text,
-                0,
+                chunk_index + 1,
             )
             .await;
         }
@@ -496,6 +726,9 @@ async fn handle_message(ctx: Arc<BridgeContext>, inbound: InboundPrompt, permit:
                 error_kind = err.privacy_safe_kind(),
                 "backend task join failed"
             );
+            if retrying && let Err(reset_err) = ctx.recovery.reset_retry(&inbound.group_ref).await {
+                warn!(target: TRACE_TARGET, method = "retry_recovery", error_kind = reset_err.privacy_safe_kind(), "failed to restore retryable recovery state");
+            }
             let _ = send_reply(
                 &ctx,
                 &inbound.account_ref,
@@ -505,11 +738,15 @@ async fn handle_message(ctx: Arc<BridgeContext>, inbound: InboundPrompt, permit:
                     "[{}] {} failed while completing this prompt.",
                     ctx.cfg.spec.reply_prefix, ctx.cfg.spec.display_name
                 ),
-                0,
+                chunk_index + 1,
             )
             .await;
         }
     }
+}
+
+async fn fifo_is_blocked(ctx: &BridgeContext, group_ref: &str) -> bool {
+    ctx.recovery.get(group_ref).await.is_some() || ctx.deliveries.has_group(group_ref).await
 }
 
 async fn handle_session_reset(ctx: &BridgeContext, inbound: &InboundPrompt) {
@@ -559,6 +796,7 @@ async fn finish_success(
     inbound: InboundPrompt,
     known_session: Option<SessionRecord>,
     cwd: PathBuf,
+    recovery_prompt: String,
     outcome: Outcome,
     delivery: DeliveryReport,
 ) {
@@ -577,14 +815,13 @@ async fn finish_success(
     let needs_persist = known_session
         .as_ref()
         .is_none_or(|record| record.session_id.is_empty());
-    if !delivery.failed
-        && needs_persist
-        && let Some(session_id) = outcome.observed_session
+    if needs_persist
+        && let Some(session_id) = outcome.observed_session.clone()
         && let Err(err) = persist_observed_session_if_unset(
             &ctx.sessions,
             &inbound.group_ref,
             known_session.as_ref(),
-            cwd,
+            cwd.clone(),
             Some(session_id),
         )
         .await
@@ -597,20 +834,66 @@ async fn finish_success(
         );
     }
 
-    if delivery.failed {
+    let completion_route = completion_route(&outcome, &delivery);
+    if completion_route == CompletionRoute::NonzeroExit {
+        let session_id = outcome
+            .observed_session
+            .clone()
+            .or_else(|| {
+                known_session
+                    .as_ref()
+                    .map(|record| record.session_id.clone())
+            })
+            .filter(|value| !value.is_empty());
+        let message = if let Some(session_id) = session_id {
+            let kind = recovery_kind_for_outcome(&outcome);
+            if let Err(err) = persist_recovery_record(
+                &ctx.recovery,
+                &inbound.group_ref,
+                recovery_prompt,
+                cwd,
+                session_id,
+                kind,
+            )
+            .await
+            {
+                warn!(target: TRACE_TARGET, method = "recovery_store", error_kind = err.privacy_safe_kind(), "failed to persist recovery record");
+                format!(
+                    "[{}] The backend exited and this attempt cannot be resumed. Send a new prompt or `/reset-session`.",
+                    ctx.cfg.spec.reply_prefix
+                )
+            } else {
+                recovery_resolution_message(ctx.cfg.spec.reply_prefix, kind)
+            }
+        } else {
+            format!(
+                "[{}] The backend exited and this attempt cannot be resumed. Send a new prompt or `/reset-session`.",
+                ctx.cfg.spec.reply_prefix
+            )
+        };
+        let _ = send_reply(
+            &ctx,
+            &inbound.account_ref,
+            &inbound.group_ref,
+            &inbound.message_ref,
+            &message,
+            delivery.status_chunk_index,
+        )
+        .await;
+    } else if completion_route == CompletionRoute::TextFinalAckUnknown {
         let _ = send_reply(
             &ctx,
             &inbound.account_ref,
             &inbound.group_ref,
             &inbound.message_ref,
             &format!(
-                "[{}] failed to deliver the complete {} response; some chunks may be missing.",
-                ctx.cfg.spec.reply_prefix, ctx.cfg.spec.display_name
+                "[{}] {TEXT_FINAL_ACK_UNKNOWN_TEXT}",
+                ctx.cfg.spec.reply_prefix
             ),
-            delivery.failure_chunk_index,
+            delivery.status_chunk_index,
         )
         .await;
-    } else if delivery.chunk_count == 0 {
+    } else if completion_route == CompletionRoute::NoText {
         let mut message = match outcome.error_summary {
             Some(summary) => format!(
                 "[{}] {} reported {summary}",
@@ -633,7 +916,7 @@ async fn finish_success(
             &inbound.group_ref,
             &inbound.message_ref,
             &message,
-            0,
+            delivery.status_chunk_index,
         )
         .await;
     }
@@ -642,23 +925,88 @@ async fn finish_success(
 struct DeliveryReport {
     chunk_count: usize,
     failed: bool,
-    failure_chunk_index: usize,
+    status_chunk_index: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CompletionRoute {
+    NonzeroExit,
+    TextFinalAckUnknown,
+    NoText,
+    Complete,
+}
+
+fn completion_route(outcome: &Outcome, delivery: &DeliveryReport) -> CompletionRoute {
+    if outcome.exit_code.is_some_and(|code| code != 0) {
+        CompletionRoute::NonzeroExit
+    } else if delivery.failed {
+        CompletionRoute::TextFinalAckUnknown
+    } else if delivery.chunk_count == 0 {
+        CompletionRoute::NoText
+    } else {
+        CompletionRoute::Complete
+    }
+}
+
+fn recovery_kind_for_outcome(outcome: &Outcome) -> RecoveryKind {
+    if outcome.no_side_effects_proven {
+        RecoveryKind::FailedResumable
+    } else {
+        RecoveryKind::UncertainOutcome
+    }
+}
+
+async fn persist_recovery_record(
+    recovery: &RecoveryStore,
+    group_ref: &str,
+    prompt: String,
+    cwd: PathBuf,
+    session_id: String,
+    kind: RecoveryKind,
+) -> Result<()> {
+    recovery
+        .set(
+            group_ref,
+            RecoveryRecord {
+                prompt,
+                cwd,
+                session_id,
+                kind,
+                status: RecoveryStatus::Pending,
+            },
+        )
+        .await
+}
+
+struct FailureRecoveryContext<'a> {
+    config: &'a Config,
+    sessions: &'a SessionStore,
+    recovery: &'a RecoveryStore,
 }
 
 async fn handle_backend_run_failure(
-    config: &Config,
-    sessions: &SessionStore,
+    context: FailureRecoveryContext<'_>,
     group_ref: &str,
     known_session: Option<&SessionRecord>,
     cwd: PathBuf,
+    prompt: String,
     failure: &RunFailure,
-    idle_timeout: Duration,
 ) -> String {
+    let FailureRecoveryContext {
+        config,
+        sessions,
+        recovery,
+    } = context;
+    let resumable_session = failure
+        .observed_session
+        .clone()
+        .or_else(|| known_session.map(|record| record.session_id.clone()))
+        .filter(|value| !value.is_empty());
     if let Err(store_err) = persist_observed_session_if_unset(
         sessions,
         group_ref,
         known_session,
-        cwd,
+        cwd.clone(),
         failure.observed_session.clone(),
     )
     .await
@@ -672,17 +1020,30 @@ async fn handle_backend_run_failure(
     }
 
     match &failure.error {
-        HarnessError::BackendIdle => format!(
-            "[{}] {} went silent for {}s without producing output; killing the invocation.",
-            config.spec.reply_prefix,
-            config.spec.display_name,
-            idle_timeout.as_secs()
-        ),
         HarnessError::BackendTimedOut => {
-            format!(
-                "[{}] {} timed out before producing a complete response.",
-                config.spec.reply_prefix, config.spec.display_name
-            )
+            if let Some(session_id) = resumable_session {
+                let record = RecoveryRecord {
+                    prompt,
+                    cwd,
+                    session_id,
+                    kind: RecoveryKind::PolicyLimit,
+                    status: RecoveryStatus::Pending,
+                };
+                if let Err(err) = recovery.set(group_ref, record).await {
+                    warn!(target: TRACE_TARGET, method = "recovery_store", error_kind = err.privacy_safe_kind(), "failed to persist recovery record");
+                    format!(
+                        "[{}] The backend exited and this attempt cannot be resumed. Send a new prompt or `/reset-session`.",
+                        config.spec.reply_prefix
+                    )
+                } else {
+                    recovery_resolution_message(config.spec.reply_prefix, RecoveryKind::PolicyLimit)
+                }
+            } else {
+                format!(
+                    "[{}] The backend exited and this attempt cannot be resumed. Send a new prompt or `/reset-session`.",
+                    config.spec.reply_prefix
+                )
+            }
         }
         HarnessError::BackendSpawn => {
             format!(
@@ -695,6 +1056,24 @@ async fn handle_backend_run_failure(
             config.spec.reply_prefix, config.spec.display_name
         ),
     }
+}
+
+fn recovery_resolution_message(prefix: &str, kind: RecoveryKind) -> String {
+    let text = match kind {
+        RecoveryKind::NotResponding => {
+            "The connector stopped this attempt and saved the backend session. Send `/retry-last` to retry it, or `/discard-last` to abandon it and continue queued work."
+        }
+        RecoveryKind::FailedResumable => {
+            "The backend exited before completing, and its session was saved. Send `/retry-last` to retry it, or `/discard-last` to abandon it and continue queued work."
+        }
+        RecoveryKind::UncertainOutcome => {
+            "This attempt stopped with an uncertain outcome and may have applied side effects. Review the results, then send `/retry-last` only if replay is safe, or `/discard-last` to abandon it and continue queued work."
+        }
+        RecoveryKind::PolicyLimit => {
+            "The configured time limit ended this attempt. The backend session was saved; send `/retry-last` to retry it, or `/discard-last` to abandon it and continue queued work."
+        }
+    };
+    format!("[{prefix}] {text}")
 }
 
 async fn persist_observed_session_if_unset(
@@ -842,6 +1221,76 @@ async fn install_allowlist(
     Ok(())
 }
 
+async fn reconcile_pending_deliveries(client: &ControlClient, store: &FinalDeliveryStore) {
+    for (key, record) in store.list().await {
+        match send_final_with_retry(
+            client,
+            &record.account_ref,
+            &record.group_ref,
+            &record.reply_to_ref,
+            &record.text,
+            record.chunk_index,
+        )
+        .await
+        {
+            Ok(()) => {
+                if let Err(err) = store.remove(&key).await {
+                    warn!(target: TRACE_TARGET, method = "final_reconcile", error_kind = err.privacy_safe_kind(), "failed to clear reconciled final-delivery record");
+                }
+            }
+            Err(err) => {
+                warn!(target: TRACE_TARGET, method = "final_reconcile", error_kind = err.privacy_safe_kind(), "final-delivery reconciliation remains pending")
+            }
+        }
+    }
+}
+
+async fn stage_backend_reply(
+    ctx: &BridgeContext,
+    account_ref: &str,
+    group_ref: &str,
+    reply_to_ref: &str,
+    text: &str,
+    chunk_index: usize,
+) -> Result<String> {
+    let key = format!("{group_ref}:{reply_to_ref}:{chunk_index}");
+    ctx.deliveries
+        .set(
+            &key,
+            FinalDeliveryRecord {
+                account_ref: account_ref.to_owned(),
+                group_ref: group_ref.to_owned(),
+                reply_to_ref: reply_to_ref.to_owned(),
+                text: text.to_owned(),
+                chunk_index,
+            },
+        )
+        .await?;
+    Ok(key)
+}
+
+async fn send_staged_backend_reply(
+    ctx: &BridgeContext,
+    key: &str,
+    account_ref: &str,
+    group_ref: &str,
+    reply_to_ref: &str,
+    text: &str,
+    chunk_index: usize,
+) -> Result<()> {
+    send_final_with_retry(
+        &ctx.client,
+        account_ref,
+        group_ref,
+        reply_to_ref,
+        text,
+        chunk_index,
+    )
+    .await?;
+    ctx.deliveries.remove(key).await?;
+    Ok(())
+}
+
 async fn send_reply(
     ctx: &BridgeContext,
     account_ref: &str,
@@ -850,10 +1299,28 @@ async fn send_reply(
     text: &str,
     chunk_index: usize,
 ) -> Result<()> {
+    send_final_with_retry(
+        &ctx.client,
+        account_ref,
+        group_ref,
+        reply_to_ref,
+        text,
+        chunk_index,
+    )
+    .await
+}
+
+async fn send_final_with_retry(
+    client: &ControlClient,
+    account_ref: &str,
+    group_ref: &str,
+    reply_to_ref: &str,
+    text: &str,
+    chunk_index: usize,
+) -> Result<()> {
     let mut last_error: Option<HarnessError> = None;
     for attempt in 1..=SEND_RETRY_ATTEMPTS {
-        match ctx
-            .client
+        match client
             .send_final(account_ref, group_ref, reply_to_ref, text, chunk_index)
             .await
         {
@@ -876,13 +1343,16 @@ struct GroupQueues {
 struct GroupQueue {
     serial: Arc<Mutex<()>>,
     pending: Arc<Semaphore>,
+    waiting: Arc<Semaphore>,
     active: AtomicUsize,
+    recovery_changed: tokio::sync::watch::Sender<u64>,
 }
 
 struct GroupPermit {
     queue: Arc<GroupQueue>,
     serial: Arc<Mutex<()>>,
-    _pending: OwnedSemaphorePermit,
+    _waiting: Option<OwnedSemaphorePermit>,
+    _pending: Option<OwnedSemaphorePermit>,
 }
 
 impl GroupQueues {
@@ -893,7 +1363,7 @@ impl GroupQueues {
         }
     }
 
-    async fn try_enter(&self, group_ref: &str) -> Option<GroupPermit> {
+    async fn queue(&self, group_ref: &str) -> Option<Arc<GroupQueue>> {
         let mut inner = self.inner.lock().await;
         if inner.len() >= GROUP_QUEUE_LIMIT {
             inner.retain(|_, queue| queue.active.load(Ordering::Relaxed) != 0);
@@ -901,22 +1371,43 @@ impl GroupQueues {
         if inner.len() >= GROUP_QUEUE_LIMIT && !inner.contains_key(group_ref) {
             return None;
         }
-        let queue = inner
-            .entry(group_ref.to_owned())
-            .or_insert_with(|| {
-                Arc::new(GroupQueue {
-                    serial: Arc::new(Mutex::new(())),
-                    pending: Arc::new(Semaphore::new(self.limit)),
-                    active: AtomicUsize::new(0),
+        Some(
+            inner
+                .entry(group_ref.to_owned())
+                .or_insert_with(|| {
+                    let (recovery_changed, _) = tokio::sync::watch::channel(0);
+                    Arc::new(GroupQueue {
+                        serial: Arc::new(Mutex::new(())),
+                        pending: Arc::new(Semaphore::new(self.limit)),
+                        waiting: Arc::new(Semaphore::new(self.limit)),
+                        active: AtomicUsize::new(0),
+                        recovery_changed,
+                    })
                 })
-            })
-            .clone();
-        let pending = queue.pending.clone().try_acquire_owned().ok()?;
+                .clone(),
+        )
+    }
+
+    async fn try_enter_waiter(&self, group_ref: &str) -> Option<GroupPermit> {
+        let queue = self.queue(group_ref).await?;
+        let waiting = queue.waiting.clone().try_acquire_owned().ok()?;
         queue.active.fetch_add(1, Ordering::Relaxed);
         Some(GroupPermit {
             queue: queue.clone(),
             serial: queue.serial.clone(),
-            _pending: pending,
+            _waiting: Some(waiting),
+            _pending: None,
+        })
+    }
+
+    async fn enter_recovery(&self, group_ref: &str) -> Option<GroupPermit> {
+        let queue = self.queue(group_ref).await?;
+        queue.active.fetch_add(1, Ordering::Relaxed);
+        Some(GroupPermit {
+            queue: queue.clone(),
+            serial: queue.serial.clone(),
+            _waiting: None,
+            _pending: None,
         })
     }
 }
@@ -1002,13 +1493,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn group_queue_enforces_pending_limit() {
+    async fn group_queue_enforces_waiting_limit_but_recovery_bypasses_it() {
         let queues = GroupQueues::new(1);
-        let first = queues.try_enter("g").await;
+        let first = queues.try_enter_waiter("g").await;
         assert!(first.is_some());
-        assert!(queues.try_enter("g").await.is_none());
+        assert_eq!(first.as_ref().unwrap().queue.pending.available_permits(), 1);
+        assert!(queues.try_enter_waiter("g").await.is_none());
+        let recovery = queues.enter_recovery("g").await;
+        assert!(recovery.is_some());
+        drop(recovery);
         drop(first);
-        assert!(queues.try_enter("g").await.is_some());
+        assert!(queues.try_enter_waiter("g").await.is_some());
     }
 
     #[test]
@@ -1035,6 +1530,154 @@ mod tests {
                 allow_workdir_picker: true,
             }
         );
+    }
+
+    #[test]
+    fn recovery_commands_are_exact_and_similar_text_stays_conversational() {
+        assert_eq!(
+            classify_prompt(" /retry-last\n"),
+            PromptDisposition::RetryLast
+        );
+        assert_eq!(
+            classify_prompt("/discard-last"),
+            PromptDisposition::DiscardLast
+        );
+        assert_eq!(
+            classify_prompt("retry"),
+            PromptDisposition::Forward {
+                prompt: "retry".to_owned(),
+                allow_workdir_picker: true,
+            }
+        );
+        assert_eq!(
+            classify_prompt("/goal retry-last"),
+            PromptDisposition::Forward {
+                prompt: "/goal retry-last".to_owned(),
+                allow_workdir_picker: true,
+            }
+        );
+        assert_eq!(
+            classify_prompt("/retry-last please"),
+            PromptDisposition::Forward {
+                prompt: "/retry-last please".to_owned(),
+                allow_workdir_picker: true,
+            }
+        );
+    }
+
+    #[test]
+    fn recovery_copy_is_typed_and_uncertainty_is_not_overstated() {
+        let not_responding = recovery_resolution_message("wn", RecoveryKind::NotResponding);
+        let failed = recovery_resolution_message("wn", RecoveryKind::FailedResumable);
+        let uncertain = recovery_resolution_message("wn", RecoveryKind::UncertainOutcome);
+        let policy = recovery_resolution_message("wn", RecoveryKind::PolicyLimit);
+        assert!(not_responding.contains("connector stopped this attempt"));
+        assert!(failed.contains("backend exited before completing"));
+        assert!(uncertain.contains("may have applied side effects"));
+        assert!(policy.contains("configured time limit"));
+        for text in [&not_responding, &failed, &policy] {
+            assert!(!text.contains("side effects"));
+            assert!(text.contains("backend"));
+        }
+        for text in [&not_responding, &failed, &uncertain, &policy] {
+            assert!(text.contains("/retry-last"));
+            assert!(text.contains("/discard-last"));
+            assert!(!text.contains("killing the invocation"));
+        }
+    }
+
+    #[test]
+    fn completion_matrix_prioritizes_nonzero_recovery_over_delivery_reconciliation() {
+        let failed_delivery = DeliveryReport {
+            chunk_count: 0,
+            failed: true,
+            status_chunk_index: 2,
+        };
+        let uncertain = Outcome {
+            observed_session: Some("session".to_owned()),
+            exit_code: Some(64),
+            error_summary: Some("failed".to_owned()),
+            no_side_effects_proven: false,
+            stderr: String::new(),
+            elapsed_ms: 1,
+        };
+        assert_eq!(
+            completion_route(&uncertain, &failed_delivery),
+            CompletionRoute::NonzeroExit
+        );
+        assert_eq!(
+            recovery_kind_for_outcome(&uncertain),
+            RecoveryKind::UncertainOutcome
+        );
+
+        let proven = Outcome {
+            no_side_effects_proven: true,
+            ..uncertain
+        };
+        assert_eq!(
+            recovery_kind_for_outcome(&proven),
+            RecoveryKind::FailedResumable
+        );
+        let completed = Outcome {
+            exit_code: Some(0),
+            ..proven
+        };
+        assert_eq!(
+            completion_route(&completed, &failed_delivery),
+            CompletionRoute::TextFinalAckUnknown
+        );
+    }
+
+    #[tokio::test]
+    async fn nonzero_completion_persists_pending_recovery_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = RecoveryStore::load(dir.path().join("recovery.json")).unwrap();
+        persist_recovery_record(
+            &store,
+            "group",
+            "private prompt".to_owned(),
+            dir.path().join("repo"),
+            "session".to_owned(),
+            RecoveryKind::UncertainOutcome,
+        )
+        .await
+        .unwrap();
+        let record = store.get("group").await.unwrap();
+        assert_eq!(record.kind, RecoveryKind::UncertainOutcome);
+        assert_eq!(record.status, RecoveryStatus::Pending);
+        assert_eq!(record.session_id, "session");
+    }
+
+    #[test]
+    fn fixed_in_progress_and_reconciliation_copy_is_exact() {
+        assert_eq!(
+            LIVENESS_UNKNOWN_TEXT,
+            "The backend is still running, but the connector cannot confirm progress. No action is needed; it will keep checking until the configured total limit."
+        );
+        assert_eq!(
+            TEXT_FINAL_ACK_UNKNOWN_TEXT,
+            "The backend finished, but the connector could not confirm delivery of its final response. No action is needed; it is reconciling delivery."
+        );
+    }
+
+    #[tokio::test]
+    async fn recovery_signal_broadcasts_and_serial_lock_rejects_active_resolution() {
+        let queues = GroupQueues::new(1);
+        let waiter = queues.try_enter_waiter("g").await.unwrap();
+        let mut changes = waiter.queue.recovery_changed.subscribe();
+        waiter
+            .queue
+            .recovery_changed
+            .send_modify(|generation| *generation += 1);
+        tokio::time::timeout(Duration::from_millis(50), changes.changed())
+            .await
+            .unwrap()
+            .unwrap();
+
+        let recovery = queues.enter_recovery("g").await.unwrap();
+        let active = recovery.serial.lock().await;
+        assert!(recovery.serial.try_lock().is_err());
+        drop(active);
     }
 
     #[test]
@@ -1120,23 +1763,29 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_failure_path_persists_first_session_and_selects_idle_reply() {
+    async fn total_limit_persists_session_and_recovery_record() {
         let dir = tempfile::tempdir().unwrap();
         let home = dir.path().to_path_buf();
         let store = SessionStore::load(home.join("sessions.json"), &home).unwrap();
+        let recovery = RecoveryStore::load(home.join("recovery.json")).unwrap();
+
         let failure = RunFailure {
-            error: HarnessError::BackendIdle,
+            error: HarnessError::BackendTimedOut,
             observed_session: Some("ses_idle".to_owned()),
         };
 
+        let config = test_config(&home);
         let reply = handle_backend_run_failure(
-            &test_config(&home),
-            &store,
+            FailureRecoveryContext {
+                config: &config,
+                sessions: &store,
+                recovery: &recovery,
+            },
             "group1",
             None,
             home.clone(),
+            "private prompt".to_owned(),
             &failure,
-            Duration::from_secs(45),
         )
         .await;
 
@@ -1145,7 +1794,10 @@ mod tests {
         assert_eq!(record.cwd, home);
         assert_eq!(
             reply,
-            "[wn-opencode] opencode went silent for 45s without producing output; killing the invocation."
+            "[wn-opencode] The configured time limit ended this attempt. The backend session was saved; send `/retry-last` to retry it, or `/discard-last` to abandon it and continue queued work."
         );
+        let recovery = recovery.get("group1").await.unwrap();
+        assert_eq!(recovery.kind, RecoveryKind::PolicyLimit);
+        assert_eq!(recovery.status, RecoveryStatus::Pending);
     }
 }

--- a/integrations/terminal-harness/src/bridge.rs
+++ b/integrations/terminal-harness/src/bridge.rs
@@ -75,6 +75,7 @@ pub async fn run<B: Backend>(config: Config, backend: B) -> Result<()> {
         sessions,
         recovery,
         deliveries,
+        reconciliation_slot: ReconciliationSlot::new(),
         queues,
         dedupe: Arc::new(InboundDedupe::new(DEDUPE_LIMIT)),
         backend: Arc::new(backend),
@@ -91,10 +92,32 @@ struct BridgeContext {
     sessions: Arc<SessionStore>,
     recovery: Arc<RecoveryStore>,
     deliveries: Arc<FinalDeliveryStore>,
+    reconciliation_slot: ReconciliationSlot,
     queues: Arc<GroupQueues>,
     dedupe: Arc<InboundDedupe>,
     backend: Arc<dyn Backend>,
     home: PathBuf,
+}
+
+struct ReconciliationSlot {
+    semaphore: Arc<Semaphore>,
+}
+
+impl ReconciliationSlot {
+    fn new() -> Self {
+        Self {
+            semaphore: Arc::new(Semaphore::new(1)),
+        }
+    }
+
+    fn try_enter(&self) -> Option<OwnedSemaphorePermit> {
+        self.semaphore.clone().try_acquire_owned().ok()
+    }
+
+    #[cfg(test)]
+    fn available_permits(&self) -> usize {
+        self.semaphore.available_permits()
+    }
 }
 
 async fn subscribe_loop(ctx: Arc<BridgeContext>) -> Result<()> {
@@ -161,7 +184,6 @@ async fn drain_events(
     let mut reconcile = interval(Duration::from_secs(30));
     reconcile.set_missed_tick_behavior(MissedTickBehavior::Delay);
     reconcile.tick().await;
-    let reconciliation_slot = Arc::new(Semaphore::new(1));
     loop {
         tokio::select! {
             result = &mut shutdown => {
@@ -197,7 +219,7 @@ async fn drain_events(
                 }
             }
             _ = reconcile.tick() => {
-                if let Ok(permit) = reconciliation_slot.clone().try_acquire_owned() {
+                if let Some(permit) = ctx.reconciliation_slot.try_enter() {
                     let ctx = ctx.clone();
                     tokio::spawn(async move {
                         let _permit = permit;
@@ -1529,6 +1551,22 @@ mod tests {
         assert!(dedupe.insert("m1".to_owned()).await);
         assert!(!dedupe.insert("m1".to_owned()).await);
         assert!(dedupe.insert("m2".to_owned()).await);
+    }
+
+    #[test]
+    fn reconnect_while_reconciliation_is_pending_keeps_maximum_concurrency_one() {
+        let slot = ReconciliationSlot::new();
+
+        let old_drain = slot.try_enter().expect("first drain starts reconciliation");
+        assert_eq!(slot.available_permits(), 0);
+        assert!(
+            slot.try_enter().is_none(),
+            "a reconnecting drain must share the process-lifetime reconciliation guard"
+        );
+
+        drop(old_drain);
+        assert_eq!(slot.available_permits(), 1);
+        assert!(slot.try_enter().is_some());
     }
 
     #[tokio::test]

--- a/integrations/terminal-harness/src/bridge.rs
+++ b/integrations/terminal-harness/src/bridge.rs
@@ -976,7 +976,7 @@ enum CompletionRoute {
 }
 
 fn completion_route(outcome: &Outcome, delivery: &DeliveryReport) -> CompletionRoute {
-    if outcome.exit_code.is_some_and(|code| code != 0) {
+    if outcome.exit_code != Some(0) {
         CompletionRoute::NonzeroExit
     } else if delivery.failed {
         CompletionRoute::TextFinalAckUnknown
@@ -1657,6 +1657,19 @@ mod tests {
             recovery_kind_for_outcome(&proven),
             RecoveryKind::FailedResumable
         );
+        let signal_terminated = Outcome {
+            observed_session: Some("session".to_owned()),
+            exit_code: None,
+            error_summary: Some("terminated".to_owned()),
+            no_side_effects_proven: true,
+            stderr: String::new(),
+            elapsed_ms: 1,
+        };
+        assert_eq!(
+            completion_route(&signal_terminated, &failed_delivery),
+            CompletionRoute::NonzeroExit
+        );
+
         let completed = Outcome {
             exit_code: Some(0),
             ..proven

--- a/integrations/terminal-harness/src/error.rs
+++ b/integrations/terminal-harness/src/error.rs
@@ -30,8 +30,6 @@ pub enum HarnessError {
     ControlRejected { method: &'static str, code: String },
     #[error("backend invocation timed out")]
     BackendTimedOut,
-    #[error("backend went idle without producing output")]
-    BackendIdle,
     #[error("backend stream error")]
     BackendStream,
     #[error("backend process failed to start")]
@@ -53,7 +51,6 @@ impl HarnessError {
             Self::UnexpectedResponse { .. } => "unexpected_response",
             Self::ControlRejected { .. } => "control_rejected",
             Self::BackendTimedOut => "backend_timeout",
-            Self::BackendIdle => "backend_idle",
             Self::BackendStream => "backend_stream",
             Self::BackendSpawn => "backend_spawn",
             Self::Join => "join",

--- a/integrations/terminal-harness/src/lib.rs
+++ b/integrations/terminal-harness/src/lib.rs
@@ -51,7 +51,7 @@ pub struct Config {
     pub state_path: PathBuf,
     /// Total backend invocation timeout.
     pub backend_timeout: Duration,
-    /// Maximum backend stdout silence.
+    /// Presentation-idle interval before liveness becomes unknown.
     pub backend_idle_timeout: Duration,
     /// Connector execution-permission policy selected by the operator.
     pub execution_profile: ExecutionProfile,
@@ -82,7 +82,7 @@ impl fmt::Debug for Config {
 pub struct Invocation {
     /// Total invocation timeout.
     pub timeout: Duration,
-    /// Maximum stdout silence.
+    /// Presentation-idle interval; expiry never authorizes teardown.
     pub idle_timeout: Duration,
     /// Validated working directory.
     pub cwd: PathBuf,
@@ -113,6 +113,8 @@ pub struct Outcome {
     pub exit_code: Option<i32>,
     /// Sanitized backend error classification.
     pub error_summary: Option<String>,
+    /// True only when the backend explicitly proves the failed turn made no side effects.
+    pub no_side_effects_proven: bool,
     /// Bounded and ANSI-stripped stderr.
     pub stderr: String,
     /// Elapsed wall-clock milliseconds.
@@ -126,6 +128,7 @@ impl fmt::Debug for Outcome {
             .field("session_present", &self.observed_session.is_some())
             .field("exit_code", &self.exit_code)
             .field("error_summary_present", &self.error_summary.is_some())
+            .field("no_side_effects_proven", &self.no_side_effects_proven)
             .field("stderr_len", &self.stderr.len())
             .field("elapsed_ms", &self.elapsed_ms)
             .finish()
@@ -155,6 +158,8 @@ impl fmt::Debug for RunFailure {
 pub enum RunnerEvent {
     /// Completed assistant text; never a thinking or tool delta.
     Text(String),
+    /// The presentation stream is idle while the backend process is still alive.
+    LivenessUnknown,
 }
 
 impl fmt::Debug for RunnerEvent {
@@ -164,6 +169,7 @@ impl fmt::Debug for RunnerEvent {
                 .debug_struct("Text")
                 .field("text_len", &text.len())
                 .finish(),
+            Self::LivenessUnknown => formatter.write_str("LivenessUnknown"),
         }
     }
 }
@@ -282,6 +288,7 @@ mod privacy_tests {
             observed_session: Some("secret-session".to_owned()),
             exit_code: Some(64),
             error_summary: Some("secret-summary".to_owned()),
+            no_side_effects_proven: false,
             stderr: "secret stderr".to_owned(),
             elapsed_ms: 10,
         };

--- a/integrations/terminal-harness/src/process.rs
+++ b/integrations/terminal-harness/src/process.rs
@@ -1,11 +1,12 @@
 use std::fmt;
 use std::path::PathBuf;
 use std::process::Stdio;
+use std::sync::Arc;
 use std::time::{Duration, Instant as StdInstant};
 
 use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStderr, ChildStdin, Command};
-use tokio::sync::mpsc;
+use tokio::sync::{Mutex, mpsc};
 use tokio::task::JoinHandle;
 use tokio::time::{Instant, sleep_until, timeout_at};
 use tracing::debug;
@@ -224,7 +225,8 @@ where
             return Err(spawn_failure());
         }
     };
-    let mut stderr_task = tokio::spawn(capture_stderr(stderr));
+    let stderr_snapshot = Arc::new(Mutex::new(String::new()));
+    let mut stderr_task = tokio::spawn(capture_stderr(stderr, stderr_snapshot.clone()));
     let started = StdInstant::now();
     let mut observed_session = None;
     let mut error_summary = None;
@@ -234,9 +236,12 @@ where
 
     let lifecycle_result = timeout_at(total_deadline, async {
         let mut lines = BufReader::new(stdout).lines();
-        loop {
-            let line = match timeout_at(idle_deadline, lines.next_line()).await {
-                Err(_) => {
+        let child_status = loop {
+            let line = tokio::select! {
+                biased;
+                line = lines.next_line() => Some(line),
+                status = child.wait() => break Some(status.map_err(HarnessError::from)?),
+                _ = sleep_until(idle_deadline) => {
                     if !reported_liveness_unknown {
                         tx.send(RunnerEvent::LivenessUnknown)
                             .await
@@ -246,9 +251,11 @@ where
                     idle_deadline = Instant::now() + idle_timeout;
                     continue;
                 }
-                Ok(Err(_)) => return Err(HarnessError::BackendStream),
-                Ok(Ok(Some(line))) => line,
-                Ok(Ok(None)) => break,
+            };
+            let line = match line.expect("line branch returns a value") {
+                Err(_) => return Err(HarnessError::BackendStream),
+                Ok(Some(line)) => line,
+                Ok(None) => break None,
             };
             if !line.is_empty() {
                 match parse_event(&line) {
@@ -304,6 +311,24 @@ where
                 }
             }
             idle_deadline = Instant::now() + idle_timeout;
+        };
+
+        if let Some(status) = child_status {
+            if let Some(task) = writer_task.as_mut() {
+                task.abort();
+                let _ = task.await;
+            }
+            stderr_task.abort();
+            let _ = (&mut stderr_task).await;
+            let stderr = stderr_snapshot.lock().await.clone();
+            return Ok(Outcome {
+                observed_session: observed_session.clone(),
+                exit_code: status.code(),
+                error_summary,
+                no_side_effects_proven,
+                stderr: strip_ansi(stderr.trim()),
+                elapsed_ms: started.elapsed().as_millis(),
+            });
         }
 
         let completion = async {
@@ -403,24 +428,33 @@ fn write_stdin(stdin: ChildStdin, prompt: String) -> JoinHandle<std::io::Result<
 }
 
 /// Captures a bounded prefix of backend stderr.
-async fn capture_stderr(stderr: ChildStderr) -> String {
-    capture_bounded(stderr).await
+async fn capture_stderr(stderr: ChildStderr, captured: Arc<Mutex<String>>) -> String {
+    capture_bounded_shared(stderr, captured).await
 }
 
-async fn capture_bounded(mut reader: impl AsyncRead + Unpin) -> String {
+#[cfg(test)]
+async fn capture_bounded(reader: impl AsyncRead + Unpin) -> String {
+    capture_bounded_shared(reader, Arc::new(Mutex::new(String::new()))).await
+}
+
+async fn capture_bounded_shared(
+    mut reader: impl AsyncRead + Unpin,
+    captured: Arc<Mutex<String>>,
+) -> String {
     let mut buf = [0_u8; 1024];
-    let mut captured = String::new();
     loop {
         match reader.read(&mut buf).await {
             Ok(0) | Err(_) => break,
-            Ok(read) if captured.len() < STDERR_CAPTURE_BYTES => {
-                captured.push_str(&String::from_utf8_lossy(&buf[..read]));
-                truncate_to_char_boundary(&mut captured, STDERR_CAPTURE_BYTES);
+            Ok(read) => {
+                let mut captured = captured.lock().await;
+                if captured.len() < STDERR_CAPTURE_BYTES {
+                    captured.push_str(&String::from_utf8_lossy(&buf[..read]));
+                    truncate_to_char_boundary(&mut captured, STDERR_CAPTURE_BYTES);
+                }
             }
-            Ok(_) => {}
         }
     }
-    captured
+    captured.lock().await.clone()
 }
 
 /// Aborts auxiliary tasks, terminates the child, and reaps it after failure.

--- a/integrations/terminal-harness/src/process.rs
+++ b/integrations/terminal-harness/src/process.rs
@@ -7,10 +7,10 @@ use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt, BufRead
 use tokio::process::{Child, ChildStderr, ChildStdin, Command};
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
-use tokio::time::{Instant, timeout_at};
+use tokio::time::{Instant, sleep_until, timeout_at};
 use tracing::debug;
 
-use crate::{HarnessError, Outcome, Result, RunFailure, RunnerEvent, TRACE_TARGET};
+use crate::{HarnessError, Outcome, RunFailure, RunnerEvent, TRACE_TARGET};
 
 const STDERR_CAPTURE_BYTES: usize = 4096;
 
@@ -73,7 +73,7 @@ pub struct ProcessSpec {
     pub backend_name: &'static str,
     /// Total wall-clock budget, including reply-channel backpressure.
     pub total_timeout: Duration,
-    /// Maximum silence between stdout reads and through the final child wait.
+    /// Presentation-idle interval. Expiry reports unknown liveness but never kills work.
     pub idle_timeout: Duration,
 }
 
@@ -106,6 +106,13 @@ pub enum ParsedEvent {
         /// Sanitized error classification; never a raw backend message.
         summary: String,
     },
+    /// A failed turn whose backend contract explicitly proves no side effects occurred.
+    FailedWithoutSideEffects {
+        /// Optional durable session id.
+        session_id: Option<String>,
+        /// Sanitized error classification.
+        summary: String,
+    },
     /// A valid event that has no durable connector effect.
     Ignored,
 }
@@ -126,6 +133,14 @@ impl fmt::Debug for ParsedEvent {
                 summary,
             } => formatter
                 .debug_struct("Error")
+                .field("session_present", &session_id.is_some())
+                .field("summary_len", &summary.len())
+                .finish(),
+            Self::FailedWithoutSideEffects {
+                session_id,
+                summary,
+            } => formatter
+                .debug_struct("FailedWithoutSideEffects")
                 .field("session_present", &session_id.is_some())
                 .field("summary_len", &summary.len())
                 .finish(),
@@ -213,13 +228,27 @@ where
     let started = StdInstant::now();
     let mut observed_session = None;
     let mut error_summary = None;
+    let mut no_side_effects_proven = false;
     let mut idle_deadline = Instant::now() + idle_timeout;
+    let mut reported_liveness_unknown = false;
 
     let lifecycle_result = timeout_at(total_deadline, async {
         let mut lines = BufReader::new(stdout).lines();
         loop {
-            let Some(line) = next_stdout_line(&mut lines, idle_deadline).await? else {
-                break;
+            let line = match timeout_at(idle_deadline, lines.next_line()).await {
+                Err(_) => {
+                    if !reported_liveness_unknown {
+                        tx.send(RunnerEvent::LivenessUnknown)
+                            .await
+                            .map_err(|_| HarnessError::BackendStream)?;
+                        reported_liveness_unknown = true;
+                    }
+                    idle_deadline = Instant::now() + idle_timeout;
+                    continue;
+                }
+                Ok(Err(_)) => return Err(HarnessError::BackendStream),
+                Ok(Ok(Some(line))) => line,
+                Ok(Ok(None)) => break,
             };
             if !line.is_empty() {
                 match parse_event(&line) {
@@ -250,6 +279,20 @@ where
                             error_summary = Some(summary);
                         }
                     }
+                    Ok(ParsedEvent::FailedWithoutSideEffects {
+                        session_id,
+                        summary,
+                    }) => {
+                        if observed_session.is_none()
+                            && let Some(session_id) = session_id.filter(|id| !id.is_empty())
+                        {
+                            observed_session = Some(session_id);
+                        }
+                        if error_summary.is_none() {
+                            error_summary = Some(summary);
+                        }
+                        no_side_effects_proven = true;
+                    }
                     Ok(ParsedEvent::Ignored) => {}
                     Err(_) => debug!(
                         target: TRACE_TARGET,
@@ -263,7 +306,7 @@ where
             idle_deadline = Instant::now() + idle_timeout;
         }
 
-        let (status, stderr) = match timeout_at(idle_deadline, async {
+        let completion = async {
             let writer = async {
                 match writer_task.as_mut() {
                     Some(task) => Some(task.await),
@@ -287,16 +330,27 @@ where
                 }
             }
             Ok::<_, HarnessError>((status, stderr))
-        })
-        .await
-        {
-            Err(_) => return Err(HarnessError::BackendIdle),
-            Ok(result) => result?,
+        };
+        tokio::pin!(completion);
+        let (status, stderr) = loop {
+            tokio::select! {
+                result = &mut completion => break result?,
+                _ = sleep_until(idle_deadline) => {
+                    if !reported_liveness_unknown {
+                        tx.send(RunnerEvent::LivenessUnknown)
+                            .await
+                            .map_err(|_| HarnessError::BackendStream)?;
+                        reported_liveness_unknown = true;
+                    }
+                    idle_deadline = Instant::now() + idle_timeout;
+                }
+            }
         };
         Ok::<_, HarnessError>(Outcome {
             observed_session: observed_session.clone(),
             exit_code: status.code(),
             error_summary,
+            no_side_effects_proven,
             stderr: strip_ansi(stderr.trim()),
             elapsed_ms: started.elapsed().as_millis(),
         })
@@ -337,18 +391,6 @@ async fn cleanup_missing_pipe(
         task.abort();
     }
     kill_and_reap(child).await;
-}
-
-/// Reads one stdout line before the current idle deadline.
-async fn next_stdout_line(
-    lines: &mut tokio::io::Lines<impl tokio::io::AsyncBufRead + Unpin>,
-    idle_deadline: Instant,
-) -> Result<Option<String>> {
-    match timeout_at(idle_deadline, lines.next_line()).await {
-        Err(_) => Err(HarnessError::BackendIdle),
-        Ok(Err(_)) => Err(HarnessError::BackendStream),
-        Ok(Ok(line)) => Ok(line),
-    }
 }
 
 /// Writes and closes backend stdin concurrently with stdout consumption.

--- a/integrations/terminal-harness/src/store.rs
+++ b/integrations/terminal-harness/src/store.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, watch};
 
 use crate::error::Result;
 
@@ -10,6 +10,43 @@ use crate::error::Result;
 pub(crate) struct SessionRecord {
     pub(crate) session_id: String,
     pub(crate) cwd: PathBuf,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum RecoveryKind {
+    FailedResumable,
+    UncertainOutcome,
+    PolicyLimit,
+    NotResponding,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum RecoveryStatus {
+    Pending,
+    Retrying,
+}
+
+/// Private durable replay obligation. Its contents are never logged.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct RecoveryRecord {
+    pub(crate) prompt: String,
+    pub(crate) cwd: PathBuf,
+    pub(crate) session_id: String,
+    pub(crate) kind: RecoveryKind,
+    pub(crate) status: RecoveryStatus,
+}
+
+/// Durable acknowledgement reconciliation for text-only `SendFinal` chunks.
+/// Media and mixed-media terminals are intentionally outside this store.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct FinalDeliveryRecord {
+    pub(crate) account_ref: String,
+    pub(crate) group_ref: String,
+    pub(crate) reply_to_ref: String,
+    pub(crate) text: String,
+    pub(crate) chunk_index: usize,
 }
 
 #[derive(Deserialize)]
@@ -93,6 +130,227 @@ impl SessionStore {
         *map = next;
         Ok(true)
     }
+}
+
+pub(crate) struct RecoveryStore {
+    path: PathBuf,
+    map: Mutex<HashMap<String, RecoveryRecord>>,
+}
+
+impl RecoveryStore {
+    pub(crate) fn load(path: PathBuf) -> Result<Self> {
+        if path.exists() {
+            fs_private::tighten_existing_private_file(&path)?;
+        }
+        let mut map: HashMap<String, RecoveryRecord> = match std::fs::read(&path) {
+            Ok(bytes) if !bytes.is_empty() => serde_json::from_slice(&bytes)?,
+            Ok(_) => HashMap::new(),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => HashMap::new(),
+            Err(err) => return Err(err.into()),
+        };
+        for record in map.values_mut() {
+            if record.status == RecoveryStatus::Retrying {
+                record.status = RecoveryStatus::Pending;
+            }
+        }
+        Ok(Self {
+            path,
+            map: Mutex::new(map),
+        })
+    }
+
+    pub(crate) async fn get(&self, group_key: &str) -> Option<RecoveryRecord> {
+        self.map.lock().await.get(group_key).cloned()
+    }
+
+    pub(crate) async fn set(&self, group_key: &str, record: RecoveryRecord) -> Result<()> {
+        let mut map = self.map.lock().await;
+        let mut next = map.clone();
+        next.insert(group_key.to_owned(), record);
+        self.commit(&mut map, next).await
+    }
+
+    /// Atomically consumes retry authority while retaining the restart barrier.
+    pub(crate) async fn begin_retry(&self, group_key: &str) -> Result<Option<RecoveryRecord>> {
+        let mut map = self.map.lock().await;
+        let Some(current) = map.get(group_key) else {
+            return Ok(None);
+        };
+        if current.status != RecoveryStatus::Pending {
+            return Ok(None);
+        }
+        let mut next = map.clone();
+        let record = next.get_mut(group_key).expect("recovery record exists");
+        record.status = RecoveryStatus::Retrying;
+        let result = record.clone();
+        self.commit(&mut map, next).await?;
+        Ok(Some(result))
+    }
+
+    pub(crate) async fn reset_retry(&self, group_key: &str) -> Result<bool> {
+        let mut map = self.map.lock().await;
+        let Some(current) = map.get(group_key) else {
+            return Ok(false);
+        };
+        if current.status != RecoveryStatus::Retrying {
+            return Ok(false);
+        }
+        let mut next = map.clone();
+        next.get_mut(group_key)
+            .expect("recovery record exists")
+            .status = RecoveryStatus::Pending;
+        self.commit(&mut map, next).await?;
+        Ok(true)
+    }
+
+    pub(crate) async fn discard(&self, group_key: &str) -> Result<bool> {
+        let mut map = self.map.lock().await;
+        if !map.contains_key(group_key) {
+            return Ok(false);
+        }
+        let mut next = map.clone();
+        next.remove(group_key);
+        self.commit(&mut map, next).await?;
+        Ok(true)
+    }
+
+    async fn commit(
+        &self,
+        map: &mut tokio::sync::MutexGuard<'_, HashMap<String, RecoveryRecord>>,
+        next: HashMap<String, RecoveryRecord>,
+    ) -> Result<()> {
+        let path = self.path.clone();
+        let snapshot = next.clone();
+        tokio::task::spawn_blocking(move || write_recovery_snapshot(&path, &snapshot)).await??;
+        **map = next;
+        Ok(())
+    }
+}
+
+pub(crate) struct FinalDeliveryStore {
+    path: PathBuf,
+    map: Mutex<HashMap<String, FinalDeliveryRecord>>,
+    changed: watch::Sender<u64>,
+}
+
+impl FinalDeliveryStore {
+    pub(crate) fn load(path: PathBuf) -> Result<Self> {
+        if path.exists() {
+            fs_private::tighten_existing_private_file(&path)?;
+        }
+        let map = match std::fs::read(&path) {
+            Ok(bytes) if !bytes.is_empty() => serde_json::from_slice(&bytes)?,
+            Ok(_) => HashMap::new(),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => HashMap::new(),
+            Err(err) => return Err(err.into()),
+        };
+        let (changed, _) = watch::channel(0);
+        Ok(Self {
+            path,
+            map: Mutex::new(map),
+            changed,
+        })
+    }
+
+    pub(crate) fn subscribe(&self) -> watch::Receiver<u64> {
+        self.changed.subscribe()
+    }
+
+    pub(crate) async fn has_group(&self, group_ref: &str) -> bool {
+        self.map
+            .lock()
+            .await
+            .values()
+            .any(|record| record.group_ref == group_ref)
+    }
+
+    pub(crate) async fn list(&self) -> Vec<(String, FinalDeliveryRecord)> {
+        let mut records: Vec<_> = self
+            .map
+            .lock()
+            .await
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect();
+        records.sort_by(|(_, left), (_, right)| {
+            (
+                &left.account_ref,
+                &left.group_ref,
+                &left.reply_to_ref,
+                left.chunk_index,
+            )
+                .cmp(&(
+                    &right.account_ref,
+                    &right.group_ref,
+                    &right.reply_to_ref,
+                    right.chunk_index,
+                ))
+        });
+        records
+    }
+
+    pub(crate) async fn set(&self, key: &str, record: FinalDeliveryRecord) -> Result<()> {
+        let mut map = self.map.lock().await;
+        let mut next = map.clone();
+        next.insert(key.to_owned(), record);
+        self.commit(&mut map, next).await?;
+        self.changed
+            .send_modify(|generation| *generation = generation.wrapping_add(1));
+        Ok(())
+    }
+
+    pub(crate) async fn remove(&self, key: &str) -> Result<bool> {
+        let mut map = self.map.lock().await;
+        if !map.contains_key(key) {
+            return Ok(false);
+        }
+        let mut next = map.clone();
+        next.remove(key);
+        self.commit(&mut map, next).await?;
+        self.changed
+            .send_modify(|generation| *generation = generation.wrapping_add(1));
+        Ok(true)
+    }
+
+    async fn commit(
+        &self,
+        map: &mut tokio::sync::MutexGuard<'_, HashMap<String, FinalDeliveryRecord>>,
+        next: HashMap<String, FinalDeliveryRecord>,
+    ) -> Result<()> {
+        let path = self.path.clone();
+        let snapshot = next.clone();
+        tokio::task::spawn_blocking(move || write_final_delivery_snapshot(&path, &snapshot))
+            .await??;
+        **map = next;
+        Ok(())
+    }
+}
+
+fn write_final_delivery_snapshot(
+    path: &Path,
+    snapshot: &HashMap<String, FinalDeliveryRecord>,
+) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs_private::create_dir_all_private(parent)?;
+    }
+    let tmp = path.with_extension("json.tmp");
+    let bytes = serde_json::to_vec_pretty(snapshot)?;
+    fs_private::write_private(&tmp, &bytes)?;
+    std::fs::rename(&tmp, path)?;
+    fs_private::tighten_existing_private_file(path)?;
+    Ok(())
+}
+
+fn write_recovery_snapshot(path: &Path, snapshot: &HashMap<String, RecoveryRecord>) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs_private::create_dir_all_private(parent)?;
+    }
+    let tmp = path.with_extension("json.tmp");
+    let bytes = serde_json::to_vec_pretty(snapshot)?;
+    fs_private::write_private(&tmp, &bytes)?;
+    std::fs::rename(&tmp, path)?;
+    fs_private::tighten_existing_private_file(path)?;
+    Ok(())
 }
 
 fn write_snapshot(path: &Path, snapshot: &HashMap<String, SessionRecord>) -> Result<()> {
@@ -218,6 +476,88 @@ mod tests {
         let record = store.get("group1").await.expect("legacy record");
         assert_eq!(record.session_id, "ses_legacy");
         assert_eq!(record.cwd, home);
+    }
+
+    #[tokio::test]
+    async fn recovery_store_persists_and_consumes_retry_exactly_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("recovery.json");
+        let record = RecoveryRecord {
+            prompt: "private prompt".to_owned(),
+            cwd: dir.path().join("repo"),
+            session_id: "session".to_owned(),
+            kind: RecoveryKind::UncertainOutcome,
+            status: RecoveryStatus::Pending,
+        };
+        RecoveryStore::load(path.clone())
+            .unwrap()
+            .set("group", record.clone())
+            .await
+            .unwrap();
+
+        let store = RecoveryStore::load(path.clone()).unwrap();
+        assert!(store.get("group").await == Some(record));
+        let first = store.begin_retry("group").await.unwrap().unwrap();
+        assert_eq!(first.status, RecoveryStatus::Retrying);
+        assert!(store.begin_retry("group").await.unwrap().is_none());
+        assert!(store.reset_retry("group").await.unwrap());
+        assert_eq!(
+            store.get("group").await.unwrap().status,
+            RecoveryStatus::Pending
+        );
+        assert!(store.begin_retry("group").await.unwrap().is_some());
+        drop(store);
+
+        let store = RecoveryStore::load(path).unwrap();
+        assert_eq!(
+            store.get("group").await.unwrap().status,
+            RecoveryStatus::Pending
+        );
+        assert!(store.begin_retry("group").await.unwrap().is_some());
+        assert!(store.discard("group").await.unwrap());
+        assert!(store.get("group").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn discard_is_idempotent_and_never_replays() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = RecoveryStore::load(dir.path().join("recovery.json")).unwrap();
+        assert!(!store.discard("missing").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn final_delivery_store_survives_restart_until_reconciled() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("delivery.json");
+        let first = FinalDeliveryRecord {
+            account_ref: "account".to_owned(),
+            group_ref: "group".to_owned(),
+            reply_to_ref: "message".to_owned(),
+            text: "first".to_owned(),
+            chunk_index: 1,
+        };
+        let second = FinalDeliveryRecord {
+            text: "second".to_owned(),
+            chunk_index: 2,
+            ..first.clone()
+        };
+        let initial = FinalDeliveryStore::load(path.clone()).unwrap();
+        initial.set("second", second.clone()).await.unwrap();
+        initial.set("first", first.clone()).await.unwrap();
+        let store = FinalDeliveryStore::load(path).unwrap();
+        let mut changed = store.subscribe();
+        assert!(store.has_group("group").await);
+        assert!(!store.has_group("other-group").await);
+        assert!(
+            store.list().await == vec![("first".to_owned(), first), ("second".to_owned(), second),]
+        );
+        assert!(store.remove("first").await.unwrap());
+        changed.changed().await.unwrap();
+        assert!(store.has_group("group").await);
+        assert!(store.remove("second").await.unwrap());
+        changed.changed().await.unwrap();
+        assert!(!store.has_group("group").await);
+        assert!(store.list().await.is_empty());
     }
 
     #[cfg(unix)]

--- a/integrations/terminal-harness/src/store.rs
+++ b/integrations/terminal-harness/src/store.rs
@@ -1,5 +1,6 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, watch};
@@ -227,10 +228,18 @@ impl RecoveryStore {
     }
 }
 
+#[derive(Clone, Default, Serialize, Deserialize)]
+struct FinalDeliverySnapshot {
+    records: HashMap<String, FinalDeliveryRecord>,
+    #[serde(default)]
+    incomplete_finals: HashMap<String, HashSet<String>>,
+}
+
 pub(crate) struct FinalDeliveryStore {
     path: PathBuf,
-    map: Mutex<HashMap<String, FinalDeliveryRecord>>,
+    state: Mutex<FinalDeliverySnapshot>,
     changed: watch::Sender<u64>,
+    fail_next_set: AtomicBool,
 }
 
 impl FinalDeliveryStore {
@@ -238,17 +247,20 @@ impl FinalDeliveryStore {
         if path.exists() {
             fs_private::tighten_existing_private_file(&path)?;
         }
-        let map = match std::fs::read(&path) {
-            Ok(bytes) if !bytes.is_empty() => serde_json::from_slice(&bytes)?,
-            Ok(_) => HashMap::new(),
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => HashMap::new(),
+        let state = match std::fs::read(&path) {
+            Ok(bytes) if !bytes.is_empty() => parse_final_delivery_snapshot(&bytes)?,
+            Ok(_) => FinalDeliverySnapshot::default(),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                FinalDeliverySnapshot::default()
+            }
             Err(err) => return Err(err.into()),
         };
         let (changed, _) = watch::channel(0);
         Ok(Self {
             path,
-            map: Mutex::new(map),
+            state: Mutex::new(state),
             changed,
+            fail_next_set: AtomicBool::new(false),
         })
     }
 
@@ -257,18 +269,34 @@ impl FinalDeliveryStore {
     }
 
     pub(crate) async fn has_group(&self, group_ref: &str) -> bool {
-        self.map
+        self.state
             .lock()
             .await
+            .records
             .values()
             .any(|record| record.group_ref == group_ref)
     }
 
-    pub(crate) async fn list(&self) -> Vec<(String, FinalDeliveryRecord)> {
-        let mut records: Vec<_> = self
-            .map
+    pub(crate) async fn has_incomplete_final(&self, group_ref: &str) -> bool {
+        self.state
             .lock()
             .await
+            .incomplete_finals
+            .get(group_ref)
+            .is_some_and(|reply_tos| !reply_tos.is_empty())
+    }
+
+    pub(crate) async fn blocks_group(&self, group_ref: &str) -> bool {
+        self.has_incomplete_final(group_ref).await || self.has_group(group_ref).await
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) async fn list(&self) -> Vec<(String, FinalDeliveryRecord)> {
+        let mut records: Vec<_> = self
+            .state
+            .lock()
+            .await
+            .records
             .iter()
             .map(|(key, value)| (key.clone(), value.clone()))
             .collect();
@@ -289,47 +317,126 @@ impl FinalDeliveryStore {
         records
     }
 
+    pub(crate) async fn list_reconcilable(&self) -> Vec<(String, FinalDeliveryRecord)> {
+        let state = self.state.lock().await;
+        let mut records: Vec<_> = state
+            .records
+            .iter()
+            .filter(|(_, record)| {
+                !state
+                    .incomplete_finals
+                    .get(&record.group_ref)
+                    .is_some_and(|reply_tos| reply_tos.contains(&record.reply_to_ref))
+            })
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect();
+        records.sort_by(|(_, left), (_, right)| {
+            (
+                &left.account_ref,
+                &left.group_ref,
+                &left.reply_to_ref,
+                left.chunk_index,
+            )
+                .cmp(&(
+                    &right.account_ref,
+                    &right.group_ref,
+                    &right.reply_to_ref,
+                    right.chunk_index,
+                ))
+        });
+        records
+    }
+
     pub(crate) async fn set(&self, key: &str, record: FinalDeliveryRecord) -> Result<()> {
-        let mut map = self.map.lock().await;
-        let mut next = map.clone();
-        next.insert(key.to_owned(), record);
-        self.commit(&mut map, next).await?;
-        self.changed
-            .send_modify(|generation| *generation = generation.wrapping_add(1));
-        Ok(())
+        if self.fail_next_set.swap(false, Ordering::SeqCst) {
+            return Err(std::io::Error::from(std::io::ErrorKind::Other).into());
+        }
+        let mut state = self.state.lock().await;
+        let mut next = state.clone();
+        next.records.insert(key.to_owned(), record);
+        self.commit(&mut state, next).await
     }
 
     pub(crate) async fn remove(&self, key: &str) -> Result<bool> {
-        let mut map = self.map.lock().await;
-        if !map.contains_key(key) {
+        let mut state = self.state.lock().await;
+        if !state.records.contains_key(key) {
             return Ok(false);
         }
-        let mut next = map.clone();
-        next.remove(key);
-        self.commit(&mut map, next).await?;
-        self.changed
-            .send_modify(|generation| *generation = generation.wrapping_add(1));
+        let mut next = state.clone();
+        next.records.remove(key);
+        self.commit(&mut state, next).await?;
         Ok(true)
+    }
+
+    pub(crate) async fn mark_incomplete_final(
+        &self,
+        group_ref: &str,
+        reply_to_ref: &str,
+    ) -> Result<()> {
+        let mut state = self.state.lock().await;
+        let mut next = state.clone();
+        next.incomplete_finals
+            .entry(group_ref.to_owned())
+            .or_default()
+            .insert(reply_to_ref.to_owned());
+        self.commit(&mut state, next).await
+    }
+
+    /// Clears the group's incomplete-final barrier and removes only the records
+    /// that belong to those incomplete reply sets. Other groups and later
+    /// complete reply sets are left in place.
+    pub(crate) async fn discard_incomplete_final(&self, group_ref: &str) -> Result<bool> {
+        let mut state = self.state.lock().await;
+        if state
+            .incomplete_finals
+            .get(group_ref)
+            .is_none_or(|reply_tos| reply_tos.is_empty())
+        {
+            return Ok(false);
+        }
+        let mut next = state.clone();
+        let reply_tos = next.incomplete_finals.remove(group_ref).unwrap_or_default();
+        next.records.retain(|_, record| {
+            record.group_ref != group_ref || !reply_tos.contains(&record.reply_to_ref)
+        });
+        self.commit(&mut state, next).await?;
+        Ok(true)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn fail_next_set(&self) {
+        self.fail_next_set.store(true, Ordering::SeqCst);
     }
 
     async fn commit(
         &self,
-        map: &mut tokio::sync::MutexGuard<'_, HashMap<String, FinalDeliveryRecord>>,
-        next: HashMap<String, FinalDeliveryRecord>,
+        state: &mut tokio::sync::MutexGuard<'_, FinalDeliverySnapshot>,
+        next: FinalDeliverySnapshot,
     ) -> Result<()> {
         let path = self.path.clone();
         let snapshot = next.clone();
         tokio::task::spawn_blocking(move || write_final_delivery_snapshot(&path, &snapshot))
             .await??;
-        **map = next;
+        **state = next;
+        self.changed
+            .send_modify(|generation| *generation = generation.wrapping_add(1));
         Ok(())
     }
 }
 
-fn write_final_delivery_snapshot(
-    path: &Path,
-    snapshot: &HashMap<String, FinalDeliveryRecord>,
-) -> Result<()> {
+fn parse_final_delivery_snapshot(bytes: &[u8]) -> Result<FinalDeliverySnapshot> {
+    let value: serde_json::Value = serde_json::from_slice(bytes)?;
+    if value.get("records").is_some() || value.get("incomplete_finals").is_some() {
+        Ok(serde_json::from_value(value)?)
+    } else {
+        Ok(FinalDeliverySnapshot {
+            records: serde_json::from_value(value)?,
+            incomplete_finals: HashMap::new(),
+        })
+    }
+}
+
+fn write_final_delivery_snapshot(path: &Path, snapshot: &FinalDeliverySnapshot) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs_private::create_dir_all_private(parent)?;
     }
@@ -558,6 +665,72 @@ mod tests {
         changed.changed().await.unwrap();
         assert!(!store.has_group("group").await);
         assert!(store.list().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn incomplete_final_barrier_survives_restart_and_blocks_reconcile() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("delivery.json");
+        let first = FinalDeliveryRecord {
+            account_ref: "account".to_owned(),
+            group_ref: "group".to_owned(),
+            reply_to_ref: "message".to_owned(),
+            text: "first".to_owned(),
+            chunk_index: 0,
+        };
+        let store = FinalDeliveryStore::load(path.clone()).unwrap();
+        store.set("first", first.clone()).await.unwrap();
+        store.fail_next_set();
+        assert!(
+            store
+                .set(
+                    "second",
+                    FinalDeliveryRecord {
+                        text: "second".to_owned(),
+                        chunk_index: 1,
+                        ..first.clone()
+                    },
+                )
+                .await
+                .is_err()
+        );
+        store
+            .mark_incomplete_final("group", "message")
+            .await
+            .unwrap();
+        drop(store);
+
+        let store = FinalDeliveryStore::load(path).unwrap();
+        assert!(store.has_incomplete_final("group").await);
+        assert!(store.blocks_group("group").await);
+        assert_eq!(store.list().await.len(), 1);
+        assert!(store.list_reconcilable().await.is_empty());
+        assert!(store.discard_incomplete_final("group").await.unwrap());
+        assert!(!store.has_incomplete_final("group").await);
+        assert!(!store.blocks_group("group").await);
+        assert!(store.list().await.is_empty());
+        assert!(!store.discard_incomplete_final("group").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn final_delivery_store_loads_legacy_bare_record_map() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("delivery.json");
+        let legacy = serde_json::json!({
+            "first": {
+                "account_ref": "account",
+                "group_ref": "group",
+                "reply_to_ref": "message",
+                "text": "first",
+                "chunk_index": 0
+            }
+        });
+        std::fs::write(&path, serde_json::to_vec(&legacy).unwrap()).unwrap();
+
+        let store = FinalDeliveryStore::load(path).unwrap();
+        assert!(store.has_group("group").await);
+        assert!(!store.has_incomplete_final("group").await);
+        assert_eq!(store.list().await.len(), 1);
     }
 
     #[cfg(unix)]

--- a/integrations/terminal-harness/tests/jsonl_process.rs
+++ b/integrations/terminal-harness/tests/jsonl_process.rs
@@ -401,6 +401,44 @@ sleep 30
 }
 
 #[tokio::test]
+async fn immediate_child_exit_does_not_wait_for_inherited_stdout_writer() {
+    let _permit = process_test_permit().await;
+    let root = tempfile::tempdir().unwrap();
+    let script = executable_script(
+        root.path(),
+        "inherited-stdout-backend",
+        r#"#!/bin/sh
+printf '%s\n' '{"type":"session","id":"immediate-exit"}'
+printf '\033[31minherited-stderr\033[0m\n' >&2
+sleep 30 &
+printf '%s' "$!" > background.pid
+exit 23
+"#,
+    );
+    let (tx, mut rx) = mpsc::channel(2);
+    let mut spec = process_spec(
+        &script,
+        root.path(),
+        PromptTransport::Stdin("x".repeat(1024 * 1024)),
+    );
+    spec.total_timeout = Duration::from_secs(3);
+    spec.idle_timeout = Duration::from_secs(2);
+
+    let started = std::time::Instant::now();
+    let outcome = run_jsonl_process(spec, tx, parse_event).await.unwrap();
+    let background_pid = std::fs::read_to_string(root.path().join("background.pid")).unwrap();
+    let _ = std::process::Command::new("kill")
+        .arg(background_pid.trim())
+        .status();
+
+    assert_eq!(outcome.exit_code, Some(23));
+    assert_eq!(outcome.observed_session.as_deref(), Some("immediate-exit"));
+    assert_eq!(outcome.stderr, "inherited-stderr");
+    assert!(started.elapsed() < Duration::from_secs(2));
+    assert!(rx.recv().await.is_none());
+}
+
+#[tokio::test]
 async fn early_stdin_closure_preserves_exit_and_bounded_sanitized_stderr() {
     let _permit = process_test_permit().await;
     let root = tempfile::tempdir().unwrap();

--- a/integrations/terminal-harness/tests/jsonl_process.rs
+++ b/integrations/terminal-harness/tests/jsonl_process.rs
@@ -49,6 +49,10 @@ fn parse_event(line: &str) -> serde_json::Result<ParsedEvent> {
                 .unwrap_or("classified_error")
                 .to_owned(),
         },
+        Some("failed_without_side_effects") => ParsedEvent::FailedWithoutSideEffects {
+            session_id: value["session_id"].as_str().map(str::to_owned),
+            summary: "failed_resumable".to_owned(),
+        },
         _ => ParsedEvent::Ignored,
     })
 }
@@ -232,6 +236,58 @@ printf '%s\n' '{"type":"text","text":"done"}'
 }
 
 #[tokio::test]
+async fn silent_live_backend_reports_unknown_once_then_completes() {
+    let _permit = process_test_permit().await;
+    let root = tempfile::tempdir().unwrap();
+    let script = executable_script(
+        root.path(),
+        "silent-live-backend",
+        r#"#!/bin/sh
+printf '%s\n' '{"type":"session","id":"silent-live"}'
+sleep 1
+printf '%s\n' '{"type":"text","text":"done"}'
+"#,
+    );
+    let (tx, mut rx) = mpsc::channel(4);
+    let mut spec = process_spec(&script, root.path(), PromptTransport::Stdin(String::new()));
+    spec.total_timeout = Duration::from_secs(3);
+    spec.idle_timeout = Duration::from_millis(250);
+
+    let outcome = run_jsonl_process(spec, tx, parse_event).await.unwrap();
+
+    assert_eq!(outcome.exit_code, Some(0));
+    assert_eq!(outcome.observed_session.as_deref(), Some("silent-live"));
+    assert_eq!(rx.recv().await, Some(RunnerEvent::LivenessUnknown));
+    assert_eq!(rx.recv().await, Some(RunnerEvent::Text("done".to_owned())));
+    assert!(rx.recv().await.is_none());
+}
+
+#[tokio::test]
+async fn explicit_no_side_effect_proof_reaches_outcome() {
+    let _permit = process_test_permit().await;
+    let root = tempfile::tempdir().unwrap();
+    let script = executable_script(
+        root.path(),
+        "proven-failure-backend",
+        r#"#!/bin/sh
+printf '%s\n' '{"type":"failed_without_side_effects","session_id":"safe-session"}'
+exit 64
+"#,
+    );
+    let (tx, _rx) = mpsc::channel(2);
+    let outcome = run_jsonl_process(
+        process_spec(&script, root.path(), PromptTransport::Stdin(String::new())),
+        tx,
+        parse_event,
+    )
+    .await
+    .unwrap();
+    assert_eq!(outcome.exit_code, Some(64));
+    assert!(outcome.no_side_effects_proven);
+    assert_eq!(outcome.observed_session.as_deref(), Some("safe-session"));
+}
+
+#[tokio::test]
 async fn channel_backpressure_is_bounded_by_total_not_idle_timeout() {
     let _permit = process_test_permit().await;
     let root = tempfile::tempdir().unwrap();
@@ -283,7 +339,7 @@ exec sleep 30
 }
 
 #[tokio::test]
-async fn idle_timeout_applies_while_reading_output() {
+async fn presentation_idle_reports_unknown_and_waits_for_total_limit() {
     let _permit = process_test_permit().await;
     let root = tempfile::tempdir().unwrap();
     let script = executable_script(
@@ -294,20 +350,23 @@ printf '%s\n' '{"type":"session","id":"output-idle"}'
 exec sleep 30
 "#,
     );
-    let (tx, _rx) = mpsc::channel(1);
+    let (tx, mut rx) = mpsc::channel(2);
     let mut spec = process_spec(&script, root.path(), PromptTransport::Stdin(String::new()));
-    spec.idle_timeout = Duration::from_secs(2);
+    spec.total_timeout = Duration::from_secs(2);
+    spec.idle_timeout = Duration::from_millis(500);
     let failure = run_jsonl_process(spec, tx, parse_event).await.unwrap_err();
 
     assert!(matches!(
         failure.error,
-        marmot_terminal_harness::HarnessError::BackendIdle
+        marmot_terminal_harness::HarnessError::BackendTimedOut
     ));
     assert_eq!(failure.observed_session.as_deref(), Some("output-idle"));
+    assert_eq!(rx.recv().await, Some(RunnerEvent::LivenessUnknown));
+    assert!(rx.recv().await.is_none());
 }
 
 #[tokio::test]
-async fn idle_timeout_applies_after_stdout_eof_during_final_wait() {
+async fn stdout_eof_while_child_lives_reports_unknown_and_waits_for_total_limit() {
     let _permit = process_test_permit().await;
     let root = tempfile::tempdir().unwrap();
     let script = executable_script(
@@ -319,7 +378,7 @@ exec 1>&-
 sleep 30
 "#,
     );
-    let (tx, _rx) = mpsc::channel(1);
+    let (tx, mut rx) = mpsc::channel(2);
     let mut spec = process_spec(
         &script,
         root.path(),
@@ -328,14 +387,17 @@ sleep 30
             prompt: "prompt".to_owned(),
         },
     );
-    spec.idle_timeout = Duration::from_secs(2);
+    spec.total_timeout = Duration::from_secs(2);
+    spec.idle_timeout = Duration::from_millis(500);
     let failure = run_jsonl_process(spec, tx, parse_event).await.unwrap_err();
 
     assert!(matches!(
         failure.error,
-        marmot_terminal_harness::HarnessError::BackendIdle
+        marmot_terminal_harness::HarnessError::BackendTimedOut
     ));
     assert_eq!(failure.observed_session.as_deref(), Some("wait-idle"));
+    assert_eq!(rx.recv().await, Some(RunnerEvent::LivenessUnknown));
+    assert!(rx.recv().await.is_none());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Treat stdout silence as presentation-idle liveness uncertainty instead of proof that a backend is hung, while retaining the independent total invocation policy limit.
- Persist typed resumable and uncertain recovery obligations, gate later group FIFO work, and add guarded `/retry-last` and `/discard-last` resolution.
- Reconcile text-only final-delivery acknowledgements idempotently before later FIFO work so an unknown acknowledgement cannot rerun backend work or duplicate a final.
- Keep recovery files private and diagnostics free of prompts, tool output, identifiers, host paths, credentials, and backend-specific secrets.

## Verification

- `python3 /opt/data/scripts/hermes_test_gate.py --tier focused -- cargo test -p marmot-terminal-harness -p wn-codex -p wn-opencode -p wn-pi`
- `python3 /opt/data/scripts/hermes_test_gate.py --tier fast -- just fast-ci`
- Sabotage check: restoring the prior presentation-idle stop behavior makes `silent_live_backend_reports_unknown_once_then_completes` fail; the implemented behavior passes.

## Scope

- Immediate-child cleanup remains the enforcement boundary for the total policy limit; descendant-process cleanup remains tracked separately by #831.
- Media and mixed-media acknowledgement recovery remain outside this text-final state machine.

Closes #1526


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added durable recovery for interrupted work with `/retry-last` and `/discard-last`.
  * Added reliable final-delivery tracking and reconciliation without replaying completed work.
  * Queued work pauses while recovery or undelivered results require attention.
  * Added clearer completion messages, including failures without side effects.

* **Bug Fixes**
  * Idle silence now reports liveness as unknown without stopping ongoing work.
  * Total execution limits remain enforced, including after output ends.

* **Documentation**
  * Clarified timeout behavior, recovery commands, and storage/privacy expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->