### PR TITLE
Fix/backfill rearm and unknown group

### DIFF
--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -180,6 +180,10 @@ pub struct Engine<S: StorageProvider> {
     /// `do_ingest` epilogue must not promote that retryable id into the
     /// terminal `seen_message_ids` cache.
     pub(crate) retryable_unpersisted_ingest_id: Option<MessageId>,
+    /// Whether the last completed `ingest` left its transport object with no
+    /// durable trace, so only relay redelivery can present it again. See
+    /// [`Engine::last_ingest_left_object_unpersisted`].
+    pub(crate) last_ingest_left_object_unpersisted: bool,
 
     /// MessageIds this engine has produced via `send` or `create_group` /
     /// `invite`. Backs the typed own-echo exclusion when a message we produced
@@ -558,6 +562,7 @@ impl<S: StorageProvider> EngineBuilder<S> {
             pending_state_changes: HashMap::new(),
             seen_message_ids: BoundedIdSet::with_capacity(DEDUP_CACHE_CAPACITY),
             retryable_unpersisted_ingest_id: None,
+            last_ingest_left_object_unpersisted: false,
             sent_message_ids: BoundedIdSet::with_capacity(DEDUP_CACHE_CAPACITY),
             leave_requests: HashMap::new(),
             leaving_groups: HashSet::new(),
@@ -819,6 +824,28 @@ impl<S: StorageProvider> Engine<S> {
 
     pub fn drain_valid_proposal_groups(&mut self) -> Vec<GroupId> {
         self.valid_proposal_groups.drain().collect()
+    }
+
+    /// Whether the last completed [`CgkaEngine::ingest`] left its transport
+    /// object unpersisted, so relay redelivery is the only path back to it.
+    ///
+    /// This is the same fact that suppresses the engine's own seen-cache
+    /// insertion (`retryable_unpersisted_ingest_id`), reported instead of left
+    /// implicit. Callers that maintain their own dedup index must skip it for
+    /// exactly these objects: an index entry with no durable object behind it
+    /// makes the object permanently unfetchable, which is the opposite of the
+    /// retry the engine deliberately left available.
+    ///
+    /// It is not recoverable from [`IngestOutcome`]. `ResourceRefused` is
+    /// always unpersisted, but `Ignored { UnknownGroup }` is returned both for
+    /// input the engine dropped without a trace (no group row: #740 forbids
+    /// retaining unknown-route floods) and for input it durably dedup-marked
+    /// (the disband-tombstone path). The two are indistinguishable in the
+    /// outcome and must be treated differently, so the engine reports the
+    /// disposition rather than making every caller re-derive a rule only it can
+    /// know.
+    pub fn last_ingest_left_object_unpersisted(&self) -> bool {
+        self.last_ingest_left_object_unpersisted
     }
 
     pub async fn ingest_with_audit_context(

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -457,6 +457,7 @@ impl<S: StorageProvider> Engine<S> {
         // Clear a marker left by cancellation/panic in an earlier ingest; only
         // the current call may suppress its own seen-cache insertion.
         self.retryable_unpersisted_ingest_id = None;
+        self.last_ingest_left_object_unpersisted = false;
         // Durable dedup / own-echo check. Storage is authoritative so a
         // restarted engine can classify replayed transport messages the same
         // way as a hot process.
@@ -498,6 +499,10 @@ impl<S: StorageProvider> Engine<S> {
             .retryable_unpersisted_ingest_id
             .take()
             .is_some_and(|id| id == msg.id);
+        // One fact, one place: the flag that suppresses this engine's own
+        // seen-cache insertion is also what it reports to callers holding a
+        // dedup index of their own.
+        self.last_ingest_left_object_unpersisted = retryable_unpersisted;
         if !retryable_unpersisted
             && !matches!(outcome, IngestOutcome::Buffered { .. })
             && self.should_remember_ingested_message(&msg.id)?

--- a/crates/cgka-engine/tests/ingest.rs
+++ b/crates/cgka-engine/tests/ingest.rs
@@ -591,6 +591,61 @@ async fn ingest_unknown_group_message_returns_unknown_group() {
     ));
 }
 
+/// Unknown-group input leaves no durable trace, and the engine says so.
+///
+/// `MlsGroup::load` missing with no group row behind it retains nothing (#740:
+/// unknown-route floods must not consume storage), so the engine deliberately
+/// keeps the id out of its seen cache and relay redelivery must process it
+/// again. That disposition is reported, not left implicit: a caller holding its
+/// own dedup index cannot derive it from the outcome, because the *same*
+/// `Ignored { UnknownGroup }` is also returned for durably dedup-marked input:
+/// the disband-tombstone branch in `ingest_group_message_from_sweep` calls
+/// `put_ingress_dedup_marker` and does *not* set this flag, so its redelivery
+/// short-circuits to `Ignored { Duplicate }` instead.
+#[tokio::test]
+async fn ingest_unknown_group_message_leaves_the_object_unpersisted() {
+    let mut engine = build_client(b"a");
+    let msg = TransportMessage {
+        id: MessageId::new(vec![7; 4]),
+        payload: vec![1, 2, 3],
+        timestamp: Timestamp(0),
+        causal_deps: vec![],
+        source: TransportSource("test".into()),
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: vec![0xBB; 32],
+        },
+    };
+
+    let outcome = engine.ingest(msg.clone()).await.unwrap();
+    assert!(matches!(
+        outcome,
+        IngestOutcome::Ignored {
+            category: InputRejectionCategory::UnknownGroup
+        }
+    ));
+    assert!(
+        engine.last_ingest_left_object_unpersisted(),
+        "an unknown-group ignore that retained nothing must report itself unpersisted",
+    );
+
+    // The contract the report exists to protect: same-id redelivery is not a
+    // duplicate, because there is no durable record for it to duplicate.
+    let redelivered = engine.ingest(msg).await.unwrap();
+    assert!(
+        matches!(
+            redelivered,
+            IngestOutcome::Ignored {
+                category: InputRejectionCategory::UnknownGroup
+            }
+        ),
+        "redelivery must be classified afresh, not as a duplicate: {redelivered:?}",
+    );
+    assert!(
+        engine.last_ingest_left_object_unpersisted(),
+        "and the redelivery is just as unpersisted as the first pass",
+    );
+}
+
 #[tokio::test]
 async fn ingest_welcome_for_another_client_returns_not_for_this_client() {
     let mut engine = build_client(b"me");

--- a/crates/cgka-session/src/lib.rs
+++ b/crates/cgka-session/src/lib.rs
@@ -296,6 +296,12 @@ pub struct CreateGroupEffects {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct IngestEffects {
     pub outcome: IngestOutcome,
+    /// The engine kept no durable trace of this delivery's transport object, so
+    /// relay redelivery is the only path back to it. A caller holding its own
+    /// dedup index must not record the object as seen. See
+    /// `Engine::last_ingest_left_object_unpersisted` for why this cannot be
+    /// derived from `outcome`.
+    pub left_object_unpersisted: bool,
     pub effects: SessionEffects,
     /// Groups for which an authenticated standalone proposal was accepted.
     /// Commits are represented by `GroupEvent::EpochChanged`.
@@ -924,6 +930,7 @@ impl AccountDeviceSession {
             "ingesting transport message"
         );
         let outcome = self.engine.ingest(msg).await?;
+        let left_object_unpersisted = self.engine.last_ingest_left_object_unpersisted();
         tracing::debug!(
             target: TRACE_TARGET,
             method = "ingest",
@@ -934,6 +941,7 @@ impl AccountDeviceSession {
         let effects = self.collect_effects(vec![]);
         Ok(IngestEffects {
             outcome,
+            left_object_unpersisted,
             effects,
             valid_proposal_groups,
         })
@@ -953,6 +961,7 @@ impl AccountDeviceSession {
             .engine
             .ingest_with_audit_context(delivery.message, Some(transport_context))
             .await?;
+        let left_object_unpersisted = self.engine.last_ingest_left_object_unpersisted();
         tracing::debug!(
             target: TRACE_TARGET,
             method = "ingest_delivery",
@@ -963,6 +972,7 @@ impl AccountDeviceSession {
         let effects = self.collect_effects(vec![]);
         Ok(IngestEffects {
             outcome,
+            left_object_unpersisted,
             effects,
             valid_proposal_groups,
         })

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -2055,6 +2055,7 @@ where
         }
         let IngestEffects {
             outcome,
+            left_object_unpersisted,
             effects,
             valid_proposal_groups,
         } = self.session.ingest_delivery(delivery).await?;
@@ -2075,7 +2076,11 @@ where
                 unique_state_bearing_groups.push(group_id);
             }
         }
-        Ok(AccountIngestEffects { outcome, effects })
+        Ok(AccountIngestEffects {
+            outcome,
+            left_object_unpersisted,
+            effects,
+        })
     }
 
     pub async fn publish_session_effects(
@@ -4003,6 +4008,9 @@ impl AccountDeviceEffects {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AccountIngestEffects {
     pub outcome: IngestOutcome,
+    /// The engine kept no durable trace of this delivery's transport object.
+    /// Carried verbatim from [`IngestEffects::left_object_unpersisted`].
+    pub left_object_unpersisted: bool,
     pub effects: AccountDeviceEffects,
 }
 

--- a/crates/marmot-app/src/client/epoch_stall.rs
+++ b/crates/marmot-app/src/client/epoch_stall.rs
@@ -293,6 +293,35 @@ impl EpochStallDetector {
         }
     }
 
+    /// Clear the replay-suppression latch for the groups a completed replay
+    /// fetched history for and could not retain.
+    ///
+    /// Withholding [`Self::mark_replayed`] on a fruitless replay re-arms
+    /// *bystanders* only. It cannot re-arm the group that caused the replay:
+    /// that group latched `fired_at_epoch` itself in [`GroupStall::arm`], which
+    /// writes the same value `mark_replayed` would have. Nothing else clears it
+    /// — [`GroupStall::observe_epoch`] clears only on a *different* epoch, and
+    /// the epoch cannot move without the very commit the replay failed to
+    /// retain. So without this, one fruitless replay permanently ends automatic
+    /// repair for that group: the refused object is neither marked seen nor
+    /// allowed past the relay `since` floor, and the armed backfill is the only
+    /// automatic path that re-serves it.
+    ///
+    /// Scoped to the refusals *this* drain counted rather than swept
+    /// account-wide: a group the replay refused nothing for learned nothing from
+    /// it, and clearing its latch would re-arm on evidence that does not exist.
+    ///
+    /// The run itself is untouched — `armed_at_epoch`, `arms` and `escalated`
+    /// all survive — so a group that keeps re-arming still escalates exactly
+    /// once per unrecovered run rather than restarting its count.
+    pub(crate) fn rearm_refused_groups(&mut self, groups: &HashSet<GroupId>) {
+        for group_id in groups {
+            if let Some(stall) = self.groups.get_mut(group_id) {
+                stall.fired_at_epoch = None;
+            }
+        }
+    }
+
     /// Note the current local epoch of an already-tracked `group` from a
     /// delivery that carried no stall evidence. Groups with no stall history are
     /// deliberately left untracked: this only exists so a tracked group's

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -144,37 +144,21 @@ struct DeliveryIngest {
     /// Membership-changing effects landed, so the app projection and the route
     /// table owe a save before anything else can fail.
     routes_dirty: bool,
-    /// The engine kept no durable trace of this object, so transport
-    /// redelivery is the only path back to it. See
-    /// [`ingest_left_object_unpersisted`].
+    /// The engine kept no durable trace of this object, so relay redelivery is
+    /// the only path back to it and this delivery must not enter `seen_events`.
+    ///
+    /// Reported by the engine rather than reconstructed from the outcome:
+    /// `Ignored { UnknownGroup }` covers both an object the engine dropped
+    /// without a trace and one it durably dedup-marked, and only the engine can
+    /// tell them apart. See `Engine::last_ingest_left_object_unpersisted`.
     must_stay_fetchable: bool,
     /// The group a resource refusal was counted against, so a drain can report
-    /// *which* groups it fetched history for and could not retain. Only
-    /// `IngestOutcome::ResourceRefused` names a group, which is exactly the
-    /// outcome the refusal count is keyed on.
+    /// *which* groups it fetched history for and could not retain, and so the
+    /// audit `refused` count keeps meaning exactly "a local resource bound
+    /// rejected this". Only `IngestOutcome::ResourceRefused` names a group, and
+    /// it is deliberately narrower than `must_stay_fetchable`: an unknown-group
+    /// object was not refused for want of a resource.
     refused_group: Option<cgka_traits::GroupId>,
-}
-
-/// Whether the engine left this outcome's transport object unpersisted, so only
-/// relay redelivery can present it again.
-///
-/// This is the app-side half of the engine's `retryable_unpersisted_ingest_id`
-/// contract. `ResourceRefused` is the one `Ok` outcome the engine drops without
-/// a durable record *and* deliberately keeps out of its own seen cache, and the
-/// trait states the consequence directly: a resource refusal "must not make
-/// same-id redelivery a duplicate". Recording it in `seen_events` (which has no
-/// removal site short of ring overflow) or letting it carry the relay `since`
-/// floor past itself makes the object permanently unfetchable — across restarts
-/// and across `repair_full_history` alike.
-///
-/// Every other `Ok` outcome leaves the engine holding durable evidence of the
-/// object: `TransportDeferred` retains the raw transport row for later peel,
-/// `Buffered` retains it for convergence replay, and the terminal
-/// classifications (`Processed`, `Ignored`, `LocalState`, `Stale`, `Rejected`)
-/// are decisions the engine can reach again from storage. Forgetting those is
-/// correct dedupe, so they stay.
-fn ingest_left_object_unpersisted(outcome: &IngestOutcome) -> bool {
-    matches!(outcome, IngestOutcome::ResourceRefused { .. })
 }
 
 /// What one drain loop saw on the wire.
@@ -1288,16 +1272,17 @@ impl AppClient {
                         .await);
                 }
             };
-            // Same rule as the receive seam above: an object the engine refused
-            // unpersisted must stay fetchable, so the relay re-serves it on a
-            // later drain instead of this one skipping it as already seen. The
-            // same flag is the refusal count, so one rule decides both.
-            if ingested.must_stay_fetchable {
+            // The refusal count is keyed on the refusal itself, so the audit
+            // row keeps meaning "a local resource bound rejected this" and not
+            // the wider "left no durable trace".
+            if let Some(group_id) = ingested.refused_group {
                 counts.refused = counts.refused.saturating_add(1);
-                if let Some(group_id) = ingested.refused_group {
-                    counts.refused_groups.insert(group_id);
-                }
-            } else {
+                counts.refused_groups.insert(group_id);
+            }
+            // Same rule as the receive seam above: an object the engine kept no
+            // durable trace of must stay fetchable, so the relay re-serves it on
+            // a later drain instead of this one skipping it as already seen.
+            if !ingested.must_stay_fetchable {
                 self.remember_seen_event(event_id);
             }
             counts.deliveries = counts.deliveries.saturating_add(1);
@@ -1453,7 +1438,7 @@ impl AppClient {
         let group_id_hint = delivery.group_id_hint.clone();
         let effects = self.runtime.ingest_delivery(delivery).await?;
         let publish_error = fail_if_publish_failed(&effects.effects).err();
-        let must_stay_fetchable = ingest_left_object_unpersisted(&effects.outcome);
+        let must_stay_fetchable = effects.left_object_unpersisted;
         let refused_group = match &effects.outcome {
             IngestOutcome::ResourceRefused { group_id, .. } => Some(group_id.clone()),
             _ => None,
@@ -1461,11 +1446,25 @@ impl AppClient {
         self.remember_buffered_convergence_outcome(&effects.outcome);
         self.remember_pending_convergence_groups(&effects.effects);
         self.observe_recovery_evidence(&effects.effects);
-        if !must_stay_fetchable {
-            // Scope fence: a `TransportDeferred` object *is* durably retained,
-            // so it advances the floor here. Whether a retained-but-unapplied
-            // object should instead hold the floor back until it converges is
-            // the separate since-floor design item, not this seam's call.
+        // The cursor is held back only by a resource refusal, which is
+        // narrower than `must_stay_fetchable` on purpose.
+        //
+        // A refusal is this device failing to keep history it was served, at a
+        // route it owns, so holding its own `since` floor back is holding back
+        // work it must redo. Unknown-route input is not: the engine drops it
+        // untraced precisely because #740 forbids letting unknown-route floods
+        // consume local resources, and the `since` floor is one of those — an
+        // attacker who can mint 445s for routes we do not have could otherwise
+        // pin the whole account's floor in the past. Skipping the seen-mark
+        // costs nothing and is what actually restores the object: the two
+        // permanent drop sites are the seen index, and the unfloored recovery
+        // replay re-serves the object once the route resolves.
+        //
+        // Scope fence: a `TransportDeferred` object *is* durably retained, so it
+        // advances the floor here. Whether a retained-but-unapplied object
+        // should instead hold the floor back until it converges is the separate
+        // since-floor design item, not this seam's call.
+        if refused_group.is_none() {
             self.remember_transport_cursor(outer_transport_at);
         }
         self.detect_epoch_stall(group_id_hint, &source_message_id_hex, &effects.outcome);

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -148,6 +148,11 @@ struct DeliveryIngest {
     /// redelivery is the only path back to it. See
     /// [`ingest_left_object_unpersisted`].
     must_stay_fetchable: bool,
+    /// The group a resource refusal was counted against, so a drain can report
+    /// *which* groups it fetched history for and could not retain. Only
+    /// `IngestOutcome::ResourceRefused` names a group, which is exactly the
+    /// outcome the refusal count is keyed on.
+    refused_group: Option<cgka_traits::GroupId>,
 }
 
 /// Whether the engine left this outcome's transport object unpersisted, so only
@@ -179,7 +184,7 @@ fn ingest_left_object_unpersisted(outcome: &IngestOutcome) -> bool {
 /// in the seen index. Keeping the two apart is what lets a field export tell a
 /// long drain that was making progress from one a relay held open with traffic
 /// carrying no new history.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub(crate) struct DrainCounts {
     pub(crate) deliveries: u64,
     pub(crate) skipped: u64,
@@ -189,6 +194,12 @@ pub(crate) struct DrainCounts {
     /// on. [`DrainCounts::durable_deliveries`] is the count that answers "did
     /// this drain recover anything".
     pub(crate) refused: u64,
+    /// The groups those refusals were counted against. Recorded at the same
+    /// site that increments `refused`, so the three consequences of a refusal —
+    /// stays fetchable, does not count as recovery, and re-arms its group after
+    /// a fruitless replay — cannot drift apart. Not an audit field: the row
+    /// carries the scalar count, and group ids never enter a forensic row.
+    pub(crate) refused_groups: std::collections::HashSet<cgka_traits::GroupId>,
 }
 
 impl DrainCounts {
@@ -196,7 +207,7 @@ impl DrainCounts {
     /// every delivery was refused fetched history it could not retain, which is
     /// no recovery at all — the objects stay fetchable (they are neither marked
     /// seen nor allowed past the cursor) but nothing durably landed.
-    fn durable_deliveries(self) -> u64 {
+    fn durable_deliveries(&self) -> u64 {
         self.deliveries.saturating_sub(self.refused)
     }
 }
@@ -1068,7 +1079,7 @@ impl AppClient {
     /// rather than queueing them: the intent is already durable and the next
     /// seam past the cooldown runs it. Caller-directed catch-up is exempt — a
     /// person asking for a repair is not a loop.
-    fn epoch_backfill_retry_is_paced(&self, seam: EpochBackfillExecutionSeam) -> bool {
+    pub(crate) fn epoch_backfill_retry_is_paced(&self, seam: EpochBackfillExecutionSeam) -> bool {
         if matches!(seam, EpochBackfillExecutionSeam::ExplicitCatchUp) {
             return false;
         }
@@ -1199,7 +1210,7 @@ impl AppClient {
                         .finish_failed_sync_drain(
                             summary,
                             routes_dirty,
-                            *counts,
+                            counts.clone(),
                             StagedSyncError::new(error.into(), SyncFailureStage::RelayReceive),
                             drain_started,
                             cursor_before_secs,
@@ -1248,7 +1259,7 @@ impl AppClient {
                     .finish_failed_sync_drain(
                         summary,
                         routes_dirty,
-                        *counts,
+                        counts.clone(),
                         StagedSyncError::new(
                             AppError::BlockingTask("injected catch-up delivery failure".to_owned()),
                             SyncFailureStage::Unknown,
@@ -1269,7 +1280,7 @@ impl AppClient {
                         .finish_failed_sync_drain(
                             summary,
                             routes_dirty,
-                            *counts,
+                            counts.clone(),
                             StagedSyncError::new(error, SyncFailureStage::CgkaIngest),
                             drain_started,
                             cursor_before_secs,
@@ -1283,6 +1294,9 @@ impl AppClient {
             // same flag is the refusal count, so one rule decides both.
             if ingested.must_stay_fetchable {
                 counts.refused = counts.refused.saturating_add(1);
+                if let Some(group_id) = ingested.refused_group {
+                    counts.refused_groups.insert(group_id);
+                }
             } else {
                 self.remember_seen_event(event_id);
             }
@@ -1300,7 +1314,7 @@ impl AppClient {
             let (summary, source) = self.checkpoint_failure_summary(summary, error);
             self.record_sync_drain(
                 drain_started.elapsed().as_millis() as u64,
-                *counts,
+                counts.clone(),
                 cursor_before_secs,
                 cursor_after_secs,
             );
@@ -1308,7 +1322,7 @@ impl AppClient {
         }
         self.record_sync_drain(
             drain_started.elapsed().as_millis() as u64,
-            *counts,
+            counts.clone(),
             cursor_before_secs,
             self.state.last_transport_timestamp,
         );
@@ -1440,6 +1454,10 @@ impl AppClient {
         let effects = self.runtime.ingest_delivery(delivery).await?;
         let publish_error = fail_if_publish_failed(&effects.effects).err();
         let must_stay_fetchable = ingest_left_object_unpersisted(&effects.outcome);
+        let refused_group = match &effects.outcome {
+            IngestOutcome::ResourceRefused { group_id, .. } => Some(group_id.clone()),
+            _ => None,
+        };
         self.remember_buffered_convergence_outcome(&effects.outcome);
         self.remember_pending_convergence_groups(&effects.effects);
         self.observe_recovery_evidence(&effects.effects);
@@ -1509,6 +1527,7 @@ impl AppClient {
         Ok(DeliveryIngest {
             routes_dirty,
             must_stay_fetchable,
+            refused_group,
         })
     }
 
@@ -1769,6 +1788,7 @@ impl AppClient {
                 deliveries,
                 skipped: 0,
                 refused,
+                ..DrainCounts::default()
             },
             true,
         );
@@ -1847,7 +1867,7 @@ impl AppClient {
         completion_kind: Option<EpochBackfillCompletionKind>,
         counts: DrainCounts,
         succeeded: bool,
-    ) {
+    ) -> bool {
         let duration_ms = execution.started.elapsed().as_millis() as u64;
         let epochs_after = self.capture_pending_group_epochs(&execution.pending);
         let observed_all_groups = epochs_after.len() == execution.pending.groups.len();
@@ -1867,17 +1887,25 @@ impl AppClient {
                 activation_outcome,
                 error_kind,
                 completion_kind,
-                counts,
+                counts: counts.clone(),
                 succeeded,
             },
         );
-        if succeeded {
-            if Self::replay_recovered_something(&execution.epochs_before, &epochs_after, counts) {
-                self.epoch_stall.mark_replayed();
-            }
-        } else {
+        if !succeeded {
             self.requeue_failed_epoch_backfill_intent(execution.pending);
+            return false;
         }
+        if Self::replay_recovered_something(&execution.epochs_before, &epochs_after, &counts) {
+            self.epoch_stall.mark_replayed();
+            return true;
+        }
+        // Fruitless but complete. Withholding `mark_replayed` re-arms bystanders
+        // only; the groups this drain actually refused history for latched
+        // themselves when they armed, so they need an explicit clear or they can
+        // never arm again at this epoch.
+        self.epoch_stall
+            .rearm_refused_groups(&counts.refused_groups);
+        false
     }
 
     /// Whether a completed replay recovered anything, and has therefore earned
@@ -1912,7 +1940,7 @@ impl AppClient {
     fn replay_recovered_something(
         epochs_before: &HashMap<cgka_traits::GroupId, u64>,
         epochs_after: &HashMap<cgka_traits::GroupId, u64>,
-        counts: DrainCounts,
+        counts: &DrainCounts,
     ) -> bool {
         counts.durable_deliveries() > 0
             || epochs_after.iter().any(|(group_id, after)| {
@@ -2044,12 +2072,12 @@ impl AppClient {
                 // disarm the detector, so it is recorded as a failed attempt
                 // and its intent stays queued for the next seam.
                 let error_kind = verdict.error_kind();
-                self.finish_epoch_backfill_execution(
+                let recovered = self.finish_epoch_backfill_execution(
                     execution,
                     EpochBackfillActivationOutcome::Succeeded,
                     error_kind.map(str::to_owned),
                     verdict.completion_kind(),
-                    counts,
+                    counts.clone(),
                     error_kind.is_none(),
                 );
                 if let Some(error_kind) = error_kind {
@@ -2067,7 +2095,23 @@ impl AppClient {
                         Some(Instant::now() + self.epoch_backfill_retry_backoff(retry_ordinal));
                     return Ok(EpochBackfillRunOutcome::Incomplete(summary));
                 }
-                self.epoch_backfill_retry_not_before = None;
+                if recovered {
+                    self.epoch_backfill_retry_not_before = None;
+                } else {
+                    // A completed-but-fruitless replay just re-armed the groups
+                    // whose history it could not retain. Clearing the cooldown
+                    // here would let that re-arm drain the whole account again
+                    // immediately, against a cap that is still full — an
+                    // unpaced arm -> drain -> clear -> re-arm loop, because a
+                    // fresh intent starts at `execution_attempts == 0`. A
+                    // fruitless success pays the same backoff an unconfirmed
+                    // drain does, which bounds the loop to one account-wide
+                    // replay per window. `epoch_backfill_retry_is_paced`
+                    // exempts caller-directed catch-up, so a person asking for
+                    // a repair still never waits on it.
+                    self.epoch_backfill_retry_not_before =
+                        Some(Instant::now() + self.epoch_backfill_retry_backoff(retry_ordinal));
+                }
                 Ok(EpochBackfillRunOutcome::Completed(summary))
             }
             Err(err) => {

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -12086,6 +12086,162 @@ fn recorded_ingest_outcomes(app: &MarmotApp, msg_id: &str) -> Vec<String> {
         .collect()
 }
 
+/// One kind-445 delivery for a route this device has no group row for.
+///
+/// The reachable production trigger is *not* a commit racing ahead of its
+/// Welcome — a device that is not in a group has no route for it, every 445
+/// filter is `#h`-scoped to a known `transport_group_id`, and the adapter
+/// re-gates every event against the route table before it becomes a delivery.
+/// It is the engine's route-backfill probe budget: on an index miss
+/// `resolve_or_backfill_group_id_for_transport` probes at most
+/// `ROUTE_BACKFILL_PROBES_PER_MISS` (4) of the groups whose durable route row
+/// was missing or stale at hydration, and otherwise falls back to the raw
+/// transport id, which misses `MlsGroup::load` and takes the unknown-group
+/// branch — for a group this device really does have. The app-side consequence
+/// is the same either way and is what these two tests pin; the engine's
+/// disposition contract is pinned in `cgka-engine`'s
+/// `ingest_unknown_group_message_leaves_the_object_unpersisted`.
+fn unknown_route_delivery(
+    account_id_hex: &str,
+    created_at: u64,
+    marker: &str,
+) -> cgka_traits::TransportDelivery {
+    cgka_traits::TransportDelivery {
+        account_id: MemberId::new(hex::decode(account_id_hex).unwrap()),
+        group_id_hint: None,
+        message: epoch_gap_probe(&"ab".repeat(32), created_at, marker)
+            .to_transport_message()
+            .expect("probe converts to a transport message"),
+        received_at: cgka_traits::transport::Timestamp(created_at),
+        source: cgka_traits::TransportDeliverySource {
+            transport: cgka_traits::transport::TransportSource("nostr".to_owned()),
+            plane: cgka_traits::TransportDeliveryPlane::Group,
+            endpoint: None,
+            subscription_id: None,
+            wire: None,
+        },
+    }
+}
+
+/// An object the engine kept no durable trace of must not enter `seen_events`,
+/// even when its outcome is an ordinary `Ignored`.
+///
+/// The engine sets `retryable_unpersisted_ingest_id` on the unknown-group
+/// branch and suppresses its own seen-cache insertion, precisely so relay
+/// redelivery can process the object once the route resolves. Recording it in
+/// `seen_events` defeats that permanently: the index is persisted, has no
+/// removal site short of ring overflow, and gates both
+/// `receive_next_delivery` and the catch-up drain — so the object becomes
+/// unfetchable across restarts and across `repair_full_history` alike.
+///
+/// The cursor still advances. Unknown-route input is exactly what #740 says
+/// must not consume local resources, and the `since` floor is one of them: an
+/// attacker minting 445s for routes we do not have could otherwise pin the
+/// whole account's floor in the past. Skipping the seen-mark is what actually
+/// restores the object, because the unfloored recovery replay re-serves it.
+#[test]
+fn an_unknown_route_delivery_is_not_marked_seen_but_still_advances_the_cursor() {
+    run_composed_app_runtime_test("unknown-route-receive-seam", || async {
+        let dir = tempfile::tempdir().unwrap();
+        let filled_through = crate::unix_now_seconds() - 1_000;
+        let (app, mut client, route) =
+            group_at_the_undecryptable_retention_cap(&dir, filled_through).await;
+
+        let unknown = unknown_route_delivery(
+            &route.account_id_hex,
+            filled_through + 500,
+            "unknown-route-commit",
+        );
+        let event_id = hex::encode(unknown.message.id.as_slice());
+        client
+            .ingest_received_delivery(unknown.clone())
+            .await
+            .expect("an unknown-route ingest still completes its pass");
+
+        assert_eq!(
+            recorded_ingest_outcomes(&app, &event_id),
+            vec!["ignored".to_owned()],
+            "the engine classifies it as an ignore, which is why the app could not \
+             tell it apart from a durably dedup-marked one",
+        );
+        assert!(
+            !client.seen_events_index.contains(&event_id),
+            "an object the engine retained nothing for must stay fetchable",
+        );
+        assert!(
+            !client.state.seen_events.contains(&event_id),
+            "and must not be persisted into the seen ring either",
+        );
+        assert_eq!(
+            client.state.last_transport_timestamp,
+            Some(filled_through + 500),
+            "but the `since` floor still advances: unknown-route input must not \
+             hold the whole account's cursor back (#740)",
+        );
+
+        // The contract the skipped seen-mark buys: redelivery is ingested again
+        // rather than dropped, so a later drain can present the object once the
+        // route resolves.
+        client
+            .ingest_received_delivery(unknown)
+            .await
+            .expect("redelivery still completes its pass");
+        assert_eq!(
+            recorded_ingest_outcomes(&app, &event_id).len(),
+            2,
+            "same-id redelivery must reach the engine a second time",
+        );
+    });
+}
+
+/// Why the drain seam cannot be driven with an unknown route from here, and
+/// what the route-backfill miss actually looks like.
+///
+/// The relay plane route-gates every inbound event before it can become a
+/// `TransportDelivery`: an unknown `#h` routes to nobody. That is the same gate
+/// that makes "a commit racing ahead of its Welcome" unreachable — a device not
+/// in a group has no route for it, so no 445 for that group is ever delivered.
+/// The reachable trigger is narrower and lives one layer down: the *adapter*
+/// has the route (the device really is in the group) while the *engine's*
+/// in-memory route index misses it and the route-backfill probe budget runs out,
+/// so `resolve_or_backfill_group_id_for_transport` falls back to the raw
+/// transport id and takes the unknown-group branch.
+///
+/// The app-side rule that branch needs is `must_stay_fetchable`, which both
+/// seams read off the identical `DeliveryIngest` field — pinned at the receive
+/// seam above, and at the drain seam by
+/// `a_refused_delivery_is_neither_marked_seen_nor_allowed_to_advance_the_cursor`.
+/// What is pinned here is the gate itself, so the unreachability claim is a
+/// test rather than a comment.
+#[test]
+fn an_unknown_route_event_is_never_routed_to_a_delivery() {
+    run_composed_app_runtime_test("unknown-route-transport-gate", || async {
+        let dir = tempfile::tempdir().unwrap();
+        let filled_through = crate::unix_now_seconds() - 1_000;
+        let (app, client, _route) =
+            group_at_the_undecryptable_retention_cap(&dir, filled_through).await;
+
+        let delivered = app
+            .relay_plane
+            .handle_relay_event_for_test(NostrRelayEvent {
+                endpoint: TransportEndpoint("wss://relay.example".to_owned()),
+                subscription_id: Some("unknown-route-test".to_owned()),
+                event: epoch_gap_probe(
+                    &"ab".repeat(32),
+                    filled_through + 500,
+                    "unknown-route-commit",
+                ),
+            })
+            .await
+            .expect("routing an unknown-route event is not an error");
+        assert_eq!(
+            delivered, 0,
+            "a 445 for a route this device does not hold must not become a delivery",
+        );
+        drop(client);
+    });
+}
+
 /// A refused object must stay fetchable: the receive seam may neither mark it
 /// seen nor let it advance the relay `since` cursor.
 ///

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -1798,12 +1798,14 @@ fn a_backfill_whose_every_delivery_was_refused_does_not_disarm_the_detector() {
         let stalled_epoch = client.group_mls_state(&route.group_id).unwrap().epoch;
         let bystander = bystander_stalled_below_threshold(&mut client, stalled_epoch);
 
-        client.apply_backfill_decision(
-            &route.group_id,
-            stalled_epoch,
-            BackfillDecision::Arm,
-            marmot_forensics::EpochStallBackfillTrigger::ResourceRefusal,
-        );
+        // Arm through the production seam rather than `apply_backfill_decision`:
+        // a refused delivery at the receive seam reaches `observe_resource_refusal`,
+        // so the armed group is tracked by the detector and its own re-arm is
+        // observable here alongside the bystander's.
+        client
+            .ingest_received_delivery(route.probe(filled_through + 400, "refusal-that-arms"))
+            .await
+            .expect("a refused ingest still completes its pass");
         let attempt_id = client
             .pending_epoch_backfill
             .as_ref()
@@ -1869,6 +1871,244 @@ fn a_backfill_whose_every_delivery_was_refused_does_not_disarm_the_detector() {
                 .iter()
                 .any(|row| row["kind"]["refused"].as_u64() == Some(1)),
             "the drain row must carry the refusal count too",
+        );
+    });
+}
+
+/// A group armed *through the detector* must be able to arm again after a
+/// replay that retained none of its history.
+///
+/// This is the shape the merged disarm tests could not observe. They armed with
+/// `apply_backfill_decision` directly, which never enters `EpochStallDetector`,
+/// so the armed group was untracked and only a bystander could show the disarm
+/// rule at work. Production arms through `observe_resource_refusal`, and that
+/// path latches `fired_at_epoch` in `GroupStall::arm` — the same value
+/// `mark_replayed` would have written. Withholding `mark_replayed` therefore did
+/// nothing for the group that caused the replay: its next same-epoch refusal
+/// still returned `Skip`, and because the refused commit is neither marked seen
+/// nor allowed past the `since` floor, the armed backfill is the *only*
+/// automatic path back to it. Nothing else clears the latch — `observe_epoch`
+/// clears it only on a different epoch, and the epoch cannot move without the
+/// commit the replay failed to retain. That is a permanent, silent end to
+/// automatic repair for that group.
+#[test]
+fn a_group_armed_through_the_detector_rearms_after_a_fruitless_replay() {
+    run_composed_app_runtime_test("backfill-fruitless-rearm", || async {
+        let dir = tempfile::tempdir().unwrap();
+        let relay = Arc::new(ScriptedPushRelayClient::default());
+        let filled_through = crate::unix_now_seconds() - 1_000;
+        let (app, mut client, route) = group_at_the_undecryptable_retention_cap_with_config(
+            &dir,
+            &relay,
+            backfill_drain_test_config(),
+            filled_through,
+        )
+        .await;
+        let stalled_epoch = client.group_mls_state(&route.group_id).unwrap().epoch;
+
+        // Arm the way production does: a refused delivery at the receive seam,
+        // which reaches `observe_resource_refusal` through `detect_epoch_stall`.
+        client
+            .ingest_received_delivery(route.probe(filled_through + 400, "refusal-that-arms"))
+            .await
+            .expect("a refused ingest still completes its pass");
+        assert!(
+            client.has_pending_epoch_backfill(),
+            "a resource refusal at the receive seam must arm one recovery intent",
+        );
+
+        // The relays serve the history; the cap is still full, so the replay
+        // fetches it and retains none of it.
+        inject_epoch_gap_probe(
+            &app,
+            epoch_gap_probe(
+                &route.nostr_group_id_hex,
+                filled_through + 500,
+                "refused-during-the-replay",
+            ),
+        )
+        .await;
+        let _eose = scripted_eose_pump(app.relay_plane.clone(), relay.clone(), every_subscription);
+        assert!(
+            matches!(
+                client
+                    .run_pending_epoch_backfill(
+                        marmot_forensics::EpochBackfillExecutionSeam::Maintenance
+                    )
+                    .await
+                    .expect("the armed replay must run"),
+                crate::EpochBackfillRunOutcome::Completed(_)
+            ),
+            "a served end-of-stored-events drain is a completed replay, fruitless or not",
+        );
+
+        assert_eq!(
+            client.epoch_stall.observe_resource_refusal(
+                route.group_id.clone(),
+                cgka_traits::EpochId(stalled_epoch)
+            ),
+            BackfillDecision::Arm,
+            "a replay that retained none of this group's refused history must leave it \
+             able to arm again at the same epoch — nothing else can clear the latch",
+        );
+    });
+}
+
+/// The re-arm above must not become a spin.
+///
+/// A re-armable group facing a cap that is still full would otherwise run
+/// arm → drain → fruitless → re-arm at full speed: a fresh intent starts at
+/// `execution_attempts == 0`, and before this rule a *completed* run cleared
+/// `epoch_backfill_retry_not_before` unconditionally, so nothing paced the next
+/// attempt. A fruitless success now pays the same cooldown an unconfirmed drain
+/// does, which bounds the loop to one account-wide replay per backoff window
+/// while leaving caller-directed repair exempt.
+#[test]
+fn consecutive_fruitless_replays_are_paced_by_the_retry_cooldown() {
+    run_composed_app_runtime_test("backfill-fruitless-pacing", || async {
+        let dir = tempfile::tempdir().unwrap();
+        let relay = Arc::new(ScriptedPushRelayClient::default());
+        let filled_through = crate::unix_now_seconds() - 1_000;
+        // A backoff long enough that the second attempt cannot slip past it
+        // inside this test, and a silence budget short enough to afford.
+        let config = MarmotAppConfig::default()
+            .with_dev_epoch_backfill_eose_wait_ms(300)
+            .with_dev_epoch_backfill_retry_backoff_ms(60_000);
+        let (app, mut client, route) = group_at_the_undecryptable_retention_cap_with_config(
+            &dir,
+            &relay,
+            config,
+            filled_through,
+        )
+        .await;
+
+        client
+            .ingest_received_delivery(route.probe(filled_through + 400, "refusal-that-arms"))
+            .await
+            .expect("a refused ingest still completes its pass");
+        inject_epoch_gap_probe(
+            &app,
+            epoch_gap_probe(
+                &route.nostr_group_id_hex,
+                filled_through + 500,
+                "refused-during-the-replay",
+            ),
+        )
+        .await;
+        let _eose = scripted_eose_pump(app.relay_plane.clone(), relay.clone(), every_subscription);
+        assert!(
+            matches!(
+                client
+                    .run_pending_epoch_backfill(
+                        marmot_forensics::EpochBackfillExecutionSeam::Maintenance
+                    )
+                    .await
+                    .expect("the armed replay must run"),
+                crate::EpochBackfillRunOutcome::Completed(_)
+            ),
+            "the first replay completes and is fruitless",
+        );
+        assert!(
+            client.epoch_backfill_retry_not_before.is_some(),
+            "a completed-but-fruitless replay must earn a retry cooldown, not clear it",
+        );
+
+        // The re-armed group arms a second intent, which the cooldown must hold.
+        client
+            .ingest_received_delivery(route.probe(filled_through + 900, "refusal-after-replay"))
+            .await
+            .expect("a refused ingest still completes its pass");
+        assert!(
+            client.has_pending_epoch_backfill(),
+            "the re-armed group must arm a fresh intent",
+        );
+        assert!(
+            matches!(
+                client
+                    .run_pending_epoch_backfill(
+                        marmot_forensics::EpochBackfillExecutionSeam::Maintenance
+                    )
+                    .await
+                    .expect("the paced seam still returns Ok"),
+                crate::EpochBackfillRunOutcome::Deferred
+            ),
+            "the second fruitless cycle must wait out the cooldown instead of \
+             draining the account again immediately",
+        );
+        // A person asking for a repair is not a loop.
+        assert!(
+            !client.epoch_backfill_retry_is_paced(
+                marmot_forensics::EpochBackfillExecutionSeam::ExplicitCatchUp
+            ),
+            "caller-directed catch-up stays exempt from the fruitless cooldown",
+        );
+    });
+}
+
+/// A fruitless replay re-arms only the groups whose refusals it counted.
+///
+/// The clear is scoped to this drain's attribution rather than swept
+/// account-wide: a group that never had history refused in this replay learned
+/// nothing from it, and clearing its latch would re-arm groups the replay says
+/// nothing about.
+#[test]
+fn a_fruitless_replay_rearms_only_the_groups_whose_refusals_it_counted() {
+    run_composed_app_runtime_test("backfill-fruitless-rearm-scope", || async {
+        let dir = tempfile::tempdir().unwrap();
+        let relay = Arc::new(ScriptedPushRelayClient::default());
+        let filled_through = crate::unix_now_seconds() - 1_000;
+        let (app, mut client, route) = group_at_the_undecryptable_retention_cap_with_config(
+            &dir,
+            &relay,
+            backfill_drain_test_config(),
+            filled_through,
+        )
+        .await;
+        let stalled_epoch = client.group_mls_state(&route.group_id).unwrap().epoch;
+
+        // An untouched group that armed at the same epoch but has no refusal in
+        // the replay below.
+        let untouched = cgka_traits::GroupId::new(vec![9_u8; 32]);
+        assert_eq!(
+            client
+                .epoch_stall
+                .observe_resource_refusal(untouched.clone(), cgka_traits::EpochId(stalled_epoch)),
+            BackfillDecision::Arm,
+        );
+
+        client
+            .ingest_received_delivery(route.probe(filled_through + 400, "refusal-that-arms"))
+            .await
+            .expect("a refused ingest still completes its pass");
+        inject_epoch_gap_probe(
+            &app,
+            epoch_gap_probe(
+                &route.nostr_group_id_hex,
+                filled_through + 500,
+                "refused-during-the-replay",
+            ),
+        )
+        .await;
+        let _eose = scripted_eose_pump(app.relay_plane.clone(), relay.clone(), every_subscription);
+        client
+            .run_pending_epoch_backfill(marmot_forensics::EpochBackfillExecutionSeam::Maintenance)
+            .await
+            .expect("the armed replay must run");
+
+        assert_eq!(
+            client.epoch_stall.observe_resource_refusal(
+                route.group_id.clone(),
+                cgka_traits::EpochId(stalled_epoch)
+            ),
+            BackfillDecision::Arm,
+            "the group whose refusal the replay counted re-arms",
+        );
+        assert_eq!(
+            client
+                .epoch_stall
+                .observe_resource_refusal(untouched, cgka_traits::EpochId(stalled_epoch)),
+            BackfillDecision::Skip,
+            "a group the replay refused nothing for keeps its latch",
         );
     });
 }


### PR DESCRIPTION
Closes both post-merge review findings on #1565.

## Re-arm the groups a fruitless backfill could not retain

An armed group could never auto-heal: arm() latches fired_at_epoch, a completed all-refused replay consumed the intent and cleared the retry cooldown, the next same-epoch refusal returned Skip, and once later traffic advanced the cursor the since-floor left the latched backfill as the only path to the missing commit. The drain now attributes refusals per group (recorded at the same statement that counts them), a fruitless-but-complete replay re-arms exactly those groups — and sets the retry backoff instead of clearing it, so the re-arm is paced rather than a spin (test-pinned across two consecutive fruitless cycles). The disarm tests now arm through observe_resource_refusal rather than injecting decisions past the detector.

## Let the engine report an unpersisted ingest instead of guessing

The app reconstructed the engine's retryable-unpersisted contract from IngestOutcome and missed Ignored{UnknownGroup}, whose retryable path the engine marks explicitly (and whose sibling disband-tombstone path returns the same variant durably — indistinguishable from outside). The disposition now rides IngestEffects end to end and the app's match is gone. Policy: an unknown-group ingest skips the seen-mark (redelivery must reprocess it) but still advances the cursor (holding the floor for unknown-route input would hand it to attacker-controllable traffic). The reachable trigger is the route-backfill probe budget, not commit-before-Welcome — the transport's double route-gating makes that race impossible, now pinned by a test that asserts an unknown-route event is never routed into a delivery at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved delivery handling when a message targets an unknown group.
  * Transport progress now continues for safely ignorable messages, while retryable resource refusals remain eligible for recovery.
  * Prevented repeated deliveries from being incorrectly classified as duplicates.
  * Improved epoch recovery retries with targeted re-arming and cooldown pacing.

* **New Features**
  * Ingestion results now indicate when a transport object was not durably retained, enabling callers to determine whether redelivery may be needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->