### PR TITLE
fix(hermes): preserve shed inbound replay

### DIFF
--- a/integrations/hermes/marmot/adapter.py
+++ b/integrations/hermes/marmot/adapter.py
@@ -1899,6 +1899,9 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
         # message (rapid catch-up after subscribe, or across a reconnect); drop
         # ids already seen so the same user message is not dispatched twice.
         self._recent_inbound_ids = _RecentKeys(DEFAULT_INBOUND_DEDUPE_WINDOW)
+        # Reserve ids while admission is being decided. A reservation prevents
+        # concurrent duplicates without making a shed message terminally seen.
+        self._pending_inbound_ids: set[str] = set()
         # Dedupe repeated ambient surfacings (deletion / group-state change) by a
         # context key (mirror inbound.ts contextKeys).
         self._recent_ambient_keys = _RecentKeys(DEFAULT_AMBIENT_CONTEXT_WINDOW)
@@ -1982,6 +1985,7 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
                 task.cancel()
         self._debounce_tasks.clear()
         self._debounce_pending.clear()
+        self._pending_inbound_ids.clear()
 
     async def send(
         self,
@@ -3241,25 +3245,37 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
         message_id_hex = event["message_id_hex"]
         # Client-side dedupe: the connector can re-emit the same inbound message
         # (rapid catch-up after subscribe, or across a reconnect). Drop a repeat
-        # silently so the same user message is not dispatched twice. Record the id
-        # BEFORE dispatching (an agent turn takes long enough that record-after
-        # would let a duplicate start a second concurrent turn). Dedupe the id
-        # once regardless of whether onboarding intercepts the message.
-        if message_id_hex in self._recent_inbound_ids:
+        # silently so the same user message is not dispatched twice. Reserve the
+        # id before queue admission so concurrent duplicates cannot race, but do
+        # not commit it to terminal dedupe until admission succeeds: a shed turn
+        # must remain replayable from connector storage.
+        if (
+            message_id_hex in self._recent_inbound_ids
+            or message_id_hex in self._pending_inbound_ids
+        ):
             return
-        self._recent_inbound_ids.add(message_id_hex)
+        self._pending_inbound_ids.add(message_id_hex)
 
         if self.debounce_ms > 0:
-            self._enqueue_debounced(event)
+            try:
+                self._enqueue_debounced(event)
+            except BaseException:
+                self._pending_inbound_ids.discard(message_id_hex)
+                raise
             return
 
         # Hand the turn off to the per-group queue and return immediately so the consume loop
         # keeps pulling events. Distinct groups dispatch concurrently; each group stays FIFO.
         group_id_hex = event["group_id_hex"]
-        self._inbound_queue.enqueue(
-            group_id_hex,
-            lambda evt=event: self._dispatch_inbound_message(evt),
-        )
+        try:
+            task = self._inbound_queue.enqueue(
+                group_id_hex,
+                lambda evt=event: self._dispatch_inbound_message(evt),
+            )
+            if task is not None:
+                self._recent_inbound_ids.add(message_id_hex)
+        finally:
+            self._pending_inbound_ids.discard(message_id_hex)
 
     async def _handle_group_invite(self, event: Dict[str, Any]) -> None:
         if not self.profile_name_onboarding_enabled or self.profile_name_onboarding is None:
@@ -3502,16 +3518,24 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
         self._debounce_tasks.pop(key, None)
         if not items:
             return
+        message_ids = [str(item.get("message_id_hex") or "") for item in items]
         # Route the coalesced turn through the per-group queue too, so a debounced
         # batch stays FIFO-ordered with non-debounced messages in the same group
         # and a slow turn does not block the debounce-flush task (mirrors the
         # direct-dispatch path's per-group serialization).
-        merged = _coalesce_inbound_events(items)
-        group_id_hex = merged["group_id_hex"]
-        self._inbound_queue.enqueue(
-            group_id_hex,
-            lambda evt=merged: self._dispatch_inbound_message(evt),
-        )
+        try:
+            merged = _coalesce_inbound_events(items)
+            group_id_hex = merged["group_id_hex"]
+            task = self._inbound_queue.enqueue(
+                group_id_hex,
+                lambda evt=merged: self._dispatch_inbound_message(evt),
+            )
+            if task is not None:
+                for message_id_hex in message_ids:
+                    self._recent_inbound_ids.add(message_id_hex)
+        finally:
+            for message_id_hex in message_ids:
+                self._pending_inbound_ids.discard(message_id_hex)
 
     async def _handle_mutation(self, event: Dict[str, Any]) -> None:
         # Mutations are quiet next-turn context and never trigger an agent turn.

--- a/integrations/hermes/marmot/tests/test_adapter.py
+++ b/integrations/hermes/marmot/tests/test_adapter.py
@@ -3461,6 +3461,95 @@ class ParityBehaviorTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(len(dispatched), 1)
 
+    async def test_shed_inbound_id_remains_replayable_after_queue_capacity_recovers(self):
+        event = {
+            "type": "inbound_message",
+            "account_id_hex": "11" * 32,
+            "group_id_hex": "22" * 32,
+            "message_id_hex": "33" * 32,
+            "sender_account_id_hex": "44" * 32,
+            "text": "retry me",
+            "mentions_self": True,
+        }
+        adapter = self._adapter(client=object())
+        adapter._inbound_queue = self.adapter_module.KeyedAsyncQueue(max_depth_per_key=1)
+        blocker_started = asyncio.Event()
+        release_blocker = asyncio.Event()
+
+        async def blocking_turn():
+            blocker_started.set()
+            await release_blocker.wait()
+
+        adapter._inbound_queue.enqueue(event["group_id_hex"], blocking_turn)
+        await asyncio.wait_for(blocker_started.wait(), timeout=1)
+
+        await adapter._handle_control_event(wire_event(event))
+        self.assertNotIn(event["message_id_hex"], adapter._recent_inbound_ids)
+
+        release_blocker.set()
+        await adapter._inbound_queue.join()
+        await adapter._handle_control_event(wire_event(event))
+        await adapter._inbound_queue.join()
+
+        self.assertEqual([message.text for message in adapter.events], ["retry me"])
+
+    async def test_debounced_shed_releases_every_source_id_for_replay(self):
+        event = {
+            "type": "inbound_message",
+            "account_id_hex": "11" * 32,
+            "group_id_hex": "22" * 32,
+            "message_id_hex": "33" * 32,
+            "sender_account_id_hex": "44" * 32,
+            "text": "retry batch",
+            "mentions_self": True,
+        }
+        sibling = dict(
+            event,
+            message_id_hex="55" * 32,
+            text="second source",
+        )
+        adapter = self._adapter(client=object(), extra={"debounce_ms": 60_000})
+        adapter._inbound_queue = self.adapter_module.KeyedAsyncQueue(max_depth_per_key=1)
+        blocker_started = asyncio.Event()
+        release_blocker = asyncio.Event()
+
+        async def blocking_turn():
+            blocker_started.set()
+            await release_blocker.wait()
+
+        adapter._inbound_queue.enqueue(event["group_id_hex"], blocking_turn)
+        await asyncio.wait_for(blocker_started.wait(), timeout=1)
+
+        await adapter._handle_control_event(wire_event(event))
+        await adapter._handle_control_event(wire_event(sibling))
+        await adapter._handle_control_event(wire_event(event))
+        key = adapter._debounce_key(event)
+        self.assertEqual(len(adapter._debounce_pending[key]), 2)
+        timer = adapter._debounce_tasks[key]
+        timer.cancel()
+        await asyncio.gather(timer, return_exceptions=True)
+        await adapter._flush_debounced(key)
+
+        for source in (event, sibling):
+            self.assertNotIn(source["message_id_hex"], adapter._recent_inbound_ids)
+            self.assertNotIn(source["message_id_hex"], adapter._pending_inbound_ids)
+
+        release_blocker.set()
+        await adapter._inbound_queue.join()
+        await adapter._handle_control_event(wire_event(event))
+        await adapter._handle_control_event(wire_event(sibling))
+        timer = adapter._debounce_tasks[key]
+        timer.cancel()
+        await asyncio.gather(timer, return_exceptions=True)
+        await adapter._flush_debounced(key)
+        await adapter._inbound_queue.join()
+
+        self.assertEqual(len(adapter.events), 1)
+        self.assertIn("retry batch", adapter.events[0].text)
+        self.assertIn("second source", adapter.events[0].text)
+        for source in (event, sibling):
+            self.assertIn(source["message_id_hex"], adapter._recent_inbound_ids)
+
     # --- Behavior 3: stream_progress wire type --------------------------------
     async def test_stream_progress_sends_progress_wire_type(self):
         requests = []


### PR DESCRIPTION
## Summary

- reserve inbound message ids while queue admission or debounce is pending without terminally deduplicating them
- commit ids to the recent-message cache only after the per-group queue accepts the turn
- release direct and debounced source ids on queue shedding, admission exceptions, and disconnect cleanup so connector/storage replay can recover them
- cover direct replay, multi-source debounced replay, and duplicate suppression while admission is pending

## Verification

- `python3 -m unittest discover -s integrations/hermes/marmot/tests` (202 passed)
- `just fast-ci`
- the new direct regression failed against the pre-fix behavior because a shed id remained terminally deduplicated
- independent review: PASS with no findings (Cursor Grok 4.6)

## Risk

The change is limited to the Hermes Marmot adapter's in-memory inbound dedupe and queue-admission bookkeeping. It does not add adapter-owned replay; recovery remains connector/storage-backed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inbound message deduplication during concurrent processing.
  * Messages dropped due to temporary queue capacity limits can now be replayed successfully.
  * Debounced message batches correctly release tracking state when admission fails, preventing messages from being lost.

* **Tests**
  * Added coverage for replaying shed messages and coalesced batches after queue recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->