### PR TITLE
feat(terminal-harness): add shared chat commands

### DIFF
--- a/integrations/codex/marmot/AGENTS.md
+++ b/integrations/codex/marmot/AGENTS.md
@@ -32,6 +32,9 @@ Rust Codex harness for Marmot through the local `wn-agent` control socket. Read
 ## Rules
 
 - Keep prompts on stdin; do not move prompt text into process arguments.
+- `codex exec` does not expand Codex's interactive slash commands; that parsing
+  lives only in `codex-rs/tui`. Do not claim Codex TUI command support here.
+  Chat-facing commands belong to the shared harness command router.
 - Keep permission argv derived from the shared typed execution profile. Do not
   add free-form backend argument configuration or mutate global Codex config.
 - Split completed assistant text into byte-budgeted Marmot messages. Keep

--- a/integrations/codex/marmot/README.md
+++ b/integrations/codex/marmot/README.md
@@ -106,9 +106,9 @@ directory by default, so select a repository before sending the first prompt.
 
 ## Chat Commands
 
-`codex exec` does not expand Codex's interactive slash commands, so `/goal`,
-`/plan`, `/review`, and the rest of the TUI command set are not available through
-this connector. The shared harness instead answers its own reserved commands
+`codex exec` does not expand Codex's interactive TUI slash commands, so Codex's
+own `/goal`, `/plan`, `/review`, and the rest of that TUI set never run here.
+The shared harness intercepts its reserved chat commands — including `/goal` —
 before Codex is invoked. Send `/help` in a chat to list them; the full table and
 the `//` literal escape are documented in the
 [shared chat-command reference](../../terminal-harness/README.md#chat-commands).

--- a/integrations/codex/marmot/README.md
+++ b/integrations/codex/marmot/README.md
@@ -104,11 +104,21 @@ starting Codex. Subsequent prompts resume that group's Codex thread. Without a
 picker, the shared harness uses `$HOME`; Codex rejects a non-Git working
 directory by default, so select a repository before sending the first prompt.
 
-Send exactly `/reset-session` to clear the current group's Codex thread id while
+## Chat Commands
+
+`codex exec` does not expand Codex's interactive slash commands, so `/goal`,
+`/plan`, `/review`, and the rest of the TUI command set are not available through
+this connector. The shared harness instead answers its own reserved commands
+before Codex is invoked. Send `/help` in a chat to list them; the full table and
+the `//` literal escape are documented in the
+[shared chat-command reference](../../terminal-harness/README.md#chat-commands).
+
+`/new` and `/reset-session` clear the current group's Codex thread id while
 preserving its selected workdir and Codex-owned transcript files. The next
 normal prompt starts and records a new Codex thread; a failed resumed prompt is
-never retried automatically. Send `//reset-session` to pass the literal
-`/reset-session` text to Codex instead of invoking the harness command.
+never retried automatically. `/goal <text>` stores a standing instruction that
+the harness prepends to every later prompt in that chat, which keeps the
+instruction alive across thread resets and Codex-side context compaction.
 
 ## Configuration
 

--- a/integrations/opencode/marmot/README.md
+++ b/integrations/opencode/marmot/README.md
@@ -168,18 +168,25 @@ for the next prompt. Symlinks that resolve outside `$HOME` are rejected after
 canonicalization. Picker-looking messages with invalid segments are rejected
 and are not forwarded to OpenCode as prompts.
 
-## Session Reset
+## Chat Commands
 
-Send exactly `/reset-session` to clear the current Marmot group's OpenCode
-session id. The harness intercepts the command, preserves the group's validated
-workdir, does not delete OpenCode-owned transcripts, and confirms the result.
-The next normal prompt creates and records a new OpenCode session in that
-workdir. A failed resumed prompt is never retried automatically because the
-original invocation may already have produced side effects.
+`opencode run` does not expand OpenCode's interactive slash commands. The shared
+harness answers its own reserved commands before OpenCode is invoked; send
+`/help` in a chat to list them. The full table and the `//` literal escape are
+documented in the
+[shared chat-command reference](../../terminal-harness/README.md#chat-commands).
 
-The command name is reserved. Send `//reset-session` when the literal
-`/reset-session` text should reach OpenCode; messages such as
-`/reset-session please` are ordinary prompts.
+`/new` and `/reset-session` clear the current Marmot group's OpenCode session
+id. The harness intercepts the command, preserves the group's validated workdir,
+does not delete OpenCode-owned transcripts, and confirms the result. The next
+normal prompt creates and records a new OpenCode session in that workdir. A
+failed resumed prompt is never retried automatically because the original
+invocation may already have produced side effects.
+
+Reserved names are not forwarded to OpenCode. Send `//reset-session` when the
+literal `/reset-session` text should reach OpenCode; a reserved name with
+arguments it does not accept, such as `/reset-session please`, returns a usage
+reply.
 
 ## OpenCode Transport Contract
 

--- a/integrations/pi/marmot/README.md
+++ b/integrations/pi/marmot/README.md
@@ -99,6 +99,15 @@ On the first message in a group, use `/<path>` to select a working directory
 under `$HOME`, using the same picker rules as `wn-opencode`. Subsequent prompts
 resume that group's Pi session.
 
+## Chat Commands
+
+Pi's non-interactive interface does not expand interactive slash commands. The
+shared harness answers its own reserved commands, including `/help`, `/status`,
+`/pwd`, `/cd`, `/new`, `/reset-session`, and `/goal`, before Pi is invoked. Send
+`/help` in a chat to list them; the full table and the `//` literal escape are
+documented in the
+[shared chat-command reference](../../terminal-harness/README.md#chat-commands).
+
 ## Configuration
 
 | Environment variable | Default | Meaning |

--- a/integrations/terminal-harness/AGENTS.md
+++ b/integrations/terminal-harness/AGENTS.md
@@ -6,10 +6,17 @@ before changing this crate.
 ## Scope
 
 - Own the `wn-agent` control client, inbound reconnect/resync loop, account and
-  allowlist selection, per-group queues, deduplication, workdir picker, private
-  session mapping, durable reply chunking, shared env configuration, process
-  lifecycle plumbing, connector e2e support, and backend lifecycle boundary.
+  allowlist selection, per-group queues, deduplication, workdir picker, reserved
+  chat commands, private session mapping, durable reply chunking, shared env
+  configuration, process lifecycle plumbing, connector e2e support, and backend
+  lifecycle boundary.
 - Keep backend command construction and event parsing in each harness crate.
+- Keep every reserved chat command in `src/commands.rs`. A reserved name must
+  never fall through to the workdir picker, and a non-reserved leading-slash
+  message must always stay a picker candidate. Adding a name is a documented
+  breaking change for anyone whose `$HOME` holds a directory of that name.
+- Keep per-group state changes on the targeted `SessionStore` mutators so a
+  session, workdir, or goal write never silently discards a sibling field.
 - Preserve privacy-safe diagnostics and never log identifiers, paths, prompts,
   model output, or transport data.
 - Changes here must be verified against every terminal harness.

--- a/integrations/terminal-harness/README.md
+++ b/integrations/terminal-harness/README.md
@@ -93,9 +93,8 @@ All connectors:
 - support only `always` activation today;
 - use `/<path>` on the first group message to select a canonical working
   directory beneath `$HOME`;
-- persist private per-group working-directory and session mappings;
-- intercept an exact `/reset-session` message before backend invocation, clear
-  only that group's backend session id, and retain its selected workdir;
+- persist private per-group working-directory, session, and goal mappings;
+- answer the reserved chat commands below before backend invocation;
 - split durable replies on UTF-8 boundaries with a 30,000-byte default and a
   60,000-byte hard ceiling;
 - report presentation-idle liveness as unknown without killing an invocation and
@@ -107,11 +106,48 @@ All connectors:
   FIFO work, without replaying the backend invocation;
 - keep diagnostics free of identifiers, paths, prompts, and backend output.
 
-`/reset-session` is reserved as a harness control message. Send
-`//reset-session` to forward the literal `/reset-session` text to the backend.
-Reset never deletes backend-owned transcripts and never retries a failed resumed
-prompt automatically; the next distinct prompt starts a new logical backend
-session in the retained workdir.
+## Chat Commands
+
+Terminal backends run through their non-interactive machine interfaces, which do
+not expand the backend's own interactive slash commands. A message whose first
+token is a reserved name below is therefore answered by the harness itself and
+never reaches the backend:
+
+| Command | Effect |
+| --- | --- |
+| `/help` | List these commands. |
+| `/status` | Report backend name, workdir, session state, execution profile, and goal. |
+| `/pwd` | Report the selected working directory as a `$HOME`-relative path. |
+| `/cd <path>` | Select a working directory under `$HOME` and start a new session epoch. |
+| `/new` | End the active backend session and keep the workdir. |
+| `/reset-session` | Same as `/new`. |
+| `/session-status` | Reserved for the active-turn status lane; until that lane is supported, return an unavailable reply without invoking the backend. |
+| `/retry-last` | Retry the durable recovery record that currently blocks this chat. |
+| `/discard-last` | Discard the durable recovery record without replay. |
+| `/goal <text>` | Store a standing instruction for this chat. `/goal` shows it; `/goal clear` removes it. |
+
+A reserved name used with arguments it does not accept, such as
+`/new right now`, returns a usage reply instead of being forwarded as a prompt.
+Any other leading-slash message keeps the existing workdir-picker behavior, so
+`/whitenoise fix the build` still selects `~/whitenoise` and prompts with the
+rest. A directory whose name collides with a reserved command must be selected
+with `/cd`.
+
+Prefix a message with `//` to strip one slash and forward the rest verbatim
+without command routing or workdir selection: `//status` sends the literal
+`/status` to the backend. Backends differ in what they do with it. `codex exec`
+and `opencode run` have no slash parsing at all, so the text is prompt prose. A
+backend that does route slash commands in its non-interactive mode receives its
+own command through this escape.
+
+`/new` and `/reset-session` never delete backend-owned transcripts and never
+retry a failed resumed prompt automatically; the next distinct prompt starts a
+new logical backend session in the retained workdir.
+
+The stored goal is prepended to every prompt in its chat as one delimited block.
+That costs prompt tokens on every turn and, in exchange, survives session
+resets, lost session ids, and backend context compaction. Goals are bounded to
+4096 bytes and live only in the connector's private per-group state file.
 
 `/retry-last` and `/discard-last` are available only while one matching durable
 recovery record blocks that group. Retry consumes that record once and runs ahead

--- a/integrations/terminal-harness/src/bridge.rs
+++ b/integrations/terminal-harness/src/bridge.rs
@@ -283,14 +283,7 @@ async fn dispatch_event(ctx: Arc<BridgeContext>, event: AgentControlEvent) -> Di
                 return DispatchOutcome::Continue;
             }
             let disposition = classify_prompt(&message.text);
-            let permit = if matches!(
-                disposition,
-                PromptDisposition::RetryLast | PromptDisposition::DiscardLast
-            ) {
-                ctx.queues.enter_recovery(&group_id_hex).await
-            } else {
-                ctx.queues.try_enter_waiter(&group_id_hex).await
-            };
+            let permit = acquire_dispatch_permit(&ctx.queues, &group_id_hex, &disposition).await;
             let Some(permit) = permit else {
                 warn!(
                     target: TRACE_TARGET,
@@ -416,6 +409,22 @@ fn is_inspect_disposition(disposition: &PromptDisposition) -> bool {
                 ChatCommand::Help | ChatCommand::Status | ChatCommand::Pwd | ChatCommand::GoalShow
             )
     )
+}
+
+async fn acquire_dispatch_permit(
+    queues: &GroupQueues,
+    group_ref: &str,
+    disposition: &PromptDisposition,
+) -> Option<GroupPermit> {
+    if matches!(
+        disposition,
+        PromptDisposition::RetryLast | PromptDisposition::DiscardLast
+    ) || is_inspect_disposition(disposition)
+    {
+        queues.enter_without_waiter_quota(group_ref).await
+    } else {
+        queues.try_enter_waiter(group_ref).await
+    }
 }
 
 async fn handle_message(ctx: Arc<BridgeContext>, inbound: InboundPrompt, mut permit: GroupPermit) {
@@ -1746,7 +1755,9 @@ impl GroupQueues {
         })
     }
 
-    async fn enter_recovery(&self, group_ref: &str) -> Option<GroupPermit> {
+    /// Admits inspect and recovery commands without consuming the waiting quota
+    /// or taking the serial lock.
+    async fn enter_without_waiter_quota(&self, group_ref: &str) -> Option<GroupPermit> {
         let queue = self.queue(group_ref).await?;
         queue.active.fetch_add(1, Ordering::Relaxed);
         Some(GroupPermit {
@@ -1922,8 +1933,11 @@ mod tests {
         (ctx, server)
     }
 
-    async fn dispatch_test_message(ctx: Arc<BridgeContext>, message_ref: &str, text: &str) {
-        let permit = ctx.queues.try_enter_waiter("group").await.unwrap();
+    async fn dispatch_test_message(ctx: Arc<BridgeContext>, message_ref: &str, text: &str) -> bool {
+        let disposition = classify_prompt(text);
+        let Some(permit) = acquire_dispatch_permit(&ctx.queues, "group", &disposition).await else {
+            return false;
+        };
         handle_message(
             ctx,
             InboundPrompt {
@@ -1935,6 +1949,7 @@ mod tests {
             permit,
         )
         .await;
+        true
     }
 
     #[tokio::test]
@@ -2000,33 +2015,37 @@ mod tests {
             .await
             .unwrap();
         assert!(fifo_is_blocked(&ctx, "group").await);
+        let mut waiters = Vec::new();
+        while let Some(permit) = ctx.queues.try_enter_waiter("group").await {
+            waiters.push(permit);
+        }
+        assert!(
+            !waiters.is_empty(),
+            "queued prompts must be able to exhaust the waiter quota"
+        );
 
-        tokio::time::timeout(
-            Duration::from_millis(500),
-            dispatch_test_message(ctx.clone(), "help", "/help"),
-        )
-        .await
-        .expect("blocked recovery must not park /help");
-        tokio::time::timeout(
-            Duration::from_millis(500),
-            dispatch_test_message(ctx.clone(), "status", "/status"),
-        )
-        .await
-        .expect("blocked recovery must not park /status");
-        tokio::time::timeout(
-            Duration::from_millis(500),
-            dispatch_test_message(ctx.clone(), "pwd", "/pwd"),
-        )
-        .await
-        .expect("blocked recovery must not park /pwd");
-        tokio::time::timeout(
-            Duration::from_millis(500),
-            dispatch_test_message(ctx.clone(), "goal-show", "/goal"),
-        )
-        .await
-        .expect("blocked recovery must not park /goal show");
+        for (message_ref, text) in [
+            ("help", "/help"),
+            ("status", "/status"),
+            ("pwd", "/pwd"),
+            ("goal-show", "/goal"),
+        ] {
+            assert!(
+                tokio::time::timeout(
+                    Duration::from_millis(500),
+                    dispatch_test_message(ctx.clone(), message_ref, text),
+                )
+                .await
+                .expect("inspect command must not wait on recovery or waiter quota")
+            );
+        }
 
         assert!(backend.invocations.lock().await.is_empty());
+        assert!(
+            !dispatch_test_message(ctx.clone(), "cd-full", "/cd repo").await,
+            "mutating commands must not steal a waiter while the quota is full"
+        );
+        drop(waiters);
         assert!(
             tokio::time::timeout(
                 Duration::from_millis(200),
@@ -2082,7 +2101,10 @@ mod tests {
         assert!(first.is_some());
         assert_eq!(first.as_ref().unwrap().queue.pending.available_permits(), 1);
         assert!(queues.try_enter_waiter("g").await.is_none());
-        let recovery = queues.enter_recovery("g").await;
+        let inspect = queues.enter_without_waiter_quota("g").await;
+        assert!(inspect.is_some());
+        drop(inspect);
+        let recovery = queues.enter_without_waiter_quota("g").await;
         assert!(recovery.is_some());
         drop(recovery);
         drop(first);
@@ -2311,7 +2333,7 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        let recovery = queues.enter_recovery("g").await.unwrap();
+        let recovery = queues.enter_without_waiter_quota("g").await.unwrap();
         let active = recovery.serial.lock().await;
         assert!(recovery.serial.try_lock().is_err());
         drop(active);

--- a/integrations/terminal-harness/src/bridge.rs
+++ b/integrations/terminal-harness/src/bridge.rs
@@ -10,6 +10,7 @@ use tokio::time::{MissedTickBehavior, interval, sleep};
 use tracing::{debug, info, warn};
 
 use crate::chunking::split_reply_chunks;
+use crate::commands::{self, ChatCommand, Routed};
 use crate::control::ControlClient;
 use crate::error::{HarnessError, Result};
 use crate::repo_picker::{RepoPicker, parse_repo_picker, resolve_repo, validate_session_cwd};
@@ -381,6 +382,8 @@ enum PromptDisposition {
     ResetSession,
     RetryLast,
     DiscardLast,
+    HarnessCommand(ChatCommand),
+    Usage(&'static str),
     Forward {
         prompt: String,
         allow_workdir_picker: bool,
@@ -388,16 +391,18 @@ enum PromptDisposition {
 }
 
 fn classify_prompt(text: &str) -> PromptDisposition {
-    match text.trim() {
-        "/reset-session" => PromptDisposition::ResetSession,
-        "/retry-last" => PromptDisposition::RetryLast,
-        "/discard-last" => PromptDisposition::DiscardLast,
-        "//reset-session" => PromptDisposition::Forward {
-            prompt: "/reset-session".to_owned(),
+    match commands::route(text) {
+        Routed::Command(ChatCommand::NewSession) => PromptDisposition::ResetSession,
+        Routed::Command(ChatCommand::RetryLast) => PromptDisposition::RetryLast,
+        Routed::Command(ChatCommand::DiscardLast) => PromptDisposition::DiscardLast,
+        Routed::Command(command) => PromptDisposition::HarnessCommand(command),
+        Routed::Usage(usage) => PromptDisposition::Usage(usage),
+        Routed::Literal(prompt) => PromptDisposition::Forward {
+            prompt,
             allow_workdir_picker: false,
         },
-        _ => PromptDisposition::Forward {
-            prompt: text.to_owned(),
+        Routed::Prompt(prompt) => PromptDisposition::Forward {
+            prompt,
             allow_workdir_picker: true,
         },
     }
@@ -479,7 +484,15 @@ async fn handle_message(ctx: Arc<BridgeContext>, inbound: InboundPrompt, mut per
     let mut retrying = false;
     let forced_run = match disposition {
         PromptDisposition::ResetSession => {
-            handle_session_reset(&ctx, &inbound).await;
+            handle_command(&ctx, &inbound, ChatCommand::NewSession).await;
+            return;
+        }
+        PromptDisposition::HarnessCommand(command) => {
+            handle_command(&ctx, &inbound, command).await;
+            return;
+        }
+        PromptDisposition::Usage(usage) => {
+            send_command_reply(&ctx, &inbound, usage).await;
             return;
         }
         PromptDisposition::DiscardLast => {
@@ -614,6 +627,11 @@ async fn handle_message(ctx: Arc<BridgeContext>, inbound: InboundPrompt, mut per
     };
     let known_session = ctx.sessions.get(&inbound.group_ref).await;
 
+    let goal = known_session
+        .as_ref()
+        .and_then(|record| record.goal.as_deref());
+    let (recovery_prompt, prompt) = prepare_prompt(goal, prompt);
+
     info!(
         target: TRACE_TARGET,
         method = "handle_message",
@@ -621,10 +639,10 @@ async fn handle_message(ctx: Arc<BridgeContext>, inbound: InboundPrompt, mut per
         has_session = known_session
             .as_ref()
             .is_some_and(|record| !record.session_id.is_empty()),
+        has_goal = goal.is_some(),
         "handling inbound prompt"
     );
 
-    let recovery_prompt = prompt.clone();
     let invocation = Invocation {
         timeout: ctx.cfg.backend_timeout,
         idle_timeout: ctx.cfg.backend_idle_timeout,
@@ -840,15 +858,55 @@ async fn fifo_is_blocked(ctx: &BridgeContext, group_ref: &str) -> bool {
     ctx.recovery.get(group_ref).await.is_some() || ctx.deliveries.blocks_group(group_ref).await
 }
 
-async fn handle_session_reset(ctx: &BridgeContext, inbound: &InboundPrompt) {
-    let message = match ctx.sessions.reset_session(&inbound.group_ref).await {
+async fn handle_command(ctx: &BridgeContext, inbound: &InboundPrompt, command: ChatCommand) {
+    let record = ctx.sessions.get(&inbound.group_ref).await;
+    let body =
+        match command {
+            ChatCommand::Help => commands::help_text(ctx.cfg.spec.display_name),
+            ChatCommand::Status => status_text(ctx, record.as_ref()),
+            ChatCommand::Pwd => match record.as_ref().and_then(|record| record.cwd.as_deref()) {
+                Some(cwd) => format!("Working directory: {}", display_home_path(cwd, &ctx.home)),
+                None => "No working directory is selected yet. Use `/cd <path>`.".to_owned(),
+            },
+            ChatCommand::NewSession => new_session_body(ctx, inbound).await,
+            ChatCommand::Cd { path } => {
+                change_workdir_body(ctx, inbound, record.as_ref(), &path).await
+            }
+            ChatCommand::GoalShow => {
+                match record.as_ref().and_then(|record| record.goal.as_deref()) {
+                    Some(goal) => format!("Standing goal:\n{goal}"),
+                    None => "No standing goal is set. Use `/goal <text>`.".to_owned(),
+                }
+            }
+            ChatCommand::GoalClear => match set_goal(ctx, &inbound.group_ref, None).await {
+                Ok(()) => "Standing goal cleared.".to_owned(),
+                Err(()) => "Failed to clear the standing goal.".to_owned(),
+            },
+            ChatCommand::GoalSet { text } => {
+                match set_goal(ctx, &inbound.group_ref, Some(text)).await {
+                    Ok(()) => {
+                        "Standing goal set. It is prepended to every prompt in this chat until you send `/goal clear`."
+                            .to_owned()
+                    }
+                    Err(()) => "Failed to set the standing goal.".to_owned(),
+                }
+            }
+            ChatCommand::RetryLast | ChatCommand::DiscardLast => {
+                unreachable!("recovery commands are handled before generic command dispatch")
+            }
+        };
+    send_command_reply(ctx, inbound, &body).await;
+}
+
+async fn new_session_body(ctx: &BridgeContext, inbound: &InboundPrompt) -> String {
+    match ctx.sessions.reset_session(&inbound.group_ref).await {
         Ok(true) => format!(
-            "[{}] Session reset. The next prompt will start a new {} session in the preserved workdir.",
-            ctx.cfg.spec.reply_prefix, ctx.cfg.spec.display_name
+            "Session reset. The next prompt will start a new {} session in the preserved workdir.",
+            ctx.cfg.spec.display_name
         ),
         Ok(false) => format!(
-            "[{}] No {} session is recorded for this group.",
-            ctx.cfg.spec.reply_prefix, ctx.cfg.spec.display_name
+            "No {} session is recorded for this chat.",
+            ctx.cfg.spec.display_name
         ),
         Err(err) => {
             warn!(
@@ -857,28 +915,119 @@ async fn handle_session_reset(ctx: &BridgeContext, inbound: &InboundPrompt) {
                 error_kind = err.privacy_safe_kind(),
                 "failed to reset backend session"
             );
-            format!(
-                "[{}] Failed to reset the {} session.",
-                ctx.cfg.spec.reply_prefix, ctx.cfg.spec.display_name
-            )
+            format!("Failed to reset the {} session.", ctx.cfg.spec.display_name)
         }
+    }
+}
+
+async fn change_workdir_body(
+    ctx: &BridgeContext,
+    inbound: &InboundPrompt,
+    record: Option<&SessionRecord>,
+    path: &str,
+) -> String {
+    let cwd = match resolve_repo(path, &ctx.home).await {
+        Ok(cwd) => cwd,
+        Err(err) => return err.to_string(),
     };
-    if let Err(err) = send_reply(
-        ctx,
-        &inbound.account_ref,
-        &inbound.group_ref,
-        &inbound.message_ref,
-        &message,
-        0,
-    )
-    .await
-    {
+    let had_session = record.is_some_and(|record| !record.session_id.is_empty());
+    match ctx.sessions.set_workdir(&inbound.group_ref, cwd).await {
+        Ok(()) if had_session => format!(
+            "Working directory set to ~/{path}. The previous {} session was ended; the next prompt starts a new one.",
+            ctx.cfg.spec.display_name
+        ),
+        Ok(()) => format!("Working directory set to ~/{path}. Send your prompt."),
+        Err(err) => {
+            warn!(
+                target: TRACE_TARGET,
+                method = "set_workdir",
+                error_kind = err.privacy_safe_kind(),
+                "failed to record selected workdir"
+            );
+            "Failed to set the working directory.".to_owned()
+        }
+    }
+}
+
+async fn set_goal(
+    ctx: &BridgeContext,
+    group_ref: &str,
+    goal: Option<String>,
+) -> std::result::Result<(), ()> {
+    ctx.sessions.set_goal(group_ref, goal).await.map_err(|err| {
         warn!(
             target: TRACE_TARGET,
-            method = "session_reset_reply",
+            method = "set_goal",
             error_kind = err.privacy_safe_kind(),
-            "failed to send session-reset reply"
+            "failed to record standing goal"
         );
+    })
+}
+
+fn status_text(ctx: &BridgeContext, record: Option<&SessionRecord>) -> String {
+    let workdir = match record.and_then(|record| record.cwd.as_deref()) {
+        Some(cwd) => display_home_path(cwd, &ctx.home),
+        None => "not selected".to_owned(),
+    };
+    let session = if record.is_some_and(|record| !record.session_id.is_empty()) {
+        "active"
+    } else {
+        "none"
+    };
+    let goal = record
+        .and_then(|record| record.goal.as_deref())
+        .unwrap_or("none");
+    format!(
+        "backend: {}\nworkdir: {workdir}\nsession: {session}\nexecution profile: {}\ngoal: {goal}",
+        ctx.cfg.spec.display_name,
+        ctx.cfg.execution_profile.as_str()
+    )
+}
+
+fn prepare_prompt(goal: Option<&str>, prompt: String) -> (String, String) {
+    // Recovery persists the original user prompt. Persisting the expanded form
+    // would prepend a standing goal again when `/retry-last` re-enters this path.
+    let recovery_prompt = prompt.clone();
+    let invocation_prompt = match goal {
+        Some(goal) => commands::apply_goal(goal, &prompt),
+        None => prompt,
+    };
+    (recovery_prompt, invocation_prompt)
+}
+
+/// Renders a stored workdir as a `$HOME`-relative display path for chat replies.
+fn display_home_path(cwd: &std::path::Path, home: &std::path::Path) -> String {
+    match cwd.strip_prefix(home) {
+        Ok(rest) if rest.as_os_str().is_empty() => "~".to_owned(),
+        Ok(rest) => format!("~/{}", rest.display()),
+        Err(_) => "outside $HOME".to_owned(),
+    }
+}
+
+async fn send_command_reply(ctx: &BridgeContext, inbound: &InboundPrompt, body: &str) {
+    let text = format!("[{}] {body}", ctx.cfg.spec.reply_prefix);
+    for (index, chunk) in split_reply_chunks(&text, ctx.cfg.max_reply_bytes)
+        .into_iter()
+        .enumerate()
+    {
+        if let Err(err) = send_reply(
+            ctx,
+            &inbound.account_ref,
+            &inbound.group_ref,
+            &inbound.message_ref,
+            chunk,
+            index,
+        )
+        .await
+        {
+            warn!(
+                target: TRACE_TARGET,
+                method = "command_reply",
+                error_kind = err.privacy_safe_kind(),
+                "failed to send harness command reply"
+            );
+            return;
+        }
     }
 }
 
@@ -1240,9 +1389,7 @@ async fn persist_observed_session_if_unset(
         .as_ref()
         .is_none_or(|record| record.session_id.is_empty());
     if needs_persist && let Some(session_id) = observed_session {
-        sessions
-            .set(group_ref, SessionRecord { session_id, cwd })
-            .await?;
+        sessions.record_session(group_ref, session_id, cwd).await?;
     }
     Ok(())
 }
@@ -1253,8 +1400,8 @@ async fn resolve_cwd_and_prompt(
     known_session: Option<&SessionRecord>,
     allow_workdir_picker: bool,
 ) -> Result<Option<(PathBuf, String)>> {
-    if let Some(record) = known_session {
-        let cwd = validate_session_cwd(&record.cwd, &ctx.home).await?;
+    if let Some(selected) = known_session.and_then(|record| record.cwd.as_deref()) {
+        let cwd = validate_session_cwd(selected, &ctx.home).await?;
         return Ok(Some((cwd, inbound.text.clone())));
     }
     if !allow_workdir_picker {
@@ -1264,15 +1411,12 @@ async fn resolve_cwd_and_prompt(
     let (name, rest) = match parse_repo_picker(&inbound.text) {
         RepoPicker::Absent => return Ok(Some((ctx.home.clone(), inbound.text.clone()))),
         RepoPicker::Invalid => {
-            send_reply(
+            send_command_reply(
                 ctx,
-                &inbound.account_ref,
-                &inbound.group_ref,
-                &inbound.message_ref,
-                &format!("[{}] Invalid workdir picker. Use /<path> with non-empty path segments containing only ASCII letters, digits, '.', '_', or '-'. Do not use '.' or '..' segments.", ctx.cfg.spec.reply_prefix),
-                0,
+                inbound,
+                "Invalid workdir picker. Use /<path> with non-empty path segments containing only ASCII letters, digits, '.', '_', or '-'. Do not use '.' or '..' segments. Send /help for the harness commands.",
             )
-            .await?;
+            .await;
             return Ok(None);
         }
         RepoPicker::Valid { path, prompt } => (path, prompt),
@@ -1280,41 +1424,23 @@ async fn resolve_cwd_and_prompt(
     let cwd = match resolve_repo(&name, &ctx.home).await {
         Ok(cwd) => cwd,
         Err(err) => {
-            let text = err.to_string();
-            send_reply(
+            send_command_reply(
                 ctx,
-                &inbound.account_ref,
-                &inbound.group_ref,
-                &inbound.message_ref,
-                &format!("[{}] {text}", ctx.cfg.spec.reply_prefix),
-                0,
+                inbound,
+                &format!("{err} Send /help for the harness commands."),
             )
-            .await?;
+            .await;
             return Ok(None);
         }
     };
     if rest.is_empty() {
-        ctx.sessions
-            .set(
-                &inbound.group_ref,
-                SessionRecord {
-                    session_id: String::new(),
-                    cwd,
-                },
-            )
-            .await?;
-        send_reply(
+        ctx.sessions.set_workdir(&inbound.group_ref, cwd).await?;
+        send_command_reply(
             ctx,
-            &inbound.account_ref,
-            &inbound.group_ref,
-            &inbound.message_ref,
-            &format!(
-                "[{}] Session workdir set to ~/{name}. Send your prompt.",
-                ctx.cfg.spec.reply_prefix
-            ),
-            0,
+            inbound,
+            &format!("Session workdir set to ~/{name}. Send your prompt."),
         )
-        .await?;
+        .await;
         return Ok(None);
     }
     Ok(Some((cwd, rest)))
@@ -1655,6 +1781,13 @@ impl InboundDedupe {
 mod tests {
     use super::*;
     use crate::store::SessionStore;
+    use agent_control::{
+        AgentControlEnvelope, AgentControlRequest, AgentControlResponse,
+        AgentControlSendMaintenanceDisposition, read_envelope, write_frame,
+    };
+    use async_trait::async_trait;
+    use tokio::io::BufReader;
+    use tokio::net::UnixListener;
 
     fn test_config(root: &std::path::Path) -> Config {
         Config {
@@ -1682,6 +1815,105 @@ mod tests {
         }
     }
 
+    #[derive(Default)]
+    struct RecordingBackend {
+        invocations: Mutex<Vec<Invocation>>,
+    }
+
+    #[async_trait]
+    impl Backend for RecordingBackend {
+        async fn run(
+            &self,
+            invocation: Invocation,
+            _tx: mpsc::Sender<RunnerEvent>,
+        ) -> std::result::Result<Outcome, RunFailure> {
+            self.invocations.lock().await.push(invocation);
+            Ok(Outcome {
+                observed_session: None,
+                exit_code: Some(0),
+                error_summary: None,
+                no_side_effects_proven: false,
+                stderr: String::new(),
+                elapsed_ms: 1,
+            })
+        }
+    }
+
+    fn spawn_final_server(socket: &std::path::Path) -> tokio::task::JoinHandle<()> {
+        let listener = UnixListener::bind(socket).unwrap();
+        tokio::spawn(async move {
+            loop {
+                let (stream, _) = listener.accept().await.unwrap();
+                let (read_half, mut write_half) = stream.into_split();
+                let mut reader = BufReader::new(read_half);
+                let request: AgentControlEnvelope<AgentControlRequest> =
+                    read_envelope(&mut reader).await.unwrap().unwrap();
+                assert!(matches!(
+                    request.payload,
+                    AgentControlRequest::SendFinal { .. }
+                ));
+                let response = AgentControlEnvelope::request(
+                    request.id,
+                    AgentControlResponse::FinalSent {
+                        message_ids_hex: vec!["reply".to_owned()],
+                        maintenance_disposition: AgentControlSendMaintenanceDisposition::Ready,
+                    },
+                );
+                write_frame(&mut write_half, &response).await.unwrap();
+            }
+        })
+    }
+
+    fn test_context(
+        root: &std::path::Path,
+        home: &std::path::Path,
+        backend: Arc<RecordingBackend>,
+    ) -> (Arc<BridgeContext>, tokio::task::JoinHandle<()>) {
+        std::fs::create_dir_all(home).unwrap();
+        let config = test_config(root);
+        let server = spawn_final_server(&config.socket);
+        let sessions = Arc::new(SessionStore::load(config.state_path.clone(), home).unwrap());
+        let recovery = Arc::new(
+            RecoveryStore::load(config.state_path.with_extension("recovery.json")).unwrap(),
+        );
+        let deliveries = Arc::new(
+            FinalDeliveryStore::load(config.state_path.with_extension("delivery.json")).unwrap(),
+        );
+        let ctx = Arc::new(BridgeContext {
+            client: ControlClient::new(
+                config.socket.clone(),
+                None,
+                Duration::from_secs(1),
+                "wn-test",
+            ),
+            cfg: Arc::new(config),
+            account_ref: "account".to_owned(),
+            sessions,
+            recovery,
+            deliveries,
+            queues: Arc::new(GroupQueues::new(4)),
+            dedupe: Arc::new(InboundDedupe::new(8)),
+            backend,
+            home: home.to_path_buf(),
+        });
+        (ctx, server)
+    }
+
+    async fn dispatch_test_message(ctx: Arc<BridgeContext>, message_ref: &str, text: &str) {
+        let permit = ctx.queues.try_enter_waiter("group").await.unwrap();
+        handle_message(
+            ctx,
+            InboundPrompt {
+                account_ref: "account".to_owned(),
+                group_ref: "group".to_owned(),
+                message_ref: message_ref.to_owned(),
+                text: text.to_owned(),
+            },
+            permit,
+        )
+        .await;
+    }
+
     #[tokio::test]
     async fn dedupe_rejects_repeated_message_refs() {
         let dedupe = InboundDedupe::new(8);
@@ -1707,6 +1939,58 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn bridge_commands_and_usage_never_invoke_backend_or_picker() {
+        let root = tempfile::tempdir().unwrap();
+        let home = root.path().join("home");
+        let backend = Arc::new(RecordingBackend::default());
+        let (ctx, server) = test_context(root.path(), &home, backend.clone());
+
+        dispatch_test_message(ctx.clone(), "help", "/help").await;
+        dispatch_test_message(ctx.clone(), "bad-cd", "/cd a b").await;
+        dispatch_test_message(ctx.clone(), "bad-retry", "/retry-last please").await;
+        dispatch_test_message(ctx.clone(), "session-status", "/session-status").await;
+
+        assert!(backend.invocations.lock().await.is_empty());
+        assert!(ctx.sessions.get("group").await.is_none());
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn bridge_literal_and_goal_invoke_backend_once_with_exact_prompt() {
+        let root = tempfile::tempdir().unwrap();
+        let home = root.path().join("home");
+        let repo = home.join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let backend = Arc::new(RecordingBackend::default());
+        let (ctx, server) = test_context(root.path(), &home, backend.clone());
+        ctx.sessions
+            .set_workdir("group", repo.canonicalize().unwrap())
+            .await
+            .unwrap();
+
+        dispatch_test_message(ctx.clone(), "literal", "  //status \n").await;
+        dispatch_test_message(ctx.clone(), "set-goal", "/goal finish the migration").await;
+        dispatch_test_message(ctx.clone(), "prompt", "check status").await;
+
+        let invocations = backend.invocations.lock().await;
+        assert_eq!(invocations.len(), 2);
+        assert_eq!(invocations[0].prompt, "  /status \n");
+        assert_eq!(
+            invocations[1].prompt,
+            commands::apply_goal("finish the migration", "check status")
+        );
+        assert_eq!(
+            invocations[1]
+                .prompt
+                .matches("Standing goal for this chat")
+                .count(),
+            1
+        );
+        drop(invocations);
+        server.abort();
+    }
+
+    #[tokio::test]
     async fn group_queue_enforces_waiting_limit_but_recovery_bypasses_it() {
         let queues = GroupQueues::new(1);
         let first = queues.try_enter_waiter("g").await;
@@ -1721,7 +2005,7 @@ mod tests {
     }
 
     #[test]
-    fn reset_command_is_exact_and_has_a_literal_escape() {
+    fn reset_command_is_reserved_and_has_a_literal_escape() {
         assert_eq!(
             classify_prompt("/reset-session"),
             PromptDisposition::ResetSession
@@ -1739,10 +2023,7 @@ mod tests {
         );
         assert_eq!(
             classify_prompt("/reset-session please"),
-            PromptDisposition::Forward {
-                prompt: "/reset-session please".to_owned(),
-                allow_workdir_picker: true,
-            }
+            PromptDisposition::Usage("`/reset-session` takes no arguments.")
         );
     }
 
@@ -1765,17 +2046,31 @@ mod tests {
         );
         assert_eq!(
             classify_prompt("/goal retry-last"),
-            PromptDisposition::Forward {
-                prompt: "/goal retry-last".to_owned(),
-                allow_workdir_picker: true,
-            }
+            PromptDisposition::HarnessCommand(ChatCommand::GoalSet {
+                text: "retry-last".to_owned(),
+            })
         );
         assert_eq!(
             classify_prompt("/retry-last please"),
-            PromptDisposition::Forward {
-                prompt: "/retry-last please".to_owned(),
-                allow_workdir_picker: true,
-            }
+            PromptDisposition::Usage("`/retry-last` takes no arguments.")
+        );
+    }
+
+    #[test]
+    fn recovery_reapplies_a_standing_goal_exactly_once() {
+        let (persisted, first_invocation) =
+            prepare_prompt(Some("finish the migration"), "check status".to_owned());
+        let (persisted_again, retry_invocation) =
+            prepare_prompt(Some("finish the migration"), persisted.clone());
+
+        assert_eq!(persisted, "check status");
+        assert_eq!(persisted_again, "check status");
+        assert_eq!(retry_invocation, first_invocation);
+        assert_eq!(
+            retry_invocation
+                .matches("Standing goal for this chat")
+                .count(),
+            1
         );
     }
 
@@ -1969,7 +2264,7 @@ mod tests {
         .unwrap();
         let record = store.get("group1").await.unwrap();
         assert_eq!(record.session_id, "ses_new");
-        assert_eq!(record.cwd, cwd);
+        assert_eq!(record.cwd.as_deref(), Some(cwd.as_path()));
 
         persist_observed_session_if_unset(
             &store,
@@ -1992,13 +2287,11 @@ mod tests {
         let cwd = home.join("proj");
         let store = SessionStore::load(path, &home).unwrap();
         store
-            .set(
-                "group1",
-                SessionRecord {
-                    session_id: "ses_old".to_owned(),
-                    cwd: cwd.clone(),
-                },
-            )
+            .record_session("group1", "ses_old".to_owned(), cwd.clone())
+            .await
+            .unwrap();
+        store
+            .set_goal("group1", Some("keep the workdir".to_owned()))
             .await
             .unwrap();
         assert!(store.reset_session("group1").await.unwrap());
@@ -2008,7 +2301,7 @@ mod tests {
             &store,
             "group1",
             Some(&reset_record),
-            reset_record.cwd.clone(),
+            reset_record.cwd.clone().unwrap(),
             Some("ses_new".to_owned()),
         )
         .await
@@ -2016,7 +2309,8 @@ mod tests {
 
         let current = store.get("group1").await.unwrap();
         assert_eq!(current.session_id, "ses_new");
-        assert_eq!(current.cwd, cwd);
+        assert_eq!(current.cwd.as_deref(), Some(cwd.as_path()));
+        assert_eq!(current.goal.as_deref(), Some("keep the workdir"));
     }
 
     #[tokio::test]
@@ -2091,7 +2385,7 @@ mod tests {
 
         let record = store.get("group1").await.unwrap();
         assert_eq!(record.session_id, "ses_idle");
-        assert_eq!(record.cwd, home);
+        assert_eq!(record.cwd.as_deref(), Some(home.as_path()));
         assert_eq!(
             reply,
             "[wn-opencode] The configured time limit ended this attempt. The backend session was saved; send `/retry-last` to retry it, or `/discard-last` to abandon it and continue queued work."

--- a/integrations/terminal-harness/src/bridge.rs
+++ b/integrations/terminal-harness/src/bridge.rs
@@ -408,9 +408,31 @@ fn classify_prompt(text: &str) -> PromptDisposition {
     }
 }
 
+fn is_inspect_disposition(disposition: &PromptDisposition) -> bool {
+    matches!(
+        disposition,
+        PromptDisposition::Usage(_)
+            | PromptDisposition::HarnessCommand(
+                ChatCommand::Help | ChatCommand::Status | ChatCommand::Pwd | ChatCommand::GoalShow
+            )
+    )
+}
+
 async fn handle_message(ctx: Arc<BridgeContext>, inbound: InboundPrompt, mut permit: GroupPermit) {
     let mut inbound = inbound;
     let disposition = classify_prompt(&inbound.text);
+    if is_inspect_disposition(&disposition) {
+        match disposition {
+            PromptDisposition::HarnessCommand(command) => {
+                handle_command(&ctx, &inbound, command).await;
+            }
+            PromptDisposition::Usage(usage) => {
+                send_command_reply(&ctx, &inbound, usage).await;
+            }
+            _ => unreachable!("inspect dispositions are read-only commands or usage"),
+        }
+        return;
+    }
     let recovery_command = matches!(
         disposition,
         PromptDisposition::RetryLast | PromptDisposition::DiscardLast
@@ -1891,6 +1913,7 @@ mod tests {
             sessions,
             recovery,
             deliveries,
+            reconciliation_slot: ReconciliationSlot::new(),
             queues: Arc::new(GroupQueues::new(4)),
             dedupe: Arc::new(InboundDedupe::new(8)),
             backend,
@@ -1951,6 +1974,68 @@ mod tests {
         dispatch_test_message(ctx.clone(), "session-status", "/session-status").await;
 
         assert!(backend.invocations.lock().await.is_empty());
+        assert!(ctx.sessions.get("group").await.is_none());
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn inspect_commands_reply_while_recovery_fifo_is_blocked() {
+        let root = tempfile::tempdir().unwrap();
+        let home = root.path().join("home");
+        let repo = home.join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let backend = Arc::new(RecordingBackend::default());
+        let (ctx, server) = test_context(root.path(), &home, backend.clone());
+        ctx.recovery
+            .set(
+                "group",
+                RecoveryRecord {
+                    prompt: "private prompt".to_owned(),
+                    cwd: repo.clone(),
+                    session_id: "session".to_owned(),
+                    kind: RecoveryKind::UncertainOutcome,
+                    status: RecoveryStatus::Pending,
+                },
+            )
+            .await
+            .unwrap();
+        assert!(fifo_is_blocked(&ctx, "group").await);
+
+        tokio::time::timeout(
+            Duration::from_millis(500),
+            dispatch_test_message(ctx.clone(), "help", "/help"),
+        )
+        .await
+        .expect("blocked recovery must not park /help");
+        tokio::time::timeout(
+            Duration::from_millis(500),
+            dispatch_test_message(ctx.clone(), "status", "/status"),
+        )
+        .await
+        .expect("blocked recovery must not park /status");
+        tokio::time::timeout(
+            Duration::from_millis(500),
+            dispatch_test_message(ctx.clone(), "pwd", "/pwd"),
+        )
+        .await
+        .expect("blocked recovery must not park /pwd");
+        tokio::time::timeout(
+            Duration::from_millis(500),
+            dispatch_test_message(ctx.clone(), "goal-show", "/goal"),
+        )
+        .await
+        .expect("blocked recovery must not park /goal show");
+
+        assert!(backend.invocations.lock().await.is_empty());
+        assert!(
+            tokio::time::timeout(
+                Duration::from_millis(200),
+                dispatch_test_message(ctx.clone(), "cd", "/cd repo"),
+            )
+            .await
+            .is_err(),
+            "mutating commands still wait on the recovery FIFO"
+        );
         assert!(ctx.sessions.get("group").await.is_none());
         server.abort();
     }
@@ -2528,13 +2613,7 @@ mod tests {
         let store = SessionStore::load(home.join("sessions.json"), &home).unwrap();
         let recovery = RecoveryStore::load(home.join("recovery.json")).unwrap();
         store
-            .set(
-                "group1",
-                SessionRecord {
-                    session_id: "ses_stream".to_owned(),
-                    cwd: home.join("repo"),
-                },
-            )
+            .record_session("group1", "ses_stream".to_owned(), home.join("repo"))
             .await
             .unwrap();
 

--- a/integrations/terminal-harness/src/commands.rs
+++ b/integrations/terminal-harness/src/commands.rs
@@ -1,0 +1,354 @@
+use crate::repo_picker::is_valid_relative_path;
+
+/// Maximum byte length of a stored standing goal.
+pub(crate) const MAX_GOAL_BYTES: usize = 4096;
+
+/// One reserved harness chat command.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ChatCommand {
+    /// List the reserved commands and the workdir picker.
+    Help,
+    /// Report this lane's workdir, session, goal, and execution profile.
+    Status,
+    /// Report this lane's working directory.
+    Pwd,
+    /// Select a working directory and start a new session epoch.
+    Cd { path: String },
+    /// End the active backend session while retaining the workdir.
+    NewSession,
+    /// Retry the durable recovery record owned by PR #1568.
+    RetryLast,
+    /// Discard the durable recovery record owned by PR #1568.
+    DiscardLast,
+    /// Report the stored standing goal.
+    GoalShow,
+    /// Remove the stored standing goal.
+    GoalClear,
+    /// Replace the stored standing goal.
+    GoalSet { text: String },
+}
+
+/// How one inbound message body is routed before backend invocation.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum Routed {
+    /// A reserved harness command with usable arguments.
+    Command(ChatCommand),
+    /// A reserved command name used with unusable arguments.
+    Usage(&'static str),
+    /// Text forwarded verbatim; the workdir picker never applies.
+    Literal(String),
+    /// Ordinary prompt text; the workdir picker still applies.
+    Prompt(String),
+}
+
+/// Reserved command names paired with their `/help` description.
+const RESERVED: &[(&str, &str)] = &[
+    ("help", "list these commands"),
+    ("status", "show this chat's workdir, session, and goal"),
+    ("pwd", "show this chat's working directory"),
+    (
+        "cd",
+        "`/cd <path>` selects a working directory under $HOME and starts a new session",
+    ),
+    (
+        "new",
+        "end the current backend session and keep the workdir",
+    ),
+    ("reset-session", "same as `/new`"),
+    (
+        "session-status",
+        "show active-turn lane status when that lane is supported",
+    ),
+    ("retry-last", "retry the last recoverable backend attempt"),
+    (
+        "discard-last",
+        "discard the last recoverable backend attempt",
+    ),
+    (
+        "goal",
+        "`/goal <text>` sets a standing instruction, `/goal` shows it, `/goal clear` removes it",
+    ),
+];
+
+/// Returns true when `name` is a reserved harness command name.
+#[cfg(test)]
+fn is_reserved(name: &str) -> bool {
+    RESERVED.iter().any(|(reserved, _)| *reserved == name)
+}
+
+/// Renders the `/help` body for one connector.
+pub(crate) fn help_text(display_name: &str) -> String {
+    let mut text = format!("Commands handled by the harness, not by {display_name}:\n");
+    for (name, description) in RESERVED {
+        text.push_str(&format!("  /{name} - {description}\n"));
+    }
+    text.push_str(
+        "\nAnything else is sent to the backend as a prompt. On a chat with no workdir yet, `/<path>` \
+         selects a working directory under $HOME and the rest of the message becomes the first prompt. \
+         Prefix a message with `//` to send a literal leading slash, for example `//status`. A directory \
+         whose name matches a reserved command must be selected with `/cd`.",
+    );
+    text
+}
+
+/// Routes one inbound message body.
+pub(crate) fn route(text: &str) -> Routed {
+    let trimmed = text.trim();
+    let Some(rest) = trimmed.strip_prefix('/') else {
+        return Routed::Prompt(text.to_owned());
+    };
+    if rest.starts_with('/') {
+        let leading_bytes = text.len() - text.trim_start().len();
+        let escaped = &text[leading_bytes + 1..];
+        return Routed::Literal(format!("{}{escaped}", &text[..leading_bytes]));
+    }
+
+    let (name, args) = split_command(rest);
+    match name {
+        "help" => bare(ChatCommand::Help, args, "`/help` takes no arguments."),
+        "status" => bare(ChatCommand::Status, args, "`/status` takes no arguments."),
+        "pwd" => bare(ChatCommand::Pwd, args, "`/pwd` takes no arguments."),
+        "new" => bare(ChatCommand::NewSession, args, "`/new` takes no arguments."),
+        "reset-session" => bare(
+            ChatCommand::NewSession,
+            args,
+            "`/reset-session` takes no arguments.",
+        ),
+        "session-status" => Routed::Usage(
+            "`/session-status` is reserved for active-turn lane status and is not available in this harness yet.",
+        ),
+        "retry-last" => bare(
+            ChatCommand::RetryLast,
+            args,
+            "`/retry-last` takes no arguments.",
+        ),
+        "discard-last" => bare(
+            ChatCommand::DiscardLast,
+            args,
+            "`/discard-last` takes no arguments.",
+        ),
+        "cd" => route_cd(args),
+        "goal" => route_goal(args),
+        _ => Routed::Prompt(text.to_owned()),
+    }
+}
+
+fn route_cd(args: &str) -> Routed {
+    const USAGE: &str =
+        "Use `/cd <path>` with one path under $HOME, for example `/cd projects/mdk`.";
+    let path = args.trim();
+    if path.is_empty() || path.split_whitespace().count() != 1 || !is_valid_relative_path(path) {
+        return Routed::Usage(USAGE);
+    }
+    Routed::Command(ChatCommand::Cd {
+        path: path.to_owned(),
+    })
+}
+
+fn route_goal(args: &str) -> Routed {
+    let text = args.trim();
+    if text.is_empty() {
+        return Routed::Command(ChatCommand::GoalShow);
+    }
+    if text == "clear" {
+        return Routed::Command(ChatCommand::GoalClear);
+    }
+    if text.len() > MAX_GOAL_BYTES {
+        return Routed::Usage("The goal is too long. Keep it under 4096 bytes.");
+    }
+    Routed::Command(ChatCommand::GoalSet {
+        text: text.to_owned(),
+    })
+}
+
+fn bare(command: ChatCommand, args: &str, usage: &'static str) -> Routed {
+    if args.trim().is_empty() {
+        Routed::Command(command)
+    } else {
+        Routed::Usage(usage)
+    }
+}
+
+fn split_command(rest: &str) -> (&str, &str) {
+    match rest.find(char::is_whitespace) {
+        Some(index) => (&rest[..index], &rest[index..]),
+        None => (rest, ""),
+    }
+}
+
+/// Prepends the stored standing goal to one prompt.
+pub(crate) fn apply_goal(goal: &str, prompt: &str) -> String {
+    format!(
+        "Standing goal for this chat, set by the user and applied to every prompt:\n{goal}\n\n---\n\n{prompt}"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bare_reserved_names_never_route_to_the_backend() {
+        assert_eq!(route("/help"), Routed::Command(ChatCommand::Help));
+        assert_eq!(route("  /status\n"), Routed::Command(ChatCommand::Status));
+        assert_eq!(route("/pwd"), Routed::Command(ChatCommand::Pwd));
+        assert_eq!(route("/new"), Routed::Command(ChatCommand::NewSession));
+        assert_eq!(
+            route("/reset-session"),
+            Routed::Command(ChatCommand::NewSession)
+        );
+        assert!(matches!(route("/session-status"), Routed::Usage(_)));
+        assert_eq!(
+            route("/retry-last"),
+            Routed::Command(ChatCommand::RetryLast)
+        );
+        assert_eq!(
+            route("/discard-last"),
+            Routed::Command(ChatCommand::DiscardLast)
+        );
+    }
+
+    #[test]
+    fn reserved_names_with_stray_arguments_report_usage_instead_of_prompting() {
+        assert_eq!(
+            route("/reset-session please"),
+            Routed::Usage("`/reset-session` takes no arguments.")
+        );
+        assert_eq!(
+            route("/new now"),
+            Routed::Usage("`/new` takes no arguments.")
+        );
+        assert_eq!(
+            route("/help me"),
+            Routed::Usage("`/help` takes no arguments.")
+        );
+    }
+
+    #[test]
+    fn double_slash_forwards_one_literal_slash_and_skips_the_picker() {
+        assert_eq!(
+            route("//reset-session"),
+            Routed::Literal("/reset-session".to_owned())
+        );
+        assert_eq!(route("//status"), Routed::Literal("/status".to_owned()));
+        assert_eq!(
+            route("//usr/bin/env is a path"),
+            Routed::Literal("/usr/bin/env is a path".to_owned())
+        );
+        assert_eq!(
+            route("  //status \n"),
+            Routed::Literal("  /status \n".to_owned())
+        );
+    }
+
+    #[test]
+    fn unreserved_leading_slash_stays_a_prompt_so_the_picker_still_applies() {
+        assert_eq!(
+            route("/whitenoise fix the build"),
+            Routed::Prompt("/whitenoise fix the build".to_owned())
+        );
+        assert_eq!(
+            route("/projects/mdk"),
+            Routed::Prompt("/projects/mdk".to_owned())
+        );
+    }
+
+    #[test]
+    fn plain_text_is_never_a_command() {
+        assert_eq!(route("hello"), Routed::Prompt("hello".to_owned()));
+        assert_eq!(
+            route("run /help for me"),
+            Routed::Prompt("run /help for me".to_owned())
+        );
+    }
+
+    #[test]
+    fn prompt_routing_preserves_the_original_bytes() {
+        assert_eq!(
+            route("  keep   my\n whitespace  "),
+            Routed::Prompt("  keep   my\n whitespace  ".to_owned())
+        );
+    }
+
+    #[test]
+    fn cd_requires_exactly_one_valid_relative_path() {
+        assert_eq!(
+            route("/cd projects/mdk"),
+            Routed::Command(ChatCommand::Cd {
+                path: "projects/mdk".to_owned()
+            })
+        );
+        for rejected in [
+            "/cd",
+            "/cd ",
+            "/cd a b",
+            "/cd ..",
+            "/cd projects/../etc",
+            "/cd /absolute",
+            "/cd projects/",
+            "/cd proj!ect",
+        ] {
+            assert!(
+                matches!(route(rejected), Routed::Usage(_)),
+                "expected usage error for {rejected}"
+            );
+        }
+    }
+
+    #[test]
+    fn goal_supports_show_set_and_clear() {
+        assert_eq!(route("/goal"), Routed::Command(ChatCommand::GoalShow));
+        assert_eq!(route("/goal   "), Routed::Command(ChatCommand::GoalShow));
+        assert_eq!(
+            route("/goal clear"),
+            Routed::Command(ChatCommand::GoalClear)
+        );
+        assert_eq!(
+            route("/goal ship the connector"),
+            Routed::Command(ChatCommand::GoalSet {
+                text: "ship the connector".to_owned()
+            })
+        );
+    }
+
+    #[test]
+    fn goal_rejects_bodies_over_the_stored_bound() {
+        let long = "g".repeat(MAX_GOAL_BYTES + 1);
+        assert!(matches!(route(&format!("/goal {long}")), Routed::Usage(_)));
+        let limit = "g".repeat(MAX_GOAL_BYTES);
+        assert_eq!(
+            route(&format!("/goal {limit}")),
+            Routed::Command(ChatCommand::GoalSet { text: limit })
+        );
+    }
+
+    #[test]
+    fn help_lists_every_reserved_command() {
+        let text = help_text("codex");
+        for (name, _) in RESERVED {
+            assert!(text.contains(&format!("/{name} ")), "missing /{name}");
+        }
+        assert!(text.contains("codex"));
+        assert!(text.contains("//"));
+    }
+
+    #[test]
+    fn every_reserved_name_routes_away_from_the_picker() {
+        for (name, _) in RESERVED {
+            assert!(is_reserved(name));
+            assert!(
+                !matches!(route(&format!("/{name}")), Routed::Prompt(_)),
+                "/{name} must not fall through to the workdir picker"
+            );
+        }
+        assert!(!is_reserved("whitenoise"));
+    }
+
+    #[test]
+    fn goal_is_prepended_as_a_delimited_block() {
+        let combined = apply_goal("keep CI green", "fix the failing test");
+        assert!(combined.starts_with("Standing goal for this chat"));
+        assert!(combined.contains("keep CI green"));
+        assert!(combined.ends_with("fix the failing test"));
+    }
+}

--- a/integrations/terminal-harness/src/lib.rs
+++ b/integrations/terminal-harness/src/lib.rs
@@ -1,5 +1,6 @@
 mod bridge;
 mod chunking;
+mod commands;
 mod config;
 mod control;
 mod error;

--- a/integrations/terminal-harness/src/repo_picker.rs
+++ b/integrations/terminal-harness/src/repo_picker.rs
@@ -22,25 +22,29 @@ pub(crate) fn parse_repo_picker(text: &str) -> RepoPicker {
         .map(|(index, _)| index)
         .unwrap_or(rest.len());
     let path = &rest[..end];
-    if path.is_empty() {
+    if !is_valid_relative_path(path) {
         return RepoPicker::Invalid;
-    }
-    for segment in path.split('/') {
-        if segment.is_empty() || matches!(segment, "." | "..") {
-            return RepoPicker::Invalid;
-        }
-        if !segment
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
-        {
-            return RepoPicker::Invalid;
-        }
     }
 
     RepoPicker::Valid {
         path: path.to_owned(),
         prompt: rest[end..].trim_start().to_owned(),
     }
+}
+
+/// Returns true when `path` is a non-empty `$HOME`-relative path built only from
+/// ASCII letters, digits, `.`, `_`, and `-` segments, with no `.` or `..` segment.
+pub(crate) fn is_valid_relative_path(path: &str) -> bool {
+    if path.is_empty() {
+        return false;
+    }
+    path.split('/').all(|segment| {
+        !segment.is_empty()
+            && !matches!(segment, "." | "..")
+            && segment
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
+    })
 }
 
 pub(crate) async fn resolve_repo(name: &str, home: &Path) -> Result<PathBuf> {

--- a/integrations/terminal-harness/src/store.rs
+++ b/integrations/terminal-harness/src/store.rs
@@ -7,10 +7,15 @@ use tokio::sync::{Mutex, watch};
 
 use crate::error::Result;
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct SessionRecord {
     pub(crate) session_id: String,
-    pub(crate) cwd: PathBuf,
+    /// Selected working directory, or `None` when this chat has not chosen one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) cwd: Option<PathBuf>,
+    /// Standing instruction prepended to every prompt in this chat.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) goal: Option<String>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -54,7 +59,13 @@ pub(crate) struct FinalDeliveryRecord {
 #[serde(untagged)]
 enum RawRecord {
     Bare(String),
-    Full { session_id: String, cwd: PathBuf },
+    Full {
+        session_id: String,
+        #[serde(default)]
+        cwd: Option<PathBuf>,
+        #[serde(default)]
+        goal: Option<String>,
+    },
 }
 
 impl RawRecord {
@@ -62,9 +73,18 @@ impl RawRecord {
         match self {
             Self::Bare(session_id) => SessionRecord {
                 session_id,
-                cwd: default_cwd.to_path_buf(),
+                cwd: Some(default_cwd.to_path_buf()),
+                goal: None,
             },
-            Self::Full { session_id, cwd } => SessionRecord { session_id, cwd },
+            Self::Full {
+                session_id,
+                cwd,
+                goal,
+            } => SessionRecord {
+                session_id,
+                cwd,
+                goal,
+            },
         }
     }
 }
@@ -100,15 +120,33 @@ impl SessionStore {
         self.map.lock().await.get(group_key).cloned()
     }
 
-    pub(crate) async fn set(&self, group_key: &str, record: SessionRecord) -> Result<()> {
-        let mut map = self.map.lock().await;
-        let mut next = map.clone();
-        next.insert(group_key.to_owned(), record);
-        let path = self.path.clone();
-        let snapshot = next.clone();
-        tokio::task::spawn_blocking(move || write_snapshot(&path, &snapshot)).await??;
-        *map = next;
-        Ok(())
+    /// Records the backend session and working directory, retaining the goal.
+    pub(crate) async fn record_session(
+        &self,
+        group_key: &str,
+        session_id: String,
+        cwd: PathBuf,
+    ) -> Result<()> {
+        self.update(group_key, |record| {
+            record.session_id = session_id;
+            record.cwd = Some(cwd);
+        })
+        .await
+    }
+
+    /// Selects the working directory and starts a new session epoch, retaining
+    /// the goal.
+    pub(crate) async fn set_workdir(&self, group_key: &str, cwd: PathBuf) -> Result<()> {
+        self.update(group_key, |record| {
+            record.session_id.clear();
+            record.cwd = Some(cwd);
+        })
+        .await
+    }
+
+    /// Replaces the standing goal, retaining the session and working directory.
+    pub(crate) async fn set_goal(&self, group_key: &str, goal: Option<String>) -> Result<()> {
+        self.update(group_key, |record| record.goal = goal).await
     }
 
     pub(crate) async fn reset_session(&self, group_key: &str) -> Result<bool> {
@@ -125,12 +163,28 @@ impl SessionStore {
             .expect("record exists in cloned session map")
             .session_id
             .clear();
-        let path = self.path.clone();
-        let snapshot = next.clone();
-        tokio::task::spawn_blocking(move || write_snapshot(&path, &snapshot)).await??;
-        *map = next;
+        persist(&self.path, &mut map, next).await?;
         Ok(true)
     }
+
+    async fn update(&self, group_key: &str, apply: impl FnOnce(&mut SessionRecord)) -> Result<()> {
+        let mut map = self.map.lock().await;
+        let mut next = map.clone();
+        apply(next.entry(group_key.to_owned()).or_default());
+        persist(&self.path, &mut map, next).await
+    }
+}
+
+async fn persist(
+    path: &Path,
+    map: &mut HashMap<String, SessionRecord>,
+    next: HashMap<String, SessionRecord>,
+) -> Result<()> {
+    let path = path.to_path_buf();
+    let snapshot = next.clone();
+    tokio::task::spawn_blocking(move || write_snapshot(&path, &snapshot)).await??;
+    *map = next;
+    Ok(())
 }
 
 pub(crate) struct RecoveryStore {
@@ -484,17 +538,76 @@ mod tests {
 
         {
             let store = SessionStore::load(path.clone(), &home).unwrap();
-            let record = SessionRecord {
-                session_id: "ses_abc123".to_owned(),
-                cwd: home.join("proj"),
-            };
-            store.set("group1", record).await.unwrap();
+            store
+                .record_session("group1", "ses_abc123".to_owned(), home.join("proj"))
+                .await
+                .unwrap();
+            store
+                .set_goal("group1", Some("ship the release".to_owned()))
+                .await
+                .unwrap();
         }
 
         let store = SessionStore::load(path.clone(), &home).unwrap();
         let record = store.get("group1").await.expect("record persisted");
         assert_eq!(record.session_id, "ses_abc123");
-        assert_eq!(record.cwd, home.join("proj"));
+        assert_eq!(record.cwd, Some(home.join("proj")));
+        assert_eq!(record.goal.as_deref(), Some("ship the release"));
+    }
+
+    #[tokio::test]
+    async fn goal_only_records_leave_the_workdir_unselected() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sessions.json");
+        let home = dir.path().to_path_buf();
+
+        {
+            let store = SessionStore::load(path.clone(), &home).unwrap();
+            store
+                .set_goal("group1", Some("pick a repo later".to_owned()))
+                .await
+                .unwrap();
+            let record = store.get("group1").await.expect("goal-only record");
+            assert_eq!(record.cwd, None);
+            assert_eq!(record.session_id, "");
+        }
+
+        let store = SessionStore::load(path, &home).unwrap();
+        let record = store
+            .get("group1")
+            .await
+            .expect("goal-only record reloaded");
+        assert_eq!(record.cwd, None);
+        assert_eq!(record.goal.as_deref(), Some("pick a repo later"));
+    }
+
+    #[tokio::test]
+    async fn set_workdir_starts_a_new_epoch_and_keeps_the_goal() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sessions.json");
+        let home = dir.path().to_path_buf();
+        let store = SessionStore::load(path, &home).unwrap();
+        store
+            .record_session("group1", "ses_old".to_owned(), home.join("first"))
+            .await
+            .unwrap();
+        store
+            .set_goal("group1", Some("keep CI green".to_owned()))
+            .await
+            .unwrap();
+
+        store
+            .set_workdir("group1", home.join("second"))
+            .await
+            .unwrap();
+
+        let record = store.get("group1").await.unwrap();
+        assert_eq!(record.session_id, "");
+        assert_eq!(record.cwd, Some(home.join("second")));
+        assert_eq!(record.goal.as_deref(), Some("keep CI green"));
+
+        store.set_goal("group1", None).await.unwrap();
+        assert_eq!(store.get("group1").await.unwrap().goal, None);
     }
 
     #[tokio::test]
@@ -508,23 +621,15 @@ mod tests {
         {
             let store = SessionStore::load(path.clone(), &home).unwrap();
             store
-                .set(
-                    "group1",
-                    SessionRecord {
-                        session_id: "ses_first".to_owned(),
-                        cwd: first_cwd.clone(),
-                    },
-                )
+                .record_session("group1", "ses_first".to_owned(), first_cwd.clone())
                 .await
                 .unwrap();
             store
-                .set(
-                    "group2",
-                    SessionRecord {
-                        session_id: "ses_second".to_owned(),
-                        cwd: second_cwd.clone(),
-                    },
-                )
+                .record_session("group2", "ses_second".to_owned(), second_cwd.clone())
+                .await
+                .unwrap();
+            store
+                .set_goal("group2", Some("second goal".to_owned()))
                 .await
                 .unwrap();
 
@@ -534,10 +639,11 @@ mod tests {
         let store = SessionStore::load(path, &home).unwrap();
         let first = store.get("group1").await.expect("first group retained");
         assert_eq!(first.session_id, "");
-        assert_eq!(first.cwd, first_cwd);
+        assert_eq!(first.cwd, Some(first_cwd));
         let second = store.get("group2").await.expect("second group retained");
         assert_eq!(second.session_id, "ses_second");
-        assert_eq!(second.cwd, second_cwd);
+        assert_eq!(second.cwd, Some(second_cwd));
+        assert_eq!(second.goal.as_deref(), Some("second goal"));
     }
 
     #[tokio::test]
@@ -548,27 +654,41 @@ mod tests {
         let cwd = home.join("proj");
         let store = SessionStore::load(path.clone(), &home).unwrap();
         store
-            .set(
-                "group1",
-                SessionRecord {
-                    session_id: "ses_original".to_owned(),
-                    cwd: cwd.clone(),
-                },
-            )
+            .record_session("group1", "ses_original".to_owned(), cwd.clone())
             .await
             .unwrap();
         std::fs::create_dir(path.with_extension("json.tmp")).unwrap();
 
         assert!(store.reset_session("group1").await.is_err());
+        assert!(
+            store
+                .set_goal("group1", Some("g".to_owned()))
+                .await
+                .is_err()
+        );
+        assert!(
+            store
+                .set_workdir("group1", home.join("other"))
+                .await
+                .is_err()
+        );
+        assert!(
+            store
+                .record_session("group1", "ses_other".to_owned(), home.join("other"))
+                .await
+                .is_err()
+        );
         let current = store.get("group1").await.unwrap();
         assert_eq!(current.session_id, "ses_original");
-        assert_eq!(current.cwd, cwd);
+        assert_eq!(current.cwd, Some(cwd.clone()));
+        assert_eq!(current.goal, None);
         drop(store);
 
         let reloaded = SessionStore::load(path, &home).unwrap();
         let current = reloaded.get("group1").await.unwrap();
         assert_eq!(current.session_id, "ses_original");
-        assert_eq!(current.cwd, cwd);
+        assert_eq!(current.cwd, Some(cwd));
+        assert_eq!(current.goal, None);
     }
 
     #[tokio::test]
@@ -582,7 +702,25 @@ mod tests {
         let store = SessionStore::load(path, &home).unwrap();
         let record = store.get("group1").await.expect("legacy record");
         assert_eq!(record.session_id, "ses_legacy");
-        assert_eq!(record.cwd, home);
+        assert_eq!(record.cwd, Some(home));
+        assert_eq!(record.goal, None);
+    }
+
+    #[tokio::test]
+    async fn session_store_accepts_records_written_before_the_goal_field_existed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sessions.json");
+        let home = dir.path().to_path_buf();
+        let legacy = serde_json::json!({
+            "group1": { "session_id": "ses_full", "cwd": home.join("proj") }
+        });
+        std::fs::write(&path, serde_json::to_vec(&legacy).unwrap()).unwrap();
+
+        let store = SessionStore::load(path, &home).unwrap();
+        let record = store.get("group1").await.expect("legacy full record");
+        assert_eq!(record.session_id, "ses_full");
+        assert_eq!(record.cwd, Some(home.join("proj")));
+        assert_eq!(record.goal, None);
     }
 
     #[tokio::test]
@@ -743,13 +881,7 @@ mod tests {
         let home = dir.path().to_path_buf();
         let store = SessionStore::load(path.clone(), &home).unwrap();
         store
-            .set(
-                "group1",
-                SessionRecord {
-                    session_id: "ses_private".to_owned(),
-                    cwd: home,
-                },
-            )
+            .record_session("group1", "ses_private".to_owned(), home)
             .await
             .unwrap();
         assert!(store.reset_session("group1").await.unwrap());


### PR DESCRIPTION
## Summary

- route `/help`, `/status`, `/pwd`, `/cd`, `/new`, `/reset-session`, `/goal`, and the recovery commands before picker or backend dispatch
- preserve unknown leading-slash prompts and forward `//` escapes byte-for-byte after stripping exactly one slash
- persist per-group workdir, session, and bounded standing-goal state with atomic sibling-preserving updates and legacy migration
- keep `/session-status` reserved for the separate active-turn lane without claiming its semantics
- reconcile command routing with the durable recovery behavior from #1568, including exactly-once standing-goal application on `/retry-last`
- let read-only inspect commands (`/help`, `/status`, `/pwd`, `/goal` show) and usage replies answer immediately while recovery FIFO is blocked
- document the shared contract for Codex, OpenCode, Pi, and future terminal adapters

## Verification

- `cargo test -p marmot-terminal-harness -p wn-codex -p wn-opencode -p wn-pi`
- `just fmt-check && just check && just clippy`

Closes #1572

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared chat commands including `/help`, `/status`, `/pwd`, `/cd`, `/new`, `/reset-session`, retry/discard controls, and `/goal`.
  * Added persistent standing goals that are included with future prompts.
  * Added `//` escaping for sending literal slash-prefixed messages.
  * Added command usage replies and session/workdir status handling.
* **Bug Fixes**
  * Reserved commands are handled consistently instead of being forwarded to backends.
  * Session resets preserve the selected workdir and transcripts.
* **Documentation**
  * Updated connector and harness documentation with the new command behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->