### PR TITLE
Let a host supply its own account secret store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3405,6 +3405,7 @@ dependencies = [
  "marmot-uniffi",
  "tempfile",
  "tokio",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/marmot-c/CHANGELOG.md
+++ b/crates/marmot-c/CHANGELOG.md
@@ -18,6 +18,11 @@ Versions track the workspace version; releases are tagged `marmotc-v<version>`.
   bundle. ([#1545](https://github.com/marmot-protocol/mdk/pull/1545))
 - `alloc-audit` test feature proving deep-free completeness; C smoke
   example run under gcc, clang, and valgrind in CI. ([#1545](https://github.com/marmot-protocol/mdk/pull/1545))
+- `marmot_client_new_with_secret_store` plus the `MarmotSecretStore`
+  callback vtable and `MarmotSecretStoreStatus`: a host can hold account
+  signing keys in its own storage (an encrypted vault, a custom keystore)
+  instead of the platform keychain. `marmot_client_new` is unchanged.
+  ([#1575](https://github.com/marmot-protocol/mdk/pull/1575))
 - `marmot_rotate_key_package`: rotate the account's KeyPackage under its
   proper name (with a matching `rotate_key_package` on the UniFFI
   surface); `marmot_publish_new_key_package` stays as the legacy alias.

--- a/crates/marmot-c/Cargo.toml
+++ b/crates/marmot-c/Cargo.toml
@@ -20,6 +20,8 @@ alloc-audit = []
 marmot-uniffi.workspace = true
 tokio = { workspace = true, features = ["io-util", "net", "time"] }
 libc.workspace = true
+# Holds a host-supplied secret-key hex only as long as the boundary needs it.
+zeroize.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/marmot-c/cbindgen.toml
+++ b/crates/marmot-c/cbindgen.toml
@@ -37,6 +37,7 @@ prefix = ""
 include = [
     "MarmotNotificationWakeSource",
     "MarmotCursorPersistence",
+    "MarmotSecretStoreStatus",
     "MarmotHostPerformanceOperation",
     "MarmotHostPerformanceOutcome",
 ]

--- a/crates/marmot-c/include/marmot.h
+++ b/crates/marmot-c/include/marmot.h
@@ -587,6 +587,33 @@ typedef enum MarmotCursorPersistence {
 } MarmotCursorPersistence;
 
 /**
+ * Status a [`MarmotSecretStore`] callback returns. Crosses as
+ * `uint32_t`; an out-of-range value is rejected as
+ * `MARMOT_STATUS_INVALID_ARGUMENT`.
+ */
+typedef enum MarmotSecretStoreStatus {
+  /**
+   * The operation succeeded.
+   */
+  MARMOT_SECRET_STORE_STATUS_OK,
+  /**
+   * No credential is stored for this account. Only `load_secret`
+   * should report it; `remove_secret` on a missing credential
+   * succeeds.
+   */
+  MARMOT_SECRET_STORE_STATUS_NOT_FOUND,
+  /**
+   * The store exists but cannot be reached right now (locked vault,
+   * keystore unavailable). The runtime treats this as recoverable.
+   */
+  MARMOT_SECRET_STORE_STATUS_UNAVAILABLE,
+  /**
+   * Any other failure.
+   */
+  MARMOT_SECRET_STORE_STATUS_FAILED,
+} MarmotSecretStoreStatus;
+
+/**
  * Host-side operation a UI can time and report back.
  */
 typedef enum MarmotHostPerformanceOperation {
@@ -670,6 +697,77 @@ typedef struct MarmotTimelineSubscription MarmotTimelineSubscription;
  * at its next checkpoint.
  */
 typedef struct MarmotUserSearchSubscription MarmotUserSearchSubscription;
+
+/**
+ * `has_secret_for_label` / `has_secret_for_account_id`: write nonzero to
+ * `out_present` when a credential exists.
+ */
+typedef uint32_t (*MarmotSecretStoreHasFn)(void *user_data, const char *key, uint8_t *out_present);
+
+/**
+ * `write_secret`: persist `secret_key_hex`, replacing any existing
+ * credential for this account.
+ */
+typedef uint32_t (*MarmotSecretStoreWriteFn)(void *user_data,
+                                             const char *label,
+                                             const char *account_id_hex,
+                                             const char *secret_key_hex);
+
+/**
+ * `load_secret`: write a NUL-terminated secret-key hex string to
+ * `out_secret_key_hex`. The library copies it and returns the buffer to
+ * `free_secret`.
+ */
+typedef uint32_t (*MarmotSecretStoreLoadFn)(void *user_data,
+                                            const char *label,
+                                            const char *account_id_hex,
+                                            char **out_secret_key_hex);
+
+/**
+ * `remove_secret`: drop this account's credential. Removing a missing
+ * credential succeeds.
+ */
+typedef uint32_t (*MarmotSecretStoreRemoveFn)(void *user_data,
+                                              const char *label,
+                                              const char *account_id_hex);
+
+/**
+ * `free_secret`: release a buffer this store returned from `load_secret`.
+ */
+typedef void (*MarmotSecretStoreFreeSecretFn)(void *user_data, char *secret_key_hex);
+
+/**
+ * `destroy`: the library is done with `user_data`.
+ */
+typedef void (*MarmotSecretStoreDestroyFn)(void *user_data);
+
+/**
+ * Callback vtable for host-owned account-secret storage. Borrowed input:
+ * the fields are copied at construction and the struct itself is never
+ * retained or freed by the library. Every function pointer except
+ * `destroy` is required.
+ *
+ * See the module documentation for the thread-safety, re-entry, and
+ * ownership rules a host must honor.
+ */
+typedef struct MarmotSecretStore {
+  /**
+   * Opaque host context passed to every callback. Must outlive the
+   * client; released by `destroy`.
+   */
+  void *user_data;
+  MarmotSecretStoreHasFn has_secret_for_label;
+  MarmotSecretStoreHasFn has_secret_for_account_id;
+  MarmotSecretStoreWriteFn write_secret;
+  MarmotSecretStoreLoadFn load_secret;
+  MarmotSecretStoreRemoveFn remove_secret;
+  MarmotSecretStoreFreeSecretFn free_secret;
+  /**
+   * Optional; invoked once when the last runtime reference to the store
+   * is released. NULL means the host reclaims `user_data` itself.
+   */
+  MarmotSecretStoreDestroyFn destroy;
+} MarmotSecretStore;
 
 /**
  * One signed-in (or signed-out but known) account.
@@ -3528,6 +3626,32 @@ MarmotStatus marmot_client_new_with_cursor_persistence(const char *root_path,
                                                        uintptr_t relay_urls_len,
                                                        uint32_t cursor_persistence,
                                                        struct MarmotClient **out_client);
+
+/**
+ * Create a Marmot client whose account signing keys live in caller-owned
+ * storage instead of the platform keychain. Otherwise identical to
+ * `marmot_client_new`.
+ *
+ * `store` is borrowed for the duration of this call: its fields are
+ * copied, so the caller may free their struct as soon as it returns.
+ * `store->user_data` must stay alive until `store->destroy` fires. Every
+ * callback except `destroy` is required; a missing one is
+ * `MARMOT_STATUS_NULL_POINTER`.
+ *
+ * The callbacks run on runtime worker threads, possibly concurrently, and
+ * must not call any `marmot_*` function on this client — see the
+ * `MarmotSecretStore` documentation for the full contract.
+ *
+ * # Safety
+ * `root_path` must be a valid NUL-terminated UTF-8 string; `relay_urls`
+ * must point to `relay_urls_len` valid strings (or be NULL with length
+ * 0); `store` and `out_client` must be valid pointers.
+ */
+MarmotStatus marmot_client_new_with_secret_store(const char *root_path,
+                                                 const char *const *relay_urls,
+                                                 uintptr_t relay_urls_len,
+                                                 const struct MarmotSecretStore *store,
+                                                 struct MarmotClient **out_client);
 
 /**
  * Start the runtime (reconcile accounts, start workers, subscribe

--- a/crates/marmot-c/include/marmot.h
+++ b/crates/marmot-c/include/marmot.h
@@ -3792,8 +3792,8 @@ MarmotStatus marmot_sign_out(const struct MarmotClient *client,
                              struct MarmotSignOutOutcome **out);
 
 /**
- * Create a brand-new Nostr identity, store its secret in the platform
- * keychain, and publish initial relay lists + key package. Free with
+ * Create a brand-new Nostr identity, store its secret in the account
+ * secret store, and publish initial relay lists + key package. Free with
  * `marmot_account_summary_free`.
  *
  * # Safety

--- a/crates/marmot-c/include/marmot.h
+++ b/crates/marmot-c/include/marmot.h
@@ -588,8 +588,12 @@ typedef enum MarmotCursorPersistence {
 
 /**
  * Status a [`MarmotSecretStore`] callback returns. Crosses as
- * `uint32_t`; an out-of-range value is rejected as
- * `MARMOT_STATUS_INVALID_ARGUMENT`.
+ * `uint32_t`. An out-of-range value is rejected, and surfaces to the
+ * caller as the store failure it is (`MARMOT_STATUS_RUNTIME`, detail
+ * text in `marmot_last_error_message`) — a callback's return travels
+ * back through the runtime's typed errors, so it cannot become
+ * `MARMOT_STATUS_INVALID_ARGUMENT`, which is reserved for values the
+ * caller passes *in*.
  */
 typedef enum MarmotSecretStoreStatus {
   /**
@@ -3636,7 +3640,9 @@ MarmotStatus marmot_client_new_with_cursor_persistence(const char *root_path,
  * copied, so the caller may free their struct as soon as it returns.
  * `store->user_data` must stay alive until `store->destroy` fires. Every
  * callback except `destroy` is required; a missing one is
- * `MARMOT_STATUS_NULL_POINTER`.
+ * `MARMOT_STATUS_NULL_POINTER`. On any status but `MARMOT_STATUS_OK` this
+ * call takes no ownership and never invokes `destroy`; reclaiming
+ * `user_data` stays the caller's job.
  *
  * The callbacks run on runtime worker threads, possibly concurrently, and
  * must not call any `marmot_*` function on this client — see the

--- a/crates/marmot-c/src/commands.rs
+++ b/crates/marmot-c/src/commands.rs
@@ -530,8 +530,8 @@ c_cmd! {
     /// NIP-09 deletions. Free with `marmot_sign_out_outcome_free`.
     async fn marmot_sign_out(account_ref: str, delete_key_packages: flag) -> rec(MarmotSignOutOutcome) = sign_out;
 
-    /// Create a brand-new Nostr identity, store its secret in the platform
-    /// keychain, and publish initial relay lists + key package. Free with
+    /// Create a brand-new Nostr identity, store its secret in the account
+    /// secret store, and publish initial relay lists + key package. Free with
     /// `marmot_account_summary_free`.
     async fn marmot_create_identity(default_relays/default_relays_len: str_arr, bootstrap_relays/bootstrap_relays_len: str_arr) -> rec(MarmotAccountSummary) = create_identity;
 

--- a/crates/marmot-c/src/lib.rs
+++ b/crates/marmot-c/src/lib.rs
@@ -212,7 +212,9 @@ pub unsafe extern "C" fn marmot_client_new_with_cursor_persistence(
 /// copied, so the caller may free their struct as soon as it returns.
 /// `store->user_data` must stay alive until `store->destroy` fires. Every
 /// callback except `destroy` is required; a missing one is
-/// `MARMOT_STATUS_NULL_POINTER`.
+/// `MARMOT_STATUS_NULL_POINTER`. On any status but `MARMOT_STATUS_OK` this
+/// call takes no ownership and never invokes `destroy`; reclaiming
+/// `user_data` stays the caller's job.
 ///
 /// The callbacks run on runtime worker threads, possibly concurrently, and
 /// must not call any `marmot_*` function on this client — see the
@@ -238,17 +240,20 @@ pub unsafe extern "C" fn marmot_client_new_with_secret_store(
             Ok(store) => Arc::new(store),
             Err(status) => return status,
         };
-        unsafe {
-            open_client(
-                root_path,
-                relay_urls,
-                relay_urls_len,
-                out_client,
+        let status = unsafe {
+            open_client(root_path, relay_urls, relay_urls_len, out_client, {
+                let store = Arc::clone(&store);
                 move |root_path, relay_urls| {
                     Marmot::new_with_secret_store(root_path, relay_urls, store)
-                },
-            )
+                }
+            })
+        };
+        // Ownership of `user_data` transfers only once the caller holds a
+        // handle: until then a failure leaves the host's store untouched.
+        if status == MarmotStatus::Ok {
+            store.arm();
         }
+        status
     })
 }
 

--- a/crates/marmot-c/src/lib.rs
+++ b/crates/marmot-c/src/lib.rs
@@ -25,6 +25,7 @@ use marmot_uniffi::Marmot;
 pub mod commands;
 pub(crate) mod macros;
 pub mod memory;
+pub mod secret_store;
 pub mod status;
 pub mod subscriptions;
 pub mod types;
@@ -32,6 +33,7 @@ pub mod types;
 pub use status::MarmotStatus;
 
 use memory::{owned_c_string, required_str, str_array};
+use secret_store::{CSecretStore, MarmotSecretStore};
 use status::set_last_error;
 use types::notification::MarmotCursorPersistence;
 
@@ -196,6 +198,54 @@ pub unsafe extern "C" fn marmot_client_new_with_cursor_persistence(
                         relay_urls,
                         cursor_persistence.into(),
                     )
+                },
+            )
+        }
+    })
+}
+
+/// Create a Marmot client whose account signing keys live in caller-owned
+/// storage instead of the platform keychain. Otherwise identical to
+/// `marmot_client_new`.
+///
+/// `store` is borrowed for the duration of this call: its fields are
+/// copied, so the caller may free their struct as soon as it returns.
+/// `store->user_data` must stay alive until `store->destroy` fires. Every
+/// callback except `destroy` is required; a missing one is
+/// `MARMOT_STATUS_NULL_POINTER`.
+///
+/// The callbacks run on runtime worker threads, possibly concurrently, and
+/// must not call any `marmot_*` function on this client — see the
+/// `MarmotSecretStore` documentation for the full contract.
+///
+/// # Safety
+/// `root_path` must be a valid NUL-terminated UTF-8 string; `relay_urls`
+/// must point to `relay_urls_len` valid strings (or be NULL with length
+/// 0); `store` and `out_client` must be valid pointers.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn marmot_client_new_with_secret_store(
+    root_path: *const c_char,
+    relay_urls: *const *const c_char,
+    relay_urls_len: usize,
+    store: *const MarmotSecretStore,
+    out_client: *mut *mut MarmotClient,
+) -> MarmotStatus {
+    ffi_guard(|| {
+        if let Err(status) = unsafe { preflight_out_ptr(out_client) } {
+            return status;
+        }
+        let store = match unsafe { CSecretStore::from_c(store) } {
+            Ok(store) => Arc::new(store),
+            Err(status) => return status,
+        };
+        unsafe {
+            open_client(
+                root_path,
+                relay_urls,
+                relay_urls_len,
+                out_client,
+                move |root_path, relay_urls| {
+                    Marmot::new_with_secret_store(root_path, relay_urls, store)
                 },
             )
         }

--- a/crates/marmot-c/src/macros.rs
+++ b/crates/marmot-c/src/macros.rs
@@ -278,6 +278,19 @@ macro_rules! c_list {
 /// `CFree`. Variant names must match the Ffi enum's.
 macro_rules! c_enum {
     ($(#[$m:meta])* $name:ident from $ffi:ty { $($(#[$vm:meta])* $v:ident),+ $(,)? }) => {
+        crate::macros::c_enum!($(#[$m])* $name { $($(#[$vm])* $v),+ });
+
+        impl From<$ffi> for $name {
+            fn from(value: $ffi) -> Self {
+                match value { $(<$ffi>::$v => Self::$v),+ }
+            }
+        }
+    };
+
+    // No `Ffi` source: a value only the *caller* produces (a callback's
+    // return status), so there is nothing to convert from — just the
+    // discriminant validation.
+    ($(#[$m:meta])* $name:ident { $($(#[$vm:meta])* $v:ident),+ $(,)? }) => {
         $(#[$m])*
         #[repr(C)]
         #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -298,12 +311,6 @@ macro_rules! c_enum {
                     ));
                     crate::MarmotStatus::InvalidArgument
                 })
-            }
-        }
-
-        impl From<$ffi> for $name {
-            fn from(value: $ffi) -> Self {
-                match value { $(<$ffi>::$v => Self::$v),+ }
             }
         }
 

--- a/crates/marmot-c/src/secret_store.rs
+++ b/crates/marmot-c/src/secret_store.rs
@@ -1,0 +1,589 @@
+//! Host-supplied account-secret storage over a C callback vtable.
+//!
+//! `marmot_client_new` keeps account signing keys in the platform keychain.
+//! A host that already owns an encrypted store (a desktop client with a
+//! password-sealed vault, for example) fills in a [`MarmotSecretStore`] and
+//! constructs with [`crate::marmot_client_new_with_secret_store`] instead.
+//! The signing key crosses as secret-key hex; an account is identified by
+//! its `label` plus `account_id_hex`.
+//!
+//! **Rules for the host, all of them load-bearing:**
+//!
+//! - **Thread safety.** The callbacks run on the runtime's worker threads
+//!   and may run concurrently. `user_data` access must be synchronized.
+//! - **No re-entry.** A callback must not call any `marmot_*` function on
+//!   the same client. It runs while the account home holds its mutation
+//!   lock, so re-entering deadlocks.
+//! - **No unwinding.** A callback must return a status, never unwind. The
+//!   callbacks are `extern "C"`, whose ABI aborts the process on an escaping
+//!   unwind, so neither a C++ exception nor a Rust panic raised *inside* a
+//!   callback can be recovered. Everything the library itself runs around
+//!   the call (argument marshalling, status validation) is wrapped in
+//!   `catch_unwind` and reported as a store failure instead.
+//! - **Storage boundary, not a security boundary.** The plaintext key hex
+//!   crosses in both directions. Rust holds it zeroizing for the shortest
+//!   window it can, and hands the buffer returned by `load_secret` straight
+//!   back to `free_secret`; protecting it at rest is the host's job.
+//! - **Ownership.** The [`MarmotSecretStore`] struct is *copied* at
+//!   construction, so the caller may free their copy as soon as the call
+//!   returns. `user_data` must stay alive until `destroy` fires, which
+//!   happens when the last runtime reference is released (at or shortly
+//!   after `marmot_client_free`).
+
+use std::ffi::{CStr, c_char, c_void};
+use std::panic::AssertUnwindSafe;
+
+use marmot_uniffi::{MarmotKitError, SecretStore};
+use zeroize::Zeroizing;
+
+use crate::MarmotStatus;
+use crate::macros::c_enum;
+use crate::status::set_last_error;
+
+c_enum! {
+    /// Status a [`MarmotSecretStore`] callback returns. Crosses as
+    /// `uint32_t`; an out-of-range value is rejected as
+    /// `MARMOT_STATUS_INVALID_ARGUMENT`.
+    MarmotSecretStoreStatus {
+        /// The operation succeeded.
+        Ok,
+        /// No credential is stored for this account. Only `load_secret`
+        /// should report it; `remove_secret` on a missing credential
+        /// succeeds.
+        NotFound,
+        /// The store exists but cannot be reached right now (locked vault,
+        /// keystore unavailable). The runtime treats this as recoverable.
+        Unavailable,
+        /// Any other failure.
+        Failed,
+    }
+}
+
+/// `has_secret_for_label` / `has_secret_for_account_id`: write nonzero to
+/// `out_present` when a credential exists.
+pub type MarmotSecretStoreHasFn = Option<
+    unsafe extern "C" fn(user_data: *mut c_void, key: *const c_char, out_present: *mut u8) -> u32,
+>;
+
+/// `write_secret`: persist `secret_key_hex`, replacing any existing
+/// credential for this account.
+pub type MarmotSecretStoreWriteFn = Option<
+    unsafe extern "C" fn(
+        user_data: *mut c_void,
+        label: *const c_char,
+        account_id_hex: *const c_char,
+        secret_key_hex: *const c_char,
+    ) -> u32,
+>;
+
+/// `load_secret`: write a NUL-terminated secret-key hex string to
+/// `out_secret_key_hex`. The library copies it and returns the buffer to
+/// `free_secret`.
+pub type MarmotSecretStoreLoadFn = Option<
+    unsafe extern "C" fn(
+        user_data: *mut c_void,
+        label: *const c_char,
+        account_id_hex: *const c_char,
+        out_secret_key_hex: *mut *mut c_char,
+    ) -> u32,
+>;
+
+/// `remove_secret`: drop this account's credential. Removing a missing
+/// credential succeeds.
+pub type MarmotSecretStoreRemoveFn = Option<
+    unsafe extern "C" fn(
+        user_data: *mut c_void,
+        label: *const c_char,
+        account_id_hex: *const c_char,
+    ) -> u32,
+>;
+
+/// `free_secret`: release a buffer this store returned from `load_secret`.
+pub type MarmotSecretStoreFreeSecretFn =
+    Option<unsafe extern "C" fn(user_data: *mut c_void, secret_key_hex: *mut c_char)>;
+
+/// `destroy`: the library is done with `user_data`.
+pub type MarmotSecretStoreDestroyFn = Option<unsafe extern "C" fn(user_data: *mut c_void)>;
+
+/// Callback vtable for host-owned account-secret storage. Borrowed input:
+/// the fields are copied at construction and the struct itself is never
+/// retained or freed by the library. Every function pointer except
+/// `destroy` is required.
+///
+/// See the module documentation for the thread-safety, re-entry, and
+/// ownership rules a host must honor.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct MarmotSecretStore {
+    /// Opaque host context passed to every callback. Must outlive the
+    /// client; released by `destroy`.
+    pub user_data: *mut c_void,
+    pub has_secret_for_label: MarmotSecretStoreHasFn,
+    pub has_secret_for_account_id: MarmotSecretStoreHasFn,
+    pub write_secret: MarmotSecretStoreWriteFn,
+    pub load_secret: MarmotSecretStoreLoadFn,
+    pub remove_secret: MarmotSecretStoreRemoveFn,
+    pub free_secret: MarmotSecretStoreFreeSecretFn,
+    /// Optional; invoked once when the last runtime reference to the store
+    /// is released. NULL means the host reclaims `user_data` itself.
+    pub destroy: MarmotSecretStoreDestroyFn,
+}
+
+/// Adapts the C vtable to the UniFFI `SecretStore` trait.
+///
+/// `Send`/`Sync` rest on the documented host contract: the callbacks and
+/// any access to `user_data` must be thread-safe, because the runtime
+/// invokes them from worker threads, possibly concurrently.
+pub(crate) struct CSecretStore {
+    vtable: MarmotSecretStore,
+}
+
+unsafe impl Send for CSecretStore {}
+unsafe impl Sync for CSecretStore {}
+
+impl CSecretStore {
+    /// Copy a caller-supplied vtable, rejecting a NULL struct or a missing
+    /// required callback. The caller's struct is borrowed only for this
+    /// call.
+    ///
+    /// # Safety
+    /// `store` must be NULL or point to a valid `MarmotSecretStore`.
+    pub(crate) unsafe fn from_c(store: *const MarmotSecretStore) -> Result<Self, MarmotStatus> {
+        if store.is_null() {
+            set_last_error("secret store argument was NULL");
+            return Err(MarmotStatus::NullPointer);
+        }
+        let vtable = unsafe { *store };
+
+        let required = [
+            (
+                "has_secret_for_label",
+                vtable.has_secret_for_label.is_some(),
+            ),
+            (
+                "has_secret_for_account_id",
+                vtable.has_secret_for_account_id.is_some(),
+            ),
+            ("write_secret", vtable.write_secret.is_some()),
+            ("load_secret", vtable.load_secret.is_some()),
+            ("remove_secret", vtable.remove_secret.is_some()),
+            ("free_secret", vtable.free_secret.is_some()),
+        ];
+        for (name, present) in required {
+            if !present {
+                set_last_error(format!("secret store callback {name} was NULL"));
+                return Err(MarmotStatus::NullPointer);
+            }
+        }
+
+        Ok(Self { vtable })
+    }
+}
+
+impl Drop for CSecretStore {
+    fn drop(&mut self) {
+        let Some(destroy) = self.vtable.destroy else {
+            return;
+        };
+        // A panic here would unwind out of a Drop the runtime is running;
+        // the host has no way to receive it either way.
+        crate::memory::free_guard(|| unsafe { destroy(self.vtable.user_data) });
+    }
+}
+
+/// Invoke one host callback, translating a panic and the returned
+/// discriminant into a typed error.
+///
+/// A caught panic becomes an opaque store failure rather than unwinding
+/// through the runtime that called us. (A panic raised inside the
+/// `extern "C"` callback itself aborts at its own ABI boundary and never
+/// reaches here; this covers the marshalling around the call.)
+fn guard(op: &str, call: impl FnOnce() -> u32) -> Result<(), MarmotKitError> {
+    let raw =
+        std::panic::catch_unwind(AssertUnwindSafe(call)).map_err(|_| MarmotKitError::Runtime {
+            details: format!("host secret store panicked in {op}"),
+        })?;
+
+    match MarmotSecretStoreStatus::from_c(raw) {
+        Ok(MarmotSecretStoreStatus::Ok) => Ok(()),
+        Ok(MarmotSecretStoreStatus::NotFound) => Err(MarmotKitError::SecretNotFound {
+            details: format!("host secret store has no credential ({op})"),
+        }),
+        Ok(MarmotSecretStoreStatus::Unavailable) => Err(MarmotKitError::KeystoreUnavailable {
+            details: format!("host secret store unavailable ({op})"),
+        }),
+        Ok(MarmotSecretStoreStatus::Failed) => Err(MarmotKitError::Runtime {
+            details: format!("host secret store failed ({op})"),
+        }),
+        Err(_) => Err(MarmotKitError::Runtime {
+            details: format!("host secret store returned status {raw} out of range ({op})"),
+        }),
+    }
+}
+
+/// Borrow an owned Rust string as a NUL-terminated C string for the
+/// duration of `call`. Labels and hex ids never contain interior NUL, so a
+/// rejected conversion is a corrupt argument, not a truncation to hide.
+fn with_c_str<R>(
+    value: &str,
+    op: &str,
+    call: impl FnOnce(*const c_char) -> Result<R, MarmotKitError>,
+) -> Result<R, MarmotKitError> {
+    let owned = std::ffi::CString::new(value).map_err(|_| MarmotKitError::Runtime {
+        details: format!("secret store argument contained a NUL byte ({op})"),
+    })?;
+    call(owned.as_ptr())
+}
+
+impl SecretStore for CSecretStore {
+    fn has_secret_for_label(&self, label: String) -> Result<bool, MarmotKitError> {
+        self.has(
+            self.vtable.has_secret_for_label,
+            &label,
+            "has_secret_for_label",
+        )
+    }
+
+    fn has_secret_for_account_id(&self, account_id_hex: String) -> Result<bool, MarmotKitError> {
+        self.has(
+            self.vtable.has_secret_for_account_id,
+            &account_id_hex,
+            "has_secret_for_account_id",
+        )
+    }
+
+    fn write_secret(
+        &self,
+        label: String,
+        account_id_hex: String,
+        secret_key_hex: String,
+    ) -> Result<(), MarmotKitError> {
+        let write = self.vtable.write_secret.expect("checked in from_c");
+        let secret_key_hex = Zeroizing::new(secret_key_hex);
+        let user_data = self.vtable.user_data;
+
+        with_c_str(&label, "write_secret", |label| {
+            with_c_str(&account_id_hex, "write_secret", |account| {
+                with_c_str(&secret_key_hex, "write_secret", |secret| {
+                    guard("write_secret", || unsafe {
+                        write(user_data, label, account, secret)
+                    })
+                })
+            })
+        })
+    }
+
+    fn load_secret(&self, label: String, account_id_hex: String) -> Result<String, MarmotKitError> {
+        let load = self.vtable.load_secret.expect("checked in from_c");
+        let free_secret = self.vtable.free_secret.expect("checked in from_c");
+        let user_data = self.vtable.user_data;
+
+        let secret_key_hex = with_c_str(&label, "load_secret", |label| {
+            with_c_str(&account_id_hex, "load_secret", |account| {
+                let mut out: *mut c_char = std::ptr::null_mut();
+                guard("load_secret", || unsafe {
+                    load(user_data, label, account, &raw mut out)
+                })?;
+                if out.is_null() {
+                    return Err(MarmotKitError::Runtime {
+                        details: "host secret store returned OK with a NULL secret".to_owned(),
+                    });
+                }
+
+                // Copy into a zeroizing buffer and hand the host's buffer
+                // back immediately: the plaintext exists in two places for
+                // as short a window as the boundary allows.
+                let copied = unsafe { CStr::from_ptr(out) }
+                    .to_str()
+                    .map(|text| Zeroizing::new(text.to_owned()))
+                    .map_err(|_| MarmotKitError::Runtime {
+                        details: "host secret store returned non-UTF-8 hex".to_owned(),
+                    });
+                crate::memory::free_guard(|| unsafe { free_secret(user_data, out) });
+                copied
+            })
+        })?;
+
+        Ok(secret_key_hex.to_string())
+    }
+
+    fn remove_secret(&self, label: String, account_id_hex: String) -> Result<(), MarmotKitError> {
+        let remove = self.vtable.remove_secret.expect("checked in from_c");
+        let user_data = self.vtable.user_data;
+
+        with_c_str(&label, "remove_secret", |label| {
+            with_c_str(&account_id_hex, "remove_secret", |account| {
+                guard("remove_secret", || unsafe {
+                    remove(user_data, label, account)
+                })
+            })
+        })
+    }
+}
+
+impl CSecretStore {
+    /// Shared body of the two `has_*` probes: both take one key and write a
+    /// `uint8_t` presence flag.
+    fn has(
+        &self,
+        callback: MarmotSecretStoreHasFn,
+        key: &str,
+        op: &str,
+    ) -> Result<bool, MarmotKitError> {
+        let callback = callback.expect("checked in from_c");
+        let user_data = self.vtable.user_data;
+
+        with_c_str(key, op, |key| {
+            let mut present: u8 = 0;
+            guard(op, || unsafe { callback(user_data, key, &raw mut present) })?;
+            Ok(crate::memory::c_bool(present))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+
+    /// Host-side state a test vtable operates on, reached through
+    /// `user_data`.
+    #[derive(Default)]
+    struct HostState {
+        entries: Mutex<Vec<(String, String)>>,
+        freed: Mutex<usize>,
+        destroyed: Mutex<bool>,
+        /// Status every op returns instead of running, when set.
+        forced_status: Mutex<Option<u32>>,
+    }
+
+    unsafe fn state<'a>(user_data: *mut c_void) -> &'a HostState {
+        unsafe { &*(user_data as *const HostState) }
+    }
+
+    unsafe extern "C" fn has_label(
+        user_data: *mut c_void,
+        key: *const c_char,
+        out_present: *mut u8,
+    ) -> u32 {
+        let host = unsafe { state(user_data) };
+        if let Some(status) = *host.forced_status.lock().unwrap() {
+            return status;
+        }
+        let key = unsafe { CStr::from_ptr(key) }.to_str().unwrap().to_owned();
+        let present = host.entries.lock().unwrap().iter().any(|(k, _)| *k == key);
+        unsafe { out_present.write(u8::from(present)) };
+        MarmotSecretStoreStatus::Ok as u32
+    }
+
+    unsafe extern "C" fn has_account(
+        _user_data: *mut c_void,
+        _key: *const c_char,
+        out_present: *mut u8,
+    ) -> u32 {
+        unsafe { out_present.write(0) };
+        MarmotSecretStoreStatus::Ok as u32
+    }
+
+    unsafe extern "C" fn write_secret(
+        user_data: *mut c_void,
+        label: *const c_char,
+        _account: *const c_char,
+        secret: *const c_char,
+    ) -> u32 {
+        let host = unsafe { state(user_data) };
+        if let Some(status) = *host.forced_status.lock().unwrap() {
+            return status;
+        }
+        let label = unsafe { CStr::from_ptr(label) }
+            .to_str()
+            .unwrap()
+            .to_owned();
+        let secret = unsafe { CStr::from_ptr(secret) }
+            .to_str()
+            .unwrap()
+            .to_owned();
+        host.entries.lock().unwrap().push((label, secret));
+        MarmotSecretStoreStatus::Ok as u32
+    }
+
+    unsafe extern "C" fn load_secret(
+        user_data: *mut c_void,
+        label: *const c_char,
+        _account: *const c_char,
+        out_secret: *mut *mut c_char,
+    ) -> u32 {
+        let host = unsafe { state(user_data) };
+        if let Some(status) = *host.forced_status.lock().unwrap() {
+            return status;
+        }
+        let label = unsafe { CStr::from_ptr(label) }
+            .to_str()
+            .unwrap()
+            .to_owned();
+        let found = host
+            .entries
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|(k, _)| *k == label)
+            .map(|(_, secret)| secret.clone());
+        let Some(secret) = found else {
+            return MarmotSecretStoreStatus::NotFound as u32;
+        };
+        // The host owns this allocation until free_secret hands it back.
+        unsafe { out_secret.write(std::ffi::CString::new(secret).unwrap().into_raw()) };
+        MarmotSecretStoreStatus::Ok as u32
+    }
+
+    unsafe extern "C" fn remove_secret(
+        user_data: *mut c_void,
+        label: *const c_char,
+        _account: *const c_char,
+    ) -> u32 {
+        let host = unsafe { state(user_data) };
+        let label = unsafe { CStr::from_ptr(label) }
+            .to_str()
+            .unwrap()
+            .to_owned();
+        host.entries.lock().unwrap().retain(|(k, _)| *k != label);
+        MarmotSecretStoreStatus::Ok as u32
+    }
+
+    unsafe extern "C" fn free_secret(user_data: *mut c_void, secret: *mut c_char) {
+        let host = unsafe { state(user_data) };
+        *host.freed.lock().unwrap() += 1;
+        drop(unsafe { std::ffi::CString::from_raw(secret) });
+    }
+
+    unsafe extern "C" fn destroy(user_data: *mut c_void) {
+        *unsafe { state(user_data) }.destroyed.lock().unwrap() = true;
+    }
+
+    fn vtable(host: &HostState) -> MarmotSecretStore {
+        MarmotSecretStore {
+            user_data: std::ptr::from_ref(host) as *mut c_void,
+            has_secret_for_label: Some(has_label),
+            has_secret_for_account_id: Some(has_account),
+            write_secret: Some(write_secret),
+            load_secret: Some(load_secret),
+            remove_secret: Some(remove_secret),
+            free_secret: Some(free_secret),
+            destroy: Some(destroy),
+        }
+    }
+
+    fn store(host: &HostState) -> CSecretStore {
+        let vtable = vtable(host);
+        unsafe { CSecretStore::from_c(&raw const vtable) }.expect("valid vtable")
+    }
+
+    #[test]
+    fn callback_store_roundtrips_a_secret() {
+        let host = HostState::default();
+        let store = store(&host);
+
+        assert!(!store.has_secret_for_label("a".into()).unwrap());
+        store
+            .write_secret("a".into(), "ff".into(), "deadbeef".into())
+            .unwrap();
+        assert!(store.has_secret_for_label("a".into()).unwrap());
+        assert_eq!(
+            store.load_secret("a".into(), "ff".into()).unwrap(),
+            "deadbeef"
+        );
+        // The host's buffer went straight back through free_secret.
+        assert_eq!(*host.freed.lock().unwrap(), 1);
+
+        store.remove_secret("a".into(), "ff".into()).unwrap();
+        assert!(!store.has_secret_for_label("a".into()).unwrap());
+        assert!(matches!(
+            store.load_secret("a".into(), "ff".into()),
+            Err(MarmotKitError::SecretNotFound { .. })
+        ));
+    }
+
+    #[test]
+    fn destroy_fires_once_when_the_store_is_released() {
+        let host = HostState::default();
+        drop(store(&host));
+        assert!(*host.destroyed.lock().unwrap());
+    }
+
+    #[test]
+    fn error_statuses_map_to_their_marmot_status() {
+        let host = HostState::default();
+        let store = store(&host);
+
+        for (raw, expected) in [
+            (
+                MarmotSecretStoreStatus::NotFound,
+                MarmotStatus::SecretNotFound,
+            ),
+            (
+                MarmotSecretStoreStatus::Unavailable,
+                MarmotStatus::KeystoreUnavailable,
+            ),
+            (MarmotSecretStoreStatus::Failed, MarmotStatus::Runtime),
+        ] {
+            *host.forced_status.lock().unwrap() = Some(raw as u32);
+            let err = store
+                .has_secret_for_label("a".into())
+                .expect_err("forced failure");
+            assert_eq!(crate::status::status_from_error(&err), expected);
+        }
+    }
+
+    #[test]
+    fn an_out_of_range_status_is_rejected_as_invalid_argument() {
+        // The discriminant validation itself is what the C caller sees as
+        // MARMOT_STATUS_INVALID_ARGUMENT.
+        assert_eq!(
+            MarmotSecretStoreStatus::from_c(4),
+            Err(MarmotStatus::InvalidArgument)
+        );
+        assert_eq!(
+            MarmotSecretStoreStatus::from_c(u32::MAX),
+            Err(MarmotStatus::InvalidArgument)
+        );
+
+        // An out-of-range status from a live callback surfaces as a store
+        // failure rather than being read as a valid enum (which would be
+        // undefined behavior).
+        let host = HostState::default();
+        let store = store(&host);
+        *host.forced_status.lock().unwrap() = Some(4242);
+        let err = store
+            .has_secret_for_label("a".into())
+            .expect_err("out-of-range status");
+        assert!(err.to_string().contains("out of range"), "{err}");
+    }
+
+    #[test]
+    fn a_panic_around_a_callback_is_caught_and_reported() {
+        // A panic must never unwind out of the store adapter into the
+        // runtime worker that called it. (A panic inside the `extern "C"`
+        // callback itself aborts at its own ABI boundary and is
+        // unreachable from here, which is exactly why the host contract
+        // forbids unwinding.)
+        let err = guard("load_secret", || panic!("marshalling blew up"))
+            .expect_err("panic must not escape");
+        assert!(err.to_string().contains("panicked"), "{err}");
+    }
+
+    #[test]
+    fn a_missing_required_callback_is_rejected() {
+        let host = HostState::default();
+        let mut vtable = vtable(&host);
+        vtable.load_secret = None;
+        assert_eq!(
+            unsafe { CSecretStore::from_c(&raw const vtable) }.err(),
+            Some(MarmotStatus::NullPointer)
+        );
+        assert_eq!(
+            unsafe { CSecretStore::from_c(std::ptr::null()) }.err(),
+            Some(MarmotStatus::NullPointer)
+        );
+    }
+}

--- a/crates/marmot-c/src/secret_store.rs
+++ b/crates/marmot-c/src/secret_store.rs
@@ -28,10 +28,13 @@
 //!   construction, so the caller may free their copy as soon as the call
 //!   returns. `user_data` must stay alive until `destroy` fires, which
 //!   happens when the last runtime reference is released (at or shortly
-//!   after `marmot_client_free`).
+//!   after `marmot_client_free`). A constructor that returns anything but
+//!   `MARMOT_STATUS_OK` never calls `destroy` — construction took no
+//!   ownership, and reclaiming `user_data` stays the host's job.
 
 use std::ffi::{CStr, c_char, c_void};
 use std::panic::AssertUnwindSafe;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use marmot_uniffi::{MarmotKitError, SecretStore};
 use zeroize::Zeroizing;
@@ -42,8 +45,12 @@ use crate::status::set_last_error;
 
 c_enum! {
     /// Status a [`MarmotSecretStore`] callback returns. Crosses as
-    /// `uint32_t`; an out-of-range value is rejected as
-    /// `MARMOT_STATUS_INVALID_ARGUMENT`.
+    /// `uint32_t`. An out-of-range value is rejected, and surfaces to the
+    /// caller as the store failure it is (`MARMOT_STATUS_RUNTIME`, detail
+    /// text in `marmot_last_error_message`) — a callback's return travels
+    /// back through the runtime's typed errors, so it cannot become
+    /// `MARMOT_STATUS_INVALID_ARGUMENT`, which is reserved for values the
+    /// caller passes *in*.
     MarmotSecretStoreStatus {
         /// The operation succeeded.
         Ok,
@@ -136,6 +143,11 @@ pub struct MarmotSecretStore {
 /// invokes them from worker threads, possibly concurrently.
 pub(crate) struct CSecretStore {
     vtable: MarmotSecretStore,
+    /// Set once the client handle reaches the caller. Construction can
+    /// still fail after the vtable is accepted (bad `root_path`, runtime
+    /// build, store open); `destroy` must not fire on that path, or a host
+    /// that reclaims `user_data` after the failed call frees it twice.
+    armed: AtomicBool,
 }
 
 unsafe impl Send for CSecretStore {}
@@ -176,12 +188,24 @@ impl CSecretStore {
             }
         }
 
-        Ok(Self { vtable })
+        Ok(Self {
+            vtable,
+            armed: AtomicBool::new(false),
+        })
+    }
+
+    /// Take ownership of `user_data`: from here on `destroy` fires when the
+    /// last runtime reference goes away.
+    pub(crate) fn arm(&self) {
+        self.armed.store(true, Ordering::Release);
     }
 }
 
 impl Drop for CSecretStore {
     fn drop(&mut self) {
+        if !self.armed.load(Ordering::Acquire) {
+            return;
+        }
         let Some(destroy) = self.vtable.destroy else {
             return;
         };
@@ -507,8 +531,19 @@ mod tests {
     #[test]
     fn destroy_fires_once_when_the_store_is_released() {
         let host = HostState::default();
-        drop(store(&host));
+        let store = store(&host);
+        store.arm();
+        drop(store);
         assert!(*host.destroyed.lock().unwrap());
+    }
+
+    #[test]
+    fn destroy_is_suppressed_when_construction_never_armed_the_store() {
+        // A constructor that fails after accepting the vtable drops the
+        // store unarmed; the host still owns user_data.
+        let host = HostState::default();
+        drop(store(&host));
+        assert!(!*host.destroyed.lock().unwrap());
     }
 
     #[test]

--- a/crates/marmot-c/tests/secret_store_client.rs
+++ b/crates/marmot-c/tests/secret_store_client.rs
@@ -1,0 +1,144 @@
+//! A host-supplied secret store must be enough to open a client, with no
+//! platform keychain involved, and must be released when the client is.
+
+use std::ffi::{CStr, CString, c_char, c_void};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use marmot_c::secret_store::{MarmotSecretStore, MarmotSecretStoreStatus};
+use marmot_c::{
+    MarmotClient, MarmotStatus, marmot_client_free, marmot_client_new_with_secret_store,
+    marmot_client_shutdown,
+};
+
+/// The host's vault, reached through `user_data`.
+static ENTRIES: Mutex<Vec<(String, String)>> = Mutex::new(Vec::new());
+static DESTROYED: AtomicBool = AtomicBool::new(false);
+
+unsafe extern "C" fn has(_user_data: *mut c_void, key: *const c_char, out: *mut u8) -> u32 {
+    let key = unsafe { CStr::from_ptr(key) }.to_str().unwrap().to_owned();
+    let present = ENTRIES.lock().unwrap().iter().any(|(k, _)| *k == key);
+    unsafe { out.write(u8::from(present)) };
+    MarmotSecretStoreStatus::Ok as u32
+}
+
+unsafe extern "C" fn write_secret(
+    _user_data: *mut c_void,
+    label: *const c_char,
+    _account: *const c_char,
+    secret: *const c_char,
+) -> u32 {
+    let label = unsafe { CStr::from_ptr(label) }
+        .to_str()
+        .unwrap()
+        .to_owned();
+    let secret = unsafe { CStr::from_ptr(secret) }
+        .to_str()
+        .unwrap()
+        .to_owned();
+    ENTRIES.lock().unwrap().push((label, secret));
+    MarmotSecretStoreStatus::Ok as u32
+}
+
+unsafe extern "C" fn load_secret(
+    _user_data: *mut c_void,
+    label: *const c_char,
+    _account: *const c_char,
+    out: *mut *mut c_char,
+) -> u32 {
+    let label = unsafe { CStr::from_ptr(label) }
+        .to_str()
+        .unwrap()
+        .to_owned();
+    let found = ENTRIES
+        .lock()
+        .unwrap()
+        .iter()
+        .find(|(k, _)| *k == label)
+        .map(|(_, secret)| secret.clone());
+    let Some(secret) = found else {
+        return MarmotSecretStoreStatus::NotFound as u32;
+    };
+    unsafe { out.write(CString::new(secret).unwrap().into_raw()) };
+    MarmotSecretStoreStatus::Ok as u32
+}
+
+unsafe extern "C" fn remove_secret(
+    _user_data: *mut c_void,
+    label: *const c_char,
+    _account: *const c_char,
+) -> u32 {
+    let label = unsafe { CStr::from_ptr(label) }
+        .to_str()
+        .unwrap()
+        .to_owned();
+    ENTRIES.lock().unwrap().retain(|(k, _)| *k != label);
+    MarmotSecretStoreStatus::Ok as u32
+}
+
+unsafe extern "C" fn free_secret(_user_data: *mut c_void, secret: *mut c_char) {
+    drop(unsafe { CString::from_raw(secret) });
+}
+
+unsafe extern "C" fn destroy(_user_data: *mut c_void) {
+    DESTROYED.store(true, Ordering::SeqCst);
+}
+
+#[test]
+fn a_host_store_opens_a_client_without_the_platform_keychain() {
+    let root = tempfile::tempdir().expect("temp dir");
+    let root_path = CString::new(root.path().to_str().expect("utf-8 temp path")).unwrap();
+    let relay = CString::new("wss://relay.example.org").unwrap();
+    let relays = [relay.as_ptr()];
+
+    let store = MarmotSecretStore {
+        user_data: std::ptr::null_mut(),
+        has_secret_for_label: Some(has),
+        has_secret_for_account_id: Some(has),
+        write_secret: Some(write_secret),
+        load_secret: Some(load_secret),
+        remove_secret: Some(remove_secret),
+        free_secret: Some(free_secret),
+        destroy: Some(destroy),
+    };
+
+    let mut client: *mut MarmotClient = std::ptr::null_mut();
+    let status = unsafe {
+        marmot_client_new_with_secret_store(
+            root_path.as_ptr(),
+            relays.as_ptr(),
+            1,
+            &raw const store,
+            &raw mut client,
+        )
+    };
+    assert_eq!(status, MarmotStatus::Ok, "host store must need no keystore");
+    assert!(!client.is_null());
+
+    unsafe { marmot_client_shutdown(client) };
+    unsafe { marmot_client_free(client) };
+
+    assert!(
+        DESTROYED.load(Ordering::SeqCst),
+        "destroy must fire once the client releases the store"
+    );
+}
+
+#[test]
+fn a_null_store_is_rejected_before_the_client_is_built() {
+    let root = tempfile::tempdir().expect("temp dir");
+    let root_path = CString::new(root.path().to_str().expect("utf-8 temp path")).unwrap();
+    let mut client: *mut MarmotClient = std::ptr::dangling_mut();
+
+    let status = unsafe {
+        marmot_client_new_with_secret_store(
+            root_path.as_ptr(),
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            &raw mut client,
+        )
+    };
+    assert_eq!(status, MarmotStatus::NullPointer);
+    assert!(client.is_null(), "out-pointer must be cleared at entry");
+}

--- a/crates/marmot-c/tests/secret_store_client.rs
+++ b/crates/marmot-c/tests/secret_store_client.rs
@@ -124,6 +124,52 @@ fn a_host_store_opens_a_client_without_the_platform_keychain() {
     );
 }
 
+/// Separate flag: the success-path `destroy` above fires in the same
+/// process, so this test cannot share it.
+static DESTROYED_AFTER_FAILURE: AtomicBool = AtomicBool::new(false);
+
+unsafe extern "C" fn destroy_after_failure(_user_data: *mut c_void) {
+    DESTROYED_AFTER_FAILURE.store(true, Ordering::SeqCst);
+}
+
+#[test]
+fn a_failure_after_the_vtable_is_accepted_leaves_user_data_to_the_host() {
+    let root = tempfile::tempdir().expect("temp dir");
+    let root_path = CString::new(root.path().to_str().expect("utf-8 temp path")).unwrap();
+    // Accepted vtable, then a bad relay array: the failure lands after the
+    // store was taken but before any handle reached the caller.
+    let relays = [std::ptr::null()];
+
+    let store = MarmotSecretStore {
+        user_data: std::ptr::null_mut(),
+        has_secret_for_label: Some(has),
+        has_secret_for_account_id: Some(has),
+        write_secret: Some(write_secret),
+        load_secret: Some(load_secret),
+        remove_secret: Some(remove_secret),
+        free_secret: Some(free_secret),
+        destroy: Some(destroy_after_failure),
+    };
+
+    let mut client: *mut MarmotClient = std::ptr::dangling_mut();
+    let status = unsafe {
+        marmot_client_new_with_secret_store(
+            root_path.as_ptr(),
+            relays.as_ptr(),
+            1,
+            &raw const store,
+            &raw mut client,
+        )
+    };
+
+    assert_eq!(status, MarmotStatus::NullPointer);
+    assert!(client.is_null());
+    assert!(
+        !DESTROYED_AFTER_FAILURE.load(Ordering::SeqCst),
+        "a failed constructor must not destroy user_data the host still owns"
+    );
+}
+
 #[test]
 fn a_null_store_is_rejected_before_the_client_is_built() {
     let root = tempfile::tempdir().expect("temp dir");

--- a/crates/marmot-uniffi/src/lib.rs
+++ b/crates/marmot-uniffi/src/lib.rs
@@ -31,6 +31,7 @@ pub mod conversions;
 mod errors;
 mod external_signer;
 mod markdown;
+mod secret_store;
 pub mod subscriptions;
 
 use conversions::group_id_from_hex;
@@ -41,6 +42,7 @@ pub use markdown::{
     MarkdownDocumentFfi, MarkdownInlineFfi, MarkdownLinkDestinationKindFfi, MarkdownListItemFfi,
     MarkdownListKindFfi, MarkdownNostrEntityFfi, MarkdownNostrHrpFfi, MarkdownTableCellFfi,
 };
+pub use secret_store::SecretStore;
 
 uniffi::setup_scaffolding!();
 
@@ -169,7 +171,36 @@ impl Marmot {
     /// to events.
     #[uniffi::constructor]
     pub fn new(root_path: String, relay_urls: Vec<String>) -> Result<Arc<Self>, MarmotKitError> {
-        Self::open(root_path, relay_urls, MarmotAppConfig::default())
+        Self::open(root_path, relay_urls, MarmotAppConfig::default(), None)
+    }
+
+    /// Open the Marmot app with host-supplied account-secret storage instead
+    /// of the platform keychain. Identical to [`Marmot::new`] except that
+    /// every read, write, and removal of an account signing key goes through
+    /// `secret_store`.
+    ///
+    /// For hosts that already own an encrypted store: a desktop client with a
+    /// password-sealed vault, an iOS host that wants its own Keychain
+    /// access-control flags, an Android host layering policy over the
+    /// Keystore. The key crosses the boundary as secret-key hex, so the store
+    /// is responsible for protecting it at rest.
+    ///
+    /// `secret_store` is called from runtime worker threads and may be called
+    /// concurrently; implementations must be thread-safe.
+    #[uniffi::constructor]
+    pub fn new_with_secret_store(
+        root_path: String,
+        relay_urls: Vec<String>,
+        secret_store: Arc<dyn SecretStore>,
+    ) -> Result<Arc<Self>, MarmotKitError> {
+        Self::open(
+            root_path,
+            relay_urls,
+            MarmotAppConfig::default(),
+            Some(Arc::new(secret_store::ForeignSecretStore::new(
+                secret_store,
+            ))),
+        )
     }
 
     /// Open the Marmot app with an explicit durable transport-cursor policy.
@@ -196,6 +227,7 @@ impl Marmot {
             root_path,
             relay_urls,
             MarmotAppConfig::default().with_cursor_persistence(cursor_persistence.into()),
+            None,
         )
     }
 
@@ -285,15 +317,20 @@ impl Marmot {
 }
 
 impl Marmot {
-    /// Shared open path behind the exported constructors: keychain-backed
-    /// account home, app configured by `config`, runtime pair.
+    /// Shared open path behind the exported constructors: account home backed
+    /// by `secret_store` (the platform keychain when `None`), app configured
+    /// by `config`, runtime pair.
     fn open(
         root_path: String,
         relay_urls: Vec<String>,
         config: MarmotAppConfig,
+        secret_store: Option<Arc<dyn marmot_account::AccountSecretStore>>,
     ) -> Result<Arc<Self>, MarmotKitError> {
-        let account_home = marmot_account::AccountHome::open_with_default_keychain(&root_path)
-            .map_err(marmot_app::AppError::from)?;
+        let account_home = match secret_store {
+            Some(store) => marmot_account::AccountHome::open_with_secret_store(&root_path, store),
+            None => marmot_account::AccountHome::open_with_default_keychain(&root_path)
+                .map_err(marmot_app::AppError::from)?,
+        };
         let app = MarmotApp::try_with_relays_and_account_home_and_config(
             &root_path,
             relay_urls,

--- a/crates/marmot-uniffi/src/secret_store.rs
+++ b/crates/marmot-uniffi/src/secret_store.rs
@@ -1,0 +1,253 @@
+//! Host-supplied account-secret storage.
+//!
+//! By default account signing keys live in the platform keychain
+//! ([`crate::Marmot::new`]). A host that already owns an encrypted store —
+//! a desktop client with a password-sealed vault, an iOS host that wants
+//! its own Keychain access-control flags, an Android host layering its own
+//! Keystore policy — implements [`SecretStore`] and constructs through
+//! [`crate::Marmot::new_with_secret_store`] instead.
+//!
+//! The boundary is strings only: the signing key crosses as secret-key hex
+//! and an account is identified by its `label` plus `account_id_hex`, which
+//! is everything a store needs from `AccountSummary`.
+
+use std::sync::Arc;
+
+use marmot_account::{AccountSecretStore, AccountSummary};
+use zeroize::Zeroizing;
+
+use crate::MarmotKitError;
+
+/// Foreign-implemented storage for account signing keys.
+///
+/// Implementations must be thread-safe: the runtime calls these methods
+/// from worker threads and may call them concurrently.
+///
+/// This is a storage boundary, not a security boundary. The plaintext
+/// secret-key hex crosses it in both directions; whatever protection the
+/// key gets (encryption, an OS keystore, a password-derived seal) is the
+/// implementation's responsibility.
+#[uniffi::export(with_foreign)]
+pub trait SecretStore: Send + Sync {
+    /// Whether a credential is stored under `label`.
+    fn has_secret_for_label(&self, label: String) -> Result<bool, MarmotKitError>;
+
+    /// Whether a credential is stored under `account_id_hex`. Stores that
+    /// key one credential per label report `false`.
+    fn has_secret_for_account_id(&self, account_id_hex: String) -> Result<bool, MarmotKitError>;
+
+    /// Persist `secret_key_hex` for this account, replacing any existing
+    /// credential.
+    fn write_secret(
+        &self,
+        label: String,
+        account_id_hex: String,
+        secret_key_hex: String,
+    ) -> Result<(), MarmotKitError>;
+
+    /// Return the stored secret-key hex, or [`MarmotKitError::SecretNotFound`]
+    /// when this account has no credential.
+    fn load_secret(&self, label: String, account_id_hex: String) -> Result<String, MarmotKitError>;
+
+    /// Remove this account's credential. Removing a missing credential
+    /// succeeds.
+    fn remove_secret(&self, label: String, account_id_hex: String) -> Result<(), MarmotKitError>;
+}
+
+/// Adapts a foreign [`SecretStore`] to the engine's [`AccountSecretStore`].
+pub(crate) struct ForeignSecretStore {
+    store: Arc<dyn SecretStore>,
+}
+
+impl ForeignSecretStore {
+    pub(crate) fn new(store: Arc<dyn SecretStore>) -> Self {
+        Self { store }
+    }
+}
+
+impl AccountSecretStore for ForeignSecretStore {
+    fn has_secret_for_label(&self, label: &str) -> marmot_account::AccountHomeResult<bool> {
+        self.store
+            .has_secret_for_label(label.to_owned())
+            .map_err(account_home_error)
+    }
+
+    fn has_secret_for_account_id(
+        &self,
+        account_id_hex: &str,
+    ) -> marmot_account::AccountHomeResult<bool> {
+        self.store
+            .has_secret_for_account_id(account_id_hex.to_owned())
+            .map_err(account_home_error)
+    }
+
+    fn write_secret(
+        &self,
+        account: &AccountSummary,
+        keys: &nostr::Keys,
+    ) -> marmot_account::AccountHomeResult<()> {
+        let secret_key_hex = Zeroizing::new(keys.secret_key().to_secret_hex());
+        self.store
+            .write_secret(
+                account.label.clone(),
+                account.account_id_hex.clone(),
+                secret_key_hex.to_string(),
+            )
+            .map_err(account_home_error)
+    }
+
+    fn load_secret(
+        &self,
+        account: &AccountSummary,
+    ) -> marmot_account::AccountHomeResult<nostr::Keys> {
+        let secret_key_hex = Zeroizing::new(
+            self.store
+                .load_secret(account.label.clone(), account.account_id_hex.clone())
+                .map_err(account_home_error)?,
+        );
+        nostr::Keys::parse(secret_key_hex.as_str())
+            .map_err(|_| marmot_account::AccountHomeError::InvalidSecretKey)
+    }
+
+    fn remove_secret(&self, account: &AccountSummary) -> marmot_account::AccountHomeResult<()> {
+        self.store
+            .remove_secret(account.label.clone(), account.account_id_hex.clone())
+            .map_err(account_home_error)
+    }
+}
+
+/// Map a host-reported failure onto the account layer's existing secret-store
+/// error variants. `SecretNotFound` and an unavailable store are the two the
+/// engine reacts to differently; everything else is opaque store failure.
+fn account_home_error(error: MarmotKitError) -> marmot_account::AccountHomeError {
+    use marmot_account::AccountHomeError;
+
+    match error {
+        MarmotKitError::SecretNotFound { details } => AccountHomeError::SecretNotFound(details),
+        MarmotKitError::KeystoreUnavailable { details } => {
+            AccountHomeError::SecretStoreUnavailable(details)
+        }
+        other => AccountHomeError::SecretStore(other.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+
+    struct MapStore {
+        entries: Mutex<Vec<(String, String)>>,
+    }
+
+    impl SecretStore for MapStore {
+        fn has_secret_for_label(&self, label: String) -> Result<bool, MarmotKitError> {
+            Ok(self
+                .entries
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|(key, _)| *key == label))
+        }
+
+        fn has_secret_for_account_id(
+            &self,
+            _account_id_hex: String,
+        ) -> Result<bool, MarmotKitError> {
+            Ok(false)
+        }
+
+        fn write_secret(
+            &self,
+            label: String,
+            _account_id_hex: String,
+            secret_key_hex: String,
+        ) -> Result<(), MarmotKitError> {
+            self.entries.lock().unwrap().push((label, secret_key_hex));
+            Ok(())
+        }
+
+        fn load_secret(
+            &self,
+            label: String,
+            _account_id_hex: String,
+        ) -> Result<String, MarmotKitError> {
+            self.entries
+                .lock()
+                .unwrap()
+                .iter()
+                .find(|(key, _)| *key == label)
+                .map(|(_, secret)| secret.clone())
+                .ok_or(MarmotKitError::SecretNotFound { details: label })
+        }
+
+        fn remove_secret(
+            &self,
+            label: String,
+            _account_id_hex: String,
+        ) -> Result<(), MarmotKitError> {
+            self.entries
+                .lock()
+                .unwrap()
+                .retain(|(key, _)| *key != label);
+            Ok(())
+        }
+    }
+
+    fn summary(keys: &nostr::Keys) -> AccountSummary {
+        AccountSummary {
+            label: "vault-account".to_owned(),
+            account_id_hex: keys.public_key().to_hex(),
+            local_signing: true,
+            external_signing: false,
+            signed_out: false,
+        }
+    }
+
+    #[test]
+    fn foreign_store_roundtrips_the_signing_key() {
+        let store = ForeignSecretStore::new(Arc::new(MapStore {
+            entries: Mutex::new(Vec::new()),
+        }));
+        let keys = nostr::Keys::generate();
+        let account = summary(&keys);
+
+        assert!(!store.has_secret_for_label(&account.label).unwrap());
+        store.write_secret(&account, &keys).unwrap();
+        assert!(store.has_secret_for_label(&account.label).unwrap());
+        assert_eq!(
+            store.load_secret(&account).unwrap().secret_key(),
+            keys.secret_key()
+        );
+
+        store.remove_secret(&account).unwrap();
+        assert!(!store.has_secret_for_label(&account.label).unwrap());
+        assert!(matches!(
+            store.load_secret(&account),
+            Err(marmot_account::AccountHomeError::SecretNotFound(_))
+        ));
+    }
+
+    #[test]
+    fn host_errors_map_onto_existing_secret_store_variants() {
+        assert!(matches!(
+            account_home_error(MarmotKitError::SecretNotFound {
+                details: "gone".into()
+            }),
+            marmot_account::AccountHomeError::SecretNotFound(_)
+        ));
+        assert!(matches!(
+            account_home_error(MarmotKitError::KeystoreUnavailable {
+                details: "locked".into()
+            }),
+            marmot_account::AccountHomeError::SecretStoreUnavailable(_)
+        ));
+        assert!(matches!(
+            account_home_error(MarmotKitError::Runtime {
+                details: "boom".into()
+            }),
+            marmot_account::AccountHomeError::SecretStore(_)
+        ));
+    }
+}


### PR DESCRIPTION
Stacked on #1545. Review that one first; this branch only adds the commit on top.

Marmots keep their keys in the burrow they trust. Right now every host gets the same burrow whether it wants it or not: `Marmot::open` hardcodes `AccountHome::open_with_default_keychain`, so account secrets land in the platform keychain and nowhere else. A host that already has its own encrypted store has no way in.

The seam exists in Rust already. `AccountHome::open_with_secret_store(root, Arc<dyn AccountSecretStore>)` has been there all along, and `LocalFileSecretStore` shows the shape a store needs. Nothing exposed it to bindings consumers.

## What this adds

`marmot-uniffi` gets a foreign-implementable `SecretStore` trait and `Marmot::new_with_secret_store`. Swift and Kotlin hosts can implement it directly, so an iOS app that wants its own Keychain policy or an Android app with a Keystore wrapper can now supply one instead of taking the default.

`marmot-c` implements that trait over a C function-pointer vtable, following the pattern `crates/marmot-c/AGENTS.md` already sketches for external signers:

```c
MarmotStatus marmot_client_new_with_secret_store(const char *root_path,
                                                 const char *const *relay_urls,
                                                 uintptr_t relay_urls_len,
                                                 const struct MarmotSecretStore *store,
                                                 struct MarmotClient **out_client);
```

`marmot_client_new` keeps its behavior; both constructors now route through one private open path.

The secret crosses as secret-key hex, which is what `LocalFileSecretStore` already writes and parses, and only `label` and `account_id_hex` come along from `AccountSummary`. That keeps the whole interface to strings, with no struct marshalling.

## Rules a host has to follow

These are in the module docs, and they are the part worth reviewing closely:

- Callbacks run on runtime worker threads and can run concurrently. Host code must be thread-safe.
- A callback must not call back into `marmot_*` on the same client. It runs while `AccountHome` holds its mutation lock, so reentry deadlocks.
- A host must not unwind through a callback. A panic raised inside an `extern "C"` callback aborts at that callback's own shim before this crate can catch it, so recovery is impossible. The `catch_unwind` here covers the marshalling around the call, not the host body. Making host panics recoverable would mean an `extern "C-unwind"` vtable, which is a separate decision.
- The callback is a storage boundary, not a security boundary. The hex is plaintext in memory while it crosses, held in `Zeroizing` between receipt and `Keys::parse`, and the host buffer goes back through `free_secret` right after.

Booleans cross as `uint8_t` and the callback status as a validated `uint32_t` discriminant, per the crate invariant against building a Rust `bool` or enum from an out-of-range integer.

## Checks

`cargo test -p marmot-c --features alloc-audit`, `cargo test -p marmot-uniffi`, `just c-header` with a clean diff, `just c-smoke`, clippy and fmt all pass. Tests cover a callback round trip through write, has, load and remove, `free_secret` firing exactly once, `destroy` on drop, error status mapping, an out-of-range discriminant, and a NULL store clearing the out-pointer before any work happens. One integration test opens a real client through a host store with no keychain involved.

## Two things I did not decide alone

`crates/marmot-uniffi` has no `CHANGELOG.md` and no workflow gates on one, so the entry went in `marmot-c` only. Say the word and I will add the file.

No workspace version bump, per `marmot-uniffi/AGENTS.md`. That reads against `marmot-c/AGENTS.md`, which asks for a bump when callback signatures change. Flagging the conflict instead of picking a side.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for host-provided account secret-key storage through the UniFFI and C APIs.
  * Applications can check, save, load, and remove account secrets using their own storage provider.
  * Added a constructor for creating clients with a custom secret store.
  * Added clear status reporting and lifecycle handling for storage operations.
* **Compatibility**
  * The existing client constructor continues to use the platform keychain unchanged.
* **Documentation**
  * Documented custom secret-store callbacks, ownership, concurrency, validation, and failure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->