### PR TITLE
fix(app): require relay coverage for replay completion

### DIFF
--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -9,6 +9,14 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ## [Unreleased]
 
+### Fixed
+
+- Multi-relay full-history recovery now requires end-of-stored-events from
+  every endpoint in the activation's frozen route snapshot. A fast, empty
+  relay or repeated unavailability can no longer falsely complete replay and
+  clear its durable recovery intent.
+  ([#1578](https://github.com/marmot-protocol/mdk/issues/1578))
+
 ## [0.9.15] - 2026-08-25
 
 ### Added

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -18,8 +18,8 @@ use crate::media::media_imeta_tags_are_valid;
 use crate::notifications;
 use crate::{
     AccountState, AppError, AppGroupAdminPolicyComponent, AppMessageProjection,
-    AppPerformanceTelemetry, ClassifiedSyncFailure, EPOCH_BACKFILL_EOSE_ATTEMPT_LIMIT,
-    EPOCH_BACKFILL_EOSE_WAIT, EPOCH_BACKFILL_EXECUTION_QUANTUM, EPOCH_BACKFILL_RETRY_BACKOFF,
+    AppPerformanceTelemetry, ClassifiedSyncFailure, EPOCH_BACKFILL_EOSE_WAIT,
+    EPOCH_BACKFILL_EXECUTION_QUANTUM, EPOCH_BACKFILL_RETRY_BACKOFF,
     EPOCH_BACKFILL_RETRY_BACKOFF_CAP, SDK_DRAIN_WAIT, SDK_FIRST_SYNC_WAIT, SelfMembership,
     SyncFailure, SyncSummary, TRANSPORT_CURSOR_MAX_FUTURE_SKEW, unix_now_seconds,
 };
@@ -92,11 +92,6 @@ enum DrainCompletion {
         silence_budget: Duration,
         execution_quantum: Duration,
     },
-    /// Epoch-gap backfill that has spent its end-of-stored-events attempt
-    /// budget ([`EPOCH_BACKFILL_EOSE_ATTEMPT_LIMIT`]). Drains exactly like
-    /// [`Self::Quiescence`] so an account whose group route has one unreachable
-    /// relay can still heal, and reports itself as the weaker claim it is.
-    QuiescenceFallback { execution_quantum: Duration },
 }
 
 impl DrainCompletion {
@@ -105,8 +100,7 @@ impl DrainCompletion {
             Self::Quiescence => None,
             Self::EndOfStoredEvents {
                 execution_quantum, ..
-            }
-            | Self::QuiescenceFallback { execution_quantum } => Some(execution_quantum),
+            } => Some(execution_quantum),
         }
     }
 }
@@ -121,10 +115,6 @@ enum DrainVerdict {
     /// Every live subscription reached end-of-stored-events and the relays then
     /// went quiet: the account's stored history was served in full.
     Complete,
-    /// The relays went quiet under the fallback contract, after the gate had
-    /// spent its attempt budget. Recovery ran and is not a failure, but nothing
-    /// confirms the history was served in full.
-    QuiescenceFallback,
     /// The silence budget ran out with stored history still unconfirmed, though
     /// some relay did reach end-of-stored-events.
     EoseTimeout,
@@ -145,7 +135,7 @@ impl DrainVerdict {
     /// The audit row's `error_kind` for a drain that did not complete.
     fn error_kind(self) -> Option<&'static str> {
         match self {
-            Self::Complete | Self::QuiescenceFallback => None,
+            Self::Complete => None,
             Self::EoseTimeout => Some("backfill_drain_eose_timeout"),
             Self::NoRelayEose => Some("backfill_drain_no_relay_eose"),
             Self::NovelProgressQuantumYield => Some("backfill_drain_novel_progress_quantum_yield"),
@@ -153,12 +143,10 @@ impl DrainVerdict {
         }
     }
 
-    /// What the completed audit row should claim about this drain, so a
-    /// fallback is never read as an end-of-stored-events confirmation.
+    /// What the completed audit row should claim about this drain.
     fn completion_kind(self) -> Option<EpochBackfillCompletionKind> {
         match self {
             Self::Complete => Some(EpochBackfillCompletionKind::EndOfStoredEvents),
-            Self::QuiescenceFallback => Some(EpochBackfillCompletionKind::QuiescenceFallback),
             Self::EoseTimeout
             | Self::NoRelayEose
             | Self::NovelProgressQuantumYield
@@ -1084,16 +1072,11 @@ impl AppClient {
     async fn backfill_sdk_relay(
         &mut self,
         counts: &mut DrainCounts,
-        eose_unconfirmed_ordinal: u64,
     ) -> Result<(SyncSummary, DrainVerdict), ClassifiedSyncFailure> {
         let execution_quantum = self.epoch_backfill_execution_quantum();
-        let completion = if eose_unconfirmed_ordinal >= EPOCH_BACKFILL_EOSE_ATTEMPT_LIMIT {
-            DrainCompletion::QuiescenceFallback { execution_quantum }
-        } else {
-            DrainCompletion::EndOfStoredEvents {
-                silence_budget: self.epoch_backfill_eose_wait(),
-                execution_quantum,
-            }
+        let completion = DrainCompletion::EndOfStoredEvents {
+            silence_budget: self.epoch_backfill_eose_wait(),
+            execution_quantum,
         };
         self.drain_sdk_relay(counts, completion).await
     }
@@ -1260,9 +1243,6 @@ impl AppClient {
                 Ok(Ok(None)) => {
                     break match completion {
                         DrainCompletion::Quiescence => DrainVerdict::Complete,
-                        DrainCompletion::QuiescenceFallback { .. } => {
-                            DrainVerdict::QuiescenceFallback
-                        }
                         DrainCompletion::EndOfStoredEvents { .. } => {
                             self.backfill_drain_verdict().await
                         }
@@ -1282,12 +1262,6 @@ impl AppClient {
                 }
                 Err(_) => match completion {
                     DrainCompletion::Quiescence => break DrainVerdict::Complete,
-                    DrainCompletion::QuiescenceFallback { execution_quantum } => {
-                        if drain_started.elapsed() >= execution_quantum {
-                            break DrainVerdict::quantum_yield(counts);
-                        }
-                        break DrainVerdict::QuiescenceFallback;
-                    }
                     DrainCompletion::EndOfStoredEvents {
                         silence_budget,
                         execution_quantum,
@@ -2227,10 +2201,7 @@ impl AppClient {
                 let retry_ordinal = execution.retry_ordinal;
                 let eose_unconfirmed_ordinal = execution.eose_unconfirmed_ordinal;
                 let no_progress_ordinal = execution.no_progress_ordinal;
-                let (mut summary, verdict) = match self
-                    .backfill_sdk_relay(&mut counts, eose_unconfirmed_ordinal)
-                    .await
-                {
+                let (mut summary, verdict) = match self.backfill_sdk_relay(&mut counts).await {
                     Ok(drained) => drained,
                     Err(err) => {
                         let terminal_error = err.source.privacy_safe_kind().to_string();
@@ -2311,7 +2282,7 @@ impl AppClient {
                         retry_ordinal,
                         deliveries = counts.deliveries,
                         skipped = counts.skipped,
-                        eose_attempt_limit = EPOCH_BACKFILL_EOSE_ATTEMPT_LIMIT,
+                        eose_unconfirmed_ordinal,
                         "epoch-gap backfill drain ended without the relays confirming stored history; retrying later"
                     );
                     self.epoch_backfill_retry_not_before = if verdict.made_novel_progress() {
@@ -3596,26 +3567,37 @@ mod tests {
 
     #[test]
     fn drain_verdict_reads_end_of_stored_events_progress() {
-        let progress = |subscriptions, with_eose| AccountSubscriptionEose {
-            subscriptions,
-            with_eose,
-        };
+        let progress =
+            |subscriptions,
+             with_eose,
+             relay_subscription_attempts,
+             relay_subscription_attempts_with_eose| AccountSubscriptionEose {
+                subscriptions,
+                with_eose,
+                relay_subscription_attempts,
+                relay_subscription_attempts_with_eose,
+            };
         assert_eq!(
-            backfill_drain_verdict(progress(2, 2)),
+            backfill_drain_verdict(progress(2, 2, 2, 2)),
             DrainVerdict::Complete
         );
         assert_eq!(
-            backfill_drain_verdict(progress(2, 1)),
+            backfill_drain_verdict(progress(2, 1, 2, 1)),
             DrainVerdict::EoseTimeout
         );
         assert_eq!(
-            backfill_drain_verdict(progress(2, 0)),
+            backfill_drain_verdict(progress(2, 0, 2, 0)),
             DrainVerdict::NoRelayEose
         );
         assert_eq!(
-            backfill_drain_verdict(progress(0, 0)),
+            backfill_drain_verdict(progress(0, 0, 0, 0)),
             DrainVerdict::NoRelayEose,
             "an account with nothing subscribed cannot have been served"
+        );
+        assert_eq!(
+            backfill_drain_verdict(progress(2, 2, 4, 2)),
+            DrainVerdict::EoseTimeout,
+            "EOSE on every logical subscription is insufficient while another relay remains uncovered"
         );
     }
 }

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -344,10 +344,10 @@ pub(crate) const EPOCH_BACKFILL_EXECUTION_QUANTUM: Duration = Duration::from_sec
 /// yields first and a later seam resubscribes. Production EOSE completion
 /// therefore requires the gate to report within that quantum (or before an
 /// adapter-closed result). A worker-quantum yield is only a scheduling event:
-/// it paces a later resubscription but does not spend the EOSE-failure budget
-/// or unlock the weaker quiescence fallback. Keeping the budgets distinct
-/// makes long-replay slicing independent from that fallback policy, and
-/// test-policy builds can exercise either boundary directly.
+/// it paces a later resubscription but does not spend the EOSE-failure ordinal.
+/// An unavailable required relay leaves the durable intent pending; bounded
+/// worker quanta and paced retries preserve availability without weakening the
+/// proof that stored history was served.
 pub(crate) const EPOCH_BACKFILL_EOSE_WAIT: Duration = Duration::from_secs(30);
 /// How long an epoch-gap backfill whose replay went unconfirmed waits before
 /// the automatic seams may try it again, doubling per attempt up to
@@ -364,18 +364,6 @@ pub(crate) const EPOCH_BACKFILL_RETRY_BACKOFF: Duration = Duration::from_secs(15
 /// intent is durable, so a five-minute floor between attempts costs nothing but
 /// leaves recovery responsive when the relay returns.
 pub(crate) const EPOCH_BACKFILL_RETRY_BACKOFF_CAP: Duration = Duration::from_secs(5 * 60);
-/// Attempts an intent spends on the end-of-stored-events gate before its drain
-/// falls back to the quiescence contract.
-///
-/// The gate requires every subscription the replay issued to be served, and a
-/// group route may carry a single relay (group routing requires only a
-/// non-empty endpoint set). One unreachable relay would otherwise leave the
-/// gate permanently unclearable and the account permanently unhealed — a worse
-/// failure than the one the gate fixes. After this many unconfirmed attempts
-/// the replay drains on the pre-gate contract instead, which still recovers
-/// whatever the reachable relays send; the audit row records that weaker claim
-/// as `quiescence_fallback` rather than passing it off as a served history.
-pub(crate) const EPOCH_BACKFILL_EOSE_ATTEMPT_LIMIT: u64 = 3;
 const APP_RUNTIME_ACCOUNT_READY_WAIT: Duration = Duration::from_secs(45);
 /// Local worker operations include SQLite's bounded busy retry but no relay or
 /// blob transfer. A missing response beyond this point indicates a wedged

--- a/crates/marmot-app/src/relay_plane/mod.rs
+++ b/crates/marmot-app/src/relay_plane/mod.rs
@@ -1252,7 +1252,8 @@ impl MarmotRelayPlaneAccountAdapter {
             .await
     }
 
-    /// End-of-stored-events progress across this account's live subscriptions.
+    /// End-of-stored-events progress across this account activation's frozen
+    /// endpoint coverage snapshot.
     ///
     /// The epoch-gap backfill drain reads this to tell a relay that has
     /// finished replaying stored history from one that has simply gone quiet.

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -1650,13 +1650,14 @@ fn unpersisted_unknown_group_stream_is_no_progress_and_paced() {
     });
 }
 
-/// Worker-quantum pacing and EOSE-failure fallback are independent policies.
-/// Repeated duplicate-only slices must never make a later quiet slice claim
-/// completion under the weaker quiescence contract.
+/// Worker-quantum yields do not count as EOSE-unconfirmed attempts. Repeated
+/// duplicate-only slices must retain the intent until the required coverage is
+/// actually confirmed.
 #[test]
 #[cfg(feature = "test-policy-overrides")]
-fn duplicate_only_quanta_do_not_spend_eose_fallback_attempts() {
+fn duplicate_only_quanta_retain_the_eose_coverage_gate() {
     run_composed_app_runtime_test("backfill-duplicate-quanta-eose-budget", || async {
+        const DUPLICATE_QUANTA: u64 = 3;
         let dir = tempfile::tempdir().unwrap();
         let relay = Arc::new(ScriptedPushRelayClient::default());
         let (app, mut client, group_id) = armed_epoch_backfill(
@@ -1674,7 +1675,7 @@ fn duplicate_only_quanta_do_not_spend_eose_fallback_attempts() {
         let duplicate = epoch_gap_probe(
             &group.nostr_routing.nostr_group_id_hex,
             crate::unix_now_seconds(),
-            "duplicates-must-not-unlock-fallback",
+            "duplicates-must-not-unlock-coverage",
         );
         client.remember_seen_event(duplicate.id.clone());
         let (stop, pump) = redelivery_pump(
@@ -1684,7 +1685,7 @@ fn duplicate_only_quanta_do_not_spend_eose_fallback_attempts() {
             Duration::from_secs(6),
         );
 
-        for attempt in 0..crate::EPOCH_BACKFILL_EOSE_ATTEMPT_LIMIT {
+        for attempt in 0..DUPLICATE_QUANTA {
             let outcome = client
                 .run_pending_epoch_backfill(
                     marmot_forensics::EpochBackfillExecutionSeam::ExplicitCatchUp,
@@ -1707,7 +1708,7 @@ fn duplicate_only_quanta_do_not_spend_eose_fallback_attempts() {
             .expect("quiet continuation runs");
         assert!(
             matches!(outcome, crate::EpochBackfillRunOutcome::Incomplete(_)),
-            "worker-quantum yields must not unlock quiescence fallback"
+            "worker-quantum yields must not weaken the EOSE coverage gate"
         );
         assert!(
             client.has_pending_epoch_backfill(),
@@ -1729,10 +1730,7 @@ fn duplicate_only_quanta_do_not_spend_eose_fallback_attempts() {
 
         let rows = recorded_audit_rows(&app);
         let failed = recorded_rows_of_kind(&rows, "epoch_stall_backfill_failed");
-        assert_eq!(
-            failed.len(),
-            crate::EPOCH_BACKFILL_EOSE_ATTEMPT_LIMIT as usize + 1
-        );
+        assert_eq!(failed.len(), DUPLICATE_QUANTA as usize + 1);
         assert!(failed.iter().all(|row| {
             row["kind"]["error_kind"].as_str() == Some("backfill_drain_no_progress_quantum_yield")
         }));
@@ -1746,7 +1744,7 @@ fn duplicate_only_quanta_do_not_spend_eose_fallback_attempts() {
 }
 
 /// Productive replays use the same worker quantum, but their checkpointed
-/// prefix survives the yield and they do not spend the EOSE fallback ordinal.
+/// prefix survives the yield and they do not spend the EOSE-failure ordinal.
 /// A later EOSE-confirmed quantum can therefore finish the same arm.
 #[test]
 #[cfg(feature = "test-policy-overrides")]
@@ -2862,9 +2860,9 @@ async fn armed_epoch_backfill_across_two_relays(
     (app, client, group_id)
 }
 
-/// [`scripted_eose_pump`] narrowed to [`FAST_RELAY`]: the account-wide gate asks
-/// for one relay per subscription, and this satisfies it from one of the two
-/// each route is published to while [`SLOW_RELAY`] answers nothing.
+/// [`scripted_eose_pump`] narrowed to [`FAST_RELAY`]. This advances partial
+/// coverage for every subscription while deliberately leaving the replay
+/// incomplete until [`SLOW_RELAY`] answers too.
 fn fast_relay_eose_pump(
     plane: MarmotRelayPlane,
     relay: Arc<ScriptedPushRelayClient>,
@@ -2933,9 +2931,9 @@ fn epoch_backfill_drain_collects_a_slow_relay_commit_inside_its_silence_window()
             .unwrap()
             .expect("local group projection");
 
-        // The fast relay satisfies the account-wide gate on its own, and only
-        // then does the slow relay answer — the drain is still inside its
-        // silence window when that commit lands.
+        // The fast relay reports first. The slow relay then serves the missing
+        // commit and only afterwards reports its EOSE, completing the frozen
+        // endpoint coverage while the drain is inside its silence window.
         let _eose = fast_relay_eose_pump(app.relay_plane.clone(), relay.clone());
         let commit = epoch_gap_probe(
             &group.nostr_routing.nostr_group_id_hex,
@@ -2945,10 +2943,17 @@ fn epoch_backfill_drain_collects_a_slow_relay_commit_inside_its_silence_window()
         let slow_relay = {
             let app = app.clone();
             let relay = relay.clone();
+            let plane = app.relay_plane.clone();
             let subscriptions_before = relay.subscription_count();
             tokio::spawn(async move {
                 epoch_backfill_subscriptions_settled(&relay, subscriptions_before).await;
                 deliver_from_slow_relay(&app, commit).await;
+                let slow = TransportEndpoint(SLOW_RELAY.to_owned());
+                for subscription in relay.accepted_subscriptions() {
+                    plane
+                        .handle_relay_eose_for_test(slow.clone(), subscription.subscription_id())
+                        .await;
+                }
             })
         };
 
@@ -2979,8 +2984,8 @@ fn epoch_backfill_drain_collects_a_slow_relay_commit_inside_its_silence_window()
 }
 
 #[test]
-fn epoch_backfill_drain_leaves_a_late_slow_relay_commit_to_the_next_drain() {
-    run_composed_app_runtime_test("backfill-drain-slow-relay-late", || async {
+fn epoch_backfill_keeps_intent_until_the_slow_relay_reconnects() {
+    run_composed_app_runtime_test("backfill-drain-slow-relay-reconnect", || async {
         let dir = tempfile::tempdir().unwrap();
         let relay = Arc::new(ScriptedPushRelayClient::default());
         let (app, mut client, group_id) = armed_epoch_backfill_across_two_relays(
@@ -2993,47 +2998,25 @@ fn epoch_backfill_drain_leaves_a_late_slow_relay_commit_to_the_next_drain() {
             .group("alice", &hex::encode(group_id.as_slice()))
             .unwrap()
             .expect("local group projection");
-        let stalled_epoch = client.group_mls_state(&group_id).unwrap().epoch;
         let _eose = fast_relay_eose_pump(app.relay_plane.clone(), relay.clone());
 
-        // The accepted trade-off, in the words of the gate's own contract:
-        // requiring *every* relay "would make one permanently unreachable relay
-        // indistinguishable from a history replay that never finished". One
-        // relay per subscription therefore ends this drain while a reachable but
-        // slower relay still owes a commit, and the drain claims
-        // `end_of_stored_events` for a history it has not seen in full.
+        // Fast, empty A cannot complete while B is unavailable.
         let outcome = client
             .run_pending_epoch_backfill(marmot_forensics::EpochBackfillExecutionSeam::Maintenance)
             .await
             .expect("armed replay must run");
         assert!(matches!(
             outcome,
-            crate::EpochBackfillRunOutcome::Completed(_)
+            crate::EpochBackfillRunOutcome::Incomplete(_)
         ));
         assert!(
-            !client.has_pending_epoch_backfill(),
-            "the fast relay's report consumes the intent"
-        );
-        // And no second replay is coming: a confirmed drain latches the group's
-        // stalled epoch, so the same epoch cannot arm again however much
-        // undecryptable traffic it goes on to accumulate.
-        let mut rearm = BackfillDecision::Skip;
-        for probe in 0..EPOCH_STALL_BACKFILL_THRESHOLD {
-            rearm = client.epoch_stall.observe_undecryptable(
-                group_id.clone(),
-                format!("after-replay-{probe}"),
-                cgka_traits::EpochId(stalled_epoch),
-            );
-        }
-        assert_eq!(
-            rearm,
-            BackfillDecision::Skip,
-            "a confirmed replay disarms the epoch it was armed at"
+            client.has_pending_epoch_backfill(),
+            "partial relay coverage must retain the durable intent"
         );
 
-        // What recovers the group is not another replay but the delivery
-        // itself: the subscriptions the backfill opened stay live, so the slow
-        // relay's answer reaches the next drain on the ordinary path.
+        // B reconnects, serves the missing commit, and reports EOSE. An ongoing
+        // pump covers the fresh subscriptions issued by the retry as well as
+        // the current generation.
         deliver_from_slow_relay(
             &app,
             epoch_gap_probe(
@@ -3043,27 +3026,35 @@ fn epoch_backfill_drain_leaves_a_late_slow_relay_commit_to_the_next_drain() {
             ),
         )
         .await;
-        client.sync().await.expect("ordinary sync must run");
+        let _all_eose =
+            scripted_eose_pump(app.relay_plane.clone(), relay.clone(), every_subscription);
+        let outcome = client
+            .run_pending_epoch_backfill(
+                marmot_forensics::EpochBackfillExecutionSeam::ExplicitCatchUp,
+            )
+            .await
+            .expect("reconnect replay must run");
+        assert!(matches!(
+            outcome,
+            crate::EpochBackfillRunOutcome::Completed(_)
+        ));
+        assert!(!client.has_pending_epoch_backfill());
         drop(client);
 
         let rows = recorded_audit_rows(&app);
+        assert_eq!(
+            recorded_rows_of_kind(&rows, "epoch_stall_backfill_failed").len(),
+            1
+        );
         let completed = recorded_rows_of_kind(&rows, "epoch_stall_backfill_completed");
         assert_eq!(completed.len(), 1);
         assert_eq!(
-            completed[0]["kind"]["deliveries"], 0,
-            "the drain ended before the slow relay answered"
+            completed[0]["kind"]["deliveries"], 1,
+            "the confirmed reconnect drain must retain B's missing commit"
         );
         assert_eq!(
             completed[0]["kind"]["completion_kind"].as_str(),
             Some("end_of_stored_events")
-        );
-        let drains = recorded_rows_of_kind(&rows, "sync_drain");
-        assert_eq!(
-            drains
-                .last()
-                .expect("the follow-up sync must record a drain")["kind"]["deliveries"],
-            1,
-            "the late commit is left to the next drain, not dropped"
         );
     });
 }
@@ -3142,8 +3133,9 @@ fn unconfirmed_epoch_backfill_paces_its_automatic_retries() {
 
 #[test]
 #[cfg(feature = "test-policy-overrides")]
-fn epoch_backfill_falls_back_to_quiescence_after_spending_its_eose_attempts() {
-    run_composed_app_runtime_test("backfill-eose-fallback", || async {
+fn epoch_backfill_remains_pending_after_repeated_unavailable_relay_attempts() {
+    run_composed_app_runtime_test("backfill-eose-remains-pending", || async {
+        const UNCONFIRMED_ATTEMPTS: u64 = 3;
         let dir = tempfile::tempdir().unwrap();
         let relay = Arc::new(ScriptedPushRelayClient::default());
         let (app, mut client, group_id) =
@@ -3153,10 +3145,10 @@ fn epoch_backfill_falls_back_to_quiescence_after_spending_its_eose_attempts() {
             .unwrap()
             .expect("local group projection");
 
-        // Stands in for the field shape this exit exists for: a group route
-        // whose only relay never answers, so the account-wide gate can never
-        // clear however long it waits.
-        for attempt in 0..crate::EPOCH_BACKFILL_EOSE_ATTEMPT_LIMIT {
+        // Stands in for a route whose required relay never answers. Repeated
+        // bounded attempts must not convert that availability failure into
+        // proof that stored history was served.
+        for attempt in 0..UNCONFIRMED_ATTEMPTS {
             let outcome = client
                 .run_pending_epoch_backfill(
                     marmot_forensics::EpochBackfillExecutionSeam::ExplicitCatchUp,
@@ -3175,48 +3167,67 @@ fn epoch_backfill_falls_back_to_quiescence_after_spending_its_eose_attempts() {
             epoch_gap_probe(
                 &group.nostr_routing.nostr_group_id_hex,
                 crate::unix_now_seconds(),
-                "fallback-history",
+                "reachable-history",
             ),
         )
         .await;
-        let fallback = client
+        let still_unconfirmed = client
             .run_pending_epoch_backfill(
                 marmot_forensics::EpochBackfillExecutionSeam::ExplicitCatchUp,
             )
             .await
-            .expect("the fallback attempt runs");
+            .expect("the next bounded attempt runs");
         assert!(
-            matches!(fallback, crate::EpochBackfillRunOutcome::Completed(_)),
-            "a spent gate must not wedge recovery forever"
+            matches!(
+                still_unconfirmed,
+                crate::EpochBackfillRunOutcome::Incomplete(_)
+            ),
+            "reachable history without required EOSE coverage remains unconfirmed"
         );
         assert!(
-            !client.has_pending_epoch_backfill(),
-            "the fallback attempt consumes the intent"
+            client.has_pending_epoch_backfill(),
+            "an unavailable required relay must leave the durable intent pending"
         );
+
+        // Once the relay reconnects and reports EOSE for the current replay,
+        // the same durable intent can complete and clear.
+        let _eose = scripted_eose_pump(app.relay_plane.clone(), relay.clone(), every_subscription);
+        let completed_after_reconnect = client
+            .run_pending_epoch_backfill(
+                marmot_forensics::EpochBackfillExecutionSeam::ExplicitCatchUp,
+            )
+            .await
+            .expect("the reconnect attempt runs");
+        assert!(matches!(
+            completed_after_reconnect,
+            crate::EpochBackfillRunOutcome::Completed(_)
+        ));
+        assert!(!client.has_pending_epoch_backfill());
         drop(client);
 
         let rows = recorded_audit_rows(&app);
         let failed = recorded_rows_of_kind(&rows, "epoch_stall_backfill_failed");
         assert_eq!(
             failed.len(),
-            crate::EPOCH_BACKFILL_EOSE_ATTEMPT_LIMIT as usize,
-            "every gated attempt must record its own honest failure"
+            UNCONFIRMED_ATTEMPTS as usize + 1,
+            "every unconfirmed attempt must record its own honest failure"
         );
         let completed = recorded_rows_of_kind(&rows, "epoch_stall_backfill_completed");
         assert_eq!(completed.len(), 1);
         assert_eq!(
             completed[0]["kind"]["completion_kind"].as_str(),
-            Some("quiescence_fallback"),
-            "a fallback completion must never read as a served history replay"
+            Some("end_of_stored_events")
         );
         assert_eq!(
             completed[0]["kind"]["retry_ordinal"].as_u64(),
-            Some(crate::EPOCH_BACKFILL_EOSE_ATTEMPT_LIMIT)
+            Some(UNCONFIRMED_ATTEMPTS + 1)
         );
         assert_eq!(
-            completed[0]["kind"]["deliveries"], 1,
-            "the fallback drain must still recover reachable history"
+            failed.last().expect("the unconfirmed delivery attempt")["kind"]["deliveries"],
+            1,
+            "the unconfirmed attempt still recovers reachable history"
         );
+        assert_eq!(completed[0]["kind"]["deliveries"], 0);
     });
 }
 

--- a/crates/marmot-forensics/src/audit.rs
+++ b/crates/marmot-forensics/src/audit.rs
@@ -254,13 +254,14 @@ pub enum EpochBackfillActivationOutcome {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum EpochBackfillCompletionKind {
-    /// Every subscription the replay issued was reported end-of-stored-events
-    /// by a relay: the account's stored history was served in full.
+    /// Every endpoint-scoped subscription attempt in the replay's frozen route
+    /// snapshot was reported end-of-stored-events: the account's stored
+    /// history was served in full.
     EndOfStoredEvents,
-    /// The end-of-stored-events gate never cleared within its attempt budget,
-    /// so this attempt fell back to draining until the relays went quiet. The
-    /// replay recovered whatever the relays sent, but nothing confirms that was
-    /// all of it — the weaker guarantee that shipped before the gate existed.
+    /// Legacy completion written by versions that converted a repeatedly
+    /// unconfirmed end-of-stored-events gate into a quiet-relay success. Kept
+    /// solely so historical audit rows remain readable; current recovery never
+    /// emits this weaker claim.
     QuiescenceFallback,
 }
 
@@ -1129,9 +1130,10 @@ pub enum AuditEventKind {
         retry_ordinal: u64,
         duration_ms: u64,
         activation_outcome: EpochBackfillActivationOutcome,
-        /// What ended the drain. A `quiescence_fallback` completion is a
-        /// weaker claim than an `end_of_stored_events` one and must not be read
-        /// as proof the account's stored history was served in full.
+        /// What ended the drain. Historical `quiescence_fallback` values are a
+        /// weaker claim than `end_of_stored_events` and must not be read as
+        /// proof the account's stored history was served in full; current
+        /// recovery emits only endpoint-covered `end_of_stored_events`.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         completion_kind: Option<EpochBackfillCompletionKind>,
         deliveries: u64,

--- a/crates/transport-nostr-adapter/src/lib.rs
+++ b/crates/transport-nostr-adapter/src/lib.rs
@@ -330,14 +330,15 @@ pub struct NostrRelayEvent {
     pub event: NostrTransportEvent,
 }
 
-/// End-of-stored-events progress across one account's live subscriptions,
+/// End-of-stored-events progress across one account replay's route snapshot,
 /// from [`NostrTransportAdapter::account_subscription_eose`].
 ///
-/// "At least one relay" rather than "every relay" is deliberate: a subscription
-/// is issued to every configured endpoint, including ones that are registered
-/// but never connect, and those never report EOSE. Requiring all of them would
-/// make one permanently unreachable relay indistinguishable from a history
-/// replay that never finished.
+/// The logical-subscription counts preserve the coarse progress used for
+/// diagnostics. Completion is deliberately stricter: every endpoint-scoped
+/// subscription attempt in the activation snapshot must report EOSE. A fast,
+/// empty relay is not evidence that another relay holding missing history has
+/// served it, and an unavailable relay leaves recovery incomplete and
+/// retryable rather than converting availability pressure into success.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct AccountSubscriptionEose {
     /// Subscriptions this account's activation issued: its inbox plus one per
@@ -347,6 +348,11 @@ pub struct AccountSubscriptionEose {
     /// Of those, how many at least one relay has reported end-of-stored-events
     /// for.
     pub with_eose: usize,
+    /// Endpoint-scoped attempts across the activation snapshot. A two-relay
+    /// inbox and two-relay group subscription contribute four attempts.
+    pub relay_subscription_attempts: usize,
+    /// Of those endpoint-scoped attempts, how many reported EOSE.
+    pub relay_subscription_attempts_with_eose: usize,
 }
 
 impl AccountSubscriptionEose {
@@ -355,14 +361,17 @@ impl AccountSubscriptionEose {
     /// An account holding no subscriptions is not complete: nothing was
     /// subscribed, so nothing can have served its stored history.
     pub fn complete(&self) -> bool {
-        self.subscriptions > 0 && self.with_eose == self.subscriptions
+        self.subscriptions > 0
+            && self.with_eose == self.subscriptions
+            && self.relay_subscription_attempts > 0
+            && self.relay_subscription_attempts_with_eose == self.relay_subscription_attempts
     }
 
     /// Whether any relay reported end-of-stored-events at all. `false` after a
     /// wait is the shape of an account whose relays accepted the subscription
     /// registration but never served it.
     pub fn any(&self) -> bool {
-        self.with_eose > 0
+        self.relay_subscription_attempts_with_eose > 0
     }
 }
 
@@ -582,12 +591,13 @@ impl NostrTransportAdapter {
             .subscription_any_eose(subscription_id)
     }
 
-    /// End-of-stored-events progress across every subscription an account
-    /// currently holds — its inbox plus one per group route.
+    /// End-of-stored-events progress across the route snapshot issued by the
+    /// account's most recent activation — its inbox plus one per group route,
+    /// with every endpoint retained as an independent proof obligation.
     ///
-    /// This is the account-wide counterpart of
-    /// [`Self::subscription_any_eose`], for a caller draining an unfloored
-    /// re-activation that must not mistake a quiet relay for a finished
+    /// A later group-route sync does not shrink the snapshot; only a new
+    /// activation replaces it. This lets a caller draining an unfloored
+    /// re-activation avoid mistaking a quiet or fast-empty relay for a finished
     /// history replay. It reports counts only: no ids, endpoints, or routes
     /// cross the boundary.
     pub async fn account_subscription_eose(
@@ -816,6 +826,7 @@ impl TransportAdapter for NostrTransportAdapter {
                 state.clear_pending_unsubscribes_for_account(&account_id);
             }
             state.record_subscription_starts(&issued, now_ms);
+            state.record_account_replay_start(&account_id, &issued);
             state.activate(activation, replaced_count);
         }
 
@@ -1114,6 +1125,51 @@ struct AccountRoutes {
     groups: Vec<TransportGroupSubscription>,
 }
 
+/// Immutable endpoint coverage for the most recent account activation.
+///
+/// Group-route synchronization may change the adapter's live routing table
+/// while a replay is draining. Keeping this snapshot separate prevents such a
+/// change from shrinking the proof obligation of the already-issued replay.
+#[derive(Clone, Default)]
+struct AccountReplayCoverage {
+    subscriptions: HashMap<String, HashMap<RelayIndex, bool>>,
+}
+
+impl AccountReplayCoverage {
+    fn snapshot(&self) -> AccountSubscriptionEose {
+        let subscriptions = self.subscriptions.len();
+        let with_eose = self
+            .subscriptions
+            .values()
+            .filter(|relays| relays.values().any(|eose_seen| *eose_seen))
+            .count();
+        let relay_subscription_attempts =
+            self.subscriptions.values().map(HashMap::len).sum::<usize>();
+        let relay_subscription_attempts_with_eose = self
+            .subscriptions
+            .values()
+            .flat_map(HashMap::values)
+            .filter(|eose_seen| **eose_seen)
+            .count();
+        AccountSubscriptionEose {
+            subscriptions,
+            with_eose,
+            relay_subscription_attempts,
+            relay_subscription_attempts_with_eose,
+        }
+    }
+
+    fn record_eose(&mut self, subscription_id: &str, relay: RelayIndex) {
+        if let Some(eose_seen) = self
+            .subscriptions
+            .get_mut(subscription_id)
+            .and_then(|relays| relays.get_mut(&relay))
+        {
+            *eose_seen = true;
+        }
+    }
+}
+
 /// A stored routing endpoint paired with its parsed/canonical `RelayUrl`, cached
 /// once when the route index is built so `routes_for` never re-parses the same
 /// verbatim signed endpoint on every inbound event (#698/#752). The verbatim
@@ -1173,6 +1229,10 @@ struct GroupRouteEntry {
 #[derive(Default)]
 struct AdapterState {
     accounts: HashMap<MemberId, AccountRoutes>,
+    /// Endpoint-level EOSE proof for the route snapshot issued by the most
+    /// recent activation of each account. This is intentionally independent of
+    /// `accounts`, whose live group routes may change during the drain.
+    account_replay_coverage: HashMap<MemberId, AccountReplayCoverage>,
     /// Derived accelerator for `routes_for` group delivery (#698/#752): maps a
     /// `transport_group_id` to its candidate routes, so an inbound group event is
     /// resolved in O(matching groups) instead of scanning O(accounts × groups)
@@ -1346,6 +1406,7 @@ impl AdapterState {
 
     fn deactivate(&mut self, account_id: &MemberId, removed_count: usize) {
         self.accounts.remove(account_id);
+        self.account_replay_coverage.remove(account_id);
         self.metrics.subscriptions_removed += removed_count;
         self.rebuild_transport_group_index();
     }
@@ -1378,6 +1439,26 @@ impl AdapterState {
             self.sync
                 .record_subscription_start(&subscription.subscription_id(), &relays, now_ms);
         }
+    }
+
+    fn record_account_replay_start(
+        &mut self,
+        account_id: &MemberId,
+        subscriptions: &[NostrSubscription],
+    ) {
+        let subscriptions = subscriptions
+            .iter()
+            .map(|subscription| {
+                let relays = subscription
+                    .endpoints()
+                    .iter()
+                    .map(|endpoint| (self.relay_index.index_for(endpoint), false))
+                    .collect();
+                (subscription.subscription_id(), relays)
+            })
+            .collect();
+        self.account_replay_coverage
+            .insert(account_id.clone(), AccountReplayCoverage { subscriptions });
     }
 
     fn stage_subscription_starts(&mut self, subscriptions: &[NostrSubscription], now_ms: u64) {
@@ -1446,16 +1527,13 @@ impl AdapterState {
         }
     }
 
-    /// End-of-stored-events progress across an account's live subscriptions.
+    /// End-of-stored-events progress across the account activation's immutable
+    /// route snapshot.
     fn account_subscription_eose(&self, account_id: &MemberId) -> AccountSubscriptionEose {
-        let ids = self.account_subscription_ids(account_id);
-        AccountSubscriptionEose {
-            subscriptions: ids.len(),
-            with_eose: ids
-                .iter()
-                .filter(|id| self.sync.subscription_any_eose(id).unwrap_or(false))
-                .count(),
-        }
+        self.account_replay_coverage
+            .get(account_id)
+            .map(AccountReplayCoverage::snapshot)
+            .unwrap_or_default()
     }
 
     fn record_subscription_first_event(
@@ -1476,6 +1554,9 @@ impl AdapterState {
     ) {
         let relay = self.relay_index.index_for(endpoint);
         self.sync.record_eose(subscription_id, relay, now_ms);
+        for coverage in self.account_replay_coverage.values_mut() {
+            coverage.record_eose(subscription_id, relay);
+        }
     }
 
     fn record_publish_attempt(&mut self) {

--- a/crates/transport-nostr-adapter/tests/inbound_routing.rs
+++ b/crates/transport-nostr-adapter/tests/inbound_routing.rs
@@ -2876,13 +2876,13 @@ async fn sync_telemetry_tracks_only_live_subscriptions_across_churn() {
 
 /// The account-wide end-of-stored-events gate an unfloored history drain reads.
 ///
-/// It must follow the *live* subscription set across route churn: count every
-/// subscription the current activation issued, stop counting one whose route is
-/// gone, and require a re-issued subscription to be confirmed again rather than
-/// inheriting the previous generation's confirmation. The tracked-subscription
-/// assertions pin the eviction that keeps churned-away ids from accumulating.
+/// A new activation replaces the prior replay snapshot and requires every
+/// re-issued subscription to be confirmed again rather than inheriting the
+/// previous generation's confirmation. The tracked-subscription assertions pin
+/// the separate telemetry eviction that keeps churned-away ids from
+/// accumulating.
 #[tokio::test]
-async fn account_subscription_eose_follows_the_live_subscription_set() {
+async fn account_subscription_eose_follows_the_latest_activation_snapshot() {
     let relay = Arc::new(FakeRelayClient::default());
     let adapter = NostrTransportAdapter::new(relay);
     let account_id = MemberId::new(vec![0xB2; 32]);
@@ -2992,6 +2992,145 @@ async fn account_subscription_eose_follows_the_live_subscription_set() {
     assert!(
         !progress.complete(),
         "an account with nothing subscribed cannot have been served"
+    );
+}
+
+/// A whole-account replay is complete only after every endpoint in the route
+/// snapshot used to issue it has served every relevant subscription. A fast,
+/// empty relay must not stand in for a slower relay that holds the missing
+/// history, and a mid-attempt route shrink must not erase that obligation.
+#[tokio::test]
+async fn account_subscription_eose_requires_the_frozen_relay_coverage() {
+    let relay = Arc::new(FakeRelayClient::default());
+    let adapter = NostrTransportAdapter::new(relay);
+    let account_id = MemberId::new(vec![0xC3; 32]);
+    let inbox_a = TransportEndpoint("wss://inbox-a.example".to_owned());
+    let inbox_b = TransportEndpoint("wss://inbox-b.example".to_owned());
+    let group_a = TransportEndpoint("wss://group-a.example".to_owned());
+    let group_b = TransportEndpoint("wss://group-b.example".to_owned());
+    let group = TransportGroupSubscription {
+        group_id: cgka_traits::GroupId::new(vec![0x33; 16]),
+        transport_group_id: vec![0x44; 32],
+        endpoints: vec![group_a.clone(), group_b.clone()],
+    };
+    let inbox_id = NostrSubscription::AccountInbox {
+        account_id: account_id.clone(),
+        endpoints: vec![inbox_a.clone(), inbox_b.clone()],
+        since: None,
+    }
+    .subscription_id();
+    let group_id = NostrSubscription::Group {
+        account_id: account_id.clone(),
+        group_id: group.group_id.clone(),
+        transport_group_id: group.transport_group_id.clone(),
+        endpoints: group.endpoints.clone(),
+        since: None,
+    }
+    .subscription_id();
+
+    adapter
+        .activate_account(TransportAccountActivation {
+            account_id: account_id.clone(),
+            inbox_endpoints: vec![inbox_a.clone(), inbox_b.clone()],
+            group_subscriptions: vec![group.clone()],
+            since: None,
+        })
+        .await
+        .expect("activation succeeds");
+
+    // Relay A is fast but empty. Its EOSE covers neither subscription on B.
+    adapter
+        .handle_relay_eose(inbox_a.clone(), inbox_id.clone())
+        .await;
+    adapter
+        .handle_relay_eose(group_a.clone(), group_id.clone())
+        .await;
+    let progress = adapter.account_subscription_eose(&account_id).await;
+    assert_eq!(progress.subscriptions, 2);
+    assert_eq!(progress.with_eose, 2);
+    assert_eq!(progress.relay_subscription_attempts, 4);
+    assert_eq!(progress.relay_subscription_attempts_with_eose, 2);
+    assert!(progress.any());
+    assert!(
+        !progress.complete(),
+        "EOSE from the fast, empty relay must not prove B served its history"
+    );
+
+    // Duplicate callbacks do not advance coverage. B can then serve the
+    // missing event before reporting its own EOSE.
+    adapter
+        .handle_relay_eose(group_a.clone(), group_id.clone())
+        .await;
+    assert_eq!(
+        adapter
+            .handle_relay_event(NostrRelayEvent {
+                endpoint: group_b.clone(),
+                subscription_id: Some(group_id.clone()),
+                event: group_event("relay-b-only", &group.transport_group_id),
+            })
+            .await
+            .expect("B's stored event is accepted"),
+        1
+    );
+    assert_eq!(
+        adapter
+            .receive()
+            .await
+            .expect("delivery receive succeeds")
+            .expect("B's event is delivered")
+            .source
+            .endpoint,
+        Some(group_b.clone())
+    );
+    adapter
+        .handle_relay_eose(inbox_b.clone(), inbox_id.clone())
+        .await;
+    assert!(
+        !adapter
+            .account_subscription_eose(&account_id)
+            .await
+            .complete(),
+        "the group subscription still lacks B's EOSE"
+    );
+
+    // An explicit route update may affect the next replay attempt, but it
+    // cannot silently shrink the coverage snapshot of this one.
+    let shrunk_group = TransportGroupSubscription {
+        endpoints: vec![group_a.clone()],
+        ..group.clone()
+    };
+    adapter
+        .sync_account_groups(TransportGroupSync {
+            account_id: account_id.clone(),
+            group_subscriptions: vec![shrunk_group.clone()],
+            since: None,
+        })
+        .await
+        .expect("route shrink succeeds");
+    let shrunk_group_id = NostrSubscription::Group {
+        account_id: account_id.clone(),
+        group_id: shrunk_group.group_id,
+        transport_group_id: shrunk_group.transport_group_id,
+        endpoints: shrunk_group.endpoints,
+        since: None,
+    }
+    .subscription_id();
+    adapter.handle_relay_eose(group_a, shrunk_group_id).await;
+    assert!(
+        !adapter
+            .account_subscription_eose(&account_id)
+            .await
+            .complete(),
+        "a route shrink must not complete an older replay attempt"
+    );
+
+    adapter.handle_relay_eose(group_b, group_id).await;
+    assert!(
+        adapter
+            .account_subscription_eose(&account_id)
+            .await
+            .complete(),
+        "the frozen snapshot completes once B serves its relevant EOSE"
     );
 }
 


### PR DESCRIPTION
## Summary
- retain endpoint-level EOSE state for the immutable route snapshot issued by each account activation, so fast-empty relay A cannot stand in for relay B's missing history
- keep the snapshot independent from live group-route churn and require full inbox/group endpoint coverage before `DrainVerdict::Complete`
- remove the quiescence fallback that converted repeated relay unavailability into success; bounded worker quanta, durable intent, and paced retries remain in place until reconnect coverage is proven
- make PR #1567's shared completion verdict conservative when that work is rebased onto this fix

## Test plan
- [x] New deterministic two-relay regression failed before the fix and passes after it
- [x] Repeated-unavailability regression failed before the fix and passes after it
- [x] `cargo test -p transport-nostr-adapter`
- [x] `cargo test -p marmot-forensics`
- [x] Recovery-focused `marmot-app` tests with `test-policy-overrides`
- [x] `just fast-ci`

The final full `marmot-app` feature-suite run passed 804 tests, ignored one benchmark, and hit one unrelated SQLCipher fixture failure under parallel execution (`file is not a database`); that exact test passed immediately on rerun.

Fixes #1578


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved full-history recovery across multiple relays by requiring completion confirmation from every relay and subscription involved.
  - Prevented fast, unavailable, or duplicate relay responses from falsely marking recovery as complete.
  - Recovery intent now remains pending when required relay history is unavailable, enabling reliable retries.
  - Replay progress resets correctly for new activations and remains tied to the original relay coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->