### PR TITLE
Fix ambiguous relay publish recovery

### DIFF
--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -792,6 +792,15 @@ impl<S: StorageProvider> Engine<S> {
         Ok(group_id)
     }
 
+    /// Originating stored commit for a live pending publication.
+    pub fn pending_origin_message_id(
+        &self,
+        pending: PendingStateRef,
+    ) -> Result<MessageId, EngineError> {
+        self.peek_pending_origin_commit(pending)
+            .ok_or(EngineError::UnknownPending)
+    }
+
     /// Confirm MLS and persist the matching fanout's terminal MLS edge in the
     /// same backend transaction.
     pub async fn confirm_published_fanout(
@@ -1666,16 +1675,37 @@ impl<S: StorageProvider> Engine<S> {
             // Validate the fanout's origin-commit row still resolves to a
             // stored OpenMLS wire message before restoring the pending
             // lifecycle around it.
+            let origin_message_id = fanout.pending_origin_message_id().cloned();
+            let stored_message_id = origin_message_id
+                .as_ref()
+                .unwrap_or_else(|| fanout.message_id());
             let stored = self
                 .storage
-                .get_message(fanout.message_id())
+                .get_message(stored_message_id)
                 .map_err(|_| GroupHydrationQuarantineReason::PendingCommitRecoveryFailed)?;
             let payload = StoredMessagePayload::decode(&stored.payload)
                 .map_err(|_| GroupHydrationQuarantineReason::PendingCommitRecoveryFailed)?;
-            if payload.as_openmls_wire().is_none() {
+            let valid_origin = if origin_message_id.is_some() {
+                payload.as_openmls_wire().is_some()
+            } else {
+                payload
+                    .as_outbound_welcome()
+                    .or_else(|| payload.as_raw_transport())
+                    .is_some_and(|message| {
+                        matches!(message.envelope, TransportEnvelope::Welcome { .. })
+                    })
+            };
+            if !valid_origin {
                 return Err(GroupHydrationQuarantineReason::PendingCommitRecoveryFailed);
             }
-            Some((pending_ref, prior_epoch, fanout.message_id().clone()))
+            Some((
+                pending_ref,
+                prior_epoch,
+                origin_message_id,
+                fanout
+                    .pending_kind()
+                    .unwrap_or(cgka_traits::FanoutPendingKind::GroupEvolution),
+            ))
         } else {
             None
         };
@@ -1811,7 +1841,16 @@ impl<S: StorageProvider> Engine<S> {
             self.epoch_manager
                 .restore_unrecoverable(group_id.clone(), group.epoch);
             ("unrecoverable", "hydrate_unrecoverable_group")
-        } else if let Some((pending_ref, prior_epoch, message_id)) = pending_recovery {
+        } else if let Some((pending_ref, prior_epoch, message_id, pending_kind)) = pending_recovery
+        {
+            let pending_kind = match pending_kind {
+                cgka_traits::FanoutPendingKind::GroupEvolution => {
+                    crate::epoch_manager::PendingKind::GroupEvolution
+                }
+                cgka_traits::FanoutPendingKind::CreateGroup => {
+                    crate::epoch_manager::PendingKind::CreateGroup
+                }
+            };
             self.epoch_manager
                 .restore_pending(
                     group_id.clone(),
@@ -1819,10 +1858,12 @@ impl<S: StorageProvider> Engine<S> {
                     EpochId(prior_epoch.0.saturating_add(1)),
                     StagedCommitHandle::from_bytes(group_id.as_slice().to_vec()),
                     pending_ref,
-                    crate::epoch_manager::PendingKind::GroupEvolution,
+                    pending_kind,
                 )
                 .map_err(|_| GroupHydrationQuarantineReason::PendingCommitRecoveryFailed)?;
-            self.track_pending_origin_commit(pending_ref, message_id);
+            if let Some(message_id) = message_id {
+                self.track_pending_origin_commit(pending_ref, message_id);
+            }
             ("pending_publish", "hydrate_stable_group")
         } else if restored_durable_evolution {
             ("pending_publish", "hydrate_stable_group")

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -797,8 +797,29 @@ impl<S: StorageProvider> Engine<S> {
         &self,
         pending: PendingStateRef,
     ) -> Result<MessageId, EngineError> {
+        self.pending_group_id(pending)?;
         self.peek_pending_origin_commit(pending)
             .ok_or(EngineError::UnknownPending)
+    }
+
+    /// Durable fanout discriminator for a live pending publication.
+    pub fn pending_fanout_kind(
+        &self,
+        pending: PendingStateRef,
+    ) -> Result<cgka_traits::FanoutPendingKind, EngineError> {
+        self.pending_group_id(pending)?;
+        match self.epoch_manager.kind_for_pending(pending) {
+            Some(crate::epoch_manager::PendingKind::CreateGroup) => {
+                Ok(cgka_traits::FanoutPendingKind::CreateGroup)
+            }
+            Some(crate::epoch_manager::PendingKind::GroupEvolution) => {
+                Ok(cgka_traits::FanoutPendingKind::GroupEvolution)
+            }
+            Some(crate::epoch_manager::PendingKind::Disband) => {
+                Ok(cgka_traits::FanoutPendingKind::Disband)
+            }
+            None => Err(EngineError::UnknownPending),
+        }
     }
 
     /// Confirm MLS and persist the matching fanout's terminal MLS edge in the
@@ -1849,6 +1870,9 @@ impl<S: StorageProvider> Engine<S> {
                 }
                 cgka_traits::FanoutPendingKind::CreateGroup => {
                     crate::epoch_manager::PendingKind::CreateGroup
+                }
+                cgka_traits::FanoutPendingKind::Disband => {
+                    crate::epoch_manager::PendingKind::Disband
                 }
             };
             self.epoch_manager

--- a/crates/cgka-session/src/lib.rs
+++ b/crates/cgka-session/src/lib.rs
@@ -1149,6 +1149,13 @@ impl AccountDeviceSession {
         Ok(self.engine.pending_origin_message_id(pending)?)
     }
 
+    pub fn pending_fanout_kind(
+        &self,
+        pending: PendingStateRef,
+    ) -> SessionResult<cgka_traits::FanoutPendingKind> {
+        Ok(self.engine.pending_fanout_kind(pending)?)
+    }
+
     pub fn outbound_fanouts(&self) -> SessionResult<Vec<OutboundFanout>> {
         Ok(self.engine.outbound_fanouts()?)
     }

--- a/crates/cgka-session/src/lib.rs
+++ b/crates/cgka-session/src/lib.rs
@@ -1145,6 +1145,10 @@ impl AccountDeviceSession {
         Ok(())
     }
 
+    pub fn pending_origin_message_id(&self, pending: PendingStateRef) -> SessionResult<MessageId> {
+        Ok(self.engine.pending_origin_message_id(pending)?)
+    }
+
     pub fn outbound_fanouts(&self) -> SessionResult<Vec<OutboundFanout>> {
         Ok(self.engine.outbound_fanouts()?)
     }

--- a/crates/cgka-session/tests/support/nostr_stack.rs
+++ b/crates/cgka-session/tests/support/nostr_stack.rs
@@ -20,9 +20,9 @@ use cgka_traits::app_components::{
 use cgka_traits::engine_state::PendingStateRef;
 use cgka_traits::{
     GroupId, MemberId, TransportAccountActivation, TransportAdapter, TransportAdapterError,
-    TransportEndpoint, TransportEndpointFailure, TransportEndpointReceipt,
-    TransportGroupSubscription, TransportGroupSync, TransportMessage, TransportPublishReport,
-    TransportPublishRequest, TransportPublishTarget,
+    TransportEndpoint, TransportEndpointFailure, TransportEndpointFailureKind,
+    TransportEndpointReceipt, TransportGroupSubscription, TransportGroupSync, TransportMessage,
+    TransportPublishReport, TransportPublishRequest, TransportPublishTarget,
 };
 use sha2::{Digest, Sha256};
 use storage_sqlite::SqlCipherKey;
@@ -128,6 +128,7 @@ impl NostrRelayClient for FakeRelayClient {
                 .map(|endpoint| TransportEndpointFailure {
                     endpoint,
                     reason: "not accepted by in-memory relay".into(),
+                    kind: TransportEndpointFailureKind::TerminalRejected,
                     rejection_category: None,
                 })
                 .collect(),

--- a/crates/marmot-account/src/lib.rs
+++ b/crates/marmot-account/src/lib.rs
@@ -28,7 +28,8 @@ pub use routing::{StaticTransportRouting, TransportRoutingError, TransportRoutin
 pub use runtime::{
     AccountDeviceEffects, AccountDeviceRuntime, AccountIngestEffects, CompletedWelcomePublishTask,
     PendingResolution, PreparedSessionCommit, PreparedSessionSend, PreparedWelcomePublishTask,
-    PublishFailure, PublishedApplicationMessage, WelcomeDeliveryFailure,
+    PublishFailure, PublishedApplicationMessage, UnresolvedApplicationMessage, UnresolvedPublish,
+    UnresolvedPublishReason, WelcomeDeliveryFailure,
 };
 pub use secret_store::{AccountSecretStore, KeychainSecretStore, LocalFileSecretStore};
 pub use time::{

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -24,11 +24,11 @@ use cgka_traits::maintenance::{
 };
 use cgka_traits::transport::{TransportEnvelope, TransportMessage};
 use cgka_traits::{
-    EpochId, FanoutMlsState, GroupId, MemberId, OutboundFanout, OutboundFanoutOutcome,
-    StorageError, Timestamp, TransportAccountActivation, TransportAdapter, TransportAdapterError,
-    TransportDelivery, TransportEndpoint, TransportEndpointFailure, TransportEndpointFailureKind,
-    TransportEndpointReceipt, TransportGroupSync, TransportPublishReport, TransportPublishRequest,
-    TransportPublishTarget,
+    EpochId, FanoutMlsState, FanoutPendingKind, GroupId, MemberId, OutboundFanout,
+    OutboundFanoutOutcome, StorageError, Timestamp, TransportAccountActivation, TransportAdapter,
+    TransportAdapterError, TransportDelivery, TransportEndpoint, TransportEndpointFailure,
+    TransportEndpointFailureKind, TransportEndpointReceipt, TransportGroupSync,
+    TransportPublishReport, TransportPublishRequest, TransportPublishTarget,
 };
 use futures::StreamExt;
 use futures::stream::FuturesUnordered;
@@ -92,6 +92,12 @@ struct PublishStatus {
     accepted_by_any_endpoint: bool,
     possible_ambiguous_exposure: bool,
     retry_deferred: bool,
+}
+
+struct PendingFanoutContinuation {
+    pending: PendingStateRef,
+    kind: FanoutPendingKind,
+    post_confirmation_welcomes: Vec<TransportMessage>,
 }
 
 enum PreparedLegacyPublish {
@@ -2124,8 +2130,8 @@ where
                     source_epoch,
                     retention,
                 } => {
-                    let engine_message_id = msg.id.clone();
                     let reports_before = output.reports.len();
+                    let unresolved_before = output.unresolved_publishes.len();
                     let status =
                         Box::pin(self.publish_one(msg, None, output, queue, context.clone()))
                             .await?;
@@ -2153,18 +2159,14 @@ where
                             );
                         }
                     } else if status.retry_deferred
-                        && let Some(unresolved) = output
-                            .unresolved_publishes
-                            .iter()
-                            .rev()
-                            .find(|unresolved| unresolved.message_id == engine_message_id)
+                        && let Some(unresolved) = output.unresolved_publishes.get(unresolved_before)
                     {
                         output
                             .unresolved_app_messages
                             .push(UnresolvedApplicationMessage {
                                 group_id,
                                 app_event_id,
-                                message_id: engine_message_id,
+                                message_id: unresolved.message_id.clone(),
                                 reason: unresolved.reason,
                             });
                     }
@@ -2553,64 +2555,27 @@ where
         queue: &mut VecDeque<PublishWork>,
         context: Option<AuditEventContext>,
     ) -> AccountResult<()> {
-        let mut all_published = true;
-        let mut any_welcome_exposed = false;
-        let mut retry_deferred = false;
-        let mut welcome_failures = Vec::new();
-        let mut delivered_welcome_ids = Vec::new();
-        for welcome in welcomes {
-            let recipient = welcome_recipient(&welcome);
-            let welcome_id = welcome.id.clone();
-            let failures_before = output.failures.len();
-            let status =
-                Box::pin(self.publish_one(welcome, None, output, queue, context.clone())).await?;
-            any_welcome_exposed |= status.accepted_by_any_endpoint;
-            retry_deferred |= status.retry_deferred;
-            if status.met_required_acks {
-                delivered_welcome_ids.push(welcome_id);
-            } else {
-                if let Some(recipient) = recipient {
-                    welcome_failures.push(self.welcome_delivery_failure(
-                        welcome_id,
-                        recipient,
-                        None,
-                        output,
-                        failures_before,
-                    ));
-                }
-                all_published = false;
-                if !any_welcome_exposed {
-                    break;
-                }
-            }
-        }
-
-        if all_published || any_welcome_exposed {
+        let mut welcomes = welcomes.into_iter();
+        let Some(first_welcome) = welcomes.next() else {
             let effects = self.confirm_published_retrying(pending).await?;
-            let group_id = confirmed_group_id(&effects);
             output
                 .pending
                 .push(PendingResolution::Confirmed { pending });
             output.absorb_session_effects(effects, queue);
-            for message_id in &delivered_welcome_ids {
-                self.mark_welcome_delivered_best_effort(message_id);
-            }
-            for failure in &mut welcome_failures {
-                if failure.group_id.is_none() {
-                    failure.group_id = group_id.clone();
-                }
-            }
-            // Only a confirmed legacy create leaves welcomes worth
-            // re-delivering; a rolled-back create discards the whole
-            // evolution, welcomes included.
-            output.welcome_failures.extend(welcome_failures);
-        } else if !retry_deferred {
-            let effects = self.session.publish_failed(pending).await?;
-            output
-                .pending
-                .push(PendingResolution::RolledBack { pending });
-            output.absorb_session_effects(effects, queue);
-        }
+            return Ok(());
+        };
+        Box::pin(self.publish_one_with_post_confirmation_welcomes(
+            first_welcome,
+            Some(PendingFanoutContinuation {
+                pending,
+                kind: FanoutPendingKind::CreateGroup,
+                post_confirmation_welcomes: welcomes.collect(),
+            }),
+            output,
+            queue,
+            context,
+        ))
+        .await?;
         Ok(())
     }
 
@@ -2792,36 +2757,18 @@ where
             return Ok(());
         }
 
-        let commit_status =
-            Box::pin(self.publish_one(commit, Some(pending), output, queue, context.clone()))
-                .await?;
-        if commit_status.accepted_by_any_endpoint {
-            let group_id = confirmed_group_id_from_events(&output.events);
-            for welcome in welcomes {
-                let recipient = welcome_recipient(&welcome);
-                let welcome_id = welcome.id.clone();
-                let failures_before = output.failures.len();
-                let status =
-                    Box::pin(self.publish_one(welcome, None, output, queue, context.clone()))
-                        .await?;
-                if status.met_required_acks {
-                    self.mark_welcome_delivered_best_effort(&welcome_id);
-                } else {
-                    // The commit is already confirmed, so this member's join
-                    // hinges on re-delivering exactly this welcome.
-                    if let Some(recipient) = recipient {
-                        let failure = self.welcome_delivery_failure(
-                            welcome_id,
-                            recipient,
-                            group_id.clone(),
-                            output,
-                            failures_before,
-                        );
-                        output.welcome_failures.push(failure);
-                    }
-                }
-            }
-        }
+        Box::pin(self.publish_one_with_post_confirmation_welcomes(
+            commit,
+            Some(PendingFanoutContinuation {
+                pending,
+                kind: FanoutPendingKind::GroupEvolution,
+                post_confirmation_welcomes: welcomes,
+            }),
+            output,
+            queue,
+            context,
+        ))
+        .await?;
         Ok(())
     }
 
@@ -3047,7 +2994,37 @@ where
         queue: &mut VecDeque<PublishWork>,
         context: Option<AuditEventContext>,
     ) -> AccountResult<PublishStatus> {
-        if matches!(message.envelope, TransportEnvelope::GroupMessage { .. }) {
+        self.publish_one_with_post_confirmation_welcomes(
+            message,
+            pending.map(|pending| PendingFanoutContinuation {
+                pending,
+                kind: FanoutPendingKind::GroupEvolution,
+                post_confirmation_welcomes: Vec::new(),
+            }),
+            output,
+            queue,
+            context,
+        )
+        .await
+    }
+
+    async fn publish_one_with_post_confirmation_welcomes(
+        &mut self,
+        message: TransportMessage,
+        continuation: Option<PendingFanoutContinuation>,
+        output: &mut AccountDeviceEffects,
+        queue: &mut VecDeque<PublishWork>,
+        context: Option<AuditEventContext>,
+    ) -> AccountResult<PublishStatus> {
+        let (pending, pending_kind, post_confirmation_welcomes) = match continuation {
+            Some(continuation) => (
+                Some(continuation.pending),
+                Some(continuation.kind),
+                continuation.post_confirmation_welcomes,
+            ),
+            None => (None, None, Vec::new()),
+        };
+        if matches!(message.envelope, TransportEnvelope::GroupMessage { .. }) || pending.is_some() {
             let target = match self.routing.publish_target(&message) {
                 Ok(target) => target,
                 Err(error) => {
@@ -3072,7 +3049,23 @@ where
                     return Err(error.into());
                 }
             };
-            let fanout = match OutboundFanout::stage(
+            let pending_origin_message_id = if pending_kind == Some(FanoutPendingKind::CreateGroup)
+            {
+                None
+            } else {
+                match pending
+                    .map(|pending| self.session.pending_origin_message_id(pending))
+                    .transpose()
+                {
+                    Ok(message_id) => message_id,
+                    Err(error) => {
+                        self.rollback_unstaged_pending(pending, output, queue)
+                            .await?;
+                        return Err(error.into());
+                    }
+                }
+            };
+            let fanout = match OutboundFanout::stage_with_post_confirmation_welcomes(
                 TransportPublishRequest {
                     account_id: self.session.self_id(),
                     message,
@@ -3082,6 +3075,9 @@ where
                 pending,
                 pending_group_id,
                 self.wall_clock.now().0.saturating_mul(1_000),
+                pending_origin_message_id,
+                pending_kind,
+                post_confirmation_welcomes,
             ) {
                 Ok(fanout) => fanout,
                 Err(error) => {
@@ -3124,7 +3120,7 @@ where
         queue: &mut VecDeque<PublishWork>,
         context: Option<AuditEventContext>,
     ) -> AccountResult<PublishStatus> {
-        self.resolve_outbound_fanout_mls(&mut fanout, output, queue)
+        self.resolve_outbound_fanout_mls(&mut fanout, output, queue, context.clone())
             .await?;
         let endpoints = fanout.request().target.endpoints().to_vec();
         let now_ms = self.wall_clock.now().0.saturating_mul(1_000);
@@ -3206,7 +3202,27 @@ where
                 }
             }
             self.session.put_outbound_fanout(&fanout)?;
-            self.resolve_outbound_fanout_mls(&mut fanout, output, queue)
+            let report = frozen_fanout_report(&fanout);
+            // Record this artifact before confirmation releases any frozen
+            // Welcome continuations, preserving transport chronology in the
+            // returned effects while keeping the MLS edge atomic below.
+            self.session.record_audit_event(
+                fanout.group_id(),
+                context.clone(),
+                AuditEventKind::PublishOutcome {
+                    msg_id: hex::encode(report.message_id.as_slice()),
+                    artifact_kind: None,
+                    target_kind: "frozen_group_fanout".into(),
+                    relay_url: None,
+                    accepted_relay_urls: Vec::new(),
+                    failed_relays: Vec::new(),
+                    required_acks: report.required_acks as u64,
+                    met_required_acks: report.met_required_acks(),
+                    transport: Some(publish_wire_metadata(&fanout.request().message)),
+                },
+            );
+            output.reports.push(report);
+            self.resolve_outbound_fanout_mls(&mut fanout, output, queue, context.clone())
                 .await?;
         }
 
@@ -3219,7 +3235,7 @@ where
             possible_ambiguous_exposure,
             retry_deferred: fanout_outcome.outstanding_targets > 0,
         };
-        if fanout_outcome.outstanding_targets > 0 {
+        if fanout_outcome.outstanding_targets > 0 && !status.met_required_acks {
             output.unresolved_publishes.push(UnresolvedPublish {
                 message_id: report.message_id.clone(),
                 reason: if possible_ambiguous_exposure {
@@ -3234,27 +3250,25 @@ where
                 reason: "insufficient publish acknowledgements".into(),
             });
         }
-        // `EpochConfirmed` / `EpochRolledBack` records the MLS edge. This
-        // endpoint-free publish row records the separate terminal fanout edge;
-        // relay URLs stay solely in the encrypted fanout record and never enter
-        // this privacy-safe audit summary.
-        if attempted_any {
-            self.session.record_audit_event(
-                fanout.group_id(),
-                context,
-                AuditEventKind::PublishOutcome {
-                    msg_id: hex::encode(report.message_id.as_slice()),
-                    artifact_kind: None,
-                    target_kind: "frozen_group_fanout".into(),
-                    relay_url: None,
-                    accepted_relay_urls: Vec::new(),
-                    failed_relays: Vec::new(),
-                    required_acks: report.required_acks as u64,
-                    met_required_acks: status.met_required_acks,
-                    transport: Some(publish_wire_metadata(&fanout.request().message)),
-                },
-            );
-            output.reports.push(report);
+        if matches!(
+            fanout.request().message.envelope,
+            TransportEnvelope::Welcome { .. }
+        ) {
+            if status.met_required_acks {
+                self.mark_welcome_delivered_best_effort(fanout.message_id());
+            } else if attempted_any
+                && matches!(fanout.mls_state(), FanoutMlsState::Confirmed)
+                && let Some(recipient) = welcome_recipient(&fanout.request().message)
+            {
+                let failure = self.welcome_delivery_failure(
+                    fanout.message_id().clone(),
+                    recipient,
+                    fanout.group_id().cloned(),
+                    output,
+                    output.failures.len().saturating_sub(1),
+                );
+                output.welcome_failures.push(failure);
+            }
         }
         output.fanout.push(fanout_outcome.clone());
         if fanout_outcome.fanout_complete
@@ -3270,6 +3284,7 @@ where
         fanout: &mut OutboundFanout,
         output: &mut AccountDeviceEffects,
         queue: &mut VecDeque<PublishWork>,
+        context: Option<AuditEventContext>,
     ) -> AccountResult<()> {
         let outcome = fanout.outcome();
         if outcome.mls_confirmation_required {
@@ -3293,6 +3308,17 @@ where
                 .pending
                 .push(PendingResolution::RolledBack { pending });
             output.absorb_session_effects(effects, queue);
+        }
+        if matches!(fanout.mls_state(), FanoutMlsState::Confirmed)
+            && !fanout.pending_post_confirmation_welcomes().is_empty()
+        {
+            let welcomes = fanout.pending_post_confirmation_welcomes().to_vec();
+            let group_id = fanout.group_id().cloned();
+            self.publish_welcome_fanout(welcomes, group_id, output, context, false)
+                .await?;
+            if fanout.mark_post_confirmation_welcomes_released() {
+                self.session.put_outbound_fanout(fanout)?;
+            }
         }
         Ok(())
     }
@@ -3995,28 +4021,6 @@ fn welcome_recipient(message: &TransportMessage) -> Option<MemberId> {
         TransportEnvelope::Welcome { recipient } => Some(recipient.clone()),
         TransportEnvelope::GroupMessage { .. } => None,
     }
-}
-
-/// Extract the group id from the event that confirms a create/evolution.
-///
-/// Session effects are drained after every session call, so the confirmation
-/// effects contain exactly one `GroupCreated` or `EpochChanged` for this
-/// pending operation rather than events left by earlier work. This per-call
-/// drain is load-bearing: batching effects across calls would require matching
-/// the event to the pending operation explicitly. Keeping extraction
-/// best-effort preserves the existing `WelcomeDeliveryFailure::group_id`
-/// contract without re-reading the durable sent-welcome record.
-fn confirmed_group_id(effects: &SessionEffects) -> Option<GroupId> {
-    confirmed_group_id_from_events(&effects.events)
-}
-
-fn confirmed_group_id_from_events(events: &[GroupEvent]) -> Option<GroupId> {
-    events.iter().rev().find_map(|event| match event {
-        GroupEvent::GroupCreated { group_id } | GroupEvent::EpochChanged { group_id, .. } => {
-            Some(group_id.clone())
-        }
-        _ => None,
-    })
 }
 
 /// Build the outbound transport wire envelope for a publish, from the message's

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -2761,7 +2761,7 @@ where
             commit,
             Some(PendingFanoutContinuation {
                 pending,
-                kind: FanoutPendingKind::GroupEvolution,
+                kind: self.session.pending_fanout_kind(pending)?,
                 post_confirmation_welcomes: welcomes,
             }),
             output,
@@ -2994,13 +2994,17 @@ where
         queue: &mut VecDeque<PublishWork>,
         context: Option<AuditEventContext>,
     ) -> AccountResult<PublishStatus> {
-        self.publish_one_with_post_confirmation_welcomes(
-            message,
-            pending.map(|pending| PendingFanoutContinuation {
+        let continuation = match pending {
+            Some(pending) => Some(PendingFanoutContinuation {
                 pending,
-                kind: FanoutPendingKind::GroupEvolution,
+                kind: self.session.pending_fanout_kind(pending)?,
                 post_confirmation_welcomes: Vec::new(),
             }),
+            None => None,
+        };
+        self.publish_one_with_post_confirmation_welcomes(
+            message,
+            continuation,
             output,
             queue,
             context,
@@ -3235,21 +3239,27 @@ where
             possible_ambiguous_exposure,
             retry_deferred: fanout_outcome.outstanding_targets > 0,
         };
-        if fanout_outcome.outstanding_targets > 0 && !status.met_required_acks {
-            output.unresolved_publishes.push(UnresolvedPublish {
-                message_id: report.message_id.clone(),
-                reason: if possible_ambiguous_exposure {
-                    UnresolvedPublishReason::AcknowledgementUnknown
-                } else {
-                    UnresolvedPublishReason::RetryableUnavailable
-                },
-            });
-        } else if !status.met_required_acks {
-            output.failures.push(PublishFailure {
-                message_id: report.message_id.clone(),
-                reason: "insufficient publish acknowledgements".into(),
-            });
-        }
+        let publish_failure_reason =
+            if fanout_outcome.outstanding_targets > 0 && !status.met_required_acks {
+                output.unresolved_publishes.push(UnresolvedPublish {
+                    message_id: report.message_id.clone(),
+                    reason: if possible_ambiguous_exposure {
+                        UnresolvedPublishReason::AcknowledgementUnknown
+                    } else {
+                        UnresolvedPublishReason::RetryableUnavailable
+                    },
+                });
+                None
+            } else if !status.met_required_acks {
+                let reason = "insufficient publish acknowledgements".to_owned();
+                output.failures.push(PublishFailure {
+                    message_id: report.message_id.clone(),
+                    reason: reason.clone(),
+                });
+                Some(reason)
+            } else {
+                None
+            };
         if matches!(
             fanout.request().message.envelope,
             TransportEnvelope::Welcome { .. }
@@ -3260,14 +3270,14 @@ where
                 && matches!(fanout.mls_state(), FanoutMlsState::Confirmed)
                 && let Some(recipient) = welcome_recipient(&fanout.request().message)
             {
-                let failure = self.welcome_delivery_failure(
-                    fanout.message_id().clone(),
+                output.welcome_failures.push(WelcomeDeliveryFailure {
+                    message_id: fanout.message_id().clone(),
                     recipient,
-                    fanout.group_id().cloned(),
-                    output,
-                    output.failures.len().saturating_sub(1),
-                );
-                output.welcome_failures.push(failure);
+                    group_id: fanout.group_id().cloned(),
+                    reason: publish_failure_reason
+                        .clone()
+                        .unwrap_or_else(|| "welcome publish failed".into()),
+                });
             }
         }
         output.fanout.push(fanout_outcome.clone());

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -26,8 +26,9 @@ use cgka_traits::transport::{TransportEnvelope, TransportMessage};
 use cgka_traits::{
     EpochId, FanoutMlsState, GroupId, MemberId, OutboundFanout, OutboundFanoutOutcome,
     StorageError, Timestamp, TransportAccountActivation, TransportAdapter, TransportAdapterError,
-    TransportDelivery, TransportEndpoint, TransportEndpointFailure, TransportEndpointReceipt,
-    TransportGroupSync, TransportPublishReport, TransportPublishRequest, TransportPublishTarget,
+    TransportDelivery, TransportEndpoint, TransportEndpointFailure, TransportEndpointFailureKind,
+    TransportEndpointReceipt, TransportGroupSync, TransportPublishReport, TransportPublishRequest,
+    TransportPublishTarget,
 };
 use futures::StreamExt;
 use futures::stream::FuturesUnordered;
@@ -57,6 +58,8 @@ const MAINTENANCE_QUIET_SECS: u64 = 60;
 const PERIODIC_MIN_SECS: u64 = 24 * 24 * 60 * 60;
 const PERIODIC_MAX_SECS: u64 = 36 * 24 * 60 * 60;
 const TRANSPORT_FANOUT_RETENTION_SECS: u64 = 24 * 60 * 60;
+const FROZEN_FANOUT_RETRY_BASE_MS: u64 = 30 * 1_000;
+const FROZEN_FANOUT_RETRY_MAX_MS: u64 = 60 * 60 * 1_000;
 
 /// Run independent async work with fixed fan-out while returning results in
 /// input order. Completion order therefore cannot reorder reports or select a
@@ -2121,6 +2124,7 @@ where
                     source_epoch,
                     retention,
                 } => {
+                    let engine_message_id = msg.id.clone();
                     let reports_before = output.reports.len();
                     let status =
                         Box::pin(self.publish_one(msg, None, output, queue, context.clone()))
@@ -2148,6 +2152,21 @@ where
                                 "accepted application publish had no transport report"
                             );
                         }
+                    } else if status.retry_deferred
+                        && let Some(unresolved) = output
+                            .unresolved_publishes
+                            .iter()
+                            .rev()
+                            .find(|unresolved| unresolved.message_id == engine_message_id)
+                    {
+                        output
+                            .unresolved_app_messages
+                            .push(UnresolvedApplicationMessage {
+                                group_id,
+                                app_event_id,
+                                message_id: engine_message_id,
+                                reason: unresolved.reason,
+                            });
                     }
                     self.resolve_regenerated_queued_intent(queued_intent, status);
                 }
@@ -3062,7 +3081,7 @@ where
                 },
                 pending,
                 pending_group_id,
-                0,
+                self.wall_clock.now().0.saturating_mul(1_000),
             ) {
                 Ok(fanout) => fanout,
                 Err(error) => {
@@ -3108,10 +3127,16 @@ where
         self.resolve_outbound_fanout_mls(&mut fanout, output, queue)
             .await?;
         let endpoints = fanout.request().target.endpoints().to_vec();
-        let outstanding = fanout.outstanding_target_indexes();
-        if !outstanding.is_empty() {
-            for &index in &outstanding {
-                fanout.mark_attempt_started(index)?;
+        let now_ms = self.wall_clock.now().0.saturating_mul(1_000);
+        let due = fanout
+            .outstanding_target_indexes()
+            .into_iter()
+            .filter(|&index| frozen_fanout_target_retry_due(&fanout, index, now_ms))
+            .collect::<Vec<_>>();
+        let attempted_any = !due.is_empty();
+        if !due.is_empty() {
+            for &index in &due {
+                fanout.mark_attempt_started_at(index, now_ms)?;
             }
             self.session.put_outbound_fanout(&fanout)?;
 
@@ -3127,7 +3152,7 @@ where
             // one-awaited-ack-at-a-time serialization.
             let adapter = &self.adapter;
             let account_id = fanout.request().account_id.clone();
-            let attempts = outstanding.iter().map(|&index| {
+            let attempts = due.iter().map(|&index| {
                 let attempt = TransportPublishRequest {
                     account_id: account_id.clone(),
                     message: fanout.request().message.clone(),
@@ -3140,20 +3165,44 @@ where
                 async move { (index, adapter.publish(attempt).await) }
             });
             for (index, result) in futures::future::join_all(attempts).await {
-                let accepted = match result {
+                let endpoint = endpoints[index].clone();
+                let failure = match result {
                     Ok(report) => {
                         fanout.record_published_message_id(report.message_id)?;
-                        report
+                        if report
                             .accepted
                             .iter()
-                            .any(|receipt| receipt.endpoint == endpoints[index])
+                            .any(|receipt| receipt.endpoint == endpoint)
+                        {
+                            fanout.mark_target_accepted(index)?;
+                            None
+                        } else {
+                            Some(
+                                report
+                                    .failed
+                                    .iter()
+                                    .find(|failure| failure.endpoint == endpoint)
+                                    .cloned()
+                                    .unwrap_or_else(|| ambiguous_endpoint_failure(endpoint)),
+                            )
+                        }
                     }
-                    Err(_) => false,
+                    Err(error) => {
+                        if let Some(message_id) = error.publish_message_id() {
+                            fanout.record_published_message_id(message_id.clone())?;
+                        }
+                        Some(
+                            error
+                                .publish_endpoint_failures()
+                                .iter()
+                                .find(|failure| failure.endpoint == endpoint)
+                                .cloned()
+                                .unwrap_or_else(|| ambiguous_endpoint_failure(endpoint)),
+                        )
+                    }
                 };
-                if accepted {
-                    fanout.mark_target_accepted(index)?;
-                } else {
-                    fanout.mark_target_failed(index)?;
+                if let Some(failure) = failure {
+                    fanout.record_target_failure(index, failure)?;
                 }
             }
             self.session.put_outbound_fanout(&fanout)?;
@@ -3162,13 +3211,24 @@ where
         }
 
         let report = frozen_fanout_report(&fanout);
+        let fanout_outcome = fanout.outcome();
+        let possible_ambiguous_exposure = fanout.possible_exposure();
         let status = PublishStatus {
             met_required_acks: report.met_required_acks(),
             accepted_by_any_endpoint: report.accepted_count() > 0,
-            possible_ambiguous_exposure: false,
-            retry_deferred: false,
+            possible_ambiguous_exposure,
+            retry_deferred: fanout_outcome.outstanding_targets > 0,
         };
-        if !status.met_required_acks {
+        if fanout_outcome.outstanding_targets > 0 {
+            output.unresolved_publishes.push(UnresolvedPublish {
+                message_id: report.message_id.clone(),
+                reason: if possible_ambiguous_exposure {
+                    UnresolvedPublishReason::AcknowledgementUnknown
+                } else {
+                    UnresolvedPublishReason::RetryableUnavailable
+                },
+            });
+        } else if !status.met_required_acks {
             output.failures.push(PublishFailure {
                 message_id: report.message_id.clone(),
                 reason: "insufficient publish acknowledgements".into(),
@@ -3178,24 +3238,26 @@ where
         // endpoint-free publish row records the separate terminal fanout edge;
         // relay URLs stay solely in the encrypted fanout record and never enter
         // this privacy-safe audit summary.
-        self.session.record_audit_event(
-            fanout.group_id(),
-            context,
-            AuditEventKind::PublishOutcome {
-                msg_id: hex::encode(report.message_id.as_slice()),
-                artifact_kind: None,
-                target_kind: "frozen_group_fanout".into(),
-                relay_url: None,
-                accepted_relay_urls: Vec::new(),
-                failed_relays: Vec::new(),
-                required_acks: report.required_acks as u64,
-                met_required_acks: status.met_required_acks,
-                transport: Some(publish_wire_metadata(&fanout.request().message)),
-            },
-        );
-        output.reports.push(report);
-        output.fanout.push(fanout.outcome());
-        if fanout.outcome().fanout_complete
+        if attempted_any {
+            self.session.record_audit_event(
+                fanout.group_id(),
+                context,
+                AuditEventKind::PublishOutcome {
+                    msg_id: hex::encode(report.message_id.as_slice()),
+                    artifact_kind: None,
+                    target_kind: "frozen_group_fanout".into(),
+                    relay_url: None,
+                    accepted_relay_urls: Vec::new(),
+                    failed_relays: Vec::new(),
+                    required_acks: report.required_acks as u64,
+                    met_required_acks: status.met_required_acks,
+                    transport: Some(publish_wire_metadata(&fanout.request().message)),
+                },
+            );
+            output.reports.push(report);
+        }
+        output.fanout.push(fanout_outcome.clone());
+        if fanout_outcome.fanout_complete
             && !matches!(fanout.mls_state(), FanoutMlsState::Pending(_))
         {
             self.session.delete_outbound_fanout(fanout.message_id())?;
@@ -3223,6 +3285,7 @@ where
             output.absorb_session_effects(effects, queue);
         } else if outcome.fanout_complete
             && outcome.accepted_targets == 0
+            && !fanout.possible_exposure()
             && let Some(pending) = fanout.pending_ref()
         {
             let effects = self.session.publish_failed_fanout(pending, fanout).await?;
@@ -3633,11 +3696,39 @@ fn publish_target_with_endpoints(
     }
 }
 
+fn ambiguous_endpoint_failure(endpoint: TransportEndpoint) -> TransportEndpointFailure {
+    TransportEndpointFailure {
+        endpoint,
+        reason: "publish acknowledgement unknown".into(),
+        kind: TransportEndpointFailureKind::PossiblyExposed,
+        rejection_category: None,
+    }
+}
+
+fn frozen_fanout_target_retry_due(fanout: &OutboundFanout, index: usize, now_ms: u64) -> bool {
+    use cgka_traits::FanoutTargetStatus;
+
+    match fanout.target_status(index) {
+        Some(FanoutTargetStatus::NotAttempted | FanoutTargetStatus::Attempting) => true,
+        Some(FanoutTargetStatus::PossiblyExposed | FanoutTargetStatus::RetryableUnavailable) => {
+            let attempt_count = fanout.target_attempt_count(index);
+            let shift = attempt_count.saturating_sub(1).min(7);
+            let backoff_ms = FROZEN_FANOUT_RETRY_BASE_MS
+                .saturating_mul(1_u64 << shift)
+                .min(FROZEN_FANOUT_RETRY_MAX_MS);
+            fanout
+                .target_last_attempt_at_ms(index)
+                .is_none_or(|last| now_ms >= last.saturating_add(backoff_ms))
+        }
+        Some(FanoutTargetStatus::Accepted | FanoutTargetStatus::Failed) | None => false,
+    }
+}
+
 fn frozen_fanout_report(fanout: &OutboundFanout) -> TransportPublishReport {
     let endpoints = fanout.request().target.endpoints();
     let mut accepted = Vec::new();
     let mut failed = Vec::new();
-    for (endpoint, status) in endpoints.iter().zip(fanout.target_statuses()) {
+    for (index, (endpoint, status)) in endpoints.iter().zip(fanout.target_statuses()).enumerate() {
         match status {
             cgka_traits::FanoutTargetStatus::Accepted => {
                 accepted.push(TransportEndpointReceipt {
@@ -3646,14 +3737,23 @@ fn frozen_fanout_report(fanout: &OutboundFanout) -> TransportPublishReport {
                 });
             }
             cgka_traits::FanoutTargetStatus::Failed => {
-                failed.push(TransportEndpointFailure {
-                    endpoint: endpoint.clone(),
-                    reason: "publish attempt failed".into(),
-                    rejection_category: None,
-                });
+                failed.push(fanout.target_failure(index).cloned().unwrap_or_else(|| {
+                    TransportEndpointFailure {
+                        endpoint: endpoint.clone(),
+                        reason: "publish attempt failed before exposure".into(),
+                        kind: TransportEndpointFailureKind::NotExposed,
+                        rejection_category: None,
+                    }
+                }));
             }
             cgka_traits::FanoutTargetStatus::NotAttempted
             | cgka_traits::FanoutTargetStatus::Attempting => {}
+            cgka_traits::FanoutTargetStatus::PossiblyExposed
+            | cgka_traits::FanoutTargetStatus::RetryableUnavailable => {
+                if let Some(failure) = fanout.target_failure(index) {
+                    failed.push(failure.clone());
+                }
+            }
         }
     }
     TransportPublishReport {
@@ -3947,6 +4047,13 @@ pub struct AccountDeviceEffects {
     /// Privacy-safe summaries separate MLS release from target fanout completion.
     pub fanout: Vec<OutboundFanoutOutcome>,
     pub failures: Vec<PublishFailure>,
+    /// Exact signed events retained because publication completion is not yet
+    /// known. This is a typed non-failure result: callers must not create a
+    /// semantically new send to recover it.
+    pub unresolved_publishes: Vec<UnresolvedPublish>,
+    /// Application-message identity attached to unresolved publication so app
+    /// consumers can keep exactly the affected local row in a sending state.
+    pub unresolved_app_messages: Vec<UnresolvedApplicationMessage>,
     /// Application messages accepted by at least one transport endpoint,
     /// carrying source-state metadata captured by the exact MLS encryption
     /// operation and the adapter-visible transport id.
@@ -3993,6 +4100,10 @@ impl AccountDeviceEffects {
             .append(&mut other.pending_convergence);
         self.reports.append(&mut other.reports);
         self.failures.append(&mut other.failures);
+        self.unresolved_publishes
+            .append(&mut other.unresolved_publishes);
+        self.unresolved_app_messages
+            .append(&mut other.unresolved_app_messages);
         self.published_app_messages
             .append(&mut other.published_app_messages);
         self.welcome_failures.append(&mut other.welcome_failures);
@@ -4018,6 +4129,26 @@ pub struct AccountIngestEffects {
 pub struct PublishFailure {
     pub message_id: cgka_traits::MessageId,
     pub reason: String,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UnresolvedPublishReason {
+    AcknowledgementUnknown,
+    RetryableUnavailable,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UnresolvedPublish {
+    pub message_id: cgka_traits::MessageId,
+    pub reason: UnresolvedPublishReason,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UnresolvedApplicationMessage {
+    pub group_id: GroupId,
+    pub app_event_id: String,
+    pub message_id: cgka_traits::MessageId,
+    pub reason: UnresolvedPublishReason,
 }
 
 /// A welcome left undelivered by a confirmed group create/evolution (mdk#352).

--- a/crates/marmot-account/tests/runtime.rs
+++ b/crates/marmot-account/tests/runtime.rs
@@ -27,8 +27,10 @@ use cgka_traits::transport::{
 use cgka_traits::{
     EpochId, FanoutMlsState, FanoutTargetStatus, GroupId, MemberId, MessageId, OutboundFanout,
     TransportAccountActivation, TransportAdapter, TransportAdapterError, TransportDelivery,
-    TransportDeliveryPlane, TransportDeliverySource, TransportEndpoint, TransportEndpointReceipt,
-    TransportGroupSync, TransportPublishReport, TransportPublishRequest, TransportPublishTarget,
+    TransportDeliveryPlane, TransportDeliverySource, TransportEndpoint, TransportEndpointFailure,
+    TransportEndpointFailureKind, TransportEndpointReceipt, TransportEndpointRejectionCategory,
+    TransportGroupSync, TransportPublishFailure, TransportPublishReport, TransportPublishRequest,
+    TransportPublishTarget,
 };
 use marmot_account::{
     AccountDeviceRuntime, AccountError, KeyPackagePublication, KeyPackagePublishError,
@@ -340,6 +342,7 @@ struct RecordingAdapterInner {
     accepted_counts: Mutex<VecDeque<usize>>,
     accept_policy: Mutex<Option<Vec<TransportEndpoint>>>,
     error_endpoints: Mutex<Vec<TransportEndpoint>>,
+    error_kind: Mutex<Option<TransportEndpointFailureKind>>,
     publish_errors: Mutex<VecDeque<bool>>,
     reported_message_ids: Mutex<VecDeque<MessageId>>,
     welcome_gate: Mutex<Option<Arc<WelcomePublishGate>>>,
@@ -391,6 +394,16 @@ impl RecordingAdapter {
     /// endpoints all sit in this set returns `Err` instead of a report.
     fn error_for_endpoints(&self, endpoints: Vec<TransportEndpoint>) {
         *self.inner.error_endpoints.lock().unwrap() = endpoints;
+        *self.inner.error_kind.lock().unwrap() = None;
+    }
+
+    fn fail_endpoints_as(
+        &self,
+        endpoints: Vec<TransportEndpoint>,
+        kind: TransportEndpointFailureKind,
+    ) {
+        *self.inner.error_endpoints.lock().unwrap() = endpoints;
+        *self.inner.error_kind.lock().unwrap() = Some(kind);
     }
 
     fn report_message_id_next(&self, message_id: MessageId) {
@@ -478,6 +491,34 @@ impl TransportAdapter for RecordingAdapter {
                     .iter()
                     .all(|endpoint| error_endpoints.contains(endpoint))
             {
+                if let Some(kind) = *self.inner.error_kind.lock().unwrap() {
+                    let failures = request
+                        .target
+                        .endpoints()
+                        .iter()
+                        .cloned()
+                        .map(|endpoint| TransportEndpointFailure {
+                            endpoint,
+                            reason: "injected typed endpoint failure".into(),
+                            kind,
+                            rejection_category: None,
+                        })
+                        .collect();
+                    let message_id = self
+                        .inner
+                        .reported_message_ids
+                        .lock()
+                        .unwrap()
+                        .pop_front()
+                        .unwrap_or(request.message.id);
+                    return Err(TransportAdapterError::PublishEndpoints(
+                        TransportPublishFailure::with_endpoint_failures(
+                            "injected typed endpoint failure",
+                            failures,
+                        )
+                        .with_message_id(message_id),
+                    ));
+                }
                 return Err(TransportAdapterError::Publish(
                     "endpoint-policy adapter error".into(),
                 ));
@@ -504,7 +545,19 @@ impl TransportAdapter for RecordingAdapter {
                         accepted_at: None,
                     })
                     .collect(),
-                failed: Vec::new(),
+                failed: request
+                    .target
+                    .endpoints()
+                    .iter()
+                    .filter(|endpoint| !accepted_endpoints.contains(endpoint))
+                    .cloned()
+                    .map(|endpoint| TransportEndpointFailure {
+                        endpoint,
+                        reason: "injected explicit relay rejection".into(),
+                        kind: TransportEndpointFailureKind::TerminalRejected,
+                        rejection_category: Some(TransportEndpointRejectionCategory::Blocked),
+                    })
+                    .collect(),
                 required_acks: request.required_acks,
             });
         }

--- a/crates/marmot-account/tests/runtime.rs
+++ b/crates/marmot-account/tests/runtime.rs
@@ -2625,7 +2625,7 @@ async fn create_group_rolls_back_pending_when_publish_acks_are_insufficient() {
     let bob_id = bob_session.self_id();
     let session = session(dir.path().join("alice.sqlite"), &key, b"alice");
     let adapter = RecordingAdapter::default();
-    adapter.accept_only_next(0);
+    adapter.accept_only_endpoints(Vec::new());
     let policy =
         StaticTransportRouting::new(vec![TransportEndpoint("wss://alice-inbox.example".into())])
             .with_inbox_route(
@@ -2669,7 +2669,7 @@ async fn create_group_with_best_effort_acks_rolls_back_when_nothing_accepted() {
     let bob_id = bob_session.self_id();
     let session = session(dir.path().join("alice.sqlite"), &key, b"alice");
     let adapter = RecordingAdapter::default();
-    adapter.accept_only_next(0);
+    adapter.accept_only_endpoints(Vec::new());
     let policy =
         StaticTransportRouting::new(vec![TransportEndpoint("wss://alice-inbox.example".into())])
             .required_acks(0)
@@ -2721,7 +2721,7 @@ async fn create_group_stops_welcome_publish_after_unexposed_failure() {
     let carol_id = carol_session.self_id();
     let session = session(dir.path().join("alice.sqlite"), &key, b"alice");
     let adapter = RecordingAdapter::default();
-    adapter.accept_only_next(0);
+    adapter.accept_only_endpoints(Vec::new());
     let policy =
         StaticTransportRouting::new(vec![TransportEndpoint("wss://alice-inbox.example".into())])
             .with_inbox_route(
@@ -3178,7 +3178,7 @@ async fn create_group_confirms_pending_when_welcome_was_partially_exposed() {
     let bob_id = bob_session.self_id();
     let session = session(dir.path().join("alice.sqlite"), &key, b"alice");
     let adapter = RecordingAdapter::default();
-    adapter.accept_only_next(1);
+    adapter.accept_only_endpoints(vec![TransportEndpoint("wss://bob-inbox-a.example".into())]);
     let policy =
         StaticTransportRouting::new(vec![TransportEndpoint("wss://alice-inbox.example".into())])
             .required_acks(2)
@@ -3231,11 +3231,13 @@ async fn create_group_confirms_pending_when_welcome_was_partially_exposed() {
     assert_eq!(runtime.session().members(&group_id).unwrap().len(), 2);
 
     let publishes = adapter.publishes();
-    assert_eq!(publishes.len(), 1);
-    assert!(matches!(
-        publishes[0].message.envelope,
-        TransportEnvelope::Welcome { .. }
-    ));
+    assert_eq!(publishes.len(), 2);
+    assert!(
+        publishes
+            .iter()
+            .all(|publish| matches!(publish.message.envelope, TransportEnvelope::Welcome { .. }))
+    );
+    assert_eq!(publishes[0].message, publishes[1].message);
 }
 
 #[tokio::test]

--- a/crates/marmot-account/tests/runtime/frozen_fanout.rs
+++ b/crates/marmot-account/tests/runtime/frozen_fanout.rs
@@ -49,7 +49,12 @@ impl TransportAdapter for CrashDuringFanoutPublishAdapter {
     }
 }
 
-async fn assert_frozen_fanout_case(accept_at: Option<usize>, error_at: &[usize]) {
+async fn assert_frozen_fanout_case(
+    accept_at: Option<usize>,
+    error_at: &[usize],
+    error_kind: Option<TransportEndpointFailureKind>,
+    expect_unresolved: bool,
+) {
     let dir = tempfile::tempdir().unwrap();
     let key = SqlCipherKey::new("marmot fanout matrix key").unwrap();
     let mut alice = session(
@@ -92,12 +97,15 @@ async fn assert_frozen_fanout_case(accept_at: Option<usize>, error_at: &[usize])
     // whole-call `Err` on that endpoint's single-endpoint publish (an unmet
     // `required_acks: 1` discards the report), so error endpoints model the
     // real contract rather than an `Ok` report with no receipt.
-    adapter.error_for_endpoints(
-        error_at
-            .iter()
-            .map(|&index| endpoints[index].clone())
-            .collect(),
-    );
+    let error_endpoints = error_at
+        .iter()
+        .map(|&index| endpoints[index].clone())
+        .collect();
+    if let Some(kind) = error_kind {
+        adapter.fail_endpoints_as(error_endpoints, kind);
+    } else {
+        adapter.error_for_endpoints(error_endpoints);
+    }
     let policy = StaticTransportRouting::new(vec![TransportEndpoint("wss://inbox.example".into())])
         .with_group_route(
             group_id.clone(),
@@ -137,11 +145,15 @@ async fn assert_frozen_fanout_case(accept_at: Option<usize>, error_at: &[usize])
     assert!(publishes.iter().all(|publish| publish.required_acks == 1));
     assert_eq!(effects.reports.len(), 1);
     assert_eq!(effects.fanout.len(), 1);
-    assert!(effects.fanout[0].fanout_complete);
-    assert_eq!(effects.fanout[0].outstanding_targets, 0);
-    assert!(
+    assert_eq!(effects.fanout[0].fanout_complete, !expect_unresolved);
+    assert_eq!(
+        effects.fanout[0].outstanding_targets,
+        if expect_unresolved { error_at.len() } else { 0 }
+    );
+    assert_eq!(
         runtime.session().outbound_fanouts().unwrap().is_empty(),
-        "terminal fanouts must be pruned after their outcome is surfaced"
+        !expect_unresolved,
+        "unresolved fanouts must remain durable while terminal fanouts are pruned"
     );
 
     if accept_at.is_some() {
@@ -152,6 +164,28 @@ async fn assert_frozen_fanout_case(accept_at: Option<usize>, error_at: &[usize])
             effects.pending.as_slice(),
             [PendingResolution::Confirmed { .. }]
         ));
+    } else if expect_unresolved {
+        assert!(effects.failures.is_empty());
+        assert!(matches!(
+            effects.unresolved_publishes.as_slice(),
+            [marmot_account::UnresolvedPublish {
+                reason,
+                ..
+            }] if *reason == match error_kind {
+                Some(TransportEndpointFailureKind::RetryableUnavailable) => {
+                    marmot_account::UnresolvedPublishReason::RetryableUnavailable
+                }
+                _ => marmot_account::UnresolvedPublishReason::AcknowledgementUnknown,
+            }
+        ));
+        assert!(!effects.fanout[0].mls_confirmed);
+        assert_eq!(effects.fanout[0].accepted_targets, 0);
+        assert_eq!(
+            runtime.session().epoch(&group_id).unwrap().0,
+            2,
+            "the staged MLS transition must remain intact while completion is unknown"
+        );
+        assert!(effects.pending.is_empty());
     } else {
         assert!(!effects.fanout[0].mls_confirmed);
         assert_eq!(effects.fanout[0].accepted_targets, 0);
@@ -174,13 +208,214 @@ async fn assert_frozen_fanout_case(accept_at: Option<usize>, error_at: &[usize])
 #[tokio::test]
 async fn frozen_fanout_first_middle_last_ack_and_all_fail_are_terminal() {
     for accept_at in [Some(0), Some(1), Some(2), None] {
-        assert_frozen_fanout_case(accept_at, &[]).await;
+        assert_frozen_fanout_case(accept_at, &[], None, false).await;
     }
 }
 
 #[tokio::test]
-async fn frozen_fanout_whole_call_adapter_errors_are_terminal() {
-    assert_frozen_fanout_case(None, &[0, 1, 2]).await;
+async fn frozen_fanout_ambiguous_adapter_errors_remain_unresolved() {
+    assert_frozen_fanout_case(None, &[0, 1, 2], None, true).await;
+}
+
+#[tokio::test]
+async fn ambiguous_commit_retries_exact_event_after_restart_and_peer_can_advance() {
+    let dir = tempfile::tempdir().unwrap();
+    let alice_path = dir.path().join("alice-unknown-retry.sqlite");
+    let key_text = "marmot unknown retry key";
+    let key = SqlCipherKey::new(key_text).unwrap();
+    let mut alice = session(&alice_path, &key, b"alice-unknown-retry");
+    let mut bob = session(
+        dir.path().join("bob-unknown-retry.sqlite"),
+        &key,
+        b"bob-unknown-retry",
+    );
+    let created = alice
+        .create_group(CreateGroupRequest {
+            name: "unknown retry".into(),
+            description: String::new(),
+            members: vec![bob.fresh_key_package().await.unwrap()],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let group_id = created.group_id.clone();
+    let (create_pending, welcome) = match &created.effects.publish[0] {
+        PublishWork::GroupCreated { pending, welcomes } => (*pending, welcomes[0].clone()),
+        other => panic!("expected GroupCreated publish work, got {other:?}"),
+    };
+    alice.confirm_published(create_pending).await.unwrap();
+    bob.ingest(welcome).await.unwrap();
+
+    let endpoint = TransportEndpoint("wss://unknown-retry.example".into());
+    let adapter = RecordingAdapter::default();
+    let transport_event_id = MessageId::new(vec![0xE7; 32]);
+    adapter.report_message_id_next(transport_event_id.clone());
+    adapter.report_message_id_next(transport_event_id.clone());
+    adapter.fail_endpoints_as(
+        vec![endpoint.clone()],
+        TransportEndpointFailureKind::PossiblyExposed,
+    );
+    let policy = StaticTransportRouting::new(vec![TransportEndpoint(
+        "wss://unknown-retry-inbox.example".into(),
+    )])
+    .with_group_route(
+        group_id.clone(),
+        group_id.as_slice().to_vec(),
+        vec![endpoint],
+    );
+    let wall = Arc::new(TestWallClock::new(100_000));
+    let mut runtime = AccountDeviceRuntime::new(
+        alice,
+        adapter.clone(),
+        policy.clone(),
+        RecordingKeyPackages::default(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(0)),
+    );
+
+    let unresolved = runtime
+        .send(SendIntent::UpdateGroupData {
+            group_id: group_id.clone(),
+            name: Some("possibly exposed".into()),
+            description: None,
+        })
+        .await
+        .unwrap();
+    assert!(unresolved.pending.is_empty());
+    assert_eq!(unresolved.unresolved_publishes.len(), 1);
+    assert_eq!(
+        unresolved.unresolved_publishes[0].message_id,
+        transport_event_id
+    );
+    let first_attempt = adapter.publishes()[0].clone();
+
+    // The endpoint could have forwarded these exact bytes even though its OK
+    // was lost. A peer applying them proves sender rollback would split state.
+    bob.ingest(first_attempt.message.clone()).await.unwrap();
+    let convergence_delay = bob
+        .prepare_convergence_cutoff_delay_ms(&group_id)
+        .unwrap()
+        .expect("buffered commit must open a convergence pass");
+    tokio::time::sleep(Duration::from_millis(convergence_delay.saturating_add(1))).await;
+    bob.advance_convergence(&group_id).await.unwrap();
+    assert_eq!(bob.epoch(&group_id).unwrap().0, 2);
+    assert_eq!(runtime.session().epoch(&group_id).unwrap().0, 2);
+    drop(runtime);
+
+    adapter.error_for_endpoints(Vec::new());
+    let reopened = session(
+        &alice_path,
+        &SqlCipherKey::new(key_text).unwrap(),
+        b"alice-unknown-retry",
+    );
+    let mut restarted = AccountDeviceRuntime::new(
+        reopened,
+        adapter.clone(),
+        policy,
+        RecordingKeyPackages::default(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(0)),
+    );
+
+    let deferred = restarted.resume_outbound_fanouts().await.unwrap();
+    assert!(deferred.reports.is_empty());
+    assert_eq!(adapter.publishes().len(), 1);
+
+    wall.set(100_030);
+    let recovered = restarted.resume_outbound_fanouts().await.unwrap();
+    assert!(matches!(
+        recovered.pending.as_slice(),
+        [PendingResolution::Confirmed { .. }]
+    ));
+    assert_eq!(restarted.session().epoch(&group_id).unwrap().0, 2);
+    assert_eq!(recovered.reports[0].message_id, transport_event_id);
+    assert!(restarted.session().outbound_fanouts().unwrap().is_empty());
+    let attempts = adapter.publishes();
+    assert_eq!(attempts.len(), 2);
+    assert_eq!(attempts[0].message.id, attempts[1].message.id);
+    assert_eq!(attempts[0].message.payload, attempts[1].message.payload);
+}
+
+#[tokio::test]
+async fn ambiguous_application_publish_is_retained_without_definite_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot unknown app message key").unwrap();
+    let mut alice = session(
+        dir.path().join("alice-unknown-app.sqlite"),
+        &key,
+        b"alice-unknown-app",
+    );
+    let mut bob = session(
+        dir.path().join("bob-unknown-app.sqlite"),
+        &key,
+        b"bob-unknown-app",
+    );
+    let alice_id = alice.self_id();
+    let alice_hex = hex::encode(alice_id.as_slice());
+    let created = alice
+        .create_group(CreateGroupRequest {
+            name: "unknown app message".into(),
+            description: String::new(),
+            members: vec![bob.fresh_key_package().await.unwrap()],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let group_id = created.group_id.clone();
+    let (create_pending, welcome) = match &created.effects.publish[0] {
+        PublishWork::GroupCreated { pending, welcomes } => (*pending, welcomes[0].clone()),
+        other => panic!("expected GroupCreated publish work, got {other:?}"),
+    };
+    alice.confirm_published(create_pending).await.unwrap();
+    bob.ingest(welcome).await.unwrap();
+    let endpoint = TransportEndpoint("wss://unknown-app.example".into());
+    let adapter = RecordingAdapter::default();
+    adapter.error_for_endpoints(vec![endpoint.clone()]);
+    let policy = StaticTransportRouting::new(vec![TransportEndpoint(
+        "wss://unknown-app-inbox.example".into(),
+    )])
+    .with_group_route(
+        group_id.clone(),
+        group_id.as_slice().to_vec(),
+        vec![endpoint],
+    );
+    let mut runtime = AccountDeviceRuntime::new(
+        alice,
+        adapter,
+        policy,
+        RecordingKeyPackages::default(),
+    );
+    let payload = app_payload_for(&alice_hex, b"only one semantic message");
+    let app_event_id = MarmotAppEvent::decode(&payload).unwrap().id;
+
+    let effects = runtime
+        .send(SendIntent::AppMessage {
+            group_id: group_id.clone(),
+            payload,
+        })
+        .await
+        .unwrap();
+
+    assert!(effects.failures.is_empty());
+    assert!(effects.published_app_messages.is_empty());
+    assert_eq!(effects.unresolved_app_messages.len(), 1);
+    assert_eq!(effects.unresolved_app_messages[0].group_id, group_id);
+    assert_eq!(effects.unresolved_app_messages[0].app_event_id, app_event_id);
+    assert_eq!(
+        effects.unresolved_app_messages[0].reason,
+        marmot_account::UnresolvedPublishReason::AcknowledgementUnknown
+    );
+    assert_eq!(runtime.session().outbound_fanouts().unwrap().len(), 1);
 }
 
 /// The production-adapter partial-accept shape: one relay accepts while its
@@ -189,8 +424,29 @@ async fn frozen_fanout_whole_call_adapter_errors_are_terminal() {
 /// "everything failed".
 #[tokio::test]
 async fn frozen_fanout_partial_accept_with_sibling_adapter_errors_confirms_mls() {
-    assert_frozen_fanout_case(Some(0), &[1, 2]).await;
-    assert_frozen_fanout_case(Some(2), &[0, 1]).await;
+    assert_frozen_fanout_case(Some(0), &[1, 2], None, true).await;
+    assert_frozen_fanout_case(Some(2), &[0, 1], None, true).await;
+    // Accepted + explicit rejection + acknowledgement-unknown remains
+    // confirmed while retaining only the unresolved endpoint.
+    assert_frozen_fanout_case(Some(0), &[2], None, true).await;
+}
+
+#[tokio::test]
+async fn frozen_fanout_typed_unavailable_is_retryable_but_rejection_is_terminal() {
+    assert_frozen_fanout_case(
+        None,
+        &[0, 1, 2],
+        Some(TransportEndpointFailureKind::RetryableUnavailable),
+        true,
+    )
+    .await;
+    assert_frozen_fanout_case(
+        None,
+        &[0, 1, 2],
+        Some(TransportEndpointFailureKind::TerminalRejected),
+        false,
+    )
+    .await;
 }
 
 async fn assert_frozen_fanout_restart_edge(send_before_ack_persist: bool) {

--- a/crates/marmot-account/tests/runtime/frozen_fanout.rs
+++ b/crates/marmot-account/tests/runtime/frozen_fanout.rs
@@ -632,6 +632,96 @@ async fn ambiguous_invite_commit_recovery_publishes_its_frozen_welcome() {
     assert_eq!(carol.epoch(&group_id).unwrap().0, 2);
 }
 
+#[tokio::test]
+async fn ambiguous_disband_recovery_preserves_terminal_pending_kind() {
+    let dir = tempfile::tempdir().unwrap();
+    let alice_path = dir.path().join("alice-disband-unknown.sqlite");
+    let key_text = "marmot unknown disband key";
+    let key = SqlCipherKey::new(key_text).unwrap();
+    let mut alice = current_session(&alice_path, &key, b"alice-disband-unknown");
+    let created = alice
+        .create_group(CreateGroupRequest {
+            name: "unknown disband".into(),
+            description: String::new(),
+            members: Vec::new(),
+            required_features: Vec::new(),
+            app_components: Vec::new(),
+            initial_admins: Vec::new(),
+        })
+        .await
+        .unwrap();
+    let group_id = created.group_id;
+    alice
+        .send(SendIntent::Disband {
+            group_id: group_id.clone(),
+        })
+        .await
+        .unwrap();
+
+    let endpoint = TransportEndpoint("wss://disband-unknown.example".into());
+    let adapter = RecordingAdapter::default();
+    adapter.fail_endpoints_as(
+        vec![endpoint.clone()],
+        TransportEndpointFailureKind::PossiblyExposed,
+    );
+    let policy = StaticTransportRouting::new(Vec::new()).with_group_route(
+        group_id.clone(),
+        group_id.as_slice().to_vec(),
+        vec![endpoint.clone()],
+    );
+    let wall = Arc::new(TestWallClock::new(400_000));
+    let mut runtime = AccountDeviceRuntime::new(
+        alice,
+        adapter.clone(),
+        policy.clone(),
+        RecordingKeyPackages::default(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(0)),
+    );
+
+    let unresolved = runtime.advance_convergence(&group_id).await.unwrap();
+    assert_eq!(unresolved.unresolved_publishes.len(), 1);
+    assert!(unresolved.pending.is_empty());
+    let original_commit = adapter.publishes()[0].message.clone();
+    drop(runtime);
+
+    adapter.fail_endpoints_as(Vec::new(), TransportEndpointFailureKind::PossiblyExposed);
+    adapter.accept_only_endpoints(vec![endpoint]);
+    let reopened = current_session(
+        &alice_path,
+        &SqlCipherKey::new(key_text).unwrap(),
+        b"alice-disband-unknown",
+    );
+    let mut restarted = AccountDeviceRuntime::new(
+        reopened,
+        adapter.clone(),
+        policy,
+        RecordingKeyPackages::default(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(0)),
+    );
+    wall.set(400_030);
+
+    let recovered = restarted.resume_outbound_fanouts().await.unwrap();
+    assert!(matches!(
+        recovered.pending.as_slice(),
+        [PendingResolution::Confirmed { .. }]
+    ));
+    assert!(
+        recovered.pending_convergence.contains(&group_id),
+        "disband confirmation must schedule its terminal convergence pass"
+    );
+    let attempts = adapter.publishes();
+    assert_eq!(attempts.len(), 2);
+    assert_eq!(attempts[1].message, original_commit);
+}
+
 /// The production-adapter partial-accept shape: one relay accepts while its
 /// siblings surface whole-call `Err`s. The accepted endpoint must stay
 /// accepted and confirm pending MLS state — sibling errors must never read as

--- a/crates/marmot-account/tests/runtime/frozen_fanout.rs
+++ b/crates/marmot-account/tests/runtime/frozen_fanout.rs
@@ -380,7 +380,12 @@ async fn ambiguous_application_publish_is_retained_without_definite_failure() {
     bob.ingest(welcome).await.unwrap();
     let endpoint = TransportEndpoint("wss://unknown-app.example".into());
     let adapter = RecordingAdapter::default();
-    adapter.error_for_endpoints(vec![endpoint.clone()]);
+    let transport_event_id = MessageId::new(vec![0xA7; 32]);
+    adapter.report_message_id_next(transport_event_id.clone());
+    adapter.fail_endpoints_as(
+        vec![endpoint.clone()],
+        TransportEndpointFailureKind::PossiblyExposed,
+    );
     let policy = StaticTransportRouting::new(vec![TransportEndpoint(
         "wss://unknown-app-inbox.example".into(),
     )])
@@ -412,10 +417,219 @@ async fn ambiguous_application_publish_is_retained_without_definite_failure() {
     assert_eq!(effects.unresolved_app_messages[0].group_id, group_id);
     assert_eq!(effects.unresolved_app_messages[0].app_event_id, app_event_id);
     assert_eq!(
+        effects.unresolved_app_messages[0].message_id,
+        transport_event_id
+    );
+    assert_eq!(
         effects.unresolved_app_messages[0].reason,
         marmot_account::UnresolvedPublishReason::AcknowledgementUnknown
     );
     assert_eq!(runtime.session().outbound_fanouts().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn ambiguous_legacy_create_welcome_confirms_after_restart_with_exact_retry() {
+    let dir = tempfile::tempdir().unwrap();
+    let alice_path = dir.path().join("alice-create-unknown.sqlite");
+    let key_text = "marmot unknown create key";
+    let key = SqlCipherKey::new(key_text).unwrap();
+    let alice = session(&alice_path, &key, b"alice-create-unknown");
+    let mut bob = session(
+        dir.path().join("bob-create-unknown.sqlite"),
+        &key,
+        b"bob-create-unknown",
+    );
+    let bob_id = bob.self_id();
+    let endpoint = TransportEndpoint("wss://create-unknown.example".into());
+    let adapter = RecordingAdapter::default();
+    let transport_event_id = MessageId::new(vec![0xC7; 32]);
+    adapter.report_message_id_next(transport_event_id.clone());
+    adapter.report_message_id_next(transport_event_id.clone());
+    adapter.fail_endpoints_as(
+        vec![endpoint.clone()],
+        TransportEndpointFailureKind::PossiblyExposed,
+    );
+    let policy = StaticTransportRouting::new(vec![endpoint.clone()])
+        .with_inbox_route(bob_id, vec![endpoint]);
+    let wall = Arc::new(TestWallClock::new(200_000));
+    let mut runtime = AccountDeviceRuntime::new(
+        alice,
+        adapter.clone(),
+        policy.clone(),
+        RecordingKeyPackages::default(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(0)),
+    );
+
+    let (group_id, unresolved) = runtime
+        .create_group(CreateGroupRequest {
+            name: "unknown create".into(),
+            description: String::new(),
+            members: vec![bob.fresh_key_package().await.unwrap()],
+            required_features: Vec::new(),
+            app_components: Vec::new(),
+            initial_admins: Vec::new(),
+        })
+        .await
+        .unwrap();
+    assert!(unresolved.pending.is_empty());
+    assert_eq!(unresolved.unresolved_publishes.len(), 1);
+    assert_eq!(runtime.session().outbound_fanouts().unwrap().len(), 1);
+    let first_attempt = adapter.publishes()[0].clone();
+    drop(runtime);
+
+    adapter.fail_endpoints_as(Vec::new(), TransportEndpointFailureKind::PossiblyExposed);
+    let reopened = session(
+        &alice_path,
+        &SqlCipherKey::new(key_text).unwrap(),
+        b"alice-create-unknown",
+    );
+    let mut restarted = AccountDeviceRuntime::new(
+        reopened,
+        adapter.clone(),
+        policy,
+        RecordingKeyPackages::default(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(0)),
+    );
+    wall.set(200_030);
+
+    let recovered = restarted.resume_outbound_fanouts().await.unwrap();
+    assert!(
+        matches!(
+            recovered.pending.as_slice(),
+            [PendingResolution::Confirmed { .. }]
+        ),
+        "recovered effects: {recovered:?}; fanouts: {:?}; quarantined: {:?}",
+        restarted.session().outbound_fanouts().unwrap(),
+        restarted.session().quarantined_groups()
+    );
+    assert_eq!(restarted.session().epoch(&group_id).unwrap().0, 1);
+    let attempts = adapter.publishes();
+    assert_eq!(attempts.len(), 2);
+    assert_eq!(attempts[0].message, attempts[1].message);
+    assert_eq!(recovered.reports[0].message_id, transport_event_id);
+    bob.ingest(first_attempt.message).await.unwrap();
+}
+
+#[tokio::test]
+async fn ambiguous_invite_commit_recovery_publishes_its_frozen_welcome() {
+    let dir = tempfile::tempdir().unwrap();
+    let alice_path = dir.path().join("alice-invite-unknown.sqlite");
+    let key_text = "marmot unknown invite key";
+    let key = SqlCipherKey::new(key_text).unwrap();
+    let mut alice = session(&alice_path, &key, b"alice-invite-unknown");
+    let mut bob = session(
+        dir.path().join("bob-invite-unknown.sqlite"),
+        &key,
+        b"bob-invite-unknown",
+    );
+    let mut carol = session(
+        dir.path().join("carol-invite-unknown.sqlite"),
+        &key,
+        b"carol-invite-unknown",
+    );
+    let carol_id = carol.self_id();
+    let created = alice
+        .create_group(CreateGroupRequest {
+            name: "unknown invite".into(),
+            description: String::new(),
+            members: vec![bob.fresh_key_package().await.unwrap()],
+            required_features: Vec::new(),
+            app_components: Vec::new(),
+            initial_admins: Vec::new(),
+        })
+        .await
+        .unwrap();
+    let create_pending = match &created.effects.publish[0] {
+        PublishWork::GroupCreated { pending, .. } => *pending,
+        other => panic!("expected GroupCreated publish work, got {other:?}"),
+    };
+    alice.confirm_published(create_pending).await.unwrap();
+    let group_id = created.group_id;
+
+    let group_endpoint = TransportEndpoint("wss://invite-commit.example".into());
+    let inbox_endpoint = TransportEndpoint("wss://invite-welcome.example".into());
+    let adapter = RecordingAdapter::default();
+    adapter.fail_endpoints_as(
+        vec![group_endpoint.clone()],
+        TransportEndpointFailureKind::PossiblyExposed,
+    );
+    let policy = StaticTransportRouting::new(vec![inbox_endpoint.clone()])
+        .with_group_route(
+            group_id.clone(),
+            group_id.as_slice().to_vec(),
+            vec![group_endpoint.clone()],
+        )
+        .with_inbox_route(carol_id, vec![inbox_endpoint.clone()]);
+    let wall = Arc::new(TestWallClock::new(300_000));
+    let mut runtime = AccountDeviceRuntime::new(
+        alice,
+        adapter.clone(),
+        policy.clone(),
+        RecordingKeyPackages::default(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(0)),
+    );
+
+    let unresolved = runtime
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![carol.fresh_key_package().await.unwrap()],
+            initial_admins: Vec::new(),
+        })
+        .await
+        .unwrap();
+    assert!(unresolved.pending.is_empty());
+    assert_eq!(unresolved.unresolved_publishes.len(), 1);
+    let original_commit = adapter.publishes()[0].message.clone();
+    drop(runtime);
+
+    adapter.fail_endpoints_as(Vec::new(), TransportEndpointFailureKind::PossiblyExposed);
+    adapter.accept_only_endpoints(vec![group_endpoint, inbox_endpoint]);
+    let reopened = session(
+        &alice_path,
+        &SqlCipherKey::new(key_text).unwrap(),
+        b"alice-invite-unknown",
+    );
+    let mut restarted = AccountDeviceRuntime::new(
+        reopened,
+        adapter.clone(),
+        policy,
+        RecordingKeyPackages::default(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(0)),
+    );
+    wall.set(300_030);
+
+    let recovered = restarted.resume_outbound_fanouts().await.unwrap();
+    assert!(matches!(
+        recovered.pending.as_slice(),
+        [PendingResolution::Confirmed { .. }]
+    ));
+    let attempts = adapter.publishes();
+    assert_eq!(attempts.len(), 3, "commit retry must release the frozen Welcome");
+    assert_eq!(attempts[1].message, original_commit);
+    let recovered_welcome = attempts
+        .iter()
+        .find(|attempt| matches!(attempt.message.envelope, TransportEnvelope::Welcome { .. }))
+        .expect("confirmed invite must publish its Welcome")
+        .message
+        .clone();
+    carol.ingest(recovered_welcome).await.unwrap();
+    assert_eq!(carol.epoch(&group_id).unwrap().0, 2);
 }
 
 /// The production-adapter partial-accept shape: one relay accepts while its

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -3031,7 +3031,7 @@ impl AppClient {
                 &event,
                 source_message_id_hex,
                 source_state,
-                true,
+                published.is_some(),
             )?;
             on_local_projection(update);
             self.prune_plaintext_retention_for_group(group_id)?;
@@ -3876,11 +3876,6 @@ impl AppClient {
         self.observe_recovery_evidence_then_fail_if_publish_failed(&effects)?;
         self.record_human_action_succeeded(group_id, &audit_context, &effects);
         self.remember_published_reports(&effects);
-        let message_ids = effects
-            .reports
-            .iter()
-            .map(|report| hex::encode(report.message_id.as_slice()))
-            .collect::<Vec<_>>();
         let group_metadata = self.runtime.group_record(group_id).ok();
         let nostr_routing = self.nostr_routing_for_group(group_id)?;
         let projection = EventGroupProjection {
@@ -3903,12 +3898,7 @@ impl AppClient {
         self.mark_group_projection_dirty(group_id);
         self.save_state_with_pending_local_group_deletion_frontier_clears()?;
         self.queue_own_group_system_projection_updates(&effects);
-        Ok(SendSummary {
-            published: effects.reports.len(),
-            message_ids,
-            accept_disposition: crate::groups::accept_disposition_from_effects(&effects),
-            maintenance_disposition: effects.maintenance_disposition,
-        })
+        Ok(send_summary_from_effects(&effects))
     }
 
     fn ensure_group(&self, group_id: &GroupId) -> Result<(), AppError> {

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -3017,6 +3017,9 @@ impl AppClient {
         let published = effects.published_app_messages.iter().find(|published| {
             published.group_id == *group_id && published.app_event_id == app_event_id
         });
+        let completion_unknown = effects.unresolved_app_messages.iter().any(|unresolved| {
+            unresolved.group_id == *group_id && unresolved.app_event_id == app_event_id
+        });
         let source_message_id_hex =
             published.map(|published| hex::encode(published.message_id.as_slice()));
         let source_state =
@@ -3055,7 +3058,7 @@ impl AppClient {
         Ok((
             event,
             SendSummary {
-                published: effects.reports.len(),
+                published: usize::from(published.is_some()),
                 message_ids: vec![app_event_id],
                 // Per-message, not per-pass: `published` above matched this
                 // exact `app_event_id` in `effects.published_app_messages`. A
@@ -3065,6 +3068,8 @@ impl AppClient {
                 // accepted and retained it (mdk#1177).
                 accept_disposition: if published.is_some() {
                     cgka_traits::SendAcceptDisposition::Published
+                } else if completion_unknown {
+                    cgka_traits::SendAcceptDisposition::CompletionUnknown
                 } else {
                     cgka_traits::SendAcceptDisposition::AcceptedPending
                 },

--- a/crates/marmot-app/src/client/push.rs
+++ b/crates/marmot-app/src/client/push.rs
@@ -110,7 +110,10 @@ impl AppClient {
                 .send_app_event(&group_id, AppMessageIntent::PushTokenRemoval { content })
                 .await
             {
-                Ok((_event, _summary)) => {
+                Ok((_event, summary))
+                    if summary.accept_disposition
+                        == cgka_traits::SendAcceptDisposition::Published =>
+                {
                     if let Err(err) = self.app.apply_local_push_removal(
                         &account.label,
                         &group_id_hex,
@@ -129,6 +132,13 @@ impl AppClient {
                         &group_id_hex,
                         &retired_registration,
                     )?;
+                }
+                Ok((_event, _summary)) => {
+                    tracing::debug!(
+                        target: "marmot_app::notifications",
+                        method = "share_push_registration",
+                        "push token removal remains durable while publication is unresolved",
+                    );
                 }
                 Err(err) => {
                     tracing::warn!(
@@ -214,7 +224,10 @@ impl AppClient {
                     .send_app_event(&group_id, AppMessageIntent::PushTokenUpdate { content })
                     .await
                 {
-                    Ok((_event, _summary)) => {
+                    Ok((_event, summary))
+                        if summary.accept_disposition
+                            == cgka_traits::SendAcceptDisposition::Published =>
+                    {
                         if let Err(err) = self.app.upsert_group_push_token(&account.label, &record)
                         {
                             tracing::warn!(
@@ -231,6 +244,13 @@ impl AppClient {
                             &registration.registration.token_fingerprint,
                             registration.registration.updated_at_ms,
                         )?;
+                    }
+                    Ok((_event, _summary)) => {
+                        tracing::debug!(
+                            target: "marmot_app::notifications",
+                            method = "share_push_registration",
+                            "push token update remains durable while publication is unresolved",
+                        );
                     }
                     Err(err) => {
                         tracing::warn!(

--- a/crates/marmot-app/src/groups.rs
+++ b/crates/marmot-app/src/groups.rs
@@ -2316,7 +2316,13 @@ pub(crate) fn send_summary_from_effects(
 pub(crate) fn accept_disposition_from_effects(
     effects: &marmot_account::AccountDeviceEffects,
 ) -> cgka_traits::SendAcceptDisposition {
-    if !effects.unresolved_publishes.is_empty() {
+    if effects
+        .reports
+        .iter()
+        .any(|report| report.accepted_count() > 0)
+    {
+        cgka_traits::SendAcceptDisposition::Published
+    } else if !effects.unresolved_publishes.is_empty() {
         cgka_traits::SendAcceptDisposition::CompletionUnknown
     } else if effects.queued.is_empty() {
         cgka_traits::SendAcceptDisposition::Published
@@ -2573,7 +2579,10 @@ mod inner_tag_tests {
 mod fail_if_publish_failed_tests {
     use super::*;
     use cgka_traits::engine_state::PendingStateRef;
-    use cgka_traits::{GroupId, MemberId, MessageId};
+    use cgka_traits::{
+        GroupId, MemberId, MessageId, TransportEndpoint, TransportEndpointReceipt,
+        TransportPublishReport,
+    };
     use marmot_account::{
         AccountDeviceEffects, PendingResolution, PublishFailure, UnresolvedPublish,
         UnresolvedPublishReason, WelcomeDeliveryFailure,
@@ -2608,6 +2617,30 @@ mod fail_if_publish_failed_tests {
         assert_eq!(
             accept_disposition_from_effects(&effects),
             cgka_traits::SendAcceptDisposition::CompletionUnknown
+        );
+    }
+
+    #[test]
+    fn accepted_report_is_published_even_when_sibling_fanout_remains_unresolved() {
+        let mut effects = AccountDeviceEffects::default();
+        let message_id = MessageId::new(vec![0xad; 32]);
+        effects.reports.push(TransportPublishReport {
+            message_id: message_id.clone(),
+            accepted: vec![TransportEndpointReceipt {
+                endpoint: TransportEndpoint("wss://accepted.example".into()),
+                accepted_at: None,
+            }],
+            failed: Vec::new(),
+            required_acks: 1,
+        });
+        effects.unresolved_publishes.push(UnresolvedPublish {
+            message_id,
+            reason: UnresolvedPublishReason::AcknowledgementUnknown,
+        });
+
+        assert_eq!(
+            accept_disposition_from_effects(&effects),
+            cgka_traits::SendAcceptDisposition::Published
         );
     }
 

--- a/crates/marmot-app/src/groups.rs
+++ b/crates/marmot-app/src/groups.rs
@@ -2287,10 +2287,15 @@ pub(crate) fn send_summary_from_effects(
     effects: &marmot_account::AccountDeviceEffects,
 ) -> SendSummary {
     SendSummary {
-        published: effects.reports.len(),
+        published: effects
+            .reports
+            .iter()
+            .filter(|report| report.accepted_count() > 0)
+            .count(),
         message_ids: effects
             .reports
             .iter()
+            .filter(|report| report.accepted_count() > 0)
             .map(|report| hex::encode(report.message_id.as_slice()))
             .collect(),
         accept_disposition: accept_disposition_from_effects(effects),
@@ -2311,7 +2316,9 @@ pub(crate) fn send_summary_from_effects(
 pub(crate) fn accept_disposition_from_effects(
     effects: &marmot_account::AccountDeviceEffects,
 ) -> cgka_traits::SendAcceptDisposition {
-    if effects.queued.is_empty() {
+    if !effects.unresolved_publishes.is_empty() {
+        cgka_traits::SendAcceptDisposition::CompletionUnknown
+    } else if effects.queued.is_empty() {
         cgka_traits::SendAcceptDisposition::Published
     } else {
         cgka_traits::SendAcceptDisposition::AcceptedPending
@@ -2568,7 +2575,8 @@ mod fail_if_publish_failed_tests {
     use cgka_traits::engine_state::PendingStateRef;
     use cgka_traits::{GroupId, MemberId, MessageId};
     use marmot_account::{
-        AccountDeviceEffects, PendingResolution, PublishFailure, WelcomeDeliveryFailure,
+        AccountDeviceEffects, PendingResolution, PublishFailure, UnresolvedPublish,
+        UnresolvedPublishReason, WelcomeDeliveryFailure,
     };
 
     fn failure(reason: &str) -> PublishFailure {
@@ -2586,6 +2594,21 @@ mod fail_if_publish_failed_tests {
     fn no_failures_is_ok() {
         let effects = AccountDeviceEffects::default();
         assert!(fail_if_publish_failed(&effects).is_ok());
+    }
+
+    #[test]
+    fn unresolved_publish_is_non_failure_with_typed_completion_unknown_disposition() {
+        let mut effects = AccountDeviceEffects::default();
+        effects.unresolved_publishes.push(UnresolvedPublish {
+            message_id: MessageId::new(vec![0xac; 32]),
+            reason: UnresolvedPublishReason::AcknowledgementUnknown,
+        });
+
+        assert!(fail_if_publish_failed(&effects).is_ok());
+        assert_eq!(
+            accept_disposition_from_effects(&effects),
+            cgka_traits::SendAcceptDisposition::CompletionUnknown
+        );
     }
 
     // mdk#428: a confirmed-but-partial create/commit (pending Confirmed,

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -1042,9 +1042,10 @@ pub struct AppMessageQuery {
 pub struct SendSummary {
     pub published: usize,
     pub message_ids: Vec<String>,
-    /// Whether the accepted send reached the transport or is retained in the
-    /// group's durable queue. Distinguishes accepted-pending from published
-    /// without inferring either from `message_ids` being empty (mdk#1177).
+    /// Whether the accepted send reached the transport, is retained in the
+    /// group's durable queue, or has unknown transport completion while the
+    /// exact event remains frozen. Callers never infer these states from an
+    /// empty `message_ids` list (mdk#1177, mdk#1577).
     pub accept_disposition: cgka_traits::SendAcceptDisposition,
     pub maintenance_disposition: cgka_traits::SendMaintenanceDisposition,
 }

--- a/crates/marmot-app/src/runtime/tests.rs
+++ b/crates/marmot-app/src/runtime/tests.rs
@@ -1,7 +1,7 @@
 use cgka_traits::TransportAdapterError;
 use cgka_traits::transport_adapter::{
-    TransportEndpoint, TransportEndpointFailure, TransportEndpointRejectionCategory,
-    TransportPublishFailure,
+    TransportEndpoint, TransportEndpointFailure, TransportEndpointFailureKind,
+    TransportEndpointRejectionCategory, TransportPublishFailure,
 };
 
 use super::subscriptions::{chat_list_mute_expiries, message_kind_filter_allows};
@@ -2428,11 +2428,13 @@ fn key_package_deletion_relay_failures_dedupe_privacy_safe_publish_endpoint_cate
                 TransportEndpointFailure {
                     endpoint: TransportEndpoint("wss://relay-a.example".into()),
                     reason: hostile_reason.to_owned(),
+                    kind: TransportEndpointFailureKind::TerminalRejected,
                     rejection_category: Some(TransportEndpointRejectionCategory::Blocked),
                 },
                 TransportEndpointFailure {
                     endpoint: TransportEndpoint("wss://relay-b.example".into()),
                     reason: hostile_reason.to_owned(),
+                    kind: TransportEndpointFailureKind::TerminalRejected,
                     rejection_category: Some(TransportEndpointRejectionCategory::Blocked),
                 },
             ],

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -6579,10 +6579,10 @@ async fn open_backfill_preserves_unread_for_still_member_account() {
 }
 
 #[tokio::test]
-async fn failed_send_keeps_read_marker_and_inbound_unread() {
-    // mdk#338: the local-send projection recorded BEFORE publish must not
-    // advance the per-group read marker. If it did, a hard publish failure
-    // would leave the marker pointing at the invalidated own message and
+async fn unresolved_send_keeps_local_message_read_marker_and_inbound_unread() {
+    // mdk#338/#1577: the local-send projection recorded BEFORE publish must
+    // not advance the per-group read marker. If it did, an unresolved publish
+    // would leave the marker pointing at the unconfirmed own message and
     // silently mark older inbound unreads as read. Only the post-publish
     // success projection may advance the marker.
     let dir = tempfile::tempdir().unwrap();
@@ -6671,23 +6671,44 @@ async fn failed_send_keeps_read_marker_and_inbound_unread() {
         sleep(Duration::from_millis(50)).await;
     }
 
-    // Hard publish failure: no relay left to accept bob's message. The failed
+    // No relay remains to confirm whether bob's message was accepted. The
     // attempt can take up to the adapter's ~20s publish overall-wait
-    // (SDK_RELAY_PUBLISH_OVERALL_WAIT) before it reports the failure.
+    // (SDK_RELAY_PUBLISH_OVERALL_WAIT) before it reports completion unknown.
     relay.shutdown();
-    bob.send(&group_id, b"bob failure")
+    let unresolved = bob
+        .send(&group_id, b"bob unresolved")
         .await
-        .expect_err("send must fail once the relay is gone");
+        .expect("an ambiguous publish is retained rather than reported as a hard failure");
+    assert_eq!(
+        unresolved.accept_disposition,
+        cgka_traits::SendAcceptDisposition::CompletionUnknown
+    );
+    assert_eq!(unresolved.published, 0);
+    let timeline = app
+        .timeline_messages_with_query(
+            "bob",
+            TimelineMessageQuery {
+                group_id_hex: Some(group_id_hex.clone()),
+                ..TimelineMessageQuery::default()
+            },
+        )
+        .unwrap();
+    assert!(
+        timeline.messages.iter().any(|message| {
+            message.direction == "sent" && message.plaintext == "bob unresolved"
+        }),
+        "an unresolved local send must remain in the timeline"
+    );
 
     let row = bob_row();
     assert_eq!(
         row.unread_count, 1,
-        "a failed send must not mark inbound unreads as read"
+        "an unresolved send must not mark inbound unreads as read"
     );
     assert_eq!(
         row.last_read_message_id_hex.as_deref(),
         Some(read_baseline_id.as_str()),
-        "a failed send must leave the read marker untouched, never at the failed event"
+        "an unresolved send must leave the read marker untouched"
     );
     assert_eq!(
         row.first_unread_message_id_hex.as_deref(),
@@ -6703,7 +6724,7 @@ async fn failed_send_keeps_read_marker_and_inbound_unread() {
         .unwrap_or(0);
     assert_eq!(
         account_unread, 1,
-        "the account-level unread aggregate must survive the failed send"
+        "the account-level unread aggregate must survive the unresolved send"
     );
 }
 

--- a/crates/marmot-uniffi/src/conversions/account.rs
+++ b/crates/marmot-uniffi/src/conversions/account.rs
@@ -92,14 +92,17 @@ pub enum SendMaintenanceDispositionFfi {
     PostJoinRotationPendingRetryable,
 }
 
-/// Whether an accepted send published or is retained pending convergence.
+/// Whether an accepted send published, is retained pending convergence, or
+/// has a frozen transport event whose acknowledgement is still unknown.
 ///
-/// `AcceptedPending` is not an error: the message is durable and publishes
-/// later. Hosts should show it as still sending rather than as failed.
+/// Neither retained state is an error. Hosts should show it as still sending
+/// or unresolved rather than failed, and must not create a new semantic send
+/// for `CompletionUnknown`.
 #[derive(Clone, Copy, Debug, uniffi::Enum)]
 pub enum SendAcceptDispositionFfi {
     Published,
     AcceptedPending,
+    CompletionUnknown,
 }
 
 impl From<SendSummary> for SendSummaryFfi {
@@ -113,6 +116,9 @@ impl From<SendSummary> for SendSummaryFfi {
                 }
                 cgka_traits::SendAcceptDisposition::AcceptedPending => {
                     SendAcceptDispositionFfi::AcceptedPending
+                }
+                cgka_traits::SendAcceptDisposition::CompletionUnknown => {
+                    SendAcceptDispositionFfi::CompletionUnknown
                 }
             },
             maintenance_disposition: match value.maintenance_disposition {
@@ -379,5 +385,20 @@ mod tests {
             "a retained send must stay distinguishable across the boundary; got {:?}",
             ffi.accept_disposition
         );
+    }
+
+    #[test]
+    fn completion_unknown_crosses_ffi_as_a_typed_disposition() {
+        let ffi = SendSummaryFfi::from(SendSummary {
+            published: 0,
+            message_ids: vec![],
+            accept_disposition: cgka_traits::SendAcceptDisposition::CompletionUnknown,
+            maintenance_disposition: cgka_traits::SendMaintenanceDisposition::Ready,
+        });
+
+        assert!(matches!(
+            ffi.accept_disposition,
+            SendAcceptDispositionFfi::CompletionUnknown
+        ));
     }
 }

--- a/crates/traits/src/engine.rs
+++ b/crates/traits/src/engine.rs
@@ -242,11 +242,11 @@ pub enum SendResult {
 /// What happened to a send the engine *accepted*, as reported back to the
 /// application.
 ///
-/// This is the app-facing projection of the [`SendResult::Queued`] versus
-/// "published now" split. `AcceptedPending` is deliberately **not** a failure:
-/// the intent is durable, survives restart, and publishes once the group's
-/// convergence input settles. A refused send never reaches this type at all —
-/// it returns an error instead.
+/// This is the app-facing projection of "published now", retained before
+/// publication, and acknowledgement-unknown. `AcceptedPending` and
+/// `CompletionUnknown` are deliberately **not** failures: in both cases the
+/// outbound obligation is durable and survives restart. A refused send never
+/// reaches this type at all — it returns an error instead.
 ///
 /// It is not an unconditional promise of publication, though. A group that goes
 /// terminal — disbanded, or this device's copy removed — discards its outbound
@@ -264,6 +264,10 @@ pub enum SendAcceptDisposition {
     /// The send was accepted and retained in the group's durable outbound
     /// queue. It publishes on a later convergence drain.
     AcceptedPending,
+    /// The exact transport event is durably retained because an endpoint may
+    /// have exposed it without returning an acknowledgement. Hosts must show
+    /// this as unresolved and must not create a semantically new send.
+    CompletionUnknown,
 }
 
 /// Group evolution produced as a side effect of inbound processing.

--- a/crates/traits/src/lib.rs
+++ b/crates/traits/src/lib.rs
@@ -113,9 +113,10 @@ pub use transport_adapter::{
     FanoutMlsState, FanoutTargetStatus, OutboundFanout, OutboundFanoutOutcome,
     TransportAccountActivation, TransportAdapter, TransportAdapterError, TransportDelivery,
     TransportDeliveryPlane, TransportDeliverySource, TransportEndpoint, TransportEndpointFailure,
-    TransportEndpointReceipt, TransportEndpointRejectionCategory, TransportGroupSubscription,
-    TransportGroupSync, TransportPublishFailure, TransportPublishReport, TransportPublishRequest,
-    TransportPublishTarget, TransportWireMetadata, collapse_publish_failure_summaries,
+    TransportEndpointFailureKind, TransportEndpointReceipt, TransportEndpointRejectionCategory,
+    TransportGroupSubscription, TransportGroupSync, TransportPublishFailure,
+    TransportPublishReport, TransportPublishRequest, TransportPublishTarget, TransportWireMetadata,
+    collapse_publish_failure_summaries,
 };
 pub use types::{Backend, EpochId, GroupId, MemberId, MessageId};
 pub use welcome::PendingWelcome;

--- a/crates/traits/src/lib.rs
+++ b/crates/traits/src/lib.rs
@@ -110,7 +110,7 @@ pub use transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
 };
 pub use transport_adapter::{
-    FanoutMlsState, FanoutTargetStatus, OutboundFanout, OutboundFanoutOutcome,
+    FanoutMlsState, FanoutPendingKind, FanoutTargetStatus, OutboundFanout, OutboundFanoutOutcome,
     TransportAccountActivation, TransportAdapter, TransportAdapterError, TransportDelivery,
     TransportDeliveryPlane, TransportDeliverySource, TransportEndpoint, TransportEndpointFailure,
     TransportEndpointFailureKind, TransportEndpointReceipt, TransportEndpointRejectionCategory,

--- a/crates/traits/src/transport_adapter.rs
+++ b/crates/traits/src/transport_adapter.rs
@@ -164,25 +164,37 @@ impl TransportPublishRequest {
     }
 }
 
-/// Durable first-attempt state for one endpoint in a frozen publish fanout.
+/// Durable state for one endpoint in a frozen publish fanout.
 ///
 /// `Attempting` is written before the external send. A process that restarts
 /// with an `Attempting` target treats it as outstanding and safely repeats the
-/// same already-signed event bytes. Terminal callbacks are idempotent: once a
-/// target is `Accepted` or `Failed`, later duplicate or contradictory results
-/// do not change it.
+/// same already-signed event bytes. Ambiguous and transient outcomes remain
+/// outstanding so that exact event can be retried. Terminal callbacks are
+/// idempotent: once a target is `Accepted` or `Failed`, later duplicate or
+/// contradictory results do not change it.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum FanoutTargetStatus {
     NotAttempted,
     Attempting,
     Accepted,
+    /// An explicit rejection or terminal no-exposure outcome.
     Failed,
+    /// The endpoint may have exposed the event but did not acknowledge it.
+    PossiblyExposed,
+    /// The endpoint was transiently unavailable without a claim of exposure.
+    RetryableUnavailable,
 }
 
 impl FanoutTargetStatus {
     pub fn is_outstanding(self) -> bool {
-        matches!(self, Self::NotAttempted | Self::Attempting)
+        matches!(
+            self,
+            Self::NotAttempted
+                | Self::Attempting
+                | Self::PossiblyExposed
+                | Self::RetryableUnavailable
+        )
     }
 
     pub fn is_terminal(self) -> bool {
@@ -220,6 +232,14 @@ pub struct OutboundFanout {
     #[serde(default)]
     published_message_id: Option<MessageId>,
     target_statuses: Vec<FanoutTargetStatus>,
+    #[serde(default)]
+    target_failures: Vec<Option<TransportEndpointFailure>>,
+    #[serde(default)]
+    target_attempt_counts: Vec<u32>,
+    #[serde(default)]
+    target_last_attempt_at_ms: Vec<Option<u64>>,
+    #[serde(default)]
+    target_possible_exposure: Vec<bool>,
     mls_state: FanoutMlsState,
     created_at_ms: u64,
 }
@@ -251,6 +271,10 @@ impl OutboundFanout {
             group_id: target_group_id.or(pending_group_id),
             published_message_id: None,
             target_statuses: vec![FanoutTargetStatus::NotAttempted; target_count],
+            target_failures: vec![None; target_count],
+            target_attempt_counts: vec![0; target_count],
+            target_last_attempt_at_ms: vec![None; target_count],
+            target_possible_exposure: vec![false; target_count],
             mls_state: pending.map_or(FanoutMlsState::NotApplicable, FanoutMlsState::Pending),
             created_at_ms,
         })
@@ -288,6 +312,25 @@ impl OutboundFanout {
         self.target_statuses.get(index).copied()
     }
 
+    pub fn target_failure(&self, index: usize) -> Option<&TransportEndpointFailure> {
+        self.target_failures.get(index).and_then(Option::as_ref)
+    }
+
+    pub fn target_attempt_count(&self, index: usize) -> u32 {
+        self.target_attempt_counts.get(index).copied().unwrap_or(0)
+    }
+
+    pub fn target_last_attempt_at_ms(&self, index: usize) -> Option<u64> {
+        self.target_last_attempt_at_ms.get(index).copied().flatten()
+    }
+
+    pub fn possible_exposure(&self) -> bool {
+        self.target_possible_exposure.iter().any(|exposed| *exposed)
+            || self
+                .target_statuses
+                .contains(&FanoutTargetStatus::PossiblyExposed)
+    }
+
     pub fn pending_ref(&self) -> Option<PendingStateRef> {
         match self.mls_state {
             FanoutMlsState::Pending(pending) => Some(pending),
@@ -311,19 +354,34 @@ impl OutboundFanout {
 
     /// Persist the send-before-side-effect edge for one target.
     ///
-    /// Returns `true` only for the first `NotAttempted -> Attempting`
-    /// transition. Re-marking an `Attempting` target after restart is harmless;
-    /// terminal targets remain unchanged.
+    /// Returns `true` when an outstanding target begins or resumes an attempt.
+    /// Re-marking an `Attempting` target after restart is safe and increments
+    /// the durable attempt counter; terminal targets remain unchanged.
     pub fn mark_attempt_started(&mut self, index: usize) -> Result<bool, TransportAdapterError> {
-        let status = self.target_status_mut(index)?;
-        match status {
-            FanoutTargetStatus::NotAttempted => {
-                *status = FanoutTargetStatus::Attempting;
+        self.mark_attempt_started_at(index, self.created_at_ms)
+    }
+
+    pub fn mark_attempt_started_at(
+        &mut self,
+        index: usize,
+        attempted_at_ms: u64,
+    ) -> Result<bool, TransportAdapterError> {
+        self.ensure_target_metadata_len();
+        match self.target_status(index).ok_or_else(|| {
+            TransportAdapterError::Other("fanout target index is out of bounds".into())
+        })? {
+            FanoutTargetStatus::NotAttempted
+            | FanoutTargetStatus::Attempting
+            | FanoutTargetStatus::PossiblyExposed
+            | FanoutTargetStatus::RetryableUnavailable => {
+                self.target_statuses[index] = FanoutTargetStatus::Attempting;
+                self.target_attempt_counts[index] =
+                    self.target_attempt_counts[index].saturating_add(1);
+                self.target_last_attempt_at_ms[index] = Some(attempted_at_ms);
+                self.target_failures[index] = None;
                 Ok(true)
             }
-            FanoutTargetStatus::Attempting
-            | FanoutTargetStatus::Accepted
-            | FanoutTargetStatus::Failed => Ok(false),
+            FanoutTargetStatus::Accepted | FanoutTargetStatus::Failed => Ok(false),
         }
     }
 
@@ -333,6 +391,45 @@ impl OutboundFanout {
 
     pub fn mark_target_failed(&mut self, index: usize) -> Result<bool, TransportAdapterError> {
         self.mark_target_terminal(index, FanoutTargetStatus::Failed)
+    }
+
+    pub fn record_target_failure(
+        &mut self,
+        index: usize,
+        failure: TransportEndpointFailure,
+    ) -> Result<bool, TransportAdapterError> {
+        if self.request.target.endpoints().get(index) != Some(&failure.endpoint) {
+            return Err(TransportAdapterError::Other(
+                "endpoint failure does not match frozen fanout target".into(),
+            ));
+        }
+        self.ensure_target_metadata_len();
+        if failure.kind == TransportEndpointFailureKind::PossiblyExposed {
+            self.target_possible_exposure[index] = true;
+        }
+        let next = if self.target_possible_exposure[index] {
+            FanoutTargetStatus::PossiblyExposed
+        } else {
+            match failure.kind {
+                TransportEndpointFailureKind::TerminalRejected
+                | TransportEndpointFailureKind::NotExposed => FanoutTargetStatus::Failed,
+                TransportEndpointFailureKind::PossiblyExposed => {
+                    FanoutTargetStatus::PossiblyExposed
+                }
+                TransportEndpointFailureKind::RetryableUnavailable => {
+                    FanoutTargetStatus::RetryableUnavailable
+                }
+            }
+        };
+        let current = self.target_status(index).ok_or_else(|| {
+            TransportAdapterError::Other("fanout target index is out of bounds".into())
+        })?;
+        if current.is_terminal() {
+            return Ok(false);
+        }
+        self.target_statuses[index] = next;
+        self.target_failures[index] = Some(failure);
+        Ok(true)
     }
 
     pub fn record_published_message_id(
@@ -419,7 +516,27 @@ impl OutboundFanout {
         let immutable_matches = self.request == previous.request
             && self.group_id == previous.group_id
             && self.created_at_ms == previous.created_at_ms
-            && self.target_statuses.len() == previous.target_statuses.len();
+            && self.target_statuses.len() == previous.target_statuses.len()
+            && fanout_metadata_len_is_compatible(
+                self.target_failures.len(),
+                previous.target_failures.len(),
+                self.target_statuses.len(),
+            )
+            && fanout_metadata_len_is_compatible(
+                self.target_attempt_counts.len(),
+                previous.target_attempt_counts.len(),
+                self.target_statuses.len(),
+            )
+            && fanout_metadata_len_is_compatible(
+                self.target_last_attempt_at_ms.len(),
+                previous.target_last_attempt_at_ms.len(),
+                self.target_statuses.len(),
+            )
+            && fanout_metadata_len_is_compatible(
+                self.target_possible_exposure.len(),
+                previous.target_possible_exposure.len(),
+                self.target_statuses.len(),
+            );
         let published_id_advances =
             match (&previous.published_message_id, &self.published_message_id) {
                 (None, _) => true,
@@ -433,8 +550,14 @@ impl OutboundFanout {
                 .iter()
                 .zip(&previous.target_statuses)
                 .all(|(next, prior)| target_status_advances(*prior, *next));
+        let exposure_advances = previous.target_possible_exposure.is_empty()
+            || self
+                .target_possible_exposure
+                .iter()
+                .zip(&previous.target_possible_exposure)
+                .all(|(next, prior)| !*prior || *next);
         let mls_advances = mls_state_advances(previous.mls_state, self.mls_state);
-        if targets_advance && mls_advances {
+        if targets_advance && exposure_advances && mls_advances {
             Ok(())
         } else {
             Err(TransportAdapterError::Other(
@@ -450,6 +573,14 @@ impl OutboundFanout {
         self.target_statuses.get_mut(index).ok_or_else(|| {
             TransportAdapterError::Other("fanout target index is out of bounds".into())
         })
+    }
+
+    fn ensure_target_metadata_len(&mut self) {
+        let target_count = self.target_statuses.len();
+        self.target_failures.resize(target_count, None);
+        self.target_attempt_counts.resize(target_count, 0);
+        self.target_last_attempt_at_ms.resize(target_count, None);
+        self.target_possible_exposure.resize(target_count, false);
     }
 
     fn mark_target_terminal(
@@ -476,9 +607,19 @@ fn target_status_advances(prior: FanoutTargetStatus, next: FanoutTargetStatus) -
                 FanoutTargetStatus::Attempting
             ) | (
                 FanoutTargetStatus::Attempting,
-                FanoutTargetStatus::Accepted | FanoutTargetStatus::Failed
+                FanoutTargetStatus::Accepted
+                    | FanoutTargetStatus::Failed
+                    | FanoutTargetStatus::PossiblyExposed
+                    | FanoutTargetStatus::RetryableUnavailable
+            ) | (
+                FanoutTargetStatus::PossiblyExposed | FanoutTargetStatus::RetryableUnavailable,
+                FanoutTargetStatus::Attempting
             )
         )
+}
+
+fn fanout_metadata_len_is_compatible(next: usize, prior: usize, targets: usize) -> bool {
+    (next == targets && (prior == targets || prior == 0)) || (next == 0 && prior == 0)
 }
 
 fn mls_state_advances(prior: FanoutMlsState, next: FanoutMlsState) -> bool {
@@ -549,12 +690,37 @@ impl TransportEndpointRejectionCategory {
     }
 }
 
+/// Exposure and retry semantics for one endpoint publish failure.
+///
+/// This classification is deliberately separate from the human-readable
+/// reason and relay rejection category. Coordinators must make rollback and
+/// retry decisions from this closed vocabulary, never by matching strings.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TransportEndpointFailureKind {
+    /// The endpoint explicitly rejected the event. Repeating the exact event
+    /// without a policy/configuration change is not useful.
+    TerminalRejected,
+    /// The adapter proved that no send attempt crossed its external boundary.
+    NotExposed,
+    /// The event may have been accepted or forwarded, but acknowledgement is
+    /// unknown. This is the conservative default for older serialized data.
+    #[default]
+    PossiblyExposed,
+    /// A pre-send connectivity/resource failure or explicitly retryable relay
+    /// rejection made the endpoint unavailable; the exact event remains
+    /// durably retryable without claiming exposure.
+    RetryableUnavailable,
+}
+
 /// Endpoint-level publish failure. The overall publish may still succeed if
 /// enough other endpoints acknowledge the message.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TransportEndpointFailure {
     pub endpoint: TransportEndpoint,
     pub reason: String,
+    #[serde(default)]
+    pub kind: TransportEndpointFailureKind,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rejection_category: Option<TransportEndpointRejectionCategory>,
 }
@@ -567,6 +733,10 @@ pub struct TransportEndpointFailure {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TransportPublishFailure {
     pub summary: String,
+    /// Deterministic transport-visible id of the exact signed event, when the
+    /// adapter prepared it before publication became unresolved.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message_id: Option<MessageId>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub endpoint_failures: Vec<TransportEndpointFailure>,
 }
@@ -578,8 +748,14 @@ impl TransportPublishFailure {
     ) -> Self {
         Self {
             summary: summary.into(),
+            message_id: None,
             endpoint_failures,
         }
+    }
+
+    pub fn with_message_id(mut self, message_id: MessageId) -> Self {
+        self.message_id = Some(message_id);
+        self
     }
 }
 
@@ -742,6 +918,13 @@ impl TransportAdapterError {
             _ => &[],
         }
     }
+
+    pub fn publish_message_id(&self) -> Option<&MessageId> {
+        match self {
+            Self::PublishEndpoints(failure) => failure.message_id.as_ref(),
+            _ => None,
+        }
+    }
 }
 
 /// Account-aware network adapter that moves wrapped transport messages.
@@ -886,6 +1069,94 @@ mod tests {
     }
 
     #[test]
+    fn frozen_fanout_ambiguous_failure_remains_outstanding_and_retryable() {
+        let mut fanout = OutboundFanout::stage(
+            fanout_request(),
+            Some(crate::engine_state::PendingStateRef::new(9)),
+            Some(GroupId::new(vec![0xD4; 16])),
+            55,
+        )
+        .unwrap();
+        fanout.mark_attempt_started_at(0, 100).unwrap();
+        fanout
+            .record_target_failure(
+                0,
+                TransportEndpointFailure {
+                    endpoint: TransportEndpoint("wss://one.example".into()),
+                    reason: "publish acknowledgement unknown".into(),
+                    kind: TransportEndpointFailureKind::PossiblyExposed,
+                    rejection_category: None,
+                },
+            )
+            .unwrap();
+
+        assert_eq!(
+            fanout.target_status(0),
+            Some(FanoutTargetStatus::PossiblyExposed)
+        );
+        assert_eq!(fanout.target_attempt_count(0), 1);
+        assert_eq!(fanout.outcome().outstanding_targets, 3);
+        assert!(!fanout.outcome().fanout_complete);
+
+        let restored: OutboundFanout =
+            serde_json::from_slice(&serde_json::to_vec(&fanout).unwrap()).unwrap();
+        assert_eq!(restored, fanout);
+    }
+
+    #[test]
+    fn later_rejection_cannot_erase_prior_possible_exposure() {
+        let mut fanout = OutboundFanout::stage(
+            fanout_request(),
+            Some(crate::engine_state::PendingStateRef::new(9)),
+            Some(GroupId::new(vec![0xD4; 16])),
+            55,
+        )
+        .unwrap();
+        fanout.mark_attempt_started_at(0, 100).unwrap();
+        fanout
+            .record_target_failure(
+                0,
+                TransportEndpointFailure {
+                    endpoint: TransportEndpoint("wss://one.example".into()),
+                    reason: "acknowledgement unknown".into(),
+                    kind: TransportEndpointFailureKind::PossiblyExposed,
+                    rejection_category: None,
+                },
+            )
+            .unwrap();
+        fanout.mark_attempt_started_at(0, 200).unwrap();
+        fanout
+            .record_target_failure(
+                0,
+                TransportEndpointFailure {
+                    endpoint: TransportEndpoint("wss://one.example".into()),
+                    reason: "later explicit rejection".into(),
+                    kind: TransportEndpointFailureKind::TerminalRejected,
+                    rejection_category: Some(TransportEndpointRejectionCategory::Blocked),
+                },
+            )
+            .unwrap();
+
+        assert!(fanout.possible_exposure());
+        assert_eq!(
+            fanout.target_status(0),
+            Some(FanoutTargetStatus::PossiblyExposed)
+        );
+        assert!(!fanout.outcome().fanout_complete);
+    }
+
+    #[test]
+    fn endpoint_failure_without_kind_deserializes_conservatively() {
+        let failure: TransportEndpointFailure = serde_json::from_value(serde_json::json!({
+            "endpoint": "wss://relay.example",
+            "reason": "legacy adapter error"
+        }))
+        .unwrap();
+
+        assert_eq!(failure.kind, TransportEndpointFailureKind::PossiblyExposed);
+    }
+
+    #[test]
     fn frozen_fanout_round_trip_preserves_bytes_id_and_original_targets() {
         let request = fanout_request();
         let original_bytes = request.message.payload.clone();
@@ -921,6 +1192,7 @@ mod tests {
                 .map(|i| TransportEndpointFailure {
                     endpoint: TransportEndpoint(format!("wss://failed-{i}.example")),
                     reason: "unreachable".into(),
+                    kind: TransportEndpointFailureKind::RetryableUnavailable,
                     rejection_category: None,
                 })
                 .collect(),

--- a/crates/traits/src/transport_adapter.rs
+++ b/crates/traits/src/transport_adapter.rs
@@ -223,6 +223,7 @@ pub enum FanoutMlsState {
 pub enum FanoutPendingKind {
     GroupEvolution,
     CreateGroup,
+    Disband,
 }
 
 /// One durable transport fanout frozen before its first external side effect.
@@ -305,7 +306,7 @@ impl OutboundFanout {
             ));
         }
         match (pending_kind, pending_origin_message_id.as_ref()) {
-            (Some(FanoutPendingKind::GroupEvolution), None) => {
+            (Some(FanoutPendingKind::GroupEvolution | FanoutPendingKind::Disband), None) => {
                 return Err(TransportAdapterError::Other(
                     "group evolution fanout requires its stored origin commit".into(),
                 ));

--- a/crates/traits/src/transport_adapter.rs
+++ b/crates/traits/src/transport_adapter.rs
@@ -217,6 +217,14 @@ pub enum FanoutMlsState {
     RolledBack,
 }
 
+/// Engine pending lifecycle restored with a durable fanout after restart.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FanoutPendingKind {
+    GroupEvolution,
+    CreateGroup,
+}
+
 /// One durable transport fanout frozen before its first external side effect.
 ///
 /// The request owns the exact serialized transport message and original target
@@ -230,6 +238,10 @@ pub struct OutboundFanout {
     request: TransportPublishRequest,
     group_id: Option<GroupId>,
     #[serde(default)]
+    pending_origin_message_id: Option<MessageId>,
+    #[serde(default)]
+    pending_kind: Option<FanoutPendingKind>,
+    #[serde(default)]
     published_message_id: Option<MessageId>,
     target_statuses: Vec<FanoutTargetStatus>,
     #[serde(default)]
@@ -240,6 +252,12 @@ pub struct OutboundFanout {
     target_last_attempt_at_ms: Vec<Option<u64>>,
     #[serde(default)]
     target_possible_exposure: Vec<bool>,
+    /// Exact Welcome artifacts that must be released only after this fanout
+    /// confirms its pending MLS transition.
+    #[serde(default)]
+    post_confirmation_welcomes: Vec<TransportMessage>,
+    #[serde(default)]
+    post_confirmation_welcomes_pending: bool,
     mls_state: FanoutMlsState,
     created_at_ms: u64,
 }
@@ -251,7 +269,67 @@ impl OutboundFanout {
         pending_group_id: Option<GroupId>,
         created_at_ms: u64,
     ) -> Result<Self, TransportAdapterError> {
+        let pending_origin_message_id = pending.map(|_| request.message.id.clone());
+        let pending_kind = pending.map(|_| FanoutPendingKind::GroupEvolution);
+        Self::stage_with_post_confirmation_welcomes(
+            request,
+            pending,
+            pending_group_id,
+            created_at_ms,
+            pending_origin_message_id,
+            pending_kind,
+            Vec::new(),
+        )
+    }
+
+    /// Freeze a publication and the Welcome artifacts released by its MLS
+    /// confirmation in one durable record.
+    pub fn stage_with_post_confirmation_welcomes(
+        request: TransportPublishRequest,
+        pending: Option<PendingStateRef>,
+        pending_group_id: Option<GroupId>,
+        created_at_ms: u64,
+        pending_origin_message_id: Option<MessageId>,
+        pending_kind: Option<FanoutPendingKind>,
+        post_confirmation_welcomes: Vec<TransportMessage>,
+    ) -> Result<Self, TransportAdapterError> {
         request.validate_envelope_matches_target()?;
+        if pending.is_none() && !post_confirmation_welcomes.is_empty() {
+            return Err(TransportAdapterError::Other(
+                "post-confirmation Welcomes require pending MLS state".into(),
+            ));
+        }
+        if pending.is_some() != pending_kind.is_some() {
+            return Err(TransportAdapterError::Other(
+                "pending MLS state and pending kind must be staged together".into(),
+            ));
+        }
+        match (pending_kind, pending_origin_message_id.as_ref()) {
+            (Some(FanoutPendingKind::GroupEvolution), None) => {
+                return Err(TransportAdapterError::Other(
+                    "group evolution fanout requires its stored origin commit".into(),
+                ));
+            }
+            (Some(FanoutPendingKind::CreateGroup), Some(_)) => {
+                return Err(TransportAdapterError::Other(
+                    "legacy group creation has no published origin commit".into(),
+                ));
+            }
+            (None, Some(_)) => {
+                return Err(TransportAdapterError::Other(
+                    "origin commit requires pending MLS state".into(),
+                ));
+            }
+            _ => {}
+        }
+        if post_confirmation_welcomes
+            .iter()
+            .any(|message| !matches!(message.envelope, TransportEnvelope::Welcome { .. }))
+        {
+            return Err(TransportAdapterError::Other(
+                "post-confirmation fanout continuation must contain only Welcomes".into(),
+            ));
+        }
         let target_group_id = match &request.target {
             TransportPublishTarget::Group { group_id, .. } => Some(group_id.clone()),
             TransportPublishTarget::Inbox { .. } => None,
@@ -269,12 +347,16 @@ impl OutboundFanout {
         Ok(Self {
             request,
             group_id: target_group_id.or(pending_group_id),
+            pending_origin_message_id,
+            pending_kind,
             published_message_id: None,
             target_statuses: vec![FanoutTargetStatus::NotAttempted; target_count],
             target_failures: vec![None; target_count],
             target_attempt_counts: vec![0; target_count],
             target_last_attempt_at_ms: vec![None; target_count],
             target_possible_exposure: vec![false; target_count],
+            post_confirmation_welcomes_pending: !post_confirmation_welcomes.is_empty(),
+            post_confirmation_welcomes,
             mls_state: pending.map_or(FanoutMlsState::NotApplicable, FanoutMlsState::Pending),
             created_at_ms,
         })
@@ -298,6 +380,26 @@ impl OutboundFanout {
 
     pub fn group_id(&self) -> Option<&GroupId> {
         self.group_id.as_ref()
+    }
+
+    /// Stored OpenMLS commit row used to restore this pending lifecycle.
+    /// Legacy-profile creation has no published commit artifact and returns
+    /// `None`; its durable Welcome plus pending-kind marker restore the edge.
+    pub fn pending_origin_message_id(&self) -> Option<&MessageId> {
+        self.pending_origin_message_id.as_ref().or_else(|| {
+            // Compatibility for fanouts written before the explicit origin
+            // field: those records could only represent group evolution, and
+            // the frozen request id was the stored origin commit id.
+            (self.pending_kind.is_none() && matches!(self.mls_state, FanoutMlsState::Pending(_)))
+                .then_some(&self.request.message.id)
+        })
+    }
+
+    pub fn pending_kind(&self) -> Option<FanoutPendingKind> {
+        self.pending_kind.or_else(|| {
+            matches!(self.mls_state, FanoutMlsState::Pending(_))
+                .then_some(FanoutPendingKind::GroupEvolution)
+        })
     }
 
     pub fn created_at_ms(&self) -> u64 {
@@ -329,6 +431,22 @@ impl OutboundFanout {
             || self
                 .target_statuses
                 .contains(&FanoutTargetStatus::PossiblyExposed)
+    }
+
+    pub fn pending_post_confirmation_welcomes(&self) -> &[TransportMessage] {
+        if self.post_confirmation_welcomes_pending {
+            &self.post_confirmation_welcomes
+        } else {
+            &[]
+        }
+    }
+
+    pub fn mark_post_confirmation_welcomes_released(&mut self) -> bool {
+        if !self.post_confirmation_welcomes_pending {
+            return false;
+        }
+        self.post_confirmation_welcomes_pending = false;
+        true
     }
 
     pub fn pending_ref(&self) -> Option<PendingStateRef> {
@@ -404,6 +522,12 @@ impl OutboundFanout {
             ));
         }
         self.ensure_target_metadata_len();
+        let current = self.target_status(index).ok_or_else(|| {
+            TransportAdapterError::Other("fanout target index is out of bounds".into())
+        })?;
+        if current.is_terminal() {
+            return Ok(false);
+        }
         if failure.kind == TransportEndpointFailureKind::PossiblyExposed {
             self.target_possible_exposure[index] = true;
         }
@@ -421,12 +545,6 @@ impl OutboundFanout {
                 }
             }
         };
-        let current = self.target_status(index).ok_or_else(|| {
-            TransportAdapterError::Other("fanout target index is out of bounds".into())
-        })?;
-        if current.is_terminal() {
-            return Ok(false);
-        }
         self.target_statuses[index] = next;
         self.target_failures[index] = Some(failure);
         Ok(true)
@@ -515,7 +633,10 @@ impl OutboundFanout {
     pub fn validate_successor_of(&self, previous: &Self) -> Result<(), TransportAdapterError> {
         let immutable_matches = self.request == previous.request
             && self.group_id == previous.group_id
+            && self.pending_origin_message_id == previous.pending_origin_message_id
+            && self.pending_kind == previous.pending_kind
             && self.created_at_ms == previous.created_at_ms
+            && self.post_confirmation_welcomes == previous.post_confirmation_welcomes
             && self.target_statuses.len() == previous.target_statuses.len()
             && fanout_metadata_len_is_compatible(
                 self.target_failures.len(),
@@ -557,7 +678,9 @@ impl OutboundFanout {
                 .zip(&previous.target_possible_exposure)
                 .all(|(next, prior)| !*prior || *next);
         let mls_advances = mls_state_advances(previous.mls_state, self.mls_state);
-        if targets_advance && exposure_advances && mls_advances {
+        let continuation_advances =
+            previous.post_confirmation_welcomes_pending || !self.post_confirmation_welcomes_pending;
+        if targets_advance && exposure_advances && mls_advances && continuation_advances {
             Ok(())
         } else {
             Err(TransportAdapterError::Other(
@@ -1146,6 +1269,46 @@ mod tests {
     }
 
     #[test]
+    fn late_ambiguous_result_cannot_reopen_terminal_no_exposure_target() {
+        let mut fanout = OutboundFanout::stage(
+            fanout_request(),
+            Some(crate::engine_state::PendingStateRef::new(9)),
+            Some(GroupId::new(vec![0xD4; 16])),
+            55,
+        )
+        .unwrap();
+        fanout.mark_attempt_started_at(0, 100).unwrap();
+        fanout
+            .record_target_failure(
+                0,
+                TransportEndpointFailure {
+                    endpoint: TransportEndpoint("wss://one.example".into()),
+                    reason: "connection failed before send".into(),
+                    kind: TransportEndpointFailureKind::NotExposed,
+                    rejection_category: None,
+                },
+            )
+            .unwrap();
+        assert_eq!(fanout.target_status(0), Some(FanoutTargetStatus::Failed));
+
+        assert!(
+            !fanout
+                .record_target_failure(
+                    0,
+                    TransportEndpointFailure {
+                        endpoint: TransportEndpoint("wss://one.example".into()),
+                        reason: "late acknowledgement unknown".into(),
+                        kind: TransportEndpointFailureKind::PossiblyExposed,
+                        rejection_category: None,
+                    },
+                )
+                .unwrap()
+        );
+        assert!(!fanout.possible_exposure());
+        assert_eq!(fanout.target_status(0), Some(FanoutTargetStatus::Failed));
+    }
+
+    #[test]
     fn endpoint_failure_without_kind_deserializes_conservatively() {
         let failure: TransportEndpointFailure = serde_json::from_value(serde_json::json!({
             "endpoint": "wss://relay.example",
@@ -1177,6 +1340,70 @@ mod tests {
         assert_eq!(restored.request().message.id, original_id);
         assert_eq!(restored.request().target.endpoints(), original_targets);
         assert_eq!(restored.outstanding_target_indexes(), vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn legacy_pending_fanout_without_explicit_origin_restores_request_id() {
+        let fanout = OutboundFanout::stage(
+            fanout_request(),
+            Some(crate::engine_state::PendingStateRef::new(9)),
+            Some(GroupId::new(vec![0xD4; 16])),
+            55,
+        )
+        .unwrap();
+        let expected = fanout.message_id().clone();
+        let mut encoded = serde_json::to_value(fanout).unwrap();
+        let object = encoded.as_object_mut().unwrap();
+        object.remove("pending_origin_message_id");
+        object.remove("pending_kind");
+
+        let restored: OutboundFanout = serde_json::from_value(encoded).unwrap();
+        assert_eq!(restored.pending_origin_message_id(), Some(&expected));
+        assert_eq!(
+            restored.pending_kind(),
+            Some(FanoutPendingKind::GroupEvolution)
+        );
+    }
+
+    #[test]
+    fn post_confirmation_welcome_release_is_durable_and_cannot_reopen() {
+        let recipient = MemberId::new(vec![0xE5; 32]);
+        let welcome = TransportMessage {
+            envelope: TransportEnvelope::Welcome {
+                recipient: recipient.clone(),
+            },
+            ..fanout_request().message
+        };
+        let request = TransportPublishRequest {
+            account_id: MemberId::new(vec![0xA1; 32]),
+            message: welcome.clone(),
+            target: TransportPublishTarget::Inbox {
+                recipient,
+                endpoints: vec![TransportEndpoint("wss://one.example".into())],
+            },
+            required_acks: 1,
+        };
+        let mut fanout = OutboundFanout::stage_with_post_confirmation_welcomes(
+            request,
+            Some(crate::engine_state::PendingStateRef::new(9)),
+            Some(GroupId::new(vec![0xD4; 16])),
+            55,
+            None,
+            Some(FanoutPendingKind::CreateGroup),
+            vec![welcome.clone()],
+        )
+        .unwrap();
+        let unreleased = fanout.clone();
+
+        assert_eq!(fanout.pending_post_confirmation_welcomes(), &[welcome]);
+        assert!(fanout.mark_post_confirmation_welcomes_released());
+        assert!(fanout.pending_post_confirmation_welcomes().is_empty());
+        fanout.validate_successor_of(&unreleased).unwrap();
+        assert!(unreleased.validate_successor_of(&fanout).is_err());
+
+        let restored: OutboundFanout =
+            serde_json::from_slice(&serde_json::to_vec(&fanout).unwrap()).unwrap();
+        assert!(restored.pending_post_confirmation_welcomes().is_empty());
     }
 
     fn report(accepted: usize, failed: usize, required_acks: usize) -> TransportPublishReport {

--- a/crates/transport-nostr-adapter/src/sdk_client.rs
+++ b/crates/transport-nostr-adapter/src/sdk_client.rs
@@ -5,8 +5,8 @@ use std::time::Duration;
 use async_trait::async_trait;
 use cgka_traits::{
     MemberId, TransportAdapterError, TransportEndpoint, TransportEndpointFailure,
-    TransportEndpointReceipt, TransportEndpointRejectionCategory, TransportPublishFailure,
-    collapse_publish_failure_summaries,
+    TransportEndpointFailureKind, TransportEndpointReceipt, TransportEndpointRejectionCategory,
+    TransportPublishFailure, collapse_publish_failure_summaries,
 };
 use nostr_sdk::prelude::{
     Alphabet, Client, Event, EventBuilder, Filter, Kind, PublicKey, RelayMessage,
@@ -466,11 +466,13 @@ impl NostrSdkRelayClient {
             Ok(Err(_)) => Err(TransportEndpointFailure {
                 endpoint: transport_endpoint,
                 reason: "connect relay failed".to_owned(),
+                kind: TransportEndpointFailureKind::RetryableUnavailable,
                 rejection_category: None,
             }),
             Err(_) => Err(TransportEndpointFailure {
                 endpoint: transport_endpoint,
                 reason: "connect relay timed out".to_owned(),
+                kind: TransportEndpointFailureKind::RetryableUnavailable,
                 rejection_category: None,
             }),
         }
@@ -485,6 +487,7 @@ impl NostrSdkRelayClient {
         let mut last_failure = TransportEndpointFailure {
             endpoint: transport_endpoint.clone(),
             reason: "send event failed".to_owned(),
+            kind: TransportEndpointFailureKind::PossiblyExposed,
             rejection_category: None,
         };
         for attempt in 1..=SDK_RELAY_PUBLISH_ATTEMPTS {
@@ -516,6 +519,7 @@ impl NostrSdkRelayClient {
                             relay_rejection_endpoint_failure(transport_endpoint.clone(), remote);
                     } else {
                         last_failure.reason = "relay did not acknowledge event".to_owned();
+                        last_failure.kind = TransportEndpointFailureKind::PossiblyExposed;
                         last_failure.rejection_category = None;
                     }
                 }
@@ -523,10 +527,12 @@ impl NostrSdkRelayClient {
                     // No sdk error Display here either — it can carry the
                     // relay URL.
                     last_failure.reason = "send event failed".to_owned();
+                    last_failure.kind = TransportEndpointFailureKind::PossiblyExposed;
                     last_failure.rejection_category = None;
                 }
                 Err(_) => {
                     last_failure.reason = "send event timed out".to_owned();
+                    last_failure.kind = TransportEndpointFailureKind::PossiblyExposed;
                     last_failure.rejection_category = None;
                 }
             }
@@ -548,6 +554,11 @@ impl NostrSdkRelayClient {
         // confirming work that no relay accepted.
         let ack_goal = request.required_acks.max(1);
         let message_id = cgka_traits::MessageId::new(request.event.id.to_bytes().to_vec());
+        let attempted_endpoints = request
+            .endpoints
+            .iter()
+            .map(|endpoint| TransportEndpoint(endpoint.to_string()))
+            .collect::<Vec<_>>();
         let mut accepted = Vec::new();
         let mut failed = Vec::new();
         let mut publishes = JoinSet::new();
@@ -575,6 +586,7 @@ impl NostrSdkRelayClient {
                 publishes.abort_all();
                 aborted_publishes = true;
                 timed_out = true;
+                append_missing_publish_failures(&mut failed, &accepted, &attempted_endpoints);
                 break Self::finish_publish_outcome(
                     message_id,
                     accepted,
@@ -588,6 +600,7 @@ impl NostrSdkRelayClient {
                     publishes.abort_all();
                     aborted_publishes = true;
                     timed_out = true;
+                    append_missing_publish_failures(&mut failed, &accepted, &attempted_endpoints);
                     break Self::finish_publish_outcome(
                         message_id,
                         accepted,
@@ -597,6 +610,7 @@ impl NostrSdkRelayClient {
                     );
                 }
                 Ok(None) => {
+                    append_missing_publish_failures(&mut failed, &accepted, &attempted_endpoints);
                     break Self::finish_publish_outcome(
                         message_id,
                         accepted,
@@ -844,6 +858,7 @@ impl NostrSdkRelayClient {
             Err(_) => Err(TransportEndpointFailure {
                 endpoint: transport_endpoint,
                 reason: "add publish relay failed".to_owned(),
+                kind: TransportEndpointFailureKind::RetryableUnavailable,
                 rejection_category: None,
             }),
         }
@@ -932,7 +947,8 @@ impl NostrSdkRelayClient {
             Err(TransportAdapterError::Publish(reason))
         } else {
             Err(TransportAdapterError::PublishEndpoints(
-                TransportPublishFailure::with_endpoint_failures(reason, failed),
+                TransportPublishFailure::with_endpoint_failures(reason, failed)
+                    .with_message_id(message_id),
             ))
         }
     }
@@ -1251,6 +1267,26 @@ fn relay_endpoint_publish_accepted(success: bool, failure_reason: Option<&str>) 
     success || failure_reason.is_some_and(relay_duplicate_acknowledgement)
 }
 
+fn append_missing_publish_failures(
+    failed: &mut Vec<TransportEndpointFailure>,
+    accepted: &[TransportEndpointReceipt],
+    attempted: &[TransportEndpoint],
+) {
+    for endpoint in attempted {
+        if accepted.iter().any(|receipt| &receipt.endpoint == endpoint)
+            || failed.iter().any(|failure| &failure.endpoint == endpoint)
+        {
+            continue;
+        }
+        failed.push(TransportEndpointFailure {
+            endpoint: endpoint.clone(),
+            reason: "publish acknowledgement unknown".into(),
+            kind: TransportEndpointFailureKind::PossiblyExposed,
+            rejection_category: None,
+        });
+    }
+}
+
 fn map_relay_rejection_category(
     prefix: nostr::message::MachineReadablePrefix,
 ) -> TransportEndpointRejectionCategory {
@@ -1274,15 +1310,42 @@ fn relay_rejection_endpoint_failure(
 ) -> TransportEndpointFailure {
     if let Some(prefix) = nostr::message::MachineReadablePrefix::parse(relay_message) {
         let category = map_relay_rejection_category(prefix);
+        // nostr-sdk also uses the generic `error:` prefix for local SDK/send
+        // failures. Without a typed SDK distinction, that prefix is not proof
+        // of a relay-level OK:false rejection and must remain conservative.
+        let kind = match category {
+            TransportEndpointRejectionCategory::Error => {
+                TransportEndpointFailureKind::PossiblyExposed
+            }
+            TransportEndpointRejectionCategory::RateLimited
+            | TransportEndpointRejectionCategory::AuthRequired => {
+                TransportEndpointFailureKind::RetryableUnavailable
+            }
+            TransportEndpointRejectionCategory::Duplicate
+            | TransportEndpointRejectionCategory::Pow
+            | TransportEndpointRejectionCategory::Blocked
+            | TransportEndpointRejectionCategory::Invalid
+            | TransportEndpointRejectionCategory::Unsupported
+            | TransportEndpointRejectionCategory::Restricted => {
+                TransportEndpointFailureKind::TerminalRejected
+            }
+        };
+        let reason = if kind == TransportEndpointFailureKind::PossiblyExposed {
+            "publish acknowledgement unknown (error)".to_owned()
+        } else {
+            format!("relay rejected event ({})", category.as_str())
+        };
         return TransportEndpointFailure {
             endpoint,
-            reason: format!("relay rejected event ({})", category.as_str()),
+            reason,
+            kind,
             rejection_category: Some(category),
         };
     }
     TransportEndpointFailure {
         endpoint,
-        reason: "relay rejected event".to_owned(),
+        reason: "publish acknowledgement unknown".to_owned(),
+        kind: TransportEndpointFailureKind::PossiblyExposed,
         rejection_category: None,
     }
 }
@@ -1318,25 +1381,29 @@ mod tests {
 
     #[test]
     fn relay_rejection_endpoint_failure_maps_machine_readable_prefix() {
-        for (message, category, summary) in [
+        for (message, category, kind, summary) in [
             (
                 "auth-required: account secret at https://evil.example/auth",
                 TransportEndpointRejectionCategory::AuthRequired,
+                TransportEndpointFailureKind::RetryableUnavailable,
                 "relay rejected event (auth-required)",
             ),
             (
                 "restricted: kind 5 disabled at https://evil.example/policy",
                 TransportEndpointRejectionCategory::Restricted,
+                TransportEndpointFailureKind::TerminalRejected,
                 "relay rejected event (restricted)",
             ),
             (
                 "invalid: leaked event payload",
                 TransportEndpointRejectionCategory::Invalid,
+                TransportEndpointFailureKind::TerminalRejected,
                 "relay rejected event (invalid)",
             ),
             (
                 "unsupported: kind 5",
                 TransportEndpointRejectionCategory::Unsupported,
+                TransportEndpointFailureKind::TerminalRejected,
                 "relay rejected event (unsupported)",
             ),
         ] {
@@ -1345,10 +1412,26 @@ mod tests {
                 message,
             );
             assert_eq!(failure.rejection_category, Some(category));
+            assert_eq!(failure.kind, kind);
             assert_eq!(failure.reason, summary);
             assert!(!failure.reason.contains("evil.example"));
             assert!(!failure.reason.contains("leaked event payload"));
         }
+    }
+
+    #[test]
+    fn generic_error_prefix_is_not_treated_as_proof_of_terminal_rejection() {
+        let failure = relay_rejection_endpoint_failure(
+            TransportEndpoint("wss://relay.example".into()),
+            "error: SDK send failed",
+        );
+
+        assert_eq!(failure.kind, TransportEndpointFailureKind::PossiblyExposed);
+        assert_eq!(
+            failure.rejection_category,
+            Some(TransportEndpointRejectionCategory::Error)
+        );
+        assert_eq!(failure.reason, "publish acknowledgement unknown (error)");
     }
 
     #[test]
@@ -1361,11 +1444,13 @@ mod tests {
                 TransportEndpointFailure {
                     endpoint: TransportEndpoint("wss://first.example".into()),
                     reason: "relay rejected event (blocked)".to_owned(),
+                    kind: TransportEndpointFailureKind::TerminalRejected,
                     rejection_category: Some(TransportEndpointRejectionCategory::Blocked),
                 },
                 TransportEndpointFailure {
                     endpoint: TransportEndpoint("wss://second.example".into()),
                     reason: "relay rejected event (blocked)".to_owned(),
+                    kind: TransportEndpointFailureKind::TerminalRejected,
                     rejection_category: Some(TransportEndpointRejectionCategory::Blocked),
                 },
             ],
@@ -1402,6 +1487,7 @@ mod tests {
         let failed = vec![TransportEndpointFailure {
             endpoint: TransportEndpoint("wss://bad.example".into()),
             reason: "relay rejected event (auth-required)".to_owned(),
+            kind: TransportEndpointFailureKind::TerminalRejected,
             rejection_category: Some(TransportEndpointRejectionCategory::AuthRequired),
         }];
         let outcome = NostrSdkRelayClient::finish_publish_outcome(
@@ -1456,6 +1542,7 @@ mod tests {
             vec![TransportEndpointFailure {
                 endpoint: endpoint.clone(),
                 reason: "connect relay failed".to_owned(),
+                kind: TransportEndpointFailureKind::RetryableUnavailable,
                 rejection_category: None,
             }],
             1,
@@ -1947,7 +2034,59 @@ mod tests {
             .expect_err("silent relay should miss the required ack deadline");
 
         assert!(err.to_string().contains("publish timed out"));
+        assert_eq!(
+            err.publish_message_id().unwrap().as_slice(),
+            hex::decode(&dto.id).unwrap()
+        );
+        assert!(
+            err.publish_endpoint_failures()
+                .iter()
+                .all(|failure| { failure.kind == TransportEndpointFailureKind::PossiblyExposed })
+        );
         assert_eq!(sdk.relay_health().await.total_relays, 0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn relay_that_stores_event_but_withholds_ok_is_possibly_exposed() {
+        let stored_ids = Arc::new(Mutex::new(Vec::new()));
+        let endpoint = TransportEndpoint(storing_no_ack_relay_url(stored_ids.clone()).await);
+        let client = Client::builder().signer(Keys::generate()).build();
+        let sdk = NostrSdkRelayClient::new(client);
+        let dto = signed_group_event_dto();
+        let expected_id = dto.id.clone();
+        let publish_sdk = sdk.clone();
+        let publish_endpoint = endpoint.clone();
+        let publish = tokio::spawn(async move {
+            publish_sdk
+                .publish_event(std::slice::from_ref(&publish_endpoint), &dto, 1)
+                .await
+        });
+
+        for _ in 0..100 {
+            if stored_ids.lock().await.contains(&expected_id) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            stored_ids.lock().await.contains(&expected_id),
+            "the relay must receive and retain the event before withholding OK"
+        );
+
+        advance(SDK_RELAY_PUBLISH_OVERALL_WAIT + Duration::from_secs(1)).await;
+        let err = publish
+            .await
+            .expect("publish task must not panic")
+            .expect_err("withheld OK must leave completion unresolved");
+        assert_eq!(
+            err.publish_message_id().unwrap().as_slice(),
+            hex::decode(expected_id).unwrap()
+        );
+        assert_eq!(err.publish_endpoint_failures().len(), 1);
+        assert_eq!(
+            err.publish_endpoint_failures()[0].kind,
+            TransportEndpointFailureKind::PossiblyExposed
+        );
     }
 
     #[tokio::test(start_paused = true)]
@@ -2235,6 +2374,14 @@ mod tests {
         assert!(
             outcomes[0].is_err(),
             "stalled request must fail in slot zero"
+        );
+        assert_eq!(
+            outcomes[0]
+                .as_ref()
+                .unwrap_err()
+                .publish_endpoint_failures()[0]
+                .kind,
+            TransportEndpointFailureKind::PossiblyExposed
         );
         assert!(
             outcomes[1].is_ok(),
@@ -2630,6 +2777,43 @@ mod tests {
                 tokio::spawn(async move {
                     if tokio_tungstenite::accept_async(stream).await.is_ok() {
                         std::future::pending::<()>().await;
+                    }
+                });
+            }
+        });
+        format!("ws://{addr}")
+    }
+
+    async fn storing_no_ack_relay_url(stored_ids: Arc<Mutex<Vec<String>>>) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            while let Ok((stream, _)) = listener.accept().await {
+                let stored_ids = stored_ids.clone();
+                tokio::spawn(async move {
+                    let Ok(mut websocket) = tokio_tungstenite::accept_async(stream).await else {
+                        return;
+                    };
+                    while let Some(Ok(message)) = websocket.next().await {
+                        let Ok(text) = message.into_text() else {
+                            continue;
+                        };
+                        let Ok(value) = serde_json::from_str::<serde_json::Value>(&text) else {
+                            continue;
+                        };
+                        let Some(items) = value.as_array() else {
+                            continue;
+                        };
+                        if items.first().and_then(serde_json::Value::as_str) != Some("EVENT") {
+                            continue;
+                        }
+                        if let Some(id) = items
+                            .get(1)
+                            .and_then(|event| event.get("id"))
+                            .and_then(serde_json::Value::as_str)
+                        {
+                            stored_ids.lock().await.push(id.to_owned());
+                        }
                     }
                 });
             }


### PR DESCRIPTION
## Summary

- classify per-endpoint publication failures by exposure and retry semantics while preserving the transport event ID on unresolved outcomes
- keep the exact frozen fanout and pending MLS state durable across ambiguous or transient failures, then retry with capped exponential backoff
- surface completion-unknown through the app and UniFFI as a non-failure without retracting the application message or encouraging a new semantic send

## Test plan

- [x] regression test failed before the implementation and passes after it
- [x] cargo test -p cgka-traits
- [x] cargo test -p marmot-account
- [x] cargo test -p transport-nostr-adapter --features sdk
- [x] targeted marmot-app and marmot-uniffi tests
- [x] workspace check and Clippy, including OTLP feature builds
- [x] all other fast-CI recipes
- [ ] just fast-ci (campaign-toolchain-gate is blocked on current master by GNU-style sed -i usage under macOS BSD sed)

Fixes #1577

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clearer message delivery outcomes, including published, retryable, terminally rejected, and completion-unknown statuses.
  - Improved retry handling for temporarily unavailable endpoints, including persistence across restarts.
  - Preserved and surfaced messages that may have been exposed but lack confirmed acknowledgement.
  - Added structured details for unresolved group and application-message publications.
  - Exposed the new completion status consistently through application interfaces.

- **Bug Fixes**
  - Corrected publication counts, summaries, and local projections to reflect confirmed event delivery.
  - Improved relay failure classification and partial-acceptance reporting.
  - Ensured deferred group invitations are released only after confirmation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->