### PR TITLE
fix(adapter): normalize relay coverage identities

### DIFF
--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -112,8 +112,9 @@ impl DrainCompletion {
 /// contract also retains its silence-specific unconfirmed verdicts.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum DrainVerdict {
-    /// Every live subscription reached end-of-stored-events and the relays then
-    /// went quiet: the account's stored history was served in full.
+    /// Every endpoint-scoped attempt in the activation's frozen route snapshot
+    /// reached end-of-stored-events and the relays then went quiet: the
+    /// account's stored history was served in full.
     Complete,
     /// The silence budget ran out with stored history still unconfirmed, though
     /// some relay did reach end-of-stored-events.

--- a/crates/transport-nostr-adapter/src/telemetry.rs
+++ b/crates/transport-nostr-adapter/src/telemetry.rs
@@ -29,6 +29,7 @@ use std::collections::HashSet;
 
 use cgka_traits::MessageId;
 use cgka_traits::TransportEndpoint;
+use nostr::RelayUrl;
 use serde::{Deserialize, Serialize};
 
 /// Upper bounds, in milliseconds, of the duration histogram buckets shared by
@@ -74,13 +75,19 @@ pub struct RelayIndexRegistry {
 
 impl RelayIndexRegistry {
     /// Stable index for `endpoint`, assigning a new one on first sighting.
+    ///
+    /// Valid relay URLs are keyed by their parsed [`RelayUrl`] spelling so a
+    /// verbatim signed route and the normalized endpoint emitted by nostr-sdk
+    /// resolve to the same device-local relay. Invalid/non-relay endpoints stay
+    /// byte-exact; this registry never rewrites authoritative routing state.
     pub fn index_for(&mut self, endpoint: &TransportEndpoint) -> RelayIndex {
-        if let Some(index) = self.indices.get(endpoint) {
+        let key = relay_index_key(endpoint);
+        if let Some(index) = self.indices.get(&key) {
             return *index;
         }
         let index = RelayIndex(self.next);
         self.next += 1;
-        self.indices.insert(endpoint.clone(), index);
+        self.indices.insert(key, index);
         index
     }
 
@@ -106,6 +113,14 @@ impl RelayIndexRegistry {
         pairs.sort_by_key(|(index, _)| index.0);
         pairs
     }
+}
+
+/// Device-local identity key shared by subscription attempts, EOSE callbacks,
+/// delivery timing, and frozen replay coverage.
+fn relay_index_key(endpoint: &TransportEndpoint) -> TransportEndpoint {
+    RelayUrl::parse(endpoint.as_str())
+        .map(|relay_url| TransportEndpoint(relay_url.to_string()))
+        .unwrap_or_else(|_| endpoint.clone())
 }
 
 /// Capability that authorizes resolving opaque [`RelayIndex`] values back to
@@ -833,6 +848,22 @@ mod tests {
         let first = registry.index_for(&a);
         assert_eq!(registry.index_for(&b), RelayIndex(1));
         assert_eq!(registry.index_for(&a), first, "stable across calls");
+    }
+
+    #[test]
+    fn registry_folds_verbatim_and_normalized_relay_spellings() {
+        let mut registry = RelayIndexRegistry::default();
+        let verbatim = TransportEndpoint("wss://Relay.Example:443".into());
+        let normalized = TransportEndpoint(
+            RelayUrl::parse(verbatim.as_str())
+                .expect("relay URL parses")
+                .to_string(),
+        );
+        assert_ne!(verbatim, normalized);
+
+        let index = registry.index_for(&verbatim);
+        assert_eq!(registry.index_for(&normalized), index);
+        assert_eq!(registry.resolutions(), vec![(index, normalized)]);
     }
 
     #[test]

--- a/crates/transport-nostr-adapter/src/telemetry.rs
+++ b/crates/transport-nostr-adapter/src/telemetry.rs
@@ -29,7 +29,7 @@ use std::collections::HashSet;
 
 use cgka_traits::MessageId;
 use cgka_traits::TransportEndpoint;
-use nostr::RelayUrl;
+use nostr::{RelayUrl, Url};
 use serde::{Deserialize, Serialize};
 
 /// Upper bounds, in milliseconds, of the duration histogram buckets shared by
@@ -76,10 +76,10 @@ pub struct RelayIndexRegistry {
 impl RelayIndexRegistry {
     /// Stable index for `endpoint`, assigning a new one on first sighting.
     ///
-    /// Valid relay URLs are keyed by their parsed [`RelayUrl`] spelling so a
-    /// verbatim signed route and the normalized endpoint emitted by nostr-sdk
-    /// resolve to the same device-local relay. Invalid/non-relay endpoints stay
-    /// byte-exact; this registry never rewrites authoritative routing state.
+    /// Valid relay URLs are keyed by their parsed URL identity so a verbatim
+    /// signed route and the normalized endpoint emitted by nostr-sdk resolve to
+    /// the same device-local relay. Invalid/non-relay endpoints stay byte-exact;
+    /// this registry never rewrites authoritative routing state.
     pub fn index_for(&mut self, endpoint: &TransportEndpoint) -> RelayIndex {
         let key = relay_index_key(endpoint);
         if let Some(index) = self.indices.get(&key) {
@@ -117,9 +117,13 @@ impl RelayIndexRegistry {
 
 /// Device-local identity key shared by subscription attempts, EOSE callbacks,
 /// delivery timing, and frozen replay coverage.
+///
+/// Serializing the inner [`Url`] discards [`RelayUrl`]'s presentation-only
+/// `has_trailing_slash` flag while preserving real path distinctions such as
+/// `/foo` versus `/foo/`, matching [`RelayUrl`]'s `Eq`/`Hash` identity.
 fn relay_index_key(endpoint: &TransportEndpoint) -> TransportEndpoint {
     RelayUrl::parse(endpoint.as_str())
-        .map(|relay_url| TransportEndpoint(relay_url.to_string()))
+        .map(|relay_url| TransportEndpoint(Url::from(relay_url).to_string()))
         .unwrap_or_else(|_| endpoint.clone())
 }
 
@@ -859,11 +863,27 @@ mod tests {
                 .expect("relay URL parses")
                 .to_string(),
         );
+        let canonical = TransportEndpoint(
+            Url::from(RelayUrl::parse(verbatim.as_str()).expect("relay URL parses")).to_string(),
+        );
         assert_ne!(verbatim, normalized);
 
         let index = registry.index_for(&verbatim);
         assert_eq!(registry.index_for(&normalized), index);
-        assert_eq!(registry.resolutions(), vec![(index, normalized)]);
+        assert_eq!(registry.resolutions(), vec![(index, canonical)]);
+    }
+
+    #[test]
+    fn registry_folds_origin_slashes_but_preserves_path_slashes() {
+        let mut registry = RelayIndexRegistry::default();
+        let origin = TransportEndpoint("wss://relay.example.com".into());
+        let origin_slash = TransportEndpoint("wss://relay.example.com/".into());
+        let path = TransportEndpoint("wss://relay.example.com/foo".into());
+        let path_slash = TransportEndpoint("wss://relay.example.com/foo/".into());
+
+        let origin_index = registry.index_for(&origin);
+        assert_eq!(registry.index_for(&origin_slash), origin_index);
+        assert_ne!(registry.index_for(&path), registry.index_for(&path_slash));
     }
 
     #[test]
@@ -873,11 +893,16 @@ mod tests {
         let b = TransportEndpoint("wss://b".into());
         let ia = registry.index_for(&a);
         let ib = registry.index_for(&b);
+        let canonical_a = relay_index_key(&a);
+        let canonical_b = relay_index_key(&b);
 
-        assert_eq!(registry.resolve(ia), Some(&a));
-        assert_eq!(registry.resolve(ib), Some(&b));
+        assert_eq!(registry.resolve(ia), Some(&canonical_a));
+        assert_eq!(registry.resolve(ib), Some(&canonical_b));
         assert_eq!(registry.resolve(RelayIndex(99)), None);
-        assert_eq!(registry.resolutions(), vec![(ia, a), (ib, b)]);
+        assert_eq!(
+            registry.resolutions(),
+            vec![(ia, canonical_a), (ib, canonical_b)]
+        );
     }
 
     #[test]

--- a/crates/transport-nostr-adapter/tests/inbound_routing.rs
+++ b/crates/transport-nostr-adapter/tests/inbound_routing.rs
@@ -9,6 +9,7 @@ use cgka_traits::{
     TransportEndpoint, TransportGroupSubscription, TransportGroupSync, TransportPublishRequest,
     TransportPublishTarget,
 };
+use nostr::RelayUrl;
 use tokio::sync::{Barrier, Notify};
 use transport_nostr_adapter::{
     NostrPublishOutcome, NostrRelayClient, NostrRelayEvent, NostrSubscription,
@@ -3007,7 +3008,16 @@ async fn account_subscription_eose_requires_the_frozen_relay_coverage() {
     let inbox_a = TransportEndpoint("wss://inbox-a.example".to_owned());
     let inbox_b = TransportEndpoint("wss://inbox-b.example".to_owned());
     let group_a = TransportEndpoint("wss://group-a.example".to_owned());
-    let group_b = TransportEndpoint("wss://group-b.example".to_owned());
+    let group_b = TransportEndpoint("wss://Group-B.Example:443".to_owned());
+    let group_b_inbound = TransportEndpoint(
+        RelayUrl::parse(group_b.as_str())
+            .expect("route B parses")
+            .to_string(),
+    );
+    assert_ne!(
+        group_b, group_b_inbound,
+        "the test requires a verbatim route spelling that normalizes on inbound"
+    );
     let group = TransportGroupSubscription {
         group_id: cgka_traits::GroupId::new(vec![0x33; 16]),
         transport_group_id: vec![0x44; 32],
@@ -3064,7 +3074,7 @@ async fn account_subscription_eose_requires_the_frozen_relay_coverage() {
     assert_eq!(
         adapter
             .handle_relay_event(NostrRelayEvent {
-                endpoint: group_b.clone(),
+                endpoint: group_b_inbound.clone(),
                 subscription_id: Some(group_id.clone()),
                 event: group_event("relay-b-only", &group.transport_group_id),
             })
@@ -3080,7 +3090,7 @@ async fn account_subscription_eose_requires_the_frozen_relay_coverage() {
             .expect("B's event is delivered")
             .source
             .endpoint,
-        Some(group_b.clone())
+        Some(group_b_inbound.clone())
     );
     adapter
         .handle_relay_eose(inbox_b.clone(), inbox_id.clone())
@@ -3124,7 +3134,7 @@ async fn account_subscription_eose_requires_the_frozen_relay_coverage() {
         "a route shrink must not complete an older replay attempt"
     );
 
-    adapter.handle_relay_eose(group_b, group_id).await;
+    adapter.handle_relay_eose(group_b_inbound, group_id).await;
     assert!(
         adapter
             .account_subscription_eose(&account_id)

--- a/crates/transport-nostr-adapter/tests/inbound_routing.rs
+++ b/crates/transport-nostr-adapter/tests/inbound_routing.rs
@@ -1467,6 +1467,14 @@ async fn resolve_relay_labels_maps_observed_indices_to_endpoints() {
         TransportEndpoint("wss://group-a.example".into()),
         TransportEndpoint("wss://group-b.example".into()),
     ];
+    let canonical_endpoints = endpoints.clone().map(|endpoint| {
+        TransportEndpoint(
+            nostr::Url::from(
+                RelayUrl::parse(endpoint.as_str()).expect("test relay URL should parse"),
+            )
+            .to_string(),
+        )
+    });
 
     // Observing per-relay copies assigns opaque indices in first-seen order.
     for endpoint in &endpoints {
@@ -1485,8 +1493,14 @@ async fn resolve_relay_labels_maps_observed_indices_to_endpoints() {
         .resolve_relay_labels(RelayExportConsent::affirm())
         .await;
     assert_eq!(resolution.len(), 2);
-    assert_eq!(resolution.label_for(RelayIndex(0)), Some(&endpoints[0]));
-    assert_eq!(resolution.label_for(RelayIndex(1)), Some(&endpoints[1]));
+    assert_eq!(
+        resolution.label_for(RelayIndex(0)),
+        Some(&canonical_endpoints[0])
+    );
+    assert_eq!(
+        resolution.label_for(RelayIndex(1)),
+        Some(&canonical_endpoints[1])
+    );
     assert_eq!(resolution.label_for(RelayIndex(2)), None);
 }
 
@@ -3008,15 +3022,16 @@ async fn account_subscription_eose_requires_the_frozen_relay_coverage() {
     let inbox_a = TransportEndpoint("wss://inbox-a.example".to_owned());
     let inbox_b = TransportEndpoint("wss://inbox-b.example".to_owned());
     let group_a = TransportEndpoint("wss://group-a.example".to_owned());
-    let group_b = TransportEndpoint("wss://Group-B.Example:443".to_owned());
-    let group_b_inbound = TransportEndpoint(
-        RelayUrl::parse(group_b.as_str())
-            .expect("route B parses")
-            .to_string(),
-    );
+    let group_b = TransportEndpoint("wss://Group-B.Example:443/".to_owned());
+    let group_b_inbound = TransportEndpoint("wss://group-b.example".to_owned());
     assert_ne!(
         group_b, group_b_inbound,
         "the test requires a verbatim route spelling that normalizes on inbound"
+    );
+    assert_eq!(
+        RelayUrl::parse(group_b.as_str()).expect("route B parses"),
+        RelayUrl::parse(group_b_inbound.as_str()).expect("inbound B parses"),
+        "the spellings must identify the same relay"
     );
     let group = TransportGroupSubscription {
         group_id: cgka_traits::GroupId::new(vec![0x33; 16]),


### PR DESCRIPTION
Follow-up to #1581 addressing its two review threads.

## Summary

- normalize valid relay URL spellings at the device-local relay-index boundary
- make route snapshots, subscription attempts, inbound EOSE, and delivery timing share the same relay identity
- cover verbatim signed routes versus nostr-sdk-normalized inbound endpoints
- correct the replay completion documentation to describe frozen endpoint coverage

## Testing

- `cargo test -p transport-nostr-adapter`
- `cargo test -p marmot-app --features test-policy-overrides slow_relay -- --nocapture`
- `just fast-ci`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved relay endpoint handling by treating equivalent URL spellings consistently, including capitalization, default ports, and trailing slashes.
  - Preserved meaningful path-slash differences when canonicalizing relay endpoints.
  - Improved event delivery and completion coverage when equivalent endpoint formats are used.
- **Documentation**
  - Clarified that synchronization is complete when all endpoint subscriptions in the activation’s frozen route snapshot have completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->