### PR TITLE
fix(marmot-app): require EOSE for full-history repair

### DIFF
--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -2714,7 +2714,19 @@ impl AppClient {
                             SyncFailureStage::Unknown,
                         )
                     })? {
-                    EpochBackfillRunOutcome::Completed(summary) => return Ok(summary),
+                    EpochBackfillRunOutcome::Completed(mut summary) => {
+                        if self.delivery_overflow_recovery_pending {
+                            self.recover_delivery_overflow_and_merge(&mut summary)
+                                .await?;
+                            if self.delivery_overflow_recovery_pending {
+                                return Err(incomplete_full_history_repair(
+                                    summary,
+                                    DrainVerdict::Overflow,
+                                ));
+                            }
+                        }
+                        return Ok(summary);
+                    }
                     // The intent's own replay could not confirm it served this
                     // account's history. Retain what it did ingest and fall
                     // through to the caller-directed unfloored repair below
@@ -3963,6 +3975,7 @@ mod tests {
             DrainVerdict::EoseTimeout,
             DrainVerdict::NovelProgressQuantumYield,
             DrainVerdict::NoProgressQuantumYield,
+            DrainVerdict::Overflow,
         ] {
             let partial = SyncSummary {
                 joined_groups: vec![cgka_traits::GroupId::new(vec![0x42])],

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -194,6 +194,25 @@ impl DrainVerdict {
     }
 }
 
+/// Turn the end-of-stored-events gate into the public outcome of an explicit
+/// full-history repair. A quiet unfloored subscription is not proof that the
+/// relay served all stored events, so retain everything that was ingested in
+/// the partial summary while failing the repair closed.
+fn incomplete_full_history_repair(
+    summary: SyncSummary,
+    verdict: DrainVerdict,
+) -> ClassifiedSyncFailure {
+    debug_assert_ne!(verdict, DrainVerdict::Complete);
+    let error_kind = verdict
+        .error_kind()
+        .unwrap_or("full_history_repair_unconfirmed");
+    ClassifiedSyncFailure::at_stage(
+        summary,
+        AppError::BlockingTask(format!("full-history repair incomplete: {error_kind}")),
+        SyncFailureStage::RelayReceive,
+    )
+}
+
 /// What one delivery's ingest settled, for the two seams that decide whether the
 /// delivery may be dropped from the fetch path.
 struct DeliveryIngest {
@@ -2739,10 +2758,15 @@ impl AppClient {
         self.pending_runtime_group_subscription_refresh = false;
         self.record_subscription_rebuild(None).await;
         let mut counts = DrainCounts::default();
-        let (mut summary, drain_verdict) = self.sync_sdk_relay(&mut counts).await?;
-        if drain_verdict == DrainVerdict::Overflow || self.delivery_overflow_recovery_pending {
+        let (mut summary, mut verdict) = self.backfill_sdk_relay(&mut counts).await?;
+        if verdict == DrainVerdict::Overflow || self.delivery_overflow_recovery_pending {
             self.recover_delivery_overflow_and_merge(&mut summary)
                 .await?;
+            verdict = if self.delivery_overflow_recovery_pending {
+                DrainVerdict::Overflow
+            } else {
+                DrainVerdict::Complete
+            };
         }
         let drained = match self.drain_pending_session_events().await {
             Ok(drained) => drained,
@@ -2756,7 +2780,11 @@ impl AppClient {
             }
         };
         summary.merge(drained);
-        Ok(summary)
+        if verdict == DrainVerdict::Complete {
+            Ok(summary)
+        } else {
+            Err(incomplete_full_history_repair(summary, verdict))
+        }
     }
 
     pub(crate) async fn advance_convergence_after_runtime_sync(
@@ -3851,8 +3879,11 @@ fn retry_backoff_for_ordinal(base: Duration, retry_ordinal: u64) -> Duration {
 
 #[cfg(test)]
 mod tests {
-    use super::{DrainVerdict, backfill_drain_verdict, retry_backoff_for_ordinal};
-    use crate::{EPOCH_BACKFILL_RETRY_BACKOFF, EPOCH_BACKFILL_RETRY_BACKOFF_CAP};
+    use super::{
+        DrainVerdict, backfill_drain_verdict, incomplete_full_history_repair,
+        retry_backoff_for_ordinal,
+    };
+    use crate::{EPOCH_BACKFILL_RETRY_BACKOFF, EPOCH_BACKFILL_RETRY_BACKOFF_CAP, SyncSummary};
     use std::time::Duration;
     use transport_nostr_adapter::AccountSubscriptionEose;
 
@@ -3915,5 +3946,29 @@ mod tests {
             DrainVerdict::EoseTimeout,
             "EOSE on every logical subscription is insufficient while another relay remains uncovered"
         );
+    }
+
+    #[test]
+    fn explicit_full_history_repair_requires_end_of_stored_events() {
+        for verdict in [
+            DrainVerdict::NoRelayEose,
+            DrainVerdict::EoseTimeout,
+            DrainVerdict::NovelProgressQuantumYield,
+            DrainVerdict::NoProgressQuantumYield,
+        ] {
+            let partial = SyncSummary {
+                joined_groups: vec![cgka_traits::GroupId::new(vec![0x42])],
+                ..SyncSummary::default()
+            };
+            let error = incomplete_full_history_repair(partial.clone(), verdict);
+            assert_eq!(error.partial_summary, partial);
+            assert!(
+                error
+                    .source
+                    .to_string()
+                    .contains(verdict.error_kind().unwrap()),
+                "the caller must be able to distinguish why the repair stayed incomplete",
+            );
+        }
     }
 }

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -3883,7 +3883,15 @@ mod tests {
         DrainVerdict, backfill_drain_verdict, incomplete_full_history_repair,
         retry_backoff_for_ordinal,
     };
-    use crate::{EPOCH_BACKFILL_RETRY_BACKOFF, EPOCH_BACKFILL_RETRY_BACKOFF_CAP, SyncSummary};
+    use crate::tests::{
+        ScriptedPushRelayClient, bounded_epoch_backfill_config, client_on_app_relay_plane,
+    };
+    use crate::{
+        EPOCH_BACKFILL_RETRY_BACKOFF, EPOCH_BACKFILL_RETRY_BACKOFF_CAP, MarmotApp,
+        SyncFailureStage, SyncSummary,
+    };
+    use marmot_account::AccountHome;
+    use std::sync::Arc;
     use std::time::Duration;
     use transport_nostr_adapter::AccountSubscriptionEose;
 
@@ -3970,5 +3978,43 @@ mod tests {
                 "the caller must be able to distinguish why the repair stayed incomplete",
             );
         }
+    }
+
+    #[tokio::test]
+    async fn explicit_full_history_repair_preserves_ingested_prefix_without_eose() {
+        let dir = tempfile::tempdir().unwrap();
+        AccountHome::open(dir.path())
+            .create_account("alice")
+            .unwrap();
+        let relay = Arc::new(ScriptedPushRelayClient::default());
+        let app = MarmotApp::with_relay_and_config(
+            dir.path(),
+            "wss://relay.example".to_owned(),
+            bounded_epoch_backfill_config(),
+        )
+        .with_test_relay_client(relay);
+        let mut client = client_on_app_relay_plane(&app, "alice").await;
+        let ingested = SyncSummary {
+            joined_groups: vec![cgka_traits::GroupId::new(vec![0x42])],
+            ..SyncSummary::default()
+        };
+        client.pending_failed_sync_summary.merge(ingested.clone());
+
+        let failure = client
+            .repair_full_history()
+            .await
+            .expect_err("relay silence cannot prove that full history was served");
+
+        assert_eq!(failure.partial_summary, ingested);
+        assert_eq!(
+            failure.classification().failure_stage,
+            SyncFailureStage::RelayReceive
+        );
+        let source = failure.source.to_string();
+        assert!(
+            source.contains("backfill_drain_no_relay_eose")
+                || source.contains("backfill_drain_no_progress_quantum_yield"),
+            "the public failure must preserve the incomplete-drain cause; actual: {source}"
+        );
     }
 }

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -5373,15 +5373,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn explicit_full_history_repair_without_eose_fails_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        AccountHome::open(dir.path())
+            .create_account("alice")
+            .unwrap();
+        let relay = Arc::new(ScriptedPushRelayClient::default());
+        let app = MarmotApp::with_relay_and_config(
+            dir.path(),
+            "wss://relay.example".to_owned(),
+            bounded_epoch_backfill_config(),
+        )
+        .with_test_relay_client(relay);
+        let mut client = client_on_app_relay_plane(&app, "alice").await;
+
+        let failure = client
+            .repair_full_history()
+            .await
+            .expect_err("relay silence cannot prove that full history was served");
+
+        assert_eq!(
+            failure.classification().failure_stage,
+            SyncFailureStage::RelayReceive
+        );
+        let source = failure.source.to_string();
+        assert!(
+            source.contains("backfill_drain_no_relay_eose")
+                || source.contains("backfill_drain_no_progress_quantum_yield"),
+            "the public failure must preserve the incomplete-drain cause; actual: {source}",
+        );
+    }
+
+    #[tokio::test]
     async fn full_history_repair_falls_back_when_every_pending_intent_defers() {
         let dir = tempfile::tempdir().unwrap();
         AccountHome::open(dir.path())
             .create_account("alice")
             .unwrap();
         let relay = Arc::new(ScriptedPushRelayClient::default());
-        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
-            .with_test_relay_client(relay.clone());
-        let mut client = app.client("alice").await.unwrap();
+        let app = MarmotApp::with_relay_and_config(
+            dir.path(),
+            "wss://relay.example".to_owned(),
+            bounded_epoch_backfill_config(),
+        )
+        .with_test_relay_client(relay.clone());
+        let _eose = scripted_eose_pump(app.relay_plane.clone(), relay.clone(), every_subscription);
+        let mut client = client_on_app_relay_plane(&app, "alice").await;
         let group_id = client
             .create_group("deferred full-history repair", &[])
             .await

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -5373,7 +5373,58 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn explicit_full_history_repair_without_eose_fails_closed() {
+    async fn full_history_repair_resolves_overflow_after_prearmed_backfill() {
+        let dir = tempfile::tempdir().unwrap();
+        AccountHome::open(dir.path())
+            .create_account("alice")
+            .unwrap();
+        let relay = Arc::new(ScriptedPushRelayClient::default());
+        let app = MarmotApp::with_relay_and_config(
+            dir.path(),
+            "wss://relay.example".to_owned(),
+            bounded_epoch_backfill_config(),
+        )
+        .with_test_relay_client(relay.clone());
+        let _eose = scripted_eose_pump(app.relay_plane.clone(), relay, every_subscription);
+        let mut client = client_on_app_relay_plane(&app, "alice").await;
+        let group_id = client
+            .create_group("combined full-history repair", &[])
+            .await
+            .unwrap();
+        let stalled_epoch = client.group_mls_state(&group_id).unwrap().epoch;
+        client.apply_backfill_decision(
+            &group_id,
+            stalled_epoch,
+            BackfillDecision::Arm,
+            EpochStallBackfillTrigger::UndecryptableThreshold,
+        );
+        let marker_token = 7;
+        app.account_storage("alice")
+            .unwrap()
+            .mark_account_delivery_recovery("alice", marker_token, 1)
+            .unwrap();
+        client.delivery_overflow_recovery_pending = true;
+        client.delivery_overflow_recovery_marker_token = Some(marker_token);
+
+        client
+            .repair_full_history()
+            .await
+            .expect("both EOSE-confirmed recovery obligations must complete");
+
+        assert!(!client.has_pending_epoch_backfill());
+        assert!(!client.delivery_overflow_recovery_pending);
+        assert!(
+            app.account_storage("alice")
+                .unwrap()
+                .account_delivery_recovery("alice")
+                .unwrap()
+                .is_none(),
+            "success must clear the durable overflow marker",
+        );
+    }
+
+    #[tokio::test]
+    async fn explicit_full_history_repair_retains_incomplete_overflow_recovery() {
         let dir = tempfile::tempdir().unwrap();
         AccountHome::open(dir.path())
             .create_account("alice")
@@ -5386,21 +5437,41 @@ mod tests {
         )
         .with_test_relay_client(relay);
         let mut client = client_on_app_relay_plane(&app, "alice").await;
+        let marker_token = 7;
+        app.account_storage("alice")
+            .unwrap()
+            .mark_account_delivery_recovery("alice", marker_token, 1)
+            .unwrap();
+        client.delivery_overflow_recovery_pending = true;
+        client.delivery_overflow_recovery_marker_token = Some(marker_token);
 
         let failure = client
             .repair_full_history()
             .await
-            .expect_err("relay silence cannot prove that full history was served");
+            .expect_err("relay silence cannot resolve the durable delivery gap");
 
         assert_eq!(
             failure.classification().failure_stage,
             SyncFailureStage::RelayReceive
         );
-        let source = failure.source.to_string();
         assert!(
-            source.contains("backfill_drain_no_relay_eose")
-                || source.contains("backfill_drain_no_progress_quantum_yield"),
-            "the public failure must preserve the incomplete-drain cause; actual: {source}",
+            failure
+                .source
+                .to_string()
+                .contains("account_delivery_queue_overflow"),
+            "the public failure must identify the unresolved durable gap",
+        );
+        assert!(
+            client.delivery_overflow_recovery_pending,
+            "an unconfirmed recovery must remain armed",
+        );
+        assert!(
+            app.account_storage("alice")
+                .unwrap()
+                .account_delivery_recovery("alice")
+                .unwrap()
+                .is_some(),
+            "an unconfirmed recovery must retain its durable marker",
         );
     }
 


### PR DESCRIPTION
## Summary

- make explicit full-history repair wait for relay end-of-stored-events instead of treating quiescence as completion
- fail incomplete EOSE, timeout, and execution-quantum outcomes closed while preserving the partial sync summary
- update the fallback repair fixture to emit EOSE under the bounded backfill policy

## Context

This follows the post-merge review of #1556. Ordinary catch-up remains latency-bound and quiescence-based; only the explicit full-history repair now uses the existing EOSE-aware drain contract.

The separate retained-progress accounting concern is already addressed on `master`: `DrainCounts::durable_deliveries()` subtracts every delivery the engine left unpersisted, including unknown-route and resource-refused input, so no additional accounting change is included here.

## Verification

- `python3 /opt/data/scripts/hermes_test_gate.py --tier focused -- cargo test -p marmot-app full_history_repair`
- `python3 /opt/data/scripts/hermes_test_gate.py --tier fast -- just fast-ci`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved full-history repair handling when synchronization ends incompletely.
  * Partial repair results are now preserved and accompanied by a classified error, making failures clearer and more actionable.
  * Repairs now fail safely when the relay does not provide the expected completion signal, while retaining successfully recovered history.
* **Tests**
  * Added coverage for incomplete repair outcomes and updated relay synchronization scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->