### PR TITLE
fix(app): wake reconnect backoff on catch-up

### DIFF
--- a/crates/marmot-app/Cargo.toml
+++ b/crates/marmot-app/Cargo.toml
@@ -59,3 +59,4 @@ zeroize.workspace = true
 keyring-core.workspace = true
 nostr-relay-builder.workspace = true
 tempfile.workspace = true
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -572,7 +572,7 @@ impl AppClient {
         self.prepare_transport_with_telemetry(None).await
     }
 
-    async fn prepare_transport_with_telemetry(
+    pub(crate) async fn prepare_transport_with_telemetry(
         &mut self,
         telemetry: Option<&AppPerformanceTelemetry>,
     ) -> Result<(), AppError> {
@@ -654,7 +654,7 @@ impl AppClient {
         }
     }
 
-    pub(crate) async fn sync_with_startup_stage_telemetry(
+    pub(crate) async fn sync_with_stage_telemetry(
         &mut self,
         telemetry: &AppPerformanceTelemetry,
     ) -> Result<SyncSummary, ClassifiedSyncFailure> {

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -689,7 +689,7 @@ async fn run_app_runtime_account_worker(
     let startup_sync_result = {
         let mut initial_sync = std::pin::pin!(async {
             let summary = client
-                .sync_with_startup_stage_telemetry(&startup_stage_telemetry)
+                .sync_with_stage_telemetry(&startup_stage_telemetry)
                 .await?;
             app.finish_client_open_network_maintenance(&mut client)
                 .await;
@@ -1327,6 +1327,7 @@ async fn run_app_runtime_account_worker(
                         // prolonged transport outage.
                         drop(client);
                         client = loop {
+                            let retry_started_at = Instant::now();
                             let mut retry_delay =
                                 std::pin::pin!(sleep(reconnect_backoff.next_delay()));
                             loop {
@@ -1336,6 +1337,27 @@ async fn run_app_runtime_account_worker(
                                     _ = &mut retry_delay => break,
                                     command = commands.recv() => {
                                         match command {
+                                            Some(command @ AccountWorkerCommand::CatchUp { .. }) => {
+                                                // A host connectivity-restored edge is the one
+                                                // command that is meaningful without an engine
+                                                // session: retain its response and use it to end
+                                                // only this stale sleep. If the network is still
+                                                // unavailable, the failed reopen below advances
+                                                // the same bounded backoff instead of spinning.
+                                                pending.push_back(command);
+                                                tracing::debug!(
+                                                    target: "marmot_app::runtime",
+                                                    method = "account_worker_reconnect",
+                                                    phase = "backoff_wait",
+                                                    outcome = "interrupted",
+                                                    elapsed_ms = u64::try_from(
+                                                        retry_started_at.elapsed().as_millis()
+                                                    )
+                                                    .unwrap_or(u64::MAX),
+                                                    "host recovery interrupted account worker reconnect backoff",
+                                                );
+                                                break;
+                                            }
                                             // There is deliberately no engine
                                             // session during this backoff.
                                             // Poll the bounded channel and
@@ -1381,10 +1403,11 @@ async fn run_app_runtime_account_worker(
                                     // loop on a full catch-up; the maintenance
                                     // path performs bounded repair syncs when
                                     // required.
+                                    let telemetry = shared.app_performance_telemetry();
                                     let prepare_transport = tokio::select! {
                                         _ = wait_for_runtime_shutdown(&mut lifecycle_shutdown) => return,
                                         _ = &mut shutdown => return,
-                                        result = reopened.prepare_transport() => result,
+                                        result = reopened.prepare_transport_with_telemetry(Some(&telemetry)) => result,
                                     };
                                     if let Err(transport_err) = prepare_transport {
                                         publish_app_runtime_account_error(
@@ -1643,8 +1666,9 @@ async fn handle_account_worker_catch_up(
     let mut deferred = VecDeque::new();
     let mut commands_open = true;
     let sync_started_at = Instant::now();
+    let stage_telemetry = context.shared.app_performance_telemetry();
     let sync_result = {
-        let mut sync = std::pin::pin!(client.sync_with_classified_partial_progress());
+        let mut sync = std::pin::pin!(client.sync_with_stage_telemetry(&stage_telemetry));
         loop {
             let command = if let Some(command) = pending.pop_front() {
                 Some(command)

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -1341,10 +1341,20 @@ async fn run_app_runtime_account_worker(
                                                 // A host connectivity-restored edge is the one
                                                 // command that is meaningful without an engine
                                                 // session: retain its response and use it to end
-                                                // only this stale sleep. If the network is still
-                                                // unavailable, the failed reopen below advances
-                                                // the same bounded backoff instead of spinning.
+                                                // only this stale sleep. Coalesce an already
+                                                // queued burst into the same reopen attempt; new
+                                                // signals can still interrupt later sleeps, so
+                                                // extra attempts remain bounded by host signal
+                                                // rate while the network stays unavailable.
                                                 pending.push_back(command);
+                                                while let Ok(command) = commands.try_recv() {
+                                                    match command {
+                                                        command @ AccountWorkerCommand::CatchUp { .. } => {
+                                                            pending.push_back(command);
+                                                        }
+                                                        command => drop(command),
+                                                    }
+                                                }
                                                 tracing::debug!(
                                                     target: "marmot_app::runtime",
                                                     method = "account_worker_reconnect",

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -9686,13 +9686,18 @@ fn connectivity_recovery_interrupts_max_account_worker_reconnect_backoff() {
             account_id: &MemberId,
             minimum: usize,
         ) {
-            for _ in 0..10_000 {
-                if relay.inbox_subscription_count(account_id) >= minimum {
+            let deadline = std::time::Instant::now() + Duration::from_secs(15);
+            loop {
+                let observed = relay.inbox_subscription_count(account_id);
+                if observed >= minimum {
                     return;
                 }
+                assert!(
+                    std::time::Instant::now() < deadline,
+                    "account inbox subscription count did not reach {minimum}; observed {observed}"
+                );
                 tokio::task::yield_now().await;
             }
-            panic!("account inbox subscription count did not reach {minimum}");
         }
 
         const ACCOUNT: &str = "alice";
@@ -9718,14 +9723,15 @@ fn connectivity_recovery_interrupts_max_account_worker_reconnect_backoff() {
                 .shared_services()
                 .relay_plane()
                 .simulate_notification_recovery_for_test(1);
-            for probe in 0..10_000 {
+            let backoff_deadline = std::time::Instant::now() + Duration::from_secs(15);
+            loop {
                 match runtime.unhydrated_group_count_for_test(ACCOUNT).await {
                     Err(AppError::TransportClosed) => break,
                     Ok(_) => tokio::task::yield_now().await,
                     Err(error) => panic!("unexpected reconnect probe error: {error:?}"),
                 }
                 assert!(
-                    probe < 9_999,
+                    std::time::Instant::now() < backoff_deadline,
                     "account worker did not enter reconnect backoff"
                 );
             }
@@ -9743,14 +9749,15 @@ fn connectivity_recovery_interrupts_max_account_worker_reconnect_backoff() {
             .shared_services()
             .relay_plane()
             .simulate_notification_recovery_for_test(1);
-        for probe in 0..10_000 {
+        let max_backoff_deadline = std::time::Instant::now() + Duration::from_secs(15);
+        loop {
             match runtime.unhydrated_group_count_for_test(ACCOUNT).await {
                 Err(AppError::TransportClosed) => break,
                 Ok(_) => tokio::task::yield_now().await,
                 Err(error) => panic!("unexpected max-backoff probe error: {error:?}"),
             }
             assert!(
-                probe < 9_999,
+                std::time::Instant::now() < max_backoff_deadline,
                 "account worker did not enter maximum reconnect backoff"
             );
         }
@@ -9768,7 +9775,8 @@ fn connectivity_recovery_interrupts_max_account_worker_reconnect_backoff() {
         };
 
         tokio::time::advance(Duration::from_secs(3)).await;
-        for _ in 0..10_000 {
+        let reconnect_deadline = std::time::Instant::now() + Duration::from_secs(15);
+        loop {
             if relay
                 .blocked_subscribe_count
                 .load(std::sync::atomic::Ordering::SeqCst)
@@ -9776,6 +9784,10 @@ fn connectivity_recovery_interrupts_max_account_worker_reconnect_backoff() {
             {
                 break;
             }
+            assert!(
+                std::time::Instant::now() < reconnect_deadline,
+                "connectivity recovery did not start a reconnect subscription"
+            );
             tokio::task::yield_now().await;
         }
         assert_eq!(

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -9677,6 +9677,139 @@ fn account_worker_reconnect_backoff_doubles_caps_and_resets() {
 }
 
 #[test]
+fn connectivity_recovery_interrupts_max_account_worker_reconnect_backoff() {
+    run_composed_app_runtime_test("connectivity-recovery-wake", || async {
+        tokio::time::pause();
+
+        async fn wait_for_inbox_subscriptions(
+            relay: &ScriptedPushRelayClient,
+            account_id: &MemberId,
+            minimum: usize,
+        ) {
+            for _ in 0..10_000 {
+                if relay.inbox_subscription_count(account_id) >= minimum {
+                    return;
+                }
+                tokio::task::yield_now().await;
+            }
+            panic!("account inbox subscription count did not reach {minimum}");
+        }
+
+        const ACCOUNT: &str = "alice";
+        let relay = Arc::new(ScriptedPushRelayClient::default());
+        let dir = tempfile::tempdir().unwrap();
+        let home = AccountHome::open(dir.path());
+        home.create_account(ACCOUNT).unwrap();
+        let account_id =
+            MemberId::new(hex::decode(home.account(ACCOUNT).unwrap().account_id_hex).unwrap());
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+            .with_test_relay_client(relay.clone());
+        let runtime = MarmotAppRuntime::new(app);
+        runtime.start().await.unwrap();
+
+        wait_for_inbox_subscriptions(&relay, &account_id, 1).await;
+
+        // Preserve the bounded exponential policy and deterministically drive
+        // the worker through 2, 4, 8, 16, and 32 second reconnect sleeps. The
+        // next receive failure therefore arms the production 60 second cap.
+        for delay in [2_u64, 4, 8, 16, 32] {
+            let subscriptions_before = relay.inbox_subscription_count(&account_id);
+            runtime
+                .shared_services()
+                .relay_plane()
+                .simulate_notification_recovery_for_test(1);
+            for probe in 0..10_000 {
+                match runtime.unhydrated_group_count_for_test(ACCOUNT).await {
+                    Err(AppError::TransportClosed) => break,
+                    Ok(_) => tokio::task::yield_now().await,
+                    Err(error) => panic!("unexpected reconnect probe error: {error:?}"),
+                }
+                assert!(
+                    probe < 9_999,
+                    "account worker did not enter reconnect backoff"
+                );
+            }
+            tokio::time::advance(Duration::from_millis(delay * 1_000 + 500)).await;
+            wait_for_inbox_subscriptions(&relay, &account_id, subscriptions_before + 1).await;
+        }
+
+        let subscriptions_before_wake = relay.inbox_subscription_count(&account_id);
+        let telemetry_before = runtime.app_performance_snapshot();
+        runtime
+            .shared_services()
+            .relay_plane()
+            .simulate_notification_recovery_for_test(1);
+        for probe in 0..10_000 {
+            match runtime.unhydrated_group_count_for_test(ACCOUNT).await {
+                Err(AppError::TransportClosed) => break,
+                Ok(_) => tokio::task::yield_now().await,
+                Err(error) => panic!("unexpected max-backoff probe error: {error:?}"),
+            }
+            assert!(
+                probe < 9_999,
+                "account worker did not enter maximum reconnect backoff"
+            );
+        }
+
+        // Repeated host recovery edges are idempotent: both callers join the
+        // same reopened worker and coalesce onto its one catch-up pass.
+        relay.block_next_subscribe();
+        let recovery_a = {
+            let runtime = runtime.clone();
+            tokio::spawn(async move { runtime.catch_up_accounts().await })
+        };
+        let recovery_b = {
+            let runtime = runtime.clone();
+            tokio::spawn(async move { runtime.catch_up_accounts().await })
+        };
+
+        tokio::time::advance(Duration::from_secs(3)).await;
+        for _ in 0..10_000 {
+            if relay
+                .blocked_subscribe_count
+                .load(std::sync::atomic::Ordering::SeqCst)
+                >= 1
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(
+            relay
+                .blocked_subscribe_count
+                .load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "connectivity recovery must start the reconnect subscription within three seconds"
+        );
+        assert!(!recovery_a.is_finished());
+        assert!(!recovery_b.is_finished());
+        relay.release_subscribe();
+
+        recovery_a.await.unwrap().unwrap();
+        recovery_b.await.unwrap().unwrap();
+        assert_eq!(
+            relay.inbox_subscription_count(&account_id),
+            subscriptions_before_wake + 2,
+            "two recovery signals must coalesce into one catch-up transport refresh after reconnect"
+        );
+
+        let telemetry_after = runtime.app_performance_snapshot();
+        assert_eq!(
+            telemetry_after.account_transport_activation.attempts,
+            telemetry_before.account_transport_activation.attempts + 2,
+            "reconnect and the one coalesced catch-up must each record a privacy-safe activation phase"
+        );
+        assert_eq!(
+            telemetry_after.account_subscription_registration.attempts,
+            telemetry_before.account_subscription_registration.attempts + 2,
+            "reconnect and the one coalesced catch-up must each record subscription readiness"
+        );
+
+        runtime.shutdown().await;
+    });
+}
+
+#[test]
 fn reconnect_drains_deferred_hydration_before_steady_state_serves_groups() {
     run_composed_app_runtime_test(
         "reconnect-deferred-hydration",

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -9729,7 +9729,11 @@ fn connectivity_recovery_interrupts_max_account_worker_reconnect_backoff() {
                     "account worker did not enter reconnect backoff"
                 );
             }
-            tokio::time::advance(Duration::from_millis(delay * 1_000 + 500)).await;
+            tokio::time::advance(
+                Duration::from_secs(delay)
+                    + Duration::from_millis(ACCOUNT_WORKER_RECONNECT_JITTER_MAX_MS + 500),
+            )
+            .await;
             wait_for_inbox_subscriptions(&relay, &account_id, subscriptions_before + 1).await;
         }
 
@@ -9794,14 +9798,14 @@ fn connectivity_recovery_interrupts_max_account_worker_reconnect_backoff() {
         );
 
         let telemetry_after = runtime.app_performance_snapshot();
-        assert_eq!(
-            telemetry_after.account_transport_activation.attempts,
-            telemetry_before.account_transport_activation.attempts + 2,
+        assert!(
+            telemetry_after.account_transport_activation.attempts
+                >= telemetry_before.account_transport_activation.attempts + 2,
             "reconnect and the one coalesced catch-up must each record a privacy-safe activation phase"
         );
-        assert_eq!(
-            telemetry_after.account_subscription_registration.attempts,
-            telemetry_before.account_subscription_registration.attempts + 2,
+        assert!(
+            telemetry_after.account_subscription_registration.attempts
+                >= telemetry_before.account_subscription_registration.attempts + 2,
             "reconnect and the one coalesced catch-up must each record subscription readiness"
         );
 


### PR DESCRIPTION
## Summary
- Preserve a host catch-up command during account-worker reconnect backoff and use it to interrupt only the stale sleep.
- Keep failed reopen attempts on the existing bounded exponential backoff, coalesce repeated recovery signals, and record reconnect/catch-up activation and subscription phases with privacy-safe telemetry.
- Add a deterministic paused-clock runtime regression that reaches the 60-second cap and proves recovery starts within 3 seconds without rebuilding the runtime.

## Test plan
- [x] New test failed before the fix and passes after
- [x] cargo test -p marmot-app reconnect
- [x] cargo test -p marmot-app notification_recovery
- [x] cargo test -p marmot-app app_telemetry::tests
- [x] Workspace check/clippy gates with and without OTLP features
- [x] Install docs, SHA-256, cargo-audit policy, and convergence policy gates
- [ ] cargo test -p marmot-app: 808 unit tests passed; five unrelated relay_runtime tests fail individually on this branch, and a representative failure reproduces unchanged on origin/master
- [ ] just fast-ci: blocked by the unchanged campaign-toolchain test using GNU-style sed -i on macOS BSD sed

Fixes #1546

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account recovery during connectivity interruptions by responding promptly to recovery signals, even during extended reconnect delays.
  * Preserved bounded retry behavior while preventing unnecessary waiting before reconnection.

* **Telemetry**
  * Added stage-aware tracking for startup, catch-up synchronization, and reconnect transport preparation.

* **Tests**
  * Expanded coverage for recovery timing, reconnect activity, coalesced refresh signals, and synchronization telemetry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->