### PR TITLE
Fix/epoch backfill error pacing

### DIFF
--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -1576,9 +1576,9 @@ impl AppClient {
     /// Whether this seam must leave a pending intent alone for now.
     ///
     /// The receive seam runs pending recovery after every inbound ingest, so an
-    /// intent that keeps failing to confirm its replay would spend the drain's
-    /// whole silence budget per delivery on the serial account worker, with
-    /// user commands queued behind it. Pacing skips those attempts outright
+    /// intent that keeps failing -- outright, or by not confirming its replay
+    /// -- would spend the drain's whole silence budget per delivery on the
+    /// serial account worker, with user commands queued behind it. Pacing skips those attempts outright
     /// rather than queueing them: the intent is already durable and the next
     /// seam past the cooldown runs it. Caller-directed catch-up is exempt — a
     /// person asking for a repair is not a loop.
@@ -2733,6 +2733,34 @@ impl AppClient {
             },
         );
         if !succeeded {
+            // Every error exit of `run_pending_epoch_backfill` lands here
+            // without ever producing a drain verdict, so none of the
+            // verdict-derived pacing rules in that function runs for it. Pace
+            // here instead, beside the requeue, which makes the rule structural
+            // rather than per-exit: an intent that goes back on the queue is
+            // always paced. Unpaced, the receive seam re-enters a whole-account
+            // replay on the very next inbound batch, and every attempt that
+            // gets as far as the drain spends the full silence budget before
+            // failing again. The verdict paths reach this branch too and
+            // overwrite the value immediately afterwards with their own richer
+            // rule, including clearing it outright for a quantum yield that
+            // made novel progress.
+            //
+            // `retry_ordinal` is the right ordinal for a failure.
+            // `begin_epoch_backfill_execution` already burned it, and what it
+            // counts is how many times this intent has spent the one
+            // account-wide replay budget -- exactly what the cooldown rations.
+            // The verdict counters stay untouched: an execution that never
+            // reached a verdict is no evidence about whether the relays serve
+            // this account's stored history, so inflating
+            // `eose_unconfirmed_attempts` would mis-shape the unconfirmed
+            // schedule, and inflating `no_progress_attempts` would defeat its
+            // reset-on-progress rule. Burning `retry_ordinal` costs nothing
+            // beyond a longer wait: no attempt limit degrades or abandons an
+            // intent, and a caller-directed repair stays exempt from the
+            // cooldown entirely.
+            let backoff = self.epoch_backfill_retry_backoff(execution.retry_ordinal);
+            self.epoch_backfill_retry_not_before = Some(Instant::now() + backoff);
             self.requeue_failed_epoch_backfill_intent(execution.pending);
             return false;
         }

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -1576,12 +1576,14 @@ impl AppClient {
     /// Whether this seam must leave a pending intent alone for now.
     ///
     /// The receive seam runs pending recovery after every inbound ingest, so an
-    /// intent that keeps failing -- outright, or by not confirming its replay
-    /// -- would spend the drain's whole silence budget per delivery on the
-    /// serial account worker, with user commands queued behind it. Pacing skips those attempts outright
-    /// rather than queueing them: the intent is already durable and the next
-    /// seam past the cooldown runs it. Caller-directed catch-up is exempt — a
-    /// person asking for a repair is not a loop.
+    /// intent that keeps failing would re-run the workflow per delivery on the
+    /// serial account worker, with user commands queued behind it — and a
+    /// failure that reaches the relay drain (outright, or by not confirming
+    /// its replay) spends the drain's whole silence budget each time. Pacing
+    /// skips those attempts outright rather than queueing them: the intent is
+    /// already durable and the next seam past the cooldown runs it.
+    /// Caller-directed catch-up is exempt — a person asking for a repair is
+    /// not a loop.
     pub(crate) fn epoch_backfill_retry_is_paced(&self, seam: EpochBackfillExecutionSeam) -> bool {
         if matches!(seam, EpochBackfillExecutionSeam::ExplicitCatchUp) {
             return false;

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -2619,6 +2619,86 @@ fn consecutive_fruitless_replays_are_paced_by_the_retry_cooldown() {
     });
 }
 
+/// An execution that ends in `Err` must earn the same cooldown a fruitless or
+/// unconfirmed one does.
+///
+/// Every error exit of `run_pending_epoch_backfill` requeues its intent and
+/// returns without a verdict, so none of the verdict-derived pacing rules ever
+/// runs for it. Unpaced, the receive seam re-enters a whole-account replay on
+/// the very next inbound batch, and each attempt that gets as far as the drain
+/// spends the full silence budget before failing again. The intent is durable;
+/// the next seam past the cooldown runs it.
+#[test]
+fn a_failed_epoch_backfill_execution_paces_the_next_automatic_seam() {
+    run_composed_app_runtime_test("backfill-error-pacing", || async {
+        let dir = tempfile::tempdir().unwrap();
+        let relay = Arc::new(ScriptedPushRelayClient::default());
+        let filled_through = crate::unix_now_seconds() - 1_000;
+        // A backoff long enough that the second batch cannot slip past it
+        // inside this test, and a silence budget short enough to afford.
+        let config = MarmotAppConfig::default()
+            .with_dev_epoch_backfill_eose_wait_ms(300)
+            .with_dev_epoch_backfill_retry_backoff_ms(60_000);
+        let (_app, mut client, route) = group_at_the_undecryptable_retention_cap_with_config(
+            &dir,
+            &relay,
+            config,
+            filled_through,
+        )
+        .await;
+
+        // First inbound batch: a refused delivery arms the intent.
+        client
+            .ingest_received_delivery(route.probe(filled_through + 400, "refusal-that-arms"))
+            .await
+            .expect("a refused ingest still completes its pass");
+        assert!(
+            client.has_pending_epoch_backfill(),
+            "the refused ingest must arm an epoch-gap replay",
+        );
+
+        relay.fail_next_subscribe();
+        client
+            .run_pending_epoch_backfill(marmot_forensics::EpochBackfillExecutionSeam::Maintenance)
+            .await
+            .expect_err("the injected activation failure must surface");
+        assert!(
+            client.has_pending_epoch_backfill(),
+            "a failed execution must retain its intent",
+        );
+        assert!(
+            client.epoch_backfill_retry_not_before.is_some(),
+            "an execution that ended in an error must earn a retry cooldown",
+        );
+
+        // Second inbound batch, immediately behind the first.
+        client
+            .ingest_received_delivery(route.probe(filled_through + 900, "refusal-after-failure"))
+            .await
+            .expect("a refused ingest still completes its pass");
+        assert!(
+            matches!(
+                client
+                    .run_pending_epoch_backfill(
+                        marmot_forensics::EpochBackfillExecutionSeam::Maintenance
+                    )
+                    .await
+                    .expect("the paced seam still returns Ok"),
+                crate::EpochBackfillRunOutcome::Deferred
+            ),
+            "the batch behind a failed execution must wait out the cooldown instead of \
+             re-entering the whole-account replay immediately",
+        );
+        // A person asking for a repair is not a loop.
+        assert!(
+            !client.epoch_backfill_retry_is_paced(
+                marmot_forensics::EpochBackfillExecutionSeam::ExplicitCatchUp
+            ),
+            "caller-directed catch-up stays exempt from the failure cooldown",
+        );
+    });
+}
+
 /// A fruitless replay re-arms only the groups whose refusals it counted.
 ///
 /// The clear is scoped to this drain's attribution rather than swept


### PR DESCRIPTION
Pace the retry after a failed epoch backfill execution

The epoch-gap backfill has six error exits (intent persist, transport sync, relay drain, session-event drain, intent clear, transport activation). None of them assigned epoch_backfill_retry_not_before, so a backfill that kept erroring was retried by the very next inbound batch: the recovery workflow re-ran per batch on the serial account worker, and failures that reached the relay drain also spent the full EOSE silence budget every time.

The fix is one assignment at the single requeue funnel (finish_epoch_backfill_execution's failure branch): a requeued intent now always earns a cooldown from retry_ordinal, on the existing 15s-to-5min doubling schedule. Verdict-bearing completions overwrite it right after with their richer rule, so their behavior is unchanged; the new assignment governs exactly the pure error exits, and any future error exit is paced by construction.

Error exits burn nothing beyond retry_ordinal (already incremented per execution). The verdict counters stay untouched: an execution that never reached a drain verdict says nothing about relay coverage. Since #1590 removed the attempt-limit fallback, a high ordinal only lengthens the wait, and ExplicitCatchUp stays exempt, so a user-requested repair never waits.

Historical note: this was tracked as "unpaced retries burn ordinals until QuiescenceFallback self-reports success." That second half no longer exists (#1548 made failure rows honest, #1590 removed the fallback). The unpaced requeue was the only surviving defect.

Tests: the regression is pinned production-shaped (cap-saturated group arms the intent, a failed subscribe errors the execution, the next inbound batch must defer), committed red first. marmot-app nextest 1011/1011, simulator-smoke, fmt/clippy all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Improved retry handling for failed synchronization recovery attempts.
- Failed recovery attempts now preserve their retry intent and establish an account-wide cooldown.
- Automatic maintenance retries wait for the configured cooldown period, while explicit catch-up actions remain available.
- Retry pacing now consistently includes outright failures and replay-confirmation failures.

## Documentation
- Clarified which failed recovery attempts count toward retry pacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->