### PR TITLE
docs(app): correct the disband passage-routing note and pin its vacuity

### DIFF
--- a/crates/cgka-session/tests/session_lifecycle.rs
+++ b/crates/cgka-session/tests/session_lifecycle.rs
@@ -886,3 +886,88 @@ fn open_rejects_invalid_convergence_policy_before_storage_open() {
         "rejected open must not create the database file"
     );
 }
+
+/// A disband request is intent persistence, not Commit preparation, so its
+/// batch carries no publish work and no events.
+///
+/// `Engine::do_send` short-circuits `SendIntent::Disband` straight to
+/// `do_request_disband` before any commit or queue machinery runs, and
+/// `collect_effects` maps the resulting `SendResult::DisbandRequested` to
+/// nothing. That is what makes the app layer's publish gate provably vacuous on
+/// `AppClient::disband_group`: with an always-empty `publish`, that seam can
+/// never produce a `PublishFailure` to gate on. The disband Commit is prepared
+/// later by `prepare_pending_disband` on the convergence seam, which does
+/// publish and does gate. Pin the emptiness here so that if the engine ever
+/// gives a disband request publish work of its own, this fails loudly and the
+/// gate decision at that seam gets made deliberately rather than by omission.
+#[tokio::test]
+async fn a_disband_request_carries_no_publish_work() {
+    let dir = tempfile::tempdir().unwrap();
+    let alice_path = dir.path().join("alice-disband.sqlite");
+    let key = SqlCipherKey::new("session disband request key").unwrap();
+    let mut alice = AccountDeviceSession::open(
+        config(&alice_path, &key, b"alice-disband").protocol_profile(ProtocolProfile::Current),
+    )
+    .unwrap();
+
+    let created = alice
+        .create_group(CreateGroupRequest {
+            name: "disband-publish-vacuity".into(),
+            description: String::new(),
+            members: vec![],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let group_id = created.group_id.clone();
+
+    // Disbanding is only requestable once lifecycle-v1 is installed and Active,
+    // so land that Commit first.
+    let enabled = alice
+        .send(SendIntent::EnableDisbanding {
+            group_id: group_id.clone(),
+        })
+        .await
+        .unwrap();
+    // A solo group merges that install without staging publish work; a Commit
+    // only appears once there is another member to publish it to.
+    assert!(enabled.publish.is_empty());
+    let _ = alice.drain();
+
+    let requested = alice
+        .send(SendIntent::Disband {
+            group_id: group_id.clone(),
+        })
+        .await
+        .unwrap();
+
+    assert!(
+        requested.publish.is_empty(),
+        "a disband request must stage no Commit and publish nothing, got {:?}",
+        requested.publish
+    );
+    assert!(
+        requested.events.is_empty(),
+        "a disband request must emit no events of its own, got {:?}",
+        requested.events
+    );
+    assert_eq!(
+        requested.pending_convergence,
+        vec![group_id.clone()],
+        "the request must schedule the convergence pass that prepares its Commit"
+    );
+    // The control: the request really did take `do_request_disband`'s full
+    // path, so the emptiness above is vacuity by design and not a no-op send.
+    assert!(
+        matches!(
+            alice.disband_request(&group_id).unwrap(),
+            Some(cgka_traits::storage::DisbandRequest {
+                status: cgka_traits::storage::DisbandRequestStatus::Pending,
+                ..
+            })
+        ),
+        "the disband request must be durably persisted as Pending"
+    );
+}

--- a/crates/marmot-app/src/client/epoch_stall.rs
+++ b/crates/marmot-app/src/client/epoch_stall.rs
@@ -344,17 +344,24 @@ impl GroupStall {
     /// The app routes that passage from every effects batch whose events it
     /// gates or projects (`AppClient::observe_recovery_evidence`) — the
     /// convergence folds a trailing device usually catches up by, and the
-    /// maintenance tick's own confirmed evolution, included. Two publishing
-    /// seams stay outside that routing. `AppClient::redeliver_welcome` is an
-    /// empty exception: it re-publishes a stored envelope without re-committing
-    /// and never drains the engine, so its batch carries no events to observe.
-    /// `AppClient::disband_group` is a real one — the engine does emit an
-    /// `EpochChanged` when it confirms a disband — and it is accepted rather
-    /// than pre-existing: passage reporting is a new contract, and this is a new
-    /// hole in it, taken because a run whose group is being destroyed has
-    /// nothing left to recover. Arming from an observed batch is conditional on
-    /// it carrying a `TransportObjectResourceRefused`; observing a passage is
-    /// not.
+    /// maintenance tick's own confirmed evolution, included. Two send-path
+    /// seams sit outside that routing, and both are empty exceptions rather
+    /// than holes. `AppClient::redeliver_welcome` re-publishes a stored
+    /// envelope without re-committing and never drains the engine, so its batch
+    /// carries no events to observe. `AppClient::disband_group` is the same
+    /// shape for a different reason: `Engine::do_send` short-circuits
+    /// `SendIntent::Disband` straight to `do_request_disband`, which persists
+    /// the durable request without staging a Commit, so that batch carries no
+    /// publish work and no events of its own
+    /// (`a_disband_request_carries_no_publish_work` pins that at the session
+    /// layer). The `EpochChanged` the engine emits when a disband Commit
+    /// confirms belongs to the later convergence pass `prepare_pending_disband`
+    /// prepares that Commit on, and that batch does reach
+    /// `observe_recovery_evidence`, through
+    /// `AppClient::observe_scheduled_convergence_effects`. So the disband
+    /// passage is reported like any other, and the same seam gates its publish.
+    /// Arming from an observed batch is conditional on it carrying a
+    /// `TransportObjectResourceRefused`; observing a passage is not.
     ///
     /// A batch that reports neither leaves the run exactly as it was: an advance
     /// nobody reports is invisible here, as


### PR DESCRIPTION
The epoch-stall passage-reporting contract recorded `disband_group` as an accepted hole, on the premise that the engine emits an `EpochChanged` into that seam's batch. It does not. `Engine::do_send` short-circuits `SendIntent::Disband` to `do_request_disband`, which persists the durable request without staging a Commit, and `collect_effects` maps `SendResult::DisbandRequested` to nothing — so the batch carries no publish work and no events at all. The confirm-time `EpochChanged` belongs to the later convergence pass that `prepare_pending_disband` prepares the Commit on, and that batch does reach `observe_recovery_evidence` via `observe_scheduled_convergence_effects`, which gates its publish too.

Rewrite the note to document why there is no hole, and add a session-layer test pinning the emptiness so a future change that gives a disband request publish work of its own fails loudly instead of silently reopening the question of whether that seam needs the publish gate.

No behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how disband commits are reported during convergence and epoch progression.
  * Documented the distinction between empty send paths and actual epoch-passage reporting.
  * Clarified that arming requires a resource-refusal event.

* **Tests**
  * Added coverage for disband requests, including pending intent persistence, convergence scheduling, event behavior, and publish-work handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->