### PR TITLE
Fix/drained seam system rows and rearm

### DIFF
--- a/crates/marmot-app/src/client/projection.rs
+++ b/crates/marmot-app/src/client/projection.rs
@@ -726,11 +726,45 @@ impl AppClient {
     /// the inbound delivery path (peer commits) and our own send path (local
     /// commits). Failures are logged, not propagated: a missing system row must
     /// never fail message delivery.
+    ///
+    /// A change whose `origin_commit_id` the same batch withdraws is skipped.
+    /// Every seam runs this once at its tail, *after* its projection loop has
+    /// already dispatched each `GroupStateInvalidated` through
+    /// [`MarmotApp::projection_update_for_invalidation_event`] — so by the time
+    /// the upsert below runs, the batch's withdrawals are all applied and it
+    /// would be the last writer. The storage upsert clears `invalidated` on
+    /// conflict, so without this filter the tail either revives a row the batch
+    /// just tombstoned or synthesizes one for a change that canonically never
+    /// happened (the withdrawal swept a row that did not exist yet).
+    ///
+    /// One batch carries both because the engine buffers convergence passes:
+    /// `events_buf` has a single take site and
+    /// `advance_convergence_inputs_with_execution` runs up to
+    /// `MAX_CONVERGENCE_REPROCESSING_PASSES` passes without one, so an earlier
+    /// pass's accepted commit can be superseded by a later pass's reorg before
+    /// anything drains. Within a *single* pass the two are disjoint by
+    /// construction — the change's origin is the accepted commit and the
+    /// superseded emitter skips accepted commits — so the single-pass shape is
+    /// not what this guards.
+    ///
+    /// Membership is the test rather than event order: a batch may carry the
+    /// withdrawal before or after the change it names, and neither ordering
+    /// makes the change canonical.
     pub(crate) fn project_group_system_rows(
         &self,
         events: &[cgka_traits::engine::GroupEvent],
         recorded_at: u64,
     ) -> Vec<crate::AppProjectionUpdate> {
+        let superseded_commits: std::collections::HashSet<&[u8]> = events
+            .iter()
+            .filter_map(|event| match event {
+                cgka_traits::engine::GroupEvent::GroupStateInvalidated {
+                    invalidated_commit_id,
+                    ..
+                } => Some(invalidated_commit_id.as_slice()),
+                _ => None,
+            })
+            .collect();
         let mut updates = Vec::new();
         for event in events {
             if let cgka_traits::engine::GroupEvent::GroupStateChanged {
@@ -741,6 +775,14 @@ impl AppClient {
                 origin_commit_id,
             } = event
             {
+                // An unattributed change carries no commit link, so nothing in
+                // this batch can name it and it is never withheld here.
+                if origin_commit_id
+                    .as_ref()
+                    .is_some_and(|id| superseded_commits.contains(id.as_slice()))
+                {
+                    continue;
+                }
                 let projection = match build_group_system_projection(
                     group_id,
                     epoch.0,

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -1122,6 +1122,17 @@ impl AppClient {
                 .retain(|message| !gossip_message_ids.contains(&message.message_id_hex));
         }
         self.clear_terminal_local_group_deletion_frontiers(effects)?;
+        // Synthesize durable kind-1210 system rows from the replayed
+        // authenticated state changes, the same tail the live seam runs. A
+        // replayed event carries no envelope of its own — that is why this seam
+        // derives a synthetic source id from the durable outbox key above — so
+        // the rows are stamped with `source_received_at`, this drain's
+        // observation time, exactly like every other projection in the loop.
+        // The row id is derived from the change and its epoch, never from the
+        // stamp, so a crash that replays the batch re-upserts the same row.
+        summary
+            .projection_updates
+            .extend(self.project_group_system_rows(&effects.events, source_received_at));
         // Reconcile transport routes once after the batch drains instead of per
         // membership-changing event. This installs a join's current route and
         // retains any still-live address displaced by a routing rotation.

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -4151,6 +4151,90 @@ mod runtime_group_subscription_refresh_tests {
         );
         assert!(!client.has_pending_runtime_group_subscription_refresh());
     }
+
+    /// The drained seam's subscription rebuild owes the same retry edge.
+    ///
+    /// Both edges that could re-fire the rebuild are spent by the pass that
+    /// failed: `drain()` empties the engine's in-memory event buffer one-shot,
+    /// so the `routes_dirty` event is gone, and `refresh_group_routes` reports
+    /// `routing_changed` only while the in-memory routing table is actually
+    /// mutating. Without an explicit arm the account's ordinary group
+    /// subscriptions stay stale until some unrelated delivery happens to dirty
+    /// the routes again — and a stale group subscription is exactly what stops
+    /// those deliveries from arriving.
+    #[tokio::test]
+    async fn drained_epilogue_arms_refresh_after_failed_subscription_rebuild() {
+        let dir = tempfile::tempdir().unwrap();
+        let account = AccountHome::open(dir.path())
+            .create_account("alice")
+            .unwrap();
+        let relay = Arc::new(ScriptedPushRelayClient::default());
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+            .with_test_relay_client(relay.clone());
+        let mut client = app.client("alice").await.unwrap();
+        client.prepare_transport().await.unwrap();
+        let telemetry = AppPerformanceTelemetry::default();
+        // The managed-runtime create, which defers the relay-side subscription
+        // install to a later refresh (the worker performs it after replying).
+        // The second group is that outstanding install: the drained disband
+        // below dirties the routes, and the rebuild it triggers is the one the
+        // relay refuses.
+        let created = client
+            .create_group_with_options_and_telemetry(
+                "drained retry intent",
+                &[],
+                crate::AppCreateGroupOptions::default(),
+                &telemetry,
+            )
+            .await
+            .unwrap();
+        client
+            .create_group_with_options_and_telemetry(
+                "drained retry bystander",
+                &[],
+                crate::AppCreateGroupOptions::default(),
+                &telemetry,
+            )
+            .await
+            .unwrap();
+
+        let effects = marmot_account::AccountDeviceEffects {
+            events: vec![cgka_traits::engine::GroupEvent::GroupStateChanged {
+                group_id: created.group_id,
+                epoch: cgka_traits::EpochId(2),
+                actor: Some(cgka_traits::MemberId::new(
+                    hex::decode(&account.account_id_hex).unwrap(),
+                )),
+                change: cgka_traits::engine::GroupStateChange::GroupDisbanded,
+                origin_commit_id: None,
+            }],
+            ..Default::default()
+        };
+        relay.fail_next_subscribe();
+        client
+            .observe_drained_session_events(&effects)
+            .await
+            .expect_err("the injected group subscription rebuild must fail the drain");
+        assert!(client.has_pending_runtime_group_subscription_refresh());
+
+        // Nothing is left to re-derive the intent from: the drained batch that
+        // dirtied the routes is consumed, and the routing table reports no
+        // further change, so the armed flag is the only surviving re-fire edge.
+        assert!(!client.refresh_group_routes().unwrap().routing_changed);
+
+        let subscriptions_before = relay.subscription_count();
+        assert!(
+            !client
+                .retry_pending_runtime_group_subscription_refresh()
+                .await
+                .unwrap()
+        );
+        assert!(!client.has_pending_runtime_group_subscription_refresh());
+        assert!(
+            relay.subscription_count() > subscriptions_before,
+            "the armed retry must actually re-issue the rebuild the drain lost"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -1140,6 +1140,18 @@ impl AppClient {
         if (routes_dirty || routes_changed)
             && let Err(error) = self.sync_runtime_groups().await
         {
+            // Retain an explicit retry edge, as the catch-up checkpoint does
+            // after its own post-persistence rebuild failure. Neither edge that
+            // reached this rebuild survives the failure: `drain()` emptied the
+            // engine's event buffer one-shot, so the `routes_dirty` event is
+            // gone, and `refresh_group_routes` reports a change only while the
+            // in-memory routing table is actually mutating, which it already
+            // did. Without this the account keeps stale group subscriptions
+            // until unrelated traffic dirties the routes again — traffic those
+            // same stale subscriptions are what stop from arriving. The save
+            // below owes no arm: when either edge was set the rebuild above
+            // already succeeded, and when neither was set nothing is owed.
+            self.pending_runtime_group_subscription_refresh = true;
             self.pending_failed_sync_summary.merge(summary);
             return Err(error);
         }

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -12058,6 +12058,102 @@ async fn replaying_a_drained_batch_the_seam_already_applied_is_a_no_op() {
     );
 }
 
+/// Issue #1177 follow-up: the drained seam owes the live seam's kind-1210
+/// system-row synthesis too.
+///
+/// `observe_account_device_effects` ends by synthesizing a durable system row
+/// for every authenticated `GroupStateChanged`; the drained seam ran its own
+/// projection loop and never called the synthesizer. Nothing else writes those
+/// rows, and a drained batch is one-shot, so a crash-replayed rename or
+/// membership change lost its timeline row permanently and silently.
+#[tokio::test]
+async fn a_drained_state_change_synthesizes_the_system_row_the_live_seam_does() {
+    let dir = tempfile::tempdir().unwrap();
+    let account = AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relay(dir.path(), "wss://drained-system-rows.example")
+        .with_test_relay_client(relay);
+    let mut client = app.client("alice").await.unwrap();
+    let group_id = client
+        .create_group("drained system rows", &[])
+        .await
+        .unwrap();
+    let group_id_hex = hex::encode(group_id.as_slice());
+    let actor = MemberId::new(hex::decode(&account.account_id_hex).unwrap());
+
+    // One authenticated rename, twice: the row id is derived from the change
+    // and its epoch, so the two seams take one epoch each rather than
+    // converging on the same deterministic row.
+    let rename = |epoch: u64, name: &str| marmot_account::AccountDeviceEffects {
+        events: vec![cgka_traits::engine::GroupEvent::GroupStateChanged {
+            group_id: group_id.clone(),
+            epoch: cgka_traits::EpochId(epoch),
+            actor: Some(actor.clone()),
+            change: cgka_traits::engine::GroupStateChange::GroupRenamed {
+                name: name.to_owned(),
+                previous_name: Some("drained system rows".to_owned()),
+            },
+            origin_commit_id: None,
+        }],
+        ..Default::default()
+    };
+
+    // Control: the live seam, which has always synthesized the row.
+    client
+        .observe_send_applied_effects(&rename(2, "live rename"))
+        .await
+        .unwrap();
+
+    let drained = client
+        .observe_drained_session_events(&rename(3, "replayed rename"))
+        .await
+        .unwrap();
+    // Crash replay is not exclusive with the first pass: the synthesizer is a
+    // deterministic upsert, so a second drain of the same batch must converge.
+    client
+        .observe_drained_session_events(&rename(3, "replayed rename"))
+        .await
+        .expect("re-observing a replayed batch must not error");
+
+    let rows = app
+        .timeline_messages_with_query(
+            "alice",
+            storage_sqlite::TimelineMessageQuery {
+                group_id_hex: Some(group_id_hex),
+                ..storage_sqlite::TimelineMessageQuery::default()
+            },
+        )
+        .unwrap()
+        .messages;
+    let system_rows = |epoch: u64| {
+        rows.iter()
+            .filter(|row| {
+                row.kind == MARMOT_APP_EVENT_KIND_GROUP_SYSTEM && row.source_epoch == Some(epoch)
+            })
+            .count()
+    };
+    assert_eq!(
+        system_rows(2),
+        1,
+        "control: the live seam synthesizes one kind-1210 row for the rename; got {rows:?}"
+    );
+    assert_eq!(
+        system_rows(3),
+        1,
+        "a crash-replayed rename owes the same durable kind-1210 row, once; got {rows:?}"
+    );
+    assert!(
+        drained.projection_updates.iter().any(|update| {
+            update.timeline_messages.iter().any(|row| {
+                row.kind == MARMOT_APP_EVENT_KIND_GROUP_SYSTEM && row.source_epoch == Some(3)
+            })
+        }),
+        "and must surface it to runtime subscribers on the same summary the seam returns"
+    );
+}
+
 #[test]
 fn transport_group_route_replacement_installs_current_and_prior_routes() {
     let routing = AppTransportRouting::new(AppRoutingState {

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -12154,6 +12154,268 @@ async fn a_drained_state_change_synthesizes_the_system_row_the_live_seam_does() 
     );
 }
 
+/// A batch that supersedes a commit must not leave that commit's kind-1210 row
+/// standing, whichever seam projects the batch.
+///
+/// Both seams invalidate per event inside their projection loop and synthesize
+/// system rows once at the tail, so every `GroupStateInvalidated` in a batch has
+/// already been applied by the time the tail upserts. The storage upsert clears
+/// `invalidated` on conflict, so an unfiltered tail either revives a row the
+/// same batch just withdrew or creates one the batch never should have had.
+///
+/// The engine reaches this by buffering two convergence passes into one batch:
+/// `events_buf` has a single take site, and
+/// `advance_convergence_inputs_with_execution` runs up to
+/// `MAX_CONVERGENCE_REPROCESSING_PASSES` passes without one. An earlier pass
+/// accepts the commit and emits its `GroupStateChanged`; a later pass reorgs and
+/// emits `GroupStateInvalidated` for that same commit. Within a *single* pass
+/// the two are disjoint by construction, so the single-pass shape is not the one
+/// under test here.
+mod superseded_system_row_shapes {
+    use super::*;
+
+    pub(super) const SUPERSEDED: &str = "SupersededByBranchSelection";
+
+    pub(super) fn renamed(
+        group_id: &GroupId,
+        actor: &MemberId,
+        epoch: u64,
+        name: &str,
+        origin_commit_id: Option<&MessageId>,
+    ) -> cgka_traits::engine::GroupEvent {
+        cgka_traits::engine::GroupEvent::GroupStateChanged {
+            group_id: group_id.clone(),
+            epoch: cgka_traits::EpochId(epoch),
+            actor: Some(actor.clone()),
+            change: cgka_traits::engine::GroupStateChange::GroupRenamed {
+                name: name.to_owned(),
+                previous_name: None,
+            },
+            origin_commit_id: origin_commit_id.cloned(),
+        }
+    }
+
+    pub(super) fn superseded(
+        group_id: &GroupId,
+        epoch: u64,
+        invalidated_commit_id: &MessageId,
+    ) -> cgka_traits::engine::GroupEvent {
+        cgka_traits::engine::GroupEvent::GroupStateInvalidated {
+            group_id: group_id.clone(),
+            epoch: cgka_traits::EpochId(epoch),
+            invalidated_commit_id: invalidated_commit_id.clone(),
+            reason: cgka_traits::engine::GroupStateInvalidationReason::SupersededByBranchSelection,
+        }
+    }
+
+    pub(super) fn batch(
+        events: Vec<cgka_traits::engine::GroupEvent>,
+    ) -> marmot_account::AccountDeviceEffects {
+        marmot_account::AccountDeviceEffects {
+            events,
+            ..Default::default()
+        }
+    }
+
+    /// The kind-1210 row for `epoch`, as `(exists, invalidation_status)`.
+    pub(super) fn system_row(
+        app: &MarmotApp,
+        group_id_hex: &str,
+        epoch: u64,
+    ) -> Option<Option<String>> {
+        app.timeline_messages_with_query(
+            "alice",
+            storage_sqlite::TimelineMessageQuery {
+                group_id_hex: Some(group_id_hex.to_owned()),
+                ..storage_sqlite::TimelineMessageQuery::default()
+            },
+        )
+        .unwrap()
+        .messages
+        .iter()
+        .find(|row| {
+            row.kind == MARMOT_APP_EVENT_KIND_GROUP_SYSTEM && row.source_epoch == Some(epoch)
+        })
+        .map(|row| row.invalidation_status.clone())
+    }
+}
+
+/// The drained seam owes the filter: a batch carrying both a commit's
+/// `GroupStateChanged` and that commit's `GroupStateInvalidated` must leave no
+/// live kind-1210 row for it — whether or not an earlier batch already
+/// synthesized the row.
+///
+/// See [`superseded_system_row_shapes`] for why one batch can carry both.
+#[tokio::test]
+async fn a_drained_batch_leaves_no_live_system_row_for_a_commit_it_supersedes() {
+    use superseded_system_row_shapes::{SUPERSEDED, batch, renamed, superseded, system_row};
+
+    let dir = tempfile::tempdir().unwrap();
+    let account = AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relay(dir.path(), "wss://drained-superseded-rows.example")
+        .with_test_relay_client(relay);
+    let mut client = app.client("alice").await.unwrap();
+    let group_id = client
+        .create_group("drained superseded rows", &[])
+        .await
+        .unwrap();
+    let group_id_hex = hex::encode(group_id.as_slice());
+    let actor = MemberId::new(hex::decode(&account.account_id_hex).unwrap());
+
+    // Shape 1 — no pre-existing row. The earlier pass's change and the later
+    // pass's withdrawal arrive together, so the invalidation sweep runs against
+    // a row that does not exist yet and the tail is the only writer left. An
+    // unfiltered tail creates a row for a change that canonically never
+    // happened.
+    let unsynthesized = MessageId::new(vec![0xBE; 32]);
+    client
+        .observe_drained_session_events(&batch(vec![
+            renamed(
+                &group_id,
+                &actor,
+                2,
+                "superseded rename",
+                Some(&unsynthesized),
+            ),
+            superseded(&group_id, 2, &unsynthesized),
+        ]))
+        .await
+        .unwrap();
+    assert_eq!(
+        system_row(&app, &group_id_hex, 2),
+        None,
+        "a commit withdrawn by its own batch must not get a kind-1210 row at all"
+    );
+
+    // Shape 2 — the row already exists from an earlier batch. Here the sweep
+    // does withdraw it, and the tail's upsert would clear `invalidated` again.
+    let synthesized = MessageId::new(vec![0xA1; 32]);
+    client
+        .observe_drained_session_events(&batch(vec![renamed(
+            &group_id,
+            &actor,
+            3,
+            "revived rename",
+            Some(&synthesized),
+        )]))
+        .await
+        .unwrap();
+    assert_eq!(
+        system_row(&app, &group_id_hex, 3),
+        Some(None),
+        "control: the first batch synthesizes a live row"
+    );
+    client
+        .observe_drained_session_events(&batch(vec![
+            renamed(&group_id, &actor, 3, "revived rename", Some(&synthesized)),
+            superseded(&group_id, 3, &synthesized),
+        ]))
+        .await
+        .unwrap();
+    assert_eq!(
+        system_row(&app, &group_id_hex, 3),
+        Some(Some(SUPERSEDED.to_owned())),
+        "the tail must not revive the row the same batch's withdrawal tombstoned"
+    );
+
+    // Guard against over-filtering: a withdrawal only silences the commit it
+    // names. A bystander change riding the same batch keeps its live row.
+    client
+        .observe_drained_session_events(&batch(vec![
+            renamed(
+                &group_id,
+                &actor,
+                4,
+                "surviving rename",
+                Some(&MessageId::new(vec![0xCF; 32])),
+            ),
+            superseded(&group_id, 3, &synthesized),
+        ]))
+        .await
+        .unwrap();
+    assert_eq!(
+        system_row(&app, &group_id_hex, 4),
+        Some(None),
+        "a change attributed to a commit the batch did not withdraw stays live"
+    );
+}
+
+/// The live seam's tail is the same shared synthesizer, reached through
+/// `observe_account_device_effects`, and carries the identical defect today.
+/// Fixing it at the call site would leave this failing, which is why the filter
+/// belongs in `project_group_system_rows`.
+#[tokio::test]
+async fn a_live_batch_leaves_no_live_system_row_for_a_commit_it_supersedes() {
+    use superseded_system_row_shapes::{SUPERSEDED, batch, renamed, superseded, system_row};
+
+    let dir = tempfile::tempdir().unwrap();
+    let account = AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relay(dir.path(), "wss://live-superseded-rows.example")
+        .with_test_relay_client(relay);
+    let mut client = app.client("alice").await.unwrap();
+    let group_id = client
+        .create_group("live superseded rows", &[])
+        .await
+        .unwrap();
+    let group_id_hex = hex::encode(group_id.as_slice());
+    let actor = MemberId::new(hex::decode(&account.account_id_hex).unwrap());
+
+    let unsynthesized = MessageId::new(vec![0xBE; 32]);
+    client
+        .observe_send_applied_effects(&batch(vec![
+            renamed(
+                &group_id,
+                &actor,
+                2,
+                "superseded rename",
+                Some(&unsynthesized),
+            ),
+            superseded(&group_id, 2, &unsynthesized),
+        ]))
+        .await
+        .unwrap();
+    assert_eq!(
+        system_row(&app, &group_id_hex, 2),
+        None,
+        "the live seam owes the same withholding as the drained one"
+    );
+
+    let synthesized = MessageId::new(vec![0xA1; 32]);
+    client
+        .observe_send_applied_effects(&batch(vec![renamed(
+            &group_id,
+            &actor,
+            3,
+            "revived rename",
+            Some(&synthesized),
+        )]))
+        .await
+        .unwrap();
+    assert_eq!(
+        system_row(&app, &group_id_hex, 3),
+        Some(None),
+        "control: the first batch synthesizes a live row"
+    );
+    client
+        .observe_send_applied_effects(&batch(vec![
+            renamed(&group_id, &actor, 3, "revived rename", Some(&synthesized)),
+            superseded(&group_id, 3, &synthesized),
+        ]))
+        .await
+        .unwrap();
+    assert_eq!(
+        system_row(&app, &group_id_hex, 3),
+        Some(Some(SUPERSEDED.to_owned())),
+        "the live tail must not revive the row the same batch's withdrawal tombstoned"
+    );
+}
+
 #[test]
 fn transport_group_route_replacement_installs_current_and_prior_routes() {
     let routing = AppTransportRouting::new(AppRoutingState {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Replayed authenticated state changes now appear consistently in the system timeline.
  * Subscription updates are retried automatically when rebuilding fails after event processing.
  * Replay handling avoids duplicate timeline entries, preserves entries across state epochs, and excludes entries invalidated within the same event batch.
  * Unrelated state changes continue to generate timeline entries as expected.

* **Tests**
  * Added regression coverage for timeline projection, replay behavior, invalidated changes, and subscription retry recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->