### PR TITLE
fix(engine): keep exact KeyPackage and fanout retries across restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1991,6 +1991,7 @@ version = "0.9.15"
 dependencies = [
  "libc",
  "tempfile",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -2056,8 +2056,8 @@ impl<S: StorageProvider> Engine<S> {
         }
 
         if let Some(mut request) = self.storage.leave_request(group_id)? {
-            if request.last_proposed_epoch.is_none()
-                && self.sent_self_remove_leaving_gate_should_restore(
+            if (request.last_proposed_epoch.is_none() || request.last_proposed_message_id.is_none())
+                && let Some(message_id) = self.sent_self_remove_message_to_restore(
                     group_id,
                     mls_group,
                     group,
@@ -2065,13 +2065,18 @@ impl<S: StorageProvider> Engine<S> {
                     stored_message_records,
                 )?
             {
-                request.last_proposed_epoch = Some(group.epoch);
+                if request.last_proposed_epoch.is_none() {
+                    request.last_proposed_epoch = Some(group.epoch);
+                }
+                if request.last_proposed_message_id.is_none() {
+                    request.last_proposed_message_id = Some(message_id);
+                }
                 self.storage.put_leave_request(&request)?;
             }
             return Ok(Some(request));
         }
 
-        if self.sent_self_remove_leaving_gate_should_restore(
+        if let Some(message_id) = self.sent_self_remove_message_to_restore(
             group_id,
             mls_group,
             group,
@@ -2082,6 +2087,7 @@ impl<S: StorageProvider> Engine<S> {
                 group_id: group_id.clone(),
                 requested_at_ms: self.convergence_now_ms(),
                 last_proposed_epoch: Some(group.epoch),
+                last_proposed_message_id: Some(message_id),
             };
             self.storage.put_leave_request(&request)?;
             return Ok(Some(request));
@@ -2215,20 +2221,20 @@ impl<S: StorageProvider> Engine<S> {
         Ok(())
     }
 
-    fn sent_self_remove_leaving_gate_should_restore(
+    fn sent_self_remove_message_to_restore(
         &self,
         group_id: &GroupId,
         mls_group: &mut openmls::group::MlsGroup,
         group: &Group,
         provider: &crate::provider::EngineOpenMlsProvider<'_, S>,
         stored_message_records: &[cgka_traits::message::MessageRecord],
-    ) -> Result<bool, cgka_traits::storage::StorageError> {
+    ) -> Result<Option<MessageId>, cgka_traits::storage::StorageError> {
         if !group
             .members
             .iter()
             .any(|member| &member.id == self.identity.self_id())
         {
-            return Ok(false);
+            return Ok(None);
         }
 
         for record in stored_message_records {
@@ -2277,11 +2283,11 @@ impl<S: StorageProvider> Engine<S> {
                 && matches!(queued.proposal(), Proposal::SelfRemove)
                 && crate::app_components::authorize_standalone_proposal(mls_group, &queued).is_ok()
             {
-                return Ok(true);
+                return Ok(Some(record.id.clone()));
             }
         }
 
-        Ok(false)
+        Ok(None)
     }
 
     fn quarantine_stored_group_on_hydrate(

--- a/crates/cgka-engine/src/group_lifecycle.rs
+++ b/crates/cgka-engine/src/group_lifecycle.rs
@@ -1197,9 +1197,16 @@ impl<S: StorageProvider> Engine<S> {
                     let mut lifecycle = maintenance
                         .key_package_lifecycle()?
                         .unwrap_or_else(|| KeyPackageLifecycleState::slot_only(String::new()));
-                    lifecycle.last_consumed_key_package_ref =
-                        Some(consumed_key_package_ref.clone());
-                    lifecycle.last_consumed_at = Some(joined_at);
+                    lifecycle
+                        .record_consumed_key_package_ref(
+                            consumed_key_package_ref.clone(),
+                            joined_at,
+                        )
+                        .map_err(|_| {
+                            EngineError::Backend(
+                                "consumed KeyPackage cleanup journal is full".into(),
+                            )
+                        })?;
                     maintenance.put_key_package_lifecycle(&lifecycle)?;
                 }
 

--- a/crates/cgka-engine/src/message_processor/send.rs
+++ b/crates/cgka-engine/src/message_processor/send.rs
@@ -705,8 +705,10 @@ impl<S: StorageProvider> Engine<S> {
             group_id: group_id.clone(),
             requested_at_ms,
             last_proposed_epoch: None,
+            last_proposed_message_id: None,
         });
         request.last_proposed_epoch = Some(proposed_epoch);
+        request.last_proposed_message_id = Some(msg.id.clone());
         self.record_sent_openmls_message_with_leave_request(
             &msg,
             proposal_bytes.as_slice(),
@@ -833,6 +835,7 @@ impl<S: StorageProvider> Engine<S> {
         let (msg, proposal_bytes, proposed_epoch) =
             self.prepare_self_remove_proposal(group_id).await?;
         request.last_proposed_epoch = Some(proposed_epoch);
+        request.last_proposed_message_id = Some(msg.id.clone());
         self.record_sent_openmls_message_with_leave_request(
             &msg,
             proposal_bytes.as_slice(),

--- a/crates/cgka-engine/tests/invite_leave.rs
+++ b/crates/cgka-engine/tests/invite_leave.rs
@@ -3029,11 +3029,18 @@ async fn leave_hydration_preserves_existing_last_proposed_message_id() {
     bob_storage.put_leave_request(&request).unwrap();
     drop(bob);
 
-    let _reopened = build_client_on_storage(b"bob", bob_storage.clone());
+    let mut reopened = build_client_on_storage(b"bob", bob_storage.clone());
+    reopened
+        .hydrate_all_stored_groups()
+        .expect("eager hydrate restores the leave request");
     let restored = bob_storage
         .leave_request(&group_id)
         .unwrap()
         .expect("hydration restores the LeaveRequest");
+    assert!(
+        restored.last_proposed_epoch.is_some(),
+        "epoch-only hydration repair must fill last_proposed_epoch"
+    );
     assert_eq!(
         restored.last_proposed_message_id.as_ref(),
         Some(&second_id),

--- a/crates/cgka-engine/tests/invite_leave.rs
+++ b/crates/cgka-engine/tests/invite_leave.rs
@@ -1336,6 +1336,7 @@ async fn realization_with_pending_leave_request_attributes_member_left() {
             group_id: group_id.clone(),
             requested_at_ms: 1,
             last_proposed_epoch: None,
+            last_proposed_message_id: None,
         })
         .unwrap();
 
@@ -2945,6 +2946,103 @@ async fn repeat_leave_in_the_same_epoch_is_classified_by_the_engine() {
         bob_storage.leave_request(&group_id).unwrap(),
         Some(recorded),
         "refused duplicates must leave the durable request byte-identical"
+    );
+}
+
+#[tokio::test]
+async fn leave_hydration_preserves_existing_last_proposed_message_id() {
+    let mut alice = build_client(b"alice");
+    let (mut bob, bob_storage) = build_with_storage(b"bob");
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "hydrate-leave-id".into(),
+            description: "".into(),
+            members: vec![bob_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let welcome_for_bob = match create {
+        SendResult::GroupCreated {
+            pending,
+            mut welcomes,
+        } => {
+            alice.confirm_published(pending).await.unwrap();
+            welcomes.remove(0)
+        }
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    bob.join_welcome(welcome_for_bob).await.unwrap();
+
+    let first = bob
+        .send(SendIntent::Leave {
+            group_id: group_id.clone(),
+        })
+        .await
+        .unwrap();
+    let first_id = match first {
+        SendResult::Proposal { msg } => msg.id,
+        other => panic!("expected SelfRemove proposal, got {other:?}"),
+    };
+
+    let rename = alice
+        .send(SendIntent::UpdateGroupData {
+            group_id: group_id.clone(),
+            name: Some("still includes bob".into()),
+            description: None,
+        })
+        .await
+        .unwrap();
+    let (commit, pending) = match rename {
+        SendResult::GroupEvolution { msg, pending, .. } => (msg, pending),
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    let routed = TransportMessage {
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+        ..commit
+    };
+    let outcome = bob.ingest(routed).await.unwrap();
+    assert!(matches!(outcome, IngestOutcome::Buffered { .. }));
+    converge_buffered_commit(&mut bob, &group_id);
+    let _ = bob.advance_convergence(&group_id).await.unwrap();
+    let reproposals = bob.drain_auto_proposals();
+    assert_eq!(reproposals.len(), 1);
+    let second_id = reproposals[0].id.clone();
+    assert_ne!(
+        first_id, second_id,
+        "the epoch-changed SelfRemove must be a new message"
+    );
+
+    let mut request = bob_storage
+        .leave_request(&group_id)
+        .unwrap()
+        .expect("reproposal keeps the durable request");
+    assert_eq!(request.last_proposed_message_id.as_ref(), Some(&second_id));
+    request.last_proposed_epoch = None;
+    bob_storage.put_leave_request(&request).unwrap();
+    drop(bob);
+
+    let _reopened = build_client_on_storage(b"bob", bob_storage.clone());
+    let restored = bob_storage
+        .leave_request(&group_id)
+        .unwrap()
+        .expect("hydration restores the LeaveRequest");
+    assert_eq!(
+        restored.last_proposed_message_id.as_ref(),
+        Some(&second_id),
+        "epoch-only hydration repair must not overwrite the exact Leave id"
+    );
+    assert_ne!(
+        restored.last_proposed_message_id.as_ref(),
+        Some(&first_id),
+        "hydration must not replace the current Leave id with an earlier SelfRemove"
     );
 }
 

--- a/crates/cgka-engine/tests/publish_lifecycle.rs
+++ b/crates/cgka-engine/tests/publish_lifecycle.rs
@@ -1606,6 +1606,7 @@ fn key_package_bundle_and_lifecycle_intent_roll_back_together() {
     let mut state = KeyPackageLifecycleState {
         stable_slot_id: "stable-slot".into(),
         phase: MaintenancePhase::Complete,
+        cutover_publication_blocked: false,
         current_key_package: None,
         current_key_package_ref: None,
         current_not_before: None,
@@ -1613,11 +1614,15 @@ fn key_package_bundle_and_lifecycle_intent_roll_back_together() {
         authored_event_id: None,
         authored_event_created_at: None,
         authored_signed_event: None,
+        deleted_live_revision_event_ids: Vec::new(),
+        deletion_overflow_owner_event_id: None,
+        retired_publications_pending_deletion: Vec::new(),
         publication_targets: Vec::new(),
         refresh_at: None,
         upgrade_rotation_recorded: false,
         last_consumed_key_package_ref: None,
         last_consumed_at: None,
+        consumed_key_package_refs: Vec::new(),
         retained_private_material: Vec::new(),
         pending_replacement: None,
     };

--- a/crates/cgka-session/src/lib.rs
+++ b/crates/cgka-session/src/lib.rs
@@ -432,6 +432,18 @@ impl AccountDeviceSession {
         &self.open_timings
     }
 
+    /// A clone of the session's closeable storage handle.
+    ///
+    /// Hosts that must release local file locks at a known instant retain this
+    /// alongside the live session and call [`SqliteAccountStorage::close`]
+    /// during terminal shutdown. Every engine/OpenMLS clone shares the same
+    /// underlying close state, so closing this handle makes the whole session
+    /// storage graph inert without requiring the session to be dropped first.
+    #[must_use]
+    pub fn storage_handle(&self) -> SqliteAccountStorage {
+        self.storage.clone()
+    }
+
     /// Promote one bounded batch of legacy message rows after session
     /// readiness.
     ///

--- a/crates/fs-private/Cargo.toml
+++ b/crates/fs-private/Cargo.toml
@@ -8,5 +8,8 @@ publish.workspace = true
 [dependencies]
 libc.workspace = true
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
+
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/fs-private/src/lib.rs
+++ b/crates/fs-private/src/lib.rs
@@ -9,9 +9,13 @@
 //! Mode application is Unix-only; on other platforms the helpers still create
 //! the artifacts and the mode calls are no-ops.
 
-use std::fs::OpenOptions;
+use std::ffi::OsString;
+use std::fs::{File, OpenOptions};
 use std::io;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static ATOMIC_PRIVATE_WRITE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// Owner-only mode for files holding private data.
 pub const PRIVATE_FILE_MODE: u32 = 0o600;
@@ -779,6 +783,110 @@ pub fn write_private(path: &Path, bytes: &[u8]) -> io::Result<()> {
     file.sync_all()
 }
 
+/// Atomically replace `path` with owner-only `bytes`.
+///
+/// The complete new value is written and synced through a private sibling
+/// inode before rename, then the parent directory is synced where supported.
+/// A process or power failure on Unix therefore leaves either the previous
+/// value or the complete new value, never a truncate-before-write fragment.
+/// The parent directory must already exist; this helper never creates or
+/// changes its permissions.
+pub fn write_private_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    use std::io::Write;
+
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let file_name = path.file_name().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "atomic private write target must name a file",
+        )
+    })?;
+
+    let mut allocated = None;
+    for _ in 0..32 {
+        let attempt = ATOMIC_PRIVATE_WRITE_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let mut temp_name = OsString::from(".");
+        temp_name.push(file_name);
+        temp_name.push(format!(".tmp.{}.{}", std::process::id(), attempt));
+        let temp_path = parent.join(temp_name);
+        match create_new_private(&temp_path) {
+            Ok(file) => {
+                allocated = Some((file, temp_path));
+                break;
+            }
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error),
+        }
+    }
+    let (mut file, temp_path) = allocated.ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "could not allocate unique atomic private write temp file",
+        )
+    })?;
+
+    let result = (|| -> io::Result<()> {
+        file.write_all(bytes)?;
+        file.sync_all()?;
+        drop(file);
+        replace_private_file(&temp_path, path)?;
+        sync_private_parent(parent)
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temp_path);
+    }
+    result
+}
+
+#[cfg(windows)]
+fn replace_private_file(temp_path: &Path, path: &Path) -> io::Result<()> {
+    use std::iter;
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::{
+        MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH, MoveFileExW,
+    };
+
+    let temp_path = temp_path
+        .as_os_str()
+        .encode_wide()
+        .chain(iter::once(0))
+        .collect::<Vec<_>>();
+    let path = path
+        .as_os_str()
+        .encode_wide()
+        .chain(iter::once(0))
+        .collect::<Vec<_>>();
+    let result = unsafe {
+        MoveFileExW(
+            temp_path.as_ptr(),
+            path.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if result == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn replace_private_file(temp_path: &Path, path: &Path) -> io::Result<()> {
+    std::fs::rename(temp_path, path)
+}
+
+#[cfg(unix)]
+fn sync_private_parent(path: &Path) -> io::Result<()> {
+    File::open(path)?.sync_all()
+}
+
+#[cfg(not(unix))]
+fn sync_private_parent(_path: &Path) -> io::Result<()> {
+    Ok(())
+}
+
 /// Open `path` for appending, creating it 0600; tightens a pre-existing file
 /// to 0600.
 pub fn open_private_append(path: &Path) -> io::Result<std::fs::File> {
@@ -1071,6 +1179,46 @@ mod tests {
             assert!(parse_octal_mode(input).is_err(), "input {input:?}");
         }
     }
+
+    #[test]
+    fn write_private_atomic_replaces_complete_value_without_temp_artifacts() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("frontier.json");
+        write_private_atomic(&path, b"old").unwrap();
+        write_private_atomic(&path, b"complete replacement").unwrap();
+
+        assert_eq!(std::fs::read(&path).unwrap(), b"complete replacement");
+        let entries = std::fs::read_dir(dir.path())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect::<Vec<_>>();
+        assert_eq!(entries, vec![path.file_name().unwrap()]);
+    }
+
+    #[test]
+    fn write_private_atomic_removes_temp_after_failed_replace() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("occupied");
+        std::fs::create_dir(&path).unwrap();
+
+        assert!(write_private_atomic(&path, b"replacement").is_err());
+        let entries = std::fs::read_dir(dir.path())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect::<Vec<_>>();
+        assert_eq!(entries, vec![path.file_name().unwrap()]);
+    }
+
+    #[test]
+    fn write_private_atomic_requires_an_existing_parent() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing_parent = dir.path().join("missing");
+        let error = write_private_atomic(&missing_parent.join("frontier.json"), b"value")
+            .expect_err("atomic writes must not create their parent");
+
+        assert_eq!(error.kind(), io::ErrorKind::NotFound);
+        assert!(!missing_parent.exists());
+    }
 }
 
 #[cfg(all(test, unix))]
@@ -1089,6 +1237,61 @@ mod unix_tests {
         write_private(&path, b"secret").unwrap();
         assert_eq!(mode_of(&path), 0o600);
         assert_eq!(std::fs::read(&path).unwrap(), b"secret");
+    }
+
+    #[test]
+    fn write_private_atomic_replacement_remains_owner_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("frontier.json");
+        write_private_atomic(&path, b"old").unwrap();
+        write_private_atomic(&path, b"new").unwrap();
+        assert_eq!(mode_of(&path), 0o600);
+    }
+
+    #[test]
+    fn write_private_atomic_preserves_existing_parent_mode() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().join("externally-managed");
+        std::fs::create_dir(&parent).unwrap();
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let path = parent.join("frontier.json");
+        write_private_atomic(&path, b"value").unwrap();
+
+        assert_eq!(mode_of(&parent), 0o755);
+        assert_eq!(mode_of(&path), 0o600);
+    }
+
+    #[test]
+    fn write_private_atomic_bare_relative_filename_child_process() {
+        let Some(directory) = std::env::var_os("FS_PRIVATE_ATOMIC_RELATIVE_CHILD_DIR") else {
+            return;
+        };
+        std::env::set_current_dir(&directory).unwrap();
+
+        write_private_atomic(Path::new("frontier.json"), b"value").unwrap();
+
+        assert_eq!(mode_of(Path::new(".")), 0o755);
+        assert_eq!(mode_of(Path::new("frontier.json")), 0o600);
+    }
+
+    #[test]
+    fn write_private_atomic_bare_relative_filename_preserves_current_directory_mode() {
+        use std::process::Command;
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
+        let status = Command::new(std::env::current_exe().unwrap())
+            .arg("--exact")
+            .arg("unix_tests::write_private_atomic_bare_relative_filename_child_process")
+            .arg("--nocapture")
+            .env("FS_PRIVATE_ATOMIC_RELATIVE_CHILD_DIR", dir.path())
+            .status()
+            .expect("run bare-relative atomic-write child test");
+
+        assert!(status.success(), "atomic-write child process failed");
+        assert_eq!(mode_of(dir.path()), 0o755);
+        assert_eq!(mode_of(&dir.path().join("frontier.json")), 0o600);
     }
 
     #[test]

--- a/crates/storage-sqlite/src/account_projection.rs
+++ b/crates/storage-sqlite/src/account_projection.rs
@@ -973,12 +973,36 @@ impl SqliteAccountStorage {
         frontiers_to_clear: &[(String, u64)],
         application_event_ids_to_ack: &[MessageId],
     ) -> StorageResult<()> {
+        self.save_account_projection_state_clearing_local_group_deletion_frontiers_and_acking_application_events_and_visibility_batches(
+            state,
+            max_seen_events,
+            max_future_skew_secs,
+            frontiers_to_clear,
+            application_event_ids_to_ack,
+            &[],
+        )
+    }
+
+    /// Persist the complete account projection and atomically transfer both
+    /// engine application events and lower account-visibility rows into app
+    /// ownership. A crash therefore replays the rows or observes their fully
+    /// committed projection, never an engine state advance with neither.
+    pub fn save_account_projection_state_clearing_local_group_deletion_frontiers_and_acking_application_events_and_visibility_batches(
+        &self,
+        state: &StoredAccountState,
+        max_seen_events: usize,
+        max_future_skew_secs: u64,
+        frontiers_to_clear: &[(String, u64)],
+        application_event_ids_to_ack: &[MessageId],
+        visibility_batch_ids_to_ack: &[Vec<u8>],
+    ) -> StorageResult<()> {
         self.save_account_projection(
             state,
             max_seen_events,
             max_future_skew_secs,
             frontiers_to_clear,
             application_event_ids_to_ack,
+            visibility_batch_ids_to_ack,
             true,
         )
     }
@@ -1001,16 +1025,38 @@ impl SqliteAccountStorage {
         frontiers_to_clear: &[(String, u64)],
         application_event_ids_to_ack: &[MessageId],
     ) -> StorageResult<()> {
+        self.save_account_projection_delta_clearing_local_group_deletion_frontiers_and_acking_application_events_and_visibility_batches(
+            state,
+            max_seen_events,
+            max_future_skew_secs,
+            frontiers_to_clear,
+            application_event_ids_to_ack,
+            &[],
+        )
+    }
+
+    /// Delta counterpart to the full-snapshot visibility transfer above.
+    pub fn save_account_projection_delta_clearing_local_group_deletion_frontiers_and_acking_application_events_and_visibility_batches(
+        &self,
+        state: &StoredAccountState,
+        max_seen_events: usize,
+        max_future_skew_secs: u64,
+        frontiers_to_clear: &[(String, u64)],
+        application_event_ids_to_ack: &[MessageId],
+        visibility_batch_ids_to_ack: &[Vec<u8>],
+    ) -> StorageResult<()> {
         self.save_account_projection(
             state,
             max_seen_events,
             max_future_skew_secs,
             frontiers_to_clear,
             application_event_ids_to_ack,
+            visibility_batch_ids_to_ack,
             false,
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn save_account_projection(
         &self,
         state: &StoredAccountState,
@@ -1018,6 +1064,7 @@ impl SqliteAccountStorage {
         max_future_skew_secs: u64,
         frontiers_to_clear: &[(String, u64)],
         application_event_ids_to_ack: &[MessageId],
+        visibility_batch_ids_to_ack: &[Vec<u8>],
         replace_group_snapshot: bool,
     ) -> StorageResult<()> {
         let now = unix_now_seconds();
@@ -1268,6 +1315,13 @@ impl SqliteAccountStorage {
                     "DELETE FROM pending_application_events WHERE message_id = ?1",
                     params![message_id.as_slice()],
                 )
+                    .storage()?;
+            }
+            for batch_id in visibility_batch_ids_to_ack {
+                conn.execute(
+                    "DELETE FROM account_visibility_journal WHERE batch_id = ?1",
+                    params![batch_id],
+                )
                 .storage()?;
             }
             Ok(())
@@ -1407,6 +1461,13 @@ impl SqliteAccountStorage {
                 deleted = deleted.saturating_add(
                     tx.execute(
                         "DELETE FROM pending_application_events WHERE group_id = ?1",
+                        params![&group_id],
+                    )
+                    .storage()?,
+                );
+                deleted = deleted.saturating_add(
+                    tx.execute(
+                        "DELETE FROM app_epoch_backfill_intents WHERE group_id = ?1",
                         params![&group_id],
                     )
                     .storage()?,

--- a/crates/storage-sqlite/src/account_projection/tests.rs
+++ b/crates/storage-sqlite/src/account_projection/tests.rs
@@ -2855,6 +2855,78 @@ fn failed_resurrection_projection_save_retains_local_deletion_frontier() {
 }
 
 #[test]
+fn visibility_batch_ack_is_atomic_with_projection_delta() {
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    let operation_id = b"visibility-operation";
+    let batch_id = b"visibility-batch".to_vec();
+    store
+        .upsert_account_visibility_journal(operation_id, 1, &batch_id, b"opaque-effects")
+        .unwrap();
+    store
+        .lock()
+        .unwrap()
+        .execute_batch(
+            "CREATE TRIGGER fail_visibility_projection
+             BEFORE INSERT ON account_groups
+             BEGIN
+                 SELECT RAISE(ABORT, 'injected visibility projection failure');
+             END;",
+        )
+        .unwrap();
+    let state = StoredAccountState {
+        label: "alice".to_owned(),
+        seen_events: vec!["visible-event".to_owned()],
+        last_transport_timestamp: None,
+        groups: vec![group("aa", "visible group")],
+    };
+
+    let result = store
+        .save_account_projection_delta_clearing_local_group_deletion_frontiers_and_acking_application_events_and_visibility_batches(
+            &state,
+            16,
+            MAX_FUTURE_SKEW_SECS,
+            &[],
+            &[],
+            std::slice::from_ref(&batch_id),
+        );
+
+    assert!(result.is_err());
+    assert_eq!(store.load_account_visibility_journal().unwrap().len(), 1);
+    assert!(
+        store
+            .load_account_projection_state("alice", 16)
+            .unwrap()
+            .groups
+            .is_empty(),
+        "a failed projection must not expose state while keeping the lower row",
+    );
+
+    store
+        .lock()
+        .unwrap()
+        .execute_batch("DROP TRIGGER fail_visibility_projection")
+        .unwrap();
+    store
+        .save_account_projection_delta_clearing_local_group_deletion_frontiers_and_acking_application_events_and_visibility_batches(
+            &state,
+            16,
+            MAX_FUTURE_SKEW_SECS,
+            &[],
+            &[],
+            std::slice::from_ref(&batch_id),
+        )
+        .unwrap();
+    assert!(store.load_account_visibility_journal().unwrap().is_empty());
+    assert_eq!(
+        store
+            .load_account_projection_state("alice", 16)
+            .unwrap()
+            .groups,
+        state.groups,
+    );
+}
+
+#[test]
 fn repeated_local_group_delete_advances_frontier_past_buffered_messages() {
     let store = SqliteAccountStorage::in_memory().unwrap();
     insert_protocol_group_marker(&store, &[0xaa]);

--- a/crates/storage-sqlite/src/account_visibility_journal.rs
+++ b/crates/storage-sqlite/src/account_visibility_journal.rs
@@ -1,0 +1,294 @@
+use crate::connection::retry_on_busy;
+use crate::{SqliteAccountStorage, SqliteResultExt, i64_to_u64, u64_to_i64};
+use cgka_traits::storage::{StorageError, StorageResult};
+use rusqlite::{OptionalExtension, params};
+
+/// One ordered opaque account-runtime visibility record.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AccountVisibilityJournalRow {
+    pub sequence: u64,
+    pub operation_id: Vec<u8>,
+    pub ordinal: u64,
+    pub batch_id: Vec<u8>,
+    pub record: Vec<u8>,
+}
+
+/// One opaque record to insert or replace as part of an atomic visibility
+/// checkpoint.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AccountVisibilityJournalUpsert {
+    pub operation_id: Vec<u8>,
+    pub ordinal: u64,
+    pub batch_id: Vec<u8>,
+    pub record: Vec<u8>,
+}
+
+impl SqliteAccountStorage {
+    /// Load every unacknowledged visibility record in insertion order.
+    pub fn load_account_visibility_journal(
+        &self,
+    ) -> StorageResult<Vec<AccountVisibilityJournalRow>> {
+        let connection = self.lock()?;
+        let mut statement = connection
+            .prepare(
+                "SELECT sequence, operation_id, ordinal, batch_id, record
+                 FROM account_visibility_journal
+                 ORDER BY sequence",
+            )
+            .storage()?;
+        let rows = statement
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, Vec<u8>>(1)?,
+                    row.get::<_, i64>(2)?,
+                    row.get::<_, Vec<u8>>(3)?,
+                    row.get::<_, Vec<u8>>(4)?,
+                ))
+            })
+            .storage()?
+            .collect::<Result<Vec<_>, _>>()
+            .storage()?;
+        rows.into_iter()
+            .map(|(sequence, operation_id, ordinal, batch_id, record)| {
+                Ok(AccountVisibilityJournalRow {
+                    sequence: i64_to_u64(sequence)?,
+                    operation_id,
+                    ordinal: i64_to_u64(ordinal)?,
+                    batch_id,
+                    record,
+                })
+            })
+            .collect()
+    }
+
+    /// Insert a new stable operation/ordinal record or replace its opaque bytes.
+    /// Existing rows retain their original global `sequence`.
+    pub fn upsert_account_visibility_journal(
+        &self,
+        operation_id: &[u8],
+        ordinal: u64,
+        batch_id: &[u8],
+        record: &[u8],
+    ) -> StorageResult<u64> {
+        let mut sequences =
+            self.upsert_account_visibility_journal_records(&[AccountVisibilityJournalUpsert {
+                operation_id: operation_id.to_vec(),
+                ordinal,
+                batch_id: batch_id.to_vec(),
+                record: record.to_vec(),
+            }])?;
+        Ok(sequences.pop().expect("one input produces one sequence"))
+    }
+
+    /// Atomically insert or replace a complete visibility checkpoint. If any
+    /// entry is invalid or conflicts, none of the rows are changed.
+    pub fn upsert_account_visibility_journal_records(
+        &self,
+        records: &[AccountVisibilityJournalUpsert],
+    ) -> StorageResult<Vec<u64>> {
+        let validated = records
+            .iter()
+            .map(|record| {
+                if record.operation_id.is_empty() || record.batch_id.is_empty() {
+                    return Err(StorageError::Backend(
+                        "account visibility operation and batch ids must be non-empty".into(),
+                    ));
+                }
+                Ok((record, u64_to_i64(record.ordinal)?))
+            })
+            .collect::<StorageResult<Vec<_>>>()?;
+        self.write_account_visibility_journal(|| {
+            self.connection.with_transaction(|| {
+                let connection = self.lock()?;
+                let mut sequences = Vec::with_capacity(validated.len());
+                for (record, ordinal) in &validated {
+                    connection
+                        .execute(
+                            "INSERT INTO account_visibility_journal
+                                (operation_id, ordinal, batch_id, record)
+                             VALUES (?1, ?2, ?3, ?4)
+                             ON CONFLICT(operation_id, ordinal) DO UPDATE SET
+                                record = excluded.record
+                             WHERE account_visibility_journal.batch_id = excluded.batch_id",
+                            params![
+                                &record.operation_id,
+                                ordinal,
+                                &record.batch_id,
+                                &record.record,
+                            ],
+                        )
+                        .storage()?;
+                    let sequence = connection
+                        .query_row(
+                            "SELECT sequence FROM account_visibility_journal
+                             WHERE operation_id = ?1 AND ordinal = ?2 AND batch_id = ?3",
+                            params![&record.operation_id, ordinal, &record.batch_id],
+                            |row| row.get::<_, i64>(0),
+                        )
+                        .optional()
+                        .storage()?
+                        .ok_or_else(|| {
+                            StorageError::Backend(
+                                "account visibility operation/ordinal reused with another batch id"
+                                    .into(),
+                            )
+                        })?;
+                    sequences.push(i64_to_u64(sequence)?);
+                }
+                Ok(sequences)
+            })
+        })
+    }
+
+    /// Atomically delete exactly the acknowledged stable batch ids.
+    pub fn delete_account_visibility_journal_batches(
+        &self,
+        batch_ids: &[Vec<u8>],
+    ) -> StorageResult<usize> {
+        self.write_account_visibility_journal(|| {
+            self.connection.with_transaction(|| {
+                let connection = self.lock()?;
+                let mut deleted = 0_usize;
+                for batch_id in batch_ids {
+                    deleted = deleted.saturating_add(
+                        connection
+                            .execute(
+                                "DELETE FROM account_visibility_journal WHERE batch_id = ?1",
+                                params![batch_id],
+                            )
+                            .storage()?,
+                    );
+                }
+                Ok(deleted)
+            })
+        })
+    }
+
+    fn write_account_visibility_journal<T>(
+        &self,
+        op: impl Fn() -> StorageResult<T>,
+    ) -> StorageResult<T> {
+        if self.connection.is_current_thread_transaction_owner() {
+            op()
+        } else {
+            retry_on_busy(op)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn journal_orders_exact_bytes_upserts_in_place_and_deletes_atomically() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let operation_a = [0_u8, 0xff, 0x80];
+        let operation_b = [2_u8, 0, 3];
+        let batch_a = [4_u8, 0xff, 5];
+        let batch_b = [6_u8, 0, 7];
+        let first = [8_u8, 0xff, 9, 0];
+        let second = [10_u8, 0, 11];
+        let replacement = [12_u8, 0xff, 13, 0];
+
+        let sequence_a = store
+            .upsert_account_visibility_journal(&operation_a, 0, &batch_a, &first)
+            .unwrap();
+        let sequence_b = store
+            .upsert_account_visibility_journal(&operation_b, 9, &batch_b, &second)
+            .unwrap();
+        assert!(sequence_a < sequence_b);
+        assert_eq!(
+            store
+                .upsert_account_visibility_journal(&operation_a, 0, &batch_a, &replacement,)
+                .unwrap(),
+            sequence_a,
+            "upsert must preserve global order"
+        );
+
+        assert_eq!(
+            store.load_account_visibility_journal().unwrap(),
+            vec![
+                AccountVisibilityJournalRow {
+                    sequence: sequence_a,
+                    operation_id: operation_a.to_vec(),
+                    ordinal: 0,
+                    batch_id: batch_a.to_vec(),
+                    record: replacement.to_vec(),
+                },
+                AccountVisibilityJournalRow {
+                    sequence: sequence_b,
+                    operation_id: operation_b.to_vec(),
+                    ordinal: 9,
+                    batch_id: batch_b.to_vec(),
+                    record: second.to_vec(),
+                },
+            ]
+        );
+
+        assert_eq!(
+            store
+                .delete_account_visibility_journal_batches(&[batch_b.to_vec(), batch_a.to_vec(),])
+                .unwrap(),
+            2
+        );
+        assert!(store.load_account_visibility_journal().unwrap().is_empty());
+    }
+
+    #[test]
+    fn upsert_rejects_operation_ordinal_or_batch_id_aba() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        store
+            .upsert_account_visibility_journal(b"operation-a", 3, b"batch-a", b"first")
+            .unwrap();
+        assert!(
+            store
+                .upsert_account_visibility_journal(b"operation-a", 3, b"batch-b", b"other")
+                .is_err()
+        );
+        assert!(
+            store
+                .upsert_account_visibility_journal(b"operation-b", 4, b"batch-a", b"other")
+                .is_err()
+        );
+        assert_eq!(
+            store.load_account_visibility_journal().unwrap()[0].record,
+            b"first"
+        );
+    }
+
+    #[test]
+    fn bulk_upsert_rolls_back_every_row_when_one_entry_conflicts() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        store
+            .upsert_account_visibility_journal(b"operation-a", 1, b"batch-a", b"original")
+            .unwrap();
+
+        let result = store.upsert_account_visibility_journal_records(&[
+            AccountVisibilityJournalUpsert {
+                operation_id: b"operation-b".to_vec(),
+                ordinal: 2,
+                batch_id: b"batch-b".to_vec(),
+                record: vec![0, 0xff, 0x80],
+            },
+            AccountVisibilityJournalUpsert {
+                operation_id: b"operation-a".to_vec(),
+                ordinal: 1,
+                batch_id: b"wrong-batch".to_vec(),
+                record: b"must-not-replace".to_vec(),
+            },
+        ]);
+        assert!(result.is_err());
+        assert_eq!(
+            store.load_account_visibility_journal().unwrap(),
+            vec![AccountVisibilityJournalRow {
+                sequence: 1,
+                operation_id: b"operation-a".to_vec(),
+                ordinal: 1,
+                batch_id: b"batch-a".to_vec(),
+                record: b"original".to_vec(),
+            }]
+        );
+    }
+}

--- a/crates/storage-sqlite/src/chat_list.rs
+++ b/crates/storage-sqlite/src/chat_list.rs
@@ -14,7 +14,7 @@ use cgka_traits::app_event::{
     GROUP_SYSTEM_TYPE_MEMBER_LEFT, GROUP_SYSTEM_TYPE_MEMBER_REMOVED, GROUP_SYSTEM_TYPE_TAG,
     MARMOT_APP_EVENT_KIND_CHAT, MARMOT_APP_EVENT_KIND_GROUP_SYSTEM,
 };
-use cgka_traits::storage::StorageResult;
+use cgka_traits::storage::{StorageError, StorageResult};
 use rusqlite::{Connection, OptionalExtension, Params, params};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -717,24 +717,60 @@ impl SqliteAccountStorage {
         group_id_hex: &str,
         mention_classifier: &MentionClassifier<'_>,
     ) -> StorageResult<Option<ChatListRow>> {
+        self.save_account_projection_delta_and_refresh_chat_list_row_acking_application_events_and_visibility_batches(
+            state,
+            max_seen_events,
+            max_future_skew_secs,
+            frontiers_to_clear,
+            application_event_ids_to_ack,
+            &[],
+            local_account_id_hex,
+            group_id_hex,
+            mention_classifier,
+        )
+    }
+
+    /// Persist an exact account-projection delta, acknowledge both engine
+    /// application events and lower account-visibility batches, and materialize
+    /// one chat-list row in the same SQLCipher transaction.
+    ///
+    /// This is the visibility-aware created-group boundary. A failed row refresh
+    /// rolls back the projection, frontier clears, and both outbox transfers;
+    /// success returns the row committed with all of them.
+    #[allow(clippy::too_many_arguments)]
+    pub fn save_account_projection_delta_and_refresh_chat_list_row_acking_application_events_and_visibility_batches(
+        &self,
+        state: &StoredAccountState,
+        max_seen_events: usize,
+        max_future_skew_secs: u64,
+        frontiers_to_clear: &[(String, u64)],
+        application_event_ids_to_ack: &[cgka_traits::MessageId],
+        visibility_batch_ids_to_ack: &[Vec<u8>],
+        local_account_id_hex: &str,
+        group_id_hex: &str,
+        mention_classifier: &MentionClassifier<'_>,
+    ) -> StorageResult<Option<ChatListRow>> {
         self.connection.with_transaction(|| {
             // `with_transaction` is intentionally nestable on the owning
             // thread, so the projection helper participates in this outer
             // transaction and cannot commit before the chat-list row exists.
-            self.save_account_projection_delta_clearing_local_group_deletion_frontiers_and_acking_application_events(
+            self.save_account_projection_delta_clearing_local_group_deletion_frontiers_and_acking_application_events_and_visibility_batches(
                 state,
                 max_seen_events,
                 max_future_skew_secs,
                 frontiers_to_clear,
                 application_event_ids_to_ack,
+                visibility_batch_ids_to_ack,
             )?;
             let conn = self.lock()?;
-            refresh_chat_list_row_tx(
+            let row = refresh_chat_list_row_tx(
                 &conn,
                 local_account_id_hex,
                 group_id_hex,
                 mention_classifier,
-            )
+            )?
+            .ok_or(StorageError::NotFound)?;
+            Ok(Some(row))
         })
     }
 

--- a/crates/storage-sqlite/src/chat_list/tests.rs
+++ b/crates/storage-sqlite/src/chat_list/tests.rs
@@ -15,7 +15,7 @@ use cgka_traits::app_event::{
     MARMOT_APP_EVENT_KIND_GROUP_SYSTEM, MARMOT_APP_EVENT_KIND_REACTION,
 };
 use cgka_traits::storage::{GroupStorage, LeaveRequest, LeaveRequestStorage};
-use cgka_traits::types::{EpochId, GroupId};
+use cgka_traits::types::{EpochId, GroupId, MessageId};
 
 const LOCAL: &str = "aa";
 const REMOTE: &str = "bb";
@@ -231,6 +231,243 @@ fn created_group_projection_and_chat_list_row_commit_atomically() {
         .unwrap()
         .expect("created chat-list row");
     assert_eq!(store.chat_list_row(GROUP).unwrap(), Some(committed));
+}
+
+#[test]
+fn created_group_visibility_transfer_and_chat_list_row_commit_atomically() {
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    let deletion_frontier = 7_u64;
+    let application_event_id = MessageId::new(vec![0x42; 32]);
+    let operation_id = b"created-chat-visibility-operation";
+    let acknowledged_batch_id = b"created-chat-acknowledged-batch".to_vec();
+    let retained_batch_id = b"created-chat-retained-batch".to_vec();
+    {
+        let connection = store.lock().unwrap();
+        connection
+            .execute(
+                "INSERT INTO local_group_deletion_frontiers
+                    (group_id_hex, message_insert_order, prior_nostr_routes_json)
+                 VALUES (?1, ?2, '[]')",
+                params![GROUP, i64::try_from(deletion_frontier).unwrap()],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO pending_application_events
+                    (message_id, group_id, message_insert_order, record)
+                 VALUES (?1, ?2, ?3, ?4)",
+                params![
+                    application_event_id.as_slice(),
+                    &[0x11_u8],
+                    i64::try_from(deletion_frontier + 1).unwrap(),
+                    b"opaque-pending-application-event",
+                ],
+            )
+            .unwrap();
+    }
+    store
+        .upsert_account_visibility_journal(
+            operation_id,
+            1,
+            &acknowledged_batch_id,
+            b"created-chat-effects",
+        )
+        .unwrap();
+    store
+        .upsert_account_visibility_journal(
+            operation_id,
+            2,
+            &retained_batch_id,
+            b"unrelated-effects",
+        )
+        .unwrap();
+    store
+        .lock()
+        .unwrap()
+        .execute_batch(
+            "CREATE TRIGGER fail_created_chat_list_visibility_row
+             BEFORE INSERT ON chat_list_rows
+             BEGIN
+                 SELECT RAISE(ABORT, 'injected created visibility row failure');
+             END;",
+        )
+        .unwrap();
+    let state = StoredAccountState {
+        label: "alice".to_owned(),
+        groups: vec![group()],
+        ..StoredAccountState::default()
+    };
+    let save = || {
+        store.save_account_projection_delta_and_refresh_chat_list_row_acking_application_events_and_visibility_batches(
+            &state,
+            256,
+            MAX_FUTURE_SKEW_SECS,
+            &[(GROUP.to_owned(), deletion_frontier)],
+            std::slice::from_ref(&application_event_id),
+            std::slice::from_ref(&acknowledged_batch_id),
+            LOCAL,
+            GROUP,
+            &no_mentions,
+        )
+    };
+    let pending_application_event_count = || {
+        store
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT COUNT(*) FROM pending_application_events WHERE message_id = ?1",
+                params![application_event_id.as_slice()],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap()
+    };
+    let visibility_batch_ids = || {
+        store
+            .load_account_visibility_journal()
+            .unwrap()
+            .into_iter()
+            .map(|row| row.batch_id)
+            .collect::<Vec<_>>()
+    };
+
+    save().expect_err("the chat-list failure must roll back the visibility transfer");
+    assert!(
+        store
+            .load_account_projection_state("alice", 256)
+            .unwrap()
+            .groups
+            .is_empty(),
+        "the failed outer transaction must roll back the projection delta",
+    );
+    assert_eq!(store.chat_list_row(GROUP).unwrap(), None);
+    assert_eq!(
+        store.local_group_deletion_frontier(GROUP).unwrap(),
+        Some(deletion_frontier),
+        "the failed row refresh must roll back the frontier clear",
+    );
+    assert_eq!(
+        pending_application_event_count(),
+        1,
+        "the failed row refresh must roll back the application-event acknowledgement",
+    );
+    assert_eq!(
+        visibility_batch_ids(),
+        vec![acknowledged_batch_id.clone(), retained_batch_id.clone()],
+        "the failed row refresh must retain every lower visibility batch",
+    );
+
+    store
+        .lock()
+        .unwrap()
+        .execute_batch("DROP TRIGGER fail_created_chat_list_visibility_row")
+        .unwrap();
+    let committed = save().unwrap().expect("created chat-list row");
+
+    assert_eq!(store.chat_list_row(GROUP).unwrap(), Some(committed));
+    assert_eq!(
+        store
+            .load_account_projection_state("alice", 256)
+            .unwrap()
+            .groups,
+        state.groups,
+    );
+    assert_eq!(store.local_group_deletion_frontier(GROUP).unwrap(), None);
+    assert_eq!(
+        pending_application_event_count(),
+        0,
+        "success must acknowledge the application event with the created row",
+    );
+    assert_eq!(
+        visibility_batch_ids(),
+        vec![retained_batch_id],
+        "success must delete exactly the passed visibility batch",
+    );
+}
+
+#[test]
+fn missing_created_chat_list_row_rolls_back_projection_and_outbox_acks() {
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    let missing_group_id_hex = "22";
+    let application_event_id = MessageId::new(vec![0x43; 32]);
+    let visibility_batch_id = b"missing-created-chat-visibility-batch".to_vec();
+    store
+        .lock()
+        .unwrap()
+        .execute(
+            "INSERT INTO pending_application_events
+                (message_id, group_id, message_insert_order, record)
+             VALUES (?1, ?2, 1, ?3)",
+            params![
+                application_event_id.as_slice(),
+                &[0x22_u8],
+                b"opaque-pending-application-event",
+            ],
+        )
+        .unwrap();
+    store
+        .upsert_account_visibility_journal(
+            b"missing-created-chat-operation",
+            1,
+            &visibility_batch_id,
+            b"missing-created-chat-effects",
+        )
+        .unwrap();
+    let state = StoredAccountState {
+        label: "alice".to_owned(),
+        groups: vec![group()],
+        ..StoredAccountState::default()
+    };
+
+    let error = store
+        .save_account_projection_delta_and_refresh_chat_list_row_acking_application_events_and_visibility_batches(
+            &state,
+            256,
+            MAX_FUTURE_SKEW_SECS,
+            &[],
+            std::slice::from_ref(&application_event_id),
+            std::slice::from_ref(&visibility_batch_id),
+            LOCAL,
+            missing_group_id_hex,
+            &no_mentions,
+        )
+        .expect_err("a missing created-chat row must abort its enclosing transaction");
+
+    assert!(matches!(
+        error,
+        cgka_traits::storage::StorageError::NotFound
+    ));
+    assert!(
+        store
+            .load_account_projection_state("alice", 256)
+            .unwrap()
+            .groups
+            .is_empty(),
+        "the missing-row error must roll back the projection delta",
+    );
+    assert_eq!(store.chat_list_row(GROUP).unwrap(), None);
+    assert_eq!(
+        store
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT COUNT(*) FROM pending_application_events WHERE message_id = ?1",
+                params![application_event_id.as_slice()],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap(),
+        1,
+        "the missing-row error must roll back the application-event acknowledgement",
+    );
+    assert_eq!(
+        store
+            .load_account_visibility_journal()
+            .unwrap()
+            .into_iter()
+            .map(|row| row.batch_id)
+            .collect::<Vec<_>>(),
+        vec![visibility_batch_id],
+        "the missing-row error must roll back the visibility-batch deletion",
+    );
 }
 
 /// Operational mdk#1487 benchmark for the post-canonical app-local tail.
@@ -3519,6 +3756,7 @@ fn chat_list_rows_report_the_durable_leave_request_at_read_time() {
             group_id: group_id.clone(),
             requested_at_ms: 1_700_000_000_123,
             last_proposed_epoch: Some(EpochId(3)),
+            last_proposed_message_id: None,
         })
         .unwrap();
 

--- a/crates/storage-sqlite/src/epoch_backfill_intent_journal.rs
+++ b/crates/storage-sqlite/src/epoch_backfill_intent_journal.rs
@@ -1,0 +1,105 @@
+use crate::connection::retry_on_busy;
+use crate::{SqliteAccountStorage, SqliteResultExt};
+use cgka_traits::storage::StorageResult;
+use rusqlite::{OptionalExtension, params};
+
+impl SqliteAccountStorage {
+    /// Load the opaque, account-wide epoch-backfill intent journal.
+    ///
+    /// Serialization belongs to the app layer so storage-format changes do not
+    /// require this crate to understand the queued intent envelope.
+    pub fn load_epoch_backfill_intent_journal(&self) -> StorageResult<Option<Vec<u8>>> {
+        self.lock()?
+            .query_row(
+                "SELECT record FROM app_epoch_backfill_intent_journal WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .optional()
+            .storage()
+    }
+
+    /// Atomically replace the opaque, account-wide epoch-backfill intent
+    /// journal.
+    pub fn store_epoch_backfill_intent_journal(&self, record: &[u8]) -> StorageResult<()> {
+        self.write_epoch_backfill_intent_journal(|| {
+            self.lock()?
+                .execute(
+                    "INSERT INTO app_epoch_backfill_intent_journal (singleton, record)
+                     VALUES (1, ?1)
+                     ON CONFLICT(singleton) DO UPDATE SET record = excluded.record",
+                    params![record],
+                )
+                .storage()?;
+            Ok(())
+        })
+    }
+
+    /// Clear the account-wide epoch-backfill intent journal, if present.
+    pub fn clear_epoch_backfill_intent_journal(&self) -> StorageResult<()> {
+        self.write_epoch_backfill_intent_journal(|| {
+            self.lock()?
+                .execute(
+                    "DELETE FROM app_epoch_backfill_intent_journal WHERE singleton = 1",
+                    [],
+                )
+                .storage()?;
+            Ok(())
+        })
+    }
+
+    fn write_epoch_backfill_intent_journal<T>(
+        &self,
+        op: impl Fn() -> StorageResult<T>,
+    ) -> StorageResult<T> {
+        if self.connection.is_current_thread_transaction_owner() {
+            op()
+        } else {
+            retry_on_busy(op)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn journal_round_trips_overwrites_and_clears_opaque_bytes() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        assert_eq!(store.load_epoch_backfill_intent_journal().unwrap(), None);
+
+        let first = [0_u8, 0xff, 0x80, 0x00, b'{'];
+        store.store_epoch_backfill_intent_journal(&first).unwrap();
+        assert_eq!(
+            store.load_epoch_backfill_intent_journal().unwrap(),
+            Some(first.to_vec())
+        );
+
+        let replacement = [9_u8, 8, 7];
+        store
+            .store_epoch_backfill_intent_journal(&replacement)
+            .unwrap();
+        assert_eq!(
+            store.load_epoch_backfill_intent_journal().unwrap(),
+            Some(replacement.to_vec()),
+            "the singleton upsert must replace, not append to, the journal"
+        );
+
+        store.clear_epoch_backfill_intent_journal().unwrap();
+        assert_eq!(store.load_epoch_backfill_intent_journal().unwrap(), None);
+        store.clear_epoch_backfill_intent_journal().unwrap();
+    }
+
+    #[test]
+    fn journal_preserves_an_explicit_empty_blob() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        store.store_epoch_backfill_intent_journal(&[]).unwrap();
+
+        assert_eq!(
+            store.load_epoch_backfill_intent_journal().unwrap(),
+            Some(Vec::new()),
+            "an empty opaque record is occupied state, not an absent journal"
+        );
+    }
+}

--- a/crates/storage-sqlite/src/lib.rs
+++ b/crates/storage-sqlite/src/lib.rs
@@ -6,11 +6,13 @@
 //! layers.
 
 mod account_projection;
+mod account_visibility_journal;
 mod agent_stream_sequences;
 mod chat_list;
 mod codec;
 mod connection;
 mod encrypted_media_secrets;
+mod epoch_backfill_intent_journal;
 mod message_drafts;
 mod migrations;
 mod openmls_storage;
@@ -29,6 +31,7 @@ pub use account_projection::{
     StoredAppMessageQuery, StoredAppMessageRecord, StoredEpochBackfillIntent,
     StoredEpochStallEvidence, StoredNostrRoute, clamp_to_max_future_skew,
 };
+pub use account_visibility_journal::{AccountVisibilityJournalRow, AccountVisibilityJournalUpsert};
 pub use chat_list::{
     AccountUnreadTotal, ChatConversationKind, ChatListAttachmentKind, ChatListAvatar,
     ChatListMessageDeliveryState, ChatListMessagePreview, ChatListQuery, ChatListRow, ChatPinError,

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -108,6 +108,12 @@ mod migration_0053_account_delivery_recovery;
 mod migration_0054_transport_reconciliation_items;
 #[path = "migrations/0055_epoch_stall_evidence.rs"]
 mod migration_0055_epoch_stall_evidence;
+#[path = "migrations/0056_key_package_lifecycle_privacy_journal.rs"]
+mod migration_0056_key_package_lifecycle_privacy_journal;
+#[path = "migrations/0057_epoch_backfill_intent_journal.rs"]
+mod migration_0057_epoch_backfill_intent_journal;
+#[path = "migrations/0058_account_visibility_journal.rs"]
+mod migration_0058_account_visibility_journal;
 #[cfg(test)]
 #[path = "migrations/test_support.rs"]
 mod test_support;
@@ -398,6 +404,21 @@ const MIGRATIONS: &[Migration] = &[
         name: "0055_epoch_stall_evidence",
         apply: migration_0055_epoch_stall_evidence::apply,
     },
+    Migration {
+        version: 56,
+        name: "0056_key_package_lifecycle_privacy_journal",
+        apply: migration_0056_key_package_lifecycle_privacy_journal::apply,
+    },
+    Migration {
+        version: 57,
+        name: "0057_epoch_backfill_intent_journal",
+        apply: migration_0057_epoch_backfill_intent_journal::apply,
+    },
+    Migration {
+        version: 58,
+        name: "0058_account_visibility_journal",
+        apply: migration_0058_account_visibility_journal::apply,
+    },
 ];
 
 pub(crate) fn run_all(connection: &mut Connection) -> StorageResult<()> {
@@ -604,8 +625,9 @@ mod tests {
         SqlCipherHardening, SqlCipherKey, SqliteAccountStorage, epoch_to_i64, message_state_to_i64,
         open_hardened_sqlcipher, serialize,
     };
+    use cgka_traits::maintenance::KeyPackageLifecycleState;
     use cgka_traits::message::{MessageRecord, MessageState, StoredMessagePayload};
-    use cgka_traits::storage::{GroupStorage, MessageStorage};
+    use cgka_traits::storage::{GroupStorage, MaintenanceStorage, MessageStorage};
     use cgka_traits::transport::{Timestamp, TransportEnvelope, TransportMessage, TransportSource};
     use std::io::{Read, Write};
     use std::path::Path;
@@ -621,6 +643,10 @@ mod tests {
     const TEST_DATABASE_KEY: &str = "storage format migration crash key";
     const V0_9_12_FIXTURE_KEY: &str = "mdk storage v1 fixture key";
     const V0_9_12_FIXTURE: &[u8] = include_bytes!("../fixtures/storage-v1-v0.9.12.bin");
+    const KEY_PACKAGE_PRIVACY_JOURNAL_TRIGGERS: [&str; 2] = [
+        "cgka_key_package_lifecycle_privacy_journal_insert",
+        "cgka_key_package_lifecycle_privacy_journal_update",
+    ];
 
     fn applied_migrations(store: &SqliteAccountStorage) -> Vec<(i64, String)> {
         let conn = store.lock().unwrap();
@@ -690,6 +716,58 @@ mod tests {
             .collect();
         drop(connection);
         messages
+    }
+
+    fn schema_51_key_package_lifecycle_record() -> Vec<u8> {
+        let mut record =
+            serde_json::to_value(KeyPackageLifecycleState::slot_only("slot".into())).unwrap();
+        let fields = record.as_object_mut().unwrap();
+        fields.remove("cutover_publication_blocked");
+        fields.remove("deleted_live_revision_event_ids");
+        fields.remove("deletion_overflow_owner_event_id");
+        fields.remove("retired_publications_pending_deletion");
+        fields.remove("consumed_key_package_refs");
+        serde_json::to_vec(&record).unwrap()
+    }
+
+    fn seed_file_backed_schema_51_key_package_lifecycle(path: &Path) -> Vec<u8> {
+        let mut connection = keyed_connection(path);
+        run(&mut connection, &MIGRATIONS[..51]).unwrap();
+        let record = schema_51_key_package_lifecycle_record();
+        connection
+            .execute(
+                "INSERT INTO cgka_key_package_lifecycle (singleton, record) VALUES (1, ?1)",
+                params![record.as_slice()],
+            )
+            .unwrap();
+        connection
+            .execute_batch("PRAGMA wal_checkpoint(TRUNCATE)")
+            .unwrap();
+        drop(connection);
+        record
+    }
+
+    fn key_package_privacy_journal_triggers(connection: &rusqlite::Connection) -> Vec<String> {
+        let mut statement = connection
+            .prepare(
+                "SELECT name
+                   FROM sqlite_schema
+                  WHERE type = 'trigger'
+                    AND name IN (?1, ?2)
+                  ORDER BY name",
+            )
+            .unwrap();
+        statement
+            .query_map(
+                params![
+                    KEY_PACKAGE_PRIVACY_JOURNAL_TRIGGERS[0],
+                    KEY_PACKAGE_PRIVACY_JOURNAL_TRIGGERS[1]
+                ],
+                |row| row.get(0),
+            )
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
     }
 
     fn benchmark_message_id(index: usize) -> cgka_traits::MessageId {
@@ -902,6 +980,36 @@ mod tests {
     }
 
     #[test]
+    fn key_package_privacy_journal_migration_refuses_schema_51_writer() {
+        let mut connection = rusqlite::Connection::open_in_memory().unwrap();
+        run(&mut connection, &MIGRATIONS[..56]).unwrap();
+        let privacy_journal = br#"{"stable_slot_id":"slot","cutover_publication_blocked":true,"deleted_live_revision_event_ids":[[1,2,3]],"deletion_overflow_owner_event_id":[4,5,6],"retired_publications_pending_deletion":[{"event_id":[4,5,6]}],"consumed_key_package_refs":[[7,8,9]]}"#;
+        connection
+            .execute(
+                "INSERT INTO cgka_key_package_lifecycle (singleton, record) VALUES (1, ?1)",
+                params![privacy_journal.as_slice()],
+            )
+            .unwrap();
+
+        let error = run(&mut connection, &MIGRATIONS[..55]).unwrap_err();
+        assert!(matches!(
+            error,
+            StorageError::UnsupportedSchemaVersion {
+                found: 56,
+                latest_supported: 55,
+            }
+        ));
+        let retained: Vec<u8> = connection
+            .query_row(
+                "SELECT record FROM cgka_key_package_lifecycle WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(retained, privacy_journal);
+    }
+
+    #[test]
     fn file_backed_v1_database_upgrades_once_and_refuses_downgrade() {
         let directory = tempfile::tempdir().unwrap();
         let database = directory.path().join("v1-upgrade.sqlite3");
@@ -922,13 +1030,19 @@ mod tests {
             .query_row("SELECT count(*) FROM cgka_messages", [], |row| row.get(0))
             .unwrap();
         let error = run(&mut older_connection, &MIGRATIONS[..46]).unwrap_err();
-        assert!(matches!(
-            error,
+        match error {
             StorageError::UnsupportedSchemaVersion {
-                found: 55,
+                found,
                 latest_supported: 46,
-            }
-        ));
+            } => assert_eq!(
+                found,
+                MIGRATIONS
+                    .last()
+                    .expect("migration registry is nonempty")
+                    .version
+            ),
+            other => panic!("expected downgrade refusal, got {other:?}"),
+        }
         let after: i64 = older_connection
             .query_row("SELECT count(*) FROM cgka_messages", [], |row| row.get(0))
             .unwrap();
@@ -978,13 +1092,19 @@ mod tests {
             connection
         };
         let error = run(&mut older_connection, &MIGRATIONS[..46]).unwrap_err();
-        assert!(matches!(
-            error,
+        match error {
             StorageError::UnsupportedSchemaVersion {
-                found: 55,
+                found,
                 latest_supported: 46,
-            }
-        ));
+            } => assert_eq!(
+                found,
+                MIGRATIONS
+                    .last()
+                    .expect("migration registry is nonempty")
+                    .version
+            ),
+            other => panic!("expected downgrade refusal, got {other:?}"),
+        }
     }
 
     #[test]
@@ -1138,6 +1258,114 @@ mod tests {
     }
 
     #[test]
+    fn process_kill_mid_key_package_privacy_migration_retries_fail_closed() {
+        let directory = tempfile::tempdir().unwrap();
+        let database = directory
+            .path()
+            .join("key-package-privacy-migration-kill.sqlite3");
+        let schema_51_record = seed_file_backed_schema_51_key_package_lifecycle(&database);
+
+        kill_child_at(
+            "migrations::tests::storage_format_migration_crash_child",
+            "migration",
+            "MDK_STORAGE_TEST_MIGRATION_CRASH_VERSION",
+            "56",
+            &database,
+            "migration-56",
+        );
+
+        let connection = keyed_connection(&database);
+        assert_eq!(applied_name(&connection, 56).unwrap(), None);
+        let rolled_back_record: Vec<u8> = connection
+            .query_row(
+                "SELECT record FROM cgka_key_package_lifecycle WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(rolled_back_record, schema_51_record);
+        let rolled_back_json: serde_json::Value =
+            serde_json::from_slice(&rolled_back_record).unwrap();
+        for field in [
+            "cutover_publication_blocked",
+            "deleted_live_revision_event_ids",
+            "deletion_overflow_owner_event_id",
+            "retired_publications_pending_deletion",
+            "consumed_key_package_refs",
+        ] {
+            assert!(
+                rolled_back_json.get(field).is_none(),
+                "killed migration must roll back the {field} backfill"
+            );
+        }
+        assert!(key_package_privacy_journal_triggers(&connection).is_empty());
+        drop(connection);
+
+        let key = SqlCipherKey::new(TEST_DATABASE_KEY).unwrap();
+        let store = SqliteAccountStorage::open_encrypted(&database, &key).unwrap();
+        let lifecycle = store.key_package_lifecycle().unwrap().unwrap();
+        assert!(
+            lifecycle.cutover_publication_blocked,
+            "an upgraded schema-51 lifecycle must remain fail-closed until relay cutover completes"
+        );
+        assert!(lifecycle.deleted_live_revision_event_ids.is_empty());
+        assert!(lifecycle.deletion_overflow_owner_event_id.is_none());
+        assert!(lifecycle.retired_publications_pending_deletion.is_empty());
+        assert!(lifecycle.consumed_key_package_refs.is_empty());
+
+        let connection = store.lock().unwrap();
+        assert_eq!(
+            applied_name(&connection, 56).unwrap().as_deref(),
+            Some("0056_key_package_lifecycle_privacy_journal")
+        );
+        let migration_count: i64 = connection
+            .query_row(
+                "SELECT count(*) FROM cgka_schema_migrations WHERE version = 56",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(migration_count, 1);
+        assert_eq!(
+            key_package_privacy_journal_triggers(&connection),
+            KEY_PACKAGE_PRIVACY_JOURNAL_TRIGGERS.map(str::to_owned)
+        );
+        let storage_type: String = connection
+            .query_row(
+                "SELECT typeof(record) FROM cgka_key_package_lifecycle WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(storage_type, "blob");
+        let upgraded_record: Vec<u8> = connection
+            .query_row(
+                "SELECT record FROM cgka_key_package_lifecycle WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let upgraded_json: serde_json::Value = serde_json::from_slice(&upgraded_record).unwrap();
+        assert_eq!(
+            upgraded_json.get("cutover_publication_blocked"),
+            Some(&serde_json::json!(true))
+        );
+        for field in [
+            "deleted_live_revision_event_ids",
+            "deletion_overflow_owner_event_id",
+            "retired_publications_pending_deletion",
+            "consumed_key_package_refs",
+        ] {
+            let expected = if field == "deletion_overflow_owner_event_id" {
+                serde_json::Value::Null
+            } else {
+                serde_json::json!([])
+            };
+            assert_eq!(upgraded_json.get(field), Some(&expected));
+        }
+    }
+
+    #[test]
     fn process_kill_mid_promotion_rolls_back_and_retry_converges() {
         let directory = tempfile::tempdir().unwrap();
         let database = directory.path().join("promotion-kill.sqlite3");
@@ -1282,13 +1510,19 @@ mod tests {
         run(&mut connection, MIGRATIONS).unwrap();
 
         let error = run(&mut connection, &MIGRATIONS[..46]).unwrap_err();
-        assert!(matches!(
-            error,
+        match error {
             StorageError::UnsupportedSchemaVersion {
-                found: 55,
+                found,
                 latest_supported: 46,
-            }
-        ));
+            } => assert_eq!(
+                found,
+                MIGRATIONS
+                    .last()
+                    .expect("migration registry is nonempty")
+                    .version
+            ),
+            other => panic!("expected downgrade refusal, got {other:?}"),
+        }
         assert_eq!(
             applied_migrations_from_connection(&connection),
             expected_migrations(),

--- a/crates/storage-sqlite/src/migrations/0056_key_package_lifecycle_privacy_journal.rs
+++ b/crates/storage-sqlite/src/migrations/0056_key_package_lifecycle_privacy_journal.rs
@@ -1,0 +1,264 @@
+use crate::SqliteResultExt;
+use cgka_traits::storage::StorageResult;
+use rusqlite::Transaction;
+
+/// Compatibility fence for privacy-critical fields added to the serialized
+/// `cgka_key_package_lifecycle.record` value.
+///
+/// Schema-51 readers deserialize that JSON permissively and would discard the
+/// exact deletion, overflow-owner, and multi-consumption journals on their
+/// next write. The
+/// migration-runner version check rejects an older binary that opens after this
+/// migration. These triggers additionally reject a schema-51 writer that was
+/// already connected while a newer process applied the migration.
+pub(crate) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
+    tx.execute_batch(
+        r#"
+UPDATE cgka_key_package_lifecycle
+SET record = CAST(
+    json_set(
+        json_insert(
+            CAST(record AS TEXT),
+            '$.deleted_live_revision_event_ids', json('[]'),
+            '$.deletion_overflow_owner_event_id', json('null'),
+            '$.retired_publications_pending_deletion', json('[]'),
+            '$.consumed_key_package_refs', json('[]')
+        ),
+        -- Every schema-51 row predates the relay cutover proof, including a
+        -- development/backport row that already serialized `false`. Force the
+        -- gate closed while preserving any journals it already carries.
+        '$.cutover_publication_blocked', json('true')
+    ) AS BLOB
+)
+WHERE singleton = 1;
+
+CREATE TRIGGER cgka_key_package_lifecycle_privacy_journal_insert
+BEFORE INSERT ON cgka_key_package_lifecycle
+WHEN CASE
+    WHEN json_valid(CAST(NEW.record AS TEXT)) = 0 THEN 1
+    WHEN json_type(CAST(NEW.record AS TEXT), '$') IS NOT 'object' THEN 1
+    WHEN json_type(CAST(NEW.record AS TEXT), '$.cutover_publication_blocked') IS NOT 'false'
+         AND json_type(CAST(NEW.record AS TEXT), '$.cutover_publication_blocked') IS NOT 'true' THEN 1
+    WHEN json_type(CAST(NEW.record AS TEXT), '$.deleted_live_revision_event_ids') IS NOT 'array' THEN 1
+    WHEN json_type(CAST(NEW.record AS TEXT), '$.deletion_overflow_owner_event_id') IS NOT 'null'
+         AND json_type(CAST(NEW.record AS TEXT), '$.deletion_overflow_owner_event_id') IS NOT 'array' THEN 1
+    WHEN json_type(CAST(NEW.record AS TEXT), '$.retired_publications_pending_deletion') IS NOT 'array' THEN 1
+    WHEN json_type(CAST(NEW.record AS TEXT), '$.consumed_key_package_refs') IS NOT 'array' THEN 1
+    ELSE 0
+END
+BEGIN
+    SELECT RAISE(ABORT, 'key package lifecycle privacy journals are required');
+END;
+
+CREATE TRIGGER cgka_key_package_lifecycle_privacy_journal_update
+BEFORE UPDATE OF record ON cgka_key_package_lifecycle
+WHEN CASE
+    WHEN json_valid(CAST(NEW.record AS TEXT)) = 0 THEN 1
+    WHEN json_type(CAST(NEW.record AS TEXT), '$') IS NOT 'object' THEN 1
+    WHEN json_type(CAST(NEW.record AS TEXT), '$.cutover_publication_blocked') IS NOT 'false'
+         AND json_type(CAST(NEW.record AS TEXT), '$.cutover_publication_blocked') IS NOT 'true' THEN 1
+    WHEN json_type(CAST(NEW.record AS TEXT), '$.deleted_live_revision_event_ids') IS NOT 'array' THEN 1
+    WHEN json_type(CAST(NEW.record AS TEXT), '$.deletion_overflow_owner_event_id') IS NOT 'null'
+         AND json_type(CAST(NEW.record AS TEXT), '$.deletion_overflow_owner_event_id') IS NOT 'array' THEN 1
+    WHEN json_type(CAST(NEW.record AS TEXT), '$.retired_publications_pending_deletion') IS NOT 'array' THEN 1
+    WHEN json_type(CAST(NEW.record AS TEXT), '$.consumed_key_package_refs') IS NOT 'array' THEN 1
+    ELSE 0
+END
+BEGIN
+    SELECT RAISE(ABORT, 'key package lifecycle privacy journals are required');
+END;
+
+-- Validate the upgraded row through the same guard. This is deliberately an
+-- identity update: valid existing bytes stay byte-for-byte unchanged.
+UPDATE cgka_key_package_lifecycle
+SET record = record
+WHERE singleton = 1;
+"#,
+    )
+    .storage()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::migrations::{MIGRATIONS, run};
+    use cgka_traits::{
+        KeyPackageLifecycleState, MessageId, RetiredKeyPackagePublication, Timestamp,
+    };
+    use rusqlite::{Connection, OptionalExtension, params};
+
+    fn schema_51_lifecycle_record() -> Vec<u8> {
+        let mut record = serde_json::to_value(KeyPackageLifecycleState::slot_only("slot".into()))
+            .expect("serialize lifecycle fixture");
+        let fields = record.as_object_mut().expect("lifecycle is an object");
+        fields.remove("cutover_publication_blocked");
+        fields.remove("deleted_live_revision_event_ids");
+        fields.remove("deletion_overflow_owner_event_id");
+        fields.remove("retired_publications_pending_deletion");
+        fields.remove("consumed_key_package_refs");
+        serde_json::to_vec(&record).expect("serialize schema-51 lifecycle fixture")
+    }
+
+    fn privacy_journal_lifecycle_record() -> Vec<u8> {
+        let mut lifecycle = KeyPackageLifecycleState::slot_only("slot".into());
+        lifecycle.cutover_publication_blocked = true;
+        lifecycle
+            .deleted_live_revision_event_ids
+            .push(MessageId::new(vec![1, 2, 3]));
+        lifecycle.deletion_overflow_owner_event_id = Some(MessageId::new(vec![4, 5, 6]));
+        lifecycle
+            .retired_publications_pending_deletion
+            .push(RetiredKeyPackagePublication {
+                event_id: MessageId::new(vec![4, 5, 6]),
+                authored_created_at: Timestamp(7),
+                key_package_ref: Some(vec![8]),
+                package_not_after: Some(Timestamp(9)),
+                delete_without_successor: true,
+                deletion_targets: Vec::new(),
+            });
+        lifecycle.consumed_key_package_refs.push(vec![10, 11]);
+        serde_json::to_vec(&lifecycle).expect("serialize lifecycle privacy journal fixture")
+    }
+
+    #[test]
+    fn migration_forces_an_existing_false_gate_without_replacing_privacy_journals() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        run(&mut connection, &MIGRATIONS[..51]).unwrap();
+        let mut before: serde_json::Value =
+            serde_json::from_slice(&privacy_journal_lifecycle_record()).unwrap();
+        before["cutover_publication_blocked"] = serde_json::json!(false);
+        let before_bytes = serde_json::to_vec(&before).unwrap();
+        connection
+            .execute(
+                "INSERT INTO cgka_key_package_lifecycle (singleton, record) VALUES (1, ?1)",
+                params![before_bytes],
+            )
+            .unwrap();
+
+        run(&mut connection, MIGRATIONS).unwrap();
+        let after: Vec<u8> = connection
+            .query_row(
+                "SELECT record FROM cgka_key_package_lifecycle WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let after: serde_json::Value = serde_json::from_slice(&after).unwrap();
+        assert_eq!(
+            after.get("cutover_publication_blocked"),
+            Some(&serde_json::json!(true))
+        );
+        for field in [
+            "deleted_live_revision_event_ids",
+            "deletion_overflow_owner_event_id",
+            "retired_publications_pending_deletion",
+            "consumed_key_package_refs",
+        ] {
+            assert_eq!(
+                after.get(field),
+                before.get(field),
+                "{field} must be preserved"
+            );
+        }
+    }
+
+    #[test]
+    fn migration_guards_blob_json_from_already_open_schema_51_writer() {
+        let directory = tempfile::tempdir().unwrap();
+        let database = directory.path().join("schema-51-open-writer.sqlite3");
+        let mut old_writer = Connection::open(&database).unwrap();
+        run(&mut old_writer, &MIGRATIONS[..51]).unwrap();
+        old_writer
+            .execute(
+                "INSERT INTO cgka_key_package_lifecycle (singleton, record) VALUES (1, ?1)",
+                params![schema_51_lifecycle_record()],
+            )
+            .unwrap();
+
+        let mut new_writer = Connection::open(&database).unwrap();
+        run(&mut new_writer, MIGRATIONS).unwrap();
+        let upgraded: Vec<u8> = new_writer
+            .query_row(
+                "SELECT record FROM cgka_key_package_lifecycle WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            new_writer
+                .query_row(
+                    "SELECT typeof(record) FROM cgka_key_package_lifecycle WHERE singleton = 1",
+                    [],
+                    |row| row.get::<_, String>(0),
+                )
+                .unwrap(),
+            "blob",
+            "JSON1 backfill must preserve the encrypted table's BLOB representation"
+        );
+        let upgraded: serde_json::Value = serde_json::from_slice(&upgraded).unwrap();
+        for field in [
+            "cutover_publication_blocked",
+            "deleted_live_revision_event_ids",
+            "deletion_overflow_owner_event_id",
+            "retired_publications_pending_deletion",
+            "consumed_key_package_refs",
+        ] {
+            let expected = match field {
+                "cutover_publication_blocked" => serde_json::json!(true),
+                "deletion_overflow_owner_event_id" => serde_json::Value::Null,
+                _ => serde_json::json!([]),
+            };
+            assert_eq!(upgraded.get(field), Some(&expected));
+        }
+
+        let privacy_record = privacy_journal_lifecycle_record();
+        new_writer
+            .execute(
+                "UPDATE cgka_key_package_lifecycle SET record = ?1 WHERE singleton = 1",
+                params![privacy_record.as_slice()],
+            )
+            .unwrap();
+
+        let error = old_writer
+            .execute(
+                "INSERT INTO cgka_key_package_lifecycle (singleton, record) VALUES (1, ?1)
+                 ON CONFLICT(singleton) DO UPDATE SET record = excluded.record",
+                params![schema_51_lifecycle_record()],
+            )
+            .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("key package lifecycle privacy journals are required")
+        );
+        let retained: Vec<u8> = new_writer
+            .query_row(
+                "SELECT record FROM cgka_key_package_lifecycle WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(retained, privacy_record);
+
+        new_writer
+            .execute("DELETE FROM cgka_key_package_lifecycle", [])
+            .unwrap();
+        assert!(
+            old_writer
+                .execute(
+                    "INSERT INTO cgka_key_package_lifecycle (singleton, record) VALUES (1, ?1)",
+                    params![schema_51_lifecycle_record()],
+                )
+                .is_err(),
+            "the insert guard must reject an old-shaped row too"
+        );
+        let absent: Option<Vec<u8>> = new_writer
+            .query_row(
+                "SELECT record FROM cgka_key_package_lifecycle WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .optional()
+            .unwrap();
+        assert!(absent.is_none());
+    }
+}

--- a/crates/storage-sqlite/src/migrations/0057_epoch_backfill_intent_journal.rs
+++ b/crates/storage-sqlite/src/migrations/0057_epoch_backfill_intent_journal.rs
@@ -1,0 +1,111 @@
+//! Migration 0057: durable per-account epoch-backfill intent state.
+
+use crate::SqliteResultExt;
+use cgka_traits::storage::StorageResult;
+use rusqlite::Transaction;
+
+pub(crate) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
+    tx.execute_batch(
+        r#"
+CREATE TABLE app_epoch_backfill_intent_journal (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    record BLOB NOT NULL
+);
+"#,
+    )
+    .storage()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::migrations::{MIGRATIONS, run};
+    use cgka_traits::storage::StorageError;
+    use rusqlite::{Connection, OptionalExtension, params};
+
+    #[test]
+    fn migration_adds_an_empty_singleton_blob_journal_after_schema_56() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        run(&mut connection, &MIGRATIONS[..56]).unwrap();
+        let absent: Option<String> = connection
+            .query_row(
+                "SELECT name FROM sqlite_schema
+                 WHERE type = 'table' AND name = 'app_epoch_backfill_intent_journal'",
+                [],
+                |row| row.get(0),
+            )
+            .optional()
+            .unwrap();
+        assert_eq!(absent, None);
+
+        run(&mut connection, &MIGRATIONS[..57]).unwrap();
+
+        let initial: Option<Vec<u8>> = connection
+            .query_row(
+                "SELECT record FROM app_epoch_backfill_intent_journal WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .optional()
+            .unwrap();
+        assert_eq!(initial, None, "migration must not synthesize an intent");
+
+        let opaque = [0_u8, 0xff, 0x80, 0x00];
+        connection
+            .execute(
+                "INSERT INTO app_epoch_backfill_intent_journal (singleton, record)
+                 VALUES (1, ?1)",
+                params![opaque.as_slice()],
+            )
+            .unwrap();
+        let stored: Vec<u8> = connection
+            .query_row(
+                "SELECT record FROM app_epoch_backfill_intent_journal WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(stored, opaque);
+
+        assert!(
+            connection
+                .execute(
+                    "INSERT INTO app_epoch_backfill_intent_journal (singleton, record)
+                     VALUES (2, ?1)",
+                    params![opaque.as_slice()],
+                )
+                .is_err(),
+            "the per-account journal must admit only its singleton row"
+        );
+    }
+
+    #[test]
+    fn schema_56_runner_refuses_a_journal_database_without_mutating_the_blob() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        run(&mut connection, &MIGRATIONS[..57]).unwrap();
+        let opaque = [0_u8, 0xff, 0x80, 0x00];
+        connection
+            .execute(
+                "INSERT INTO app_epoch_backfill_intent_journal (singleton, record)
+                 VALUES (1, ?1)",
+                params![opaque.as_slice()],
+            )
+            .unwrap();
+
+        let error = run(&mut connection, &MIGRATIONS[..56]).unwrap_err();
+        assert!(matches!(
+            error,
+            StorageError::UnsupportedSchemaVersion {
+                found: 57,
+                latest_supported: 56,
+            }
+        ));
+        let retained: Vec<u8> = connection
+            .query_row(
+                "SELECT record FROM app_epoch_backfill_intent_journal WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(retained, opaque);
+    }
+}

--- a/crates/storage-sqlite/src/migrations/0058_account_visibility_journal.rs
+++ b/crates/storage-sqlite/src/migrations/0058_account_visibility_journal.rs
@@ -1,0 +1,112 @@
+//! Migration 0058: durable ordered account-runtime visibility outbox.
+
+use crate::SqliteResultExt;
+use cgka_traits::storage::StorageResult;
+use rusqlite::Transaction;
+
+pub(crate) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
+    tx.execute_batch(
+        r#"
+CREATE TABLE account_visibility_journal (
+    sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+    operation_id BLOB NOT NULL CHECK (length(operation_id) > 0),
+    ordinal INTEGER NOT NULL CHECK (ordinal >= 0),
+    batch_id BLOB NOT NULL UNIQUE CHECK (length(batch_id) > 0),
+    record BLOB NOT NULL,
+    UNIQUE (operation_id, ordinal)
+);
+"#,
+    )
+    .storage()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::migrations::{MIGRATIONS, run};
+    use cgka_traits::storage::StorageError;
+    use rusqlite::{Connection, OptionalExtension, params};
+
+    #[test]
+    fn migration_adds_an_empty_ordered_visibility_journal_after_schema_57() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        run(&mut connection, &MIGRATIONS[..57]).unwrap();
+        let absent: Option<String> = connection
+            .query_row(
+                "SELECT name FROM sqlite_schema
+                 WHERE type = 'table' AND name = 'account_visibility_journal'",
+                [],
+                |row| row.get(0),
+            )
+            .optional()
+            .unwrap();
+        assert_eq!(absent, None);
+
+        run(&mut connection, MIGRATIONS).unwrap();
+        let initial: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM account_visibility_journal",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(initial, 0, "migration must not synthesize visibility");
+
+        let operation = [0_u8, 0xff, 0x80];
+        let batch = [9_u8, 0, 8];
+        let record = [7_u8, 0xff, 6, 0];
+        connection
+            .execute(
+                "INSERT INTO account_visibility_journal
+                    (operation_id, ordinal, batch_id, record)
+                 VALUES (?1, 0, ?2, ?3)",
+                params![operation.as_slice(), batch.as_slice(), record.as_slice()],
+            )
+            .unwrap();
+        let stored: (Vec<u8>, i64, Vec<u8>, Vec<u8>) = connection
+            .query_row(
+                "SELECT operation_id, ordinal, batch_id, record
+                 FROM account_visibility_journal",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            stored,
+            (operation.to_vec(), 0, batch.to_vec(), record.to_vec())
+        );
+    }
+
+    #[test]
+    fn schema_57_runner_refuses_a_visibility_journal_database_without_mutating_rows() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        run(&mut connection, MIGRATIONS).unwrap();
+        let operation = [1_u8, 2, 3];
+        let batch = [4_u8, 5, 6];
+        let record = [0_u8, 0xff, 0x80, 0x00];
+        connection
+            .execute(
+                "INSERT INTO account_visibility_journal
+                    (operation_id, ordinal, batch_id, record)
+                 VALUES (?1, 0, ?2, ?3)",
+                params![operation.as_slice(), batch.as_slice(), record.as_slice()],
+            )
+            .unwrap();
+
+        let error = run(&mut connection, &MIGRATIONS[..57]).unwrap_err();
+        assert!(matches!(
+            error,
+            StorageError::UnsupportedSchemaVersion {
+                found: 58,
+                latest_supported: 57,
+            }
+        ));
+        let retained: Vec<u8> = connection
+            .query_row(
+                "SELECT record FROM account_visibility_journal WHERE batch_id = ?1",
+                params![batch.as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(retained, record);
+    }
+}

--- a/crates/storage-sqlite/src/shared.rs
+++ b/crates/storage-sqlite/src/shared.rs
@@ -257,6 +257,33 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
         Ok(Some(record))
     }
 
+    /// Remove one exact cached KeyPackage projection without disturbing the
+    /// identity's public profile, relay lists, follow edges, or their generic
+    /// event provenance.
+    ///
+    /// `expected_key_package_json` makes this a compare-and-swap: a sibling
+    /// device may publish under a different NIP-33 `d` slot while a removed
+    /// local slot is being scrubbed, and that newer projection must survive.
+    pub fn clear_public_directory_key_package_if_matches(
+        &self,
+        account_id_hex: &str,
+        expected_key_package_json: &str,
+    ) -> StorageResult<bool> {
+        retry_on_busy(|| {
+            let conn = self.lock()?;
+            let changed = conn
+                .execute(
+                    "UPDATE directory_users
+                     SET key_package_json = NULL
+                     WHERE account_id_hex = ?1
+                       AND key_package_json = ?2",
+                    params![account_id_hex, expected_key_package_json],
+                )
+                .storage()?;
+            Ok(changed != 0)
+        })
+    }
+
     pub fn public_directory_users(&self) -> StorageResult<Vec<PublicDirectoryUserRecord>> {
         self.public_directory_users_capped(PUBLIC_DIRECTORY_USERS_MAX)
     }
@@ -620,6 +647,64 @@ mod tests {
                 .unwrap(),
             record
         );
+    }
+
+    #[test]
+    fn conditional_key_package_clear_preserves_public_identity_projection() {
+        let storage = SqliteSharedStorage::in_memory().unwrap();
+        let record = PublicDirectoryUserRecord {
+            account_id_hex: "aa".repeat(32),
+            npub: "npub1example".to_owned(),
+            profile_json: Some(r#"{"name":"Alice"}"#.to_owned()),
+            relay_lists_json: r#"{"nip65":["wss://relay.example"]}"#.to_owned(),
+            key_package_json: Some(r#"{"key_package_id":"removed-slot"}"#.to_owned()),
+            event_id_hex: Some("bb".repeat(32)),
+            // These columns describe the combined public-directory projection,
+            // not exclusively its KeyPackage. Use profile-like provenance so
+            // this regression catches a scrub that damages profile ordering.
+            event_kind: Some(0),
+            event_created_at: Some(1_700_000_000),
+            follows: vec!["cc".repeat(32)],
+        };
+        storage.put_public_directory_user(&record).unwrap();
+
+        assert!(
+            !storage
+                .clear_public_directory_key_package_if_matches(
+                    &record.account_id_hex,
+                    r#"{"key_package_id":"sibling-slot"}"#,
+                )
+                .unwrap(),
+            "a changed sibling-device projection must win the CAS"
+        );
+        assert_eq!(
+            storage
+                .public_directory_user(&record.account_id_hex)
+                .unwrap()
+                .unwrap(),
+            record
+        );
+
+        assert!(
+            storage
+                .clear_public_directory_key_package_if_matches(
+                    &record.account_id_hex,
+                    record.key_package_json.as_deref().unwrap(),
+                )
+                .unwrap()
+        );
+        let scrubbed = storage
+            .public_directory_user(&record.account_id_hex)
+            .unwrap()
+            .unwrap();
+        assert_eq!(scrubbed.npub, record.npub);
+        assert_eq!(scrubbed.profile_json, record.profile_json);
+        assert_eq!(scrubbed.relay_lists_json, record.relay_lists_json);
+        assert_eq!(scrubbed.follows, record.follows);
+        assert!(scrubbed.key_package_json.is_none());
+        assert_eq!(scrubbed.event_id_hex, record.event_id_hex);
+        assert_eq!(scrubbed.event_kind, record.event_kind);
+        assert_eq!(scrubbed.event_created_at, record.event_created_at);
     }
 
     #[test]

--- a/crates/storage-sqlite/src/storage/leave_requests.rs
+++ b/crates/storage-sqlite/src/storage/leave_requests.rs
@@ -104,6 +104,7 @@ mod tests {
             group_id: group.id.clone(),
             requested_at_ms: 42,
             last_proposed_epoch: Some(EpochId(3)),
+            last_proposed_message_id: None,
         };
         store.put_leave_request(&request).unwrap();
         assert_eq!(store.leave_request(&group.id).unwrap(), Some(request));

--- a/crates/traits/src/lib.rs
+++ b/crates/traits/src/lib.rs
@@ -87,10 +87,11 @@ pub use ingest::{
     ProposalRejectionCategory, StaleReason,
 };
 pub use maintenance::{
-    DurableGroupEvolution, DurableTransportFanout, GroupEvolutionPhase, GroupEvolutionSemantic,
-    GroupMaintenanceState, GroupMaintenanceStatus, KeyPackageLifecycleState, MaintenanceObligation,
-    MaintenancePhase, MaintenanceRandom, MaintenanceRunSummary, MaintenanceTrigger, MonotonicClock,
-    PendingKeyPackageReplacement, PeriodicMaintenancePolicy, RetainedKeyPackagePrivateMaterial,
+    ConsumedKeyPackageRefJournalFull, DurableGroupEvolution, DurableTransportFanout,
+    GroupEvolutionPhase, GroupEvolutionSemantic, GroupMaintenanceState, GroupMaintenanceStatus,
+    KeyPackageLifecycleState, MaintenanceObligation, MaintenancePhase, MaintenanceRandom,
+    MaintenanceRunSummary, MaintenanceTrigger, MonotonicClock, PendingKeyPackageReplacement,
+    PeriodicMaintenancePolicy, RetainedKeyPackagePrivateMaterial, RetiredKeyPackagePublication,
     SendMaintenanceDisposition, SignedPublicationArtifact, TransportFanoutAttemptState,
     TransportFanoutTarget, WallClock,
 };

--- a/crates/traits/src/maintenance.rs
+++ b/crates/traits/src/maintenance.rs
@@ -11,6 +11,36 @@ use crate::transport::{Timestamp, TransportMessage};
 use crate::transport_adapter::{TransportEndpoint, TransportPublishTarget};
 use crate::types::{EpochId, GroupId, MessageId};
 use serde::{Deserialize, Serialize};
+
+/// Maximum durable exact `(signed event id, relay endpoint)` liabilities held
+/// by one account-device KeyPackage lifecycle.
+pub const MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES: usize = 256;
+/// Additional exact endpoint liabilities reserved exclusively for atomically
+/// deleting one explicitly selected KeyPackage revision. An event id that is
+/// not projected as current/pending is still treated as potentially live for
+/// this purpose because the deletion API carries no stable-slot proof. The
+/// app's relay safety boundary caps one publication route at sixteen
+/// endpoints. Keeping the reserve separate means a full ordinary journal
+/// cannot force partial same-slot deletion, while discovery and new
+/// publication remain bound by
+/// [`MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES`].
+pub const MAX_KEY_PACKAGE_LIVE_DELETION_OVERFLOW_LIABILITIES: usize = 16;
+/// Absolute lifecycle bound while a live-revision deletion is in flight.
+pub const MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES_WITH_LIVE_DELETION_OVERFLOW: usize =
+    MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES
+        + MAX_KEY_PACKAGE_LIVE_DELETION_OVERFLOW_LIABILITIES;
+/// Maximum distinct consumed KeyPackage references awaiting account cleanup.
+/// The journal never evicts live evidence; a transaction that would exceed
+/// this cap fails closed before committing the Welcome.
+pub const MAX_CONSUMED_KEY_PACKAGE_REFS_PENDING_CLEANUP: usize = 256;
+
+/// The durable consumed-KeyPackage cleanup journal has no free slot.
+///
+/// Welcome processing must fail closed instead of evicting an older, still
+/// unswept consumption record.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+#[error("consumed KeyPackage cleanup journal is full")]
+pub struct ConsumedKeyPackageRefJournalFull;
 use std::time::Duration;
 
 pub const POST_JOIN_CONTENTION_JITTER_MAX_MS: u64 = 30_000;
@@ -219,8 +249,8 @@ pub struct DurableTransportFanout {
     pub bounded_until: Option<Timestamp>,
 }
 
-/// Transport-neutral exact signed artifact used for account-scoped
-/// replaceable events such as a KeyPackage publication.
+/// One exact signed revision of an account-scoped replaceable event such as a
+/// KeyPackage publication.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SignedPublicationArtifact {
     pub id: MessageId,
@@ -228,13 +258,45 @@ pub struct SignedPublicationArtifact {
     pub bytes: Vec<u8>,
 }
 
+/// A superseded signed KeyPackage revision that still has relay-side deletion
+/// work outstanding.
+///
+/// Reauthoring keeps the same replaceable-event coordinate, but a relay that
+/// accepted (or may ambiguously have accepted) the older event can retain that
+/// exact event id. Each endpoint remains listed until it explicitly
+/// acknowledges a deletion for `event_id`.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RetiredKeyPackagePublication {
+    pub event_id: MessageId,
+    pub authored_created_at: Timestamp,
+    /// Reference of the semantic MLS KeyPackage carried by this signed
+    /// revision. This lets consumption make every older transport revision of
+    /// the same single-use package immediately eligible for deletion.
+    #[serde(default)]
+    pub key_package_ref: Option<Vec<u8>>,
+    /// MLS lifetime boundary for the semantic KeyPackage carried by this
+    /// revision. Once reached, the old event may be deleted even when no newer
+    /// revision reached that endpoint.
+    #[serde(default)]
+    pub package_not_after: Option<Timestamp>,
+    /// The underlying single-use KeyPackage is no longer usable locally (for
+    /// example because a Welcome consumed it), so successor acknowledgement is
+    /// not required before deleting this revision.
+    #[serde(default)]
+    pub delete_without_successor: bool,
+    #[serde(default)]
+    pub deletion_targets: Vec<TransportFanoutTarget>,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PendingKeyPackageReplacement {
     pub key_package: KeyPackage,
     pub key_package_ref: Vec<u8>,
-    /// Transport authoring time selected before signing. The private bundle
-    /// and this enclosing lifecycle intent are persisted atomically; signing
-    /// may therefore resume safely after a crash.
+    /// Transport authoring time of the current pending signed revision. The
+    /// private bundle and this enclosing lifecycle intent are persisted
+    /// atomically; signing may therefore resume safely after a crash. A
+    /// bounded-age transport updates this field and `signed_event` together
+    /// before exposing a newer revision.
     pub authored_created_at: Timestamp,
     pub not_before: Timestamp,
     pub not_after: Timestamp,
@@ -260,17 +322,49 @@ pub struct KeyPackageLifecycleState {
     pub stable_slot_id: String,
     #[serde(default)]
     pub phase: MaintenancePhase,
+    /// Durable fail-closed gate for upgrade cutover discovery. While set, the
+    /// account may prepare local KeyPackage material and retry exact deletion
+    /// obligations, but it must not publish, republish, or fan out a kind
+    /// 30443 revision. The app clears this only after every authoritative
+    /// relay completed its scan and every discovered exact endpoint liability
+    /// was admitted durably.
+    #[serde(default)]
+    pub cutover_publication_blocked: bool,
     pub current_key_package: Option<KeyPackage>,
     pub current_key_package_ref: Option<Vec<u8>>,
     pub current_not_before: Option<Timestamp>,
     pub current_not_after: Option<Timestamp>,
     pub authored_event_id: Option<MessageId>,
+    /// Highest transport authoring time durably selected for this stable
+    /// replaceable-event slot. This normally describes the current artifact,
+    /// but remains above it when a newer pending artifact was consumed before
+    /// acknowledgement so the required fresh replacement sorts after both.
     pub authored_event_created_at: Option<Timestamp>,
-    /// Exact current replaceable event retained until its snapshotted fanout
-    /// finishes. Local lifecycle promotion still occurs on the first accepted
-    /// acknowledgement.
+    /// Current signed revision retained for restart-safe exact retries within
+    /// that revision. A bounded-age transport may atomically replace it with a
+    /// strictly newer revision at the same coordinate and reset every live
+    /// target before fanout continues. Local lifecycle promotion still occurs
+    /// on the first accepted acknowledgement.
     #[serde(default)]
     pub authored_signed_event: Option<SignedPublicationArtifact>,
+    /// Current or pending signed revision ids selected for relay deletion.
+    /// An artifact remains forbidden from exact republication while its id is
+    /// present; the marker follows that exact revision rather than leaking
+    /// onto a newly generated KeyPackage after expiry or promotion.
+    #[serde(default)]
+    pub deleted_live_revision_event_ids: Vec<MessageId>,
+    /// Exact deletion currently entitled to use the bounded liabilities above
+    /// [`MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES`]. The owner remains
+    /// durable until every one of that event's deletion targets has a terminal
+    /// receipt, preventing two atomic exact-deletion sets from sharing the
+    /// overflow reserve across retries or process restarts.
+    #[serde(default)]
+    pub deletion_overflow_owner_event_id: Option<MessageId>,
+    /// Superseded signed revisions whose possible relay copies still require
+    /// explicit deletion acknowledgement. This is independent of MLS private
+    /// material retention and therefore survives package expiry and restart.
+    #[serde(default)]
+    pub retired_publications_pending_deletion: Vec<RetiredKeyPackagePublication>,
     #[serde(default)]
     pub publication_targets: Vec<TransportFanoutTarget>,
     pub refresh_at: Option<Timestamp>,
@@ -282,6 +376,12 @@ pub struct KeyPackageLifecycleState {
     pub last_consumed_key_package_ref: Option<Vec<u8>>,
     #[serde(default)]
     pub last_consumed_at: Option<Timestamp>,
+    /// Durable, deduplicated references of locally owned KeyPackages proven
+    /// consumed by successfully processed Welcomes. Only the account sweep
+    /// may remove evidence after it has handled the matching private material;
+    /// unmatched upgrade-era evidence is retained fail-closed.
+    #[serde(default)]
+    pub consumed_key_package_refs: Vec<Vec<u8>>,
     /// Prior, unconsumed packages remain decryptable until their MLS lifetime
     /// expires so an invite already in flight can still be processed.
     #[serde(default)]
@@ -297,6 +397,7 @@ impl KeyPackageLifecycleState {
         Self {
             stable_slot_id,
             phase: MaintenancePhase::Complete,
+            cutover_publication_blocked: false,
             current_key_package: None,
             current_key_package_ref: None,
             current_not_before: None,
@@ -304,13 +405,80 @@ impl KeyPackageLifecycleState {
             authored_event_id: None,
             authored_event_created_at: None,
             authored_signed_event: None,
+            deleted_live_revision_event_ids: Vec::new(),
+            deletion_overflow_owner_event_id: None,
+            retired_publications_pending_deletion: Vec::new(),
             publication_targets: Vec::new(),
             refresh_at: None,
             upgrade_rotation_recorded: false,
             last_consumed_key_package_ref: None,
             last_consumed_at: None,
+            consumed_key_package_refs: Vec::new(),
             retained_private_material: Vec::new(),
             pending_replacement: None,
+        }
+    }
+
+    /// Record a locally matched Welcome consumption without overwriting an
+    /// earlier still-live reference. The legacy `last_consumed_*` fields remain
+    /// the latest-consumption status projection.
+    pub fn record_consumed_key_package_ref(
+        &mut self,
+        key_package_ref: Vec<u8>,
+        consumed_at: Timestamp,
+    ) -> Result<(), ConsumedKeyPackageRefJournalFull> {
+        if !self.consumed_key_package_refs.contains(&key_package_ref) {
+            if self.consumed_key_package_refs.len() >= MAX_CONSUMED_KEY_PACKAGE_REFS_PENDING_CLEANUP
+            {
+                return Err(ConsumedKeyPackageRefJournalFull);
+            }
+            self.consumed_key_package_refs.push(key_package_ref.clone());
+        }
+        self.last_consumed_key_package_ref = Some(key_package_ref);
+        self.last_consumed_at = Some(consumed_at);
+        Ok(())
+    }
+
+    /// Import the legacy last-consumed marker and deduplicate without pruning.
+    /// Only the account sweep that actually handles matching private/lifecycle
+    /// material may clear consumption evidence; an upgrade row may not yet
+    /// project its still-owned OpenMLS bundle into these lifecycle fields.
+    pub fn reconcile_consumed_key_package_refs(&mut self) {
+        if let Some(last) = self.last_consumed_key_package_ref.as_ref()
+            && !self
+                .consumed_key_package_refs
+                .iter()
+                .any(|candidate| candidate == last)
+            && self.consumed_key_package_refs.len() < MAX_CONSUMED_KEY_PACKAGE_REFS_PENDING_CLEANUP
+        {
+            self.consumed_key_package_refs.push(last.clone());
+        }
+        let mut reconciled = Vec::with_capacity(self.consumed_key_package_refs.len());
+        for consumed in self.consumed_key_package_refs.drain(..) {
+            if !reconciled.iter().any(|candidate| candidate == &consumed) {
+                reconciled.push(consumed);
+            }
+        }
+        self.consumed_key_package_refs = reconciled;
+    }
+
+    /// Whether a still-live/private lifecycle reference has durable Welcome
+    /// consumption evidence. The legacy field is accepted for upgrade safety.
+    pub fn key_package_ref_is_consumed(&self, key_package_ref: &[u8]) -> bool {
+        self.consumed_key_package_refs
+            .iter()
+            .any(|candidate| candidate.as_slice() == key_package_ref)
+            || self.last_consumed_key_package_ref.as_deref() == Some(key_package_ref)
+    }
+
+    /// Clear one consumption marker only after the account sweep has handled
+    /// the matching current/pending/retained private material.
+    pub fn clear_consumed_key_package_ref(&mut self, key_package_ref: &[u8]) {
+        self.consumed_key_package_refs
+            .retain(|candidate| candidate.as_slice() != key_package_ref);
+        if self.last_consumed_key_package_ref.as_deref() == Some(key_package_ref) {
+            self.last_consumed_key_package_ref = self.consumed_key_package_refs.last().cloned();
+            self.last_consumed_at = None;
         }
     }
 }
@@ -359,7 +527,10 @@ pub struct GroupMaintenanceStatus {
 
 #[cfg(test)]
 mod tests {
-    use super::MaintenancePhase;
+    use super::{
+        KeyPackageLifecycleState, MAX_CONSUMED_KEY_PACKAGE_REFS_PENDING_CLEANUP, MaintenancePhase,
+    };
+    use crate::Timestamp;
 
     #[test]
     fn maintenance_phase_names_are_stable_snake_case() {
@@ -374,6 +545,73 @@ mod tests {
         assert_eq!(
             MaintenancePhase::ClockSkewBlocked.as_str(),
             "clock_skew_blocked"
+        );
+    }
+
+    #[test]
+    fn consumed_key_package_ref_journal_is_serde_defaulted_deduplicated_and_reconciled() {
+        let mut legacy_json =
+            serde_json::to_value(KeyPackageLifecycleState::slot_only("stable-slot".into()))
+                .unwrap();
+        legacy_json
+            .as_object_mut()
+            .unwrap()
+            .remove("consumed_key_package_refs");
+        legacy_json
+            .as_object_mut()
+            .unwrap()
+            .remove("cutover_publication_blocked");
+        legacy_json
+            .as_object_mut()
+            .unwrap()
+            .remove("deletion_overflow_owner_event_id");
+        let legacy: KeyPackageLifecycleState = serde_json::from_value(legacy_json).unwrap();
+        assert!(legacy.consumed_key_package_refs.is_empty());
+        assert!(!legacy.cutover_publication_blocked);
+        assert!(legacy.deletion_overflow_owner_event_id.is_none());
+
+        let mut lifecycle = KeyPackageLifecycleState::slot_only("stable-slot".into());
+        lifecycle.current_key_package_ref = Some(vec![1]);
+        lifecycle
+            .record_consumed_key_package_ref(vec![1], Timestamp(10))
+            .unwrap();
+        lifecycle
+            .record_consumed_key_package_ref(vec![1], Timestamp(11))
+            .unwrap();
+        assert_eq!(lifecycle.consumed_key_package_refs, vec![vec![1]]);
+        assert_eq!(lifecycle.last_consumed_at, Some(Timestamp(11)));
+
+        lifecycle.current_key_package_ref = Some(vec![2]);
+        lifecycle
+            .record_consumed_key_package_ref(vec![2], Timestamp(12))
+            .unwrap();
+        assert_eq!(
+            lifecycle.consumed_key_package_refs,
+            vec![vec![1], vec![2]],
+            "only the account sweep may clear older unswept evidence"
+        );
+        lifecycle.clear_consumed_key_package_ref(&[1]);
+        assert_eq!(lifecycle.consumed_key_package_refs, vec![vec![2]]);
+        lifecycle.current_key_package_ref = None;
+        lifecycle.clear_consumed_key_package_ref(&[2]);
+        assert!(lifecycle.consumed_key_package_refs.is_empty());
+        assert!(lifecycle.last_consumed_key_package_ref.is_none());
+        assert!(lifecycle.last_consumed_at.is_none());
+
+        let mut bounded = KeyPackageLifecycleState::slot_only(String::new());
+        for index in 0..MAX_CONSUMED_KEY_PACKAGE_REFS_PENDING_CLEANUP {
+            bounded
+                .record_consumed_key_package_ref(
+                    u64::try_from(index).unwrap().to_be_bytes().to_vec(),
+                    Timestamp(index as u64),
+                )
+                .unwrap();
+        }
+        assert!(
+            bounded
+                .record_consumed_key_package_ref(vec![0xff; 9], Timestamp(u64::MAX))
+                .is_err(),
+            "the journal fails closed rather than evicting unswept evidence"
         );
     }
 }

--- a/crates/traits/src/storage.rs
+++ b/crates/traits/src/storage.rs
@@ -403,6 +403,11 @@ pub struct LeaveRequest {
     pub group_id: GroupId,
     pub requested_at_ms: u64,
     pub last_proposed_epoch: Option<EpochId>,
+    /// Exact engine message id of the most recently accepted SelfRemove.
+    /// Older records predate this attribution and hydrate it from the paired
+    /// durable sent-message row.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_proposed_message_id: Option<MessageId>,
 }
 
 pub trait LeaveRequestStorage {

--- a/crates/traits/src/transport_adapter.rs
+++ b/crates/traits/src/transport_adapter.rs
@@ -849,6 +849,16 @@ pub struct TransportEndpointFailure {
     pub rejection_category: Option<TransportEndpointRejectionCategory>,
 }
 
+impl TransportEndpointFailure {
+    /// Whether the adapter mapped an exact, stable relay response to terminal
+    /// target-absence evidence. The sentinel reason is adapter-authored and
+    /// privacy-safe; arbitrary relay suffix text is never retained here.
+    pub fn confirms_target_absence(&self) -> bool {
+        self.rejection_category == Some(TransportEndpointRejectionCategory::Invalid)
+            && self.reason == "relay rejected event (not-found)"
+    }
+}
+
 /// Publish failure surfaced by transport adapters.
 ///
 /// `summary` is safe for `Display`/logging. Per-endpoint diagnostics live in

--- a/crates/transport-nostr-adapter/src/lib.rs
+++ b/crates/transport-nostr-adapter/src/lib.rs
@@ -92,6 +92,7 @@ pub use telemetry::{
 };
 
 const DELIVERY_BUFFER: usize = 1024;
+const GROUP_MAINTENANCE_SUBSCRIPTION_ID_PREFIX: &str = "marmot:group-maintenance:";
 
 fn unix_now_seconds() -> u64 {
     SystemTime::now()
@@ -672,12 +673,14 @@ impl NostrTransportAdapter {
         subscription: NostrSubscription,
     ) -> Result<(), TransportAdapterError> {
         let _subscription_guard = self.subscription_lock.lock().await;
-        self.relay_client.unsubscribe(subscription.clone()).await?;
+        // Local teardown is authoritative even when relay cleanup fails or is
+        // cancelled: once the caller removes this temporary subscription, a
+        // late raw relay copy must no longer be an account delivery path.
         self.state
             .write()
             .await
             .forget_subscription_starts(std::slice::from_ref(&subscription));
-        Ok(())
+        self.relay_client.unsubscribe(subscription).await
     }
 
     /// Resolve opaque relay indices to relay endpoints for the opt-in export
@@ -722,6 +725,37 @@ impl NostrTransportAdapter {
             .await
     }
 
+    /// Route a raw SDK relay copy only when it belongs to an active temporary
+    /// group-maintenance subscription.
+    ///
+    /// The SDK's database is shared by every local account. When another
+    /// account has already cached an event, a later full-history REQ emits only
+    /// the raw per-subscription copy; the SDK's ordinary deduplicated `Event`
+    /// notification is suppressed. Subscription ownership restores that replay
+    /// for the requesting account without turning ordinary raw copies into a
+    /// second, cross-account delivery path.
+    #[cfg(feature = "sdk")]
+    pub async fn handle_group_maintenance_replay(
+        &self,
+        relay_event: NostrRelayEvent,
+    ) -> Result<usize, TransportAdapterError> {
+        let Some(subscription_id) = relay_event.subscription_id.as_deref() else {
+            return Ok(0);
+        };
+        let account_id = self
+            .state
+            .read()
+            .await
+            .group_maintenance_accounts
+            .get(subscription_id)
+            .cloned();
+        let Some(account_id) = account_id else {
+            return Ok(0);
+        };
+        self.handle_relay_event_scoped(relay_event, Some(&account_id))
+            .await
+    }
+
     async fn handle_relay_event_scoped(
         &self,
         relay_event: NostrRelayEvent,
@@ -734,6 +768,27 @@ impl NostrTransportAdapter {
         let received_at = Timestamp(unix_now_seconds());
         let mut routes = {
             let state = self.state.read().await;
+            if let Some(subscription_id) = relay_event.subscription_id.as_deref()
+                && subscription_id.starts_with(GROUP_MAINTENANCE_SUBSCRIPTION_ID_PREFIX)
+                && state
+                    .group_maintenance_accounts
+                    .get(subscription_id)
+                    .is_none_or(|owner| account_id.is_some_and(|account_id| owner != account_id))
+            {
+                // nostr-relay-pool does not verify subscription existence by
+                // default. A relay can therefore race a queued EVENT behind
+                // CLOSE (or keep sending after failed remote teardown), and
+                // the SDK may surface that stale maintenance copy as its
+                // deduplicated Event. Once local ownership is gone, fail
+                // closed instead of letting the stale temporary REQ re-enter
+                // ordinary group routing.
+                tracing::debug!(
+                    target: "transport_nostr_adapter::adapter",
+                    method = "handle_relay_event_scoped",
+                    "ignored event for inactive maintenance subscription"
+                );
+                return Ok(0);
+            }
             state.routes_for(&message, &relay_event.endpoint)
         };
         if let Some(account_id) = account_id {
@@ -1296,6 +1351,15 @@ struct AdapterState {
     /// sync may append only missing pre-REQ routes while a subscribe batch is in
     /// flight; both success and failure rebuild the index before returning.
     by_transport_group: HashMap<Vec<u8>, Vec<GroupRouteEntry>>,
+    /// Account ownership for active full-history post-join subscriptions.
+    ///
+    /// `nostr-sdk` suppresses its deduplicated `Event` notification when a
+    /// relay replays an event already present in the shared SDK database, but
+    /// still emits the raw per-subscription copy. Keeping this ownership map
+    /// lets that raw maintenance replay use the ordinary signed-routing table
+    /// while remaining scoped to the account that requested it. Ordinary raw
+    /// subscription copies remain telemetry-only.
+    group_maintenance_accounts: HashMap<String, MemberId>,
     /// Unconfirmed relay unsubscribes retained until teardown succeeds.
     /// Routing state (`accounts`/`by_transport_group`) already reflects the
     /// removal; these are relay-side cleanups only, drained on later
@@ -1486,13 +1550,18 @@ impl AdapterState {
 
     fn record_subscription_starts(&mut self, subscriptions: &[NostrSubscription], now_ms: u64) {
         for subscription in subscriptions {
+            let subscription_id = subscription.subscription_id();
+            if let NostrSubscription::GroupMaintenance { account_id, .. } = subscription {
+                self.group_maintenance_accounts
+                    .insert(subscription_id.clone(), account_id.clone());
+            }
             let relays: Vec<RelayIndex> = subscription
                 .endpoints()
                 .iter()
                 .map(|endpoint| self.relay_index.index_for(endpoint))
                 .collect();
             self.sync
-                .record_subscription_start(&subscription.subscription_id(), &relays, now_ms);
+                .record_subscription_start(&subscription_id, &relays, now_ms);
         }
     }
 
@@ -1541,8 +1610,11 @@ impl AdapterState {
     /// telemetry map tracks live subscriptions rather than historical churn.
     fn forget_subscription_starts(&mut self, subscriptions: &[NostrSubscription]) {
         for subscription in subscriptions {
-            self.sync
-                .forget_subscription(&subscription.subscription_id());
+            let subscription_id = subscription.subscription_id();
+            self.sync.forget_subscription(&subscription_id);
+            if matches!(subscription, NostrSubscription::GroupMaintenance { .. }) {
+                self.group_maintenance_accounts.remove(&subscription_id);
+            }
         }
     }
 
@@ -1579,6 +1651,17 @@ impl AdapterState {
     fn forget_account_subscription_starts(&mut self, account_id: &MemberId) {
         for id in self.account_subscription_ids(account_id) {
             self.sync.forget_subscription(&id);
+        }
+        let maintenance_ids = self
+            .group_maintenance_accounts
+            .iter()
+            .filter_map(|(subscription_id, owner)| {
+                (owner == account_id).then_some(subscription_id.clone())
+            })
+            .collect::<Vec<_>>();
+        for subscription_id in maintenance_ids {
+            self.group_maintenance_accounts.remove(&subscription_id);
+            self.sync.forget_subscription(&subscription_id);
         }
     }
 

--- a/crates/transport-nostr-adapter/src/lib.rs
+++ b/crates/transport-nostr-adapter/src/lib.rs
@@ -1037,14 +1037,19 @@ impl TransportAdapter for NostrTransportAdapter {
             subscriptions_removed = removed_count,
             "deactivating transport account"
         );
-        self.relay_client.unsubscribe_account(account_id).await?;
-        let mut state = self.state.write().await;
-        state.forget_account_subscription_starts(account_id);
-        // The blanket `unsubscribe_account` above supersedes any queued
-        // per-subscription unsubscribes for this account.
-        state.clear_pending_unsubscribes_for_account(account_id);
-        state.deactivate(account_id, removed_count);
-        Ok(())
+        // Commit the local teardown before the fallible/cancellable relay I/O.
+        // A signed-out or wiped account cannot remain an active delivery target
+        // merely because a relay is unavailable or this future is cancelled.
+        {
+            let mut state = self.state.write().await;
+            state.forget_account_subscription_starts(account_id);
+            // The blanket `unsubscribe_account` below supersedes queued
+            // per-subscription relay cleanup for this account.
+            state.clear_pending_unsubscribes_for_account(account_id);
+            state.deactivate(account_id, removed_count);
+        }
+
+        self.relay_client.unsubscribe_account(account_id).await
     }
 
     async fn publish(

--- a/crates/transport-nostr-adapter/src/sdk_client.rs
+++ b/crates/transport-nostr-adapter/src/sdk_client.rs
@@ -478,23 +478,31 @@ impl NostrSdkRelayClient {
                                         event,
                                     },
                             } => {
-                                // Raw per-relay copy (not deduplicated): telemetry
-                                // only, so cross-relay spread sees every relay's
-                                // copy. Delivery happens on the deduplicated
-                                // `Event` notification above.
+                                // Raw per-relay copy (not deduplicated): always
+                                // retain it for telemetry, so cross-relay spread
+                                // sees every relay's copy. Normally delivery
+                                // happens on the deduplicated `Event`
+                                // notification above. One exception is an active
+                                // full-history group-maintenance subscription:
+                                // nostr-sdk suppresses `Event` when another local
+                                // account already cached the replayed event in
+                                // the shared database, while this verified raw
+                                // copy is still emitted. The adapter registry
+                                // scopes that replay to the requesting account.
                                 if let Ok(event) = NostrTransportEvent::from_nostr_event(&event) {
                                     tracing::trace!(
                                         target: "transport_nostr_adapter::sdk_client",
                                         method = "spawn_notification_forwarder",
                                         "observing per-relay event copy"
                                     );
-                                    adapter
-                                        .observe_relay_event(NostrRelayEvent {
-                                            endpoint: TransportEndpoint(relay_url.to_string()),
-                                            subscription_id: Some(subscription_id.to_string()),
-                                            event,
-                                        })
-                                        .await;
+                                    let relay_event = NostrRelayEvent {
+                                        endpoint: TransportEndpoint(relay_url.to_string()),
+                                        subscription_id: Some(subscription_id.to_string()),
+                                        event,
+                                    };
+                                    adapter.observe_relay_event(relay_event.clone()).await;
+                                    let _ =
+                                        adapter.handle_group_maintenance_replay(relay_event).await;
                                 }
                                 Ok(false)
                             }
@@ -1577,8 +1585,10 @@ fn relay_rejection_endpoint_failure(
 mod tests {
     use super::*;
     use crate::NostrKeyPackagePublication;
-    use cgka_traits::Timestamp;
     use cgka_traits::engine::KeyPackage;
+    use cgka_traits::{
+        Timestamp, TransportAccountActivation, TransportAdapter, TransportGroupSubscription,
+    };
     use futures::{SinkExt, StreamExt};
     use nostr_relay_builder::MockRelay;
     use nostr_sdk::prelude::{DatabaseEventStatus, EventBuilder, Keys, Kind, Tag};
@@ -1600,6 +1610,204 @@ mod tests {
             .sign_with_keys(&ephemeral)
             .expect("sign ephemeral 445");
         NostrTransportEvent::from_nostr_event(&signed).expect("dto from signed event")
+    }
+
+    #[tokio::test]
+    async fn shared_sdk_cache_replays_group_history_only_to_maintenance_owner() {
+        let relay = timeout(Duration::from_secs(5), MockRelay::run())
+            .await
+            .expect("local relay starts within the test budget")
+            .expect("start relay");
+        let endpoint = TransportEndpoint(relay.url().await.to_string());
+        let sdk = NostrSdkRelayClient::new(Client::builder().build());
+        let adapter = NostrTransportAdapter::new(Arc::new(sdk.clone()));
+        let forwarder = sdk.spawn_notification_forwarder(adapter.clone());
+        // Let the spawned task install its notification receiver before the
+        // first subscription can produce stored-event notifications.
+        tokio::task::yield_now().await;
+
+        let alice = MemberId::new(Keys::generate().public_key().to_bytes().to_vec());
+        let bob = MemberId::new(Keys::generate().public_key().to_bytes().to_vec());
+        let group = TransportGroupSubscription {
+            group_id: cgka_traits::GroupId::new(vec![0xAB; 32]),
+            transport_group_id: vec![0xCC; 32],
+            endpoints: vec![endpoint.clone()],
+        };
+        timeout(
+            Duration::from_secs(5),
+            adapter.activate_account(TransportAccountActivation {
+                account_id: alice.clone(),
+                inbox_endpoints: vec![endpoint.clone()],
+                group_subscriptions: vec![group.clone()],
+                since: None,
+            }),
+        )
+        .await
+        .expect("account A activation finishes within the test budget")
+        .expect("activate account A");
+
+        let event = signed_group_event_dto();
+        // Use a distinct client/database for the remote sender. Publishing
+        // through the recipient client would pre-cache the outgoing event and
+        // suppress A's initial deduplicated Event notification too, which is a
+        // different scenario from A caching a genuinely received event.
+        let publisher = NostrSdkRelayClient::new(Client::builder().build());
+        timeout(
+            Duration::from_secs(5),
+            publisher.publish_event(std::slice::from_ref(&endpoint), &event, 1),
+        )
+        .await
+        .expect("publish finishes within the test budget")
+        .expect("publish event for account A's live subscription");
+        let alice_delivery = timeout(Duration::from_secs(5), adapter.receive())
+            .await
+            .expect("account A receives the live event")
+            .expect("delivery queue remains open")
+            .expect("account A delivery exists");
+        assert_eq!(alice_delivery.account_id, alice);
+
+        // Account B shares the same nostr-sdk client/database. Its ordinary
+        // group REQ gets the relay's raw stored copy, but nostr-sdk suppresses
+        // the deduplicated Event notification because A already cached it.
+        timeout(
+            Duration::from_secs(5),
+            adapter.activate_account(TransportAccountActivation {
+                account_id: bob.clone(),
+                inbox_endpoints: vec![endpoint.clone()],
+                group_subscriptions: vec![group.clone()],
+                since: None,
+            }),
+        )
+        .await
+        .expect("account B activation finishes within the test budget")
+        .expect("activate account B");
+        assert!(
+            timeout(Duration::from_millis(250), adapter.receive())
+                .await
+                .is_err(),
+            "ordinary raw replays must remain telemetry-only"
+        );
+
+        let maintenance_id = timeout(
+            Duration::from_secs(5),
+            adapter.install_group_maintenance_subscription(&bob, &group),
+        )
+        .await
+        .expect("maintenance install finishes within the test budget")
+        .expect("install account B maintenance subscription");
+        let bob_delivery = timeout(Duration::from_secs(5), adapter.receive())
+            .await
+            .expect("maintenance REQ recovers the shared-cache event")
+            .expect("delivery queue remains open")
+            .expect("account B delivery exists");
+        assert_eq!(bob_delivery.account_id, bob);
+        assert_eq!(bob_delivery.group_id_hint, Some(group.group_id.clone()));
+        assert_eq!(
+            bob_delivery.source.subscription_id.as_deref(),
+            Some(maintenance_id.as_str())
+        );
+        assert!(
+            timeout(Duration::from_millis(250), adapter.receive())
+                .await
+                .is_err(),
+            "account B's maintenance replay must not fan out to account A"
+        );
+
+        let maintenance = NostrSubscription::GroupMaintenance {
+            account_id: bob.clone(),
+            group_id: group.group_id.clone(),
+            transport_group_id: group.transport_group_id.clone(),
+            endpoints: group.endpoints.clone(),
+        };
+        timeout(
+            Duration::from_secs(5),
+            adapter.remove_group_maintenance_subscription(maintenance.clone()),
+        )
+        .await
+        .expect("maintenance removal finishes within the test budget")
+        .expect("remove maintenance subscription");
+        let replay_after_remove = adapter
+            .handle_group_maintenance_replay(NostrRelayEvent {
+                endpoint: endpoint.clone(),
+                subscription_id: Some(maintenance_id.clone()),
+                event: event.clone(),
+            })
+            .await
+            .expect("removed replay is ignored");
+        assert_eq!(replay_after_remove, 0);
+
+        // Account teardown is also authoritative for an otherwise-live
+        // maintenance registration.
+        timeout(
+            Duration::from_secs(5),
+            adapter.install_group_maintenance_subscription(&bob, &group),
+        )
+        .await
+        .expect("maintenance reinstall finishes within the test budget")
+        .expect("reinstall maintenance subscription");
+        assert_eq!(
+            adapter
+                .state
+                .read()
+                .await
+                .group_maintenance_accounts
+                .get(&maintenance_id),
+            Some(&bob)
+        );
+        timeout(Duration::from_secs(5), adapter.deactivate_account(&bob))
+            .await
+            .expect("account B teardown finishes within the test budget")
+            .expect("deactivate account B");
+        assert!(
+            !adapter
+                .state
+                .read()
+                .await
+                .group_maintenance_accounts
+                .contains_key(&maintenance_id),
+            "account teardown must remove raw-replay ownership"
+        );
+
+        publisher.client().shutdown().await;
+        sdk.client().shutdown().await;
+        timeout(Duration::from_secs(5), forwarder)
+            .await
+            .expect("notification forwarder shuts down")
+            .expect("notification forwarder does not panic");
+    }
+
+    #[tokio::test]
+    async fn failed_maintenance_subscribe_rolls_back_raw_replay_scope() {
+        let sdk = NostrSdkRelayClient::new(Client::builder().build());
+        let adapter = NostrTransportAdapter::new(Arc::new(sdk));
+        let account_id = MemberId::new(Keys::generate().public_key().to_bytes().to_vec());
+        let group = TransportGroupSubscription {
+            group_id: cgka_traits::GroupId::new(vec![0x11; 32]),
+            transport_group_id: vec![0x22; 32],
+            endpoints: vec![TransportEndpoint("not a relay URL".into())],
+        };
+        let maintenance_id = NostrSubscription::GroupMaintenance {
+            account_id: account_id.clone(),
+            group_id: group.group_id.clone(),
+            transport_group_id: group.transport_group_id.clone(),
+            endpoints: group.endpoints.clone(),
+        }
+        .subscription_id();
+
+        adapter
+            .install_group_maintenance_subscription(&account_id, &group)
+            .await
+            .expect_err("invalid endpoint rejects the maintenance REQ");
+
+        assert!(
+            !adapter
+                .state
+                .read()
+                .await
+                .group_maintenance_accounts
+                .contains_key(&maintenance_id),
+            "failed subscribe must not leave raw-replay ownership active"
+        );
     }
 
     #[test]

--- a/crates/transport-nostr-adapter/src/sdk_client.rs
+++ b/crates/transport-nostr-adapter/src/sdk_client.rs
@@ -1520,6 +1520,17 @@ fn relay_rejection_endpoint_failure(
     endpoint: TransportEndpoint,
     relay_message: &str,
 ) -> TransportEndpointFailure {
+    // Buzz relays currently expose deletion target absence through this exact
+    // stable rejection. Do not generalize the free-text suffix across other
+    // NIP-01 prefixes: only the observed full response is terminal evidence.
+    if relay_message == "invalid: target event not found" {
+        return TransportEndpointFailure {
+            endpoint,
+            reason: "relay rejected event (not-found)".to_owned(),
+            kind: TransportEndpointFailureKind::TerminalRejected,
+            rejection_category: Some(TransportEndpointRejectionCategory::Invalid),
+        };
+    }
     if let Some(prefix) = nostr::message::MachineReadablePrefix::parse(relay_message) {
         let category = map_relay_rejection_category(prefix);
         // nostr-sdk also uses the generic `error:` prefix for local SDK/send
@@ -1638,6 +1649,12 @@ mod tests {
                 "relay rejected event (invalid)",
             ),
             (
+                "invalid: target event not found",
+                TransportEndpointRejectionCategory::Invalid,
+                TransportEndpointFailureKind::TerminalRejected,
+                "relay rejected event (not-found)",
+            ),
+            (
                 "unsupported: kind 5",
                 TransportEndpointRejectionCategory::Unsupported,
                 TransportEndpointFailureKind::TerminalRejected,
@@ -1653,6 +1670,32 @@ mod tests {
             assert_eq!(failure.reason, summary);
             assert!(!failure.reason.contains("evil.example"));
             assert!(!failure.reason.contains("leaked event payload"));
+        }
+        assert!(
+            relay_rejection_endpoint_failure(
+                TransportEndpoint("wss://relay.example".into()),
+                "invalid: target event not found",
+            )
+            .confirms_target_absence()
+        );
+    }
+
+    #[test]
+    fn target_absence_requires_the_exact_known_relay_response() {
+        for message in [
+            "error: target event not found",
+            "blocked: target event not found",
+            "invalid: target event not found elsewhere",
+            "invalid: Target event not found",
+        ] {
+            let failure = relay_rejection_endpoint_failure(
+                TransportEndpoint("wss://relay.example".into()),
+                message,
+            );
+            assert!(
+                !failure.confirms_target_absence(),
+                "unrecognized free text must remain retryable: {message}"
+            );
         }
     }
 

--- a/crates/transport-nostr-adapter/tests/inbound_routing.rs
+++ b/crates/transport-nostr-adapter/tests/inbound_routing.rs
@@ -342,6 +342,9 @@ struct FlakyUnsubscribeRelayClient {
     unsubscribed: Mutex<Vec<transport_nostr_adapter::NostrSubscription>>,
     unsubscribed_accounts: Mutex<Vec<MemberId>>,
     fail_next_unsubscribes: AtomicUsize,
+    fail_next_account_unsubscribes: AtomicUsize,
+    block_account_unsubscribes: AtomicBool,
+    account_unsubscribe_entered: AtomicUsize,
 }
 
 #[async_trait]
@@ -377,6 +380,22 @@ impl NostrRelayClient for FlakyUnsubscribeRelayClient {
         &self,
         account_id: &MemberId,
     ) -> Result<(), cgka_traits::TransportAdapterError> {
+        if self.block_account_unsubscribes.load(Ordering::SeqCst) {
+            self.account_unsubscribe_entered
+                .fetch_add(1, Ordering::SeqCst);
+            std::future::pending::<()>().await;
+        }
+        if self
+            .fail_next_account_unsubscribes
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |armed| {
+                armed.checked_sub(1)
+            })
+            .is_ok()
+        {
+            return Err(cgka_traits::TransportAdapterError::Subscription(
+                "injected account unsubscribe failure".into(),
+            ));
+        }
         self.unsubscribed_accounts
             .lock()
             .unwrap()
@@ -2381,6 +2400,111 @@ async fn deactivate_account_clears_pending_unsubscribes() {
         std::slice::from_ref(&account_id)
     );
     assert_eq!(adapter.metrics().await.unsubscribe_retries_pending, 0);
+}
+
+#[tokio::test]
+async fn failed_account_unsubscribe_still_clears_local_account_routes() {
+    let relay = Arc::new(FlakyUnsubscribeRelayClient::default());
+    let adapter = NostrTransportAdapter::new(relay.clone());
+    let account_id = MemberId::new(vec![0xA1; 32]);
+
+    adapter
+        .activate_account(TransportAccountActivation {
+            account_id: account_id.clone(),
+            inbox_endpoints: vec![TransportEndpoint("wss://inbox.example".into())],
+            group_subscriptions: vec![],
+            since: None,
+        })
+        .await
+        .expect("activation succeeds");
+    assert_eq!(adapter.metrics().await.active_accounts, 1);
+
+    relay
+        .fail_next_account_unsubscribes
+        .store(1, Ordering::SeqCst);
+    adapter
+        .deactivate_account(&account_id)
+        .await
+        .expect_err("relay-side account unsubscribe is injected to fail");
+
+    assert_eq!(
+        adapter.metrics().await.active_accounts,
+        0,
+        "local routing must be inactive even when relay unsubscribe fails"
+    );
+    assert!(
+        relay.unsubscribed_accounts.lock().unwrap().is_empty(),
+        "the injected failure must not be recorded as a relay acknowledgement"
+    );
+}
+
+#[tokio::test]
+async fn cancelled_pending_account_unsubscribe_keeps_local_account_deactivated() {
+    let relay = Arc::new(FlakyUnsubscribeRelayClient::default());
+    let adapter = NostrTransportAdapter::new(relay.clone());
+    let account_id = MemberId::new(vec![0xA1; 32]);
+    let group = TransportGroupSubscription {
+        group_id: cgka_traits::GroupId::new(vec![0xB2; 32]),
+        transport_group_id: vec![0xC3; 32],
+        endpoints: vec![TransportEndpoint("wss://group.example".into())],
+    };
+
+    adapter
+        .activate_account(TransportAccountActivation {
+            account_id: account_id.clone(),
+            inbox_endpoints: vec![TransportEndpoint("wss://inbox.example".into())],
+            group_subscriptions: vec![group],
+            since: None,
+        })
+        .await
+        .expect("activation succeeds");
+    relay.fail_next_unsubscribes.store(1, Ordering::SeqCst);
+    adapter
+        .sync_account_groups(TransportGroupSync {
+            account_id: account_id.clone(),
+            group_subscriptions: vec![],
+            since: None,
+        })
+        .await
+        .expect("group removal commits despite failed relay cleanup");
+    assert_eq!(adapter.metrics().await.unsubscribe_retries_pending, 1);
+
+    relay
+        .block_account_unsubscribes
+        .store(true, Ordering::SeqCst);
+    let adapter_for_deactivation = adapter.clone();
+    let account_for_deactivation = account_id.clone();
+    let deactivation = tokio::spawn(async move {
+        adapter_for_deactivation
+            .deactivate_account(&account_for_deactivation)
+            .await
+    });
+    tokio::time::timeout(concurrent_subscribe_timeout(), async {
+        while relay.account_unsubscribe_entered.load(Ordering::SeqCst) == 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("deactivation must reach the pending relay unsubscribe");
+
+    let metrics = adapter.metrics().await;
+    assert_eq!(metrics.active_accounts, 0);
+    assert_eq!(metrics.active_group_subscriptions, 0);
+    assert_eq!(
+        metrics.unsubscribe_retries_pending, 0,
+        "blanket account teardown must clear queued relay cleanup before awaiting"
+    );
+    assert_eq!(adapter.relay_sync().await.tracked_subscriptions, 0);
+
+    deactivation.abort();
+    let join_error = deactivation
+        .await
+        .expect_err("pending deactivation must be cancellable");
+    assert!(join_error.is_cancelled());
+
+    let metrics = adapter.metrics().await;
+    assert_eq!(metrics.active_accounts, 0);
+    assert_eq!(metrics.unsubscribe_retries_pending, 0);
 }
 
 #[tokio::test]

--- a/crates/transport-nostr-adapter/tests/inbound_routing.rs
+++ b/crates/transport-nostr-adapter/tests/inbound_routing.rs
@@ -704,6 +704,95 @@ async fn group_subscription_id_fans_out_to_matching_accounts_and_replays_route_a
 }
 
 #[tokio::test]
+async fn failed_maintenance_unsubscribe_blocks_late_deduplicated_event() {
+    let relay = Arc::new(FlakyUnsubscribeRelayClient::default());
+    let adapter = NostrTransportAdapter::new(relay.clone());
+    let account_id = MemberId::new(vec![0xA1; 32]);
+    let group_id = cgka_traits::GroupId::new(vec![0xB2; 32]);
+    let transport_group_id = vec![0xC3; 32];
+    let endpoint = TransportEndpoint("wss://group.example".into());
+    let group = TransportGroupSubscription {
+        group_id: group_id.clone(),
+        transport_group_id: transport_group_id.clone(),
+        endpoints: vec![endpoint.clone()],
+    };
+    adapter
+        .activate_account(TransportAccountActivation {
+            account_id: account_id.clone(),
+            inbox_endpoints: vec![TransportEndpoint("wss://inbox.example".into())],
+            group_subscriptions: vec![group.clone()],
+            since: None,
+        })
+        .await
+        .expect("activate account");
+
+    let maintenance_id = adapter
+        .install_group_maintenance_subscription(&account_id, &group)
+        .await
+        .expect("install maintenance subscription");
+    let maintenance = NostrSubscription::GroupMaintenance {
+        account_id: account_id.clone(),
+        group_id: group_id.clone(),
+        transport_group_id: transport_group_id.clone(),
+        endpoints: vec![endpoint.clone()],
+    };
+    let delivered = adapter
+        .handle_relay_event(NostrRelayEvent {
+            endpoint: endpoint.clone(),
+            subscription_id: Some(maintenance_id.clone()),
+            event: group_event("active-maintenance", &transport_group_id),
+        })
+        .await
+        .expect("active maintenance event remains routable");
+    assert_eq!(delivered, 1);
+    assert_eq!(
+        adapter.receive().await.unwrap().unwrap().account_id,
+        account_id
+    );
+
+    relay.fail_next_unsubscribes.store(1, Ordering::SeqCst);
+    adapter
+        .remove_group_maintenance_subscription(maintenance)
+        .await
+        .expect_err("inject relay-side unsubscribe failure");
+
+    let delivered = adapter
+        .handle_relay_event(NostrRelayEvent {
+            endpoint: endpoint.clone(),
+            subscription_id: Some(maintenance_id),
+            event: group_event("retired-maintenance", &transport_group_id),
+        })
+        .await
+        .expect("late maintenance event is handled fail-closed");
+    assert_eq!(
+        delivered, 0,
+        "a retired maintenance REQ must not re-enter ordinary group routing"
+    );
+
+    let ordinary_id = NostrSubscription::Group {
+        account_id: account_id.clone(),
+        group_id,
+        transport_group_id: transport_group_id.clone(),
+        endpoints: vec![endpoint.clone()],
+        since: None,
+    }
+    .subscription_id();
+    let delivered = adapter
+        .handle_relay_event(NostrRelayEvent {
+            endpoint,
+            subscription_id: Some(ordinary_id),
+            event: group_event("ordinary-live", &transport_group_id),
+        })
+        .await
+        .expect("ordinary group event remains routable");
+    assert_eq!(delivered, 1);
+    assert_eq!(
+        adapter.receive().await.unwrap().unwrap().account_id,
+        account_id
+    );
+}
+
+#[tokio::test]
 async fn reconciled_group_event_routes_only_to_the_compared_account() {
     let relay = Arc::new(FakeRelayClient::default());
     let adapter = NostrTransportAdapter::new(relay);

--- a/crates/transport-quic-broker/src/tests.rs
+++ b/crates/transport-quic-broker/src/tests.rs
@@ -3,6 +3,7 @@
 
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use cgka_traits::agent_text_stream::{
@@ -18,7 +19,8 @@ use tokio::sync::oneshot;
 use tokio::time::{sleep, timeout};
 use transport_quic_stream::{
     AgentTextStreamCrypto, AgentTextStreamReceiveLimitError, AgentTextStreamReceiveLimits,
-    EphemeralPublisherSequenceStore, stream_record_text,
+    EphemeralPublisherSequenceStore, PublisherSequenceReservation, PublisherSequenceSnapshot,
+    PublisherSequenceStore, prepare_text_stream_crypto_for_network_handoff, stream_record_text,
 };
 
 use crate::client::{
@@ -55,6 +57,55 @@ fn test_state(max_backlog: usize) -> BrokerState {
         DEFAULT_BROKER_MAX_BACKLOG_BYTES,
         MAX_BROKER_REPLAY_TTL,
     )
+}
+
+struct ClosablePublisherSequenceStore {
+    inner: EphemeralPublisherSequenceStore,
+    closed: AtomicBool,
+}
+
+impl ClosablePublisherSequenceStore {
+    fn new() -> Self {
+        Self {
+            inner: EphemeralPublisherSequenceStore::default(),
+            closed: AtomicBool::new(false),
+        }
+    }
+
+    fn close(&self) {
+        self.closed.store(true, Ordering::SeqCst);
+    }
+
+    fn ensure_open(&self) -> Result<(), String> {
+        if self.closed.load(Ordering::SeqCst) {
+            Err("publisher sequence backend is closed".to_owned())
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl PublisherSequenceStore for ClosablePublisherSequenceStore {
+    fn load(&self, context_id: &[u8; 32]) -> Result<Option<PublisherSequenceSnapshot>, String> {
+        self.ensure_open()?;
+        self.inner.load(context_id)
+    }
+
+    fn reserve(
+        &self,
+        context_id: &[u8; 32],
+        initial_transcript_hash: &[u8; 32],
+        reservation: &PublisherSequenceReservation,
+    ) -> Result<(), String> {
+        self.ensure_open()?;
+        self.inner
+            .reserve(context_id, initial_transcript_hash, reservation)
+    }
+
+    fn confirm(&self, context_id: &[u8; 32], token: &[u8; 16]) -> Result<(), String> {
+        self.ensure_open()?;
+        self.inner.confirm(context_id, token)
+    }
 }
 
 #[tokio::test]
@@ -110,6 +161,84 @@ async fn broker_forwards_live_records_to_subscriber_with_same_transcript() {
     assert_eq!(received.chunk_count, 4);
     assert_eq!(sent.chunk_count, received.chunk_count);
     assert_eq!(sent.transcript_hash, received.transcript_hash);
+
+    let _ = shutdown_tx.send(());
+    broker_task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn broker_publishes_preconfirmed_range_after_sequence_backend_closes() {
+    let server = QuicBrokerServer::bind(QuicBrokerConfig {
+        bind_addr: LOCAL_SERVER_BIND,
+        ..QuicBrokerConfig::default()
+    })
+    .unwrap();
+    let broker_addr = server.local_addr().unwrap();
+    let server_cert = server.server_cert_der().to_vec();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let broker_task = tokio::spawn(server.run_until(async {
+        let _ = shutdown_rx.await;
+    }));
+
+    let stream_id = vec![0xa8; 32];
+    let start_event_id = MessageId::new(vec![0x18; 32]);
+    let stream_secret = SecretBytes::new(vec![0x28; 32]);
+    let context = AgentTextStreamKeyContextV1::new(
+        GroupId::new(vec![0x38; 32]),
+        stream_id.clone(),
+        EpochId(4),
+        MemberId::new(vec![0x48; 32]),
+        start_event_id.clone(),
+    );
+    let sequence_backend = Arc::new(ClosablePublisherSequenceStore::new());
+    let durable_crypto = AgentTextStreamCrypto::new(stream_secret.clone(), context.clone())
+        .with_publisher_sequence_store(sequence_backend.clone());
+    let text = "publish after root shutdown";
+    let detached_crypto = prepare_text_stream_crypto_for_network_handoff(
+        durable_crypto,
+        &stream_id,
+        &start_event_id,
+        text,
+        7,
+        None,
+    )
+    .expect("reserve and confirm the exact range before shutdown");
+    sequence_backend.close();
+
+    let receiver_crypto = AgentTextStreamCrypto::new(stream_secret, context);
+    let subscriber = tokio::spawn(subscribe_text_from_broker(SubscribeTextFromBroker {
+        broker_addr,
+        server_name: "localhost".to_owned(),
+        trust: BrokerServerTrust::CertificateDer(server_cert.clone()),
+        stream_id: stream_id.clone(),
+        start_event_id: start_event_id.clone(),
+        crypto: Some(receiver_crypto),
+    }));
+    sleep(Duration::from_millis(100)).await;
+
+    let sent = publish_text_to_broker(PublishTextToBroker {
+        broker_addr,
+        server_name: "localhost".to_owned(),
+        trust: BrokerServerTrust::CertificateDer(server_cert),
+        stream_id: stream_id.clone(),
+        start_event_id,
+        text: text.to_owned(),
+        max_chunk_bytes: 7,
+        chunk_delay: Duration::ZERO,
+        crypto: Some(detached_crypto),
+        max_plaintext_frame_len: None,
+    })
+    .await
+    .expect("publish must use only the detached one-shot capability");
+    let received = timeout(Duration::from_secs(5), subscriber)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(received.text, text);
+    assert_eq!(received.transcript_hash, sent.transcript_hash);
+    assert_eq!(received.chunk_count, sent.chunk_count);
 
     let _ = shutdown_tx.send(());
     broker_task.await.unwrap().unwrap();

--- a/crates/transport-quic-stream/src/lib.rs
+++ b/crates/transport-quic-stream/src/lib.rs
@@ -50,5 +50,6 @@ pub use receive::{
     QuicTextStreamReceiver, ReceivedTextChunk, ReceivedTextStream, ServerTrust, stream_record_text,
 };
 pub use send::{
-    SendTextStream, SentTextStream, random_stream_id, send_text_stream, split_text_deltas,
+    SendTextStream, SentTextStream, prepare_text_stream_crypto_for_network_handoff,
+    random_stream_id, send_text_stream, split_text_deltas,
 };

--- a/crates/transport-quic-stream/src/publisher_sequence.rs
+++ b/crates/transport-quic-stream/src/publisher_sequence.rs
@@ -42,15 +42,110 @@ pub struct ReservedPublisherRecords {
     pub transcript_hash: [u8; 32],
     pub chunk_count: u64,
     context_id: [u8; 32],
-    token: [u8; 16],
+    initial_transcript_hash: [u8; 32],
+    reservation: PublisherSequenceReservation,
     store: Arc<dyn PublisherSequenceStore>,
 }
 
 impl ReservedPublisherRecords {
     pub fn confirm(self) -> Result<(), QuicTextStreamError> {
         self.store
-            .confirm(&self.context_id, &self.token)
+            .confirm(&self.context_id, &self.reservation.token)
             .map_err(QuicTextStreamError::PublisherSequence)
+    }
+
+    pub(crate) fn confirm_and_detach_store(
+        self,
+    ) -> Result<Arc<dyn PublisherSequenceStore>, QuicTextStreamError> {
+        self.store
+            .confirm(&self.context_id, &self.reservation.token)
+            .map_err(QuicTextStreamError::PublisherSequence)?;
+        Ok(Arc::new(DetachedPublisherSequenceStore {
+            context_id: self.context_id,
+            initial_transcript_hash: self.initial_transcript_hash,
+            expected: self.reservation.expected,
+            resulting: self.reservation.resulting,
+            state: Mutex::new(DetachedPublisherSequenceState::Ready),
+        }))
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DetachedPublisherSequenceState {
+    Ready,
+    Reserved([u8; 16]),
+    Exhausted,
+}
+
+/// One-shot capability for replaying one already-durable reservation after
+/// its SQLCipher store has been closed for a root-ownership handoff.
+struct DetachedPublisherSequenceStore {
+    context_id: [u8; 32],
+    initial_transcript_hash: [u8; 32],
+    expected: PublisherSequenceSnapshot,
+    resulting: PublisherSequenceSnapshot,
+    state: Mutex<DetachedPublisherSequenceState>,
+}
+
+impl PublisherSequenceStore for DetachedPublisherSequenceStore {
+    fn load(&self, context_id: &[u8; 32]) -> Result<Option<PublisherSequenceSnapshot>, String> {
+        if context_id != &self.context_id {
+            return Err("detached publisher context does not match".to_owned());
+        }
+        match *self
+            .state
+            .lock()
+            .map_err(|_| "detached publisher state lock poisoned")?
+        {
+            DetachedPublisherSequenceState::Ready => Ok(Some(self.expected)),
+            DetachedPublisherSequenceState::Reserved(_) => {
+                Err("publisher continuity is ambiguous".to_owned())
+            }
+            DetachedPublisherSequenceState::Exhausted => {
+                Err("detached publisher sequence capability is exhausted".to_owned())
+            }
+        }
+    }
+
+    fn reserve(
+        &self,
+        context_id: &[u8; 32],
+        initial_transcript_hash: &[u8; 32],
+        reservation: &PublisherSequenceReservation,
+    ) -> Result<(), String> {
+        if context_id != &self.context_id
+            || initial_transcript_hash != &self.initial_transcript_hash
+            || reservation.expected != self.expected
+            || reservation.resulting != self.resulting
+        {
+            return Err("detached publisher reservation does not match".to_owned());
+        }
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| "detached publisher state lock poisoned")?;
+        if *state != DetachedPublisherSequenceState::Ready {
+            return Err("detached publisher sequence capability is not available".to_owned());
+        }
+        *state = DetachedPublisherSequenceState::Reserved(reservation.token);
+        Ok(())
+    }
+
+    fn confirm(&self, context_id: &[u8; 32], token: &[u8; 16]) -> Result<(), String> {
+        if context_id != &self.context_id {
+            return Err("detached publisher context does not match".to_owned());
+        }
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| "detached publisher state lock poisoned")?;
+        match *state {
+            DetachedPublisherSequenceState::Reserved(current) if &current == token => {
+                *state = DetachedPublisherSequenceState::Exhausted;
+                Ok(())
+            }
+            _ => Err("detached publisher reservation is not current".to_owned()),
+        }
     }
 }
 
@@ -110,23 +205,21 @@ pub fn reserve_publisher_records(
         transcript_hash: transcript.hash(),
         chunk_count: transcript.chunk_count(),
     };
+    let reservation = PublisherSequenceReservation {
+        expected,
+        resulting,
+        token,
+    };
     store
-        .reserve(
-            &context_id,
-            &initial,
-            &PublisherSequenceReservation {
-                expected,
-                resulting,
-                token,
-            },
-        )
+        .reserve(&context_id, &initial, &reservation)
         .map_err(QuicTextStreamError::PublisherSequence)?;
     Ok(ReservedPublisherRecords {
         records,
         transcript_hash: resulting.transcript_hash,
         chunk_count: resulting.chunk_count,
         context_id,
-        token,
+        initial_transcript_hash: initial,
+        reservation,
         store,
     })
 }
@@ -260,6 +353,69 @@ mod tests {
                 &stream_id,
                 &start,
                 &[(AGENT_TEXT_STREAM_RECORD_TEXT_DELTA, b"retry".to_vec())],
+            ),
+            Err(QuicTextStreamError::PublisherSequence(_))
+        ));
+    }
+
+    #[test]
+    fn confirmed_detached_capability_replays_exact_durable_range_once() {
+        let store = Arc::new(EphemeralPublisherSequenceStore::default());
+        let durable_crypto = crypto(store);
+        let stream_id = durable_crypto.context.stream_id.clone();
+        let start = durable_crypto.context.start_event_id.clone();
+        let detached_crypto = crate::prepare_text_stream_crypto_for_network_handoff(
+            durable_crypto.clone(),
+            &stream_id,
+            &start,
+            "detached",
+            1024,
+            None,
+        )
+        .unwrap();
+
+        let frames = vec![(AGENT_TEXT_STREAM_RECORD_TEXT_DELTA, b"detached".to_vec())];
+        let detached = reserve_publisher_records(&detached_crypto, &stream_id, &start, &frames)
+            .expect("the exact preconfirmed range remains usable after storage closes");
+        assert_eq!(detached.records[0].seq, 1);
+        detached.confirm().unwrap();
+        assert!(matches!(
+            reserve_publisher_records(&detached_crypto, &stream_id, &start, &frames),
+            Err(QuicTextStreamError::PublisherSequence(_))
+        ));
+
+        let next = reserve_publisher_records(
+            &durable_crypto,
+            &stream_id,
+            &start,
+            &[(AGENT_TEXT_STREAM_RECORD_TEXT_DELTA, b"next".to_vec())],
+        )
+        .expect("durable state advanced before the detached send");
+        assert_eq!(next.records[0].seq, 2);
+        next.confirm().unwrap();
+    }
+
+    #[test]
+    fn detached_capability_rejects_a_different_frame_set() {
+        let durable_crypto = crypto(Arc::new(EphemeralPublisherSequenceStore::default()));
+        let stream_id = durable_crypto.context.stream_id.clone();
+        let start = durable_crypto.context.start_event_id.clone();
+        let detached_crypto = crate::prepare_text_stream_crypto_for_network_handoff(
+            durable_crypto,
+            &stream_id,
+            &start,
+            "authorized",
+            1024,
+            None,
+        )
+        .unwrap();
+
+        assert!(matches!(
+            reserve_publisher_records(
+                &detached_crypto,
+                &stream_id,
+                &start,
+                &[(AGENT_TEXT_STREAM_RECORD_TEXT_DELTA, b"different".to_vec())],
             ),
             Err(QuicTextStreamError::PublisherSequence(_))
         ));

--- a/crates/transport-quic-stream/src/send.rs
+++ b/crates/transport-quic-stream/src/send.rs
@@ -47,20 +47,11 @@ pub struct SentTextStream {
 pub async fn send_text_stream(
     config: SendTextStream,
 ) -> Result<SentTextStream, QuicTextStreamError> {
-    if config.max_chunk_bytes == 0 {
-        return Err(QuicTextStreamError::EmptyChunkSize);
-    }
-    if config.max_chunk_bytes > AGENT_TEXT_STREAM_MAX_PLAINTEXT_FRAME_LEN as usize {
-        return Err(QuicTextStreamError::ChunkSizeTooLarge(
-            config.max_chunk_bytes,
-        ));
-    }
-    // Clamp the chunk size to the group policy cap when the caller supplied
-    // one. A plaintext within the cap always encrypts to a ciphertext within
-    // the record's `ciphertext<0..2^16-1>` field bound (cap + 16 <= 65535).
-    let max_chunk_bytes = config
-        .max_chunk_bytes
-        .min(effective_plaintext_cap(config.max_plaintext_frame_len));
+    let frames = text_delta_frames(
+        &config.text,
+        config.max_chunk_bytes,
+        config.max_plaintext_frame_len,
+    )?;
 
     let endpoint = client_endpoint(config.trust, config.server_addr)?;
     let connection = connect_with_timeout(
@@ -71,15 +62,6 @@ pub async fn send_text_stream(
     )
     .await?;
     let mut send = connection.open_uni().await?;
-    let frames = split_text_deltas(&config.text, max_chunk_bytes)
-        .into_iter()
-        .map(|chunk| {
-            (
-                cgka_traits::agent_text_stream::AGENT_TEXT_STREAM_RECORD_TEXT_DELTA,
-                chunk,
-            )
-        })
-        .collect::<Vec<_>>();
     let mut transcript =
         AgentTextStreamTranscriptV1::new(config.stream_id.clone(), config.start_event_id.clone());
     let reservation = config
@@ -138,6 +120,57 @@ pub async fn send_text_stream(
         transcript_hash,
         chunk_count,
     })
+}
+
+/// Persist and confirm exactly one bounded text-record range, then replace the
+/// crypto's SQL-backed sequence store with a one-shot in-memory capability for
+/// that same range. This is for hosts that must terminally close storage before
+/// network I/O to transfer exclusive root ownership.
+///
+/// A later network failure burns the confirmed range rather than risking nonce
+/// reuse. The returned capability rejects any different frame set and cannot be
+/// reused for another send.
+pub fn prepare_text_stream_crypto_for_network_handoff(
+    crypto: AgentTextStreamCrypto,
+    stream_id: &[u8],
+    start_event_id: &MessageId,
+    text: &str,
+    max_chunk_bytes: usize,
+    max_plaintext_frame_len: Option<u32>,
+) -> Result<AgentTextStreamCrypto, QuicTextStreamError> {
+    let frames = text_delta_frames(text, max_chunk_bytes, max_plaintext_frame_len)?;
+    if frames.is_empty() {
+        return Ok(crypto);
+    }
+    let detached_store = reserve_publisher_records(&crypto, stream_id, start_event_id, &frames)?
+        .confirm_and_detach_store()?;
+    Ok(crypto.with_publisher_sequence_store(detached_store))
+}
+
+fn text_delta_frames(
+    text: &str,
+    max_chunk_bytes: usize,
+    max_plaintext_frame_len: Option<u32>,
+) -> Result<Vec<(u8, Vec<u8>)>, QuicTextStreamError> {
+    if max_chunk_bytes == 0 {
+        return Err(QuicTextStreamError::EmptyChunkSize);
+    }
+    if max_chunk_bytes > AGENT_TEXT_STREAM_MAX_PLAINTEXT_FRAME_LEN as usize {
+        return Err(QuicTextStreamError::ChunkSizeTooLarge(max_chunk_bytes));
+    }
+    // Clamp the chunk size to the group policy cap when the caller supplied
+    // one. A plaintext within the cap always encrypts to a ciphertext within
+    // the record's `ciphertext<0..2^16-1>` field bound (cap + 16 <= 65535).
+    let max_chunk_bytes = max_chunk_bytes.min(effective_plaintext_cap(max_plaintext_frame_len));
+    Ok(split_text_deltas(text, max_chunk_bytes)
+        .into_iter()
+        .map(|chunk| {
+            (
+                cgka_traits::agent_text_stream::AGENT_TEXT_STREAM_RECORD_TEXT_DELTA,
+                chunk,
+            )
+        })
+        .collect())
 }
 
 pub fn random_stream_id() -> Vec<u8> {


### PR DESCRIPTION
## Split of #1594 (2/6)

Engine/session/transport: exact signed KeyPackage and fanout publisher sequences survive restart.

GitHub will not accept a fork `split/1594-*` branch as the **base** on `marmot-protocol/mdk` (base must already exist here; we cannot push those branches). This PR therefore targets `master`. **Files changed vs `master` includes slice 1.** Review the latest commit, or the incremental compare:

https://github.com/marmot-protocol/mdk/compare/romainPellerin:split/1594-storage-journals...romainPellerin:split/1594-engine-transport

**Incremental diff vs slice 1:** 13 files, +679 / −57

Depends on #1595.

**Stack on this repo (review latest commit / incremental compare, merge in this order):**
1. storage/journals — https://github.com/marmot-protocol/mdk/pull/1595
2. engine/transport exact-retry — https://github.com/marmot-protocol/mdk/pull/1596
3. account visibility + KeyPackage persist — https://github.com/marmot-protocol/mdk/pull/1597
4. app projection / Leave / tombstones / backfill — https://github.com/marmot-protocol/mdk/pull/1598
5. app tests — https://github.com/marmot-protocol/mdk/pull/1599
6. CLI / UniFFI / docs — https://github.com/marmot-protocol/mdk/pull/1600


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable tracking for leave proposals and improved restoration after hydration.
  * Added reliable journal-based tracking for visibility updates, key-package cleanup, and epoch backfill tasks.
  * Added atomic private-file replacement and explicit session storage shutdown support.
  * Improved maintenance event routing across accounts and added network handoff support for text streams.
* **Bug Fixes**
  * Improved rollback behavior for failed saves and clarified missing chat-row errors.
  * Preserved leave-request data and prevented stale maintenance events after unsubscribe failures.
* **Compatibility**
  * Added database migrations for the new durable state and journals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->