### PR TITLE
fix(account): persist KeyPackage retry and source-aware visibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1991,6 +1991,7 @@ version = "0.9.15"
 dependencies = [
  "libc",
  "tempfile",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -2056,8 +2056,8 @@ impl<S: StorageProvider> Engine<S> {
         }
 
         if let Some(mut request) = self.storage.leave_request(group_id)? {
-            if request.last_proposed_epoch.is_none()
-                && self.sent_self_remove_leaving_gate_should_restore(
+            if (request.last_proposed_epoch.is_none() || request.last_proposed_message_id.is_none())
+                && let Some(message_id) = self.sent_self_remove_message_to_restore(
                     group_id,
                     mls_group,
                     group,
@@ -2065,13 +2065,18 @@ impl<S: StorageProvider> Engine<S> {
                     stored_message_records,
                 )?
             {
-                request.last_proposed_epoch = Some(group.epoch);
+                if request.last_proposed_epoch.is_none() {
+                    request.last_proposed_epoch = Some(group.epoch);
+                }
+                if request.last_proposed_message_id.is_none() {
+                    request.last_proposed_message_id = Some(message_id);
+                }
                 self.storage.put_leave_request(&request)?;
             }
             return Ok(Some(request));
         }
 
-        if self.sent_self_remove_leaving_gate_should_restore(
+        if let Some(message_id) = self.sent_self_remove_message_to_restore(
             group_id,
             mls_group,
             group,
@@ -2082,6 +2087,7 @@ impl<S: StorageProvider> Engine<S> {
                 group_id: group_id.clone(),
                 requested_at_ms: self.convergence_now_ms(),
                 last_proposed_epoch: Some(group.epoch),
+                last_proposed_message_id: Some(message_id),
             };
             self.storage.put_leave_request(&request)?;
             return Ok(Some(request));
@@ -2215,20 +2221,20 @@ impl<S: StorageProvider> Engine<S> {
         Ok(())
     }
 
-    fn sent_self_remove_leaving_gate_should_restore(
+    fn sent_self_remove_message_to_restore(
         &self,
         group_id: &GroupId,
         mls_group: &mut openmls::group::MlsGroup,
         group: &Group,
         provider: &crate::provider::EngineOpenMlsProvider<'_, S>,
         stored_message_records: &[cgka_traits::message::MessageRecord],
-    ) -> Result<bool, cgka_traits::storage::StorageError> {
+    ) -> Result<Option<MessageId>, cgka_traits::storage::StorageError> {
         if !group
             .members
             .iter()
             .any(|member| &member.id == self.identity.self_id())
         {
-            return Ok(false);
+            return Ok(None);
         }
 
         for record in stored_message_records {
@@ -2277,11 +2283,11 @@ impl<S: StorageProvider> Engine<S> {
                 && matches!(queued.proposal(), Proposal::SelfRemove)
                 && crate::app_components::authorize_standalone_proposal(mls_group, &queued).is_ok()
             {
-                return Ok(true);
+                return Ok(Some(record.id.clone()));
             }
         }
 
-        Ok(false)
+        Ok(None)
     }
 
     fn quarantine_stored_group_on_hydrate(

--- a/crates/cgka-engine/src/group_lifecycle.rs
+++ b/crates/cgka-engine/src/group_lifecycle.rs
@@ -1197,9 +1197,16 @@ impl<S: StorageProvider> Engine<S> {
                     let mut lifecycle = maintenance
                         .key_package_lifecycle()?
                         .unwrap_or_else(|| KeyPackageLifecycleState::slot_only(String::new()));
-                    lifecycle.last_consumed_key_package_ref =
-                        Some(consumed_key_package_ref.clone());
-                    lifecycle.last_consumed_at = Some(joined_at);
+                    lifecycle
+                        .record_consumed_key_package_ref(
+                            consumed_key_package_ref.clone(),
+                            joined_at,
+                        )
+                        .map_err(|_| {
+                            EngineError::Backend(
+                                "consumed KeyPackage cleanup journal is full".into(),
+                            )
+                        })?;
                     maintenance.put_key_package_lifecycle(&lifecycle)?;
                 }
 

--- a/crates/cgka-engine/src/message_processor/send.rs
+++ b/crates/cgka-engine/src/message_processor/send.rs
@@ -705,8 +705,10 @@ impl<S: StorageProvider> Engine<S> {
             group_id: group_id.clone(),
             requested_at_ms,
             last_proposed_epoch: None,
+            last_proposed_message_id: None,
         });
         request.last_proposed_epoch = Some(proposed_epoch);
+        request.last_proposed_message_id = Some(msg.id.clone());
         self.record_sent_openmls_message_with_leave_request(
             &msg,
             proposal_bytes.as_slice(),
@@ -833,6 +835,7 @@ impl<S: StorageProvider> Engine<S> {
         let (msg, proposal_bytes, proposed_epoch) =
             self.prepare_self_remove_proposal(group_id).await?;
         request.last_proposed_epoch = Some(proposed_epoch);
+        request.last_proposed_message_id = Some(msg.id.clone());
         self.record_sent_openmls_message_with_leave_request(
             &msg,
             proposal_bytes.as_slice(),

--- a/crates/cgka-engine/tests/invite_leave.rs
+++ b/crates/cgka-engine/tests/invite_leave.rs
@@ -3029,11 +3029,18 @@ async fn leave_hydration_preserves_existing_last_proposed_message_id() {
     bob_storage.put_leave_request(&request).unwrap();
     drop(bob);
 
-    let _reopened = build_client_on_storage(b"bob", bob_storage.clone());
+    let mut reopened = build_client_on_storage(b"bob", bob_storage.clone());
+    reopened
+        .hydrate_all_stored_groups()
+        .expect("eager hydrate restores the leave request");
     let restored = bob_storage
         .leave_request(&group_id)
         .unwrap()
         .expect("hydration restores the LeaveRequest");
+    assert!(
+        restored.last_proposed_epoch.is_some(),
+        "epoch-only hydration repair must fill last_proposed_epoch"
+    );
     assert_eq!(
         restored.last_proposed_message_id.as_ref(),
         Some(&second_id),

--- a/crates/cgka-engine/tests/invite_leave.rs
+++ b/crates/cgka-engine/tests/invite_leave.rs
@@ -1336,6 +1336,7 @@ async fn realization_with_pending_leave_request_attributes_member_left() {
             group_id: group_id.clone(),
             requested_at_ms: 1,
             last_proposed_epoch: None,
+            last_proposed_message_id: None,
         })
         .unwrap();
 
@@ -2945,6 +2946,103 @@ async fn repeat_leave_in_the_same_epoch_is_classified_by_the_engine() {
         bob_storage.leave_request(&group_id).unwrap(),
         Some(recorded),
         "refused duplicates must leave the durable request byte-identical"
+    );
+}
+
+#[tokio::test]
+async fn leave_hydration_preserves_existing_last_proposed_message_id() {
+    let mut alice = build_client(b"alice");
+    let (mut bob, bob_storage) = build_with_storage(b"bob");
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "hydrate-leave-id".into(),
+            description: "".into(),
+            members: vec![bob_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let welcome_for_bob = match create {
+        SendResult::GroupCreated {
+            pending,
+            mut welcomes,
+        } => {
+            alice.confirm_published(pending).await.unwrap();
+            welcomes.remove(0)
+        }
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    bob.join_welcome(welcome_for_bob).await.unwrap();
+
+    let first = bob
+        .send(SendIntent::Leave {
+            group_id: group_id.clone(),
+        })
+        .await
+        .unwrap();
+    let first_id = match first {
+        SendResult::Proposal { msg } => msg.id,
+        other => panic!("expected SelfRemove proposal, got {other:?}"),
+    };
+
+    let rename = alice
+        .send(SendIntent::UpdateGroupData {
+            group_id: group_id.clone(),
+            name: Some("still includes bob".into()),
+            description: None,
+        })
+        .await
+        .unwrap();
+    let (commit, pending) = match rename {
+        SendResult::GroupEvolution { msg, pending, .. } => (msg, pending),
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    let routed = TransportMessage {
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+        ..commit
+    };
+    let outcome = bob.ingest(routed).await.unwrap();
+    assert!(matches!(outcome, IngestOutcome::Buffered { .. }));
+    converge_buffered_commit(&mut bob, &group_id);
+    let _ = bob.advance_convergence(&group_id).await.unwrap();
+    let reproposals = bob.drain_auto_proposals();
+    assert_eq!(reproposals.len(), 1);
+    let second_id = reproposals[0].id.clone();
+    assert_ne!(
+        first_id, second_id,
+        "the epoch-changed SelfRemove must be a new message"
+    );
+
+    let mut request = bob_storage
+        .leave_request(&group_id)
+        .unwrap()
+        .expect("reproposal keeps the durable request");
+    assert_eq!(request.last_proposed_message_id.as_ref(), Some(&second_id));
+    request.last_proposed_epoch = None;
+    bob_storage.put_leave_request(&request).unwrap();
+    drop(bob);
+
+    let _reopened = build_client_on_storage(b"bob", bob_storage.clone());
+    let restored = bob_storage
+        .leave_request(&group_id)
+        .unwrap()
+        .expect("hydration restores the LeaveRequest");
+    assert_eq!(
+        restored.last_proposed_message_id.as_ref(),
+        Some(&second_id),
+        "epoch-only hydration repair must not overwrite the exact Leave id"
+    );
+    assert_ne!(
+        restored.last_proposed_message_id.as_ref(),
+        Some(&first_id),
+        "hydration must not replace the current Leave id with an earlier SelfRemove"
     );
 }
 

--- a/crates/cgka-engine/tests/publish_lifecycle.rs
+++ b/crates/cgka-engine/tests/publish_lifecycle.rs
@@ -1606,6 +1606,7 @@ fn key_package_bundle_and_lifecycle_intent_roll_back_together() {
     let mut state = KeyPackageLifecycleState {
         stable_slot_id: "stable-slot".into(),
         phase: MaintenancePhase::Complete,
+        cutover_publication_blocked: false,
         current_key_package: None,
         current_key_package_ref: None,
         current_not_before: None,
@@ -1613,11 +1614,15 @@ fn key_package_bundle_and_lifecycle_intent_roll_back_together() {
         authored_event_id: None,
         authored_event_created_at: None,
         authored_signed_event: None,
+        deleted_live_revision_event_ids: Vec::new(),
+        deletion_overflow_owner_event_id: None,
+        retired_publications_pending_deletion: Vec::new(),
         publication_targets: Vec::new(),
         refresh_at: None,
         upgrade_rotation_recorded: false,
         last_consumed_key_package_ref: None,
         last_consumed_at: None,
+        consumed_key_package_refs: Vec::new(),
         retained_private_material: Vec::new(),
         pending_replacement: None,
     };

--- a/crates/cgka-session/src/lib.rs
+++ b/crates/cgka-session/src/lib.rs
@@ -432,6 +432,18 @@ impl AccountDeviceSession {
         &self.open_timings
     }
 
+    /// A clone of the session's closeable storage handle.
+    ///
+    /// Hosts that must release local file locks at a known instant retain this
+    /// alongside the live session and call [`SqliteAccountStorage::close`]
+    /// during terminal shutdown. Every engine/OpenMLS clone shares the same
+    /// underlying close state, so closing this handle makes the whole session
+    /// storage graph inert without requiring the session to be dropped first.
+    #[must_use]
+    pub fn storage_handle(&self) -> SqliteAccountStorage {
+        self.storage.clone()
+    }
+
     /// Promote one bounded batch of legacy message rows after session
     /// readiness.
     ///

--- a/crates/fs-private/Cargo.toml
+++ b/crates/fs-private/Cargo.toml
@@ -8,5 +8,8 @@ publish.workspace = true
 [dependencies]
 libc.workspace = true
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
+
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/fs-private/src/lib.rs
+++ b/crates/fs-private/src/lib.rs
@@ -9,9 +9,13 @@
 //! Mode application is Unix-only; on other platforms the helpers still create
 //! the artifacts and the mode calls are no-ops.
 
-use std::fs::OpenOptions;
+use std::ffi::OsString;
+use std::fs::{File, OpenOptions};
 use std::io;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static ATOMIC_PRIVATE_WRITE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// Owner-only mode for files holding private data.
 pub const PRIVATE_FILE_MODE: u32 = 0o600;
@@ -779,6 +783,110 @@ pub fn write_private(path: &Path, bytes: &[u8]) -> io::Result<()> {
     file.sync_all()
 }
 
+/// Atomically replace `path` with owner-only `bytes`.
+///
+/// The complete new value is written and synced through a private sibling
+/// inode before rename, then the parent directory is synced where supported.
+/// A process or power failure on Unix therefore leaves either the previous
+/// value or the complete new value, never a truncate-before-write fragment.
+/// The parent directory must already exist; this helper never creates or
+/// changes its permissions.
+pub fn write_private_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    use std::io::Write;
+
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let file_name = path.file_name().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "atomic private write target must name a file",
+        )
+    })?;
+
+    let mut allocated = None;
+    for _ in 0..32 {
+        let attempt = ATOMIC_PRIVATE_WRITE_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let mut temp_name = OsString::from(".");
+        temp_name.push(file_name);
+        temp_name.push(format!(".tmp.{}.{}", std::process::id(), attempt));
+        let temp_path = parent.join(temp_name);
+        match create_new_private(&temp_path) {
+            Ok(file) => {
+                allocated = Some((file, temp_path));
+                break;
+            }
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error),
+        }
+    }
+    let (mut file, temp_path) = allocated.ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "could not allocate unique atomic private write temp file",
+        )
+    })?;
+
+    let result = (|| -> io::Result<()> {
+        file.write_all(bytes)?;
+        file.sync_all()?;
+        drop(file);
+        replace_private_file(&temp_path, path)?;
+        sync_private_parent(parent)
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temp_path);
+    }
+    result
+}
+
+#[cfg(windows)]
+fn replace_private_file(temp_path: &Path, path: &Path) -> io::Result<()> {
+    use std::iter;
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::{
+        MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH, MoveFileExW,
+    };
+
+    let temp_path = temp_path
+        .as_os_str()
+        .encode_wide()
+        .chain(iter::once(0))
+        .collect::<Vec<_>>();
+    let path = path
+        .as_os_str()
+        .encode_wide()
+        .chain(iter::once(0))
+        .collect::<Vec<_>>();
+    let result = unsafe {
+        MoveFileExW(
+            temp_path.as_ptr(),
+            path.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if result == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn replace_private_file(temp_path: &Path, path: &Path) -> io::Result<()> {
+    std::fs::rename(temp_path, path)
+}
+
+#[cfg(unix)]
+fn sync_private_parent(path: &Path) -> io::Result<()> {
+    File::open(path)?.sync_all()
+}
+
+#[cfg(not(unix))]
+fn sync_private_parent(_path: &Path) -> io::Result<()> {
+    Ok(())
+}
+
 /// Open `path` for appending, creating it 0600; tightens a pre-existing file
 /// to 0600.
 pub fn open_private_append(path: &Path) -> io::Result<std::fs::File> {
@@ -1071,6 +1179,46 @@ mod tests {
             assert!(parse_octal_mode(input).is_err(), "input {input:?}");
         }
     }
+
+    #[test]
+    fn write_private_atomic_replaces_complete_value_without_temp_artifacts() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("frontier.json");
+        write_private_atomic(&path, b"old").unwrap();
+        write_private_atomic(&path, b"complete replacement").unwrap();
+
+        assert_eq!(std::fs::read(&path).unwrap(), b"complete replacement");
+        let entries = std::fs::read_dir(dir.path())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect::<Vec<_>>();
+        assert_eq!(entries, vec![path.file_name().unwrap()]);
+    }
+
+    #[test]
+    fn write_private_atomic_removes_temp_after_failed_replace() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("occupied");
+        std::fs::create_dir(&path).unwrap();
+
+        assert!(write_private_atomic(&path, b"replacement").is_err());
+        let entries = std::fs::read_dir(dir.path())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect::<Vec<_>>();
+        assert_eq!(entries, vec![path.file_name().unwrap()]);
+    }
+
+    #[test]
+    fn write_private_atomic_requires_an_existing_parent() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing_parent = dir.path().join("missing");
+        let error = write_private_atomic(&missing_parent.join("frontier.json"), b"value")
+            .expect_err("atomic writes must not create their parent");
+
+        assert_eq!(error.kind(), io::ErrorKind::NotFound);
+        assert!(!missing_parent.exists());
+    }
 }
 
 #[cfg(all(test, unix))]
@@ -1089,6 +1237,61 @@ mod unix_tests {
         write_private(&path, b"secret").unwrap();
         assert_eq!(mode_of(&path), 0o600);
         assert_eq!(std::fs::read(&path).unwrap(), b"secret");
+    }
+
+    #[test]
+    fn write_private_atomic_replacement_remains_owner_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("frontier.json");
+        write_private_atomic(&path, b"old").unwrap();
+        write_private_atomic(&path, b"new").unwrap();
+        assert_eq!(mode_of(&path), 0o600);
+    }
+
+    #[test]
+    fn write_private_atomic_preserves_existing_parent_mode() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().join("externally-managed");
+        std::fs::create_dir(&parent).unwrap();
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let path = parent.join("frontier.json");
+        write_private_atomic(&path, b"value").unwrap();
+
+        assert_eq!(mode_of(&parent), 0o755);
+        assert_eq!(mode_of(&path), 0o600);
+    }
+
+    #[test]
+    fn write_private_atomic_bare_relative_filename_child_process() {
+        let Some(directory) = std::env::var_os("FS_PRIVATE_ATOMIC_RELATIVE_CHILD_DIR") else {
+            return;
+        };
+        std::env::set_current_dir(&directory).unwrap();
+
+        write_private_atomic(Path::new("frontier.json"), b"value").unwrap();
+
+        assert_eq!(mode_of(Path::new(".")), 0o755);
+        assert_eq!(mode_of(Path::new("frontier.json")), 0o600);
+    }
+
+    #[test]
+    fn write_private_atomic_bare_relative_filename_preserves_current_directory_mode() {
+        use std::process::Command;
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
+        let status = Command::new(std::env::current_exe().unwrap())
+            .arg("--exact")
+            .arg("unix_tests::write_private_atomic_bare_relative_filename_child_process")
+            .arg("--nocapture")
+            .env("FS_PRIVATE_ATOMIC_RELATIVE_CHILD_DIR", dir.path())
+            .status()
+            .expect("run bare-relative atomic-write child test");
+
+        assert!(status.success(), "atomic-write child process failed");
+        assert_eq!(mode_of(dir.path()), 0o755);
+        assert_eq!(mode_of(&dir.path().join("frontier.json")), 0o600);
     }
 
     #[test]

--- a/crates/marmot-account/Cargo.toml
+++ b/crates/marmot-account/Cargo.toml
@@ -18,6 +18,7 @@ marmot-forensics.workspace = true
 nostr.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+storage-sqlite.workspace = true
 rand.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
@@ -27,7 +28,6 @@ zeroize.workspace = true
 [dev-dependencies]
 cgka-engine.workspace = true
 rusqlite.workspace = true
-storage-sqlite.workspace = true
 tempfile.workspace = true
 tokio.workspace = true
 

--- a/crates/marmot-account/src/home.rs
+++ b/crates/marmot-account/src/home.rs
@@ -10,7 +10,8 @@ use zeroize::Zeroizing;
 
 use crate::error::{AccountHomeError, AccountHomeResult};
 use crate::io::{
-    read_json, validate_account_label, write_json, write_secret_bytes, write_secret_json,
+    read_json, sync_directory, validate_account_label, write_json, write_secret_bytes,
+    write_secret_json,
 };
 use crate::secret_store::{
     AccountSecretStore, KeychainSecretStore, LocalFileSecretStore,
@@ -586,6 +587,7 @@ impl AccountHome {
 
     pub fn complete_account_setup(&self, account_ref: &str) -> AccountHomeResult<()> {
         let account = self.account(account_ref)?;
+        let account_dir = self.account_dir(&account.label);
         for path in [
             self.account_setup_state_path(&account.label),
             self.account_setup_context_path(&account.label),
@@ -596,6 +598,10 @@ impl AccountHome {
                 Err(err) => return Err(err.into()),
             }
         }
+        // Setup completion is the durable commit record for restart. Persist
+        // both unlinks before reporting success so a crash cannot resurrect
+        // only one side of the state/context pair.
+        sync_directory(&account_dir)?;
         Ok(())
     }
 

--- a/crates/marmot-account/src/io.rs
+++ b/crates/marmot-account/src/io.rs
@@ -206,12 +206,12 @@ fn replace_file(temp_path: &Path, path: &Path) -> io::Result<()> {
 }
 
 #[cfg(unix)]
-fn sync_directory(path: &Path) -> io::Result<()> {
+pub(crate) fn sync_directory(path: &Path) -> io::Result<()> {
     File::open(path)?.sync_all()
 }
 
 #[cfg(not(unix))]
-fn sync_directory(_path: &Path) -> io::Result<()> {
+pub(crate) fn sync_directory(_path: &Path) -> io::Result<()> {
     Ok(())
 }
 

--- a/crates/marmot-account/src/key_package.rs
+++ b/crates/marmot-account/src/key_package.rs
@@ -3,7 +3,7 @@
 use async_trait::async_trait;
 use cgka_traits::engine::KeyPackage;
 use cgka_traits::maintenance::SignedPublicationArtifact;
-use cgka_traits::{MemberId, Timestamp, TransportEndpoint};
+use cgka_traits::{MemberId, MessageId, Timestamp, TransportEndpoint};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct KeyPackagePublication {
@@ -22,13 +22,63 @@ pub struct KeyPackagePublishReceipt {
     pub failed: Vec<TransportEndpoint>,
 }
 
+/// Endpoint-level publication evidence for lifecycle-aware callers.
+///
+/// This additive receipt preserves distinctions that the legacy
+/// [`KeyPackagePublishReceipt`] cannot represent. Implementers that only
+/// provide the legacy publisher method remain source-compatible: the trait's
+/// default detailed method adapts their accepted/failed result.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct DetailedKeyPackagePublishReceipt {
+    pub accepted: Vec<TransportEndpoint>,
+    /// Endpoint returned an explicit negative acknowledgement for this exact
+    /// publication attempt. This remains retryable and does not prove absence:
+    /// a legacy client may have exposed the same signed event before crashing
+    /// without persisting its pre-I/O marker.
+    pub rejected: Vec<TransportEndpoint>,
+    /// Endpoint explicitly proved the exact event absent (for example a
+    /// kind-5 target-not-found response). This is terminal for deletion and
+    /// proves a rejected publication revision needs no later deletion there.
+    pub confirmed_absent: Vec<TransportEndpoint>,
+    pub failed: Vec<TransportEndpoint>,
+}
+
+impl From<KeyPackagePublishReceipt> for DetailedKeyPackagePublishReceipt {
+    fn from(receipt: KeyPackagePublishReceipt) -> Self {
+        Self {
+            accepted: receipt.accepted,
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: receipt.failed,
+        }
+    }
+}
+
+impl From<DetailedKeyPackagePublishReceipt> for KeyPackagePublishReceipt {
+    fn from(mut receipt: DetailedKeyPackagePublishReceipt) -> Self {
+        receipt.failed.append(&mut receipt.rejected);
+        receipt.failed.append(&mut receipt.confirmed_absent);
+        receipt.failed.sort();
+        receipt.failed.dedup();
+        receipt
+            .failed
+            .retain(|endpoint| !receipt.accepted.contains(endpoint));
+        Self {
+            accepted: receipt.accepted,
+            failed: receipt.failed,
+        }
+    }
+}
+
 /// Failure returned by a [`KeyPackagePublisher`].
 ///
 /// `externally_exposed` records whether the exact signed event crossed the
 /// transport boundary before the error occurred. The pending replacement and
 /// its private bundle remain durable in either case until acknowledgement or
 /// MLS lifetime expiry; this bit only distinguishes safe regeneration before
-/// exposure from an ambiguous publication that must retry identical bytes.
+/// exposure from an ambiguous publication that must retry identical bytes
+/// within the authored revision. A bounded-age transport may later supersede
+/// that revision at the same replaceable coordinate.
 #[derive(Debug, thiserror::Error)]
 #[error("key package publication failed: {message}")]
 pub struct KeyPackagePublishError {
@@ -69,19 +119,66 @@ pub trait KeyPackagePublisher: Send + Sync {
         Ok(None)
     }
 
+    /// Inclusive age at which a prepared signed artifact is reauthored before
+    /// the next publish attempt.
+    ///
+    /// `None` disables age-based reauthoring and preserves legacy exact-retry
+    /// behavior. Transports whose relays enforce a bounded timestamp window
+    /// may return an age below that window. At `artifact_age >= threshold`,
+    /// the account runtime requests a strictly newer `created_at` for the same
+    /// semantic KeyPackage and stable replaceable-event slot, then persists
+    /// that replacement revision before any network attempt.
+    fn signed_artifact_reauthor_at_age_secs(&self) -> Option<u64> {
+        None
+    }
+
     /// Produce the exact signed transport artifact without network exposure.
     async fn prepare_key_package(
         &self,
         publication: KeyPackagePublication,
     ) -> Result<SignedPublicationArtifact, KeyPackagePublishError>;
 
-    /// Publish an already signed artifact. Retries must pass the identical
-    /// bytes returned by `prepare_key_package`.
+    /// Publish an already signed artifact. Retries within one authored
+    /// revision must pass the identical bytes returned by
+    /// `prepare_key_package`. The runtime may prepare and durably replace a
+    /// stale revision first when [`Self::signed_artifact_reauthor_at_age_secs`]
+    /// opts this transport into bounded-age reauthoring.
     async fn publish_prepared_key_package(
         &self,
         publication: &KeyPackagePublication,
         artifact: &SignedPublicationArtifact,
     ) -> Result<KeyPackagePublishReceipt, KeyPackagePublishError>;
+
+    /// Publish an already signed artifact with detailed endpoint evidence.
+    ///
+    /// Existing implementations need not override this additive method; their
+    /// legacy accepted/failed receipt is promoted conservatively by default.
+    async fn publish_prepared_key_package_detailed(
+        &self,
+        publication: &KeyPackagePublication,
+        artifact: &SignedPublicationArtifact,
+    ) -> Result<DetailedKeyPackagePublishReceipt, KeyPackagePublishError> {
+        self.publish_prepared_key_package(publication, artifact)
+            .await
+            .map(Into::into)
+    }
+
+    /// Delete one superseded signed revision from the listed transport
+    /// endpoints.
+    ///
+    /// Implementations must report endpoint identities exactly. The account
+    /// runtime removes only acknowledged endpoints from its durable deletion
+    /// obligation; a failed, cancelled, or ambiguous call remains retryable.
+    async fn delete_key_package_revision(
+        &self,
+        _event_id: &MessageId,
+        endpoints: &[TransportEndpoint],
+    ) -> Result<DetailedKeyPackagePublishReceipt, KeyPackagePublishError> {
+        Err(KeyPackagePublishError::unexposed(format!(
+            "key package revision deletion is unsupported for {} endpoint(s)",
+            endpoints.len()
+        )))
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -112,6 +209,19 @@ impl KeyPackagePublisher for NoopKeyPackagePublisher {
     ) -> Result<KeyPackagePublishReceipt, KeyPackagePublishError> {
         Ok(KeyPackagePublishReceipt {
             accepted: publication.endpoints.clone(),
+            failed: Vec::new(),
+        })
+    }
+
+    async fn delete_key_package_revision(
+        &self,
+        _event_id: &MessageId,
+        endpoints: &[TransportEndpoint],
+    ) -> Result<DetailedKeyPackagePublishReceipt, KeyPackagePublishError> {
+        Ok(DetailedKeyPackagePublishReceipt {
+            accepted: endpoints.to_vec(),
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
             failed: Vec::new(),
         })
     }

--- a/crates/marmot-account/src/lib.rs
+++ b/crates/marmot-account/src/lib.rs
@@ -21,15 +21,19 @@ pub use home::{
     DEFAULT_KEYCHAIN_SERVICE_NAME, EXTERNAL_SQLCIPHER_SECRET_FILE, NostrAccountImport,
 };
 pub use key_package::{
-    KeyPackagePublication, KeyPackagePublishError, KeyPackagePublishReceipt, KeyPackagePublisher,
-    NoopKeyPackagePublisher,
+    DetailedKeyPackagePublishReceipt, KeyPackagePublication, KeyPackagePublishError,
+    KeyPackagePublishReceipt, KeyPackagePublisher, NoopKeyPackagePublisher,
 };
 pub use routing::{StaticTransportRouting, TransportRoutingError, TransportRoutingPolicy};
 pub use runtime::{
-    AccountDeviceEffects, AccountDeviceRuntime, AccountIngestEffects, CompletedWelcomePublishTask,
+    AccountDeviceEffects, AccountDeviceRuntime, AccountIngestEffects,
+    AccountVisibilityActionOutcome, AccountVisibilityBatch, AccountVisibilityLease,
+    AccountVisibilityOutboundAction, AccountVisibilityRecordKind, AccountVisibilitySource,
+    CompletedWelcomePublishTask, LeasedAccountDeviceEffects, LeasedAccountIngestEffects,
     PendingResolution, PreparedSessionCommit, PreparedSessionSend, PreparedWelcomePublishTask,
-    PublishFailure, PublishedApplicationMessage, UnresolvedApplicationMessage, UnresolvedPublish,
-    UnresolvedPublishReason, WelcomeDeliveryFailure,
+    PublishFailure, PublishedApplicationMessage, RetiredKeyPackageDeletionPassReport,
+    UnresolvedApplicationMessage, UnresolvedPublish, UnresolvedPublishReason,
+    WelcomeDeliveryFailure,
 };
 pub use secret_store::{AccountSecretStore, KeychainSecretStore, LocalFileSecretStore};
 pub use time::{

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -1,7 +1,7 @@
 //! Account-device runtime: drives session effects through transport publish,
 //! confirmation, and rollback, and the effect aggregates it produces.
 
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -18,13 +18,16 @@ use cgka_traits::group::{Group, Member};
 use cgka_traits::ingest::IngestOutcome;
 use cgka_traits::maintenance::{
     DurableTransportFanout, GroupEvolutionPhase, GroupEvolutionSemantic, GroupMaintenanceStatus,
-    KeyPackageLifecycleState, MaintenanceObligation, MaintenancePhase, MaintenanceTrigger,
-    PeriodicMaintenancePolicy, RetainedKeyPackagePrivateMaterial, SendMaintenanceDisposition,
-    TransportFanoutAttemptState, TransportFanoutTarget,
+    KeyPackageLifecycleState, MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES,
+    MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES_WITH_LIVE_DELETION_OVERFLOW,
+    MaintenanceObligation, MaintenancePhase, MaintenanceTrigger, PeriodicMaintenancePolicy,
+    RetainedKeyPackagePrivateMaterial, RetiredKeyPackagePublication, SendMaintenanceDisposition,
+    SignedPublicationArtifact, TransportFanoutAttemptState, TransportFanoutTarget,
 };
+use cgka_traits::storage::{LeaveRequestStorage, MessageStorage, StorageProvider};
 use cgka_traits::transport::{TransportEnvelope, TransportMessage};
 use cgka_traits::{
-    EpochId, FanoutMlsState, FanoutPendingKind, GroupId, MemberId, OutboundFanout,
+    EpochId, FanoutMlsState, FanoutPendingKind, GroupId, MemberId, MessageId, OutboundFanout,
     OutboundFanoutOutcome, StorageError, Timestamp, TransportAccountActivation, TransportAdapter,
     TransportAdapterError, TransportDelivery, TransportEndpoint, TransportEndpointFailure,
     TransportEndpointFailureKind, TransportEndpointReceipt, TransportGroupSync,
@@ -35,9 +38,18 @@ use futures::stream::FuturesUnordered;
 use marmot_forensics::{
     AuditEventContext, AuditEventKind, AuditTransportWire, MessageArtifactKind, PublishRelayFailure,
 };
+use rand::RngCore;
+use rand::rngs::OsRng;
+use serde::{Deserialize, Serialize};
+use storage_sqlite::{
+    AccountVisibilityJournalRow, AccountVisibilityJournalUpsert, SqliteAccountStorage,
+};
 
 use crate::error::{AccountError, AccountResult};
-use crate::key_package::{KeyPackagePublication, KeyPackagePublisher, NoopKeyPackagePublisher};
+use crate::key_package::{
+    DetailedKeyPackagePublishReceipt, KeyPackagePublication, KeyPackagePublisher,
+    NoopKeyPackagePublisher,
+};
 use crate::routing::{
     StaticTransportRouting, TransportRoutingPolicy, publish_target_group_id, publish_target_kind,
     publish_target_relay_urls,
@@ -50,6 +62,10 @@ use crate::time::{
 const TRACE_TARGET: &str = "marmot_account::runtime";
 const WELCOME_PUBLISH_CONCURRENCY: usize = 8;
 const KEY_PACKAGE_MAX_FUTURE_SKEW_SECS: u64 = 5 * 60;
+// One relay attempt bounds a maintenance call by one transport publish
+// deadline even when the durable privacy journal is full. Later ticks drain
+// additional endpoints without monopolizing the serialized account worker.
+const KEY_PACKAGE_RETIRED_DELETION_ATTEMPTS_PER_CALL: usize = 1;
 const KEY_PACKAGE_REFRESH_MIN_LEAD_SECS: u64 = 14 * 24 * 60 * 60;
 const KEY_PACKAGE_REFRESH_MAX_LEAD_SECS: u64 = 21 * 24 * 60 * 60;
 const MAINTENANCE_EOSE_TIMEOUT_SECS: u64 = 5 * 60;
@@ -60,6 +76,9 @@ const PERIODIC_MAX_SECS: u64 = 36 * 24 * 60 * 60;
 const TRANSPORT_FANOUT_RETENTION_SECS: u64 = 24 * 60 * 60;
 const FROZEN_FANOUT_RETRY_BASE_MS: u64 = 30 * 1_000;
 const FROZEN_FANOUT_RETRY_MAX_MS: u64 = 60 * 60 * 1_000;
+const ACCOUNT_VISIBILITY_RECORD_VERSION: u8 = 1;
+const ACCOUNT_VISIBILITY_CONTROL_ORDINAL: u64 = i64::MAX as u64 - 1;
+const ACCOUNT_VISIBILITY_NON_SESSION_ORDINAL: u64 = i64::MAX as u64;
 
 /// Run independent async work with fixed fan-out while returning results in
 /// input order. Completion order therefore cannot reorder reports or select a
@@ -98,6 +117,21 @@ struct PendingFanoutContinuation {
     pending: PendingStateRef,
     kind: FanoutPendingKind,
     post_confirmation_welcomes: Vec<TransportMessage>,
+}
+
+/// Cutover-facing outcome from one bounded retired-KeyPackage deletion pass.
+///
+/// `terminal_endpoints` contains only endpoints whose accepted deletion or
+/// confirmed-absence receipt has already been committed durably. A remaining
+/// uncovered deletion is currently eligible even though no strictly newer
+/// live revision has an accepted receipt at that endpoint; cutover discovery
+/// must therefore stay armed because a later retry may reveal older relay
+/// history.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[must_use]
+pub struct RetiredKeyPackageDeletionPassReport {
+    pub terminal_endpoints: Vec<TransportEndpoint>,
+    pub has_uncovered_eligible_deletion: bool,
 }
 
 enum PreparedLegacyPublish {
@@ -147,6 +181,91 @@ struct CompletedWelcomePublish {
     group_id: Option<GroupId>,
     metadata: Vec<WelcomePublishMetadata>,
     completions: Vec<Option<LegacyPublishCompletion>>,
+}
+
+/// One caller-visible account-effects batch that has not yet crossed the
+/// account-runtime boundary.
+///
+/// The engine persists application deliveries for process-restart replay, but
+/// its live `events_buf` and the account runtime's publication summaries are
+/// one-shot. Keeping the complete account-shaped batch prevents a failed or
+/// cancelled later publish from losing an earlier report, application-message
+/// acceptance, pending resolution, or session event.
+struct RetainedSessionVisibilityBatch {
+    operation_id: Option<[u8; 16]>,
+    effects: AccountDeviceEffects,
+}
+
+#[derive(Clone, Copy)]
+struct SessionVisibilityHandoff {
+    retained_batch_count: usize,
+    operation_id: [u8; 16],
+    fragment_id: u64,
+}
+
+struct DurableVisibilityOperation {
+    source: AccountVisibilitySource,
+    next_event_ordinal: u64,
+    session_control: StoredSessionControlV1,
+    non_session_fragments: BTreeMap<u64, AccountDeviceEffects>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct StoredAccountVisibilityRecordV1 {
+    version: u8,
+    source: AccountVisibilitySource,
+    payload: StoredAccountVisibilityPayloadV1,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum StoredAccountVisibilityPayloadV1 {
+    Header {
+        maintenance_disposition: SendMaintenanceDisposition,
+    },
+    Event {
+        event: GroupEvent,
+        engine_outbox_provenance: bool,
+    },
+    SessionControl(StoredSessionControlV1),
+    NonSession(StoredNonSessionEffectsV1),
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+struct StoredSessionControlV1 {
+    queued: Vec<StoredQueuedIntentRefV1>,
+    pending_convergence: Vec<GroupId>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct StoredQueuedIntentRefV1 {
+    group_id: GroupId,
+    intent_id: MessageId,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+struct StoredNonSessionEffectsV1 {
+    reports: Vec<TransportPublishReport>,
+    fanout: Vec<OutboundFanoutOutcome>,
+    failures: Vec<PublishFailure>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    action_outcomes: Vec<AccountVisibilityActionOutcome>,
+    published_app_messages: Vec<PublishedApplicationMessage>,
+    welcome_failures: Vec<WelcomeDeliveryFailure>,
+    pending: Vec<PendingResolution>,
+}
+
+/// Opaque generation for one account-effects visibility handoff.
+///
+/// Acknowledging a stale generation is a no-op: every later leased return
+/// supersedes the prior lease and contains its still-unacknowledged effects.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[must_use = "the matching visibility lease must be acknowledged after projection staging"]
+pub struct AccountVisibilityLease(u64);
+
+struct RetainedReturnedVisibilityLease {
+    lease: AccountVisibilityLease,
+    batch_ids: Vec<Vec<u8>>,
 }
 
 /// Relay-only half of a prepared Welcome retry.
@@ -275,6 +394,25 @@ pub struct AccountDeviceRuntime<A, R = StaticTransportRouting, K = NoopKeyPackag
     /// legacy publish for this message id fails with a transient storage
     /// error. Never set by production code.
     finish_stage_failure: Option<cgka_traits::MessageId>,
+    /// Session visibility drained before an awaited publication completed.
+    /// Batches stay here across `Err` and future cancellation. A later
+    /// successful leased return hands them off in original order.
+    retained_session_visibility: VecDeque<RetainedSessionVisibilityBatch>,
+    visibility_storage: SqliteAccountStorage,
+    durable_visibility_operations: HashMap<[u8; 16], DurableVisibilityOperation>,
+    active_visibility_operation: Option<[u8; 16]>,
+    next_visibility_fragment_id: u64,
+    visibility_load_error: Option<String>,
+    /// Engine application-outbox events are hydrated into the session's live
+    /// buffer before this runtime opens. When the same exact event already has
+    /// a durable visibility row, suppress that one live copy so replay + later
+    /// drain cannot publish it twice.
+    hydrated_visibility_suppressions: Vec<GroupEvent>,
+    /// Exact effects already returned through a leased API but not yet
+    /// acknowledged by the app projection/V1 boundary. A later leased return
+    /// prepends this batch without re-running any publication work.
+    returned_visibility_lease: Option<RetainedReturnedVisibilityLease>,
+    next_visibility_lease_id: u64,
 }
 
 impl<A, R, K> AccountDeviceRuntime<A, R, K>
@@ -284,6 +422,34 @@ where
     K: KeyPackagePublisher,
 {
     pub fn new(session: AccountDeviceSession, adapter: A, routing: R, key_packages: K) -> Self {
+        let visibility_storage = session.storage_handle();
+        let (visibility_load_error, hydrated_visibility_suppressions) =
+            match visibility_storage.load_account_visibility_journal() {
+                Ok(rows) => {
+                    let mut suppressions = Vec::new();
+                    let mut decode_error = None;
+                    for row in rows {
+                        match decode_account_visibility_row(row) {
+                            Ok(batch) => {
+                                if matches!(
+                                    batch.kind,
+                                    AccountVisibilityRecordKind::Event {
+                                        engine_outbox_provenance: true
+                                    }
+                                ) {
+                                    suppressions.extend(batch.effects.events);
+                                }
+                            }
+                            Err(error) => {
+                                decode_error = Some(error.to_string());
+                                break;
+                            }
+                        }
+                    }
+                    (decode_error, suppressions)
+                }
+                Err(error) => (Some(error.to_string()), Vec::new()),
+            };
         Self {
             session,
             adapter,
@@ -296,6 +462,15 @@ where
             maintenance_quiet_monotonic: HashMap::new(),
             detached_welcome_publishes: HashSet::new(),
             finish_stage_failure: None,
+            retained_session_visibility: VecDeque::new(),
+            visibility_storage,
+            durable_visibility_operations: HashMap::new(),
+            active_visibility_operation: None,
+            next_visibility_fragment_id: 1,
+            visibility_load_error,
+            hydrated_visibility_suppressions,
+            returned_visibility_lease: None,
+            next_visibility_lease_id: 1,
         }
     }
 
@@ -472,8 +647,10 @@ where
         Ok(())
     }
 
-    /// Re-send the exact current durable authored KeyPackage event to the
-    /// current authoritative publication targets without staging a replacement.
+    /// Re-send the current durable authored KeyPackage event to the current
+    /// authoritative publication targets without staging a replacement MLS
+    /// KeyPackage. A bounded-age transport may first author a newer signed
+    /// revision at the same replaceable-event coordinate.
     ///
     /// When no usable current package or signed artifact exists, this falls back to
     /// [`Self::publish_fresh_key_package`].
@@ -487,6 +664,7 @@ where
             );
             return self.publish_fresh_key_package().await;
         };
+        ensure_key_package_cutover_publication_allowed(&lifecycle)?;
         if lifecycle.pending_replacement.is_some() {
             return Err(AccountError::KeyPackageRotationInProgress);
         }
@@ -515,6 +693,19 @@ where
         );
 
         let current_endpoints = self.routing.key_package_endpoints();
+        let additional_policy_targets = current_endpoints
+            .iter()
+            .filter(|endpoint| {
+                !lifecycle
+                    .publication_targets
+                    .iter()
+                    .any(|target| target.endpoint == **endpoint)
+            })
+            .count();
+        self.ensure_key_package_publication_liability_capacity(
+            &mut lifecycle,
+            additional_policy_targets,
+        )?;
         merge_republish_publication_targets(&mut lifecycle.publication_targets, &current_endpoints);
         let endpoints = current_endpoints.to_vec();
         if endpoints.is_empty() {
@@ -525,15 +716,6 @@ where
             .into());
         }
 
-        let Some(artifact) = lifecycle.authored_signed_event.clone() else {
-            tracing::debug!(
-                target: TRACE_TARGET,
-                method = "republish_key_package",
-                fallback_reason = "missing_authored_signed_event",
-                "no republishable current key package artifact; falling back to fresh publication"
-            );
-            return self.publish_fresh_key_package().await;
-        };
         let Some(key_package) = lifecycle.current_key_package.clone() else {
             tracing::debug!(
                 target: TRACE_TARGET,
@@ -543,9 +725,18 @@ where
             );
             return self.publish_fresh_key_package().await;
         };
+        self.reauthor_current_key_package_if_stale(&mut lifecycle, &key_package, &endpoints)
+            .await?;
+        let Some(artifact) = lifecycle.authored_signed_event.clone() else {
+            tracing::debug!(
+                target: TRACE_TARGET,
+                method = "republish_key_package",
+                fallback_reason = "missing_authored_signed_event",
+                "no republishable current key package artifact; falling back to fresh publication"
+            );
+            return self.publish_fresh_key_package().await;
+        };
 
-        lifecycle.phase = cgka_traits::MaintenancePhase::Fanout;
-        self.session.put_key_package_lifecycle(&lifecycle)?;
         let publication = KeyPackagePublication {
             account_id: self.session.self_id().clone(),
             key_package: key_package.clone(),
@@ -553,18 +744,26 @@ where
             created_at: artifact.created_at,
             endpoints: endpoints.clone(),
         };
+        lifecycle.phase = cgka_traits::MaintenancePhase::Fanout;
+        begin_key_package_attempt(
+            &mut lifecycle.publication_targets,
+            &publication.endpoints,
+            self.wall_clock.now(),
+        );
+        self.session.put_key_package_lifecycle(&lifecycle)?;
         match self
             .key_packages
-            .publish_prepared_key_package(&publication, &artifact)
+            .publish_prepared_key_package_detailed(&publication, &artifact)
             .await
         {
             Ok(receipt) => {
-                note_key_package_attempt(
+                let receipt = scope_key_package_publish_receipt(receipt, &publication.endpoints);
+                finish_key_package_attempt(
                     &mut lifecycle.publication_targets,
-                    &publication.endpoints,
                     &receipt.accepted,
+                    &receipt.rejected,
+                    &receipt.confirmed_absent,
                     &receipt.failed,
-                    self.wall_clock.now(),
                 );
                 if receipt.accepted.is_empty() {
                     lifecycle.phase = cgka_traits::MaintenancePhase::Retry;
@@ -574,13 +773,11 @@ where
                     )
                     .into());
                 }
-                lifecycle.phase = if lifecycle.publication_targets.iter().all(|target| {
-                    matches!(
-                        target.state,
-                        TransportFanoutAttemptState::Accepted
-                            | TransportFanoutAttemptState::PolicyProhibited
-                    )
-                }) {
+                lifecycle.phase = if lifecycle
+                    .publication_targets
+                    .iter()
+                    .all(key_package_target_is_terminal)
+                {
                     cgka_traits::MaintenancePhase::Complete
                 } else {
                     cgka_traits::MaintenancePhase::Fanout
@@ -589,13 +786,6 @@ where
                 Ok(key_package)
             }
             Err(error) => {
-                note_key_package_attempt(
-                    &mut lifecycle.publication_targets,
-                    &publication.endpoints,
-                    &[],
-                    &[],
-                    self.wall_clock.now(),
-                );
                 lifecycle.phase = if error.externally_exposed {
                     cgka_traits::MaintenancePhase::Fanout
                 } else {
@@ -607,13 +797,213 @@ where
         }
     }
 
-    /// Stage the exact next KeyPackage and authored publication bytes without
-    /// performing any network I/O.
+    /// Replace a stale pending transport revision without replacing the MLS
+    /// KeyPackage or its durable private material. The signed revision and all
+    /// correlated lifecycle fields are committed before any network call.
+    async fn reauthor_pending_key_package_if_stale(
+        &mut self,
+        lifecycle: &mut KeyPackageLifecycleState,
+    ) -> AccountResult<()> {
+        let Some(pending) = lifecycle.pending_replacement.as_ref() else {
+            return Ok(());
+        };
+        let Some(previous_artifact) = pending.signed_event.clone() else {
+            return Ok(());
+        };
+        let pending_key_package = pending.key_package.clone();
+        let pending_key_package_ref = pending.key_package_ref.clone();
+        let pending_not_after = pending.not_after;
+        let pending_targets = pending.targets.clone();
+        let now = self.wall_clock.now();
+        let force_reauthor = lifecycle
+            .deleted_live_revision_event_ids
+            .contains(&previous_artifact.id);
+        let reauthor_after = force_reauthor
+            .then_some(0)
+            .or(self.key_packages.signed_artifact_reauthor_at_age_secs());
+        let created_at = match key_package_reauthor_created_at(
+            &previous_artifact,
+            now,
+            reauthor_after,
+            lifecycle.authored_event_created_at,
+            true,
+        ) {
+            Ok(Some(created_at)) => created_at,
+            Ok(None) => return Ok(()),
+            Err(()) => {
+                lifecycle.phase = MaintenancePhase::ClockSkewBlocked;
+                self.session.put_key_package_lifecycle(lifecycle)?;
+                return Err(AccountError::ClockSkewBlocked);
+            }
+        };
+        let endpoints = pending_targets
+            .iter()
+            .filter(|target| target.state != TransportFanoutAttemptState::PolicyProhibited)
+            .map(|target| target.endpoint.clone())
+            .collect::<Vec<_>>();
+        let publication = KeyPackagePublication {
+            account_id: self.session.self_id().clone(),
+            key_package: pending_key_package,
+            slot_id: lifecycle.stable_slot_id.clone(),
+            created_at,
+            endpoints: endpoints.clone(),
+        };
+        let retired_publication = retired_key_package_publication(
+            &previous_artifact,
+            Some(&pending_key_package_ref),
+            Some(pending_not_after),
+            false,
+            &pending_targets,
+        );
+        let projected_liabilities = projected_pending_key_package_reauthor_liability_count(
+            lifecycle,
+            retired_publication.as_ref(),
+            &endpoints,
+        );
+        self.ensure_key_package_publication_liability_count(lifecycle, projected_liabilities)?;
+        let artifact = self.key_packages.prepare_key_package(publication).await?;
+        validate_reauthored_key_package_artifact(&previous_artifact, created_at, &artifact)?;
+
+        if let Some(retired_publication) = retired_publication {
+            retain_retired_key_package_publication(lifecycle, retired_publication);
+        }
+        let pending = lifecycle
+            .pending_replacement
+            .as_mut()
+            .expect("pending replacement remains serialized while reauthoring");
+        pending.authored_created_at = artifact.created_at;
+        pending.signed_event = Some(artifact);
+        pending.attempt_count = 0;
+        pending.last_failure_code = None;
+        replace_key_package_publication_targets(&mut pending.targets, &endpoints);
+        lifecycle
+            .deleted_live_revision_event_ids
+            .retain(|event_id| *event_id != previous_artifact.id);
+        lifecycle.phase = MaintenancePhase::PendingPublication;
+        self.session.put_key_package_lifecycle(lifecycle)?;
+        Ok(())
+    }
+
+    /// Reconcile a durable pending revision with the account's current
+    /// authoritative publication policy before either reauthoring or sending
+    /// it. Endpoint changes do not alter the signed Nostr event bytes, but they
+    /// do alter the exact privacy-liability set and therefore must pass the
+    /// global bound and commit before network I/O.
+    fn reconcile_pending_key_package_publication_targets(
+        &mut self,
+        lifecycle: &mut KeyPackageLifecycleState,
+        authoritative_endpoints: &[TransportEndpoint],
+    ) -> AccountResult<()> {
+        let Some(_) = lifecycle.pending_replacement.as_ref() else {
+            return Ok(());
+        };
+        let mut reconciled = lifecycle.clone();
+        merge_republish_publication_targets(
+            &mut reconciled
+                .pending_replacement
+                .as_mut()
+                .expect("pending replacement remains present in cloned lifecycle")
+                .targets,
+            authoritative_endpoints,
+        );
+        if key_package_signed_publication_liability_count(&reconciled)
+            > MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES
+        {
+            lifecycle.phase = MaintenancePhase::Retry;
+            self.session.put_key_package_lifecycle(lifecycle)?;
+            return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                "key package signed-publication endpoint-liability journal is full",
+            )
+            .into());
+        }
+        if reconciled != *lifecycle {
+            *lifecycle = reconciled;
+            self.session.put_key_package_lifecycle(lifecycle)?;
+        }
+        Ok(())
+    }
+
+    /// Replace a stale current transport revision while retaining the same MLS
+    /// KeyPackage coordinate. Every live target must receive the newer
+    /// parameterized-replaceable event, including relays that acknowledged the
+    /// superseded revision.
+    async fn reauthor_current_key_package_if_stale(
+        &mut self,
+        lifecycle: &mut KeyPackageLifecycleState,
+        key_package: &KeyPackage,
+        live_endpoints: &[TransportEndpoint],
+    ) -> AccountResult<()> {
+        let Some(previous_artifact) = lifecycle.authored_signed_event.clone() else {
+            return Ok(());
+        };
+        let now = self.wall_clock.now();
+        let force_reauthor = lifecycle
+            .deleted_live_revision_event_ids
+            .contains(&previous_artifact.id);
+        let reauthor_after = force_reauthor
+            .then_some(0)
+            .or(self.key_packages.signed_artifact_reauthor_at_age_secs());
+        let created_at = match key_package_reauthor_created_at(
+            &previous_artifact,
+            now,
+            reauthor_after,
+            lifecycle.authored_event_created_at,
+            false,
+        ) {
+            Ok(Some(created_at)) => created_at,
+            Ok(None) => return Ok(()),
+            Err(()) => {
+                lifecycle.phase = MaintenancePhase::ClockSkewBlocked;
+                self.session.put_key_package_lifecycle(lifecycle)?;
+                return Err(AccountError::ClockSkewBlocked);
+            }
+        };
+        let publication = KeyPackagePublication {
+            account_id: self.session.self_id().clone(),
+            key_package: key_package.clone(),
+            slot_id: lifecycle.stable_slot_id.clone(),
+            created_at,
+            endpoints: live_endpoints.to_vec(),
+        };
+        let retired_publication = retired_key_package_publication(
+            &previous_artifact,
+            lifecycle.current_key_package_ref.as_deref(),
+            lifecycle.current_not_after,
+            false,
+            &lifecycle.publication_targets,
+        );
+        let projected_liabilities = projected_current_key_package_reauthor_liability_count(
+            lifecycle,
+            retired_publication.as_ref(),
+            live_endpoints,
+        );
+        self.ensure_key_package_publication_liability_count(lifecycle, projected_liabilities)?;
+        let artifact = self.key_packages.prepare_key_package(publication).await?;
+        validate_reauthored_key_package_artifact(&previous_artifact, created_at, &artifact)?;
+
+        if let Some(retired_publication) = retired_publication {
+            retain_retired_key_package_publication(lifecycle, retired_publication);
+        }
+        lifecycle.authored_event_id = Some(artifact.id.clone());
+        lifecycle.authored_event_created_at = Some(artifact.created_at);
+        lifecycle.authored_signed_event = Some(artifact);
+        lifecycle
+            .deleted_live_revision_event_ids
+            .retain(|event_id| *event_id != previous_artifact.id);
+        replace_key_package_publication_targets(&mut lifecycle.publication_targets, live_endpoints);
+        lifecycle.phase = MaintenancePhase::Fanout;
+        self.session.put_key_package_lifecycle(lifecycle)?;
+        Ok(())
+    }
+
+    /// Stage the next MLS KeyPackage, durable private material, and initial
+    /// signed publication revision without performing any network I/O.
     ///
     /// This is the durable local-readiness boundary for generated accounts:
     /// callers may return the identity only after this succeeds, then resume
-    /// [`Self::publish_fresh_key_package`] later with the same persisted
-    /// private material and signed artifact.
+    /// the same durable lifecycle later. Publication uses the current signed
+    /// revision exactly unless bounded-age policy first persists a newer
+    /// revision at the same replaceable-event coordinate.
     pub async fn prepare_fresh_key_package(
         &mut self,
         endpoints: Vec<TransportEndpoint>,
@@ -624,6 +1014,7 @@ where
             endpoint_count = endpoints.len(),
             "preparing fresh key package for later publication"
         );
+        self.sweep_expired_key_package_private_material()?;
         let now = self.wall_clock.now();
         let mut lifecycle = match self.session.key_package_lifecycle()? {
             Some(state) => state,
@@ -639,6 +1030,7 @@ where
                 KeyPackageLifecycleState {
                     stable_slot_id,
                     phase: cgka_traits::MaintenancePhase::Complete,
+                    cutover_publication_blocked: false,
                     current_key_package: None,
                     current_key_package_ref: None,
                     current_not_before: None,
@@ -646,11 +1038,15 @@ where
                     authored_event_id: None,
                     authored_event_created_at: None,
                     authored_signed_event: None,
+                    deleted_live_revision_event_ids: Vec::new(),
+                    deletion_overflow_owner_event_id: None,
+                    retired_publications_pending_deletion: Vec::new(),
                     publication_targets: Vec::new(),
                     refresh_at: None,
                     upgrade_rotation_recorded: false,
                     last_consumed_key_package_ref: None,
                     last_consumed_at: None,
+                    consumed_key_package_refs: Vec::new(),
                     retained_private_material: Vec::new(),
                     pending_replacement: None,
                 }
@@ -685,7 +1081,8 @@ where
                 created_at,
                 lead,
                 endpoints
-                    .into_iter()
+                    .iter()
+                    .cloned()
                     .map(|endpoint| TransportFanoutTarget {
                         endpoint,
                         state: TransportFanoutAttemptState::Unattempted,
@@ -696,6 +1093,12 @@ where
                     .collect(),
             )?;
         }
+
+        // A pending replacement can outlive the route policy that originally
+        // staged it. Reconcile before signing so a zero-target draft is not
+        // frozen into an artifact that a real transport correctly refuses to
+        // publish once a route later appears.
+        self.reconcile_pending_key_package_publication_targets(&mut lifecycle, &endpoints)?;
 
         if lifecycle
             .pending_replacement
@@ -714,9 +1117,14 @@ where
                 endpoints: pending
                     .targets
                     .iter()
+                    .filter(|target| target.state != TransportFanoutAttemptState::PolicyProhibited)
                     .map(|target| target.endpoint.clone())
                     .collect(),
             };
+            self.ensure_key_package_publication_liability_capacity(
+                &mut lifecycle,
+                publication.endpoints.len(),
+            )?;
             let artifact = self.key_packages.prepare_key_package(publication).await?;
             lifecycle
                 .pending_replacement
@@ -726,6 +1134,14 @@ where
             // Exact signed bytes are durable before the first network call.
             self.session.put_key_package_lifecycle(&lifecycle)?;
         }
+
+        // Relay discovery may have advanced the stable-slot high-water after
+        // this exact pending artifact was signed. Reauthor locally while the
+        // cutover gate is still armed; the superseded exact revision and the
+        // strict-newer signed bytes commit before this method returns, and no
+        // network I/O occurs here.
+        self.reauthor_pending_key_package_if_stale(&mut lifecycle)
+            .await?;
 
         Ok(lifecycle
             .pending_replacement
@@ -742,12 +1158,20 @@ where
             endpoint_count = self.routing.key_package_endpoints().len(),
             "publishing fresh key package"
         );
+        if let Some(lifecycle) = self.session.key_package_lifecycle()? {
+            ensure_key_package_cutover_publication_allowed(&lifecycle)?;
+        }
         let endpoints = self.routing.key_package_endpoints().to_vec();
-        self.prepare_fresh_key_package(endpoints).await?;
+        self.prepare_fresh_key_package(endpoints.clone()).await?;
         let mut lifecycle = self
             .session
             .key_package_lifecycle()?
             .expect("prepared lifecycle is durable");
+
+        self.reconcile_pending_key_package_publication_targets(&mut lifecycle, &endpoints)?;
+
+        self.reauthor_pending_key_package_if_stale(&mut lifecycle)
+            .await?;
 
         let pending = lifecycle
             .pending_replacement
@@ -766,15 +1190,27 @@ where
             endpoints: pending
                 .targets
                 .iter()
+                .filter(|target| target.state != TransportFanoutAttemptState::PolicyProhibited)
                 .map(|target| target.endpoint.clone())
                 .collect(),
         };
+        begin_key_package_attempt(
+            &mut lifecycle
+                .pending_replacement
+                .as_mut()
+                .expect("pending replacement remains durable before publication")
+                .targets,
+            &publication.endpoints,
+            self.wall_clock.now(),
+        );
+        lifecycle.phase = MaintenancePhase::PendingPublication;
+        self.session.put_key_package_lifecycle(&lifecycle)?;
         let receipt = match self
             .key_packages
-            .publish_prepared_key_package(&publication, &artifact)
+            .publish_prepared_key_package_detailed(&publication, &artifact)
             .await
         {
-            Ok(receipt) => receipt,
+            Ok(receipt) => scope_key_package_publish_receipt(receipt, &publication.endpoints),
             Err(error) => {
                 if let Some(pending) = lifecycle.pending_replacement.as_mut() {
                     pending.attempt_count = pending.attempt_count.saturating_add(1);
@@ -786,13 +1222,6 @@ where
                         }
                         .into(),
                     );
-                    note_key_package_attempt(
-                        &mut pending.targets,
-                        &publication.endpoints,
-                        &[],
-                        &[],
-                        self.wall_clock.now(),
-                    );
                 }
                 lifecycle.phase = cgka_traits::MaintenancePhase::Retry;
                 self.session.put_key_package_lifecycle(&lifecycle)?;
@@ -803,12 +1232,12 @@ where
             if let Some(pending) = lifecycle.pending_replacement.as_mut() {
                 pending.attempt_count = pending.attempt_count.saturating_add(1);
                 pending.last_failure_code = Some("ambiguous_exposure".into());
-                note_key_package_attempt(
+                finish_key_package_attempt(
                     &mut pending.targets,
-                    &publication.endpoints,
                     &receipt.accepted,
+                    &receipt.rejected,
+                    &receipt.confirmed_absent,
                     &receipt.failed,
-                    self.wall_clock.now(),
                 );
             }
             lifecycle.phase = cgka_traits::MaintenancePhase::Retry;
@@ -823,16 +1252,27 @@ where
             .pending_replacement
             .take()
             .expect("published replacement exists");
-        note_key_package_attempt(
+        finish_key_package_attempt(
             &mut replacement.targets,
-            &publication.endpoints,
             &receipt.accepted,
+            &receipt.rejected,
+            &receipt.confirmed_absent,
             &receipt.failed,
-            self.wall_clock.now(),
         );
         let previous = lifecycle.current_key_package.clone();
-        let previous_was_consumed = lifecycle.current_key_package_ref.is_some()
-            && lifecycle.current_key_package_ref == lifecycle.last_consumed_key_package_ref;
+        let previous_key_package_ref = lifecycle.current_key_package_ref.clone();
+        let previous_was_consumed = previous_key_package_ref
+            .as_deref()
+            .is_some_and(|key_package_ref| lifecycle.key_package_ref_is_consumed(key_package_ref));
+        let superseded_publication =
+            retired_current_key_package_publication(&lifecycle, previous_was_consumed);
+        if let Some(superseded_publication) = superseded_publication {
+            retain_retired_key_package_publication(&mut lifecycle, superseded_publication);
+        }
+        if previous_was_consumed && let Some(key_package_ref) = previous_key_package_ref.as_deref()
+        {
+            mark_retired_key_package_revisions_unusable(&mut lifecycle, key_package_ref);
+        }
         if !previous_was_consumed
             && let (Some(key_package), Some(key_package_ref), Some(not_after)) = (
                 previous.clone(),
@@ -856,22 +1296,27 @@ where
         lifecycle.authored_event_id = Some(artifact.id.clone());
         lifecycle.authored_event_created_at = Some(artifact.created_at);
         lifecycle.authored_signed_event = Some(artifact);
+        // A relay-acknowledged semantic replacement supersedes every deleted
+        // live revision that could otherwise have been retried.
+        lifecycle.deleted_live_revision_event_ids.clear();
         lifecycle.publication_targets = replacement.targets;
         lifecycle.refresh_at = Some(replacement.refresh_at);
-        lifecycle.phase = if lifecycle.publication_targets.iter().all(|target| {
-            matches!(
-                target.state,
-                TransportFanoutAttemptState::Accepted
-                    | TransportFanoutAttemptState::PolicyProhibited
-            )
-        }) {
+        lifecycle.phase = if lifecycle
+            .publication_targets
+            .iter()
+            .all(key_package_target_is_terminal)
+        {
             cgka_traits::MaintenancePhase::Complete
         } else {
             cgka_traits::MaintenancePhase::Fanout
         };
         lifecycle.upgrade_rotation_recorded = true;
-        lifecycle.last_consumed_key_package_ref = None;
-        lifecycle.last_consumed_at = None;
+        if previous_was_consumed
+            && let Some(key_package_ref) = previous_key_package_ref.as_deref()
+            && !key_package_ref_has_live_private_material(&lifecycle, key_package_ref)
+        {
+            lifecycle.clear_consumed_key_package_ref(key_package_ref);
+        }
         let retired = if previous_was_consumed {
             previous.into_iter().collect::<Vec<_>>()
         } else {
@@ -888,6 +1333,659 @@ where
         Ok(self.session.key_package_lifecycle()?)
     }
 
+    /// Transfer cutover-era Welcome-consumption evidence onto every exact
+    /// relay revision admitted by a completed authoritative scan, then reclaim
+    /// bounded ref-journal entries that no longer protect live private
+    /// material.
+    ///
+    /// The app calls this after all authoritative relay pages were processed
+    /// and before it persists the scan-complete marker or clears the
+    /// publication gate. A crash beforehand retains the refs; afterward each
+    /// matching exact liability independently carries
+    /// `delete_without_successor`.
+    pub fn finalize_key_package_cutover_consumption_evidence(&mut self) -> AccountResult<()> {
+        let Some(mut lifecycle) = self.session.key_package_lifecycle()? else {
+            return Ok(());
+        };
+        let mut live_refs = lifecycle
+            .current_key_package_ref
+            .clone()
+            .into_iter()
+            .chain(
+                lifecycle
+                    .pending_replacement
+                    .as_ref()
+                    .map(|pending| pending.key_package_ref.clone()),
+            )
+            .chain(
+                lifecycle
+                    .retained_private_material
+                    .iter()
+                    .map(|retained| retained.key_package_ref.clone()),
+            )
+            .collect::<Vec<_>>();
+        for key_package in self.session.durably_owned_key_packages()? {
+            let metadata = self.session.key_package_metadata(&key_package)?;
+            live_refs.push(hex::decode(&metadata.key_package_ref_hex).map_err(|error| {
+                cgka_traits::EngineError::Serialize(format!(
+                    "durable key package reference: {error}"
+                ))
+            })?);
+        }
+        live_refs.sort();
+        live_refs.dedup();
+
+        let refs = lifecycle.consumed_key_package_refs.clone();
+        for key_package_ref in refs {
+            mark_retired_key_package_revisions_unusable(&mut lifecycle, &key_package_ref);
+            if live_refs.contains(&key_package_ref) {
+                continue;
+            }
+            lifecycle.clear_consumed_key_package_ref(&key_package_ref);
+        }
+        self.session.put_key_package_lifecycle(&lifecycle)?;
+        Ok(())
+    }
+
+    /// Persist the upgrade-cutover publication interlock under the account
+    /// runtime's single-writer authority.
+    ///
+    /// Exact retired-revision deletion remains available while blocked. Every
+    /// kind-30443 publication path checks this bit immediately before it can
+    /// prepare a network attempt, so worker ticks and manual commands cannot
+    /// race an incomplete relay scan.
+    pub fn set_key_package_cutover_publication_blocked(
+        &mut self,
+        blocked: bool,
+    ) -> AccountResult<()> {
+        let Some(mut lifecycle) = self.session.key_package_lifecycle()? else {
+            return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                "cannot update the key package cutover gate without lifecycle state",
+            )
+            .into());
+        };
+        if lifecycle.stable_slot_id.is_empty() {
+            return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                "cannot update the key package cutover gate without a stable slot",
+            )
+            .into());
+        }
+        if lifecycle.cutover_publication_blocked != blocked {
+            lifecycle.cutover_publication_blocked = blocked;
+            self.session.put_key_package_lifecycle(&lifecycle)?;
+        }
+        Ok(())
+    }
+
+    /// Retain the signed relay timestamp of an exact live same-slot revision.
+    ///
+    /// Upgrade-era cache rows can carry a defaulted or stale `published_at`
+    /// even though the relay still has the exact signed event.  A strict
+    /// cutover scan verifies the event signature and stable slot before
+    /// calling this method. Persisting both the raw timestamp and every exact
+    /// source endpoint before the scan is marked complete prevents a later
+    /// replacement from losing NIP-33 ordering or hiding an old relay copy
+    /// after a local clock rollback or route change. Endpoints beyond the
+    /// ordinary liability bound are returned deferred; strict cutover must
+    /// retain its publication gate until those endpoints are durable.
+    pub fn observe_live_key_package_publication(
+        &mut self,
+        stable_slot_id: String,
+        event_id: &MessageId,
+        authored_created_at: Timestamp,
+        mut endpoints: Vec<TransportEndpoint>,
+    ) -> AccountResult<(Vec<TransportEndpoint>, Vec<TransportEndpoint>)> {
+        if endpoints.is_empty() {
+            return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                "observed live key package revision requires at least one source endpoint",
+            )
+            .into());
+        }
+        let Some(mut lifecycle) = self.session.key_package_lifecycle()? else {
+            return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                "cannot observe a live key package revision without lifecycle state",
+            )
+            .into());
+        };
+        if lifecycle.stable_slot_id.is_empty() || lifecycle.stable_slot_id != stable_slot_id {
+            return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                "observed live key package revision does not match the local stable slot",
+            )
+            .into());
+        }
+        let matches_current = lifecycle
+            .authored_signed_event
+            .as_ref()
+            .is_some_and(|artifact| artifact.id == *event_id)
+            || lifecycle.authored_event_id.as_ref() == Some(event_id);
+        let matches_pending = lifecycle
+            .pending_replacement
+            .as_ref()
+            .and_then(|pending| pending.signed_event.as_ref())
+            .is_some_and(|artifact| artifact.id == *event_id);
+        if !matches_current && !matches_pending {
+            return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                "observed key package revision is not the exact live current or pending event",
+            )
+            .into());
+        }
+
+        endpoints.sort();
+        endpoints.dedup();
+        let mut liability_count = key_package_signed_publication_liability_count(&lifecycle);
+        let mut admitted = Vec::new();
+        let mut deferred = Vec::new();
+        for endpoint in endpoints {
+            let already_durable =
+                key_package_event_endpoint_is_liability(&lifecycle, event_id, &endpoint);
+            if !already_durable && liability_count >= MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES
+            {
+                deferred.push(endpoint);
+                continue;
+            }
+            if !already_durable {
+                liability_count = liability_count.saturating_add(1);
+            }
+            admitted.push(endpoint);
+        }
+
+        let targets = if matches_current {
+            &mut lifecycle.publication_targets
+        } else {
+            &mut lifecycle
+                .pending_replacement
+                .as_mut()
+                .expect("a matching pending artifact remains in lifecycle state")
+                .targets
+        };
+        let mut targets_changed = false;
+        for endpoint in &admitted {
+            if let Some(target) = targets
+                .iter_mut()
+                .find(|target| target.endpoint == *endpoint)
+            {
+                let observed_attempt_at = target
+                    .last_attempt_at
+                    .map(|previous| previous.max(authored_created_at))
+                    .unwrap_or(authored_created_at);
+                if target.state != TransportFanoutAttemptState::Accepted
+                    || target.attempt_count == 0
+                    || target.last_attempt_at != Some(observed_attempt_at)
+                    || target.failure_code.is_some()
+                {
+                    target.state = TransportFanoutAttemptState::Accepted;
+                    target.attempt_count = target.attempt_count.max(1);
+                    target.last_attempt_at = Some(observed_attempt_at);
+                    target.failure_code = None;
+                    targets_changed = true;
+                }
+            } else {
+                targets.push(TransportFanoutTarget {
+                    endpoint: endpoint.clone(),
+                    state: TransportFanoutAttemptState::Accepted,
+                    attempt_count: 1,
+                    last_attempt_at: Some(authored_created_at),
+                    failure_code: None,
+                });
+                targets_changed = true;
+            }
+        }
+        targets.sort_by(|left, right| left.endpoint.cmp(&right.endpoint));
+
+        let observed_high_water = lifecycle
+            .authored_event_created_at
+            .map(|previous| previous.max(authored_created_at))
+            .unwrap_or(authored_created_at);
+        if lifecycle.authored_event_created_at != Some(observed_high_water) || targets_changed {
+            lifecycle.authored_event_created_at = Some(observed_high_water);
+            self.session.put_key_package_lifecycle(&lifecycle)?;
+        }
+        Ok((admitted, deferred))
+    }
+
+    /// Durably import an exact non-live KeyPackage revision discovered during
+    /// an upgrade relay scan, without performing transport I/O.
+    ///
+    /// The caller must pass the parsed event's stable slot and
+    /// safety-canonicalized source endpoints. The slot must match this local
+    /// account-device lifecycle; same-account directory scans can also return
+    /// sibling-device slots, which must never be deleted. Existing
+    /// event/endpoint liabilities are returned as admitted, while newly seen
+    /// endpoints are admitted individually up to the global journal bound and
+    /// the remainder are returned as deferred. A live current or pending event
+    /// id is rejected so discovery cannot reclassify the selected revision as
+    /// retired behind the account worker's back.
+    pub fn journal_discovered_retired_key_package_publication(
+        &mut self,
+        stable_slot_id: String,
+        event_id: MessageId,
+        authored_created_at: Timestamp,
+        key_package_ref: Vec<u8>,
+        package_not_after: Timestamp,
+        endpoints: Vec<TransportEndpoint>,
+    ) -> AccountResult<(Vec<TransportEndpoint>, Vec<TransportEndpoint>)> {
+        self.journal_discovered_retired_key_package_publication_with_policy(
+            stable_slot_id,
+            event_id,
+            authored_created_at,
+            key_package_ref,
+            package_not_after,
+            endpoints,
+            false,
+        )
+    }
+
+    /// The teardown variant commits destructive eligibility in the same SQL
+    /// lifecycle update that first journals a relay-revealed predecessor.
+    #[allow(clippy::too_many_arguments)]
+    pub fn journal_discovered_retired_key_package_publication_with_policy(
+        &mut self,
+        stable_slot_id: String,
+        event_id: MessageId,
+        authored_created_at: Timestamp,
+        key_package_ref: Vec<u8>,
+        package_not_after: Timestamp,
+        mut endpoints: Vec<TransportEndpoint>,
+        delete_without_successor: bool,
+    ) -> AccountResult<(Vec<TransportEndpoint>, Vec<TransportEndpoint>)> {
+        if endpoints.is_empty() {
+            return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                "discovered key package revision requires at least one source endpoint",
+            )
+            .into());
+        }
+        let Some(mut lifecycle) = self.session.key_package_lifecycle()? else {
+            return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                "cannot journal a discovered key package revision without lifecycle state",
+            )
+            .into());
+        };
+        if lifecycle.stable_slot_id.is_empty() {
+            return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                "cannot journal a discovered key package revision without a stable slot",
+            )
+            .into());
+        }
+        if stable_slot_id != lifecycle.stable_slot_id {
+            return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                "discovered key package revision does not match the local stable slot",
+            )
+            .into());
+        }
+        let matches_current = lifecycle
+            .authored_signed_event
+            .as_ref()
+            .is_some_and(|artifact| artifact.id == event_id)
+            || lifecycle.authored_event_id.as_ref() == Some(&event_id);
+        let matches_pending = lifecycle
+            .pending_replacement
+            .as_ref()
+            .and_then(|pending| pending.signed_event.as_ref())
+            .is_some_and(|artifact| artifact.id == event_id);
+        let matches_durably_deleted_live_revision = lifecycle
+            .deleted_live_revision_event_ids
+            .contains(&event_id);
+        if (matches_current || matches_pending) && !matches_durably_deleted_live_revision {
+            return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                "cannot classify a live key package revision as relay-discovered retirement",
+            )
+            .into());
+        }
+
+        // A relay can expose a same-slot revision authored by an older client
+        // after the local lifecycle snapshot was persisted. Preserve that
+        // transport ordering evidence even when journal capacity defers every
+        // endpoint: the next fresh artifact must sort strictly after every
+        // discovered revision or it cannot supersede the relay copy.
+        let previous_authored_high_water = lifecycle.authored_event_created_at;
+        lifecycle.authored_event_created_at = Some(
+            previous_authored_high_water
+                .map(|previous| previous.max(authored_created_at))
+                .unwrap_or(authored_created_at),
+        );
+        let authored_high_water_advanced =
+            lifecycle.authored_event_created_at != previous_authored_high_water;
+
+        endpoints.sort();
+        endpoints.dedup();
+        let mut liability_count = key_package_signed_publication_liability_count(&lifecycle);
+        let mut admitted = Vec::new();
+        let mut deferred = Vec::new();
+        for endpoint in endpoints {
+            let already_durable =
+                key_package_event_endpoint_is_liability(&lifecycle, &event_id, &endpoint);
+            if !already_durable && liability_count >= MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES
+            {
+                deferred.push(endpoint);
+                continue;
+            }
+            if !already_durable {
+                liability_count = liability_count.saturating_add(1);
+            }
+            admitted.push(endpoint);
+        }
+        let delete_without_successor = delete_without_successor
+            || matches_durably_deleted_live_revision
+            || lifecycle.key_package_ref_is_consumed(&key_package_ref);
+        if !admitted.is_empty() {
+            retain_retired_key_package_publication(
+                &mut lifecycle,
+                RetiredKeyPackagePublication {
+                    event_id,
+                    authored_created_at,
+                    key_package_ref: Some(key_package_ref),
+                    package_not_after: Some(package_not_after),
+                    delete_without_successor,
+                    deletion_targets: admitted
+                        .iter()
+                        .cloned()
+                        .map(|endpoint| TransportFanoutTarget {
+                            endpoint,
+                            state: TransportFanoutAttemptState::Unattempted,
+                            attempt_count: 0,
+                            last_attempt_at: None,
+                            failure_code: None,
+                        })
+                        .collect(),
+                },
+            );
+        }
+        if !admitted.is_empty() || authored_high_water_advanced {
+            self.session.put_key_package_lifecycle(&lifecycle)?;
+        }
+        Ok((admitted, deferred))
+    }
+
+    /// Serialize exact endpoint-scoped recovery intent before an explicit
+    /// transport deletion can escape.
+    ///
+    /// Unknown relay-discovered event ids are journaled too: a later local
+    /// NIP-33 replacement cannot supersede an event in another stable slot.
+    /// The returned deferred endpoints were not journaled and must not be sent.
+    pub fn prepare_key_package_deletion_recovery(
+        &mut self,
+        event_id: &cgka_traits::MessageId,
+        endpoints: Vec<TransportEndpoint>,
+    ) -> AccountResult<(Vec<TransportEndpoint>, Vec<TransportEndpoint>)> {
+        if endpoints.is_empty() {
+            return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                "key package deletion requires at least one relay endpoint",
+            )
+            .into());
+        }
+        let mut lifecycle = match self.session.key_package_lifecycle()? {
+            Some(lifecycle) => lifecycle,
+            None => {
+                let stable_slot_id = self
+                    .key_packages
+                    .legacy_slot_id(&self.session.self_id())?
+                    .ok_or_else(|| {
+                        crate::key_package::KeyPackagePublishError::unexposed(
+                            "cannot durably journal KeyPackage deletion without a stable slot",
+                        )
+                    })?;
+                KeyPackageLifecycleState::slot_only(stable_slot_id)
+            }
+        };
+        if lifecycle.stable_slot_id.is_empty() {
+            return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                "cannot durably journal KeyPackage deletion without a stable slot",
+            )
+            .into());
+        }
+
+        let deletes_live_revision = lifecycle
+            .authored_signed_event
+            .as_ref()
+            .is_some_and(|artifact| artifact.id == *event_id)
+            || lifecycle
+                .authored_event_id
+                .as_ref()
+                .is_some_and(|authored| authored == event_id)
+            || lifecycle
+                .pending_replacement
+                .as_ref()
+                .and_then(|pending| pending.signed_event.as_ref())
+                .is_some_and(|artifact| artifact.id == *event_id);
+        let mut endpoints = endpoints;
+        endpoints.sort();
+        endpoints.dedup();
+        let overflow_owner_before = lifecycle.deletion_overflow_owner_event_id.clone();
+        let (admitted, deferred) = admit_atomic_exact_key_package_deletion_liabilities(
+            &mut lifecycle,
+            event_id,
+            endpoints,
+        );
+        if !admitted.is_empty()
+            && deletes_live_revision
+            && !lifecycle.deleted_live_revision_event_ids.contains(event_id)
+        {
+            lifecycle
+                .deleted_live_revision_event_ids
+                .push(event_id.clone());
+        }
+        if !admitted.is_empty()
+            || lifecycle.deletion_overflow_owner_event_id != overflow_owner_before
+        {
+            self.session.put_key_package_lifecycle(&lifecycle)?;
+        }
+        Ok((admitted, deferred))
+    }
+
+    /// Atomically retain an unparsable/legacy same-slot revision's exact
+    /// endpoint liabilities and its signed NIP-33 ordering high-water.
+    ///
+    /// This differs from arbitrary manual deletion admission: the caller has
+    /// verified the event signature and stable `d` coordinate, so its raw
+    /// `created_at` must constrain every later replacement even when journal
+    /// capacity defers the endpoint set. The whole exact source set is admitted
+    /// atomically through the bounded deletion reserve or returned deferred;
+    /// live current/pending ids are rejected rather than reclassified as
+    /// cutover debris.
+    pub fn journal_discovered_unparsed_key_package_publication(
+        &mut self,
+        stable_slot_id: String,
+        event_id: cgka_traits::MessageId,
+        authored_created_at: Timestamp,
+        endpoints: Vec<TransportEndpoint>,
+    ) -> AccountResult<(Vec<TransportEndpoint>, Vec<TransportEndpoint>)> {
+        if endpoints.is_empty() {
+            return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                "discovered key package revision requires at least one source endpoint",
+            )
+            .into());
+        }
+        let Some(mut lifecycle) = self.session.key_package_lifecycle()? else {
+            return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                "cannot journal a discovered key package revision without lifecycle state",
+            )
+            .into());
+        };
+        if lifecycle.stable_slot_id.is_empty() || lifecycle.stable_slot_id != stable_slot_id {
+            return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                "discovered key package revision does not match the local stable slot",
+            )
+            .into());
+        }
+        let matches_current = lifecycle
+            .authored_signed_event
+            .as_ref()
+            .is_some_and(|artifact| artifact.id == event_id)
+            || lifecycle.authored_event_id.as_ref() == Some(&event_id);
+        let matches_pending = lifecycle
+            .pending_replacement
+            .as_ref()
+            .and_then(|pending| pending.signed_event.as_ref())
+            .is_some_and(|artifact| artifact.id == event_id);
+        if matches_current || matches_pending {
+            return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                "cannot classify a live key package revision as relay-discovered retirement",
+            )
+            .into());
+        }
+
+        let previous_authored_high_water = lifecycle.authored_event_created_at;
+        lifecycle.authored_event_created_at = Some(
+            previous_authored_high_water
+                .map(|previous| previous.max(authored_created_at))
+                .unwrap_or(authored_created_at),
+        );
+        let authored_high_water_advanced =
+            lifecycle.authored_event_created_at != previous_authored_high_water;
+        let mut endpoints = endpoints;
+        endpoints.sort();
+        endpoints.dedup();
+        let overflow_owner_before = lifecycle.deletion_overflow_owner_event_id.clone();
+        let (admitted, deferred) = admit_atomic_exact_key_package_deletion_liabilities(
+            &mut lifecycle,
+            &event_id,
+            endpoints,
+        );
+        if let Some(retired) = lifecycle
+            .retired_publications_pending_deletion
+            .iter_mut()
+            .find(|retired| retired.event_id == event_id)
+        {
+            retired.authored_created_at = retired.authored_created_at.max(authored_created_at);
+        }
+        if !admitted.is_empty()
+            || authored_high_water_advanced
+            || lifecycle.deletion_overflow_owner_event_id != overflow_owner_before
+        {
+            self.session.put_key_package_lifecycle(&lifecycle)?;
+        }
+        Ok((admitted, deferred))
+    }
+
+    /// Delete an exact signed KeyPackage revision with the account worker as
+    /// the sole lifecycle-row owner. Admission and a possible-exposure marker
+    /// are durable before network I/O; only endpoint-specific Accepted or
+    /// confirmed-absence receipts prune the retry journal.
+    pub async fn delete_key_package_revision_durably(
+        &mut self,
+        event_id: &cgka_traits::MessageId,
+        endpoints: Vec<TransportEndpoint>,
+    ) -> AccountResult<(DetailedKeyPackagePublishReceipt, Vec<TransportEndpoint>)> {
+        let (mut admitted, mut deferred) =
+            self.prepare_key_package_deletion_recovery(event_id, endpoints)?;
+        let mut combined = DetailedKeyPackagePublishReceipt::default();
+        let mut attempted_cleanup_for_capacity = false;
+
+        loop {
+            if admitted.is_empty() {
+                if deferred.is_empty() || attempted_cleanup_for_capacity {
+                    break;
+                }
+                // A full journal must not permanently wedge explicit cleanup.
+                // One bounded active-deletion attempt may free a slot; failure
+                // leaves every existing liability durable and the new pair
+                // unsent/deferred.
+                attempted_cleanup_for_capacity = true;
+                let _ = self.retry_retired_key_package_deletions().await;
+                (admitted, deferred) =
+                    self.prepare_key_package_deletion_recovery(event_id, deferred)?;
+                continue;
+            }
+
+            let mut lifecycle = self
+                .session
+                .key_package_lifecycle()?
+                .expect("manual KeyPackage deletion admission persists lifecycle state");
+            let retired = lifecycle
+                .retired_publications_pending_deletion
+                .iter_mut()
+                .find(|retired| retired.event_id == *event_id)
+                .expect("manual KeyPackage deletion admission persists the exact event");
+            begin_key_package_attempt(
+                &mut retired.deletion_targets,
+                &admitted,
+                self.wall_clock.now(),
+            );
+            self.session.put_key_package_lifecycle(&lifecycle)?;
+
+            let receipt = self
+                .key_packages
+                .delete_key_package_revision(event_id, &admitted)
+                .await?;
+            let accepted = receipt
+                .accepted
+                .into_iter()
+                .filter(|endpoint| admitted.contains(endpoint))
+                .collect::<Vec<_>>();
+            let rejected = receipt
+                .rejected
+                .into_iter()
+                .filter(|endpoint| admitted.contains(endpoint))
+                .collect::<Vec<_>>();
+            let confirmed_absent = receipt
+                .confirmed_absent
+                .into_iter()
+                .filter(|endpoint| admitted.contains(endpoint))
+                .collect::<Vec<_>>();
+            let failed = receipt
+                .failed
+                .into_iter()
+                .filter(|endpoint| admitted.contains(endpoint))
+                .collect::<Vec<_>>();
+
+            let retired = lifecycle
+                .retired_publications_pending_deletion
+                .iter_mut()
+                .find(|retired| retired.event_id == *event_id)
+                .expect("manual KeyPackage deletion remains serialized through receipt commit");
+            finish_key_package_attempt(
+                &mut retired.deletion_targets,
+                &accepted,
+                &rejected,
+                &confirmed_absent,
+                &failed,
+            );
+            retired.deletion_targets.retain(|target| {
+                !accepted.contains(&target.endpoint) && !confirmed_absent.contains(&target.endpoint)
+            });
+            lifecycle
+                .retired_publications_pending_deletion
+                .retain(|retired| {
+                    retired.event_id != *event_id || !retired.deletion_targets.is_empty()
+                });
+            release_settled_key_package_deletion_overflow_owner(&mut lifecycle);
+            let terminal_endpoints = accepted
+                .iter()
+                .chain(confirmed_absent.iter())
+                .cloned()
+                .collect::<Vec<_>>();
+            mark_live_key_package_revision_endpoints_absent(
+                &mut lifecycle,
+                event_id,
+                &terminal_endpoints,
+            );
+            self.session.put_key_package_lifecycle(&lifecycle)?;
+
+            combined.accepted.extend(accepted);
+            combined.rejected.extend(rejected);
+            combined.confirmed_absent.extend(confirmed_absent);
+            combined.failed.extend(failed);
+            if deferred.is_empty() {
+                break;
+            }
+            // Terminal receipts above may have freed journal capacity. Admit
+            // only the previously deferred endpoints, never resending an
+            // endpoint already attempted by this command.
+            (admitted, deferred) =
+                self.prepare_key_package_deletion_recovery(event_id, deferred)?;
+        }
+
+        combined.accepted.sort();
+        combined.accepted.dedup();
+        combined.rejected.sort();
+        combined.rejected.dedup();
+        combined.confirmed_absent.sort();
+        combined.confirmed_absent.dedup();
+        combined.failed.sort();
+        combined.failed.dedup();
+        Ok((combined, deferred))
+    }
+
     pub fn durably_owned_key_packages(&self) -> AccountResult<Vec<KeyPackage>> {
         Ok(self.session.durably_owned_key_packages()?)
     }
@@ -896,18 +1994,32 @@ where
         let now = self.wall_clock.now();
         Ok(match self.session.key_package_lifecycle()? {
             None => true,
+            Some(lifecycle) if lifecycle.cutover_publication_blocked => false,
             Some(lifecycle) => match lifecycle.pending_replacement.as_ref() {
                 Some(pending) => {
-                    pending.signed_event.is_none()
+                    pending.signed_event.as_ref().is_some_and(|artifact| {
+                        lifecycle
+                            .deleted_live_revision_event_ids
+                            .contains(&artifact.id)
+                            || lifecycle
+                                .authored_event_created_at
+                                .is_some_and(|high_water| artifact.created_at < high_water)
+                    }) || lifecycle.key_package_ref_is_consumed(&pending.key_package_ref)
+                        || pending.signed_event.is_none()
                         || pending
                             .targets
                             .iter()
                             .any(|target| key_package_target_retry_due(target, now))
                 }
                 None => {
-                    lifecycle.current_key_package.is_none()
-                        || lifecycle.last_consumed_key_package_ref
-                            == lifecycle.current_key_package_ref
+                    current_key_package_revision_is_deleted(&lifecycle)
+                        || current_key_package_artifact_precedes_authoring_high_water(&lifecycle)
+                        || lifecycle.current_key_package.is_none()
+                        || lifecycle.current_key_package_ref.as_deref().is_some_and(
+                            |key_package_ref| {
+                                lifecycle.key_package_ref_is_consumed(key_package_ref)
+                            },
+                        )
                         || lifecycle.refresh_at.is_some_and(|deadline| deadline <= now)
                         || !lifecycle.upgrade_rotation_recorded
                 }
@@ -916,28 +2028,315 @@ where
     }
 
     pub fn key_package_has_pending_fanout(&self) -> AccountResult<bool> {
+        let authoritative_endpoints = self.routing.key_package_endpoints();
         Ok(self
             .session
             .key_package_lifecycle()?
             .is_some_and(|lifecycle| {
-                lifecycle.authored_signed_event.is_some()
-                    && lifecycle.publication_targets.iter().any(|target| {
-                        matches!(
-                            target.state,
-                            TransportFanoutAttemptState::Unattempted
-                                | TransportFanoutAttemptState::AttemptedFailed
-                        )
-                    })
+                !lifecycle.cutover_publication_blocked
+                    && lifecycle
+                        .current_key_package_ref
+                        .as_deref()
+                        .is_some_and(|key_package_ref| {
+                            !lifecycle.key_package_ref_is_consumed(key_package_ref)
+                        })
+                    && lifecycle.authored_signed_event.is_some()
+                    && (lifecycle
+                        .publication_targets
+                        .iter()
+                        .any(key_package_target_is_retryable)
+                        || key_package_publication_targets_need_policy_reconciliation(
+                            &lifecycle.publication_targets,
+                            &authoritative_endpoints,
+                        ))
             }))
+    }
+
+    /// Run one bounded pass over eligible superseded-revision deletions.
+    ///
+    /// This is the narrow post-discovery seam for hosts that first journal
+    /// exact relay-observed revisions with
+    /// [`Self::journal_discovered_retired_key_package_publication`]. The
+    /// durable journal is the crash boundary; this call performs at most the
+    /// configured per-pass deletion budget and leaves every failed or deferred
+    /// endpoint for ordinary maintenance/restart recovery.
+    pub async fn retry_retired_key_package_deletions_once(&mut self) -> AccountResult<()> {
+        self.retry_retired_key_package_deletions().await.map(|_| ())
+    }
+
+    /// Make every durably journaled retired revision immediately deletable.
+    ///
+    /// This is reserved for quiesced account teardown after the user requested
+    /// removal of their KeyPackages. Ordinary maintenance must continue to
+    /// require a strictly newer accepted successor so it does not reduce
+    /// invitation availability while the account remains active.
+    pub fn authorize_teardown_key_package_deletions_without_successor(
+        &mut self,
+    ) -> AccountResult<()> {
+        let Some(mut lifecycle) = self.session.key_package_lifecycle()? else {
+            return Ok(());
+        };
+        let mut changed = false;
+        for retired in &mut lifecycle.retired_publications_pending_deletion {
+            if !retired.delete_without_successor {
+                retired.delete_without_successor = true;
+                changed = true;
+            }
+        }
+        if changed {
+            self.session.put_key_package_lifecycle(&lifecycle)?;
+        }
+        Ok(())
+    }
+
+    /// Run one bounded deletion pass and return the durable terminal endpoints
+    /// that a cutover relay-history scan must immediately re-fetch.
+    ///
+    /// Unlike ordinary maintenance, cutover also needs to know whether a later
+    /// retry can delete a revision without an accepted strictly newer successor
+    /// covering that endpoint. The report ignores retry backoff for that
+    /// classification so a deferred liability cannot let the cutover gate open.
+    pub async fn retry_retired_key_package_deletions_once_reported(
+        &mut self,
+    ) -> AccountResult<RetiredKeyPackageDeletionPassReport> {
+        self.retry_retired_key_package_deletions().await
+    }
+
+    /// Retry durable deletion obligations for superseded signed revisions.
+    ///
+    /// A live endpoint is eligible only after it acknowledges a strictly
+    /// newer current revision. Removed-policy endpoints and expired packages
+    /// are eligible immediately. Accepted endpoints are pruned synchronously
+    /// before this future reaches another cancellation point; a process crash
+    /// before that commit merely causes a safe duplicate deletion retry.
+    async fn retry_retired_key_package_deletions(
+        &mut self,
+    ) -> AccountResult<RetiredKeyPackageDeletionPassReport> {
+        let Some(mut lifecycle) = self.session.key_package_lifecycle()? else {
+            return Ok(RetiredKeyPackageDeletionPassReport::default());
+        };
+        let now = self.wall_clock.now();
+        let event_ids = lifecycle
+            .retired_publications_pending_deletion
+            .iter()
+            .map(|retired| retired.event_id.clone())
+            .collect::<Vec<_>>();
+        let mut first_error = None;
+        let mut attempts_remaining = KEY_PACKAGE_RETIRED_DELETION_ATTEMPTS_PER_CALL;
+        let mut reported_terminal_endpoints = Vec::new();
+
+        for event_id in event_ids {
+            if attempts_remaining == 0 {
+                break;
+            }
+            let Some(retired) = lifecycle
+                .retired_publications_pending_deletion
+                .iter()
+                .find(|retired| retired.event_id == event_id)
+                .cloned()
+            else {
+                continue;
+            };
+            let endpoints = retired
+                .deletion_targets
+                .iter()
+                .filter(|target| {
+                    retired_key_package_deletion_target_is_eligible(
+                        &lifecycle, &retired, target, now,
+                    ) && key_package_target_retry_due(target, now)
+                })
+                .map(|target| target.endpoint.clone())
+                .take(attempts_remaining)
+                .collect::<Vec<_>>();
+            if endpoints.is_empty() {
+                continue;
+            }
+            attempts_remaining = attempts_remaining.saturating_sub(endpoints.len());
+            begin_key_package_attempt(
+                &mut lifecycle
+                    .retired_publications_pending_deletion
+                    .iter_mut()
+                    .find(|retired| retired.event_id == event_id)
+                    .expect("retired KeyPackage revision remains serialized before deletion")
+                    .deletion_targets,
+                &endpoints,
+                self.wall_clock.now(),
+            );
+            self.session.put_key_package_lifecycle(&lifecycle)?;
+
+            let (accepted, rejected, confirmed_absent, failed, error) = match self
+                .key_packages
+                .delete_key_package_revision(&event_id, &endpoints)
+                .await
+            {
+                Ok(receipt) => {
+                    let accepted = receipt
+                        .accepted
+                        .into_iter()
+                        .filter(|endpoint| endpoints.contains(endpoint))
+                        .collect::<Vec<_>>();
+                    let rejected = receipt
+                        .rejected
+                        .into_iter()
+                        .filter(|endpoint| endpoints.contains(endpoint))
+                        .collect::<Vec<_>>();
+                    let confirmed_absent = receipt
+                        .confirmed_absent
+                        .into_iter()
+                        .filter(|endpoint| endpoints.contains(endpoint))
+                        .collect::<Vec<_>>();
+                    let failed = receipt
+                        .failed
+                        .into_iter()
+                        .filter(|endpoint| endpoints.contains(endpoint))
+                        .collect::<Vec<_>>();
+                    (accepted, rejected, confirmed_absent, failed, None)
+                }
+                Err(error) => (Vec::new(), Vec::new(), Vec::new(), Vec::new(), Some(error)),
+            };
+
+            let retired = lifecycle
+                .retired_publications_pending_deletion
+                .iter_mut()
+                .find(|retired| retired.event_id == event_id)
+                .expect("retired KeyPackage revision remains serialized during deletion");
+            finish_key_package_attempt(
+                &mut retired.deletion_targets,
+                &accepted,
+                &rejected,
+                &confirmed_absent,
+                &failed,
+            );
+            retired.deletion_targets.retain(|target| {
+                !accepted.contains(&target.endpoint) && !confirmed_absent.contains(&target.endpoint)
+            });
+            lifecycle
+                .retired_publications_pending_deletion
+                .retain(|retired| {
+                    retired.event_id != event_id || !retired.deletion_targets.is_empty()
+                });
+            release_settled_key_package_deletion_overflow_owner(&mut lifecycle);
+            let newly_terminal_endpoints = accepted
+                .iter()
+                .chain(confirmed_absent.iter())
+                .cloned()
+                .collect::<Vec<_>>();
+            mark_live_key_package_revision_endpoints_absent(
+                &mut lifecycle,
+                &event_id,
+                &newly_terminal_endpoints,
+            );
+            self.session.put_key_package_lifecycle(&lifecycle)?;
+            reported_terminal_endpoints.extend(newly_terminal_endpoints);
+
+            if let Some(error) = error
+                && first_error.is_none()
+            {
+                first_error = Some(AccountError::from(error));
+            }
+        }
+
+        match first_error {
+            Some(error) => Err(error),
+            None => Ok(retired_key_package_deletion_pass_report(
+                &lifecycle,
+                self.wall_clock.now(),
+                reported_terminal_endpoints,
+            )),
+        }
+    }
+
+    fn ensure_key_package_publication_liability_capacity(
+        &mut self,
+        lifecycle: &mut KeyPackageLifecycleState,
+        additional_revisions: usize,
+    ) -> AccountResult<()> {
+        let projected = key_package_signed_publication_liability_count(lifecycle)
+            .saturating_add(additional_revisions);
+        self.ensure_key_package_publication_liability_count(lifecycle, projected)
+    }
+
+    fn ensure_key_package_publication_liability_count(
+        &mut self,
+        lifecycle: &mut KeyPackageLifecycleState,
+        projected: usize,
+    ) -> AccountResult<()> {
+        if projected <= MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES {
+            return Ok(());
+        }
+        lifecycle.phase = MaintenancePhase::Retry;
+        self.session.put_key_package_lifecycle(lifecycle)?;
+        Err(crate::key_package::KeyPackagePublishError::unexposed(
+            "key package signed-publication endpoint-liability journal is full",
+        )
+        .into())
     }
 
     async fn retry_key_package_fanout(&mut self) -> AccountResult<()> {
         let Some(mut lifecycle) = self.session.key_package_lifecycle()? else {
             return Ok(());
         };
+        ensure_key_package_cutover_publication_allowed(&lifecycle)?;
         if lifecycle.pending_replacement.is_some() {
             return Ok(());
         }
+        if lifecycle
+            .current_key_package_ref
+            .as_deref()
+            .is_some_and(|key_package_ref| lifecycle.key_package_ref_is_consumed(key_package_ref))
+        {
+            // An MLS KeyPackage is single-use. Once a Welcome consumes the
+            // current revision, only a newly generated replacement may be
+            // published; retrying the exact deleted event would advertise
+            // private material that no longer exists locally.
+            return Ok(());
+        }
+        let Some(key_package) = lifecycle.current_key_package.clone() else {
+            return Ok(());
+        };
+        let live_endpoints = self.routing.key_package_endpoints().to_vec();
+        // Apply removals and re-authorizations of already-journaled endpoints
+        // before admitting any new liability. If the journal is full, a newly
+        // added endpoint may remain deferred, but an endpoint removed from the
+        // authoritative policy must never remain eligible for automatic I/O.
+        let represented_live_endpoints = live_endpoints
+            .iter()
+            .filter(|endpoint| {
+                lifecycle
+                    .publication_targets
+                    .iter()
+                    .any(|target| target.endpoint == **endpoint)
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        let targets_before_policy_update = lifecycle.publication_targets.clone();
+        merge_republish_publication_targets(
+            &mut lifecycle.publication_targets,
+            &represented_live_endpoints,
+        );
+        if lifecycle.publication_targets != targets_before_policy_update {
+            self.session.put_key_package_lifecycle(&lifecycle)?;
+        }
+        let additional_policy_targets = live_endpoints
+            .iter()
+            .filter(|endpoint| {
+                !lifecycle
+                    .publication_targets
+                    .iter()
+                    .any(|target| target.endpoint == **endpoint)
+            })
+            .count();
+        self.ensure_key_package_publication_liability_capacity(
+            &mut lifecycle,
+            additional_policy_targets,
+        )?;
+        let targets_before_reconciliation = lifecycle.publication_targets.clone();
+        merge_republish_publication_targets(&mut lifecycle.publication_targets, &live_endpoints);
+        if lifecycle.publication_targets != targets_before_reconciliation {
+            self.session.put_key_package_lifecycle(&lifecycle)?;
+        }
+        self.reauthor_current_key_package_if_stale(&mut lifecycle, &key_package, &live_endpoints)
+            .await?;
         let Some(artifact) = lifecycle.authored_signed_event.clone() else {
             return Ok(());
         };
@@ -950,11 +2349,6 @@ where
         if endpoints.is_empty() {
             return Ok(());
         }
-        let Some(key_package) = lifecycle.current_key_package.clone() else {
-            return Ok(());
-        };
-        lifecycle.phase = cgka_traits::MaintenancePhase::Fanout;
-        self.session.put_key_package_lifecycle(&lifecycle)?;
         let publication = KeyPackagePublication {
             account_id: self.session.self_id().clone(),
             key_package,
@@ -962,26 +2356,32 @@ where
             created_at: artifact.created_at,
             endpoints,
         };
+        lifecycle.phase = cgka_traits::MaintenancePhase::Fanout;
+        begin_key_package_attempt(
+            &mut lifecycle.publication_targets,
+            &publication.endpoints,
+            self.wall_clock.now(),
+        );
+        self.session.put_key_package_lifecycle(&lifecycle)?;
         match self
             .key_packages
-            .publish_prepared_key_package(&publication, &artifact)
+            .publish_prepared_key_package_detailed(&publication, &artifact)
             .await
         {
             Ok(receipt) => {
-                note_key_package_attempt(
+                let receipt = scope_key_package_publish_receipt(receipt, &publication.endpoints);
+                finish_key_package_attempt(
                     &mut lifecycle.publication_targets,
-                    &publication.endpoints,
                     &receipt.accepted,
+                    &receipt.rejected,
+                    &receipt.confirmed_absent,
                     &receipt.failed,
-                    self.wall_clock.now(),
                 );
-                lifecycle.phase = if lifecycle.publication_targets.iter().all(|target| {
-                    matches!(
-                        target.state,
-                        TransportFanoutAttemptState::Accepted
-                            | TransportFanoutAttemptState::PolicyProhibited
-                    )
-                }) {
+                lifecycle.phase = if lifecycle
+                    .publication_targets
+                    .iter()
+                    .all(key_package_target_is_terminal)
+                {
                     cgka_traits::MaintenancePhase::Complete
                 } else {
                     cgka_traits::MaintenancePhase::Fanout
@@ -990,13 +2390,6 @@ where
                 Ok(())
             }
             Err(error) => {
-                note_key_package_attempt(
-                    &mut lifecycle.publication_targets,
-                    &publication.endpoints,
-                    &[],
-                    &[],
-                    self.wall_clock.now(),
-                );
                 lifecycle.phase = cgka_traits::MaintenancePhase::Fanout;
                 self.session.put_key_package_lifecycle(&lifecycle)?;
                 Err(error.into())
@@ -1008,13 +2401,19 @@ where
         let now = self.wall_clock.now();
         Ok(match self.session.key_package_lifecycle()? {
             None => true,
-            Some(lifecycle) => {
-                lifecycle.pending_replacement.is_none()
-                    && lifecycle.last_consumed_key_package_ref != lifecycle.current_key_package_ref
-                    && (lifecycle.current_key_package.is_none()
+            Some(lifecycle) => match lifecycle.pending_replacement.as_ref() {
+                Some(pending) => lifecycle.key_package_ref_is_consumed(&pending.key_package_ref),
+                None => {
+                    lifecycle.current_key_package.is_none()
+                        || lifecycle.current_key_package_ref.as_deref().is_some_and(
+                            |key_package_ref| {
+                                lifecycle.key_package_ref_is_consumed(key_package_ref)
+                            },
+                        )
                         || lifecycle.refresh_at.is_some_and(|deadline| deadline <= now)
-                        || !lifecycle.upgrade_rotation_recorded)
-            }
+                        || !lifecycle.upgrade_rotation_recorded
+                }
+            },
         })
     }
 
@@ -1025,20 +2424,173 @@ where
         let Some(mut lifecycle) = self.session.key_package_lifecycle()? else {
             return Ok(0);
         };
+        let legacy_only_consumption_evidence = lifecycle.consumed_key_package_refs.is_empty()
+            && lifecycle.last_consumed_key_package_ref.is_some();
+        let consumed_refs_before = lifecycle.consumed_key_package_refs.clone();
+        // Import the legacy single marker and deduplicate before making any
+        // consumption decision. Only handled refs are cleared below.
+        lifecycle.reconcile_consumed_key_package_refs();
+        if legacy_only_consumption_evidence {
+            // Legacy writers overwrote this single marker on each Welcome, so
+            // the surviving ref cannot prove that any other durable bundle is
+            // unconsumed, including pre-lifecycle bundles with no current,
+            // pending, or retained projection. Pay a one-time availability
+            // cost at upgrade: retire every durably owned package and every
+            // known signed revision, then force a fresh replacement. Keep the
+            // bounded ref tombstones so a later strict relay scan can classify
+            // an exact revision for deletion without first publishing a
+            // successor. The lifecycle transition and private-material
+            // deletion commit atomically, so a crash observes either the
+            // legacy sentinel again or the complete fail-closed state, never a
+            // republishable half-transition.
+            let legacy_last_consumed_ref = lifecycle.last_consumed_key_package_ref.clone();
+            let legacy_last_consumed_at = lifecycle.last_consumed_at;
+            let durably_owned = self.session.durably_owned_key_packages()?;
+            let mut legacy_consumed_refs = lifecycle.consumed_key_package_refs.clone();
+            let mut durable_packages = Vec::with_capacity(durably_owned.len());
+            for key_package in durably_owned {
+                let metadata = self.session.key_package_metadata(&key_package)?;
+                let key_package_ref =
+                    hex::decode(&metadata.key_package_ref_hex).map_err(|error| {
+                        cgka_traits::EngineError::Serialize(format!(
+                            "durable key package reference: {error}"
+                        ))
+                    })?;
+                legacy_consumed_refs.push(key_package_ref.clone());
+                durable_packages.push((key_package, key_package_ref));
+            }
+            legacy_consumed_refs.sort();
+            legacy_consumed_refs.dedup();
+            if legacy_consumed_refs.len()
+                > cgka_traits::maintenance::MAX_CONSUMED_KEY_PACKAGE_REFS_PENDING_CLEANUP
+            {
+                return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                    "legacy consumed KeyPackage cleanup journal is full",
+                )
+                .into());
+            }
+            let mut retired = retire_legacy_only_consumption_projections(&mut lifecycle, now);
+            for (key_package, key_package_ref) in durable_packages {
+                mark_retired_key_package_revisions_unusable(&mut lifecycle, &key_package_ref);
+                retain_key_package_for_private_material_retirement(&mut retired, key_package);
+            }
+            lifecycle.consumed_key_package_refs = legacy_consumed_refs;
+            lifecycle.last_consumed_key_package_ref = legacy_last_consumed_ref;
+            lifecycle.last_consumed_at = legacy_last_consumed_at;
+            let deleted = retired.len();
+            if deleted > 0 {
+                self.session
+                    .promote_key_package_lifecycle(&retired, &lifecycle)?;
+            } else {
+                self.session.put_key_package_lifecycle(&lifecycle)?;
+            }
+            return Ok(deleted);
+        }
         let mut retired = Vec::new();
+        let mut handled_consumed_refs = Vec::new();
+        let mut lifecycle_changed = lifecycle.consumed_key_package_refs != consumed_refs_before;
+
+        for key_package in self.session.durably_owned_key_packages()? {
+            let metadata = self.session.key_package_metadata(&key_package)?;
+            let key_package_ref = hex::decode(&metadata.key_package_ref_hex).map_err(|error| {
+                cgka_traits::EngineError::Serialize(format!(
+                    "durable key package reference: {error}"
+                ))
+            })?;
+            if lifecycle.key_package_ref_is_consumed(&key_package_ref)
+                && !key_package_ref_has_live_private_material(&lifecycle, &key_package_ref)
+            {
+                mark_retired_key_package_revisions_unusable(&mut lifecycle, &key_package_ref);
+                handled_consumed_refs.push(key_package_ref);
+                retired.push(key_package);
+                lifecycle_changed = true;
+            }
+        }
+        let current_was_consumed = lifecycle
+            .current_key_package_ref
+            .as_deref()
+            .is_some_and(|key_package_ref| lifecycle.key_package_ref_is_consumed(key_package_ref));
+        if current_was_consumed
+            && let Some(key_package_ref) = lifecycle.current_key_package_ref.clone()
+        {
+            let retired_before = lifecycle.retired_publications_pending_deletion.clone();
+            if let Some(retired_publication) =
+                retired_current_key_package_publication(&lifecycle, true)
+            {
+                retain_retired_key_package_publication(&mut lifecycle, retired_publication);
+            }
+            mark_retired_key_package_revisions_unusable(&mut lifecycle, &key_package_ref);
+            lifecycle_changed |= lifecycle.retired_publications_pending_deletion != retired_before;
+        }
         if lifecycle
             .current_not_after
             .is_some_and(|deadline| deadline <= now)
-            && let Some(expired) = lifecycle.current_key_package.take()
+            && lifecycle.current_key_package.is_some()
         {
+            let expired_key_package_ref = lifecycle.current_key_package_ref.clone();
+            if let Some(retired_publication) =
+                retired_current_key_package_publication(&lifecycle, true)
+            {
+                retain_retired_key_package_publication(&mut lifecycle, retired_publication);
+            }
+            let expired = lifecycle
+                .current_key_package
+                .take()
+                .expect("expired current KeyPackage remains present");
             lifecycle.current_key_package_ref = None;
             lifecycle.current_not_before = None;
             lifecycle.current_not_after = None;
+            lifecycle.authored_event_id = None;
+            // Keep the stable-slot authoring high-water even after the
+            // semantic package expires so its replacement cannot sort behind
+            // a relay copy of this exact revision after clock rollback.
             lifecycle.authored_signed_event = None;
             lifecycle.publication_targets.clear();
             lifecycle.refresh_at = None;
             lifecycle.phase = cgka_traits::MaintenancePhase::Retry;
+            if current_was_consumed && let Some(key_package_ref) = expired_key_package_ref {
+                handled_consumed_refs.push(key_package_ref);
+            }
             retired.push(expired);
+            lifecycle_changed = true;
+        }
+        let pending_was_consumed = lifecycle
+            .pending_replacement
+            .as_ref()
+            .is_some_and(|pending| lifecycle.key_package_ref_is_consumed(&pending.key_package_ref));
+        if pending_was_consumed && let Some(consumed) = lifecycle.pending_replacement.take() {
+            let consumed_created_at = consumed
+                .signed_event
+                .as_ref()
+                .map(|artifact| artifact.created_at)
+                .unwrap_or(consumed.authored_created_at);
+            if let Some(retired_publication) = consumed.signed_event.as_ref().and_then(|artifact| {
+                retired_key_package_publication(
+                    artifact,
+                    Some(&consumed.key_package_ref),
+                    Some(consumed.not_after),
+                    true,
+                    &consumed.targets,
+                )
+            }) {
+                retain_retired_key_package_publication(&mut lifecycle, retired_publication);
+            }
+            mark_retired_key_package_revisions_unusable(&mut lifecycle, &consumed.key_package_ref);
+            // The relay may already have selected this newer pending revision
+            // despite the missing acknowledgement. Preserve its authoring
+            // high-water and force an immediate semantic replacement so the
+            // consumed single-use package cannot remain the NIP-33 winner.
+            lifecycle.authored_event_created_at = Some(
+                lifecycle
+                    .authored_event_created_at
+                    .map(|current| current.max(consumed_created_at))
+                    .unwrap_or(consumed_created_at),
+            );
+            lifecycle.refresh_at = Some(now);
+            lifecycle.phase = cgka_traits::MaintenancePhase::Retry;
+            handled_consumed_refs.push(consumed.key_package_ref.clone());
+            retired.push(consumed.key_package);
+            lifecycle_changed = true;
         }
         if lifecycle
             .pending_replacement
@@ -1046,31 +2598,79 @@ where
             .is_some_and(|pending| pending.not_after <= now)
             && let Some(expired) = lifecycle.pending_replacement.take()
         {
-            lifecycle.phase = cgka_traits::MaintenancePhase::Failed;
+            let expired_created_at = expired
+                .signed_event
+                .as_ref()
+                .map(|artifact| artifact.created_at)
+                .unwrap_or(expired.authored_created_at);
+            if let Some(retired_publication) = expired.signed_event.as_ref().and_then(|artifact| {
+                retired_key_package_publication(
+                    artifact,
+                    Some(&expired.key_package_ref),
+                    Some(expired.not_after),
+                    true,
+                    &expired.targets,
+                )
+            }) {
+                retain_retired_key_package_publication(&mut lifecycle, retired_publication);
+            }
+            lifecycle.authored_event_created_at = Some(
+                lifecycle
+                    .authored_event_created_at
+                    .map(|current| current.max(expired_created_at))
+                    .unwrap_or(expired_created_at),
+            );
+            lifecycle.refresh_at = Some(now);
+            lifecycle.phase = cgka_traits::MaintenancePhase::Retry;
             retired.push(expired.key_package);
+            lifecycle_changed = true;
         }
-        let consumed_ref = lifecycle.last_consumed_key_package_ref.as_deref();
-        let mut consumed_retained_deleted = false;
+        let consumed_refs = lifecycle.consumed_key_package_refs.clone();
+        let mut consumed_retained_refs = Vec::new();
         let mut retained = Vec::with_capacity(lifecycle.retained_private_material.len());
         for material in lifecycle.retained_private_material.drain(..) {
-            let was_consumed = consumed_ref
-                .is_some_and(|consumed| consumed == material.key_package_ref.as_slice());
+            let was_consumed = consumed_refs
+                .iter()
+                .any(|consumed| consumed == &material.key_package_ref);
             if material.not_after <= now || was_consumed {
-                consumed_retained_deleted |= was_consumed;
+                if was_consumed {
+                    consumed_retained_refs.push(material.key_package_ref.clone());
+                }
                 retired.push(material.key_package);
             } else {
                 retained.push(material);
             }
         }
         lifecycle.retained_private_material = retained;
-        if consumed_retained_deleted {
-            lifecycle.last_consumed_key_package_ref = None;
-            lifecycle.last_consumed_at = None;
+        for key_package_ref in consumed_retained_refs {
+            mark_retired_key_package_revisions_unusable(&mut lifecycle, &key_package_ref);
+            handled_consumed_refs.push(key_package_ref);
         }
+        handled_consumed_refs.sort();
+        handled_consumed_refs.dedup();
+        for key_package_ref in handled_consumed_refs {
+            if !key_package_ref_has_live_private_material(&lifecycle, &key_package_ref)
+                && !lifecycle.cutover_publication_blocked
+            {
+                lifecycle.clear_consumed_key_package_ref(&key_package_ref);
+            }
+        }
+        let consumed_refs_before_reconcile = lifecycle.consumed_key_package_refs.clone();
+        let last_consumed_before_reconcile = lifecycle.last_consumed_key_package_ref.clone();
+        lifecycle.reconcile_consumed_key_package_refs();
+        lifecycle_changed |= lifecycle.consumed_key_package_refs != consumed_refs_before_reconcile
+            || lifecycle.last_consumed_key_package_ref != last_consumed_before_reconcile;
+        let deleted_live_revision_event_ids_before =
+            lifecycle.deleted_live_revision_event_ids.clone();
+        retain_only_live_deleted_key_package_revision_ids(&mut lifecycle);
+        lifecycle_changed |=
+            lifecycle.deleted_live_revision_event_ids != deleted_live_revision_event_ids_before;
         let deleted = retired.len();
         if deleted > 0 {
             self.session
                 .promote_key_package_lifecycle(&retired, &lifecycle)?;
+        } else if lifecycle_changed {
+            self.session.put_key_package_lifecycle(&lifecycle)?;
         }
         Ok(deleted)
     }
@@ -1245,9 +2845,28 @@ where
     /// Advance durable maintenance state and publish work whose safety windows
     /// have elapsed. Callers may invoke this from any timer cadence; all
     /// deadlines and sampled jitter are persisted.
+    pub async fn run_due_maintenance_leased(
+        &mut self,
+    ) -> AccountResult<LeasedAccountDeviceEffects> {
+        let effects = self.run_due_maintenance_recording_visibility().await?;
+        self.lease_current_returned_visibility(effects)
+    }
+
     pub async fn run_due_maintenance(&mut self) -> AccountResult<AccountDeviceEffects> {
+        let effects = self.run_due_maintenance_recording_visibility().await?;
+        self.discard_active_visibility_operation()?;
+        Ok(effects)
+    }
+
+    async fn run_due_maintenance_recording_visibility(
+        &mut self,
+    ) -> AccountResult<AccountDeviceEffects> {
         use sha2::{Digest, Sha256};
 
+        self.start_account_visibility_operation(AccountVisibilitySource::Maintenance {
+            observed_at: self.wall_clock.now(),
+        })?;
+        let visibility_handoff = self.begin_session_visibility_handoff()?;
         self.sweep_expired_key_package_private_material()?;
         let mut output = AccountDeviceEffects::default();
         // Hydration recreates the publication edge for a surviving staged
@@ -1259,12 +2878,16 @@ where
         // this safe to call before a failed target is retryable.
         let recovered = self.session.drain();
         if !recovered.is_empty() {
-            let recovered = self.publish_session_effects(recovered).await?;
+            let recovered = self
+                .publish_session_effects_in_current_operation(recovered, None)
+                .await?;
+            self.retain_account_visibility_memory_only(&recovered);
             output.absorb_account_effects(recovered);
         }
         let now = self.wall_clock.now();
-        // Fanout of an already-acknowledged exact event is publication
-        // recovery, not a new preparation, so it continues while paused.
+        // Fanout of an already-acknowledged KeyPackage is publication recovery,
+        // not a new MLS preparation, so it continues while paused. A transport
+        // may first supersede a stale signed revision at the same coordinate.
         if self.key_package_has_pending_fanout()?
             && let Err(_error) = self.retry_key_package_fanout().await
         {
@@ -1272,30 +2895,68 @@ where
                 target: TRACE_TARGET,
                 method = "run_due_maintenance",
                 error_kind = "key_package_fanout_retry",
-                "key package exact-event fanout remains retryable"
+                "key package event fanout remains retryable"
             );
         }
         let key_package_due = self.key_package_network_maintenance_due()?;
-        let key_package_prepared = self
-            .session
-            .key_package_lifecycle()?
+        let key_package_lifecycle = self.session.key_package_lifecycle()?;
+        let key_package_prepared = key_package_lifecycle
+            .as_ref()
             .is_some_and(|lifecycle| lifecycle.pending_replacement.is_some());
+        let force_current_reauthor = key_package_lifecycle.as_ref().is_some_and(|lifecycle| {
+            lifecycle.pending_replacement.is_none()
+                && lifecycle.current_key_package.is_some()
+                && lifecycle
+                    .current_key_package_ref
+                    .as_deref()
+                    .is_some_and(|key_package_ref| {
+                        !lifecycle.key_package_ref_is_consumed(key_package_ref)
+                    })
+                && lifecycle.authored_signed_event.is_some()
+                && (current_key_package_revision_is_deleted(lifecycle)
+                    || current_key_package_artifact_precedes_authoring_high_water(lifecycle))
+        });
         if key_package_due
-            && (!self.maintenance_paused || key_package_prepared)
-            && let Err(error) = self.publish_fresh_key_package().await
+            && (!self.maintenance_paused || key_package_prepared || force_current_reauthor)
         {
+            let result = if force_current_reauthor {
+                self.republish_key_package().await.map(|_| ())
+            } else {
+                self.publish_fresh_key_package().await.map(|_| ())
+            };
+            if let Err(error) = result {
+                tracing::warn!(
+                    target: TRACE_TARGET,
+                    method = "run_due_maintenance",
+                    error_kind = if matches!(error, AccountError::ClockSkewBlocked) {
+                        "clock_skew_blocked"
+                    } else {
+                        "key_package_retry"
+                    },
+                    "key package maintenance remains retryable"
+                );
+            }
+        }
+        if self.retry_retired_key_package_deletions().await.is_err() {
             tracing::warn!(
                 target: TRACE_TARGET,
                 method = "run_due_maintenance",
-                error_kind = if matches!(error, AccountError::ClockSkewBlocked) {
-                    "clock_skew_blocked"
-                } else {
-                    "key_package_retry"
-                },
-                "key package maintenance remains retryable"
+                error_kind = "key_package_revision_deletion_retry",
+                "superseded key package revision deletion remains retryable"
             );
         }
-        self.retry_confirmed_transport_fanouts(&mut output).await?;
+        let retry_visibility_handoff = self.begin_session_visibility_handoff()?;
+        self.start_current_publish_visibility(retry_visibility_handoff);
+        let mut retried_fanouts = AccountDeviceEffects::default();
+        self.retry_confirmed_transport_fanouts(
+            &mut retried_fanouts,
+            Some(retry_visibility_handoff),
+        )
+        .await?;
+        self.checkpoint_current_publish_visibility(retry_visibility_handoff, &retried_fanouts)?;
+        self.finish_current_visibility_handoff(retry_visibility_handoff);
+        self.retain_account_visibility_memory_only(&retried_fanouts);
+        output.absorb_account_effects(retried_fanouts);
 
         // Old groups have no enrollment row and are intentionally excluded.
         let active_obligations = self.session.maintenance_obligations()?;
@@ -1510,7 +3171,9 @@ where
                                 queued: Vec::new(),
                                 pending_convergence: Vec::new(),
                             };
-                            let retried = self.publish_session_effects(retry).await?;
+                            let retried = self
+                                .publish_session_effects_in_current_operation(retry, None)
+                                .await?;
                             let confirmed = retried.pending.iter().any(|resolution| {
                                 matches!(
                                     resolution,
@@ -1518,6 +3181,7 @@ where
                                         if *resolved == pending
                                 )
                             });
+                            self.retain_account_visibility_memory_only(&retried);
                             output.absorb_account_effects(retried);
                             if confirmed {
                                 self.complete_maintenance_obligation(&mut obligation, now)?;
@@ -1561,16 +3225,21 @@ where
             }
 
             let group_id = obligation.group_id.clone();
+            let send_visibility_handoff = self.begin_session_visibility_handoff()?;
             match self
-                .send(SendIntent::SelfUpdate {
-                    group_id: group_id.clone(),
-                })
+                .send_in_current_operation(
+                    SendIntent::SelfUpdate {
+                        group_id: group_id.clone(),
+                    },
+                    None,
+                )
                 .await
             {
                 Ok(effects) => {
                     let confirmed = effects.pending.iter().any(|resolution| {
                         matches!(resolution, PendingResolution::Confirmed { .. })
                     });
+                    self.retain_account_visibility_memory_only(&effects);
                     output.absorb_account_effects(effects);
                     if confirmed {
                         self.complete_maintenance_obligation(&mut obligation, now)?;
@@ -1584,6 +3253,13 @@ where
                     }
                 }
                 Err(error) => {
+                    // Maintenance treats one failed self-update as retryable
+                    // and continues the outer pass. Preserve any session
+                    // events the failed child produced before its later
+                    // publication/storage error by copying those journaled
+                    // batches into this call's output before the outer
+                    // handoff clears its own range.
+                    self.append_retained_visibility_since(send_visibility_handoff, &mut output);
                     obligation.phase = MaintenancePhase::Retry;
                     obligation.attempt_count = obligation.attempt_count.saturating_add(1);
                     obligation.last_failure_code = Some(
@@ -1597,6 +3273,7 @@ where
                 }
             }
         }
+        self.finish_current_visibility_handoff(visibility_handoff);
         Ok(output)
     }
 
@@ -1687,8 +3364,33 @@ where
         &mut self,
         request: CreateGroupRequest,
     ) -> AccountResult<(GroupId, AccountDeviceEffects)> {
+        let (group_id, effects) = self.create_group_recording_visibility(request).await?;
+        self.discard_active_visibility_operation()?;
+        Ok((group_id, effects))
+    }
+
+    pub async fn create_group_leased(
+        &mut self,
+        request: CreateGroupRequest,
+    ) -> AccountResult<(GroupId, LeasedAccountDeviceEffects)> {
+        let (group_id, effects) = self.create_group_recording_visibility(request).await?;
+        Ok((group_id, self.lease_current_returned_visibility(effects)?))
+    }
+
+    async fn create_group_recording_visibility(
+        &mut self,
+        request: CreateGroupRequest,
+    ) -> AccountResult<(GroupId, AccountDeviceEffects)> {
+        self.start_account_visibility_operation(AccountVisibilitySource::Outbound {
+            group_id: None,
+            observed_at: self.wall_clock.now(),
+            action: None,
+            action_message_id: None,
+        })?;
         let CreateGroupEffects { group_id, effects } = self.session.create_group(request).await?;
-        let effects = self.publish_session_effects(effects).await?;
+        let effects = self
+            .publish_session_effects_in_current_operation(effects, None)
+            .await?;
         Ok((group_id, effects))
     }
 
@@ -1759,20 +3461,43 @@ where
             .await
     }
 
+    pub async fn publish_prepared_session_effects_with_audit_context_leased(
+        &mut self,
+        effects: SessionEffects,
+        context: AuditEventContext,
+    ) -> AccountResult<LeasedAccountDeviceEffects> {
+        let effects = self
+            .publish_session_effects_recording_visibility(effects, Some(context))
+            .await?;
+        self.lease_current_returned_visibility(effects)
+    }
+
     pub async fn send(&mut self, intent: SendIntent) -> AccountResult<AccountDeviceEffects> {
-        let disposition_group = match &intent {
-            SendIntent::AppMessage { group_id, .. } => Some(group_id.clone()),
-            _ => None,
-        };
-        let effects = self.session.send(intent).await?;
-        let mut output = self.publish_session_effects(effects).await?;
-        if let Some(group_id) = disposition_group
-            && self.post_join_rotation_pending(&group_id)?
-        {
-            output.maintenance_disposition =
-                SendMaintenanceDisposition::PostJoinRotationPendingRetryable;
-        }
-        Ok(output)
+        let effects = self.send_recording_visibility(intent, None).await?;
+        self.discard_active_visibility_operation()?;
+        Ok(effects)
+    }
+
+    pub async fn send_leased(
+        &mut self,
+        intent: SendIntent,
+    ) -> AccountResult<LeasedAccountDeviceEffects> {
+        let effects = self.send_recording_visibility(intent, None).await?;
+        self.lease_current_returned_visibility(effects)
+    }
+
+    async fn send_recording_visibility(
+        &mut self,
+        intent: SendIntent,
+        context: Option<AuditEventContext>,
+    ) -> AccountResult<AccountDeviceEffects> {
+        self.start_account_visibility_operation(AccountVisibilitySource::Outbound {
+            group_id: send_intent_group_id(&intent),
+            observed_at: self.wall_clock.now(),
+            action: account_visibility_outbound_action(&intent),
+            action_message_id: None,
+        })?;
+        self.send_in_current_operation(intent, context).await
     }
 
     pub async fn send_with_audit_context(
@@ -1780,23 +3505,63 @@ where
         intent: SendIntent,
         context: AuditEventContext,
     ) -> AccountResult<AccountDeviceEffects> {
+        let effects = self
+            .send_recording_visibility(intent, Some(context))
+            .await?;
+        self.discard_active_visibility_operation()?;
+        Ok(effects)
+    }
+
+    pub async fn send_with_audit_context_leased(
+        &mut self,
+        intent: SendIntent,
+        context: AuditEventContext,
+    ) -> AccountResult<LeasedAccountDeviceEffects> {
+        let effects = self
+            .send_recording_visibility(intent, Some(context))
+            .await?;
+        self.lease_current_returned_visibility(effects)
+    }
+
+    async fn send_in_current_operation(
+        &mut self,
+        intent: SendIntent,
+        context: Option<AuditEventContext>,
+    ) -> AccountResult<AccountDeviceEffects> {
+        let visibility_handoff = self.begin_session_visibility_handoff()?;
+        let outbound_action = account_visibility_outbound_action(&intent);
         let disposition_group = match &intent {
             SendIntent::AppMessage { group_id, .. } => Some(group_id.clone()),
             _ => None,
         };
-        let effects = self
-            .session
-            .send_with_audit_context(intent, context.clone())
-            .await?;
+        let effects = match context.as_ref() {
+            Some(context) => {
+                self.session
+                    .send_with_audit_context(intent, context.clone())
+                    .await?
+            }
+            None => self.session.send(intent).await?,
+        };
+        if let Some(action) = outbound_action {
+            let message_id = outbound_action_message_id(action, &effects).ok_or_else(|| {
+                account_visibility_error(
+                    "accepted outbound action did not produce its exact publish message",
+                )
+            })?;
+            self.bind_active_outbound_action_message(action, message_id)?;
+        }
         let mut output = self
-            .publish_session_effects_with_audit_context(effects, Some(context))
+            .publish_session_effects_in_current_operation(effects, context)
             .await?;
+        self.retain_account_visibility_memory_only(&output);
         if let Some(group_id) = disposition_group
             && self.post_join_rotation_pending(&group_id)?
         {
             output.maintenance_disposition =
                 SendMaintenanceDisposition::PostJoinRotationPendingRetryable;
+            self.update_active_visibility_header(output.maintenance_disposition)?;
         }
+        self.finish_current_visibility_handoff(visibility_handoff);
         Ok(output)
     }
 
@@ -1833,21 +3598,63 @@ where
         &mut self,
         prepared: PreparedSessionCommit,
     ) -> AccountResult<AccountDeviceEffects> {
+        let effects = self
+            .rollback_prepared_session_commit_recording_visibility(prepared)
+            .await?;
+        self.discard_active_visibility_operation()?;
+        Ok(effects)
+    }
+
+    pub async fn rollback_prepared_session_commit_leased(
+        &mut self,
+        prepared: PreparedSessionCommit,
+    ) -> AccountResult<LeasedAccountDeviceEffects> {
+        let effects = self
+            .rollback_prepared_session_commit_recording_visibility(prepared)
+            .await?;
+        self.lease_current_returned_visibility(effects)
+    }
+
+    async fn rollback_prepared_session_commit_recording_visibility(
+        &mut self,
+        prepared: PreparedSessionCommit,
+    ) -> AccountResult<AccountDeviceEffects> {
+        self.start_account_visibility_operation(AccountVisibilitySource::Outbound {
+            group_id: None,
+            observed_at: self.wall_clock.now(),
+            action: None,
+            action_message_id: None,
+        })?;
+        let visibility_handoff = self.begin_session_visibility_handoff()?;
+        self.start_current_publish_visibility(visibility_handoff);
         let (mut prepared_effects, _welcomes, pending) = prepared.into_parts();
         prepared_effects.publish.clear();
 
         let mut output = AccountDeviceEffects::default();
         let mut queue = VecDeque::new();
-        output.absorb_session_effects(prepared_effects, &mut queue);
+        self.absorb_session_effects_retaining_visibility(
+            &mut output,
+            prepared_effects,
+            &mut queue,
+            visibility_handoff,
+        )?;
 
         let rollback_effects = self.session.publish_failed(pending).await?;
         output
             .pending
             .push(PendingResolution::RolledBack { pending });
-        output.absorb_session_effects(rollback_effects, &mut queue);
-        self.publish_queue(&mut output, &mut queue, None).await?;
+        self.absorb_session_effects_retaining_visibility(
+            &mut output,
+            rollback_effects,
+            &mut queue,
+            visibility_handoff,
+        )?;
+        self.checkpoint_current_publish_visibility(visibility_handoff, &output)?;
+        self.publish_queue(&mut output, &mut queue, None, visibility_handoff)
+            .await?;
         self.reconcile_confirmed_own_leaf_rotations(&output.events)?;
         self.reconcile_superseded_maintenance(&output.events)?;
+        self.finish_current_visibility_handoff(visibility_handoff);
         Ok(output)
     }
 
@@ -1862,6 +3669,36 @@ where
         intent: SendIntent,
         context: AuditEventContext,
     ) -> AccountResult<(AccountDeviceEffects, Vec<TransportMessage>)> {
+        let (effects, welcomes) = self
+            .send_confirming_commit_with_audit_context_recording_visibility(intent, context)
+            .await?;
+        self.discard_active_visibility_operation()?;
+        Ok((effects, welcomes))
+    }
+
+    pub async fn send_confirming_commit_with_audit_context_leased(
+        &mut self,
+        intent: SendIntent,
+        context: AuditEventContext,
+    ) -> AccountResult<(LeasedAccountDeviceEffects, Vec<TransportMessage>)> {
+        let (effects, welcomes) = self
+            .send_confirming_commit_with_audit_context_recording_visibility(intent, context)
+            .await?;
+        Ok((self.lease_current_returned_visibility(effects)?, welcomes))
+    }
+
+    async fn send_confirming_commit_with_audit_context_recording_visibility(
+        &mut self,
+        intent: SendIntent,
+        context: AuditEventContext,
+    ) -> AccountResult<(AccountDeviceEffects, Vec<TransportMessage>)> {
+        self.start_account_visibility_operation(AccountVisibilitySource::Outbound {
+            group_id: send_intent_group_id(&intent),
+            observed_at: self.wall_clock.now(),
+            action: account_visibility_outbound_action(&intent),
+            action_message_id: None,
+        })?;
+        let visibility_handoff = self.begin_session_visibility_handoff()?;
         let disposition_group = match &intent {
             SendIntent::AppMessage { group_id, .. } => Some(group_id.clone()),
             _ => None,
@@ -1877,14 +3714,17 @@ where
             PreparedSessionSend::Queued(effects) => (effects, Vec::new()),
         };
         let mut output = self
-            .publish_session_effects_with_audit_context(session_effects, Some(context))
+            .publish_session_effects_in_current_operation(session_effects, Some(context))
             .await?;
+        self.retain_account_visibility_memory_only(&output);
         if let Some(group_id) = disposition_group
             && self.post_join_rotation_pending(&group_id)?
         {
             output.maintenance_disposition =
                 SendMaintenanceDisposition::PostJoinRotationPendingRetryable;
+            self.update_active_visibility_header(output.maintenance_disposition)?;
         }
+        self.finish_current_visibility_handoff(visibility_handoff);
         Ok((output, welcomes))
     }
 
@@ -1896,7 +3736,7 @@ where
         context: AuditEventContext,
     ) -> AccountResult<AccountDeviceEffects> {
         let mut output = AccountDeviceEffects::default();
-        self.publish_welcome_fanout(welcomes, group_id, &mut output, Some(context), false)
+        self.publish_welcome_fanout(welcomes, group_id, &mut output, Some(context), false, None)
             .await?;
         Ok(output)
     }
@@ -1909,7 +3749,7 @@ where
         context: AuditEventContext,
     ) -> AccountResult<AccountDeviceEffects> {
         let mut output = AccountDeviceEffects::default();
-        self.publish_welcome_fanout(welcomes, None, &mut output, Some(context), true)
+        self.publish_welcome_fanout(welcomes, None, &mut output, Some(context), true, None)
             .await?;
         Ok(output)
     }
@@ -1954,7 +3794,9 @@ where
             message_ids,
         } = task;
         let mut output = AccountDeviceEffects::default();
-        let result = self.finish_welcome_publish(completed, &mut output).await;
+        let result = self
+            .finish_welcome_publish(completed, &mut output, None)
+            .await;
         self.abandon_welcome_publish_task(&message_ids);
         result.map(|()| output)
     }
@@ -1975,16 +3817,51 @@ where
         context: AuditEventContext,
     ) -> AccountResult<AccountDeviceEffects> {
         let effects = self
+            .queue_app_message_with_audit_context_recording_visibility(group_id, payload, context)
+            .await?;
+        self.discard_active_visibility_operation()?;
+        Ok(effects)
+    }
+
+    pub async fn queue_app_message_with_audit_context_leased(
+        &mut self,
+        group_id: GroupId,
+        payload: Vec<u8>,
+        context: AuditEventContext,
+    ) -> AccountResult<LeasedAccountDeviceEffects> {
+        let effects = self
+            .queue_app_message_with_audit_context_recording_visibility(group_id, payload, context)
+            .await?;
+        self.lease_current_returned_visibility(effects)
+    }
+
+    async fn queue_app_message_with_audit_context_recording_visibility(
+        &mut self,
+        group_id: GroupId,
+        payload: Vec<u8>,
+        context: AuditEventContext,
+    ) -> AccountResult<AccountDeviceEffects> {
+        self.start_account_visibility_operation(AccountVisibilitySource::Outbound {
+            group_id: Some(group_id.clone()),
+            observed_at: self.wall_clock.now(),
+            action: None,
+            action_message_id: None,
+        })?;
+        let visibility_handoff = self.begin_session_visibility_handoff()?;
+        let effects = self
             .session
             .queue_app_message_with_audit_context(group_id.clone(), payload, context.clone())
             .await?;
         let mut output = self
-            .publish_session_effects_with_audit_context(effects, Some(context))
+            .publish_session_effects_in_current_operation(effects, Some(context))
             .await?;
+        self.retain_account_visibility_memory_only(&output);
         if self.post_join_rotation_pending(&group_id)? {
             output.maintenance_disposition =
                 SendMaintenanceDisposition::PostJoinRotationPendingRetryable;
+            self.update_active_visibility_header(output.maintenance_disposition)?;
         }
+        self.finish_current_visibility_handoff(visibility_handoff);
         Ok(output)
     }
 
@@ -2006,8 +3883,34 @@ where
         &mut self,
         group_id: &GroupId,
     ) -> AccountResult<AccountDeviceEffects> {
+        let effects = self
+            .advance_convergence_recording_visibility(group_id)
+            .await?;
+        self.discard_active_visibility_operation()?;
+        Ok(effects)
+    }
+
+    async fn advance_convergence_recording_visibility(
+        &mut self,
+        group_id: &GroupId,
+    ) -> AccountResult<AccountDeviceEffects> {
+        self.start_account_visibility_operation(AccountVisibilitySource::Convergence {
+            group_id: group_id.clone(),
+            observed_at: self.wall_clock.now(),
+        })?;
         let effects = self.session.advance_convergence(group_id).await?;
-        self.publish_session_effects(effects).await
+        self.publish_session_effects_in_current_operation(effects, None)
+            .await
+    }
+
+    pub async fn advance_convergence_leased(
+        &mut self,
+        group_id: &GroupId,
+    ) -> AccountResult<LeasedAccountDeviceEffects> {
+        let effects = self
+            .advance_convergence_recording_visibility(group_id)
+            .await?;
+        self.lease_current_returned_visibility(effects)
     }
 
     pub fn has_pending_convergence_inputs(&self, group_id: &GroupId) -> AccountResult<bool> {
@@ -2048,27 +3951,64 @@ where
     /// to trigger a drain (mdk#426). Publishes any incidental transport
     /// work the same way `ingest_delivery` does.
     pub async fn drain(&mut self) -> AccountResult<AccountDeviceEffects> {
+        let (effects, recovered_operation_ids) = self.drain_recording_visibility().await?;
+        self.discard_visibility_operations(&recovered_operation_ids)?;
+        Ok(effects)
+    }
+
+    async fn drain_recording_visibility(
+        &mut self,
+    ) -> AccountResult<(AccountDeviceEffects, Vec<[u8; 16]>)> {
+        self.start_account_visibility_operation(AccountVisibilitySource::Drain {
+            observed_at: self.wall_clock.now(),
+        })?;
         let effects = self.session.drain();
-        let mut output = self.publish_session_effects(effects).await?;
-        let resumed = self.resume_outbound_fanouts().await?;
+        let (mut output, current_visibility_batch) = self
+            .publish_session_effects_retaining_visibility(effects, None)
+            .await?;
+        let resumed = self.resume_outbound_fanouts_in_current_operation().await?;
         output.extend(resumed);
-        Ok(output)
+        let recovered_operation_ids =
+            self.finish_drain_visibility_handoff(current_visibility_batch, &mut output);
+        Ok((output, recovered_operation_ids))
+    }
+
+    pub async fn drain_leased(&mut self) -> AccountResult<LeasedAccountDeviceEffects> {
+        let (effects, _) = self.drain_recording_visibility().await?;
+        self.lease_current_returned_visibility(effects)
     }
 
     pub async fn ingest_delivery(
         &mut self,
         delivery: TransportDelivery,
     ) -> AccountResult<AccountIngestEffects> {
+        let effects = self.ingest_delivery_recording_visibility(delivery).await?;
+        self.discard_active_visibility_operation()?;
+        Ok(effects)
+    }
+
+    async fn ingest_delivery_recording_visibility(
+        &mut self,
+        delivery: TransportDelivery,
+    ) -> AccountResult<AccountIngestEffects> {
         if delivery.account_id != self.session.self_id() {
             return Err(AccountError::WrongAccountDelivery);
         }
+        let source_delivery = delivery.clone();
         let IngestEffects {
             outcome,
             left_object_unpersisted,
             effects,
             valid_proposal_groups,
         } = self.session.ingest_delivery(delivery).await?;
-        let effects = self.publish_session_effects(effects).await?;
+        self.start_account_visibility_operation(AccountVisibilitySource::Inbound {
+            delivery: source_delivery,
+            outcome: outcome.clone(),
+            observed_at: self.wall_clock.now(),
+        })?;
+        let (effects, current_visibility_batch) = self
+            .publish_session_effects_retaining_visibility(effects, None)
+            .await?;
         let mut state_bearing_groups = effects
             .events
             .iter()
@@ -2085,10 +4025,31 @@ where
                 unique_state_bearing_groups.push(group_id);
             }
         }
+        self.finish_current_visibility_handoff(current_visibility_batch);
         Ok(AccountIngestEffects {
             outcome,
             left_object_unpersisted,
             effects,
+        })
+    }
+
+    pub async fn ingest_delivery_leased(
+        &mut self,
+        delivery: TransportDelivery,
+    ) -> AccountResult<LeasedAccountIngestEffects> {
+        let AccountIngestEffects {
+            outcome,
+            left_object_unpersisted,
+            effects,
+        } = self.ingest_delivery_recording_visibility(delivery).await?;
+        let leased = self.lease_current_returned_visibility(effects)?;
+        Ok(LeasedAccountIngestEffects {
+            outcome,
+            left_object_unpersisted,
+            effects: leased.effects,
+            batches: leased.batches,
+            lease: leased.lease,
+            current_operation_id: leased.current_operation_id,
         })
     }
 
@@ -2105,13 +4066,1038 @@ where
         effects: SessionEffects,
         context: Option<AuditEventContext>,
     ) -> AccountResult<AccountDeviceEffects> {
+        let output = self
+            .publish_session_effects_recording_visibility(effects, context)
+            .await?;
+        self.discard_active_visibility_operation()?;
+        Ok(output)
+    }
+
+    async fn publish_session_effects_recording_visibility(
+        &mut self,
+        effects: SessionEffects,
+        context: Option<AuditEventContext>,
+    ) -> AccountResult<AccountDeviceEffects> {
+        self.start_account_visibility_operation(AccountVisibilitySource::Outbound {
+            group_id: None,
+            observed_at: self.wall_clock.now(),
+            action: None,
+            action_message_id: None,
+        })?;
+        self.publish_session_effects_in_current_operation(effects, context)
+            .await
+    }
+
+    async fn publish_session_effects_in_current_operation(
+        &mut self,
+        effects: SessionEffects,
+        context: Option<AuditEventContext>,
+    ) -> AccountResult<AccountDeviceEffects> {
+        let (output, current_visibility_batch) = self
+            .publish_session_effects_retaining_visibility(effects, context)
+            .await?;
+        self.finish_current_visibility_handoff(current_visibility_batch);
+        Ok(output)
+    }
+
+    /// Publish one session batch while leaving its caller-visible vectors in
+    /// runtime-owned memory until the outermost account operation is ready to
+    /// return. This is the cancellation boundary shared by `drain`, ingest,
+    /// and direct session-effect publication.
+    async fn publish_session_effects_retaining_visibility(
+        &mut self,
+        effects: SessionEffects,
+        context: Option<AuditEventContext>,
+    ) -> AccountResult<(AccountDeviceEffects, SessionVisibilityHandoff)> {
+        let visibility_handoff = self.begin_session_visibility_handoff()?;
+        self.start_current_publish_visibility(visibility_handoff);
         let mut output = AccountDeviceEffects::default();
         let mut queue = VecDeque::new();
-        output.absorb_session_effects(effects, &mut queue);
-        self.publish_queue(&mut output, &mut queue, context).await?;
+        self.absorb_session_effects_retaining_visibility(
+            &mut output,
+            effects,
+            &mut queue,
+            visibility_handoff,
+        )?;
+        self.publish_queue(&mut output, &mut queue, context, visibility_handoff)
+            .await?;
         self.reconcile_confirmed_own_leaf_rotations(&output.events)?;
         self.reconcile_superseded_maintenance(&output.events)?;
-        Ok(output)
+        Ok((output, visibility_handoff))
+    }
+
+    fn start_account_visibility_operation(
+        &mut self,
+        source: AccountVisibilitySource,
+    ) -> AccountResult<()> {
+        self.ensure_visibility_journal_loaded()?;
+        let mut operation_id = [0_u8; 16];
+        loop {
+            OsRng.fill_bytes(&mut operation_id);
+            if !self
+                .durable_visibility_operations
+                .contains_key(&operation_id)
+            {
+                break;
+            }
+        }
+        let header = StoredAccountVisibilityRecordV1 {
+            version: ACCOUNT_VISIBILITY_RECORD_VERSION,
+            source: source.clone(),
+            payload: StoredAccountVisibilityPayloadV1::Header {
+                maintenance_disposition: SendMaintenanceDisposition::Ready,
+            },
+        };
+        self.upsert_visibility_record(&operation_id, 0, &header)?;
+        self.durable_visibility_operations.insert(
+            operation_id,
+            DurableVisibilityOperation {
+                source,
+                next_event_ordinal: 1,
+                session_control: StoredSessionControlV1::default(),
+                non_session_fragments: BTreeMap::new(),
+            },
+        );
+        self.active_visibility_operation = Some(operation_id);
+        Ok(())
+    }
+
+    fn begin_session_visibility_handoff(&mut self) -> AccountResult<SessionVisibilityHandoff> {
+        let operation_id = self
+            .active_visibility_operation
+            .ok_or_else(|| account_visibility_error("visibility operation was not started"))?;
+        let fragment_id = self.next_visibility_fragment_id;
+        self.next_visibility_fragment_id = self.next_visibility_fragment_id.wrapping_add(1).max(1);
+        self.durable_visibility_operations
+            .get_mut(&operation_id)
+            .expect("active visibility operation must have durable state")
+            .non_session_fragments
+            .insert(fragment_id, AccountDeviceEffects::default());
+        Ok(SessionVisibilityHandoff {
+            retained_batch_count: self.retained_session_visibility.len(),
+            operation_id,
+            fragment_id,
+        })
+    }
+
+    /// Reserve the first batch in a publish handoff for a replaceable snapshot
+    /// of every non-session field accumulated by completed publish work. The
+    /// following session-event batches remain append-only and preserve their
+    /// own engine order.
+    fn start_current_publish_visibility(&mut self, handoff: SessionVisibilityHandoff) {
+        debug_assert_eq!(
+            self.retained_session_visibility.len(),
+            handoff.retained_batch_count
+        );
+        self.retained_session_visibility
+            .push_back(RetainedSessionVisibilityBatch {
+                operation_id: Some(handoff.operation_id),
+                effects: AccountDeviceEffects::default(),
+            });
+    }
+
+    /// Replace the current publish handoff's non-session snapshot before the
+    /// queue crosses its next await. Replacing one slot instead of appending
+    /// cumulative snapshots prevents replay duplicates.
+    fn checkpoint_current_publish_visibility(
+        &mut self,
+        handoff: SessionVisibilityHandoff,
+        output: &AccountDeviceEffects,
+    ) -> AccountResult<()> {
+        let Some(batch) = self
+            .retained_session_visibility
+            .get_mut(handoff.retained_batch_count)
+        else {
+            debug_assert!(false, "publish visibility slot must remain live");
+            return Err(account_visibility_error(
+                "publish visibility slot did not remain live",
+            ));
+        };
+        batch.effects = output.non_session_visibility_clone();
+        let operation = self
+            .durable_visibility_operations
+            .get_mut(&handoff.operation_id)
+            .ok_or_else(|| account_visibility_error("visibility operation state is missing"))?;
+        operation
+            .non_session_fragments
+            .insert(handoff.fragment_id, output.non_session_visibility_clone());
+        let source = operation.source.clone();
+        let mut cumulative = AccountDeviceEffects::default();
+        for fragment in operation.non_session_fragments.values() {
+            cumulative.extend(fragment.non_session_visibility_clone());
+        }
+        let record = StoredAccountVisibilityRecordV1 {
+            version: ACCOUNT_VISIBILITY_RECORD_VERSION,
+            source,
+            payload: StoredAccountVisibilityPayloadV1::NonSession(
+                StoredNonSessionEffectsV1::from_effects(&cumulative),
+            ),
+        };
+        self.upsert_visibility_record(
+            &handoff.operation_id,
+            ACCOUNT_VISIBILITY_NON_SESSION_ORDINAL,
+            &record,
+        )?;
+        Ok(())
+    }
+
+    fn checkpoint_optional_publish_visibility(
+        &mut self,
+        handoff: Option<SessionVisibilityHandoff>,
+        output: &AccountDeviceEffects,
+    ) -> AccountResult<()> {
+        if let Some(handoff) = handoff {
+            self.checkpoint_current_publish_visibility(handoff, output)?;
+        }
+        Ok(())
+    }
+
+    fn retain_session_visibility(
+        &mut self,
+        handoff: SessionVisibilityHandoff,
+        effects: &SessionEffects,
+    ) -> AccountResult<()> {
+        if effects.events.is_empty()
+            && effects.queued.is_empty()
+            && effects.pending_convergence.is_empty()
+        {
+            return Ok(());
+        }
+
+        let (source, first_event_ordinal, mut control) = {
+            let operation = self
+                .durable_visibility_operations
+                .get(&handoff.operation_id)
+                .ok_or_else(|| account_visibility_error("visibility operation state is missing"))?;
+            (
+                operation.source.clone(),
+                operation.next_event_ordinal,
+                operation.session_control.clone(),
+            )
+        };
+        let mut records = Vec::with_capacity(effects.events.len().saturating_add(1));
+        for (index, event) in effects.events.iter().enumerate() {
+            let ordinal = first_event_ordinal.saturating_add(index as u64);
+            let record = StoredAccountVisibilityRecordV1 {
+                version: ACCOUNT_VISIBILITY_RECORD_VERSION,
+                source: source.clone(),
+                payload: StoredAccountVisibilityPayloadV1::Event {
+                    event: event.clone(),
+                    engine_outbox_provenance: matches!(
+                        event,
+                        GroupEvent::MessageReceived { .. } | GroupEvent::GroupJoined { .. }
+                    ),
+                },
+            };
+            records.push(self.encode_visibility_upsert(&handoff.operation_id, ordinal, &record)?);
+        }
+
+        if !effects.queued.is_empty() || !effects.pending_convergence.is_empty() {
+            control
+                .queued
+                .extend(effects.queued.iter().map(|queued| StoredQueuedIntentRefV1 {
+                    group_id: queued.group_id.clone(),
+                    intent_id: queued.intent_id.clone(),
+                }));
+            control
+                .pending_convergence
+                .extend(effects.pending_convergence.iter().cloned());
+            let record = StoredAccountVisibilityRecordV1 {
+                version: ACCOUNT_VISIBILITY_RECORD_VERSION,
+                source: source.clone(),
+                payload: StoredAccountVisibilityPayloadV1::SessionControl(control.clone()),
+            };
+            records.push(self.encode_visibility_upsert(
+                &handoff.operation_id,
+                ACCOUNT_VISIBILITY_CONTROL_ORDINAL,
+                &record,
+            )?);
+        }
+
+        self.visibility_storage
+            .upsert_account_visibility_journal_records(&records)
+            .map_err(|error| AccountError::Session(SessionError::Storage(error)))?;
+        let operation = self
+            .durable_visibility_operations
+            .get_mut(&handoff.operation_id)
+            .expect("visibility operation remains live after atomic persistence");
+        operation.next_event_ordinal = first_event_ordinal
+            .saturating_add(u64::try_from(effects.events.len()).unwrap_or(u64::MAX));
+        operation.session_control = control;
+
+        self.retained_session_visibility
+            .push_back(RetainedSessionVisibilityBatch {
+                operation_id: Some(handoff.operation_id),
+                effects: AccountDeviceEffects {
+                    events: effects.events.clone(),
+                    queued: effects.queued.clone(),
+                    pending_convergence: effects.pending_convergence.clone(),
+                    ..AccountDeviceEffects::default()
+                },
+            });
+        Ok(())
+    }
+
+    fn retain_account_visibility_memory_only(&mut self, effects: &AccountDeviceEffects) {
+        if effects == &AccountDeviceEffects::default() {
+            return;
+        }
+
+        self.retained_session_visibility
+            .push_back(RetainedSessionVisibilityBatch {
+                operation_id: self.active_visibility_operation,
+                effects: effects.clone(),
+            });
+    }
+
+    fn absorb_session_effects_retaining_visibility(
+        &mut self,
+        output: &mut AccountDeviceEffects,
+        mut effects: SessionEffects,
+        queue: &mut VecDeque<PublishWork>,
+        handoff: SessionVisibilityHandoff,
+    ) -> AccountResult<()> {
+        self.suppress_hydrated_visibility_duplicates(&mut effects);
+        self.retain_session_visibility(handoff, &effects)?;
+        output.absorb_session_effects(effects, queue);
+        Ok(())
+    }
+
+    fn absorb_session_effects_retaining_optional_visibility(
+        &mut self,
+        output: &mut AccountDeviceEffects,
+        mut effects: SessionEffects,
+        queue: &mut VecDeque<PublishWork>,
+        handoff: Option<SessionVisibilityHandoff>,
+    ) -> AccountResult<()> {
+        self.suppress_hydrated_visibility_duplicates(&mut effects);
+        if let Some(handoff) = handoff {
+            self.retain_session_visibility(handoff, &effects)?;
+        }
+        output.absorb_session_effects(effects, queue);
+        Ok(())
+    }
+
+    fn suppress_hydrated_visibility_duplicates(&mut self, effects: &mut SessionEffects) {
+        effects.events.retain(|event| {
+            let Some(index) = self
+                .hydrated_visibility_suppressions
+                .iter()
+                .position(|retained| retained == event)
+            else {
+                return true;
+            };
+            self.hydrated_visibility_suppressions.remove(index);
+            false
+        });
+    }
+
+    /// Every batch created by this operation is already present in its
+    /// `output`; only remove those journal copies after the operation's final
+    /// fallible step has finished.
+    fn finish_current_visibility_handoff(&mut self, handoff: SessionVisibilityHandoff) {
+        self.retained_session_visibility
+            .truncate(handoff.retained_batch_count);
+    }
+
+    fn append_retained_visibility_since(
+        &self,
+        handoff: SessionVisibilityHandoff,
+        output: &mut AccountDeviceEffects,
+    ) {
+        for batch in self
+            .retained_session_visibility
+            .iter()
+            .skip(handoff.retained_batch_count)
+        {
+            output.extend(batch.effects.clone());
+        }
+    }
+
+    fn take_retained_visibility(&mut self) -> AccountDeviceEffects {
+        let mut recovered = AccountDeviceEffects::default();
+        for batch in self.retained_session_visibility.drain(..) {
+            recovered.extend(batch.effects);
+        }
+        recovered
+    }
+
+    /// A no-inbound drain is the replay surface for batches stranded by an
+    /// earlier failed or cancelled operation. Exclude the current batch (it is
+    /// already at the front of `output`) and prepend every older batch in its
+    /// original order. No await may follow this handoff.
+    ///
+    /// Returns the cancelled operations whose effects were actually prepended
+    /// so a legacy `drain` can ACK them in the same transaction as the current
+    /// operation.
+    fn finish_drain_visibility_handoff(
+        &mut self,
+        handoff: SessionVisibilityHandoff,
+        output: &mut AccountDeviceEffects,
+    ) -> Vec<[u8; 16]> {
+        self.finish_current_visibility_handoff(handoff);
+        let mut recovered_operation_ids = Vec::new();
+        let mut seen = HashSet::new();
+        for batch in &self.retained_session_visibility {
+            if let Some(operation_id) = batch.operation_id
+                && seen.insert(operation_id)
+            {
+                recovered_operation_ids.push(operation_id);
+            }
+        }
+        if self.retained_session_visibility.is_empty() {
+            return recovered_operation_ids;
+        }
+
+        let mut recovered = self.take_retained_visibility();
+        recovered.extend(std::mem::take(output));
+        *output = recovered;
+        recovered_operation_ids
+    }
+
+    fn lease_current_returned_visibility(
+        &mut self,
+        effects: AccountDeviceEffects,
+    ) -> AccountResult<LeasedAccountDeviceEffects> {
+        let operation_id = self.active_visibility_operation.ok_or_else(|| {
+            account_visibility_error("leased visibility operation was not started")
+        })?;
+        self.update_active_visibility_header(effects.maintenance_disposition)?;
+        self.lease_returned_visibility(effects, Some(operation_id))
+    }
+
+    fn lease_returned_visibility(
+        &mut self,
+        effects: AccountDeviceEffects,
+        current_operation_id: Option<[u8; 16]>,
+    ) -> AccountResult<LeasedAccountDeviceEffects> {
+        let batches = self.load_visibility_batches()?;
+
+        let lease = AccountVisibilityLease(self.next_visibility_lease_id);
+        self.next_visibility_lease_id = self.next_visibility_lease_id.wrapping_add(1).max(1);
+        self.returned_visibility_lease = Some(RetainedReturnedVisibilityLease {
+            lease,
+            batch_ids: batches.iter().map(|batch| batch.batch_id.clone()).collect(),
+        });
+        Ok(LeasedAccountDeviceEffects {
+            effects,
+            batches,
+            lease,
+            current_operation_id: current_operation_id.map(|operation_id| operation_id.to_vec()),
+        })
+    }
+
+    /// Return durable visibility left by an earlier cancelled/dropped runtime
+    /// before starting any new transport work.
+    pub fn replay_visibility_leased(
+        &mut self,
+    ) -> AccountResult<Option<LeasedAccountDeviceEffects>> {
+        if self
+            .visibility_storage
+            .load_account_visibility_journal()
+            .map_err(|error| AccountError::Session(SessionError::Storage(error)))?
+            .is_empty()
+        {
+            return Ok(None);
+        }
+        self.lease_returned_visibility(AccountDeviceEffects::default(), None)
+            .map(Some)
+    }
+
+    /// Stable row ids for deletion in the app's projection transaction.
+    pub fn visibility_lease_batch_ids(
+        &self,
+        lease: AccountVisibilityLease,
+    ) -> Option<Vec<Vec<u8>>> {
+        self.returned_visibility_lease
+            .as_ref()
+            .filter(|retained| retained.lease == lease)
+            .map(|retained| retained.batch_ids.clone())
+    }
+
+    /// Acknowledge that the app has durably staged every effect carried by
+    /// `lease`. Returns `false` for an already-acknowledged or superseded
+    /// generation and never clears a newer handoff.
+    pub fn acknowledge_visibility_lease(&mut self, lease: AccountVisibilityLease) -> bool {
+        let Some(batch_ids) = self.visibility_lease_batch_ids(lease) else {
+            return false;
+        };
+        self.delete_visibility_batches_acking_engine_outbox(&batch_ids)
+            .is_ok()
+            && self
+                .forget_durably_acknowledged_visibility_lease(lease)
+                .unwrap_or(false)
+    }
+
+    /// Delete visibility rows and ACK any engine application-event ids they
+    /// carry in one storage transaction. Legacy `drain` / `ingest_delivery`
+    /// transfer ownership synchronously; without this ACK a returned
+    /// `MessageReceived` / `GroupJoined` is hydrated back into the engine
+    /// outbox on every reopen.
+    fn delete_visibility_batches_acking_engine_outbox(
+        &self,
+        batch_ids: &[Vec<u8>],
+    ) -> AccountResult<()> {
+        if batch_ids.is_empty() {
+            return Ok(());
+        }
+        let batches = self.load_visibility_batches()?;
+        let engine_outbox_ids = batches
+            .iter()
+            .filter(|batch| batch_ids.contains(&batch.batch_id))
+            .filter(|batch| {
+                matches!(
+                    batch.kind,
+                    AccountVisibilityRecordKind::Event {
+                        engine_outbox_provenance: true
+                    }
+                )
+            })
+            .flat_map(|batch| batch.effects.events.iter())
+            .filter_map(engine_outbox_event_id)
+            .collect::<Vec<_>>();
+        self.visibility_storage
+            .with_transaction(|storage| {
+                storage.delete_pending_application_events(&engine_outbox_ids)?;
+                storage.delete_account_visibility_journal_batches(batch_ids)?;
+                Ok::<_, StorageError>(())
+            })
+            .map_err(|error| AccountError::Session(SessionError::Storage(error)))?;
+        Ok(())
+    }
+
+    /// Forget a lease only after its rows were durably deleted, normally inside
+    /// the app's projection transaction through `SqliteAccountStorage`.
+    pub fn forget_durably_acknowledged_visibility_lease(
+        &mut self,
+        lease: AccountVisibilityLease,
+    ) -> AccountResult<bool> {
+        let Some(batch_ids) = self.visibility_lease_batch_ids(lease) else {
+            return Ok(false);
+        };
+        self.forget_durably_acknowledged_visibility_batches(lease, &batch_ids)
+    }
+
+    /// Advance one lease after the app atomically deleted a projected subset
+    /// of its stable row ids. Returns `true` only when the lease is now fully
+    /// acknowledged; a projected prefix leaves the remaining ids leased.
+    ///
+    /// This boundary is deliberately storage-free. The caller invokes it only
+    /// after its projection transaction has committed the row deletions, and a
+    /// terminal close is allowed to close SQLite immediately after that
+    /// commit. Re-reading the journal here would turn harmless in-memory lease
+    /// cleanup into a post-commit failure window where both durable copies are
+    /// gone but the app cannot promote its one-shot visibility summary.
+    pub fn forget_durably_acknowledged_visibility_batches(
+        &mut self,
+        lease: AccountVisibilityLease,
+        acknowledged_batch_ids: &[Vec<u8>],
+    ) -> AccountResult<bool> {
+        let Some(retained) = self.returned_visibility_lease.as_ref() else {
+            return Ok(false);
+        };
+        if retained.lease != lease
+            || acknowledged_batch_ids
+                .iter()
+                .any(|batch_id| !retained.batch_ids.contains(batch_id))
+        {
+            return Ok(false);
+        }
+        let retained = self
+            .returned_visibility_lease
+            .as_mut()
+            .expect("matching lease remains live");
+        retained
+            .batch_ids
+            .retain(|batch_id| !acknowledged_batch_ids.contains(batch_id));
+        if !retained.batch_ids.is_empty() {
+            return Ok(false);
+        }
+        self.returned_visibility_lease = None;
+        self.retained_session_visibility.clear();
+        // A matching lease is always the newest generation and snapshots every
+        // journal row then present. `&mut self` prevents a new account
+        // operation from adding rows between its return and this advancement;
+        // any later operation would instead have installed a newer lease and
+        // made the generation mismatch above return `false`.
+        self.durable_visibility_operations.clear();
+        Ok(true)
+    }
+
+    fn ensure_visibility_journal_loaded(&self) -> AccountResult<()> {
+        match &self.visibility_load_error {
+            Some(error) => Err(account_visibility_error(format!(
+                "load account visibility journal: {error}"
+            ))),
+            None => Ok(()),
+        }
+    }
+
+    /// Compatibility boundary for legacy methods that return effects without
+    /// an explicit projection lease. A successful legacy call has transferred
+    /// ownership synchronously to its caller, so only that operation's rows
+    /// are removed; older failed/cancelled operations remain replayable.
+    fn discard_active_visibility_operation(&mut self) -> AccountResult<()> {
+        self.discard_visibility_operations(&[])
+    }
+
+    /// ACK the current operation plus every recovered operation whose effects
+    /// were actually handed off, in one storage transaction. Used by legacy
+    /// `drain`, which prepends cancelled batches and must not leave their
+    /// journal rows and engine outbox ids live across reopen.
+    fn discard_visibility_operations(
+        &mut self,
+        recovered_operation_ids: &[[u8; 16]],
+    ) -> AccountResult<()> {
+        let mut operation_ids = recovered_operation_ids.to_vec();
+        if let Some(operation_id) = self.active_visibility_operation.take() {
+            operation_ids.push(operation_id);
+        }
+        if operation_ids.is_empty() {
+            return Ok(());
+        }
+        let batch_ids = self
+            .visibility_storage
+            .load_account_visibility_journal()
+            .map_err(|error| AccountError::Session(SessionError::Storage(error)))?
+            .into_iter()
+            .filter(|row| {
+                operation_ids
+                    .iter()
+                    .any(|operation_id| row.operation_id.as_slice() == operation_id)
+            })
+            .map(|row| row.batch_id)
+            .collect::<Vec<_>>();
+        self.delete_visibility_batches_acking_engine_outbox(&batch_ids)?;
+        for operation_id in operation_ids {
+            self.durable_visibility_operations.remove(&operation_id);
+        }
+        Ok(())
+    }
+
+    fn upsert_visibility_record(
+        &self,
+        operation_id: &[u8; 16],
+        ordinal: u64,
+        record: &StoredAccountVisibilityRecordV1,
+    ) -> AccountResult<u64> {
+        let upsert = self.encode_visibility_upsert(operation_id, ordinal, record)?;
+        self.visibility_storage
+            .upsert_account_visibility_journal(
+                &upsert.operation_id,
+                upsert.ordinal,
+                &upsert.batch_id,
+                &upsert.record,
+            )
+            .map_err(|error| AccountError::Session(SessionError::Storage(error)))
+    }
+
+    fn encode_visibility_upsert(
+        &self,
+        operation_id: &[u8; 16],
+        ordinal: u64,
+        record: &StoredAccountVisibilityRecordV1,
+    ) -> AccountResult<AccountVisibilityJournalUpsert> {
+        let encoded = serde_json::to_vec(record).map_err(|error| {
+            account_visibility_error(format!("serialize account visibility record: {error}"))
+        })?;
+        Ok(AccountVisibilityJournalUpsert {
+            operation_id: operation_id.to_vec(),
+            ordinal,
+            batch_id: account_visibility_batch_id(operation_id, ordinal),
+            record: encoded,
+        })
+    }
+
+    fn update_active_visibility_header(
+        &self,
+        maintenance_disposition: SendMaintenanceDisposition,
+    ) -> AccountResult<()> {
+        let Some(operation_id) = self.active_visibility_operation else {
+            return Ok(());
+        };
+        let source = self
+            .durable_visibility_operations
+            .get(&operation_id)
+            .ok_or_else(|| account_visibility_error("visibility operation state is missing"))?
+            .source
+            .clone();
+        let record = StoredAccountVisibilityRecordV1 {
+            version: ACCOUNT_VISIBILITY_RECORD_VERSION,
+            source,
+            payload: StoredAccountVisibilityPayloadV1::Header {
+                maintenance_disposition,
+            },
+        };
+        self.upsert_visibility_record(&operation_id, 0, &record)?;
+        Ok(())
+    }
+
+    fn bind_active_outbound_action_message(
+        &mut self,
+        action: AccountVisibilityOutboundAction,
+        message_id: MessageId,
+    ) -> AccountResult<()> {
+        let operation_id = self.active_visibility_operation.ok_or_else(|| {
+            account_visibility_error("bound outbound action has no visibility operation")
+        })?;
+        let operation = self
+            .durable_visibility_operations
+            .get_mut(&operation_id)
+            .ok_or_else(|| account_visibility_error("visibility operation state is missing"))?;
+        match &mut operation.source {
+            AccountVisibilitySource::Outbound {
+                action: initiating_action,
+                action_message_id,
+                ..
+            } if *initiating_action == Some(action) => {
+                *action_message_id = Some(message_id);
+            }
+            _ => {
+                return Err(account_visibility_error(
+                    "bound outbound action does not match its visibility source",
+                ));
+            }
+        }
+        // Session acceptance has already atomically installed the exact sent
+        // SelfRemove and LeaveRequest. Rewrite the pre-acceptance Header before
+        // any relay await; a crash in the narrow interval between those writes
+        // is repaired from the request's paired message id below.
+        self.update_active_visibility_header(SendMaintenanceDisposition::Ready)
+    }
+
+    fn load_visibility_batches(&self) -> AccountResult<Vec<AccountVisibilityBatch>> {
+        self.ensure_visibility_journal_loaded()?;
+        let mut batches = self
+            .visibility_storage
+            .load_account_visibility_journal()
+            .map_err(|error| AccountError::Session(SessionError::Storage(error)))?
+            .into_iter()
+            .map(decode_account_visibility_row)
+            .collect::<AccountResult<Vec<_>>>()?;
+        struct LeaveHeaderRef {
+            index: usize,
+            sequence: u64,
+            operation_id: Vec<u8>,
+            bound: Option<MessageId>,
+        }
+        let mut by_group = HashMap::<GroupId, Vec<LeaveHeaderRef>>::new();
+        for (index, batch) in batches.iter().enumerate() {
+            let AccountVisibilitySource::Outbound {
+                group_id: Some(group_id),
+                action: Some(AccountVisibilityOutboundAction::Leave),
+                action_message_id,
+                ..
+            } = &batch.source
+            else {
+                continue;
+            };
+            by_group
+                .entry(group_id.clone())
+                .or_default()
+                .push(LeaveHeaderRef {
+                    index,
+                    sequence: batch.sequence,
+                    operation_id: batch.operation_id.clone(),
+                    bound: action_message_id.clone(),
+                });
+        }
+        let mut repaired = Vec::new();
+        for (group_id, mut headers) in by_group {
+            headers.sort_by_key(|header| header.sequence);
+            let current_id = self
+                .visibility_storage
+                .leave_request(&group_id)
+                .map_err(|error| AccountError::Session(SessionError::Storage(error)))?
+                .and_then(|request| request.last_proposed_message_id);
+            let Some(current_id) = current_id else {
+                continue;
+            };
+            // One semantic owner per group. Prefer a Header already bound to
+            // the live Leave id, else the newest previously bound Header so
+            // M1 follows to M2, else the newest unbound pre-acceptance Header.
+            // A later LeaveAlreadyRequested Header must not also inherit.
+            let owner_operation_id = headers
+                .iter()
+                .find(|header| header.bound.as_ref() == Some(&current_id))
+                .map(|header| header.operation_id.clone())
+                .or_else(|| {
+                    headers
+                        .iter()
+                        .rev()
+                        .find(|header| header.bound.is_some())
+                        .map(|header| header.operation_id.clone())
+                })
+                .or_else(|| headers.last().map(|header| header.operation_id.clone()));
+            let Some(owner_operation_id) = owner_operation_id else {
+                continue;
+            };
+            for header in &headers {
+                let AccountVisibilitySource::Outbound {
+                    action_message_id, ..
+                } = &mut batches[header.index].source
+                else {
+                    continue;
+                };
+                let desired = if header.operation_id == owner_operation_id {
+                    Some(current_id.clone())
+                } else if action_message_id.as_ref() == Some(&current_id) {
+                    None
+                } else {
+                    continue;
+                };
+                if action_message_id != &desired {
+                    *action_message_id = desired;
+                    repaired.push(header.index);
+                }
+            }
+        }
+        self.persist_repaired_leave_sources(&batches, &repaired)?;
+        Ok(batches)
+    }
+
+    fn persist_repaired_leave_sources(
+        &self,
+        batches: &[AccountVisibilityBatch],
+        repaired: &[usize],
+    ) -> AccountResult<()> {
+        if repaired.is_empty() {
+            return Ok(());
+        }
+        let repaired_ids = repaired
+            .iter()
+            .map(|&index| batches[index].batch_id.clone())
+            .collect::<HashSet<_>>();
+        let rows = self
+            .visibility_storage
+            .load_account_visibility_journal()
+            .map_err(|error| AccountError::Session(SessionError::Storage(error)))?;
+        let mut upserts = Vec::new();
+        for row in rows {
+            if !repaired_ids.contains(&row.batch_id) {
+                continue;
+            }
+            let live = batches
+                .iter()
+                .find(|batch| batch.batch_id == row.batch_id)
+                .ok_or_else(|| {
+                    account_visibility_error("repaired visibility batch is missing from memory")
+                })?;
+            let mut record: StoredAccountVisibilityRecordV1 = serde_json::from_slice(&row.record)
+                .map_err(|error| {
+                account_visibility_error(format!("decode account visibility record: {error}"))
+            })?;
+            if record.source == live.source {
+                continue;
+            }
+            record.source = live.source.clone();
+            let encoded = serde_json::to_vec(&record).map_err(|error| {
+                account_visibility_error(format!("serialize account visibility record: {error}"))
+            })?;
+            upserts.push(AccountVisibilityJournalUpsert {
+                operation_id: row.operation_id,
+                ordinal: row.ordinal,
+                batch_id: row.batch_id,
+                record: encoded,
+            });
+        }
+        if !upserts.is_empty() {
+            self.visibility_storage
+                .upsert_account_visibility_journal_records(&upserts)
+                .map_err(|error| AccountError::Session(SessionError::Storage(error)))?;
+        }
+        Ok(())
+    }
+
+    fn record_terminal_outbound_action_outcome(
+        &self,
+        message_id: &MessageId,
+        published: bool,
+        output: &mut AccountDeviceEffects,
+    ) -> AccountResult<()> {
+        if let Some(existing) = output
+            .action_outcomes
+            .iter()
+            .find(|outcome| &outcome.message_id == message_id)
+        {
+            if existing.published != published {
+                return Err(account_visibility_error(
+                    "outbound action changed its terminal publish outcome",
+                ));
+            }
+            return Ok(());
+        }
+
+        let batches = self.load_visibility_batches()?;
+        if let Some(existing) = batches
+            .iter()
+            .flat_map(|batch| &batch.effects.action_outcomes)
+            .find(|outcome| &outcome.message_id == message_id)
+        {
+            if existing.published != published {
+                return Err(account_visibility_error(
+                    "durable outbound action changed its terminal publish outcome",
+                ));
+            }
+            return Ok(());
+        }
+        let mut pending = None::<AccountVisibilityActionOutcome>;
+        for batch in &batches {
+            let AccountVisibilitySource::Outbound {
+                group_id: Some(group_id),
+                action: Some(action),
+                action_message_id: Some(bound_message_id),
+                ..
+            } = &batch.source
+            else {
+                continue;
+            };
+            if bound_message_id != message_id {
+                continue;
+            }
+            let candidate = AccountVisibilityActionOutcome {
+                operation_id: batch.operation_id.clone(),
+                group_id: group_id.clone(),
+                message_id: message_id.clone(),
+                action: *action,
+                published,
+            };
+            match &pending {
+                Some(existing) if existing != &candidate => {
+                    return Err(account_visibility_error(
+                        "outbound action message is bound to multiple visibility operations",
+                    ));
+                }
+                Some(_) => {}
+                None => pending = Some(candidate),
+            }
+        }
+        if pending.is_none() {
+            // Provenance must outlive Header ACK. Terminal M1 failure deletes
+            // the Leave Header; an epoch-driven M2 still has the LeaveRequest
+            // naming this exact SelfRemove.
+            pending = self.leave_request_outcome_for_message(message_id, published)?;
+        }
+        if let Some(outcome) = pending {
+            output.action_outcomes.push(outcome);
+        }
+        Ok(())
+    }
+
+    fn leave_request_outcome_for_message(
+        &self,
+        message_id: &MessageId,
+        published: bool,
+    ) -> AccountResult<Option<AccountVisibilityActionOutcome>> {
+        let mut group_ids = Vec::new();
+        let fanouts = self.session.outbound_fanouts()?;
+        for fanout in fanouts {
+            if fanout.message_id() == message_id
+                && let Some(group_id) = fanout.group_id()
+                && !group_ids.contains(group_id)
+            {
+                group_ids.push(group_id.clone());
+            }
+        }
+        if let Some(operation_id) = self.active_visibility_operation
+            && let Some(operation) = self.durable_visibility_operations.get(&operation_id)
+            && let AccountVisibilitySource::Outbound {
+                group_id: Some(group_id),
+                action: Some(AccountVisibilityOutboundAction::Leave),
+                ..
+            } = &operation.source
+            && !group_ids.contains(group_id)
+        {
+            group_ids.push(group_id.clone());
+        }
+        for group_id in group_ids {
+            let owns_message = self
+                .visibility_storage
+                .leave_request(&group_id)
+                .map_err(|error| AccountError::Session(SessionError::Storage(error)))?
+                .and_then(|request| request.last_proposed_message_id)
+                .as_ref()
+                == Some(message_id);
+            if !owns_message {
+                continue;
+            }
+            let operation_id = self
+                .active_visibility_operation
+                .map(|operation_id| operation_id.to_vec())
+                .unwrap_or_else(|| message_id.as_slice().to_vec());
+            return Ok(Some(AccountVisibilityActionOutcome {
+                operation_id,
+                group_id,
+                message_id: message_id.clone(),
+                action: AccountVisibilityOutboundAction::Leave,
+                published,
+            }));
+        }
+        Ok(None)
+    }
+
+    fn leave_fanout_requires_action_outcome(&self, fanout: &OutboundFanout) -> AccountResult<bool> {
+        let Some(group_id) = fanout.group_id() else {
+            return Ok(false);
+        };
+        Ok(self
+            .visibility_storage
+            .leave_request(group_id)
+            .map_err(|error| AccountError::Session(SessionError::Storage(error)))?
+            .and_then(|request| request.last_proposed_message_id)
+            .as_ref()
+            == Some(fanout.message_id()))
+    }
+
+    fn leave_action_outcome_is_recorded(
+        &self,
+        message_id: &MessageId,
+        published: bool,
+        output: &AccountDeviceEffects,
+    ) -> AccountResult<bool> {
+        if let Some(existing) = output
+            .action_outcomes
+            .iter()
+            .find(|outcome| &outcome.message_id == message_id)
+        {
+            if existing.published != published {
+                return Err(account_visibility_error(
+                    "outbound action changed its terminal publish outcome",
+                ));
+            }
+            return Ok(true);
+        }
+        let batches = self.load_visibility_batches()?;
+        if let Some(existing) = batches
+            .iter()
+            .flat_map(|batch| &batch.effects.action_outcomes)
+            .find(|outcome| &outcome.message_id == message_id)
+        {
+            if existing.published != published {
+                return Err(account_visibility_error(
+                    "durable outbound action changed its terminal publish outcome",
+                ));
+            }
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
+    fn ensure_leave_fanout_outcome_recorded(
+        &self,
+        fanout: &OutboundFanout,
+        published: bool,
+        output: &AccountDeviceEffects,
+    ) -> AccountResult<()> {
+        if !self.leave_fanout_requires_action_outcome(fanout)? {
+            return Ok(());
+        }
+        if self.leave_action_outcome_is_recorded(fanout.message_id(), published, output)? {
+            return Ok(());
+        }
+        Err(account_visibility_error(
+            "leave fanout produced no durable action outcome",
+        ))
     }
 
     async fn publish_queue(
@@ -2119,6 +5105,7 @@ where
         output: &mut AccountDeviceEffects,
         queue: &mut VecDeque<PublishWork>,
         context: Option<AuditEventContext>,
+        visibility_handoff: SessionVisibilityHandoff,
     ) -> AccountResult<()> {
         while let Some(work) = queue.pop_front() {
             match work {
@@ -2132,9 +5119,15 @@ where
                 } => {
                     let reports_before = output.reports.len();
                     let unresolved_before = output.unresolved_publishes.len();
-                    let status =
-                        Box::pin(self.publish_one(msg, None, output, queue, context.clone()))
-                            .await?;
+                    let status = Box::pin(self.publish_one(
+                        msg,
+                        None,
+                        output,
+                        queue,
+                        context.clone(),
+                        Some(visibility_handoff),
+                    ))
+                    .await?;
                     if status.accepted_by_any_endpoint {
                         if let Some(message_id) = output
                             .reports
@@ -2173,9 +5166,15 @@ where
                     self.resolve_regenerated_queued_intent(queued_intent, status);
                 }
                 PublishWork::Proposal { msg, queued_intent } => {
-                    let status =
-                        Box::pin(self.publish_one(msg, None, output, queue, context.clone()))
-                            .await?;
+                    let status = Box::pin(self.publish_one(
+                        msg,
+                        None,
+                        output,
+                        queue,
+                        context.clone(),
+                        Some(visibility_handoff),
+                    ))
+                    .await?;
                     self.resolve_regenerated_queued_intent(queued_intent, status);
                 }
                 PublishWork::GroupCreated { welcomes, pending } => {
@@ -2185,12 +5184,19 @@ where
                         output,
                         queue,
                         context.clone(),
+                        visibility_handoff,
                     ))
                     .await?;
                 }
                 PublishWork::FoundingGroupCreated { welcomes } => {
-                    self.publish_founding_group_created(welcomes, output, queue, context.clone())
-                        .await?;
+                    self.publish_founding_group_created(
+                        welcomes,
+                        output,
+                        queue,
+                        context.clone(),
+                        visibility_handoff,
+                    )
+                    .await?;
                 }
                 PublishWork::GroupEvolution {
                     msg,
@@ -2204,20 +5210,46 @@ where
                         output,
                         queue,
                         context.clone(),
+                        visibility_handoff,
                     ))
                     .await?;
                 }
                 PublishWork::AutoPublish { msg, pending } => {
-                    self.publish_pending(vec![msg], pending, output, queue, context.clone())
-                        .await?;
+                    self.publish_pending(
+                        vec![msg],
+                        pending,
+                        output,
+                        queue,
+                        context.clone(),
+                        visibility_handoff,
+                    )
+                    .await?;
                 }
             }
+            // This checkpoint is synchronous and is the final action before
+            // the loop can poll the next PublishWork. A later work item may
+            // block or fail, but every caller-visible field produced so far is
+            // now replayable without publishing the completed item again.
+            self.checkpoint_current_publish_visibility(visibility_handoff, output)?;
         }
         Ok(())
     }
 
     /// Resume every incomplete frozen fanout in original staging order.
     pub async fn resume_outbound_fanouts(&mut self) -> AccountResult<AccountDeviceEffects> {
+        self.start_account_visibility_operation(AccountVisibilitySource::Drain {
+            observed_at: self.wall_clock.now(),
+        })?;
+        let effects = self.resume_outbound_fanouts_in_current_operation().await?;
+        self.discard_active_visibility_operation()?;
+        Ok(effects)
+    }
+
+    async fn resume_outbound_fanouts_in_current_operation(
+        &mut self,
+    ) -> AccountResult<AccountDeviceEffects> {
+        let visibility_handoff = self.begin_session_visibility_handoff()?;
+        self.start_current_publish_visibility(visibility_handoff);
         let fanouts = self.session.outbound_fanouts()?;
         let mut output = AccountDeviceEffects::default();
         let mut queue = VecDeque::new();
@@ -2226,14 +5258,32 @@ where
             if outcome.outstanding_targets > 0
                 || matches!(fanout.mls_state(), FanoutMlsState::Pending(_))
             {
-                Box::pin(self.drive_outbound_fanout(fanout, &mut output, &mut queue, None)).await?;
+                Box::pin(self.drive_outbound_fanout(
+                    fanout,
+                    &mut output,
+                    &mut queue,
+                    None,
+                    Some(visibility_handoff),
+                ))
+                .await?;
+                self.checkpoint_current_publish_visibility(visibility_handoff, &output)?;
             } else {
+                let published = outcome.accepted_targets >= fanout.request().required_acks.max(1);
+                self.record_terminal_outbound_action_outcome(
+                    fanout.message_id(),
+                    published,
+                    &mut output,
+                )?;
+                self.ensure_leave_fanout_outcome_recorded(&fanout, published, &output)?;
+                self.checkpoint_current_publish_visibility(visibility_handoff, &output)?;
                 self.session.delete_outbound_fanout(fanout.message_id())?;
             }
         }
-        self.publish_queue(&mut output, &mut queue, None).await?;
+        self.publish_queue(&mut output, &mut queue, None, visibility_handoff)
+            .await?;
         self.reconcile_confirmed_own_leaf_rotations(&output.events)?;
         self.reconcile_superseded_maintenance(&output.events)?;
+        self.finish_current_visibility_handoff(visibility_handoff);
         Ok(output)
     }
 
@@ -2462,6 +5512,7 @@ where
         output: &mut AccountDeviceEffects,
         queue: &mut VecDeque<PublishWork>,
         context: Option<AuditEventContext>,
+        visibility_handoff: SessionVisibilityHandoff,
     ) -> AccountResult<()> {
         let maintenance_evolution = messages.len() == 1
             && self
@@ -2488,9 +5539,16 @@ where
                 output
                     .pending
                     .push(PendingResolution::Confirmed { pending });
-                output.absorb_session_effects(effects, queue);
+                self.absorb_session_effects_retaining_visibility(
+                    output,
+                    effects,
+                    queue,
+                    visibility_handoff,
+                )?;
                 self.mark_transport_fanout_evolution_confirmed(&message.id);
-                self.finish_transport_fanout(&message.id, output).await?;
+                self.checkpoint_current_publish_visibility(visibility_handoff, output)?;
+                self.finish_transport_fanout(&message.id, output, Some(visibility_handoff))
+                    .await?;
                 return Ok(());
             }
 
@@ -2502,7 +5560,7 @@ where
             for message in messages {
                 message_ids.push(message.id.clone());
                 let status = self
-                    .publish_legacy_one(message, output, context.clone())
+                    .publish_legacy_one(message, output, context.clone(), Some(visibility_handoff))
                     .await?;
                 any_accepted |= status.accepted_by_any_endpoint;
                 all_published &= status.met_required_acks;
@@ -2515,17 +5573,29 @@ where
                 output
                     .pending
                     .push(PendingResolution::Confirmed { pending });
-                output.absorb_session_effects(effects, queue);
+                self.absorb_session_effects_retaining_visibility(
+                    output,
+                    effects,
+                    queue,
+                    visibility_handoff,
+                )?;
+                self.checkpoint_current_publish_visibility(visibility_handoff, output)?;
                 for message_id in message_ids {
                     self.mark_transport_fanout_evolution_confirmed(&message_id);
-                    self.finish_transport_fanout(&message_id, output).await?;
+                    self.finish_transport_fanout(&message_id, output, Some(visibility_handoff))
+                        .await?;
                 }
             } else if !ambiguous_exposure && !retry_deferred {
                 let effects = self.session.publish_failed(pending).await?;
                 output
                     .pending
                     .push(PendingResolution::RolledBack { pending });
-                output.absorb_session_effects(effects, queue);
+                self.absorb_session_effects_retaining_visibility(
+                    output,
+                    effects,
+                    queue,
+                    visibility_handoff,
+                )?;
             }
             return Ok(());
         }
@@ -2539,11 +5609,24 @@ where
             output
                 .pending
                 .push(PendingResolution::RolledBack { pending });
-            output.absorb_session_effects(effects, queue);
+            self.absorb_session_effects_retaining_visibility(
+                output,
+                effects,
+                queue,
+                visibility_handoff,
+            )?;
             return Ok(());
         };
         debug_assert!(messages.next().is_none());
-        Box::pin(self.publish_one(message, Some(pending), output, queue, context)).await?;
+        Box::pin(self.publish_one(
+            message,
+            Some(pending),
+            output,
+            queue,
+            context,
+            Some(visibility_handoff),
+        ))
+        .await?;
         Ok(())
     }
 
@@ -2554,6 +5637,7 @@ where
         output: &mut AccountDeviceEffects,
         queue: &mut VecDeque<PublishWork>,
         context: Option<AuditEventContext>,
+        visibility_handoff: SessionVisibilityHandoff,
     ) -> AccountResult<()> {
         let mut welcomes = welcomes.into_iter();
         let Some(first_welcome) = welcomes.next() else {
@@ -2561,7 +5645,12 @@ where
             output
                 .pending
                 .push(PendingResolution::Confirmed { pending });
-            output.absorb_session_effects(effects, queue);
+            self.absorb_session_effects_retaining_visibility(
+                output,
+                effects,
+                queue,
+                visibility_handoff,
+            )?;
             return Ok(());
         };
         Box::pin(self.publish_one_with_post_confirmation_welcomes(
@@ -2574,6 +5663,7 @@ where
             output,
             queue,
             context,
+            Some(visibility_handoff),
         ))
         .await?;
         Ok(())
@@ -2585,13 +5675,21 @@ where
         output: &mut AccountDeviceEffects,
         _queue: &mut VecDeque<PublishWork>,
         context: Option<AuditEventContext>,
+        visibility_handoff: SessionVisibilityHandoff,
     ) -> AccountResult<()> {
         let group_id = output.events.iter().find_map(|event| match event {
             GroupEvent::GroupCreated { group_id } => Some(group_id.clone()),
             _ => None,
         });
-        self.publish_welcome_fanout(welcomes, group_id, output, context, false)
-            .await
+        self.publish_welcome_fanout(
+            welcomes,
+            group_id,
+            output,
+            context,
+            false,
+            Some(visibility_handoff),
+        )
+        .await
     }
 
     /// Bounded-concurrency Welcome publication used by founding creates and by
@@ -2603,10 +5701,19 @@ where
         output: &mut AccountDeviceEffects,
         context: Option<AuditEventContext>,
         force_retry: bool,
+        visibility_handoff: Option<SessionVisibilityHandoff>,
     ) -> AccountResult<()> {
         let prepared = self.prepare_welcome_publish(welcomes, group_id, context, force_retry)?;
+        if visibility_handoff.is_some() {
+            let mut prepared_visibility = output.clone();
+            for metadata in &prepared.metadata {
+                prepared_visibility.extend(metadata.effects.clone());
+            }
+            self.checkpoint_optional_publish_visibility(visibility_handoff, &prepared_visibility)?;
+        }
         let completed = prepared.publish(&self.adapter).await;
-        self.finish_welcome_publish(completed, output).await
+        self.finish_welcome_publish(completed, output, visibility_handoff)
+            .await
     }
 
     fn prepare_welcome_publish(
@@ -2654,6 +5761,7 @@ where
         &mut self,
         completed: CompletedWelcomePublish,
         output: &mut AccountDeviceEffects,
+        visibility_handoff: Option<SessionVisibilityHandoff>,
     ) -> AccountResult<()> {
         let CompletedWelcomePublish {
             group_id,
@@ -2672,13 +5780,20 @@ where
             let WelcomePublishMetadata {
                 recipient,
                 welcome_id,
-                mut effects,
+                effects,
             } = metadata;
+            let failures_before = output.failures.len();
+            output.extend(effects);
             let status = match completion.expect("every Welcome publish completed") {
                 LegacyPublishCompletion::Complete(status) => Ok(status),
                 LegacyPublishCompletion::Network(attempt, result) => {
-                    self.finish_prepared_legacy_publish(*attempt, result, &mut effects)
-                        .await
+                    self.finish_prepared_legacy_publish(
+                        *attempt,
+                        result,
+                        output,
+                        visibility_handoff,
+                    )
+                    .await
                 }
             };
             let status = match status {
@@ -2694,16 +5809,16 @@ where
                 if status.met_required_acks {
                     self.mark_welcome_delivered_best_effort(&welcome_id);
                 } else if let Some(recipient) = recipient {
-                    effects.welcome_failures.push(self.welcome_delivery_failure(
+                    output.welcome_failures.push(self.welcome_delivery_failure(
                         welcome_id,
                         recipient,
                         group_id.clone(),
-                        &effects,
-                        0,
+                        output,
+                        failures_before,
                     ));
                 }
             }
-            output.extend(effects);
+            self.checkpoint_optional_publish_visibility(visibility_handoff, output)?;
         }
         match first_error {
             Some(error) => Err(error),
@@ -2711,6 +5826,7 @@ where
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn publish_group_evolution(
         &mut self,
         commit: TransportMessage,
@@ -2719,6 +5835,7 @@ where
         output: &mut AccountDeviceEffects,
         queue: &mut VecDeque<PublishWork>,
         context: Option<AuditEventContext>,
+        visibility_handoff: SessionVisibilityHandoff,
     ) -> AccountResult<()> {
         let commit_id = commit.id.clone();
         let maintenance_evolution = self
@@ -2734,16 +5851,23 @@ where
             });
         if maintenance_evolution {
             let commit_status = self
-                .publish_legacy_one(commit, output, context.clone())
+                .publish_legacy_one(commit, output, context.clone(), Some(visibility_handoff))
                 .await?;
             if commit_status.met_required_acks || commit_status.accepted_by_any_endpoint {
                 let effects = self.confirm_published_retrying(pending).await?;
                 output
                     .pending
                     .push(PendingResolution::Confirmed { pending });
-                output.absorb_session_effects(effects, queue);
+                self.absorb_session_effects_retaining_visibility(
+                    output,
+                    effects,
+                    queue,
+                    visibility_handoff,
+                )?;
                 self.mark_transport_fanout_evolution_confirmed(&commit_id);
-                self.finish_transport_fanout(&commit_id, output).await?;
+                self.checkpoint_current_publish_visibility(visibility_handoff, output)?;
+                self.finish_transport_fanout(&commit_id, output, Some(visibility_handoff))
+                    .await?;
                 debug_assert!(welcomes.is_empty());
                 return Ok(());
             }
@@ -2752,7 +5876,12 @@ where
                 output
                     .pending
                     .push(PendingResolution::RolledBack { pending });
-                output.absorb_session_effects(effects, queue);
+                self.absorb_session_effects_retaining_visibility(
+                    output,
+                    effects,
+                    queue,
+                    visibility_handoff,
+                )?;
             }
             return Ok(());
         }
@@ -2767,6 +5896,7 @@ where
             output,
             queue,
             context,
+            Some(visibility_handoff),
         ))
         .await?;
         Ok(())
@@ -2788,8 +5918,9 @@ where
     }
 
     async fn retry_confirmed_transport_fanouts(
-        &self,
+        &mut self,
         output: &mut AccountDeviceEffects,
+        visibility_handoff: Option<SessionVisibilityHandoff>,
     ) -> AccountResult<()> {
         let now = self.wall_clock.now();
         for fanout in self.session.transport_fanouts()? {
@@ -2803,7 +5934,8 @@ where
             if fanout.evolution_id.is_some() && !fanout.evolution_confirmed {
                 continue;
             }
-            self.finish_transport_fanout(&fanout.id, output).await?;
+            self.finish_transport_fanout(&fanout.id, output, visibility_handoff)
+                .await?;
         }
         Ok(())
     }
@@ -2814,9 +5946,10 @@ where
     /// has been applied locally. These attempts therefore cannot reopen the MLS
     /// pending state or change the canonical branch.
     async fn finish_transport_fanout(
-        &self,
+        &mut self,
         message_id: &cgka_traits::MessageId,
         output: &mut AccountDeviceEffects,
+        visibility_handoff: Option<SessionVisibilityHandoff>,
     ) -> AccountResult<()> {
         if self.detached_welcome_publishes.contains(message_id) {
             return Ok(());
@@ -2882,6 +6015,7 @@ where
                     }
                 }
             }
+            self.checkpoint_optional_publish_visibility(visibility_handoff, output)?;
             self.session.put_transport_fanout(&fanout)?;
         }
         Ok(())
@@ -2909,7 +6043,7 @@ where
         // wait for the automatic fanout backoff window. The original exact
         // Welcome and target snapshot are still reused.
         let status = self
-            .publish_one_with_retry_policy(message, &mut output, None, true)
+            .publish_one_with_retry_policy(message, &mut output, None, true, None)
             .await?;
         if status.met_required_acks {
             self.mark_welcome_delivered_best_effort(message_id);
@@ -2993,6 +6127,7 @@ where
         output: &mut AccountDeviceEffects,
         queue: &mut VecDeque<PublishWork>,
         context: Option<AuditEventContext>,
+        visibility_handoff: Option<SessionVisibilityHandoff>,
     ) -> AccountResult<PublishStatus> {
         let continuation = match pending {
             Some(pending) => Some(PendingFanoutContinuation {
@@ -3008,6 +6143,7 @@ where
             output,
             queue,
             context,
+            visibility_handoff,
         )
         .await
     }
@@ -3019,6 +6155,7 @@ where
         output: &mut AccountDeviceEffects,
         queue: &mut VecDeque<PublishWork>,
         context: Option<AuditEventContext>,
+        visibility_handoff: Option<SessionVisibilityHandoff>,
     ) -> AccountResult<PublishStatus> {
         let (pending, pending_kind, post_confirmation_welcomes) = match continuation {
             Some(continuation) => (
@@ -3033,11 +6170,13 @@ where
                 Ok(target) => target,
                 Err(error) => {
                     output.failures.push(PublishFailure {
-                        message_id: message.id,
+                        message_id: message.id.clone(),
                         reason: error.to_string(),
                     });
-                    self.rollback_unstaged_pending(pending, output, queue)
+                    self.rollback_unstaged_pending(pending, output, queue, visibility_handoff)
                         .await?;
+                    self.record_terminal_outbound_action_outcome(&message.id, false, output)?;
+                    self.checkpoint_optional_publish_visibility(visibility_handoff, output)?;
                     return Ok(PublishStatus::default());
                 }
             };
@@ -3048,7 +6187,7 @@ where
             {
                 Ok(group_id) => group_id,
                 Err(error) => {
-                    self.rollback_unstaged_pending(pending, output, queue)
+                    self.rollback_unstaged_pending(pending, output, queue, visibility_handoff)
                         .await?;
                     return Err(error.into());
                 }
@@ -3063,7 +6202,7 @@ where
                 {
                     Ok(message_id) => message_id,
                     Err(error) => {
-                        self.rollback_unstaged_pending(pending, output, queue)
+                        self.rollback_unstaged_pending(pending, output, queue, visibility_handoff)
                             .await?;
                         return Err(error.into());
                     }
@@ -3085,19 +6224,21 @@ where
             ) {
                 Ok(fanout) => fanout,
                 Err(error) => {
-                    self.rollback_unstaged_pending(pending, output, queue)
+                    self.rollback_unstaged_pending(pending, output, queue, visibility_handoff)
                         .await?;
                     return Err(error.into());
                 }
             };
             if let Err(error) = self.session.put_outbound_fanout(&fanout) {
-                self.rollback_unstaged_pending(pending, output, queue)
+                self.rollback_unstaged_pending(pending, output, queue, visibility_handoff)
                     .await?;
                 return Err(error.into());
             }
-            Box::pin(self.drive_outbound_fanout(fanout, output, queue, context)).await
+            Box::pin(self.drive_outbound_fanout(fanout, output, queue, context, visibility_handoff))
+                .await
         } else {
-            self.publish_legacy_one(message, output, context).await
+            self.publish_legacy_one(message, output, context, visibility_handoff)
+                .await
         }
     }
 
@@ -3106,13 +6247,20 @@ where
         pending: Option<PendingStateRef>,
         output: &mut AccountDeviceEffects,
         queue: &mut VecDeque<PublishWork>,
+        visibility_handoff: Option<SessionVisibilityHandoff>,
     ) -> AccountResult<()> {
         if let Some(pending) = pending {
+            self.checkpoint_optional_publish_visibility(visibility_handoff, output)?;
             let effects = self.session.publish_failed(pending).await?;
             output
                 .pending
                 .push(PendingResolution::RolledBack { pending });
-            output.absorb_session_effects(effects, queue);
+            self.absorb_session_effects_retaining_optional_visibility(
+                output,
+                effects,
+                queue,
+                visibility_handoff,
+            )?;
         }
         Ok(())
     }
@@ -3123,9 +6271,17 @@ where
         output: &mut AccountDeviceEffects,
         queue: &mut VecDeque<PublishWork>,
         context: Option<AuditEventContext>,
+        visibility_handoff: Option<SessionVisibilityHandoff>,
     ) -> AccountResult<PublishStatus> {
-        self.resolve_outbound_fanout_mls(&mut fanout, output, queue, context.clone())
-            .await?;
+        self.resolve_outbound_fanout_mls(
+            &mut fanout,
+            output,
+            queue,
+            context.clone(),
+            visibility_handoff,
+        )
+        .await?;
+        self.checkpoint_optional_publish_visibility(visibility_handoff, output)?;
         let endpoints = fanout.request().target.endpoints().to_vec();
         let now_ms = self.wall_clock.now().0.saturating_mul(1_000);
         let due = fanout
@@ -3210,6 +6366,10 @@ where
             // Record this artifact before confirmation releases any frozen
             // Welcome continuations, preserving transport chronology in the
             // returned effects while keeping the MLS edge atomic below.
+            // `EpochConfirmed` / `EpochRolledBack` records the MLS edge. This
+            // endpoint-free publish row records the separate terminal fanout
+            // edge; relay URLs stay solely in the encrypted fanout record and
+            // never enter this privacy-safe audit summary.
             self.session.record_audit_event(
                 fanout.group_id(),
                 context.clone(),
@@ -3226,8 +6386,14 @@ where
                 },
             );
             output.reports.push(report);
-            self.resolve_outbound_fanout_mls(&mut fanout, output, queue, context.clone())
-                .await?;
+            self.resolve_outbound_fanout_mls(
+                &mut fanout,
+                output,
+                queue,
+                context.clone(),
+                visibility_handoff,
+            )
+            .await?;
         }
 
         let report = frozen_fanout_report(&fanout);
@@ -3281,6 +6447,20 @@ where
             }
         }
         output.fanout.push(fanout_outcome.clone());
+        // Leave membership is authorized by `published: true`. Required ACKs
+        // can land while an optional target stays retryable, so emit durable
+        // true at quorum rather than waiting for complete fanout. `published:
+        // false` stays terminal: only a finished fanout that missed quorum.
+        if status.met_required_acks {
+            self.record_terminal_outbound_action_outcome(fanout.message_id(), true, output)?;
+        } else if fanout_outcome.fanout_complete {
+            self.record_terminal_outbound_action_outcome(fanout.message_id(), false, output)?;
+        }
+        if fanout_outcome.fanout_complete {
+            let published = status.met_required_acks;
+            self.ensure_leave_fanout_outcome_recorded(&fanout, published, output)?;
+        }
+        self.checkpoint_optional_publish_visibility(visibility_handoff, output)?;
         if fanout_outcome.fanout_complete
             && !matches!(fanout.mls_state(), FanoutMlsState::Pending(_))
         {
@@ -3295,6 +6475,7 @@ where
         output: &mut AccountDeviceEffects,
         queue: &mut VecDeque<PublishWork>,
         context: Option<AuditEventContext>,
+        visibility_handoff: Option<SessionVisibilityHandoff>,
     ) -> AccountResult<()> {
         let outcome = fanout.outcome();
         if outcome.mls_confirmation_required {
@@ -3307,7 +6488,12 @@ where
             output
                 .pending
                 .push(PendingResolution::Confirmed { pending });
-            output.absorb_session_effects(effects, queue);
+            self.absorb_session_effects_retaining_optional_visibility(
+                output,
+                effects,
+                queue,
+                visibility_handoff,
+            )?;
         } else if outcome.fanout_complete
             && outcome.accepted_targets == 0
             && !fanout.possible_exposure()
@@ -3317,15 +6503,27 @@ where
             output
                 .pending
                 .push(PendingResolution::RolledBack { pending });
-            output.absorb_session_effects(effects, queue);
+            self.absorb_session_effects_retaining_optional_visibility(
+                output,
+                effects,
+                queue,
+                visibility_handoff,
+            )?;
         }
         if matches!(fanout.mls_state(), FanoutMlsState::Confirmed)
             && !fanout.pending_post_confirmation_welcomes().is_empty()
         {
             let welcomes = fanout.pending_post_confirmation_welcomes().to_vec();
             let group_id = fanout.group_id().cloned();
-            self.publish_welcome_fanout(welcomes, group_id, output, context, false)
-                .await?;
+            self.publish_welcome_fanout(
+                welcomes,
+                group_id,
+                output,
+                context,
+                false,
+                visibility_handoff,
+            )
+            .await?;
             if fanout.mark_post_confirmation_welcomes_released() {
                 self.session.put_outbound_fanout(fanout)?;
             }
@@ -3334,27 +6532,29 @@ where
     }
 
     async fn publish_legacy_one(
-        &self,
+        &mut self,
         message: TransportMessage,
         output: &mut AccountDeviceEffects,
         context: Option<AuditEventContext>,
+        visibility_handoff: Option<SessionVisibilityHandoff>,
     ) -> AccountResult<PublishStatus> {
-        self.publish_one_with_retry_policy(message, output, context, false)
+        self.publish_one_with_retry_policy(message, output, context, false, visibility_handoff)
             .await
     }
 
     async fn publish_one_with_retry_policy(
-        &self,
+        &mut self,
         message: TransportMessage,
         output: &mut AccountDeviceEffects,
         context: Option<AuditEventContext>,
         retry_immediately: bool,
+        visibility_handoff: Option<SessionVisibilityHandoff>,
     ) -> AccountResult<PublishStatus> {
         match self.prepare_legacy_publish(message, output, context, retry_immediately)? {
             PreparedLegacyPublish::Complete(status) => Ok(status),
             PreparedLegacyPublish::Network(attempt) => {
                 let result = self.adapter.publish(attempt.request.clone()).await;
-                self.finish_prepared_legacy_publish(*attempt, result, output)
+                self.finish_prepared_legacy_publish(*attempt, result, output, visibility_handoff)
                     .await
             }
         }
@@ -3565,10 +6765,11 @@ where
     }
 
     async fn finish_prepared_legacy_publish(
-        &self,
+        &mut self,
         attempt: PreparedLegacyPublishAttempt,
         result: Result<TransportPublishReport, TransportAdapterError>,
         output: &mut AccountDeviceEffects,
+        visibility_handoff: Option<SessionVisibilityHandoff>,
     ) -> AccountResult<PublishStatus> {
         let PreparedLegacyPublishAttempt {
             message_id,
@@ -3699,8 +6900,10 @@ where
             });
         }
         output.reports.push(report);
+        self.checkpoint_optional_publish_visibility(visibility_handoff, output)?;
         if !defers_remaining_fanout_until_confirmation {
-            self.finish_transport_fanout(&message_id, output).await?;
+            self.finish_transport_fanout(&message_id, output, visibility_handoff)
+                .await?;
         }
         Ok(PublishStatus {
             met_required_acks: published,
@@ -3758,6 +6961,104 @@ fn frozen_fanout_target_retry_due(fanout: &OutboundFanout, index: usize, now_ms:
         }
         Some(FanoutTargetStatus::Accepted | FanoutTargetStatus::Failed) | None => false,
     }
+}
+
+fn account_visibility_error(error: impl Into<String>) -> AccountError {
+    AccountError::Session(SessionError::Storage(StorageError::Backend(error.into())))
+}
+
+fn account_visibility_batch_id(operation_id: &[u8; 16], ordinal: u64) -> Vec<u8> {
+    use sha2::{Digest, Sha256};
+
+    let mut hasher = Sha256::new();
+    hasher.update(b"marmot-account-visibility-v1");
+    hasher.update(operation_id);
+    hasher.update(ordinal.to_be_bytes());
+    hasher.finalize().to_vec()
+}
+
+fn decode_account_visibility_row(
+    row: AccountVisibilityJournalRow,
+) -> AccountResult<AccountVisibilityBatch> {
+    let operation_id = <[u8; 16]>::try_from(row.operation_id.as_slice())
+        .map_err(|_| account_visibility_error("visibility operation id has invalid length"))?;
+    if row.batch_id != account_visibility_batch_id(&operation_id, row.ordinal) {
+        return Err(account_visibility_error(
+            "visibility batch id does not match its operation and ordinal",
+        ));
+    }
+    let record: StoredAccountVisibilityRecordV1 =
+        serde_json::from_slice(&row.record).map_err(|error| {
+            account_visibility_error(format!("decode account visibility record: {error}"))
+        })?;
+    if record.version != ACCOUNT_VISIBILITY_RECORD_VERSION {
+        return Err(account_visibility_error(format!(
+            "unsupported account visibility record version {}",
+            record.version
+        )));
+    }
+    let mut effects = AccountDeviceEffects::default();
+    let kind = match record.payload {
+        StoredAccountVisibilityPayloadV1::Header {
+            maintenance_disposition,
+        } => {
+            if row.ordinal != 0 {
+                return Err(account_visibility_error(
+                    "visibility header has a nonzero ordinal",
+                ));
+            }
+            effects.maintenance_disposition = maintenance_disposition;
+            AccountVisibilityRecordKind::Header
+        }
+        StoredAccountVisibilityPayloadV1::Event {
+            event,
+            engine_outbox_provenance,
+        } => {
+            if row.ordinal == 0 || row.ordinal >= ACCOUNT_VISIBILITY_CONTROL_ORDINAL {
+                return Err(account_visibility_error(
+                    "visibility event has a reserved ordinal",
+                ));
+            }
+            effects.events.push(event);
+            AccountVisibilityRecordKind::Event {
+                engine_outbox_provenance,
+            }
+        }
+        StoredAccountVisibilityPayloadV1::SessionControl(control) => {
+            if row.ordinal != ACCOUNT_VISIBILITY_CONTROL_ORDINAL {
+                return Err(account_visibility_error(
+                    "visibility session-control record has the wrong ordinal",
+                ));
+            }
+            effects.queued = control
+                .queued
+                .into_iter()
+                .map(|queued| QueuedIntentRef {
+                    group_id: queued.group_id,
+                    intent_id: queued.intent_id,
+                })
+                .collect();
+            effects.pending_convergence = control.pending_convergence;
+            AccountVisibilityRecordKind::SessionControl
+        }
+        StoredAccountVisibilityPayloadV1::NonSession(non_session) => {
+            if row.ordinal != ACCOUNT_VISIBILITY_NON_SESSION_ORDINAL {
+                return Err(account_visibility_error(
+                    "visibility non-session record has the wrong ordinal",
+                ));
+            }
+            effects = non_session.into_effects();
+            AccountVisibilityRecordKind::NonSession
+        }
+    };
+    Ok(AccountVisibilityBatch {
+        sequence: row.sequence,
+        operation_id: row.operation_id,
+        batch_id: row.batch_id,
+        source: record.source,
+        kind,
+        effects,
+    })
 }
 
 fn frozen_fanout_report(fanout: &OutboundFanout) -> TransportPublishReport {
@@ -3844,6 +7145,46 @@ fn apply_report_to_fanout(
     }
 }
 
+/// Whether durable teardown evidence says the live current revision was
+/// deleted. Pre-artifact lifecycle rows can carry only `authored_event_id`, so
+/// both identity representations are authoritative during upgrade recovery.
+fn current_key_package_revision_is_deleted(lifecycle: &KeyPackageLifecycleState) -> bool {
+    lifecycle
+        .authored_signed_event
+        .as_ref()
+        .is_some_and(|artifact| {
+            lifecycle
+                .deleted_live_revision_event_ids
+                .contains(&artifact.id)
+        })
+        || lifecycle
+            .authored_event_id
+            .as_ref()
+            .is_some_and(|event_id| lifecycle.deleted_live_revision_event_ids.contains(event_id))
+}
+
+fn current_key_package_artifact_precedes_authoring_high_water(
+    lifecycle: &KeyPackageLifecycleState,
+) -> bool {
+    lifecycle
+        .authored_signed_event
+        .as_ref()
+        .zip(lifecycle.authored_event_created_at)
+        .is_some_and(|(artifact, high_water)| artifact.created_at < high_water)
+}
+
+fn ensure_key_package_cutover_publication_allowed(
+    lifecycle: &KeyPackageLifecycleState,
+) -> AccountResult<()> {
+    if lifecycle.cutover_publication_blocked {
+        return Err(crate::key_package::KeyPackagePublishError::unexposed(
+            "key package publication is blocked until strict cutover discovery completes",
+        )
+        .into());
+    }
+    Ok(())
+}
+
 fn current_key_package_republish_blocker(
     lifecycle: &KeyPackageLifecycleState,
     now: Timestamp,
@@ -3868,7 +7209,18 @@ fn current_key_package_republish_blocker(
         Some("missing_authored_event_created_at")
     } else if lifecycle.authored_signed_event.is_none() {
         Some("missing_authored_signed_event")
-    } else if lifecycle.last_consumed_key_package_ref == lifecycle.current_key_package_ref {
+    } else if lifecycle
+        .authored_signed_event
+        .as_ref()
+        .zip(lifecycle.authored_event_created_at)
+        .is_some_and(|(artifact, high_water)| artifact.created_at < high_water)
+    {
+        Some("newer_stable_slot_revision_requires_semantic_replacement")
+    } else if lifecycle
+        .current_key_package_ref
+        .as_deref()
+        .is_some_and(|key_package_ref| lifecycle.key_package_ref_is_consumed(key_package_ref))
+    {
         Some("current_key_package_ref_consumed")
     } else if !lifecycle.upgrade_rotation_recorded {
         Some("upgrade_rotation_required")
@@ -3887,10 +7239,15 @@ fn merge_republish_publication_targets(
             .find(|target| target.endpoint == *endpoint)
         {
             if target.state == TransportFanoutAttemptState::PolicyProhibited {
-                target.state = TransportFanoutAttemptState::Unattempted;
-                target.attempt_count = 0;
-                target.last_attempt_at = None;
-                target.failure_code = None;
+                if target.attempt_count == 0 && target.last_attempt_at.is_none() {
+                    target.state = TransportFanoutAttemptState::Unattempted;
+                    target.failure_code = None;
+                } else {
+                    // Re-authorizing the same exact event at a formerly removed
+                    // endpoint must retain its historical exposure evidence.
+                    target.state = TransportFanoutAttemptState::AttemptedFailed;
+                    target.failure_code = Some("possible_exposure".into());
+                }
             }
             continue;
         }
@@ -3914,11 +7271,811 @@ fn merge_republish_publication_targets(
     }
 }
 
-fn note_key_package_attempt(
+fn key_package_publication_targets_need_policy_reconciliation(
+    targets: &[TransportFanoutTarget],
+    current_endpoints: &[TransportEndpoint],
+) -> bool {
+    current_endpoints.iter().any(|endpoint| {
+        !targets.iter().any(|target| {
+            target.endpoint == *endpoint
+                && target.state != TransportFanoutAttemptState::PolicyProhibited
+        })
+    }) || targets.iter().any(|target| {
+        target.state != TransportFanoutAttemptState::PolicyProhibited
+            && !current_endpoints.contains(&target.endpoint)
+    })
+}
+
+fn key_package_reauthor_created_at(
+    artifact: &SignedPublicationArtifact,
+    now: Timestamp,
+    reauthor_after_secs: Option<u64>,
+    ordering_high_water: Option<Timestamp>,
+    require_strictly_above_high_water: bool,
+) -> Result<Option<Timestamp>, ()> {
+    let ordering_requires_reauthor = ordering_high_water.is_some_and(|high_water| {
+        if require_strictly_above_high_water {
+            high_water >= artifact.created_at
+        } else {
+            high_water > artifact.created_at
+        }
+    });
+    if reauthor_after_secs.is_none() && !ordering_requires_reauthor {
+        return Ok(None);
+    }
+    if artifact.created_at.0 > now.0.saturating_add(KEY_PACKAGE_MAX_FUTURE_SKEW_SECS) {
+        return Err(());
+    }
+    let policy_requires_reauthor = reauthor_after_secs.is_some_and(|reauthor_after_secs| {
+        now.0.saturating_sub(artifact.created_at.0) >= reauthor_after_secs
+    });
+    if !policy_requires_reauthor && !ordering_requires_reauthor {
+        return Ok(None);
+    }
+    let strictly_newer = artifact.created_at.0.checked_add(1).ok_or(())?;
+    let strictly_above_high_water = ordering_high_water
+        .filter(|high_water| *high_water > artifact.created_at)
+        .map(|high_water| high_water.0.checked_add(1).ok_or(()))
+        .transpose()?
+        .unwrap_or(strictly_newer);
+    let created_at = Timestamp(now.0.max(strictly_newer).max(strictly_above_high_water));
+    if created_at.0 <= artifact.created_at.0
+        || created_at.0 > now.0.saturating_add(KEY_PACKAGE_MAX_FUTURE_SKEW_SECS)
+    {
+        return Err(());
+    }
+    Ok(Some(created_at))
+}
+
+fn validate_reauthored_key_package_artifact(
+    previous: &SignedPublicationArtifact,
+    requested_created_at: Timestamp,
+    replacement: &SignedPublicationArtifact,
+) -> AccountResult<()> {
+    if replacement.created_at != requested_created_at
+        || replacement.created_at <= previous.created_at
+        || replacement.id == previous.id
+        || replacement.bytes == previous.bytes
+    {
+        return Err(crate::key_package::KeyPackagePublishError::unexposed(
+            "reauthored KeyPackage event does not form a strictly newer signed revision",
+        )
+        .into());
+    }
+    Ok(())
+}
+
+fn replace_key_package_publication_targets(
+    targets: &mut Vec<TransportFanoutTarget>,
+    live_endpoints: &[TransportEndpoint],
+) {
+    *targets = live_endpoints
+        .iter()
+        .cloned()
+        .map(|endpoint| TransportFanoutTarget {
+            endpoint,
+            state: TransportFanoutAttemptState::Unattempted,
+            attempt_count: 0,
+            last_attempt_at: None,
+            failure_code: None,
+        })
+        .collect();
+}
+
+fn retired_key_package_publication(
+    artifact: &SignedPublicationArtifact,
+    key_package_ref: Option<&[u8]>,
+    package_not_after: Option<Timestamp>,
+    delete_without_successor: bool,
+    targets: &[TransportFanoutTarget],
+) -> Option<RetiredKeyPackagePublication> {
+    retired_key_package_publication_from_identity(
+        &artifact.id,
+        artifact.created_at,
+        key_package_ref,
+        package_not_after,
+        delete_without_successor,
+        targets,
+    )
+}
+
+/// Snapshot the exact current publication even for upgrade rows that predate
+/// durable signed-artifact bytes. `authored_event_id` plus the stable-slot
+/// high-water and endpoint fanout remain sufficient deletion evidence; losing
+/// that identity while superseding private material would make an exposed
+/// relay revision permanently unreachable.
+fn retired_current_key_package_publication(
+    lifecycle: &KeyPackageLifecycleState,
+    delete_without_successor: bool,
+) -> Option<RetiredKeyPackagePublication> {
+    let (event_id, authored_created_at) = match lifecycle.authored_signed_event.as_ref() {
+        Some(artifact) => (&artifact.id, artifact.created_at),
+        None => (
+            lifecycle.authored_event_id.as_ref()?,
+            lifecycle.authored_event_created_at.unwrap_or(Timestamp(0)),
+        ),
+    };
+    retired_key_package_publication_from_identity(
+        event_id,
+        authored_created_at,
+        lifecycle.current_key_package_ref.as_deref(),
+        lifecycle.current_not_after,
+        delete_without_successor,
+        &lifecycle.publication_targets,
+    )
+}
+
+fn retired_key_package_publication_from_identity(
+    event_id: &cgka_traits::MessageId,
+    authored_created_at: Timestamp,
+    key_package_ref: Option<&[u8]>,
+    package_not_after: Option<Timestamp>,
+    delete_without_successor: bool,
+    targets: &[TransportFanoutTarget],
+) -> Option<RetiredKeyPackagePublication> {
+    // Every snapshotted endpoint is a possible exposure. Publication records
+    // are updated only after the awaited network call returns, so cancellation
+    // or process death can leave a relay-held event marked `Unattempted` (and a
+    // later policy edit can turn that same ambiguous target `PolicyProhibited`).
+    let mut deletion_targets = targets
+        .iter()
+        .filter(|target| target.failure_code.as_deref() != Some("confirmed_absent"))
+        .map(|target| TransportFanoutTarget {
+            endpoint: target.endpoint.clone(),
+            state: TransportFanoutAttemptState::Unattempted,
+            attempt_count: 0,
+            last_attempt_at: None,
+            failure_code: None,
+        })
+        .collect::<Vec<_>>();
+    deletion_targets.sort_by(|left, right| left.endpoint.cmp(&right.endpoint));
+    deletion_targets.dedup_by(|left, right| left.endpoint == right.endpoint);
+    (!deletion_targets.is_empty()).then(|| RetiredKeyPackagePublication {
+        event_id: event_id.clone(),
+        authored_created_at,
+        key_package_ref: key_package_ref.map(ToOwned::to_owned),
+        package_not_after,
+        delete_without_successor,
+        deletion_targets,
+    })
+}
+
+fn manual_key_package_deletion_liability(
+    lifecycle: &KeyPackageLifecycleState,
+    event_id: &cgka_traits::MessageId,
+    endpoint: TransportEndpoint,
+) -> RetiredKeyPackagePublication {
+    let current_matches = lifecycle
+        .authored_signed_event
+        .as_ref()
+        .is_some_and(|artifact| artifact.id == *event_id)
+        || lifecycle.authored_event_id.as_ref() == Some(event_id);
+    let pending = lifecycle.pending_replacement.as_ref().filter(|pending| {
+        pending
+            .signed_event
+            .as_ref()
+            .is_some_and(|artifact| artifact.id == *event_id)
+    });
+    let existing = lifecycle
+        .retired_publications_pending_deletion
+        .iter()
+        .find(|retired| retired.event_id == *event_id);
+    let authored_created_at = existing
+        .map(|retired| retired.authored_created_at)
+        .or_else(|| {
+            current_matches.then(|| {
+                lifecycle
+                    .authored_signed_event
+                    .as_ref()
+                    .filter(|artifact| artifact.id == *event_id)
+                    .map(|artifact| artifact.created_at)
+                    .or(lifecycle.authored_event_created_at)
+                    .unwrap_or(Timestamp(0))
+            })
+        })
+        .or_else(|| pending.map(|pending| pending.authored_created_at))
+        .unwrap_or(Timestamp(0));
+    let key_package_ref = existing
+        .and_then(|retired| retired.key_package_ref.clone())
+        .or_else(|| {
+            current_matches
+                .then(|| lifecycle.current_key_package_ref.clone())
+                .flatten()
+        })
+        .or_else(|| pending.map(|pending| pending.key_package_ref.clone()));
+    let package_not_after = existing
+        .and_then(|retired| retired.package_not_after)
+        .or_else(|| {
+            current_matches
+                .then_some(lifecycle.current_not_after)
+                .flatten()
+        })
+        .or_else(|| pending.map(|pending| pending.not_after));
+    RetiredKeyPackagePublication {
+        event_id: event_id.clone(),
+        authored_created_at,
+        key_package_ref,
+        package_not_after,
+        delete_without_successor: true,
+        deletion_targets: vec![TransportFanoutTarget {
+            endpoint,
+            state: TransportFanoutAttemptState::Unattempted,
+            attempt_count: 0,
+            last_attempt_at: None,
+            failure_code: None,
+        }],
+    }
+}
+
+fn admit_manual_key_package_deletion_liabilities(
+    lifecycle: &mut KeyPackageLifecycleState,
+    event_id: &cgka_traits::MessageId,
+    mut endpoints: Vec<TransportEndpoint>,
+    liability_limit: usize,
+) -> (Vec<TransportEndpoint>, Vec<TransportEndpoint>) {
+    endpoints.sort();
+    endpoints.dedup();
+    let mut liability_count = key_package_signed_publication_liability_count(lifecycle);
+    let mut admitted = Vec::new();
+    let mut deferred = Vec::new();
+    for endpoint in endpoints {
+        let already_durable =
+            key_package_event_endpoint_is_liability(lifecycle, event_id, &endpoint);
+        if !already_durable && liability_count >= liability_limit {
+            deferred.push(endpoint);
+            continue;
+        }
+        if !already_durable {
+            liability_count = liability_count.saturating_add(1);
+        }
+        admitted.push(endpoint.clone());
+        let retired = manual_key_package_deletion_liability(lifecycle, event_id, endpoint);
+        retain_retired_key_package_publication(lifecycle, retired);
+    }
+    (admitted, deferred)
+}
+
+/// Admit one exact deletion set atomically while giving its event exclusive
+/// use of the small overflow above the ordinary signed-publication bound.
+///
+/// Requests that fit under the ordinary bound do not consume the reserve. The
+/// first request that crosses that bound becomes the durable owner; until its
+/// last deletion target is terminal, a different exact event is wholly
+/// deferred even if some ordinary capacity later becomes available. This
+/// prevents two independently atomic relay sets from sharing a reserve whose
+/// safety argument assumes one selected deletion.
+fn admit_atomic_exact_key_package_deletion_liabilities(
+    lifecycle: &mut KeyPackageLifecycleState,
+    event_id: &cgka_traits::MessageId,
+    mut endpoints: Vec<TransportEndpoint>,
+) -> (Vec<TransportEndpoint>, Vec<TransportEndpoint>) {
+    endpoints.sort();
+    endpoints.dedup();
+    release_settled_key_package_deletion_overflow_owner(lifecycle);
+
+    if lifecycle
+        .deletion_overflow_owner_event_id
+        .as_ref()
+        .is_some_and(|owner| owner != event_id)
+    {
+        return (Vec::new(), endpoints);
+    }
+
+    let additional_liabilities = endpoints
+        .iter()
+        .filter(|endpoint| !key_package_event_endpoint_is_liability(lifecycle, event_id, endpoint))
+        .count();
+    let projected = key_package_signed_publication_liability_count(lifecycle)
+        .saturating_add(additional_liabilities);
+    if projected > MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES_WITH_LIVE_DELETION_OVERFLOW {
+        return (Vec::new(), endpoints);
+    }
+    if projected > MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES
+        && lifecycle.deletion_overflow_owner_event_id.is_none()
+    {
+        lifecycle.deletion_overflow_owner_event_id = Some(event_id.clone());
+    }
+
+    let liability_limit = if lifecycle.deletion_overflow_owner_event_id.as_ref() == Some(event_id) {
+        MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES_WITH_LIVE_DELETION_OVERFLOW
+    } else {
+        MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES
+    };
+    let (admitted, deferred) = admit_manual_key_package_deletion_liabilities(
+        lifecycle,
+        event_id,
+        endpoints,
+        liability_limit,
+    );
+    debug_assert!(
+        deferred.is_empty(),
+        "atomic exact deletion was preflighted against its complete endpoint set"
+    );
+    (admitted, deferred)
+}
+
+fn release_settled_key_package_deletion_overflow_owner(lifecycle: &mut KeyPackageLifecycleState) {
+    let owner_is_settled = lifecycle
+        .deletion_overflow_owner_event_id
+        .as_ref()
+        .is_some_and(|owner| {
+            !lifecycle
+                .retired_publications_pending_deletion
+                .iter()
+                .any(|retired| {
+                    retired.event_id == *owner
+                        && retired.deletion_targets.iter().any(|target| {
+                            target.failure_code.as_deref() != Some("confirmed_absent")
+                        })
+                })
+        });
+    if owner_is_settled {
+        lifecycle.deletion_overflow_owner_event_id = None;
+    }
+}
+
+fn retain_retired_key_package_publication(
+    lifecycle: &mut KeyPackageLifecycleState,
+    retired: RetiredKeyPackagePublication,
+) {
+    if let Some(existing) = lifecycle
+        .retired_publications_pending_deletion
+        .iter_mut()
+        .find(|existing| existing.event_id == retired.event_id)
+    {
+        if existing.key_package_ref.is_none() {
+            existing.key_package_ref = retired.key_package_ref;
+        }
+        existing.package_not_after = match (existing.package_not_after, retired.package_not_after) {
+            (Some(left), Some(right)) => Some(left.min(right)),
+            (left @ Some(_), None) | (None, left @ Some(_)) => left,
+            (None, None) => None,
+        };
+        existing.delete_without_successor |= retired.delete_without_successor;
+        for target in retired.deletion_targets {
+            if !existing
+                .deletion_targets
+                .iter()
+                .any(|existing| existing.endpoint == target.endpoint)
+            {
+                existing.deletion_targets.push(target);
+            }
+        }
+        existing
+            .deletion_targets
+            .sort_by(|left, right| left.endpoint.cmp(&right.endpoint));
+        return;
+    }
+    lifecycle
+        .retired_publications_pending_deletion
+        .push(retired);
+    lifecycle
+        .retired_publications_pending_deletion
+        .sort_by(|left, right| {
+            left.authored_created_at
+                .cmp(&right.authored_created_at)
+                .then_with(|| left.event_id.as_slice().cmp(right.event_id.as_slice()))
+        });
+}
+
+fn mark_retired_key_package_revisions_unusable(
+    lifecycle: &mut KeyPackageLifecycleState,
+    key_package_ref: &[u8],
+) {
+    for retired in &mut lifecycle.retired_publications_pending_deletion {
+        if retired.key_package_ref.as_deref() == Some(key_package_ref) {
+            retired.delete_without_successor = true;
+        }
+    }
+}
+
+/// Consume the ambiguous legacy single-ref marker by retiring every semantic
+/// KeyPackage it could have overwritten evidence for.
+///
+/// OpenMLS intentionally retains last-resort KeyPackage bundles after a
+/// Welcome, so local bundle presence cannot distinguish an unconsumed package
+/// from one whose older marker was overwritten. This one-time upgrade path
+/// therefore chooses privacy over availability and forces a fresh package.
+fn retire_legacy_only_consumption_projections(
+    lifecycle: &mut KeyPackageLifecycleState,
+    now: Timestamp,
+) -> Vec<KeyPackage> {
+    let mut retired_private_material = Vec::new();
+    let mut projected_refs = lifecycle.consumed_key_package_refs.clone();
+    let mut authored_high_water = lifecycle.authored_event_created_at;
+
+    if let Some(retired_publication) = retired_current_key_package_publication(lifecycle, true) {
+        retain_retired_key_package_publication(lifecycle, retired_publication);
+    }
+    if let Some(key_package_ref) = lifecycle.current_key_package_ref.clone() {
+        projected_refs.push(key_package_ref);
+    }
+    if let Some(created_at) = lifecycle
+        .authored_signed_event
+        .as_ref()
+        .map(|artifact| artifact.created_at)
+    {
+        authored_high_water = Some(
+            authored_high_water
+                .map(|current| current.max(created_at))
+                .unwrap_or(created_at),
+        );
+    }
+    if let Some(key_package) = lifecycle.current_key_package.take() {
+        retain_key_package_for_private_material_retirement(
+            &mut retired_private_material,
+            key_package,
+        );
+    }
+    lifecycle.current_key_package_ref = None;
+    lifecycle.current_not_before = None;
+    lifecycle.current_not_after = None;
+    lifecycle.authored_event_id = None;
+    lifecycle.authored_signed_event = None;
+    lifecycle.publication_targets.clear();
+
+    if let Some(pending) = lifecycle.pending_replacement.take() {
+        let pending_created_at = pending
+            .signed_event
+            .as_ref()
+            .map(|artifact| artifact.created_at)
+            .unwrap_or(pending.authored_created_at);
+        authored_high_water = Some(
+            authored_high_water
+                .map(|current| current.max(pending_created_at))
+                .unwrap_or(pending_created_at),
+        );
+        if let Some(retired_publication) = pending.signed_event.as_ref().and_then(|artifact| {
+            retired_key_package_publication(
+                artifact,
+                Some(&pending.key_package_ref),
+                Some(pending.not_after),
+                true,
+                &pending.targets,
+            )
+        }) {
+            retain_retired_key_package_publication(lifecycle, retired_publication);
+        }
+        projected_refs.push(pending.key_package_ref);
+        retain_key_package_for_private_material_retirement(
+            &mut retired_private_material,
+            pending.key_package,
+        );
+    }
+
+    for retained in std::mem::take(&mut lifecycle.retained_private_material) {
+        projected_refs.push(retained.key_package_ref);
+        retain_key_package_for_private_material_retirement(
+            &mut retired_private_material,
+            retained.key_package,
+        );
+    }
+    projected_refs.sort();
+    projected_refs.dedup();
+    for key_package_ref in projected_refs {
+        mark_retired_key_package_revisions_unusable(lifecycle, &key_package_ref);
+    }
+
+    lifecycle.authored_event_created_at = authored_high_water;
+    lifecycle.refresh_at = Some(now);
+    lifecycle.phase = MaintenancePhase::Retry;
+    lifecycle.consumed_key_package_refs.clear();
+    lifecycle.last_consumed_key_package_ref = None;
+    lifecycle.last_consumed_at = None;
+    retain_only_live_deleted_key_package_revision_ids(lifecycle);
+    retired_private_material
+}
+
+fn retain_key_package_for_private_material_retirement(
+    retired: &mut Vec<KeyPackage>,
+    key_package: KeyPackage,
+) {
+    if !retired.contains(&key_package) {
+        retired.push(key_package);
+    }
+}
+
+fn key_package_ref_has_live_private_material(
+    lifecycle: &KeyPackageLifecycleState,
+    key_package_ref: &[u8],
+) -> bool {
+    lifecycle.current_key_package_ref.as_deref() == Some(key_package_ref)
+        || lifecycle
+            .pending_replacement
+            .as_ref()
+            .is_some_and(|pending| pending.key_package_ref == key_package_ref)
+        || lifecycle
+            .retained_private_material
+            .iter()
+            .any(|retained| retained.key_package_ref == key_package_ref)
+}
+
+fn retain_only_live_deleted_key_package_revision_ids(lifecycle: &mut KeyPackageLifecycleState) {
+    let current_event_id = lifecycle
+        .authored_signed_event
+        .as_ref()
+        .map(|artifact| artifact.id.clone())
+        .or_else(|| lifecycle.authored_event_id.clone());
+    let pending_event_id = lifecycle
+        .pending_replacement
+        .as_ref()
+        .and_then(|pending| pending.signed_event.as_ref())
+        .map(|artifact| artifact.id.clone());
+    lifecycle
+        .deleted_live_revision_event_ids
+        .retain(|event_id| {
+            current_event_id.as_ref() == Some(event_id)
+                || pending_event_id.as_ref() == Some(event_id)
+        });
+}
+
+fn mark_live_key_package_revision_endpoints_absent(
+    lifecycle: &mut KeyPackageLifecycleState,
+    event_id: &cgka_traits::MessageId,
+    endpoints: &[TransportEndpoint],
+) {
+    if endpoints.is_empty() {
+        return;
+    }
+    if lifecycle
+        .authored_signed_event
+        .as_ref()
+        .is_some_and(|artifact| artifact.id == *event_id)
+        || lifecycle.authored_event_id.as_ref() == Some(event_id)
+    {
+        for target in &mut lifecycle.publication_targets {
+            if endpoints.contains(&target.endpoint) {
+                target.state = TransportFanoutAttemptState::AttemptedFailed;
+                target.failure_code = Some("confirmed_absent".into());
+            }
+        }
+    }
+    if let Some(pending) = lifecycle.pending_replacement.as_mut()
+        && pending
+            .signed_event
+            .as_ref()
+            .is_some_and(|artifact| artifact.id == *event_id)
+    {
+        for target in &mut pending.targets {
+            if endpoints.contains(&target.endpoint) {
+                target.state = TransportFanoutAttemptState::AttemptedFailed;
+                target.failure_code = Some("confirmed_absent".into());
+            }
+        }
+    }
+}
+
+fn key_package_signed_publication_liability_count(lifecycle: &KeyPackageLifecycleState) -> usize {
+    let mut liabilities = HashSet::new();
+    for retired in &lifecycle.retired_publications_pending_deletion {
+        insert_key_package_endpoint_liabilities(
+            &mut liabilities,
+            &retired.event_id,
+            &retired.deletion_targets,
+        );
+    }
+    if let Some(event_id) = lifecycle
+        .authored_signed_event
+        .as_ref()
+        .map(|artifact| &artifact.id)
+        .or(lifecycle.authored_event_id.as_ref())
+    {
+        insert_key_package_endpoint_liabilities(
+            &mut liabilities,
+            event_id,
+            &lifecycle.publication_targets,
+        );
+    }
+    if let Some(pending) = lifecycle.pending_replacement.as_ref()
+        && let Some(artifact) = pending.signed_event.as_ref()
+    {
+        insert_key_package_endpoint_liabilities(&mut liabilities, &artifact.id, &pending.targets);
+    }
+    liabilities.len()
+}
+
+fn projected_current_key_package_reauthor_liability_count(
+    lifecycle: &KeyPackageLifecycleState,
+    retired_publication: Option<&RetiredKeyPackagePublication>,
+    live_endpoints: &[TransportEndpoint],
+) -> usize {
+    let mut projected = lifecycle.clone();
+    if let Some(retired_publication) = retired_publication {
+        retain_retired_key_package_publication(&mut projected, retired_publication.clone());
+    }
+    let projected_event_id = unused_projected_key_package_event_id(&projected);
+    projected.authored_event_id = Some(projected_event_id.clone());
+    projected.authored_signed_event = Some(SignedPublicationArtifact {
+        id: projected_event_id,
+        created_at: Timestamp(0),
+        bytes: Vec::new(),
+    });
+    replace_key_package_publication_targets(&mut projected.publication_targets, live_endpoints);
+    key_package_signed_publication_liability_count(&projected)
+}
+
+fn projected_pending_key_package_reauthor_liability_count(
+    lifecycle: &KeyPackageLifecycleState,
+    retired_publication: Option<&RetiredKeyPackagePublication>,
+    live_endpoints: &[TransportEndpoint],
+) -> usize {
+    let mut projected = lifecycle.clone();
+    if let Some(retired_publication) = retired_publication {
+        retain_retired_key_package_publication(&mut projected, retired_publication.clone());
+    }
+    let projected_event_id = unused_projected_key_package_event_id(&projected);
+    if let Some(pending) = projected.pending_replacement.as_mut() {
+        pending.signed_event = Some(SignedPublicationArtifact {
+            id: projected_event_id,
+            created_at: Timestamp(0),
+            bytes: Vec::new(),
+        });
+        replace_key_package_publication_targets(&mut pending.targets, live_endpoints);
+    }
+    key_package_signed_publication_liability_count(&projected)
+}
+
+/// Model a future signed revision in capacity projections without depending on
+/// its not-yet-authored hash. The synthetic id never leaves memory and is
+/// chosen outside every identity currently represented in the lifecycle.
+fn unused_projected_key_package_event_id(lifecycle: &KeyPackageLifecycleState) -> MessageId {
+    let event_id_is_used = |candidate: &[u8]| {
+        lifecycle
+            .authored_signed_event
+            .as_ref()
+            .is_some_and(|artifact| artifact.id.as_slice() == candidate)
+            || lifecycle
+                .authored_event_id
+                .as_ref()
+                .is_some_and(|event_id| event_id.as_slice() == candidate)
+            || lifecycle
+                .pending_replacement
+                .as_ref()
+                .and_then(|pending| pending.signed_event.as_ref())
+                .is_some_and(|artifact| artifact.id.as_slice() == candidate)
+            || lifecycle
+                .retired_publications_pending_deletion
+                .iter()
+                .any(|retired| retired.event_id.as_slice() == candidate)
+    };
+    let mut candidate = vec![0_u8; 33];
+    while event_id_is_used(&candidate) {
+        candidate.push(0);
+    }
+    MessageId::new(candidate)
+}
+
+fn key_package_event_endpoint_is_liability(
+    lifecycle: &KeyPackageLifecycleState,
+    event_id: &cgka_traits::MessageId,
+    endpoint: &TransportEndpoint,
+) -> bool {
+    let target_is_liability = |target: &TransportFanoutTarget| {
+        target.endpoint == *endpoint && target.failure_code.as_deref() != Some("confirmed_absent")
+    };
+    lifecycle
+        .retired_publications_pending_deletion
+        .iter()
+        .any(|retired| {
+            retired.event_id == *event_id
+                && retired.deletion_targets.iter().any(target_is_liability)
+        })
+        || (lifecycle
+            .authored_signed_event
+            .as_ref()
+            .map(|artifact| &artifact.id)
+            .or(lifecycle.authored_event_id.as_ref())
+            == Some(event_id)
+            && lifecycle
+                .publication_targets
+                .iter()
+                .any(target_is_liability))
+        || lifecycle
+            .pending_replacement
+            .as_ref()
+            .is_some_and(|pending| {
+                pending
+                    .signed_event
+                    .as_ref()
+                    .is_some_and(|artifact| artifact.id == *event_id)
+                    && pending.targets.iter().any(target_is_liability)
+            })
+}
+
+fn insert_key_package_endpoint_liabilities(
+    liabilities: &mut HashSet<(Vec<u8>, TransportEndpoint)>,
+    event_id: &cgka_traits::MessageId,
+    targets: &[TransportFanoutTarget],
+) {
+    for target in targets {
+        if target.failure_code.as_deref() != Some("confirmed_absent") {
+            liabilities.insert((event_id.as_slice().to_vec(), target.endpoint.clone()));
+        }
+    }
+}
+
+fn retired_key_package_deletion_target_is_eligible(
+    lifecycle: &KeyPackageLifecycleState,
+    retired: &RetiredKeyPackagePublication,
+    target: &TransportFanoutTarget,
+    now: Timestamp,
+) -> bool {
+    if retired.delete_without_successor
+        || retired
+            .package_not_after
+            .is_some_and(|not_after| not_after <= now)
+    {
+        return true;
+    }
+    let Some(current_artifact) = lifecycle.authored_signed_event.as_ref() else {
+        return false;
+    };
+    if current_artifact.created_at <= retired.authored_created_at {
+        return false;
+    }
+    match lifecycle
+        .publication_targets
+        .iter()
+        .find(|current| current.endpoint == target.endpoint)
+    {
+        Some(current) => matches!(
+            current.state,
+            TransportFanoutAttemptState::Accepted | TransportFanoutAttemptState::PolicyProhibited
+        ),
+        None => true,
+    }
+}
+
+fn retired_key_package_deletion_pass_report(
+    lifecycle: &KeyPackageLifecycleState,
+    now: Timestamp,
+    mut terminal_endpoints: Vec<TransportEndpoint>,
+) -> RetiredKeyPackageDeletionPassReport {
+    terminal_endpoints.sort();
+    terminal_endpoints.dedup();
+    let has_uncovered_eligible_deletion = lifecycle
+        .retired_publications_pending_deletion
+        .iter()
+        .any(|retired| {
+            retired.deletion_targets.iter().any(|target| {
+                retired_key_package_deletion_target_is_eligible(lifecycle, retired, target, now)
+                    && !retired_key_package_deletion_target_has_accepted_newer_successor(
+                        lifecycle, retired, target,
+                    )
+            })
+        });
+    RetiredKeyPackageDeletionPassReport {
+        terminal_endpoints,
+        has_uncovered_eligible_deletion,
+    }
+}
+
+fn retired_key_package_deletion_target_has_accepted_newer_successor(
+    lifecycle: &KeyPackageLifecycleState,
+    retired: &RetiredKeyPackagePublication,
+    target: &TransportFanoutTarget,
+) -> bool {
+    let Some(current_artifact) = lifecycle.authored_signed_event.as_ref() else {
+        return false;
+    };
+    if current_artifact.created_at <= retired.authored_created_at
+        || lifecycle
+            .deleted_live_revision_event_ids
+            .contains(&current_artifact.id)
+    {
+        return false;
+    }
+    lifecycle.publication_targets.iter().any(|current| {
+        current.endpoint == target.endpoint
+            && current.state == TransportFanoutAttemptState::Accepted
+    })
+}
+
+/// Persist this before awaiting transport. A crash after the socket send then
+/// leaves durable possible-exposure evidence instead of an `Unattempted` lie.
+fn begin_key_package_attempt(
     targets: &mut [TransportFanoutTarget],
     attempted: &[TransportEndpoint],
-    accepted: &[TransportEndpoint],
-    failed: &[TransportEndpoint],
     attempted_at: Timestamp,
 ) {
     for target in targets {
@@ -3929,25 +8086,92 @@ fn note_key_package_attempt(
         }
         target.attempt_count = target.attempt_count.saturating_add(1);
         target.last_attempt_at = Some(attempted_at);
+        target.state = TransportFanoutAttemptState::AttemptedFailed;
+        target.failure_code = Some("possible_exposure".into());
+    }
+}
+
+/// Constrain an untrusted publication receipt to the exact fanout attempted by
+/// this call. A category may mention an endpoint at most once, and stronger
+/// evidence wins when a malformed adapter reports the same endpoint in more
+/// than one category. `confirmed_absent` is deletion-only evidence: a kind
+/// 30443 publication adapter cannot prove that no older delivery exists, so
+/// such a claim is conservatively demoted to an ambiguous failure.
+fn scope_key_package_publish_receipt(
+    mut receipt: crate::key_package::DetailedKeyPackagePublishReceipt,
+    attempted: &[TransportEndpoint],
+) -> crate::key_package::DetailedKeyPackagePublishReceipt {
+    let scope = attempted.iter().cloned().collect::<HashSet<_>>();
+    let normalize = |endpoints: &mut Vec<TransportEndpoint>| {
+        endpoints.retain(|endpoint| scope.contains(endpoint));
+        endpoints.sort();
+        endpoints.dedup();
+    };
+    normalize(&mut receipt.accepted);
+    normalize(&mut receipt.confirmed_absent);
+    normalize(&mut receipt.rejected);
+    normalize(&mut receipt.failed);
+    receipt
+        .rejected
+        .retain(|endpoint| !receipt.accepted.contains(endpoint));
+    receipt.failed.append(&mut receipt.confirmed_absent);
+    receipt.failed.sort();
+    receipt.failed.dedup();
+    receipt.failed.retain(|endpoint| {
+        !receipt.accepted.contains(endpoint) && !receipt.rejected.contains(endpoint)
+    });
+    receipt
+}
+
+fn finish_key_package_attempt(
+    targets: &mut [TransportFanoutTarget],
+    accepted: &[TransportEndpoint],
+    rejected: &[TransportEndpoint],
+    confirmed_absent: &[TransportEndpoint],
+    failed: &[TransportEndpoint],
+) {
+    for target in targets {
+        if target.state == TransportFanoutAttemptState::Accepted {
+            continue;
+        }
         if accepted.contains(&target.endpoint) {
             target.state = TransportFanoutAttemptState::Accepted;
             target.failure_code = None;
-        } else {
+        } else if confirmed_absent.contains(&target.endpoint) {
             target.state = TransportFanoutAttemptState::AttemptedFailed;
-            target.failure_code = Some(
-                if failed.contains(&target.endpoint) {
-                    "transport_rejected"
-                } else {
-                    "publish_failed"
-                }
-                .into(),
-            );
+            target.failure_code = Some("confirmed_absent".into());
+        } else if rejected.contains(&target.endpoint) {
+            target.state = TransportFanoutAttemptState::AttemptedFailed;
+            // A negative publication ACK does not prove absence. Older
+            // clients did not persist a pre-I/O marker, so a durable
+            // `Unattempted` row may already have escaped to this relay before
+            // a crash. Only a deletion-specific NotFound receipt is terminal.
+            target.failure_code = Some("transport_rejected".into());
+        } else if failed.contains(&target.endpoint) {
+            // The pre-I/O marker is already the conservative terminal state
+            // for a timeout, disconnect, or other ambiguous transport result.
+            target.state = TransportFanoutAttemptState::AttemptedFailed;
+            target.failure_code = Some("possible_exposure".into());
         }
     }
 }
 
 fn key_package_target_retry_due(target: &TransportFanoutTarget, now: Timestamp) -> bool {
+    if !key_package_target_is_retryable(target) {
+        return false;
+    }
     transport_fanout_target_retry_due(target, now)
+}
+
+fn key_package_target_is_terminal(target: &TransportFanoutTarget) -> bool {
+    matches!(
+        target.state,
+        TransportFanoutAttemptState::Accepted | TransportFanoutAttemptState::PolicyProhibited
+    ) || target.failure_code.as_deref() == Some("confirmed_absent")
+}
+
+fn key_package_target_is_retryable(target: &TransportFanoutTarget) -> bool {
+    !key_package_target_is_terminal(target)
 }
 
 fn transport_fanout_target_retry_due(target: &TransportFanoutTarget, now: Timestamp) -> bool {
@@ -3996,6 +8220,52 @@ fn supports_deferred_commit_publish(intent: &SendIntent) -> bool {
             | SendIntent::UpdateGroupData { .. }
             | SendIntent::EnableDisbanding { .. }
     )
+}
+
+fn send_intent_group_id(intent: &SendIntent) -> Option<GroupId> {
+    Some(match intent {
+        SendIntent::AppMessage { group_id, .. }
+        | SendIntent::Invite { group_id, .. }
+        | SendIntent::RemoveMembers { group_id, .. }
+        | SendIntent::Leave { group_id }
+        | SendIntent::SelfUpdate { group_id }
+        | SendIntent::UpdateAppComponents { group_id, .. }
+        | SendIntent::UpdateGroupData { group_id, .. }
+        | SendIntent::EnableDisbanding { group_id }
+        | SendIntent::Disband { group_id } => group_id.clone(),
+    })
+}
+
+fn account_visibility_outbound_action(
+    intent: &SendIntent,
+) -> Option<AccountVisibilityOutboundAction> {
+    match intent {
+        SendIntent::Leave { .. } => Some(AccountVisibilityOutboundAction::Leave),
+        _ => None,
+    }
+}
+
+fn outbound_action_message_id(
+    action: AccountVisibilityOutboundAction,
+    effects: &SessionEffects,
+) -> Option<MessageId> {
+    match action {
+        AccountVisibilityOutboundAction::Leave => effects.publish.iter().find_map(|work| {
+            if let PublishWork::Proposal { msg, .. } = work {
+                Some(msg.id.clone())
+            } else {
+                None
+            }
+        }),
+    }
+}
+
+fn engine_outbox_event_id(event: &GroupEvent) -> Option<MessageId> {
+    match event {
+        GroupEvent::MessageReceived { message_id, .. } => Some(message_id.clone()),
+        GroupEvent::GroupJoined { via_welcome, .. } => Some(via_welcome.clone()),
+        _ => None,
+    }
 }
 
 fn classify_prepared_session_send(
@@ -4052,6 +8322,79 @@ fn publish_wire_metadata(message: &TransportMessage) -> AuditTransportWire {
     }
 }
 
+/// Outbound action whose app-side tail must retain source semantics across
+/// cancellation and process restart.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AccountVisibilityOutboundAction {
+    Leave,
+}
+
+/// Terminal publish result for a source-attributed outbound action.
+///
+/// `operation_id` names the original operation whose Header remains pending;
+/// recovery may carry this outcome in a later Drain operation after resuming
+/// the exact frozen fanout.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AccountVisibilityActionOutcome {
+    pub operation_id: Vec<u8>,
+    pub group_id: GroupId,
+    pub message_id: MessageId,
+    pub action: AccountVisibilityOutboundAction,
+    pub published: bool,
+}
+
+/// Fixed attribution for one durable visibility operation.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+#[allow(clippy::large_enum_variant)]
+pub enum AccountVisibilitySource {
+    Inbound {
+        delivery: TransportDelivery,
+        outcome: IngestOutcome,
+        observed_at: Timestamp,
+    },
+    Drain {
+        observed_at: Timestamp,
+    },
+    Convergence {
+        group_id: GroupId,
+        observed_at: Timestamp,
+    },
+    Maintenance {
+        observed_at: Timestamp,
+    },
+    Outbound {
+        group_id: Option<GroupId>,
+        observed_at: Timestamp,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        action: Option<AccountVisibilityOutboundAction>,
+        /// Exact engine message id bound atomically after acceptance and before
+        /// relay I/O. A pending pre-acceptance Header leaves this absent.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        action_message_id: Option<MessageId>,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AccountVisibilityRecordKind {
+    Header,
+    Event { engine_outbox_provenance: bool },
+    SessionControl,
+    NonSession,
+}
+
+/// One independently acknowledgeable, source-attributed durable visibility row.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AccountVisibilityBatch {
+    pub sequence: u64,
+    pub operation_id: Vec<u8>,
+    pub batch_id: Vec<u8>,
+    pub source: AccountVisibilitySource,
+    pub kind: AccountVisibilityRecordKind,
+    pub effects: AccountDeviceEffects,
+}
+
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AccountDeviceEffects {
     pub events: Vec<GroupEvent>,
@@ -4068,6 +8411,9 @@ pub struct AccountDeviceEffects {
     /// Application-message identity attached to unresolved publication so app
     /// consumers can keep exactly the affected local row in a sending state.
     pub unresolved_app_messages: Vec<UnresolvedApplicationMessage>,
+    /// Terminal source-action results, including recovered fanouts whose
+    /// originating visibility Header belongs to an older operation.
+    pub action_outcomes: Vec<AccountVisibilityActionOutcome>,
     /// Application messages accepted by at least one transport endpoint,
     /// carrying source-state metadata captured by the exact MLS encryption
     /// operation and the adapter-visible transport id.
@@ -4081,7 +8427,7 @@ pub struct AccountDeviceEffects {
     pub maintenance_disposition: SendMaintenanceDisposition,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PublishedApplicationMessage {
     pub group_id: GroupId,
     pub app_event_id: String,
@@ -4091,6 +8437,22 @@ pub struct PublishedApplicationMessage {
 }
 
 impl AccountDeviceEffects {
+    fn non_session_visibility_clone(&self) -> Self {
+        Self {
+            reports: self.reports.clone(),
+            fanout: self.fanout.clone(),
+            failures: self.failures.clone(),
+            unresolved_publishes: self.unresolved_publishes.clone(),
+            unresolved_app_messages: self.unresolved_app_messages.clone(),
+            action_outcomes: self.action_outcomes.clone(),
+            published_app_messages: self.published_app_messages.clone(),
+            welcome_failures: self.welcome_failures.clone(),
+            pending: self.pending.clone(),
+            maintenance_disposition: self.maintenance_disposition,
+            ..Self::default()
+        }
+    }
+
     fn extend(&mut self, mut other: Self) {
         self.fanout.append(&mut other.fanout);
         self.absorb_account_effects(other);
@@ -4118,6 +8480,7 @@ impl AccountDeviceEffects {
             .append(&mut other.unresolved_publishes);
         self.unresolved_app_messages
             .append(&mut other.unresolved_app_messages);
+        self.action_outcomes.append(&mut other.action_outcomes);
         self.published_app_messages
             .append(&mut other.published_app_messages);
         self.welcome_failures.append(&mut other.welcome_failures);
@@ -4126,6 +8489,33 @@ impl AccountDeviceEffects {
             == SendMaintenanceDisposition::PostJoinRotationPendingRetryable
         {
             self.maintenance_disposition = other.maintenance_disposition;
+        }
+    }
+}
+
+impl StoredNonSessionEffectsV1 {
+    fn from_effects(effects: &AccountDeviceEffects) -> Self {
+        Self {
+            reports: effects.reports.clone(),
+            fanout: effects.fanout.clone(),
+            failures: effects.failures.clone(),
+            action_outcomes: effects.action_outcomes.clone(),
+            published_app_messages: effects.published_app_messages.clone(),
+            welcome_failures: effects.welcome_failures.clone(),
+            pending: effects.pending.clone(),
+        }
+    }
+
+    fn into_effects(self) -> AccountDeviceEffects {
+        AccountDeviceEffects {
+            reports: self.reports,
+            fanout: self.fanout,
+            failures: self.failures,
+            action_outcomes: self.action_outcomes,
+            published_app_messages: self.published_app_messages,
+            welcome_failures: self.welcome_failures,
+            pending: self.pending,
+            ..AccountDeviceEffects::default()
         }
     }
 }
@@ -4139,7 +8529,36 @@ pub struct AccountIngestEffects {
     pub effects: AccountDeviceEffects,
 }
 
+/// Account effects retained by [`AccountDeviceRuntime`] until the app
+/// explicitly acknowledges projection/V1 ownership.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[must_use = "acknowledge `lease` only after the effects are durably staged"]
+pub struct LeasedAccountDeviceEffects {
+    pub effects: AccountDeviceEffects,
+    pub batches: Vec<AccountVisibilityBatch>,
+    pub lease: AccountVisibilityLease,
+    /// Operation produced by the command that returned this lease. `None`
+    /// identifies replay-only handoffs, where every batch predates the caller.
+    pub current_operation_id: Option<Vec<u8>>,
+}
+
+/// Ingest outcome plus account effects retained until the app explicitly
+/// acknowledges projection/V1 ownership.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[must_use = "acknowledge `lease` only after the effects are durably staged"]
+pub struct LeasedAccountIngestEffects {
+    pub outcome: IngestOutcome,
+    /// The engine kept no durable trace of this delivery's transport object.
+    /// Carried verbatim from [`AccountIngestEffects::left_object_unpersisted`].
+    pub left_object_unpersisted: bool,
+    pub effects: AccountDeviceEffects,
+    pub batches: Vec<AccountVisibilityBatch>,
+    pub lease: AccountVisibilityLease,
+    /// Operation produced by the inbound delivery that returned this lease.
+    pub current_operation_id: Option<Vec<u8>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PublishFailure {
     pub message_id: cgka_traits::MessageId,
     pub reason: String,
@@ -4171,7 +8590,7 @@ pub struct UnresolvedApplicationMessage {
 /// cannot be rolled back (it is already confirmed and externally visible), so
 /// re-delivery is the only repair. The wrapped welcome stays available in the
 /// engine's sent-message store under `message_id`.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WelcomeDeliveryFailure {
     pub message_id: cgka_traits::MessageId,
     pub recipient: MemberId,
@@ -4181,7 +8600,7 @@ pub struct WelcomeDeliveryFailure {
     pub reason: String,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PendingResolution {
     Confirmed { pending: PendingStateRef },
     RolledBack { pending: PendingStateRef },
@@ -4190,6 +8609,275 @@ pub enum PendingResolution {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn signed_artifact_at(created_at: u64) -> SignedPublicationArtifact {
+        SignedPublicationArtifact {
+            id: cgka_traits::MessageId::new(created_at.to_be_bytes().to_vec()),
+            created_at: Timestamp(created_at),
+            bytes: created_at.to_be_bytes().to_vec(),
+        }
+    }
+
+    #[test]
+    fn key_package_reauthor_policy_is_opt_in_and_uses_an_inclusive_age_boundary() {
+        let artifact = signed_artifact_at(10_000);
+        assert_eq!(
+            key_package_reauthor_created_at(&artifact, Timestamp(1), None, None, false),
+            Ok(None),
+            "publishers that do not opt in preserve exact retries across clock rollback"
+        );
+        assert_eq!(
+            key_package_reauthor_created_at(&artifact, Timestamp(10_599), Some(600), None, false),
+            Ok(None)
+        );
+        assert_eq!(
+            key_package_reauthor_created_at(&artifact, Timestamp(10_600), Some(600), None, false),
+            Ok(Some(Timestamp(10_600)))
+        );
+        assert_eq!(
+            key_package_reauthor_created_at(&artifact, Timestamp(1), Some(600), None, false),
+            Err(()),
+            "an opted-in transport fails closed after a large wall-clock rollback"
+        );
+        assert_eq!(
+            key_package_reauthor_created_at(
+                &artifact,
+                Timestamp(10_000),
+                None,
+                Some(Timestamp(10_020)),
+                false,
+            ),
+            Ok(Some(Timestamp(10_021))),
+            "a relay-discovered same-slot high-water forces a strictly newer revision"
+        );
+        assert_eq!(
+            key_package_reauthor_created_at(
+                &signed_artifact_at(u64::MAX),
+                Timestamp(u64::MAX),
+                Some(0),
+                None,
+                false,
+            ),
+            Err(()),
+            "a strictly newer timestamp must be representable"
+        );
+    }
+
+    #[test]
+    fn reauthor_replacement_targets_only_the_current_live_policy() {
+        let prohibited_endpoint = TransportEndpoint("wss://removed.example".into());
+        let live_endpoint = TransportEndpoint("wss://live.example".into());
+        let mut targets = vec![
+            TransportFanoutTarget {
+                endpoint: prohibited_endpoint.clone(),
+                state: TransportFanoutAttemptState::PolicyProhibited,
+                attempt_count: 7,
+                last_attempt_at: Some(Timestamp(9)),
+                failure_code: Some("endpoint_removed_from_policy".into()),
+            },
+            TransportFanoutTarget {
+                endpoint: live_endpoint.clone(),
+                state: TransportFanoutAttemptState::Accepted,
+                attempt_count: 3,
+                last_attempt_at: Some(Timestamp(8)),
+                failure_code: None,
+            },
+        ];
+
+        replace_key_package_publication_targets(&mut targets, std::slice::from_ref(&live_endpoint));
+
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].endpoint, live_endpoint);
+        assert_eq!(targets[0].state, TransportFanoutAttemptState::Unattempted);
+        assert_eq!(targets[0].attempt_count, 0);
+        assert!(targets[0].last_attempt_at.is_none());
+        assert!(targets[0].failure_code.is_none());
+    }
+
+    #[test]
+    fn retired_key_package_publication_keeps_every_possibly_exposed_target() {
+        let artifact = signed_artifact_at(10);
+        let target =
+            |endpoint: &str,
+             state: TransportFanoutAttemptState,
+             attempt_count: u32,
+             last_attempt_at: Option<Timestamp>| TransportFanoutTarget {
+                endpoint: TransportEndpoint(endpoint.into()),
+                state,
+                attempt_count,
+                last_attempt_at,
+                failure_code: None,
+            };
+        let retired = retired_key_package_publication(
+            &artifact,
+            Some(b"key-package-ref"),
+            Some(Timestamp(20)),
+            false,
+            &[
+                target(
+                    "wss://accepted.example",
+                    TransportFanoutAttemptState::Accepted,
+                    1,
+                    Some(Timestamp(1)),
+                ),
+                target(
+                    "wss://failed.example",
+                    TransportFanoutAttemptState::AttemptedFailed,
+                    1,
+                    Some(Timestamp(1)),
+                ),
+                target(
+                    "wss://removed-after-attempt.example",
+                    TransportFanoutAttemptState::PolicyProhibited,
+                    2,
+                    Some(Timestamp(2)),
+                ),
+                target(
+                    "wss://never-attempted.example",
+                    TransportFanoutAttemptState::Unattempted,
+                    0,
+                    None,
+                ),
+                target(
+                    "wss://prohibited-before-attempt.example",
+                    TransportFanoutAttemptState::PolicyProhibited,
+                    0,
+                    None,
+                ),
+            ],
+        )
+        .expect("attempted targets create a deletion obligation");
+
+        assert_eq!(retired.event_id, artifact.id);
+        assert_eq!(retired.authored_created_at, artifact.created_at);
+        assert_eq!(
+            retired.key_package_ref.as_deref(),
+            Some(&b"key-package-ref"[..])
+        );
+        assert_eq!(retired.package_not_after, Some(Timestamp(20)));
+        assert!(!retired.delete_without_successor);
+        assert_eq!(
+            retired
+                .deletion_targets
+                .iter()
+                .map(|target| target.endpoint.clone())
+                .collect::<Vec<_>>(),
+            vec![
+                TransportEndpoint("wss://accepted.example".into()),
+                TransportEndpoint("wss://failed.example".into()),
+                TransportEndpoint("wss://never-attempted.example".into()),
+                TransportEndpoint("wss://prohibited-before-attempt.example".into()),
+                TransportEndpoint("wss://removed-after-attempt.example".into()),
+            ]
+        );
+        assert!(retired.deletion_targets.iter().all(|target| {
+            target.state == TransportFanoutAttemptState::Unattempted
+                && target.attempt_count == 0
+                && target.last_attempt_at.is_none()
+        }));
+    }
+
+    #[test]
+    fn key_package_liability_counter_counts_each_event_endpoint_pair() {
+        let endpoints = (0..256)
+            .map(|index| TransportFanoutTarget {
+                endpoint: TransportEndpoint(format!("wss://liability-{index}.example")),
+                state: TransportFanoutAttemptState::Unattempted,
+                attempt_count: 0,
+                last_attempt_at: None,
+                failure_code: None,
+            })
+            .collect::<Vec<_>>();
+        let mut lifecycle = KeyPackageLifecycleState::slot_only("slot".into());
+        lifecycle
+            .retired_publications_pending_deletion
+            .push(RetiredKeyPackagePublication {
+                event_id: cgka_traits::MessageId::new(vec![0x73; 32]),
+                authored_created_at: Timestamp(1),
+                key_package_ref: None,
+                package_not_after: None,
+                delete_without_successor: true,
+                deletion_targets: endpoints,
+            });
+
+        assert_eq!(
+            key_package_signed_publication_liability_count(&lifecycle),
+            MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES
+        );
+    }
+
+    #[test]
+    fn deletion_pass_report_dedupes_terminals_and_ignores_backoff_for_uncovered_work() {
+        let covered_endpoint = TransportEndpoint("wss://covered.example".into());
+        let uncovered_endpoint = TransportEndpoint("wss://uncovered.example".into());
+        let deletion_target = |endpoint: TransportEndpoint| TransportFanoutTarget {
+            endpoint,
+            state: TransportFanoutAttemptState::AttemptedFailed,
+            attempt_count: 9,
+            last_attempt_at: Some(Timestamp(50)),
+            failure_code: Some("possible_exposure".into()),
+        };
+        let current_artifact = signed_artifact_at(20);
+        let mut lifecycle = KeyPackageLifecycleState::slot_only("slot".into());
+        lifecycle.authored_signed_event = Some(current_artifact.clone());
+        lifecycle.publication_targets = vec![
+            TransportFanoutTarget {
+                endpoint: covered_endpoint.clone(),
+                state: TransportFanoutAttemptState::Accepted,
+                attempt_count: 1,
+                last_attempt_at: Some(Timestamp(20)),
+                failure_code: None,
+            },
+            TransportFanoutTarget {
+                endpoint: uncovered_endpoint.clone(),
+                state: TransportFanoutAttemptState::PolicyProhibited,
+                attempt_count: 0,
+                last_attempt_at: None,
+                failure_code: Some("endpoint_removed_from_policy".into()),
+            },
+        ];
+        lifecycle
+            .retired_publications_pending_deletion
+            .push(RetiredKeyPackagePublication {
+                event_id: MessageId::new(vec![0x7a; 32]),
+                authored_created_at: Timestamp(10),
+                key_package_ref: None,
+                package_not_after: Some(Timestamp(1_000)),
+                delete_without_successor: false,
+                deletion_targets: vec![
+                    deletion_target(covered_endpoint.clone()),
+                    deletion_target(uncovered_endpoint.clone()),
+                ],
+            });
+
+        let report = retired_key_package_deletion_pass_report(
+            &lifecycle,
+            Timestamp(50),
+            vec![covered_endpoint.clone(), covered_endpoint.clone()],
+        );
+        assert_eq!(report.terminal_endpoints, vec![covered_endpoint]);
+        assert!(
+            report.has_uncovered_eligible_deletion,
+            "a policy-removed target remains eligible without an accepted successor even during retry backoff"
+        );
+
+        lifecycle.publication_targets[1].state = TransportFanoutAttemptState::Accepted;
+        lifecycle.publication_targets[1].failure_code = None;
+        assert!(
+            !retired_key_package_deletion_pass_report(&lifecycle, Timestamp(50), Vec::new())
+                .has_uncovered_eligible_deletion,
+            "strictly newer accepted successors cover every eligible deletion"
+        );
+
+        lifecycle
+            .deleted_live_revision_event_ids
+            .push(current_artifact.id);
+        assert!(
+            retired_key_package_deletion_pass_report(&lifecycle, Timestamp(50), Vec::new())
+                .has_uncovered_eligible_deletion,
+            "a live revision already marked for deletion cannot cover its predecessors"
+        );
+    }
 
     fn published_message(id: u8) -> PublishedApplicationMessage {
         PublishedApplicationMessage {
@@ -4256,6 +8944,101 @@ mod tests {
                 members: Vec::new(),
             }
         ));
+    }
+
+    #[test]
+    fn outbound_visibility_action_is_typed_and_legacy_json_defaults_to_none() {
+        let group_id = GroupId::new(vec![7]);
+        let source = AccountVisibilitySource::Outbound {
+            group_id: Some(group_id.clone()),
+            observed_at: Timestamp(42),
+            action: Some(AccountVisibilityOutboundAction::Leave),
+            action_message_id: Some(MessageId::new(vec![4])),
+        };
+        let mut json = serde_json::to_value(&source).expect("serialize outbound source");
+        assert_eq!(json.get("action"), Some(&serde_json::json!("leave")));
+        assert!(json.get("action_message_id").is_some());
+        assert_eq!(
+            serde_json::from_value::<AccountVisibilitySource>(json.clone())
+                .expect("decode typed outbound action"),
+            source
+        );
+
+        json.as_object_mut()
+            .expect("tagged source is an object")
+            .remove("action");
+        json.as_object_mut()
+            .expect("tagged source is an object")
+            .remove("action_message_id");
+        let legacy = serde_json::from_value::<AccountVisibilitySource>(json)
+            .expect("legacy outbound source without action still decodes");
+        assert_eq!(
+            legacy,
+            AccountVisibilitySource::Outbound {
+                group_id: Some(group_id),
+                observed_at: Timestamp(42),
+                action: None,
+                action_message_id: None,
+            }
+        );
+        assert!(
+            serde_json::to_value(legacy)
+                .expect("serialize legacy-compatible source")
+                .get("action")
+                .is_none(),
+            "None keeps the exact legacy JSON shape"
+        );
+    }
+
+    #[test]
+    fn legacy_outbound_visibility_record_decodes_without_a_version_bump() {
+        let operation_id = [0x5a; 16];
+        let group_id = GroupId::new(vec![8]);
+        let record = StoredAccountVisibilityRecordV1 {
+            version: ACCOUNT_VISIBILITY_RECORD_VERSION,
+            source: AccountVisibilitySource::Outbound {
+                group_id: Some(group_id.clone()),
+                observed_at: Timestamp(77),
+                action: Some(AccountVisibilityOutboundAction::Leave),
+                action_message_id: Some(MessageId::new(vec![5])),
+            },
+            payload: StoredAccountVisibilityPayloadV1::Header {
+                maintenance_disposition: SendMaintenanceDisposition::Ready,
+            },
+        };
+        let mut json = serde_json::to_value(record).expect("serialize visibility record");
+        json.get_mut("source")
+            .and_then(serde_json::Value::as_object_mut)
+            .expect("visibility source is an object")
+            .remove("action");
+        json.get_mut("source")
+            .and_then(serde_json::Value::as_object_mut)
+            .expect("visibility source is an object")
+            .remove("action_message_id");
+        assert_eq!(
+            json.get("version"),
+            Some(&serde_json::json!(1)),
+            "adding source semantics must not bump the decodable V1 record"
+        );
+
+        let decoded = decode_account_visibility_row(AccountVisibilityJournalRow {
+            sequence: 1,
+            operation_id: operation_id.to_vec(),
+            ordinal: 0,
+            batch_id: account_visibility_batch_id(&operation_id, 0),
+            record: serde_json::to_vec(&json).expect("encode legacy visibility row"),
+        })
+        .expect("decode legacy V1 visibility row");
+        assert_eq!(decoded.kind, AccountVisibilityRecordKind::Header);
+        assert_eq!(
+            decoded.source,
+            AccountVisibilitySource::Outbound {
+                group_id: Some(group_id),
+                observed_at: Timestamp(77),
+                action: None,
+                action_message_id: None,
+            }
+        );
     }
 
     #[tokio::test]

--- a/crates/marmot-account/tests/runtime.rs
+++ b/crates/marmot-account/tests/runtime.rs
@@ -8557,11 +8557,8 @@ async fn zero_accept_best_effort_leave_does_not_publish_on_restart() {
     let (bob, bob_path, bob_identity, group_id) =
         joined_selfremove_member(dir.path(), &key, "zero-ack-leave").await;
     let adapter = RecordingAdapter::default();
+    let gate = adapter.gate_all_publishes();
     let group_endpoint = TransportEndpoint("wss://zero-ack-leave-group.example".into());
-    adapter.fail_endpoints_as(
-        vec![group_endpoint.clone()],
-        TransportEndpointFailureKind::TerminalRejected,
-    );
     let route = || {
         StaticTransportRouting::new(vec![TransportEndpoint(
             "wss://zero-ack-leave-inbox.example".into(),
@@ -8573,23 +8570,56 @@ async fn zero_accept_best_effort_leave_does_not_publish_on_restart() {
             vec![group_endpoint.clone()],
         )
     };
-    let mut runtime =
-        AccountDeviceRuntime::new(bob, adapter, route(), RecordingKeyPackages::default());
+    let mut runtime = AccountDeviceRuntime::new(
+        bob,
+        adapter.clone(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
     runtime.pause_maintenance();
-    let leased = runtime
-        .send_leased(SendIntent::Leave {
-            group_id: group_id.clone(),
-        })
-        .await
+    let mut cancelled = Box::pin(runtime.send_leased(SendIntent::Leave {
+        group_id: group_id.clone(),
+    }));
+    tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::select! {
+            result = &mut cancelled => panic!("Leave returned before the terminal-fanout crash window: {result:?}"),
+            () = async {
+                while adapter.publishes().is_empty() {
+                    tokio::task::yield_now().await;
+                }
+            } => {}
+        }
+    })
+    .await
+    .expect("Leave reaches the blocked relay publish");
+    drop(cancelled);
+
+    let mut fanouts = runtime.session().outbound_fanouts().unwrap();
+    assert_eq!(
+        fanouts.len(),
+        1,
+        "cancelled Leave retains its frozen fanout"
+    );
+    let mut fanout = fanouts.pop().unwrap();
+    assert_eq!(fanout.request().required_acks, 0);
+    fanout
+        .record_target_failure(
+            0,
+            TransportEndpointFailure {
+                endpoint: group_endpoint.clone(),
+                reason: "injected terminal rejection before outcome checkpoint".into(),
+                kind: TransportEndpointFailureKind::TerminalRejected,
+                rejection_category: None,
+            },
+        )
         .unwrap();
     assert!(
-        leased
-            .effects
-            .action_outcomes
-            .iter()
-            .all(|outcome| !outcome.published),
-        "required_acks=0 still needs at least one accept"
+        fanout.outcome().fanout_complete && fanout.outcome().accepted_targets == 0,
+        "the persisted crash window must contain one terminal zero-accept fanout"
     );
+    let leave_message_id = fanout.message_id().clone();
+    runtime.session_mut().put_outbound_fanout(&fanout).unwrap();
+    drop(gate);
     drop(runtime);
 
     let reopened = session_with_registry(&bob_path, &key, &bob_identity, selfremove_registry());
@@ -8600,26 +8630,12 @@ async fn zero_accept_best_effort_leave_does_not_publish_on_restart() {
         RecordingKeyPackages::default(),
     );
     restarted.pause_maintenance();
-    if let Some(replayed) = restarted.replay_visibility_leased().unwrap() {
-        assert!(
-            flatten_visibility_batches(&replayed.batches)
-                .action_outcomes
-                .iter()
-                .all(|outcome| !outcome.published),
-            "restart must not upgrade a zero-accept Leave to published:true"
-        );
-        assert!(restarted.acknowledge_visibility_lease(replayed.lease));
-    }
+    let fanouts = restarted.session().outbound_fanouts().unwrap();
+    assert_eq!(fanouts.len(), 1, "restart must recover the terminal fanout");
+    assert_eq!(fanouts[0].message_id(), &leave_message_id);
     assert!(
-        restarted
-            .session()
-            .outbound_fanouts()
-            .unwrap()
-            .iter()
-            .all(|fanout| {
-                fanout.outcome().accepted_targets < fanout.request().required_acks.max(1)
-            }),
-        "a surviving terminal zero-accept fanout must still miss required_acks.max(1)"
+        fanouts[0].outcome().accepted_targets < fanouts[0].request().required_acks.max(1),
+        "the recovered zero-accept fanout must miss required_acks.max(1)"
     );
     let drained = restarted.drain_leased().await.unwrap();
     assert!(
@@ -8627,13 +8643,35 @@ async fn zero_accept_best_effort_leave_does_not_publish_on_restart() {
             .effects
             .action_outcomes
             .iter()
-            .all(|outcome| !outcome.published),
-        "resuming a terminal zero-accept Leave must not authorize Left"
+            .any(|outcome| outcome.message_id == leave_message_id && !outcome.published),
+        "terminal-fanout recovery must durably record unpublished, not authorize Left"
     );
     assert!(
         restarted.session().outbound_fanouts().unwrap().is_empty(),
         "terminal zero-accept resume must finish the Leave fanout without publishing"
     );
+    drop(restarted);
+
+    let reopened = session_with_registry(&bob_path, &key, &bob_identity, selfremove_registry());
+    let mut recovered = AccountDeviceRuntime::new(
+        reopened,
+        RecordingAdapter::default(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    recovered.pause_maintenance();
+    let replayed = recovered
+        .replay_visibility_leased()
+        .unwrap()
+        .expect("unpublished Leave outcome must survive fanout deletion and restart");
+    assert!(
+        flatten_visibility_batches(&replayed.batches)
+            .action_outcomes
+            .iter()
+            .any(|outcome| outcome.message_id == leave_message_id && !outcome.published),
+        "restart must replay the exact terminal zero-accept outcome"
+    );
+    assert!(recovered.acknowledge_visibility_lease(replayed.lease));
 }
 
 #[tokio::test]
@@ -8720,23 +8758,24 @@ async fn leave_m1_to_m2_repair_persists_every_row_so_cleared_request_does_not_sp
         }
     }
     assert!(
-        unique_source_by_operation
-            .values()
-            .any(|bound| bound.as_ref() == Some(&later_id)),
-        "repaired Leave source must name the live M2 id: {leave_sources:?}"
+        !unique_source_by_operation.is_empty()
+            && unique_source_by_operation
+                .values()
+                .all(|bound| bound.as_ref() == Some(&later_id)),
+        "repaired Leave source must name the live M2 id on every row: {leave_sources:?}"
     );
     drop(replayed);
     drop(repaired);
 
-    let storage_session =
-        session_with_registry(&bob_path, &key, &bob_identity, selfremove_registry());
-    storage_session
+    // Open the engine first, then clear the request on that same session. A
+    // second engine reopen would legitimately rehydrate M1 from its retained
+    // SelfRemove and mask whether the repaired journal itself persisted M2.
+    let reopened = session_with_registry(&bob_path, &key, &bob_identity, selfremove_registry());
+    reopened
         .storage_handle()
         .clear_leave_request(&group_id)
         .unwrap();
-    drop(storage_session);
 
-    let reopened = session_with_registry(&bob_path, &key, &bob_identity, selfremove_registry());
     let mut restarted = AccountDeviceRuntime::new(
         reopened,
         RecordingAdapter::default(),
@@ -8779,8 +8818,8 @@ async fn leave_m1_to_m2_repair_persists_every_row_so_cleared_request_does_not_sp
         !unique_source_by_operation.is_empty()
             && unique_source_by_operation
                 .values()
-                .all(|bound| bound.is_some()),
-        "cleared LeaveRequest must not resurrect a split or unbound Leave source: {leave_sources:?}"
+                .all(|bound| bound.as_ref() == Some(&later_id)),
+        "cleared LeaveRequest must retain the exact M2 source on every row: {leave_sources:?}"
     );
 }
 
@@ -9343,8 +9382,14 @@ async fn leave_quorum_records_published_true_while_optional_target_stays_retryab
             vec![required.clone(), optional.clone()],
         )
     };
+    let wall = Arc::new(TestWallClock::new(10_000));
     let mut runtime =
-        AccountDeviceRuntime::new(bob, adapter, route(), RecordingKeyPackages::default());
+        AccountDeviceRuntime::new(bob, adapter, route(), RecordingKeyPackages::default())
+            .with_maintenance_sources(
+                wall.clone(),
+                Arc::new(TestMonotonicClock::default()),
+                Arc::new(TestRandom::new(0)),
+            );
     runtime.pause_maintenance();
     let leased = runtime
         .send_leased(SendIntent::Leave {
@@ -9353,6 +9398,7 @@ async fn leave_quorum_records_published_true_while_optional_target_stays_retryab
         .await
         .unwrap();
     assert_eq!(leased.effects.action_outcomes.len(), 1);
+    let published_message_id = leased.effects.action_outcomes[0].message_id.clone();
     assert!(
         leased.effects.action_outcomes[0].published,
         "meeting required ACKs must authorize Left even if an optional target is still retryable"
@@ -9366,6 +9412,7 @@ async fn leave_quorum_records_published_true_while_optional_target_stays_retryab
         "the optional target must remain outstanding so this is not the complete-fanout path"
     );
     drop(runtime);
+    wall.set(20_000);
 
     let reopened = session_with_registry(&bob_path, &key, &bob_identity, selfremove_registry());
     let mut restarted = AccountDeviceRuntime::new(
@@ -9373,6 +9420,11 @@ async fn leave_quorum_records_published_true_while_optional_target_stays_retryab
         RecordingAdapter::default(),
         route(),
         RecordingKeyPackages::default(),
+    )
+    .with_maintenance_sources(
+        wall,
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(0)),
     );
     restarted.pause_maintenance();
     let replayed = restarted
@@ -9392,12 +9444,15 @@ async fn leave_quorum_records_published_true_while_optional_target_stays_retryab
         .await
         .expect("optional Leave completion must accept an already-durable published outcome");
     assert!(
-        drained
-            .effects
+        flatten_visibility_batches(&drained.batches)
             .action_outcomes
             .iter()
-            .all(|outcome| outcome.published),
-        "completing the optional target must not rewrite the durable published:true outcome"
+            .any(|outcome| { outcome.message_id == published_message_id && outcome.published }),
+        "the superseding lease must contain the exact durable published:true outcome"
+    );
+    assert!(
+        restarted.session().outbound_fanouts().unwrap().is_empty(),
+        "optional completion must delete the fanout after preserving its durable outcome"
     );
     if !restarted.acknowledge_visibility_lease(replayed.lease) {
         assert!(restarted.acknowledge_visibility_lease(drained.lease));

--- a/crates/marmot-account/tests/runtime.rs
+++ b/crates/marmot-account/tests/runtime.rs
@@ -20,23 +20,30 @@ use cgka_traits::group::ProtocolProfile;
 use cgka_traits::group_context::GroupContextSnapshot;
 use cgka_traits::ingest::{PeeledContent, PeeledMessage};
 use cgka_traits::peeler::TransportPeeler;
-use cgka_traits::storage::{KeyPackageBundleStorage, MaintenanceStorage, OutboundFanoutStorage};
+use cgka_traits::storage::{
+    KeyPackageBundleStorage, LeaveRequestStorage, MaintenanceStorage, MessageStorage,
+    OutboundFanoutStorage,
+};
 use cgka_traits::transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
 };
 use cgka_traits::{
     EpochId, FanoutMlsState, FanoutTargetStatus, GroupId, MemberId, MessageId, OutboundFanout,
-    TransportAccountActivation, TransportAdapter, TransportAdapterError, TransportDelivery,
-    TransportDeliveryPlane, TransportDeliverySource, TransportEndpoint, TransportEndpointFailure,
-    TransportEndpointFailureKind, TransportEndpointReceipt, TransportEndpointRejectionCategory,
-    TransportGroupSync, TransportPublishFailure, TransportPublishReport, TransportPublishRequest,
-    TransportPublishTarget,
+    RetiredKeyPackagePublication, TransportAccountActivation, TransportAdapter,
+    TransportAdapterError, TransportDelivery, TransportDeliveryPlane, TransportDeliverySource,
+    TransportEndpoint, TransportEndpointFailure, TransportEndpointFailureKind,
+    TransportEndpointReceipt, TransportEndpointRejectionCategory, TransportFanoutAttemptState,
+    TransportFanoutTarget, TransportGroupSync, TransportPublishFailure, TransportPublishReport,
+    TransportPublishRequest, TransportPublishTarget,
 };
 use marmot_account::{
-    AccountDeviceRuntime, AccountError, KeyPackagePublication, KeyPackagePublishError,
-    KeyPackagePublishReceipt, KeyPackagePublisher, MaintenanceRandom, MonotonicClock,
-    NoopKeyPackagePublisher, PendingResolution, PublishedApplicationMessage,
-    StaticTransportRouting, TransportRoutingError, TransportRoutingPolicy, WallClock,
+    AccountDeviceEffects, AccountDeviceRuntime, AccountError, AccountVisibilityBatch,
+    AccountVisibilityOutboundAction, AccountVisibilitySource,
+    DetailedKeyPackagePublishReceipt as KeyPackagePublishReceipt, KeyPackagePublication,
+    KeyPackagePublishError, KeyPackagePublishReceipt as LegacyKeyPackagePublishReceipt,
+    KeyPackagePublisher, MaintenanceRandom, MonotonicClock, NoopKeyPackagePublisher,
+    PendingResolution, PublishedApplicationMessage, StaticTransportRouting, TransportRoutingError,
+    TransportRoutingPolicy, WallClock,
 };
 use storage_sqlite::{SqlCipherKey, SqliteAccountStorage};
 
@@ -92,6 +99,32 @@ fn hash_id(bytes: &[u8]) -> MessageId {
     let mut h = DefaultHasher::new();
     bytes.hash(&mut h);
     MessageId::new(h.finish().to_be_bytes().to_vec())
+}
+
+fn flatten_visibility_batches(batches: &[AccountVisibilityBatch]) -> AccountDeviceEffects {
+    let mut effects = AccountDeviceEffects::default();
+    for batch in batches {
+        effects.events.extend(batch.effects.events.clone());
+        effects.queued.extend(batch.effects.queued.clone());
+        effects
+            .pending_convergence
+            .extend(batch.effects.pending_convergence.clone());
+        effects.reports.extend(batch.effects.reports.clone());
+        effects.fanout.extend(batch.effects.fanout.clone());
+        effects.failures.extend(batch.effects.failures.clone());
+        effects
+            .action_outcomes
+            .extend(batch.effects.action_outcomes.clone());
+        effects
+            .published_app_messages
+            .extend(batch.effects.published_app_messages.clone());
+        effects
+            .welcome_failures
+            .extend(batch.effects.welcome_failures.clone());
+        effects.pending.extend(batch.effects.pending.clone());
+        effects.maintenance_disposition = batch.effects.maintenance_disposition;
+    }
+    effects
 }
 
 struct MockPeeler;
@@ -329,6 +362,39 @@ fn selfremove_registry() -> FeatureRegistry {
     registry
 }
 
+async fn joined_selfremove_member(
+    directory: &std::path::Path,
+    key: &SqlCipherKey,
+    tag: &str,
+) -> (AccountDeviceSession, std::path::PathBuf, Vec<u8>, GroupId) {
+    let alice_identity = format!("alice-{tag}").into_bytes();
+    let bob_identity = format!("bob-{tag}").into_bytes();
+    let alice_path = directory.join(format!("alice-{tag}.sqlite"));
+    let bob_path = directory.join(format!("bob-{tag}.sqlite"));
+    let mut alice = session_with_registry(alice_path, key, &alice_identity, selfremove_registry());
+    let mut bob = session_with_registry(&bob_path, key, &bob_identity, selfremove_registry());
+    let bob_key_package = bob.fresh_key_package().await.unwrap();
+    let created = alice
+        .create_group(CreateGroupRequest {
+            name: format!("selfremove {tag}"),
+            description: String::new(),
+            members: vec![bob_key_package],
+            required_features: Vec::new(),
+            app_components: Vec::new(),
+            initial_admins: Vec::new(),
+        })
+        .await
+        .unwrap();
+    let group_id = created.group_id;
+    let (pending, welcome) = match created.effects.publish.as_slice() {
+        [PublishWork::GroupCreated { pending, welcomes }] => (*pending, welcomes[0].clone()),
+        other => panic!("expected one GroupCreated publish work, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    bob.ingest(welcome).await.unwrap();
+    (bob, bob_path, bob_identity, group_id)
+}
+
 #[derive(Clone, Default)]
 struct RecordingAdapter {
     inner: Arc<RecordingAdapterInner>,
@@ -346,6 +412,7 @@ struct RecordingAdapterInner {
     publish_errors: Mutex<VecDeque<bool>>,
     reported_message_ids: Mutex<VecDeque<MessageId>>,
     welcome_gate: Mutex<Option<Arc<WelcomePublishGate>>>,
+    all_publish_gate: Mutex<Option<Arc<WelcomePublishGate>>>,
 }
 
 struct WelcomePublishGate {
@@ -368,6 +435,12 @@ impl RecordingAdapter {
     fn gate_welcome_publishes(&self) -> Arc<WelcomePublishGate> {
         let gate = Arc::new(WelcomePublishGate::default());
         *self.inner.welcome_gate.lock().unwrap() = Some(gate.clone());
+        gate
+    }
+
+    fn gate_all_publishes(&self) -> Arc<WelcomePublishGate> {
+        let gate = Arc::new(WelcomePublishGate::default());
+        *self.inner.all_publish_gate.lock().unwrap() = Some(gate.clone());
         gate
     }
 
@@ -457,13 +530,18 @@ impl TransportAdapter for RecordingAdapter {
         request: TransportPublishRequest,
     ) -> Result<TransportPublishReport, TransportAdapterError> {
         self.inner.publishes.lock().unwrap().push(request.clone());
-        let welcome_gate = if matches!(&request.message.envelope, TransportEnvelope::Welcome { .. })
-        {
-            self.inner.welcome_gate.lock().unwrap().clone()
-        } else {
-            None
-        };
-        if let Some(gate) = welcome_gate {
+        let publish_gate = self
+            .inner
+            .all_publish_gate
+            .lock()
+            .unwrap()
+            .clone()
+            .or_else(|| {
+                matches!(&request.message.envelope, TransportEnvelope::Welcome { .. })
+                    .then(|| self.inner.welcome_gate.lock().unwrap().clone())
+                    .flatten()
+            });
+        if let Some(gate) = publish_gate {
             let active = gate.active.fetch_add(1, Ordering::SeqCst) + 1;
             gate.max_active.fetch_max(active, Ordering::SeqCst);
             let permit = gate.release.acquire().await.unwrap();
@@ -665,9 +743,9 @@ impl KeyPackagePublisher for RecordingKeyPackages {
         &self,
         publication: &KeyPackagePublication,
         _artifact: &cgka_traits::SignedPublicationArtifact,
-    ) -> Result<KeyPackagePublishReceipt, KeyPackagePublishError> {
+    ) -> Result<LegacyKeyPackagePublishReceipt, KeyPackagePublishError> {
         self.publications.lock().unwrap().push(publication.clone());
-        Ok(KeyPackagePublishReceipt {
+        Ok(LegacyKeyPackagePublishReceipt {
             accepted: publication.endpoints.clone(),
             failed: Vec::new(),
         })
@@ -690,9 +768,15 @@ struct PartialFanoutKeyPackages {
             )>,
         >,
     >,
+    reauthor_after_secs: Option<u64>,
 }
 
 impl PartialFanoutKeyPackages {
+    fn reauthor_after_secs(mut self, seconds: u64) -> Self {
+        self.reauthor_after_secs = Some(seconds);
+        self
+    }
+
     fn publications(
         &self,
     ) -> Vec<(
@@ -712,6 +796,10 @@ impl KeyPackagePublisher for PartialFanoutKeyPackages {
         Ok(Some(test_key_package_slot(account_id)))
     }
 
+    fn signed_artifact_reauthor_at_age_secs(&self) -> Option<u64> {
+        self.reauthor_after_secs
+    }
+
     async fn prepare_key_package(
         &self,
         publication: KeyPackagePublication,
@@ -723,19 +811,19 @@ impl KeyPackagePublisher for PartialFanoutKeyPackages {
         &self,
         publication: &KeyPackagePublication,
         artifact: &cgka_traits::SignedPublicationArtifact,
-    ) -> Result<KeyPackagePublishReceipt, KeyPackagePublishError> {
+    ) -> Result<LegacyKeyPackagePublishReceipt, KeyPackagePublishError> {
         let call_index = self.publications.lock().unwrap().len();
         self.publications
             .lock()
             .unwrap()
             .push((publication.clone(), artifact.clone()));
         if call_index == 0 {
-            Ok(KeyPackagePublishReceipt {
+            Ok(LegacyKeyPackagePublishReceipt {
                 accepted: publication.endpoints.iter().take(1).cloned().collect(),
                 failed: publication.endpoints.iter().skip(1).cloned().collect(),
             })
         } else {
-            Ok(KeyPackagePublishReceipt {
+            Ok(LegacyKeyPackagePublishReceipt {
                 accepted: publication.endpoints.clone(),
                 failed: Vec::new(),
             })
@@ -777,8 +865,53 @@ impl KeyPackagePublisher for PrepareFailsKeyPackages {
         &self,
         _publication: &KeyPackagePublication,
         _artifact: &cgka_traits::SignedPublicationArtifact,
-    ) -> Result<KeyPackagePublishReceipt, KeyPackagePublishError> {
+    ) -> Result<LegacyKeyPackagePublishReceipt, KeyPackagePublishError> {
         panic!("an unsigned replacement must never reach the network")
+    }
+}
+
+#[derive(Clone, Default)]
+struct ReauthorPrepareFailsKeyPackages {
+    preparations: Arc<Mutex<Vec<KeyPackagePublication>>>,
+    publications: Arc<Mutex<Vec<KeyPackagePublication>>>,
+}
+
+#[async_trait]
+impl KeyPackagePublisher for ReauthorPrepareFailsKeyPackages {
+    fn legacy_slot_id(
+        &self,
+        account_id: &MemberId,
+    ) -> Result<Option<String>, KeyPackagePublishError> {
+        Ok(Some(test_key_package_slot(account_id)))
+    }
+
+    fn signed_artifact_reauthor_at_age_secs(&self) -> Option<u64> {
+        Some(600)
+    }
+
+    async fn prepare_key_package(
+        &self,
+        publication: KeyPackagePublication,
+    ) -> Result<cgka_traits::SignedPublicationArtifact, KeyPackagePublishError> {
+        let mut preparations = self.preparations.lock().unwrap();
+        preparations.push(publication.clone());
+        if preparations.len() > 1 {
+            return Err(KeyPackagePublishError::unexposed(
+                "injected reauthor signing failure",
+            ));
+        }
+        Ok(test_key_package_artifact(&publication))
+    }
+
+    async fn publish_prepared_key_package(
+        &self,
+        publication: &KeyPackagePublication,
+        _artifact: &cgka_traits::SignedPublicationArtifact,
+    ) -> Result<LegacyKeyPackagePublishReceipt, KeyPackagePublishError> {
+        self.publications.lock().unwrap().push(publication.clone());
+        Err(KeyPackagePublishError::unexposed(
+            "injected initial publish failure",
+        ))
     }
 }
 
@@ -787,19 +920,32 @@ impl KeyPackagePublisher for PrepareFailsKeyPackages {
 #[derive(Clone)]
 struct FlakyKeyPackages {
     publications: Arc<Mutex<Vec<KeyPackagePublication>>>,
+    artifacts: Arc<Mutex<Vec<cgka_traits::SignedPublicationArtifact>>>,
     remaining_failures: Arc<Mutex<usize>>,
+    reauthor_after_secs: Option<u64>,
 }
 
 impl FlakyKeyPackages {
     fn new(fail_first: usize) -> Self {
         Self {
             publications: Arc::new(Mutex::new(Vec::new())),
+            artifacts: Arc::new(Mutex::new(Vec::new())),
             remaining_failures: Arc::new(Mutex::new(fail_first)),
+            reauthor_after_secs: None,
         }
+    }
+
+    fn reauthor_after_secs(mut self, seconds: u64) -> Self {
+        self.reauthor_after_secs = Some(seconds);
+        self
     }
 
     fn publications(&self) -> Vec<KeyPackagePublication> {
         self.publications.lock().unwrap().clone()
+    }
+
+    fn artifacts(&self) -> Vec<cgka_traits::SignedPublicationArtifact> {
+        self.artifacts.lock().unwrap().clone()
     }
 }
 
@@ -812,6 +958,10 @@ impl KeyPackagePublisher for FlakyKeyPackages {
         Ok(Some(test_key_package_slot(account_id)))
     }
 
+    fn signed_artifact_reauthor_at_age_secs(&self) -> Option<u64> {
+        self.reauthor_after_secs
+    }
+
     async fn prepare_key_package(
         &self,
         publication: KeyPackagePublication,
@@ -822,9 +972,10 @@ impl KeyPackagePublisher for FlakyKeyPackages {
     async fn publish_prepared_key_package(
         &self,
         publication: &KeyPackagePublication,
-        _artifact: &cgka_traits::SignedPublicationArtifact,
-    ) -> Result<KeyPackagePublishReceipt, KeyPackagePublishError> {
+        artifact: &cgka_traits::SignedPublicationArtifact,
+    ) -> Result<LegacyKeyPackagePublishReceipt, KeyPackagePublishError> {
         self.publications.lock().unwrap().push(publication.clone());
+        self.artifacts.lock().unwrap().push(artifact.clone());
         let mut remaining = self.remaining_failures.lock().unwrap();
         if *remaining > 0 {
             *remaining -= 1;
@@ -832,7 +983,7 @@ impl KeyPackagePublisher for FlakyKeyPackages {
                 "injected publish failure",
             ));
         }
-        Ok(KeyPackagePublishReceipt {
+        Ok(LegacyKeyPackagePublishReceipt {
             accepted: publication.endpoints.clone(),
             failed: Vec::new(),
         })
@@ -875,13 +1026,228 @@ impl KeyPackagePublisher for ExposedThenFailsKeyPackages {
         &self,
         publication: &KeyPackagePublication,
         _artifact: &cgka_traits::SignedPublicationArtifact,
-    ) -> Result<KeyPackagePublishReceipt, KeyPackagePublishError> {
+    ) -> Result<LegacyKeyPackagePublishReceipt, KeyPackagePublishError> {
         self.publications.lock().unwrap().push(publication.clone());
         // External publish succeeded; a subsequent local step (e.g. cache write)
         // failed. The KeyPackage is already exposed.
         Err(KeyPackagePublishError::exposed(
             "injected post-exposure failure (e.g. local cache write)",
         ))
+    }
+}
+
+/// Publisher that crosses the external-send boundary and then deliberately
+/// remains pending. Dropping the caller future deterministically models task
+/// cancellation between socket I/O and receipt persistence.
+#[derive(Clone)]
+struct BlockingAfterSendKeyPackages {
+    sent: Arc<tokio::sync::Semaphore>,
+    release: Arc<tokio::sync::Semaphore>,
+    publications: Arc<Mutex<Vec<KeyPackagePublication>>>,
+    artifacts: Arc<Mutex<Vec<cgka_traits::SignedPublicationArtifact>>>,
+}
+
+impl Default for BlockingAfterSendKeyPackages {
+    fn default() -> Self {
+        Self {
+            sent: Arc::new(tokio::sync::Semaphore::new(0)),
+            release: Arc::new(tokio::sync::Semaphore::new(0)),
+            publications: Arc::new(Mutex::new(Vec::new())),
+            artifacts: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+}
+
+#[async_trait]
+impl KeyPackagePublisher for BlockingAfterSendKeyPackages {
+    fn legacy_slot_id(
+        &self,
+        account_id: &MemberId,
+    ) -> Result<Option<String>, KeyPackagePublishError> {
+        Ok(Some(test_key_package_slot(account_id)))
+    }
+
+    fn signed_artifact_reauthor_at_age_secs(&self) -> Option<u64> {
+        Some(600)
+    }
+
+    async fn prepare_key_package(
+        &self,
+        publication: KeyPackagePublication,
+    ) -> Result<cgka_traits::SignedPublicationArtifact, KeyPackagePublishError> {
+        Ok(test_key_package_artifact(&publication))
+    }
+
+    async fn publish_prepared_key_package(
+        &self,
+        publication: &KeyPackagePublication,
+        artifact: &cgka_traits::SignedPublicationArtifact,
+    ) -> Result<LegacyKeyPackagePublishReceipt, KeyPackagePublishError> {
+        self.publications.lock().unwrap().push(publication.clone());
+        self.artifacts.lock().unwrap().push(artifact.clone());
+        self.sent.add_permits(1);
+        let permit = self
+            .release
+            .acquire()
+            .await
+            .expect("test release semaphore remains open");
+        permit.forget();
+        Ok(LegacyKeyPackagePublishReceipt {
+            accepted: publication.endpoints.clone(),
+            failed: Vec::new(),
+        })
+    }
+}
+
+/// Scriptable transport boundary for privacy-journal recovery tests. Empty
+/// receipt queues default to successful endpoint acknowledgements.
+type KeyPackageDeletionCall = (MessageId, Vec<TransportEndpoint>);
+
+#[derive(Clone, Default)]
+struct JournalKeyPackages {
+    publications: Arc<Mutex<Vec<KeyPackagePublication>>>,
+    artifacts: Arc<Mutex<Vec<cgka_traits::SignedPublicationArtifact>>>,
+    publication_receipts: Arc<Mutex<VecDeque<KeyPackagePublishReceipt>>>,
+    deletions: Arc<Mutex<Vec<KeyPackageDeletionCall>>>,
+    deletion_receipts: Arc<Mutex<VecDeque<KeyPackagePublishReceipt>>>,
+    reauthor_after_secs: Option<u64>,
+    reject_empty_prepares: bool,
+}
+
+impl JournalKeyPackages {
+    fn reauthor_after_secs(mut self, seconds: u64) -> Self {
+        self.reauthor_after_secs = Some(seconds);
+        self
+    }
+
+    fn reject_empty_prepares(mut self) -> Self {
+        self.reject_empty_prepares = true;
+        self
+    }
+
+    fn with_publication_receipts(self, receipts: Vec<KeyPackagePublishReceipt>) -> Self {
+        *self.publication_receipts.lock().unwrap() = receipts.into();
+        self
+    }
+
+    fn with_deletion_receipts(self, receipts: Vec<KeyPackagePublishReceipt>) -> Self {
+        *self.deletion_receipts.lock().unwrap() = receipts.into();
+        self
+    }
+
+    fn artifacts(&self) -> Vec<cgka_traits::SignedPublicationArtifact> {
+        self.artifacts.lock().unwrap().clone()
+    }
+
+    fn publications(&self) -> Vec<KeyPackagePublication> {
+        self.publications.lock().unwrap().clone()
+    }
+
+    fn deletions(&self) -> Vec<KeyPackageDeletionCall> {
+        self.deletions.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl KeyPackagePublisher for JournalKeyPackages {
+    fn legacy_slot_id(
+        &self,
+        account_id: &MemberId,
+    ) -> Result<Option<String>, KeyPackagePublishError> {
+        Ok(Some(test_key_package_slot(account_id)))
+    }
+
+    fn signed_artifact_reauthor_at_age_secs(&self) -> Option<u64> {
+        self.reauthor_after_secs
+    }
+
+    async fn prepare_key_package(
+        &self,
+        publication: KeyPackagePublication,
+    ) -> Result<cgka_traits::SignedPublicationArtifact, KeyPackagePublishError> {
+        if self.reject_empty_prepares && publication.endpoints.is_empty() {
+            return Err(KeyPackagePublishError::unexposed(
+                "test publisher refuses to sign an empty relay fanout",
+            ));
+        }
+        Ok(test_key_package_artifact(&publication))
+    }
+
+    async fn publish_prepared_key_package(
+        &self,
+        publication: &KeyPackagePublication,
+        artifact: &cgka_traits::SignedPublicationArtifact,
+    ) -> Result<LegacyKeyPackagePublishReceipt, KeyPackagePublishError> {
+        self.publish_prepared_key_package_detailed(publication, artifact)
+            .await
+            .map(Into::into)
+    }
+
+    async fn publish_prepared_key_package_detailed(
+        &self,
+        publication: &KeyPackagePublication,
+        artifact: &cgka_traits::SignedPublicationArtifact,
+    ) -> Result<KeyPackagePublishReceipt, KeyPackagePublishError> {
+        self.publications.lock().unwrap().push(publication.clone());
+        self.artifacts.lock().unwrap().push(artifact.clone());
+        Ok(self
+            .publication_receipts
+            .lock()
+            .unwrap()
+            .pop_front()
+            .unwrap_or_else(|| KeyPackagePublishReceipt {
+                accepted: publication.endpoints.clone(),
+                rejected: Vec::new(),
+                confirmed_absent: Vec::new(),
+                failed: Vec::new(),
+            }))
+    }
+
+    async fn delete_key_package_revision(
+        &self,
+        event_id: &MessageId,
+        endpoints: &[TransportEndpoint],
+    ) -> Result<KeyPackagePublishReceipt, KeyPackagePublishError> {
+        self.deletions
+            .lock()
+            .unwrap()
+            .push((event_id.clone(), endpoints.to_vec()));
+        Ok(self
+            .deletion_receipts
+            .lock()
+            .unwrap()
+            .pop_front()
+            .unwrap_or_else(|| KeyPackagePublishReceipt {
+                accepted: endpoints.to_vec(),
+                rejected: Vec::new(),
+                confirmed_absent: Vec::new(),
+                failed: Vec::new(),
+            }))
+    }
+}
+
+fn deletion_target(endpoint: &TransportEndpoint) -> TransportFanoutTarget {
+    TransportFanoutTarget {
+        endpoint: endpoint.clone(),
+        state: TransportFanoutAttemptState::Unattempted,
+        attempt_count: 0,
+        last_attempt_at: None,
+        failure_code: None,
+    }
+}
+
+fn retired_revision(
+    event_id: MessageId,
+    authored_created_at: Timestamp,
+    endpoints: &[TransportEndpoint],
+) -> RetiredKeyPackagePublication {
+    RetiredKeyPackagePublication {
+        event_id,
+        authored_created_at,
+        key_package_ref: None,
+        package_not_after: None,
+        delete_without_successor: true,
+        deletion_targets: endpoints.iter().map(deletion_target).collect(),
     }
 }
 
@@ -966,6 +1332,240 @@ async fn publish_fresh_key_package_uses_directory_boundary() {
         runtime.durably_owned_key_packages().unwrap(),
         vec![key_package],
         "a generated package is local only when its OpenMLS private bundle is present"
+    );
+}
+
+#[tokio::test]
+async fn durable_cutover_gate_blocks_manual_and_automatic_publication_but_not_exact_deletion() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot durable cutover publication gate key").unwrap();
+    let endpoint_a = TransportEndpoint("wss://keys-a.example".into());
+    let endpoint_b = TransportEndpoint("wss://keys-b.example".into());
+    let routing = StaticTransportRouting::new(vec![])
+        .key_package_endpoints(vec![endpoint_a.clone(), endpoint_b.clone()]);
+    let publisher = JournalKeyPackages::default().with_publication_receipts(vec![
+        KeyPackagePublishReceipt {
+            accepted: vec![endpoint_a.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: vec![endpoint_b.clone()],
+        },
+        KeyPackagePublishReceipt {
+            accepted: vec![endpoint_b.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+    ]);
+    let wall = Arc::new(TestWallClock::new(10_000));
+    let mut runtime = AccountDeviceRuntime::new(
+        session(database.clone(), &key, b"alice"),
+        RecordingAdapter::default(),
+        routing.clone(),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(23)),
+    );
+
+    runtime.publish_fresh_key_package().await.unwrap();
+    let deletion_id = MessageId::new(vec![0x81; 32]);
+    runtime
+        .prepare_key_package_deletion_recovery(&deletion_id, vec![endpoint_a.clone()])
+        .unwrap();
+    runtime
+        .set_key_package_cutover_publication_blocked(true)
+        .unwrap();
+    assert!(!runtime.key_package_network_maintenance_due().unwrap());
+    assert!(!runtime.key_package_has_pending_fanout().unwrap());
+
+    runtime.run_due_maintenance().await.unwrap();
+    assert_eq!(publisher.publications().len(), 1);
+    assert_eq!(
+        publisher.deletions(),
+        vec![(deletion_id, vec![endpoint_a.clone()])],
+        "the publication gate must not suppress durable exact deletion retry"
+    );
+    for error in [
+        runtime.republish_key_package().await.unwrap_err(),
+        runtime.publish_fresh_key_package().await.unwrap_err(),
+    ] {
+        assert!(error.to_string().contains("cutover discovery"));
+    }
+    assert_eq!(publisher.publications().len(), 1);
+    drop(runtime);
+
+    let mut restarted = AccountDeviceRuntime::new(
+        session(database, &key, b"alice"),
+        RecordingAdapter::default(),
+        routing,
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(23)),
+    );
+    assert!(
+        restarted
+            .key_package_maintenance_status()
+            .unwrap()
+            .unwrap()
+            .cutover_publication_blocked
+    );
+    assert!(
+        restarted.publish_fresh_key_package().await.is_err(),
+        "restart must not clear the durable cutover interlock"
+    );
+
+    wall.set(10_031);
+    restarted
+        .set_key_package_cutover_publication_blocked(false)
+        .unwrap();
+    assert!(restarted.key_package_has_pending_fanout().unwrap());
+    restarted.run_due_maintenance().await.unwrap();
+    let publications = publisher.publications();
+    assert_eq!(publications.len(), 2);
+    assert_eq!(publications[1].endpoints, vec![endpoint_b]);
+}
+
+#[tokio::test]
+async fn observing_exact_live_revision_preserves_relay_ordering_high_water() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot live revision high-water key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let publisher = JournalKeyPackages::default();
+    let wall = Arc::new(TestWallClock::new(10_000));
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall,
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(29)),
+    );
+
+    runtime.publish_fresh_key_package().await.unwrap();
+    runtime
+        .set_key_package_cutover_publication_blocked(true)
+        .unwrap();
+    let lifecycle = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let live_event_id = lifecycle.authored_event_id.unwrap();
+    let stable_slot_id = lifecycle.stable_slot_id;
+    let observed_created_at = Timestamp(10_025);
+    let observed_endpoint = TransportEndpoint("wss://historical-keys.example".into());
+    assert!(
+        runtime
+            .observe_live_key_package_publication(
+                stable_slot_id.clone(),
+                &MessageId::new(vec![0xa1; 32]),
+                observed_created_at,
+                vec![observed_endpoint.clone()],
+            )
+            .is_err(),
+        "an unrelated same-slot event may not rewrite live lifecycle metadata"
+    );
+    let (admitted, deferred) = runtime
+        .observe_live_key_package_publication(
+            stable_slot_id,
+            &live_event_id,
+            observed_created_at,
+            vec![observed_endpoint.clone()],
+        )
+        .unwrap();
+    assert_eq!(admitted, vec![observed_endpoint.clone()]);
+    assert!(deferred.is_empty());
+    let observed = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(
+        observed.authored_event_created_at,
+        Some(observed_created_at)
+    );
+    assert!(observed.publication_targets.iter().any(|target| {
+        target.endpoint == observed_endpoint
+            && target.state == TransportFanoutAttemptState::Accepted
+    }));
+
+    runtime
+        .set_key_package_cutover_publication_blocked(false)
+        .unwrap();
+    runtime.publish_fresh_key_package().await.unwrap();
+    assert_eq!(publisher.artifacts()[1].created_at, Timestamp(10_026));
+}
+
+#[tokio::test]
+async fn unparsed_same_slot_discovery_preserves_ordering_high_water_with_failed_deletion() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot unparsed discovery high-water key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let publisher =
+        JournalKeyPackages::default().with_deletion_receipts(vec![KeyPackagePublishReceipt {
+            accepted: Vec::new(),
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: vec![endpoint.clone()],
+        }]);
+    let wall = Arc::new(TestWallClock::new(10_000));
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint.clone()]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall,
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(31)),
+    );
+
+    runtime.publish_fresh_key_package().await.unwrap();
+    runtime
+        .set_key_package_cutover_publication_blocked(true)
+        .unwrap();
+    let lifecycle = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let stable_slot_id = lifecycle.stable_slot_id;
+    let discovered_id = MessageId::new(vec![0x91; 32]);
+    let discovered_created_at = Timestamp(10_025);
+    let (admitted, deferred) = runtime
+        .journal_discovered_unparsed_key_package_publication(
+            stable_slot_id,
+            discovered_id.clone(),
+            discovered_created_at,
+            vec![endpoint.clone()],
+        )
+        .unwrap();
+    assert_eq!(admitted, vec![endpoint.clone()]);
+    assert!(deferred.is_empty());
+    assert_eq!(
+        runtime
+            .key_package_maintenance_status()
+            .unwrap()
+            .unwrap()
+            .authored_event_created_at,
+        Some(discovered_created_at)
+    );
+
+    runtime
+        .set_key_package_cutover_publication_blocked(false)
+        .unwrap();
+    runtime.publish_fresh_key_package().await.unwrap();
+    let artifacts = publisher.artifacts();
+    assert_eq!(artifacts.len(), 2);
+    assert_eq!(artifacts[1].created_at, Timestamp(10_026));
+    let repaired = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert!(
+        repaired
+            .retired_publications_pending_deletion
+            .iter()
+            .any(|retired| retired.event_id == discovered_id
+                && retired.authored_created_at == discovered_created_at
+                && retired.deletion_targets.len() == 1),
+        "an ambiguous deletion keeps the exact discovered liability durable"
     );
 }
 
@@ -1063,6 +1663,2059 @@ async fn publish_fresh_key_package_retries_the_same_durable_replacement() {
         vec![key_package],
         "publish failure and retry must retain the staged private bundle"
     );
+}
+
+#[tokio::test]
+async fn stale_pending_key_package_is_reauthored_once_and_survives_restart() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot stale pending key package key").unwrap();
+    let wall = Arc::new(TestWallClock::new(10_000));
+    let policy = StaticTransportRouting::new(vec![])
+        .key_package_endpoints(vec![TransportEndpoint("wss://keys.example".into())]);
+    let publisher = FlakyKeyPackages::new(3).reauthor_after_secs(600);
+    let mut runtime = AccountDeviceRuntime::new(
+        session(database.clone(), &key, b"alice"),
+        RecordingAdapter::default(),
+        policy.clone(),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(31)),
+    );
+
+    runtime
+        .publish_fresh_key_package()
+        .await
+        .expect_err("first publication is intentionally unacknowledged");
+    wall.set(10_599);
+    runtime
+        .publish_fresh_key_package()
+        .await
+        .expect_err("an artifact younger than the policy boundary stays exact");
+    wall.set(10_600);
+    runtime
+        .publish_fresh_key_package()
+        .await
+        .expect_err("the first publication of the reauthored revision is injected to fail");
+
+    let publications = publisher.publications();
+    let artifacts = publisher.artifacts();
+    assert_eq!(publications.len(), 3);
+    assert_eq!(artifacts.len(), 3);
+    assert_eq!(publications[0], publications[1]);
+    assert_eq!(artifacts[0], artifacts[1]);
+    assert_eq!(publications[2].key_package, publications[0].key_package);
+    assert_eq!(publications[2].slot_id, publications[0].slot_id);
+    assert_eq!(publications[2].created_at, Timestamp(10_600));
+    assert_ne!(artifacts[2], artifacts[0]);
+
+    let pending = runtime
+        .key_package_maintenance_status()
+        .unwrap()
+        .unwrap()
+        .pending_replacement
+        .expect("failed reauthored publication remains durable");
+    assert_eq!(pending.authored_created_at, Timestamp(10_600));
+    assert_eq!(pending.signed_event, Some(artifacts[2].clone()));
+    assert_eq!(pending.targets[0].attempt_count, 1);
+    drop(runtime);
+
+    wall.set(10_601);
+    let mut restarted = AccountDeviceRuntime::new(
+        session(database, &key, b"alice"),
+        RecordingAdapter::default(),
+        policy,
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(31)),
+    );
+    restarted
+        .publish_fresh_key_package()
+        .await
+        .expect("restart retries the durable reauthored revision exactly");
+
+    let publications = publisher.publications();
+    let artifacts = publisher.artifacts();
+    assert_eq!(publications.len(), 4);
+    assert_eq!(publications[3], publications[2]);
+    assert_eq!(artifacts[3], artifacts[2]);
+    let current = restarted.key_package_maintenance_status().unwrap().unwrap();
+    assert!(current.pending_replacement.is_none());
+    assert_eq!(current.authored_event_id, Some(artifacts[2].id.clone()));
+    assert_eq!(current.authored_event_created_at, Some(Timestamp(10_600)));
+    assert_eq!(current.authored_signed_event, Some(artifacts[2].clone()));
+}
+
+#[tokio::test]
+async fn cancelled_key_package_send_keeps_possible_exposure_and_retires_old_revision_after_restart()
+{
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot cancelled key package send key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let routing = StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint.clone()]);
+    let wall = Arc::new(TestWallClock::new(10_000));
+    let blocking = BlockingAfterSendKeyPackages::default();
+    let sent = blocking.sent.clone();
+    let mut runtime = AccountDeviceRuntime::new(
+        session(database.clone(), &key, b"alice"),
+        RecordingAdapter::default(),
+        routing.clone(),
+        blocking.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(53)),
+    );
+
+    let mut publish = Box::pin(runtime.publish_fresh_key_package());
+    let sent_permit = tokio::select! {
+        permit = sent.acquire() => permit.expect("send marker semaphore remains open"),
+        result = &mut publish => panic!("publisher returned before cancellation boundary: {result:?}"),
+    };
+    sent_permit.forget();
+    drop(publish);
+
+    let old_artifact = blocking.artifacts.lock().unwrap()[0].clone();
+    let after_cancel = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let pending = after_cancel
+        .pending_replacement
+        .expect("cancelled send retains its durable pending replacement");
+    assert_eq!(pending.signed_event, Some(old_artifact.clone()));
+    assert_eq!(pending.targets.len(), 1);
+    assert_eq!(
+        pending.targets[0].state,
+        TransportFanoutAttemptState::AttemptedFailed
+    );
+    assert_eq!(pending.targets[0].attempt_count, 1);
+    assert_eq!(
+        pending.targets[0].failure_code.as_deref(),
+        Some("possible_exposure")
+    );
+    drop(runtime);
+
+    wall.set(10_600);
+    let succeeding = JournalKeyPackages::default().reauthor_after_secs(600);
+    let mut restarted = AccountDeviceRuntime::new(
+        session(database.clone(), &key, b"alice"),
+        RecordingAdapter::default(),
+        routing.clone(),
+        succeeding.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(53)),
+    );
+    restarted
+        .publish_fresh_key_package()
+        .await
+        .expect("stale cancelled revision is reauthored and published");
+    let reauthored = succeeding.artifacts();
+    assert_eq!(reauthored.len(), 1);
+    assert_ne!(reauthored[0].id, old_artifact.id);
+    let lifecycle = restarted.key_package_maintenance_status().unwrap().unwrap();
+    let retired = lifecycle
+        .retired_publications_pending_deletion
+        .iter()
+        .find(|retired| retired.event_id == old_artifact.id)
+        .expect("old ambiguously exposed event remains a durable deletion obligation");
+    assert_eq!(retired.deletion_targets.len(), 1);
+    assert_eq!(retired.deletion_targets[0].endpoint, endpoint);
+    drop(restarted);
+
+    let reopened = AccountDeviceRuntime::new(
+        session(database, &key, b"alice"),
+        RecordingAdapter::default(),
+        routing,
+        succeeding,
+    )
+    .with_maintenance_sources(
+        wall,
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(53)),
+    );
+    let after_second_restart = reopened.key_package_maintenance_status().unwrap().unwrap();
+    assert!(
+        after_second_restart
+            .retired_publications_pending_deletion
+            .iter()
+            .any(|retired| {
+                retired.event_id == old_artifact.id
+                    && retired
+                        .deletion_targets
+                        .iter()
+                        .any(|target| target.endpoint == endpoint)
+            })
+    );
+}
+
+#[tokio::test]
+async fn publication_negative_ack_never_proves_the_signed_event_absent() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot publication negative ack key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let wall = Arc::new(TestWallClock::new(20_000));
+    let publisher = JournalKeyPackages::default()
+        .reauthor_after_secs(600)
+        .with_publication_receipts(vec![
+            KeyPackagePublishReceipt {
+                accepted: Vec::new(),
+                rejected: vec![endpoint.clone()],
+                confirmed_absent: Vec::new(),
+                failed: Vec::new(),
+            },
+            KeyPackagePublishReceipt {
+                accepted: vec![endpoint.clone()],
+                rejected: Vec::new(),
+                confirmed_absent: Vec::new(),
+                failed: Vec::new(),
+            },
+        ]);
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint.clone()]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(59)),
+    );
+
+    runtime
+        .publish_fresh_key_package()
+        .await
+        .expect_err("a negative publication acknowledgement accepts no endpoint");
+    let old_artifact = publisher.artifacts()[0].clone();
+    let after_negative = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(
+        after_negative.pending_replacement.as_ref().unwrap().targets[0]
+            .failure_code
+            .as_deref(),
+        Some("transport_rejected"),
+        "normal publication cannot distinguish a truly first attempt from legacy possible exposure"
+    );
+
+    wall.set(20_600);
+    runtime
+        .publish_fresh_key_package()
+        .await
+        .expect("a stale negatively acknowledged revision may be replaced");
+    assert!(
+        runtime
+            .key_package_maintenance_status()
+            .unwrap()
+            .unwrap()
+            .retired_publications_pending_deletion
+            .iter()
+            .any(|retired| {
+                retired.event_id == old_artifact.id
+                    && retired
+                        .deletion_targets
+                        .iter()
+                        .any(|target| target.endpoint == endpoint)
+            }),
+        "the negative acknowledgement cannot erase possible pre-upgrade relay exposure"
+    );
+}
+
+#[tokio::test]
+async fn fresh_publication_ignores_extraneous_acceptance_and_retries_deletion_only_absence_claim() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot scoped fresh publication receipt key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let extraneous = TransportEndpoint("wss://not-attempted.example".into());
+    let wall = Arc::new(TestWallClock::new(21_000));
+    let publisher = JournalKeyPackages::default().with_publication_receipts(vec![
+        KeyPackagePublishReceipt {
+            accepted: vec![extraneous.clone(), extraneous],
+            rejected: Vec::new(),
+            confirmed_absent: vec![endpoint.clone(), endpoint.clone()],
+            failed: Vec::new(),
+        },
+        KeyPackagePublishReceipt {
+            accepted: vec![endpoint.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+    ]);
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint.clone()]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(60)),
+    );
+
+    runtime
+        .publish_fresh_key_package()
+        .await
+        .expect_err("an acceptance outside the attempted fanout cannot promote a replacement");
+    let pending = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert!(pending.current_key_package.is_none());
+    let target = &pending.pending_replacement.as_ref().unwrap().targets[0];
+    assert_eq!(target.endpoint, endpoint);
+    assert_eq!(target.state, TransportFanoutAttemptState::AttemptedFailed);
+    assert_eq!(target.failure_code.as_deref(), Some("possible_exposure"));
+    assert_ne!(target.failure_code.as_deref(), Some("confirmed_absent"));
+
+    runtime.pause_maintenance();
+    wall.set(21_030);
+    runtime
+        .run_due_maintenance()
+        .await
+        .expect("the pending revision remains automatically retryable");
+    let promoted = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert!(promoted.pending_replacement.is_none());
+    assert!(promoted.current_key_package.is_some());
+    assert_eq!(publisher.publications().len(), 2);
+    assert_eq!(publisher.publications()[1].endpoints, vec![endpoint]);
+}
+
+#[tokio::test]
+async fn current_republication_ignores_extraneous_acceptance_and_retries_absence_claim() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot scoped current publication receipt key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let extraneous = TransportEndpoint("wss://not-attempted.example".into());
+    let wall = Arc::new(TestWallClock::new(22_000));
+    let publisher = JournalKeyPackages::default().with_publication_receipts(vec![
+        KeyPackagePublishReceipt {
+            accepted: vec![endpoint.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+        KeyPackagePublishReceipt {
+            accepted: vec![extraneous],
+            rejected: Vec::new(),
+            confirmed_absent: vec![endpoint.clone()],
+            failed: Vec::new(),
+        },
+        KeyPackagePublishReceipt {
+            accepted: vec![endpoint.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+    ]);
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint.clone()]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(62)),
+    );
+    runtime.publish_fresh_key_package().await.unwrap();
+    let mut lifecycle = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let artifact = lifecycle.authored_signed_event.clone().unwrap();
+    let republish_at = lifecycle.current_not_before.unwrap().0;
+    lifecycle.publication_targets[0].state = TransportFanoutAttemptState::Unattempted;
+    lifecycle.publication_targets[0].attempt_count = 0;
+    lifecycle.publication_targets[0].last_attempt_at = None;
+    lifecycle.publication_targets[0].failure_code = None;
+    runtime
+        .session()
+        .put_key_package_lifecycle(&lifecycle)
+        .unwrap();
+    wall.set(republish_at);
+
+    runtime
+        .republish_key_package()
+        .await
+        .expect_err("an out-of-scope acceptance cannot make republication succeed");
+    let retrying = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(retrying.authored_signed_event, Some(artifact.clone()));
+    assert_eq!(
+        (
+            retrying.publication_targets[0].state,
+            retrying.publication_targets[0].failure_code.as_deref(),
+        ),
+        (
+            TransportFanoutAttemptState::AttemptedFailed,
+            Some("possible_exposure"),
+        )
+    );
+    assert_ne!(
+        retrying.publication_targets[0].failure_code.as_deref(),
+        Some("confirmed_absent")
+    );
+
+    runtime.pause_maintenance();
+    wall.set(republish_at.saturating_add(30));
+    runtime
+        .run_due_maintenance()
+        .await
+        .expect("the current exact revision remains automatically retryable");
+    let completed = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(completed.authored_signed_event, Some(artifact));
+    assert_eq!(
+        completed.publication_targets[0].state,
+        TransportFanoutAttemptState::Accepted
+    );
+    assert_eq!(publisher.publications().len(), 3);
+    assert_eq!(publisher.publications()[2].endpoints, vec![endpoint]);
+}
+
+#[tokio::test]
+async fn legacy_signed_unattempted_revision_negative_retry_remains_deletable_after_reauthor() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot legacy unattempted upgrade key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let routing = StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint.clone()]);
+    let wall = Arc::new(TestWallClock::new(30_000));
+
+    let mut legacy = AccountDeviceRuntime::new(
+        session(database.clone(), &key, b"alice"),
+        RecordingAdapter::default(),
+        routing.clone(),
+        JournalKeyPackages::default(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(61)),
+    );
+    legacy
+        .prepare_fresh_key_package(vec![endpoint.clone()])
+        .await
+        .expect("legacy fixture has a durable signed revision before network I/O");
+    let legacy_lifecycle = legacy.key_package_maintenance_status().unwrap().unwrap();
+    let legacy_pending = legacy_lifecycle.pending_replacement.unwrap();
+    let old_artifact = legacy_pending.signed_event.unwrap();
+    assert_eq!(legacy_pending.targets.len(), 1);
+    assert_eq!(
+        legacy_pending.targets[0].state,
+        TransportFanoutAttemptState::Unattempted
+    );
+    assert_eq!(legacy_pending.targets[0].attempt_count, 0);
+    assert!(legacy_pending.targets[0].last_attempt_at.is_none());
+    drop(legacy);
+
+    let upgraded_publisher = JournalKeyPackages::default()
+        .reauthor_after_secs(600)
+        .with_publication_receipts(vec![
+            KeyPackagePublishReceipt {
+                accepted: Vec::new(),
+                rejected: vec![endpoint.clone()],
+                confirmed_absent: Vec::new(),
+                failed: Vec::new(),
+            },
+            KeyPackagePublishReceipt {
+                accepted: vec![endpoint.clone()],
+                rejected: Vec::new(),
+                confirmed_absent: Vec::new(),
+                failed: Vec::new(),
+            },
+        ]);
+    let mut upgraded = AccountDeviceRuntime::new(
+        session(database.clone(), &key, b"alice"),
+        RecordingAdapter::default(),
+        routing.clone(),
+        upgraded_publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(61)),
+    );
+    upgraded
+        .publish_fresh_key_package()
+        .await
+        .expect_err("the legacy revision retry is negatively acknowledged");
+    let after_negative = upgraded.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(
+        after_negative
+            .pending_replacement
+            .as_ref()
+            .unwrap()
+            .signed_event,
+        Some(old_artifact.clone())
+    );
+    assert_eq!(
+        after_negative.pending_replacement.as_ref().unwrap().targets[0]
+            .failure_code
+            .as_deref(),
+        Some("transport_rejected")
+    );
+    drop(upgraded);
+
+    wall.set(30_600);
+    let mut restarted = AccountDeviceRuntime::new(
+        session(database.clone(), &key, b"alice"),
+        RecordingAdapter::default(),
+        routing.clone(),
+        upgraded_publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(61)),
+    );
+    restarted
+        .publish_fresh_key_package()
+        .await
+        .expect("the stale legacy revision is reauthored after restart");
+    let upgraded_artifacts = upgraded_publisher.artifacts();
+    assert_eq!(upgraded_artifacts[0], old_artifact);
+    assert_ne!(upgraded_artifacts[1].id, old_artifact.id);
+    let retired = restarted
+        .key_package_maintenance_status()
+        .unwrap()
+        .unwrap()
+        .retired_publications_pending_deletion
+        .into_iter()
+        .find(|retired| retired.event_id == old_artifact.id)
+        .expect("legacy possibly exposed event id remains durably deletable");
+    assert_eq!(retired.deletion_targets.len(), 1);
+    assert_eq!(retired.deletion_targets[0].endpoint, endpoint);
+    drop(restarted);
+
+    let reopened = AccountDeviceRuntime::new(
+        session(database, &key, b"alice"),
+        RecordingAdapter::default(),
+        routing,
+        upgraded_publisher,
+    )
+    .with_maintenance_sources(
+        wall,
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(61)),
+    );
+    assert!(
+        reopened
+            .key_package_maintenance_status()
+            .unwrap()
+            .unwrap()
+            .retired_publications_pending_deletion
+            .iter()
+            .any(|retired| {
+                retired.event_id == old_artifact.id
+                    && retired
+                        .deletion_targets
+                        .iter()
+                        .any(|target| target.endpoint == endpoint)
+            })
+    );
+}
+
+#[tokio::test]
+async fn due_maintenance_retries_all_rejected_pending_key_package_after_backoff() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot all rejected worker retry key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let wall = Arc::new(TestWallClock::new(35_000));
+    let publisher = JournalKeyPackages::default().with_publication_receipts(vec![
+        KeyPackagePublishReceipt {
+            accepted: Vec::new(),
+            rejected: vec![endpoint.clone()],
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+        KeyPackagePublishReceipt {
+            accepted: vec![endpoint.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+    ]);
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint.clone()]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(63)),
+    );
+    runtime
+        .publish_fresh_key_package()
+        .await
+        .expect_err("the first normal publication is rejected everywhere");
+    let first = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(
+        first.pending_replacement.as_ref().unwrap().targets[0]
+            .failure_code
+            .as_deref(),
+        Some("transport_rejected")
+    );
+    runtime.pause_maintenance();
+
+    wall.set(35_030);
+    runtime
+        .run_due_maintenance()
+        .await
+        .expect("worker-shaped maintenance retries the durable pending revision");
+    let artifacts = publisher.artifacts();
+    assert_eq!(artifacts.len(), 2);
+    assert_eq!(artifacts[0], artifacts[1]);
+    let recovered = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert!(recovered.pending_replacement.is_none());
+    assert_eq!(recovered.authored_signed_event, Some(artifacts[0].clone()));
+    assert!(recovered.publication_targets.iter().all(|target| {
+        target.endpoint == endpoint
+            && target.state == TransportFanoutAttemptState::Accepted
+            && target.failure_code.is_none()
+    }));
+}
+
+#[tokio::test]
+async fn due_maintenance_finishes_partially_accepted_key_package_fanout_after_backoff() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot partial worker fanout key").unwrap();
+    let endpoint_a = TransportEndpoint("wss://keys-a.example".into());
+    let endpoint_b = TransportEndpoint("wss://keys-b.example".into());
+    let wall = Arc::new(TestWallClock::new(36_000));
+    let publisher = JournalKeyPackages::default().with_publication_receipts(vec![
+        KeyPackagePublishReceipt {
+            accepted: vec![endpoint_a.clone()],
+            rejected: vec![endpoint_b.clone()],
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+        KeyPackagePublishReceipt {
+            accepted: vec![endpoint_b.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+    ]);
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![])
+            .key_package_endpoints(vec![endpoint_a.clone(), endpoint_b.clone()]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(65)),
+    );
+    runtime
+        .publish_fresh_key_package()
+        .await
+        .expect("one accepted endpoint promotes the current key package");
+    let partial = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(partial.phase, cgka_traits::MaintenancePhase::Fanout);
+    let rejected = partial
+        .publication_targets
+        .iter()
+        .find(|target| target.endpoint == endpoint_b)
+        .unwrap();
+    assert_eq!(rejected.failure_code.as_deref(), Some("transport_rejected"));
+    runtime.pause_maintenance();
+
+    wall.set(36_030);
+    runtime
+        .run_due_maintenance()
+        .await
+        .expect("worker-shaped maintenance retries only the rejected endpoint");
+    let publications = publisher.publications();
+    assert_eq!(publications.len(), 2);
+    assert_eq!(publications[1].endpoints, vec![endpoint_b.clone()]);
+    let artifacts = publisher.artifacts();
+    assert_eq!(artifacts.len(), 2);
+    assert_eq!(artifacts[0], artifacts[1]);
+    let completed = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(completed.phase, cgka_traits::MaintenancePhase::Complete);
+    assert!(completed.publication_targets.iter().all(|target| {
+        (target.endpoint == endpoint_a || target.endpoint == endpoint_b)
+            && target.state == TransportFanoutAttemptState::Accepted
+            && target.failure_code.is_none()
+    }));
+}
+
+#[tokio::test]
+async fn due_maintenance_reconciles_current_fanout_to_authoritative_routes_after_restart() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot current fanout route reconcile key").unwrap();
+    let endpoint_a = TransportEndpoint("wss://keys-a.example".into());
+    let removed_endpoint = TransportEndpoint("wss://keys-b.example".into());
+    let added_endpoint = TransportEndpoint("wss://keys-c.example".into());
+    let wall = Arc::new(TestWallClock::new(36_500));
+    let publisher = PartialFanoutKeyPackages::default();
+
+    let original_artifact;
+    {
+        let mut runtime = AccountDeviceRuntime::new(
+            session(&database, &key, b"alice"),
+            RecordingAdapter::default(),
+            StaticTransportRouting::new(vec![])
+                .key_package_endpoints(vec![endpoint_a.clone(), removed_endpoint.clone()]),
+            publisher.clone(),
+        )
+        .with_maintenance_sources(
+            wall.clone(),
+            Arc::new(TestMonotonicClock::default()),
+            Arc::new(TestRandom::new(67)),
+        );
+        runtime.publish_fresh_key_package().await.unwrap();
+        let partial = runtime.key_package_maintenance_status().unwrap().unwrap();
+        original_artifact = partial.authored_signed_event.unwrap();
+        assert!(partial.publication_targets.iter().any(|target| {
+            target.endpoint == removed_endpoint
+                && target.state == TransportFanoutAttemptState::AttemptedFailed
+        }));
+    }
+
+    wall.set(36_530);
+    let mut restarted = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![])
+            .key_package_endpoints(vec![endpoint_a.clone(), added_endpoint.clone()]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall,
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(67)),
+    );
+    restarted.pause_maintenance();
+    restarted.run_due_maintenance().await.unwrap();
+
+    let publications = publisher.publications();
+    assert_eq!(publications.len(), 2);
+    assert_eq!(publications[1].0.endpoints, vec![added_endpoint.clone()]);
+    assert_eq!(publications[1].1, original_artifact);
+    assert!(!publications[1].0.endpoints.contains(&removed_endpoint));
+
+    let reconciled = restarted.key_package_maintenance_status().unwrap().unwrap();
+    assert!(reconciled.publication_targets.iter().any(|target| {
+        target.endpoint == removed_endpoint
+            && target.state == TransportFanoutAttemptState::PolicyProhibited
+    }));
+    assert!(reconciled.publication_targets.iter().any(|target| {
+        target.endpoint == added_endpoint && target.state == TransportFanoutAttemptState::Accepted
+    }));
+}
+
+#[tokio::test]
+async fn pending_replacement_reconciles_a_to_b_policy_and_cannot_promote_from_stale_a_ack() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot pending route switch key").unwrap();
+    let endpoint_a = TransportEndpoint("wss://keys-a.example".into());
+    let endpoint_b = TransportEndpoint("wss://keys-b.example".into());
+    let publisher = JournalKeyPackages::default().with_publication_receipts(vec![
+        KeyPackagePublishReceipt {
+            accepted: Vec::new(),
+            rejected: vec![endpoint_a.clone()],
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+        KeyPackagePublishReceipt {
+            accepted: vec![endpoint_a.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: vec![endpoint_b.clone()],
+        },
+        KeyPackagePublishReceipt {
+            accepted: vec![endpoint_b.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+    ]);
+    {
+        let mut runtime = AccountDeviceRuntime::new(
+            session(&database, &key, b"alice"),
+            RecordingAdapter::default(),
+            StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint_a.clone()]),
+            publisher.clone(),
+        );
+        runtime
+            .publish_fresh_key_package()
+            .await
+            .expect_err("the original A-only route rejects the pending revision");
+    }
+
+    let mut restarted = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint_b.clone()]),
+        publisher.clone(),
+    );
+    restarted
+        .publish_fresh_key_package()
+        .await
+        .expect_err("an acknowledgement for removed A is outside the B-only attempted fanout");
+    let pending = restarted.key_package_maintenance_status().unwrap().unwrap();
+    assert!(pending.current_key_package.is_none());
+    let pending = pending.pending_replacement.unwrap();
+    let removed_a = pending
+        .targets
+        .iter()
+        .find(|target| target.endpoint == endpoint_a)
+        .unwrap();
+    assert_eq!(
+        removed_a.state,
+        TransportFanoutAttemptState::PolicyProhibited
+    );
+    let live_b = pending
+        .targets
+        .iter()
+        .find(|target| target.endpoint == endpoint_b)
+        .unwrap();
+    assert_eq!(live_b.state, TransportFanoutAttemptState::AttemptedFailed);
+    assert_eq!(live_b.failure_code.as_deref(), Some("possible_exposure"));
+
+    restarted
+        .publish_fresh_key_package()
+        .await
+        .expect("the pending revision promotes only after authoritative B acknowledges");
+    let promoted = restarted.key_package_maintenance_status().unwrap().unwrap();
+    assert!(promoted.pending_replacement.is_none());
+    assert!(promoted.publication_targets.iter().any(|target| {
+        target.endpoint == endpoint_b && target.state == TransportFanoutAttemptState::Accepted
+    }));
+    assert_eq!(
+        publisher
+            .publications()
+            .into_iter()
+            .map(|publication| publication.endpoints)
+            .collect::<Vec<_>>(),
+        vec![vec![endpoint_a], vec![endpoint_b.clone()], vec![endpoint_b]]
+    );
+}
+
+#[tokio::test]
+async fn zero_target_pending_replacement_publishes_when_an_authoritative_route_appears() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot pending zero route recovery key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let publisher = JournalKeyPackages::default().reject_empty_prepares();
+    {
+        let mut runtime = AccountDeviceRuntime::new(
+            session(&database, &key, b"alice"),
+            RecordingAdapter::default(),
+            StaticTransportRouting::new(vec![]),
+            publisher.clone(),
+        );
+        runtime
+            .publish_fresh_key_package()
+            .await
+            .expect_err("a prepared zero-target revision cannot yet be acknowledged");
+        let pending = runtime.key_package_maintenance_status().unwrap().unwrap();
+        assert!(
+            pending
+                .pending_replacement
+                .as_ref()
+                .unwrap()
+                .targets
+                .is_empty()
+        );
+        assert!(
+            pending
+                .pending_replacement
+                .as_ref()
+                .unwrap()
+                .signed_event
+                .is_none(),
+            "the transport-like empty-route failure must leave an unsigned durable draft"
+        );
+    }
+
+    let mut restarted = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint.clone()]),
+        publisher.clone(),
+    );
+    restarted
+        .publish_fresh_key_package()
+        .await
+        .expect("the newly authoritative route is persisted and receives the exact pending event");
+    assert!(
+        restarted
+            .key_package_maintenance_status()
+            .unwrap()
+            .unwrap()
+            .pending_replacement
+            .is_none()
+    );
+    assert_eq!(
+        publisher
+            .publications()
+            .into_iter()
+            .map(|publication| publication.endpoints)
+            .collect::<Vec<_>>(),
+        vec![vec![endpoint]]
+    );
+}
+
+#[tokio::test]
+async fn saturated_pending_route_addition_fails_without_persisting_the_257th_pair() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot pending route capacity key").unwrap();
+    let endpoint = TransportEndpoint("wss://new.example".into());
+    let publisher = JournalKeyPackages::default();
+    {
+        let mut runtime = AccountDeviceRuntime::new(
+            session(&database, &key, b"alice"),
+            RecordingAdapter::default(),
+            StaticTransportRouting::new(vec![]),
+            publisher.clone(),
+        );
+        runtime.prepare_fresh_key_package(Vec::new()).await.unwrap();
+        let mut lifecycle = runtime.key_package_maintenance_status().unwrap().unwrap();
+        let full_endpoints = (0..256)
+            .map(|index| TransportEndpoint(format!("wss://retired-{index}.example")))
+            .collect::<Vec<_>>();
+        lifecycle
+            .retired_publications_pending_deletion
+            .push(RetiredKeyPackagePublication {
+                event_id: MessageId::new(vec![0x7d; 32]),
+                authored_created_at: Timestamp(u64::MAX),
+                key_package_ref: None,
+                package_not_after: None,
+                delete_without_successor: false,
+                deletion_targets: full_endpoints.iter().map(deletion_target).collect(),
+            });
+        runtime
+            .session()
+            .put_key_package_lifecycle(&lifecycle)
+            .unwrap();
+    }
+
+    let mut restarted = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint]),
+        publisher.clone(),
+    );
+    let error = restarted
+        .publish_fresh_key_package()
+        .await
+        .expect_err("adding a distinct pending endpoint above the global cap must fail");
+    assert!(
+        error
+            .to_string()
+            .contains("signed-publication endpoint-liability journal is full")
+    );
+    let unchanged = restarted.key_package_maintenance_status().unwrap().unwrap();
+    assert!(
+        unchanged
+            .pending_replacement
+            .as_ref()
+            .unwrap()
+            .targets
+            .is_empty(),
+        "the over-cap authoritative endpoint must not partially persist"
+    );
+    assert!(publisher.publications().is_empty());
+}
+
+#[test]
+fn discovered_retired_key_package_admission_is_idempotent_bounded_and_io_free() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot discovered revision admission key").unwrap();
+    let publisher = JournalKeyPackages::default();
+    let mut lifecycle = cgka_traits::KeyPackageLifecycleState::slot_only("stable-slot".into());
+    lifecycle
+        .retired_publications_pending_deletion
+        .push(RetiredKeyPackagePublication {
+            event_id: MessageId::new(vec![0x81; 32]),
+            authored_created_at: Timestamp(1),
+            key_package_ref: None,
+            package_not_after: None,
+            delete_without_successor: false,
+            deletion_targets: (0
+                ..cgka_traits::maintenance::MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES - 1)
+                .map(|index| {
+                    deletion_target(&TransportEndpoint(format!(
+                        "wss://existing-{index}.example"
+                    )))
+                })
+                .collect(),
+        });
+    session(&database, &key, b"alice")
+        .put_key_package_lifecycle(&lifecycle)
+        .unwrap();
+
+    let event_id = MessageId::new(vec![0x82; 32]);
+    let key_package_ref = vec![0x83; 32];
+    let endpoint_a = TransportEndpoint("wss://discovered-a.example".into());
+    let endpoint_b = TransportEndpoint("wss://discovered-b.example".into());
+    let mut runtime = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]),
+        publisher.clone(),
+    );
+    let (admitted, deferred) = runtime
+        .journal_discovered_retired_key_package_publication(
+            "stable-slot".into(),
+            event_id.clone(),
+            Timestamp(200),
+            key_package_ref.clone(),
+            Timestamp(900),
+            vec![endpoint_b.clone(), endpoint_a.clone(), endpoint_a.clone()],
+        )
+        .unwrap();
+    assert_eq!(admitted, vec![endpoint_a.clone()]);
+    assert_eq!(deferred, vec![endpoint_b.clone()]);
+    let journaled = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(
+        journaled.authored_event_created_at,
+        Some(Timestamp(200)),
+        "relay-discovered same-slot revisions advance the authoring high-water"
+    );
+    let discovered = journaled
+        .retired_publications_pending_deletion
+        .iter()
+        .find(|retired| retired.event_id == event_id)
+        .unwrap();
+    assert_eq!(discovered.authored_created_at, Timestamp(200));
+    assert_eq!(discovered.key_package_ref, Some(key_package_ref.clone()));
+    assert_eq!(discovered.package_not_after, Some(Timestamp(900)));
+    assert!(!discovered.delete_without_successor);
+    assert_eq!(discovered.deletion_targets.len(), 1);
+    assert_eq!(discovered.deletion_targets[0].endpoint, endpoint_a);
+    assert!(publisher.publications().is_empty());
+    assert!(publisher.deletions().is_empty());
+    drop(runtime);
+
+    let mut restarted = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]),
+        publisher.clone(),
+    );
+    let (admitted, deferred) = restarted
+        .journal_discovered_retired_key_package_publication(
+            "stable-slot".into(),
+            event_id.clone(),
+            Timestamp(200),
+            key_package_ref,
+            Timestamp(900),
+            vec![endpoint_b.clone(), endpoint_a.clone()],
+        )
+        .unwrap();
+    assert_eq!(admitted, vec![endpoint_a]);
+    assert_eq!(deferred, vec![endpoint_b.clone()]);
+
+    let wrong_slot_error = restarted
+        .journal_discovered_retired_key_package_publication(
+            "sibling-device-slot".into(),
+            MessageId::new(vec![0x86; 32]),
+            Timestamp(201),
+            vec![0x87; 32],
+            Timestamp(901),
+            vec![endpoint_b.clone()],
+        )
+        .expect_err("a sibling-device stable slot must never enter the local deletion journal");
+    assert!(wrong_slot_error.to_string().contains("local stable slot"));
+
+    let live_event_id = MessageId::new(vec![0x84; 32]);
+    let mut live = restarted.key_package_maintenance_status().unwrap().unwrap();
+    live.authored_event_id = Some(live_event_id.clone());
+    restarted
+        .session()
+        .put_key_package_lifecycle(&live)
+        .unwrap();
+    let error = restarted
+        .journal_discovered_retired_key_package_publication(
+            "stable-slot".into(),
+            live_event_id,
+            Timestamp(201),
+            vec![0x85; 32],
+            Timestamp(901),
+            vec![endpoint_b],
+        )
+        .expect_err("a selected live revision cannot be imported as retired");
+    assert!(error.to_string().contains("live key package revision"));
+    assert!(publisher.publications().is_empty());
+    assert!(publisher.deletions().is_empty());
+}
+
+#[tokio::test]
+async fn discovered_consumed_revision_is_deletable_without_a_successor_after_restart() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot consumed discovered revision key").unwrap();
+    let event_id = MessageId::new(vec![0x88; 32]);
+    let key_package_ref = vec![0x89; 32];
+    let endpoint = TransportEndpoint("wss://consumed-discovered.example".into());
+    let publisher = JournalKeyPackages::default();
+    let mut lifecycle = cgka_traits::KeyPackageLifecycleState::slot_only("stable-slot".into());
+    lifecycle.cutover_publication_blocked = true;
+    lifecycle.consumed_key_package_refs = vec![key_package_ref.clone()];
+    session(&database, &key, b"alice")
+        .put_key_package_lifecycle(&lifecycle)
+        .unwrap();
+
+    let mut runtime = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]),
+        publisher.clone(),
+    );
+    runtime
+        .journal_discovered_retired_key_package_publication(
+            "stable-slot".into(),
+            event_id.clone(),
+            Timestamp(300),
+            key_package_ref,
+            Timestamp(900),
+            vec![endpoint.clone()],
+        )
+        .unwrap();
+    let admitted = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert!(
+        admitted
+            .retired_publications_pending_deletion
+            .iter()
+            .find(|retired| retired.event_id == event_id)
+            .unwrap()
+            .delete_without_successor,
+        "durable Welcome evidence must transfer onto the exact relay revision"
+    );
+    assert!(publisher.deletions().is_empty());
+    drop(runtime);
+
+    let mut restarted = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]),
+        publisher.clone(),
+    );
+    restarted
+        .retry_retired_key_package_deletions_once()
+        .await
+        .unwrap();
+    assert_eq!(
+        publisher.deletions(),
+        vec![(event_id.clone(), vec![endpoint])]
+    );
+    assert!(publisher.publications().is_empty());
+    assert!(
+        restarted
+            .key_package_maintenance_status()
+            .unwrap()
+            .unwrap()
+            .retired_publications_pending_deletion
+            .iter()
+            .all(|retired| retired.event_id != event_id),
+        "the exact accepted deletion acknowledgement must settle the liability"
+    );
+}
+
+#[tokio::test]
+async fn live_revision_deletion_uses_only_the_bounded_atomic_overflow_reserve() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot live deletion atomic capacity key").unwrap();
+    let live_event_id = MessageId::new(vec![0xa1; 32]);
+    let existing_event_id = MessageId::new(vec![0xa2; 32]);
+    let mut live_endpoints = (0
+        ..=cgka_traits::maintenance::MAX_KEY_PACKAGE_LIVE_DELETION_OVERFLOW_LIABILITIES)
+        .map(|index| TransportEndpoint(format!("wss://live-{index}.example")))
+        .collect::<Vec<_>>();
+    live_endpoints.sort();
+    let existing_endpoints = (0
+        ..cgka_traits::maintenance::MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES)
+        .map(|index| TransportEndpoint(format!("wss://existing-{index}.example")))
+        .collect::<Vec<_>>();
+    let mut lifecycle = cgka_traits::KeyPackageLifecycleState::slot_only("stable-slot".into());
+    lifecycle.authored_event_id = Some(live_event_id.clone());
+    lifecycle
+        .retired_publications_pending_deletion
+        .push(RetiredKeyPackagePublication {
+            event_id: existing_event_id.clone(),
+            authored_created_at: Timestamp(1),
+            key_package_ref: None,
+            package_not_after: None,
+            delete_without_successor: true,
+            deletion_targets: existing_endpoints.iter().map(deletion_target).collect(),
+        });
+    session(&database, &key, b"alice")
+        .put_key_package_lifecycle(&lifecycle)
+        .unwrap();
+    let admitted_live_endpoints = live_endpoints
+        [..cgka_traits::maintenance::MAX_KEY_PACKAGE_LIVE_DELETION_OVERFLOW_LIABILITIES]
+        .to_vec();
+    let publisher =
+        JournalKeyPackages::default().with_deletion_receipts(vec![KeyPackagePublishReceipt {
+            accepted: Vec::new(),
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: admitted_live_endpoints.clone(),
+        }]);
+    let mut runtime = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]),
+        publisher.clone(),
+    );
+
+    let (admitted, deferred) = runtime
+        .prepare_key_package_deletion_recovery(&live_event_id, live_endpoints.clone())
+        .unwrap();
+    assert!(admitted.is_empty());
+    assert_eq!(deferred, live_endpoints);
+    let before_admission = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert!(
+        !before_admission
+            .deleted_live_revision_event_ids
+            .contains(&live_event_id)
+    );
+    assert!(
+        before_admission
+            .retired_publications_pending_deletion
+            .iter()
+            .all(|retired| retired.event_id != live_event_id),
+        "a request larger than the reserve must not admit a live endpoint subset"
+    );
+
+    let (receipt, deferred) = runtime
+        .delete_key_package_revision_durably(&live_event_id, admitted_live_endpoints.clone())
+        .await
+        .unwrap();
+    assert_eq!(receipt.failed, admitted_live_endpoints);
+    assert!(deferred.is_empty());
+    assert_eq!(publisher.deletions().len(), 1);
+    assert_eq!(publisher.deletions()[0].0, live_event_id);
+    let retained = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert!(
+        retained
+            .deleted_live_revision_event_ids
+            .contains(&live_event_id)
+    );
+    let live_retired = retained
+        .retired_publications_pending_deletion
+        .iter()
+        .find(|retired| retired.event_id == live_event_id)
+        .expect("every failed live endpoint remains durably retryable");
+    assert_eq!(
+        live_retired.deletion_targets.len(),
+        cgka_traits::maintenance::MAX_KEY_PACKAGE_LIVE_DELETION_OVERFLOW_LIABILITIES
+    );
+    assert_eq!(
+        retained
+            .retired_publications_pending_deletion
+            .iter()
+            .map(|retired| retired.deletion_targets.len())
+            .sum::<usize>(),
+        cgka_traits::maintenance::MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES_WITH_LIVE_DELETION_OVERFLOW
+    );
+    assert_eq!(
+        retained.deletion_overflow_owner_event_id,
+        Some(live_event_id.clone())
+    );
+
+    drop(runtime);
+    let mut restarted = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]),
+        publisher,
+    );
+    let (admitted, deferred) = restarted
+        .prepare_key_package_deletion_recovery(
+            &live_event_id,
+            vec![live_endpoints.last().unwrap().clone()],
+        )
+        .unwrap();
+    assert!(admitted.is_empty());
+    assert_eq!(deferred, vec![live_endpoints.last().unwrap().clone()]);
+    let restarted_status = restarted.key_package_maintenance_status().unwrap().unwrap();
+    assert!(
+        restarted_status
+            .deleted_live_revision_event_ids
+            .contains(&live_event_id),
+        "restart must retain both the live-delete marker and the full reserve"
+    );
+    assert_eq!(
+        restarted_status.deletion_overflow_owner_event_id,
+        Some(live_event_id),
+        "the full reserve must retain its exact owner after restart"
+    );
+}
+
+#[tokio::test]
+async fn unknown_exact_deletion_uses_the_reserve_instead_of_partial_admission() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot unknown exact deletion reserve key").unwrap();
+    let existing_event_id = MessageId::new(vec![0xb1; 32]);
+    let deleting_event_id = MessageId::new(vec![0xb2; 32]);
+    let existing_endpoints = (0
+        ..cgka_traits::maintenance::MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES - 1)
+        .map(|index| TransportEndpoint(format!("wss://existing-{index}.example")))
+        .collect::<Vec<_>>();
+    let mut deleting_endpoints = vec![
+        TransportEndpoint("wss://delete-b.example".into()),
+        TransportEndpoint("wss://delete-a.example".into()),
+    ];
+    deleting_endpoints.sort();
+    let mut lifecycle = cgka_traits::KeyPackageLifecycleState::slot_only("stable-slot".into());
+    lifecycle
+        .retired_publications_pending_deletion
+        .push(RetiredKeyPackagePublication {
+            event_id: existing_event_id,
+            authored_created_at: Timestamp(1),
+            key_package_ref: None,
+            package_not_after: None,
+            delete_without_successor: true,
+            deletion_targets: existing_endpoints.iter().map(deletion_target).collect(),
+        });
+    session(&database, &key, b"alice")
+        .put_key_package_lifecycle(&lifecycle)
+        .unwrap();
+    let mut runtime = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]),
+        JournalKeyPackages::default(),
+    );
+
+    let (admitted, deferred) = runtime
+        .prepare_key_package_deletion_recovery(&deleting_event_id, deleting_endpoints.clone())
+        .unwrap();
+    assert_eq!(admitted, deleting_endpoints);
+    assert!(deferred.is_empty());
+    let retained = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(
+        retained
+            .retired_publications_pending_deletion
+            .iter()
+            .map(|retired| retired.deletion_targets.len())
+            .sum::<usize>(),
+        cgka_traits::maintenance::MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES + 1
+    );
+    assert_eq!(
+        retained
+            .retired_publications_pending_deletion
+            .iter()
+            .find(|retired| retired.event_id == deleting_event_id)
+            .unwrap()
+            .deletion_targets
+            .len(),
+        2,
+        "an unprojected id can still be an older same-slot revision, so its relay set is atomic"
+    );
+    assert_eq!(
+        retained.deletion_overflow_owner_event_id,
+        Some(deleting_event_id.clone()),
+        "the exact event that crossed the ordinary bound must durably own the reserve"
+    );
+    drop(runtime);
+
+    let restarted = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]),
+        JournalKeyPackages::default(),
+    );
+    let restarted = restarted.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(
+        restarted
+            .retired_publications_pending_deletion
+            .iter()
+            .find(|retired| retired.event_id == deleting_event_id)
+            .unwrap()
+            .deletion_targets
+            .len(),
+        2
+    );
+    assert_eq!(
+        restarted.deletion_overflow_owner_event_id,
+        Some(deleting_event_id),
+        "reserve ownership must survive reopening the account database"
+    );
+}
+
+#[tokio::test]
+async fn exact_deletion_overflow_owner_blocks_siblings_until_all_targets_are_terminal() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot exact deletion reserve owner key").unwrap();
+    let existing_event_id = MessageId::new(vec![0xc1; 32]);
+    let owner_event_id = MessageId::new(vec![0xc2; 32]);
+    let sibling_event_id = MessageId::new(vec![0xc3; 32]);
+    let existing_endpoints = (0
+        ..cgka_traits::maintenance::MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES - 1)
+        .map(|index| TransportEndpoint(format!("wss://existing-owner-{index}.example")))
+        .collect::<Vec<_>>();
+    let owner_a = TransportEndpoint("wss://owner-a.example".into());
+    let owner_b = TransportEndpoint("wss://owner-b.example".into());
+    let owner_c = TransportEndpoint("wss://owner-c.example".into());
+    let sibling_a = TransportEndpoint("wss://sibling-a.example".into());
+    let sibling_b = TransportEndpoint("wss://sibling-b.example".into());
+    let mut lifecycle = cgka_traits::KeyPackageLifecycleState::slot_only("stable-slot".into());
+    lifecycle
+        .retired_publications_pending_deletion
+        .push(RetiredKeyPackagePublication {
+            event_id: existing_event_id,
+            authored_created_at: Timestamp(1),
+            key_package_ref: None,
+            package_not_after: None,
+            delete_without_successor: true,
+            deletion_targets: existing_endpoints.iter().map(deletion_target).collect(),
+        });
+    session(&database, &key, b"alice")
+        .put_key_package_lifecycle(&lifecycle)
+        .unwrap();
+    let publisher = JournalKeyPackages::default().with_deletion_receipts(vec![
+        KeyPackagePublishReceipt {
+            accepted: vec![owner_a.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: vec![owner_b.clone(), owner_c.clone()],
+        },
+        KeyPackagePublishReceipt {
+            accepted: vec![owner_b.clone(), owner_c.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+    ]);
+    let mut runtime = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]),
+        publisher.clone(),
+    );
+
+    let (admitted, deferred) = runtime
+        .prepare_key_package_deletion_recovery(
+            &owner_event_id,
+            vec![owner_b.clone(), owner_a.clone()],
+        )
+        .unwrap();
+    assert_eq!(admitted, vec![owner_a.clone(), owner_b.clone()]);
+    assert!(deferred.is_empty());
+    assert_eq!(
+        runtime
+            .key_package_maintenance_status()
+            .unwrap()
+            .unwrap()
+            .deletion_overflow_owner_event_id,
+        Some(owner_event_id.clone())
+    );
+    drop(runtime);
+
+    let mut restarted = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]),
+        publisher.clone(),
+    );
+    let (admitted, deferred) = restarted
+        .prepare_key_package_deletion_recovery(
+            &owner_event_id,
+            vec![owner_c.clone(), owner_b.clone(), owner_a.clone()],
+        )
+        .unwrap();
+    assert_eq!(
+        admitted,
+        vec![owner_a.clone(), owner_b.clone(), owner_c.clone()],
+        "same-event retries must return already durable targets and atomically add new ones"
+    );
+    assert!(deferred.is_empty());
+
+    let (admitted, deferred) = restarted
+        .prepare_key_package_deletion_recovery(&sibling_event_id, vec![sibling_a.clone()])
+        .unwrap();
+    assert!(admitted.is_empty());
+    assert_eq!(deferred, vec![sibling_a.clone()]);
+
+    let (receipt, deferred) = restarted
+        .delete_key_package_revision_durably(
+            &owner_event_id,
+            vec![owner_c.clone(), owner_b.clone(), owner_a.clone()],
+        )
+        .await
+        .unwrap();
+    assert_eq!(receipt.accepted, vec![owner_a.clone()]);
+    assert_eq!(receipt.failed, vec![owner_b.clone(), owner_c.clone()]);
+    assert!(deferred.is_empty());
+    assert_eq!(
+        restarted
+            .key_package_maintenance_status()
+            .unwrap()
+            .unwrap()
+            .deletion_overflow_owner_event_id,
+        Some(owner_event_id.clone()),
+        "partial terminal receipts must not release the reserve owner"
+    );
+    let (admitted, deferred) = restarted
+        .prepare_key_package_deletion_recovery(&sibling_event_id, vec![sibling_a.clone()])
+        .unwrap();
+    assert!(admitted.is_empty());
+    assert_eq!(deferred, vec![sibling_a.clone()]);
+
+    let (receipt, deferred) = restarted
+        .delete_key_package_revision_durably(
+            &owner_event_id,
+            vec![owner_c.clone(), owner_b.clone()],
+        )
+        .await
+        .unwrap();
+    assert_eq!(receipt.accepted, vec![owner_b.clone(), owner_c.clone()]);
+    assert!(deferred.is_empty());
+    assert!(
+        restarted
+            .key_package_maintenance_status()
+            .unwrap()
+            .unwrap()
+            .deletion_overflow_owner_event_id
+            .is_none(),
+        "the final terminal receipt must release the durable owner"
+    );
+
+    let (admitted, deferred) = restarted
+        .prepare_key_package_deletion_recovery(
+            &sibling_event_id,
+            vec![sibling_b.clone(), sibling_a.clone()],
+        )
+        .unwrap();
+    assert_eq!(admitted, vec![sibling_a, sibling_b]);
+    assert!(deferred.is_empty());
+    assert_eq!(
+        restarted
+            .key_package_maintenance_status()
+            .unwrap()
+            .unwrap()
+            .deletion_overflow_owner_event_id,
+        Some(sibling_event_id),
+        "a later exact deletion may claim the reserve only after release"
+    );
+}
+
+#[tokio::test]
+async fn maintenance_retry_releases_the_overflow_owner_after_its_terminal_receipt() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot maintenance deletion reserve release key").unwrap();
+    let owner_event_id = MessageId::new(vec![0xd1; 32]);
+    let ordinary_event_id = MessageId::new(vec![0xd2; 32]);
+    let owner_endpoint = TransportEndpoint("wss://maintenance-owner.example".into());
+    let ordinary_endpoints = (0
+        ..cgka_traits::maintenance::MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES)
+        .map(|index| TransportEndpoint(format!("wss://maintenance-ordinary-{index}.example")))
+        .collect::<Vec<_>>();
+    let mut lifecycle = cgka_traits::KeyPackageLifecycleState::slot_only("stable-slot".into());
+    lifecycle.deletion_overflow_owner_event_id = Some(owner_event_id.clone());
+    lifecycle
+        .retired_publications_pending_deletion
+        .push(retired_revision(
+            owner_event_id.clone(),
+            Timestamp(0),
+            std::slice::from_ref(&owner_endpoint),
+        ));
+    lifecycle
+        .retired_publications_pending_deletion
+        .push(retired_revision(
+            ordinary_event_id,
+            Timestamp(1),
+            &ordinary_endpoints,
+        ));
+    session(&database, &key, b"alice")
+        .put_key_package_lifecycle(&lifecycle)
+        .unwrap();
+    let publisher = JournalKeyPackages::default();
+    let mut restarted = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]),
+        publisher.clone(),
+    );
+
+    restarted
+        .retry_retired_key_package_deletions_once()
+        .await
+        .unwrap();
+    assert_eq!(
+        publisher.deletions(),
+        vec![(owner_event_id.clone(), vec![owner_endpoint])]
+    );
+    let settled = restarted.key_package_maintenance_status().unwrap().unwrap();
+    assert!(settled.deletion_overflow_owner_event_id.is_none());
+    assert!(
+        settled
+            .retired_publications_pending_deletion
+            .iter()
+            .all(|retired| retired.event_id != owner_event_id)
+    );
+    assert_eq!(
+        settled
+            .retired_publications_pending_deletion
+            .iter()
+            .map(|retired| retired.deletion_targets.len())
+            .sum::<usize>(),
+        cgka_traits::maintenance::MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES
+    );
+}
+
+#[test]
+fn unparsed_exact_discovery_claims_the_overflow_and_blocks_another_exact_event() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot unparsed deletion reserve owner key").unwrap();
+    let existing_event_id = MessageId::new(vec![0xe1; 32]);
+    let owner_event_id = MessageId::new(vec![0xe2; 32]);
+    let sibling_event_id = MessageId::new(vec![0xe3; 32]);
+    let existing_endpoints = (0
+        ..cgka_traits::maintenance::MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES)
+        .map(|index| TransportEndpoint(format!("wss://unparsed-existing-{index}.example")))
+        .collect::<Vec<_>>();
+    let owner_endpoint = TransportEndpoint("wss://unparsed-owner.example".into());
+    let sibling_endpoint = TransportEndpoint("wss://unparsed-sibling.example".into());
+    let mut lifecycle = cgka_traits::KeyPackageLifecycleState::slot_only("stable-slot".into());
+    lifecycle
+        .retired_publications_pending_deletion
+        .push(retired_revision(
+            existing_event_id,
+            Timestamp(1),
+            &existing_endpoints,
+        ));
+    session(&database, &key, b"alice")
+        .put_key_package_lifecycle(&lifecycle)
+        .unwrap();
+    let mut runtime = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]),
+        JournalKeyPackages::default(),
+    );
+
+    let (admitted, deferred) = runtime
+        .journal_discovered_unparsed_key_package_publication(
+            "stable-slot".into(),
+            owner_event_id.clone(),
+            Timestamp(2),
+            vec![owner_endpoint.clone()],
+        )
+        .unwrap();
+    assert_eq!(admitted, vec![owner_endpoint]);
+    assert!(deferred.is_empty());
+    assert_eq!(
+        runtime
+            .key_package_maintenance_status()
+            .unwrap()
+            .unwrap()
+            .deletion_overflow_owner_event_id,
+        Some(owner_event_id)
+    );
+
+    let (admitted, deferred) = runtime
+        .journal_discovered_unparsed_key_package_publication(
+            "stable-slot".into(),
+            sibling_event_id.clone(),
+            Timestamp(3),
+            vec![sibling_endpoint.clone()],
+        )
+        .unwrap();
+    assert!(admitted.is_empty());
+    assert_eq!(deferred, vec![sibling_endpoint]);
+    let retained = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(retained.authored_event_created_at, Some(Timestamp(3)));
+    assert!(
+        retained
+            .retired_publications_pending_deletion
+            .iter()
+            .all(|retired| retired.event_id != sibling_event_id),
+        "a sibling exact set must remain wholly outside the durable journal"
+    );
+}
+
+#[test]
+fn active_overflow_owner_allows_only_ordinary_refill_to_the_base_bound() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot ordinary refill with reserve owner key").unwrap();
+    let owner_event_id = MessageId::new(vec![0xf1; 32]);
+    let existing_event_id = MessageId::new(vec![0xf2; 32]);
+    let ordinary_event_id = MessageId::new(vec![0xf3; 32]);
+    let sibling_exact_event_id = MessageId::new(vec![0xf4; 32]);
+    let existing_endpoints = (0..250)
+        .map(|index| TransportEndpoint(format!("wss://refill-existing-{index}.example")))
+        .collect::<Vec<_>>();
+    let owner_endpoints = (0..4)
+        .map(|index| TransportEndpoint(format!("wss://refill-owner-{index}.example")))
+        .collect::<Vec<_>>();
+    let mut ordinary_endpoints = vec![
+        TransportEndpoint("wss://refill-ordinary-c.example".into()),
+        TransportEndpoint("wss://refill-ordinary-a.example".into()),
+        TransportEndpoint("wss://refill-ordinary-b.example".into()),
+    ];
+    ordinary_endpoints.sort();
+    let sibling_endpoint = TransportEndpoint("wss://refill-sibling-exact.example".into());
+    let mut lifecycle = cgka_traits::KeyPackageLifecycleState::slot_only("stable-slot".into());
+    lifecycle.deletion_overflow_owner_event_id = Some(owner_event_id.clone());
+    lifecycle
+        .retired_publications_pending_deletion
+        .push(retired_revision(
+            owner_event_id.clone(),
+            Timestamp(0),
+            &owner_endpoints,
+        ));
+    lifecycle
+        .retired_publications_pending_deletion
+        .push(retired_revision(
+            existing_event_id,
+            Timestamp(1),
+            &existing_endpoints,
+        ));
+    session(&database, &key, b"alice")
+        .put_key_package_lifecycle(&lifecycle)
+        .unwrap();
+    let mut runtime = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]),
+        JournalKeyPackages::default(),
+    );
+
+    let (admitted, deferred) = runtime
+        .journal_discovered_retired_key_package_publication(
+            "stable-slot".into(),
+            ordinary_event_id,
+            Timestamp(2),
+            vec![0x55; 32],
+            Timestamp(900),
+            ordinary_endpoints.clone(),
+        )
+        .unwrap();
+    assert_eq!(admitted, ordinary_endpoints[..2]);
+    assert_eq!(deferred, ordinary_endpoints[2..]);
+    let retained = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(
+        retained.deletion_overflow_owner_event_id,
+        Some(owner_event_id)
+    );
+    assert_eq!(
+        retained
+            .retired_publications_pending_deletion
+            .iter()
+            .map(|retired| retired.deletion_targets.len())
+            .sum::<usize>(),
+        cgka_traits::maintenance::MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES
+    );
+
+    let (admitted, deferred) = runtime
+        .prepare_key_package_deletion_recovery(
+            &sibling_exact_event_id,
+            vec![sibling_endpoint.clone()],
+        )
+        .unwrap();
+    assert!(admitted.is_empty());
+    assert_eq!(deferred, vec![sibling_endpoint]);
+}
+
+#[tokio::test]
+async fn discovered_high_water_forces_pending_revision_strictly_newer_before_retry() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot discovered high-water pending key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let publisher = JournalKeyPackages::default().with_publication_receipts(vec![
+        KeyPackagePublishReceipt {
+            accepted: Vec::new(),
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: vec![endpoint.clone()],
+        },
+        KeyPackagePublishReceipt {
+            accepted: vec![endpoint.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+    ]);
+    let wall = Arc::new(TestWallClock::new(10_000));
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint.clone()]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall,
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(103)),
+    );
+
+    runtime
+        .publish_fresh_key_package()
+        .await
+        .expect_err("the first pending revision remains ambiguously exposed");
+    let original = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let original_pending = original.pending_replacement.as_ref().unwrap();
+    let original_artifact = original_pending.signed_event.clone().unwrap();
+    let discovered_event_id = MessageId::new(vec![0x91; 32]);
+    let discovered_created_at = Timestamp(original_artifact.created_at.0 + 25);
+    runtime
+        .journal_discovered_retired_key_package_publication(
+            original.stable_slot_id,
+            discovered_event_id.clone(),
+            discovered_created_at,
+            vec![0x92; 32],
+            Timestamp(20_000),
+            vec![endpoint.clone()],
+        )
+        .unwrap();
+    assert!(
+        runtime.key_package_network_maintenance_due().unwrap(),
+        "ordering repair must not wait for the failed target's ordinary backoff"
+    );
+
+    runtime
+        .run_due_maintenance()
+        .await
+        .expect("maintenance must supersede the relay-discovered high-water");
+    runtime
+        .retry_retired_key_package_deletions_once()
+        .await
+        .expect("the bounded follow-up pass deletes the second eligible predecessor");
+
+    let artifacts = publisher.artifacts();
+    assert_eq!(artifacts.len(), 2);
+    assert_eq!(artifacts[0], original_artifact);
+    assert!(artifacts[1].created_at > discovered_created_at);
+    assert_ne!(artifacts[1].id, original_artifact.id);
+    let repaired = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert!(repaired.pending_replacement.is_none());
+    assert_eq!(repaired.authored_signed_event, Some(artifacts[1].clone()));
+    assert_eq!(
+        repaired.authored_event_created_at,
+        Some(artifacts[1].created_at)
+    );
+    assert!(
+        repaired
+            .retired_publications_pending_deletion
+            .iter()
+            .all(|retired| retired.event_id != discovered_event_id),
+        "the accepted strictly newer successor makes the discovered revision deletable"
+    );
+    assert!(
+        publisher
+            .deletions()
+            .iter()
+            .any(|(event_id, endpoints)| event_id == &discovered_event_id
+                && endpoints == std::slice::from_ref(&endpoint))
+    );
+}
+
+#[tokio::test]
+async fn repeated_ambiguous_stale_retries_keep_every_predecessor_and_continue_forward() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot ambiguous stale chain key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let failed_receipt = || KeyPackagePublishReceipt {
+        accepted: Vec::new(),
+        rejected: Vec::new(),
+        confirmed_absent: Vec::new(),
+        failed: vec![endpoint.clone()],
+    };
+    let publisher = JournalKeyPackages::default()
+        .reauthor_after_secs(600)
+        .with_publication_receipts(vec![failed_receipt(), failed_receipt(), failed_receipt()]);
+    let wall = Arc::new(TestWallClock::new(40_000));
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint.clone()]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(67)),
+    );
+
+    for now in [40_000, 40_600, 41_200] {
+        wall.set(now);
+        runtime
+            .publish_fresh_key_package()
+            .await
+            .expect_err("each ambiguous relay attempt remains unacknowledged");
+    }
+
+    let artifacts = publisher.artifacts();
+    assert_eq!(artifacts.len(), 3);
+    assert_ne!(artifacts[0].id, artifacts[1].id);
+    assert_ne!(artifacts[1].id, artifacts[2].id);
+    let lifecycle = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let retired_ids = lifecycle
+        .retired_publications_pending_deletion
+        .iter()
+        .map(|retired| retired.event_id.clone())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        retired_ids,
+        vec![artifacts[0].id.clone(), artifacts[1].id.clone()]
+    );
+    assert!(
+        lifecycle
+            .retired_publications_pending_deletion
+            .iter()
+            .all(|retired| retired.deletion_targets.len() == 1
+                && retired.deletion_targets[0].endpoint == endpoint)
+    );
+    assert_eq!(
+        lifecycle
+            .pending_replacement
+            .as_ref()
+            .and_then(|pending| pending.signed_event.as_ref())
+            .map(|artifact| artifact.id.clone()),
+        Some(artifacts[2].id.clone())
+    );
+}
+
+#[tokio::test]
+async fn stale_pending_reauthor_prepare_failure_keeps_prior_lifecycle_unchanged() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot failed pending reauthor key").unwrap();
+    let wall = Arc::new(TestWallClock::new(20_000));
+    let publisher = ReauthorPrepareFailsKeyPackages::default();
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![])
+            .key_package_endpoints(vec![TransportEndpoint("wss://keys.example".into())]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(47)),
+    );
+
+    runtime
+        .publish_fresh_key_package()
+        .await
+        .expect_err("initial publication is injected to fail");
+    let before = runtime.key_package_maintenance_status().unwrap().unwrap();
+    wall.set(20_600);
+    runtime
+        .publish_fresh_key_package()
+        .await
+        .expect_err("reauthor signing failure must propagate before network exposure");
+
+    assert_eq!(
+        runtime.key_package_maintenance_status().unwrap(),
+        Some(before),
+        "signing precedes mutation, so the old durable revision remains exactly retryable"
+    );
+    assert_eq!(publisher.preparations.lock().unwrap().len(), 2);
+    assert_eq!(
+        publisher.publications.lock().unwrap().len(),
+        1,
+        "a failed replacement signature must never reach the transport"
+    );
+}
+
+#[tokio::test]
+async fn opted_in_pending_key_package_retry_blocks_on_large_clock_rollback() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot pending retry rollback key").unwrap();
+    let wall = Arc::new(TestWallClock::new(50_000));
+    let publisher = FlakyKeyPackages::new(1).reauthor_after_secs(600);
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![])
+            .key_package_endpoints(vec![TransportEndpoint("wss://keys.example".into())]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(37)),
+    );
+
+    runtime
+        .publish_fresh_key_package()
+        .await
+        .expect_err("first publication is intentionally unacknowledged");
+    let original = runtime
+        .key_package_maintenance_status()
+        .unwrap()
+        .unwrap()
+        .pending_replacement
+        .unwrap()
+        .signed_event
+        .unwrap();
+    wall.set(1);
+    let error = runtime
+        .publish_fresh_key_package()
+        .await
+        .expect_err("a far-future durable artifact must not be sent after clock rollback");
+    assert!(matches!(error, AccountError::ClockSkewBlocked));
+    assert_eq!(publisher.publications().len(), 1);
+    let lifecycle = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(
+        lifecycle.phase,
+        cgka_traits::MaintenancePhase::ClockSkewBlocked
+    );
+    assert_eq!(
+        lifecycle.pending_replacement.unwrap().signed_event,
+        Some(original)
+    );
+}
+
+#[tokio::test]
+async fn publisher_without_reauthor_policy_preserves_exact_retry_across_clock_rollback() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot exact retry rollback key").unwrap();
+    let wall = Arc::new(TestWallClock::new(50_000));
+    let publisher = FlakyKeyPackages::new(1);
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![])
+            .key_package_endpoints(vec![TransportEndpoint("wss://keys.example".into())]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(41)),
+    );
+
+    runtime
+        .publish_fresh_key_package()
+        .await
+        .expect_err("first publication is intentionally unacknowledged");
+    wall.set(1);
+    runtime
+        .publish_fresh_key_package()
+        .await
+        .expect("a publisher that did not opt in retains legacy exact-retry behavior");
+
+    let publications = publisher.publications();
+    let artifacts = publisher.artifacts();
+    assert_eq!(publications.len(), 2);
+    assert_eq!(publications[0], publications[1]);
+    assert_eq!(artifacts[0], artifacts[1]);
 }
 
 #[tokio::test]
@@ -1256,10 +3909,146 @@ async fn key_package_rotation_reuses_stable_slot_and_monotonically_advances_crea
     assert_ne!(first, second);
 
     let lifecycle = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let first_event_id = test_key_package_artifact(&publications[0]).id;
+    let retired = lifecycle
+        .retired_publications_pending_deletion
+        .iter()
+        .find(|retired| retired.event_id == first_event_id)
+        .expect("routine rotation retains the superseded signed event id");
+    assert_eq!(
+        retired
+            .deletion_targets
+            .iter()
+            .map(|target| target.endpoint.clone())
+            .collect::<Vec<_>>(),
+        publications[0].endpoints
+    );
     assert_eq!(lifecycle.retained_private_material.len(), 1);
     assert_eq!(
         lifecycle.retained_private_material[0].key_package,
         publications[0].key_package
+    );
+}
+
+#[tokio::test]
+async fn legacy_current_without_signed_bytes_is_retired_across_partial_rotation_and_restart() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot legacy current rotation journal key").unwrap();
+    let endpoint_a = TransportEndpoint("wss://keys-a.example".into());
+    let endpoint_b = TransportEndpoint("wss://keys-b.example".into());
+    let routing = StaticTransportRouting::new(vec![])
+        .key_package_endpoints(vec![endpoint_a.clone(), endpoint_b.clone()]);
+    let wall = Arc::new(TestWallClock::new(23_000));
+    let publisher = JournalKeyPackages::default().with_publication_receipts(vec![
+        KeyPackagePublishReceipt {
+            accepted: vec![endpoint_a.clone(), endpoint_b.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+        KeyPackagePublishReceipt {
+            accepted: vec![endpoint_a.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: vec![endpoint_b.clone()],
+        },
+        KeyPackagePublishReceipt {
+            accepted: vec![endpoint_b.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+    ]);
+    let old_event_id;
+    let old_created_at;
+    let old_key_package_ref;
+    {
+        let mut runtime = AccountDeviceRuntime::new(
+            session(&database, &key, b"alice"),
+            RecordingAdapter::default(),
+            routing.clone(),
+            publisher.clone(),
+        )
+        .with_maintenance_sources(
+            wall.clone(),
+            Arc::new(TestMonotonicClock::default()),
+            Arc::new(TestRandom::new(12)),
+        );
+        runtime.publish_fresh_key_package().await.unwrap();
+        let mut legacy = runtime.key_package_maintenance_status().unwrap().unwrap();
+        old_event_id = legacy.authored_event_id.clone().unwrap();
+        old_created_at = legacy.authored_event_created_at.unwrap();
+        old_key_package_ref = legacy.current_key_package_ref.clone().unwrap();
+        legacy.authored_signed_event = None;
+        runtime
+            .session()
+            .put_key_package_lifecycle(&legacy)
+            .unwrap();
+
+        runtime
+            .publish_fresh_key_package()
+            .await
+            .expect("one successor ACK promotes despite partial fanout");
+        let rotated = runtime.key_package_maintenance_status().unwrap().unwrap();
+        let retired = rotated
+            .retired_publications_pending_deletion
+            .iter()
+            .find(|retired| retired.event_id == old_event_id)
+            .expect("legacy authored id is snapshotted before promotion overwrites it");
+        assert_eq!(retired.authored_created_at, old_created_at);
+        assert_eq!(retired.key_package_ref, Some(old_key_package_ref.clone()));
+        assert!(!retired.delete_without_successor);
+        assert_eq!(
+            retired
+                .deletion_targets
+                .iter()
+                .map(|target| target.endpoint.clone())
+                .collect::<Vec<_>>(),
+            vec![endpoint_a.clone(), endpoint_b.clone()]
+        );
+    }
+
+    wall.set(23_030);
+    let mut restarted = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        routing.clone(),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(12)),
+    );
+    restarted.pause_maintenance();
+    restarted.run_due_maintenance().await.unwrap();
+    assert_eq!(
+        publisher.deletions(),
+        vec![(old_event_id.clone(), vec![endpoint_a.clone()])],
+        "the replacement first completes fanout, then one old endpoint drains per call"
+    );
+    let after_first = restarted.key_package_maintenance_status().unwrap().unwrap();
+    let retired = after_first
+        .retired_publications_pending_deletion
+        .iter()
+        .find(|retired| retired.event_id == old_event_id)
+        .expect("the second endpoint remains durable across the restarted call boundary");
+    assert_eq!(retired.deletion_targets.len(), 1);
+    assert_eq!(retired.deletion_targets[0].endpoint, endpoint_b);
+    restarted.run_due_maintenance().await.unwrap();
+    assert_eq!(
+        publisher.deletions()[1],
+        (old_event_id.clone(), vec![endpoint_b])
+    );
+    assert!(
+        restarted
+            .key_package_maintenance_status()
+            .unwrap()
+            .unwrap()
+            .retired_publications_pending_deletion
+            .iter()
+            .all(|retired| retired.event_id != old_event_id)
     );
 }
 
@@ -1343,6 +4132,306 @@ async fn key_package_first_ack_promotes_then_paused_maintenance_finishes_exact_f
             .iter()
             .all(|target| { target.state == cgka_traits::TransportFanoutAttemptState::Accepted })
     );
+}
+
+#[tokio::test]
+async fn stale_current_key_package_reauthor_resets_and_fans_out_to_every_live_target() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot stale current fanout key").unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let publisher = PartialFanoutKeyPackages::default().reauthor_after_secs(600);
+    let wall = Arc::new(TestWallClock::new(70_000));
+    let routing = StaticTransportRouting::new(vec![]).key_package_endpoints(vec![
+        TransportEndpoint("wss://keys-a.example".into()),
+        TransportEndpoint("wss://keys-b.example".into()),
+    ]);
+    let mut runtime = AccountDeviceRuntime::new(
+        session(database.clone(), &key, b"alice"),
+        RecordingAdapter::default(),
+        routing.clone(),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(43)),
+    );
+
+    runtime
+        .publish_fresh_key_package()
+        .await
+        .expect("one acknowledgement promotes the first revision");
+    let before = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let before_artifact = before.authored_signed_event.clone().unwrap();
+    assert_eq!(
+        before
+            .publication_targets
+            .iter()
+            .filter(|target| target.state == cgka_traits::TransportFanoutAttemptState::Accepted)
+            .count(),
+        1
+    );
+    drop(runtime);
+
+    wall.set(70_600);
+    let mut restarted = AccountDeviceRuntime::new(
+        session(database, &key, b"alice"),
+        RecordingAdapter::default(),
+        routing,
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall,
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(43)),
+    );
+    restarted.pause_maintenance();
+    restarted
+        .run_due_maintenance()
+        .await
+        .expect("stale current revision is reauthored and fanned out");
+
+    let calls = publisher.publications();
+    assert_eq!(calls.len(), 2);
+    assert_eq!(calls[1].0.key_package, calls[0].0.key_package);
+    assert_eq!(calls[1].0.slot_id, calls[0].0.slot_id);
+    assert_eq!(calls[1].0.created_at, Timestamp(70_600));
+    assert_ne!(calls[1].1, before_artifact);
+    assert_eq!(
+        calls[1].0.endpoints,
+        vec![
+            TransportEndpoint("wss://keys-a.example".into()),
+            TransportEndpoint("wss://keys-b.example".into()),
+        ],
+        "a newer replaceable revision must supersede the old event on every live relay"
+    );
+    let after = restarted.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(after.authored_event_id, Some(calls[1].1.id.clone()));
+    assert_eq!(after.authored_event_created_at, Some(Timestamp(70_600)));
+    assert_eq!(after.authored_signed_event, Some(calls[1].1.clone()));
+    assert!(after.publication_targets.iter().all(|target| {
+        target.state == cgka_traits::TransportFanoutAttemptState::Accepted
+            && target.attempt_count == 1
+            && target.failure_code.is_none()
+    }));
+}
+
+#[tokio::test]
+async fn retired_deletion_prunes_only_acked_endpoint_and_restart_retries_the_failed_endpoint() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot retired endpoint deletion key").unwrap();
+    let endpoint_a = TransportEndpoint("wss://keys-a.example".into());
+    let endpoint_b = TransportEndpoint("wss://keys-b.example".into());
+    let unknown_provenance_id = MessageId::new(vec![0x70; 32]);
+    let retired_id = MessageId::new(vec![0x71; 32]);
+    let wall = Arc::new(TestWallClock::new(50_000));
+    let publisher = JournalKeyPackages::default().with_deletion_receipts(vec![
+        KeyPackagePublishReceipt {
+            accepted: vec![endpoint_a.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+        KeyPackagePublishReceipt {
+            accepted: Vec::new(),
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: vec![endpoint_b.clone()],
+        },
+        KeyPackagePublishReceipt {
+            accepted: vec![endpoint_b.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+    ]);
+    let routing = StaticTransportRouting::new(vec![])
+        .key_package_endpoints(vec![endpoint_a.clone(), endpoint_b.clone()]);
+    let mut runtime = AccountDeviceRuntime::new(
+        session(database.clone(), &key, b"alice"),
+        RecordingAdapter::default(),
+        routing.clone(),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(71)),
+    );
+    runtime.publish_fresh_key_package().await.unwrap();
+    let mut lifecycle = runtime.key_package_maintenance_status().unwrap().unwrap();
+    lifecycle
+        .retired_publications_pending_deletion
+        .push(retired_revision(
+            unknown_provenance_id.clone(),
+            Timestamp(48_000),
+            &[],
+        ));
+    lifecycle
+        .retired_publications_pending_deletion
+        .push(retired_revision(
+            retired_id.clone(),
+            Timestamp(49_000),
+            &[endpoint_a.clone(), endpoint_b.clone()],
+        ));
+    runtime
+        .session()
+        .put_key_package_lifecycle(&lifecycle)
+        .unwrap();
+    runtime.pause_maintenance();
+
+    runtime.run_due_maintenance().await.unwrap();
+    assert_eq!(
+        publisher.deletions(),
+        vec![(retired_id.clone(), vec![endpoint_a.clone()])],
+        "one maintenance call is bounded to one endpoint deletion attempt"
+    );
+    let after_a = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let retained = after_a
+        .retired_publications_pending_deletion
+        .iter()
+        .find(|retired| retired.event_id == retired_id)
+        .unwrap();
+    assert_eq!(retained.deletion_targets.len(), 1);
+    assert_eq!(retained.deletion_targets[0].endpoint, endpoint_b);
+
+    runtime.run_due_maintenance().await.unwrap();
+    assert_eq!(
+        publisher.deletions()[1],
+        (retired_id.clone(), vec![endpoint_b.clone()])
+    );
+    let after_failure = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let failed_target = &after_failure
+        .retired_publications_pending_deletion
+        .iter()
+        .find(|retired| retired.event_id == retired_id)
+        .unwrap()
+        .deletion_targets[0];
+    assert_eq!(
+        failed_target.state,
+        TransportFanoutAttemptState::AttemptedFailed
+    );
+    assert_eq!(failed_target.attempt_count, 1);
+    assert_eq!(
+        failed_target.failure_code.as_deref(),
+        Some("possible_exposure")
+    );
+    drop(runtime);
+
+    wall.set(50_030);
+    let mut restarted = AccountDeviceRuntime::new(
+        session(database, &key, b"alice"),
+        RecordingAdapter::default(),
+        routing,
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall,
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(71)),
+    );
+    restarted.pause_maintenance();
+    restarted.run_due_maintenance().await.unwrap();
+    assert_eq!(
+        publisher.deletions()[2],
+        (retired_id.clone(), vec![endpoint_b])
+    );
+    assert!(
+        restarted
+            .key_package_maintenance_status()
+            .unwrap()
+            .unwrap()
+            .retired_publications_pending_deletion
+            .iter()
+            .all(|retired| retired.event_id != retired_id)
+    );
+    let unknown_provenance = restarted
+        .key_package_maintenance_status()
+        .unwrap()
+        .unwrap()
+        .retired_publications_pending_deletion
+        .into_iter()
+        .find(|retired| retired.event_id == unknown_provenance_id)
+        .expect("unrelated deletion ACKs must preserve unknown-provenance evidence across restart");
+    assert!(unknown_provenance.deletion_targets.is_empty());
+}
+
+#[tokio::test]
+async fn retired_deletion_confirmed_absent_is_terminal_and_cleanup_calls_drain_one_target_each() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot retired deletion budget key").unwrap();
+    let endpoints = (0..3)
+        .map(|index| TransportEndpoint(format!("wss://keys-{index}.example")))
+        .collect::<Vec<_>>();
+    let retired_id = MessageId::new(vec![0x72; 32]);
+    let wall = Arc::new(TestWallClock::new(60_000));
+    let publisher = JournalKeyPackages::default().with_deletion_receipts(vec![
+        KeyPackagePublishReceipt {
+            accepted: Vec::new(),
+            rejected: Vec::new(),
+            confirmed_absent: vec![endpoints[0].clone()],
+            failed: Vec::new(),
+        },
+        KeyPackagePublishReceipt {
+            accepted: vec![endpoints[1].clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+        KeyPackagePublishReceipt {
+            accepted: vec![endpoints[2].clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+    ]);
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(endpoints.clone()),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall,
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(73)),
+    );
+    runtime.publish_fresh_key_package().await.unwrap();
+    let mut lifecycle = runtime.key_package_maintenance_status().unwrap().unwrap();
+    lifecycle
+        .retired_publications_pending_deletion
+        .push(retired_revision(
+            retired_id.clone(),
+            Timestamp(59_000),
+            &endpoints,
+        ));
+    runtime
+        .session()
+        .put_key_package_lifecycle(&lifecycle)
+        .unwrap();
+    runtime.pause_maintenance();
+
+    for expected_call_count in 1..=3 {
+        runtime.run_due_maintenance().await.unwrap();
+        let calls = publisher.deletions();
+        assert_eq!(calls.len(), expected_call_count);
+        assert_eq!(calls.last().unwrap().1.len(), 1);
+        assert_eq!(
+            calls.last().unwrap().1[0],
+            endpoints[expected_call_count - 1]
+        );
+        let remaining = runtime
+            .key_package_maintenance_status()
+            .unwrap()
+            .unwrap()
+            .retired_publications_pending_deletion
+            .iter()
+            .find(|retired| retired.event_id == retired_id)
+            .map(|retired| retired.deletion_targets.len())
+            .unwrap_or(0);
+        assert_eq!(remaining, 3 - expected_call_count);
+    }
 }
 
 #[tokio::test]
@@ -1661,8 +4750,13 @@ async fn republish_key_package_falls_back_when_current_ref_is_consumed() {
     assert_eq!(publications.len(), 2);
     assert_ne!(first, second);
     let after = runtime.key_package_maintenance_status().unwrap().unwrap();
-    assert_ne!(after.current_key_package_ref, Some(consumed_ref));
-    assert!(after.last_consumed_key_package_ref.is_none());
+    assert_ne!(after.current_key_package_ref, Some(consumed_ref.clone()));
+    assert_eq!(
+        after.last_consumed_key_package_ref,
+        Some(consumed_ref.clone()),
+        "legacy-only consumption evidence stays durable until strict relay cutover transfers it"
+    );
+    assert!(after.consumed_key_package_refs.contains(&consumed_ref));
     assert_eq!(after.retained_private_material.len(), 0);
 }
 
@@ -1825,8 +4919,105 @@ async fn republish_key_package_reauthorizes_previously_removed_endpoint() {
         reauthorized.state,
         cgka_traits::TransportFanoutAttemptState::Accepted
     );
-    assert_eq!(reauthorized.attempt_count, 1);
+    assert_eq!(
+        reauthorized.attempt_count, 2,
+        "the first attempt plus the conservative pre-I/O reauthorization marker are durable"
+    );
     assert!(reauthorized.failure_code.is_none());
+}
+
+#[tokio::test]
+async fn accepted_endpoint_removed_then_readded_keeps_exposure_after_negative_ack() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot readded endpoint exposure key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let wall = Arc::new(TestWallClock::new(70_000));
+    let publisher = JournalKeyPackages::default().with_publication_receipts(vec![
+        KeyPackagePublishReceipt {
+            accepted: vec![endpoint.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+        KeyPackagePublishReceipt {
+            accepted: Vec::new(),
+            rejected: vec![endpoint.clone()],
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+    ]);
+    let mut initial = AccountDeviceRuntime::new(
+        session(database.clone(), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint.clone()]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(79)),
+    );
+    initial.publish_fresh_key_package().await.unwrap();
+    let current_not_before = initial
+        .key_package_maintenance_status()
+        .unwrap()
+        .unwrap()
+        .current_not_before
+        .unwrap();
+    wall.set(current_not_before.0);
+    drop(initial);
+
+    let mut removed = AccountDeviceRuntime::new(
+        session(database.clone(), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(79)),
+    );
+    removed
+        .republish_key_package()
+        .await
+        .expect_err("removed policy has no authoritative endpoint");
+    let prohibited = removed.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(
+        prohibited.publication_targets[0].state,
+        TransportFanoutAttemptState::PolicyProhibited
+    );
+    assert_eq!(prohibited.publication_targets[0].attempt_count, 1);
+    drop(removed);
+
+    let mut restored = AccountDeviceRuntime::new(
+        session(database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint.clone()]),
+        publisher,
+    )
+    .with_maintenance_sources(
+        wall,
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(79)),
+    );
+    restored
+        .republish_key_package()
+        .await
+        .expect_err("negative acknowledgement has no accepted endpoint");
+    let target = restored
+        .key_package_maintenance_status()
+        .unwrap()
+        .unwrap()
+        .publication_targets
+        .into_iter()
+        .find(|target| target.endpoint == endpoint)
+        .unwrap();
+    assert_eq!(target.state, TransportFanoutAttemptState::AttemptedFailed);
+    assert_eq!(target.attempt_count, 2);
+    assert_eq!(target.failure_code.as_deref(), Some("transport_rejected"));
+    assert_ne!(target.failure_code.as_deref(), Some("confirmed_absent"));
 }
 
 #[tokio::test]
@@ -1904,11 +5095,14 @@ async fn key_package_expiry_sweep_deletes_private_material_while_network_mainten
     );
 
     runtime.publish_fresh_key_package().await.unwrap();
-    let not_after = runtime
-        .key_package_maintenance_status()
-        .unwrap()
-        .unwrap()
-        .current_not_after
+    let mut before_expiry = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let not_after = before_expiry.current_not_after.unwrap();
+    let expired_event_id = before_expiry.authored_event_id.clone().unwrap();
+    let authored_created_at = before_expiry.authored_event_created_at.unwrap();
+    before_expiry.authored_signed_event = None;
+    runtime
+        .session()
+        .put_key_package_lifecycle(&before_expiry)
         .unwrap();
 
     runtime.pause_maintenance();
@@ -1925,7 +5119,657 @@ async fn key_package_expiry_sweep_deletes_private_material_while_network_mainten
     assert!(expired.current_key_package_ref.is_none());
     assert!(expired.authored_signed_event.is_none());
     assert!(expired.publication_targets.is_empty());
+    let retired = expired
+        .retired_publications_pending_deletion
+        .iter()
+        .find(|retired| retired.event_id == expired_event_id)
+        .expect("expiry retains a legacy authored id even when signed bytes are unavailable");
+    assert_eq!(retired.authored_created_at, authored_created_at);
+    assert!(retired.delete_without_successor);
+    assert_eq!(retired.package_not_after, Some(not_after));
+    assert_eq!(retired.deletion_targets.len(), 1);
     assert!(runtime.key_package_network_maintenance_due().unwrap());
+}
+
+#[tokio::test]
+async fn paused_maintenance_still_reauthors_a_deleted_live_current_revision() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot paused deleted current recovery key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let wall = Arc::new(TestWallClock::new(82_000));
+    let publisher = JournalKeyPackages::default();
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint.clone()]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(31)),
+    );
+
+    let current_key_package = runtime.publish_fresh_key_package().await.unwrap();
+    let mut before_delete = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let unknown_provenance_event_id = MessageId::new(vec![0x75; 32]);
+    before_delete
+        .retired_publications_pending_deletion
+        .push(retired_revision(
+            unknown_provenance_event_id.clone(),
+            Timestamp(81_000),
+            &[],
+        ));
+    runtime
+        .session()
+        .put_key_package_lifecycle(&before_delete)
+        .unwrap();
+    wall.set(
+        before_delete
+            .current_not_before
+            .expect("published current KeyPackage must persist its validity start")
+            .0,
+    );
+    let deleted_event_id = before_delete.authored_event_id.clone().unwrap();
+    runtime.pause_maintenance();
+    let (deletion, deferred) = runtime
+        .delete_key_package_revision_durably(&deleted_event_id, vec![endpoint.clone()])
+        .await
+        .unwrap();
+    assert_eq!(deletion.accepted, vec![endpoint]);
+    assert!(deferred.is_empty());
+    assert!(runtime.key_package_network_maintenance_due().unwrap());
+
+    runtime
+        .run_due_maintenance()
+        .await
+        .expect("privacy recovery must cross the process-local maintenance pause");
+
+    let publications = publisher.publications();
+    let artifacts = publisher.artifacts();
+    assert_eq!(publications.len(), 2);
+    assert_eq!(artifacts.len(), 2);
+    assert_eq!(publications[1].key_package, current_key_package);
+    assert_ne!(artifacts[1].id, deleted_event_id);
+    assert!(artifacts[1].created_at > artifacts[0].created_at);
+    let recovered = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(recovered.authored_event_id, Some(artifacts[1].id.clone()));
+    assert!(recovered.deleted_live_revision_event_ids.is_empty());
+    assert!(
+        recovered
+            .retired_publications_pending_deletion
+            .iter()
+            .any(|retired| retired.event_id == unknown_provenance_event_id
+                && retired.deletion_targets.is_empty())
+    );
+    assert!(runtime.maintenance_is_paused());
+}
+
+#[tokio::test]
+async fn paused_maintenance_reauthors_a_deleted_live_current_revision_after_refresh_is_due() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot paused overdue deleted current recovery key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let wall = Arc::new(TestWallClock::new(83_000));
+    let publisher = JournalKeyPackages::default();
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint.clone()]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(33)),
+    );
+
+    let current_key_package = runtime.publish_fresh_key_package().await.unwrap();
+    let before_delete = runtime.key_package_maintenance_status().unwrap().unwrap();
+    wall.set(before_delete.refresh_at.unwrap().0);
+    let deleted_event_id = before_delete.authored_event_id.clone().unwrap();
+    runtime.pause_maintenance();
+    let (deletion, deferred) = runtime
+        .delete_key_package_revision_durably(&deleted_event_id, vec![endpoint.clone()])
+        .await
+        .unwrap();
+    assert_eq!(deletion.accepted, vec![endpoint]);
+    assert!(deferred.is_empty());
+
+    runtime
+        .run_due_maintenance()
+        .await
+        .expect("deleted-revision recovery must override pause even after refresh is due");
+
+    let publications = publisher.publications();
+    let artifacts = publisher.artifacts();
+    assert_eq!(publications.len(), 2);
+    assert_eq!(artifacts.len(), 2);
+    assert_eq!(publications[1].key_package, current_key_package);
+    assert_ne!(artifacts[1].id, deleted_event_id);
+    assert!(artifacts[1].created_at > artifacts[0].created_at);
+    let recovered = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(recovered.authored_event_id, Some(artifacts[1].id.clone()));
+    assert!(recovered.deleted_live_revision_event_ids.is_empty());
+    assert!(runtime.maintenance_is_paused());
+    assert!(runtime.key_package_network_maintenance_due().unwrap());
+}
+
+#[tokio::test]
+async fn pending_key_package_expiry_retains_signed_event_deletion_obligation() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot pending key package expiry key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let wall = Arc::new(TestWallClock::new(85_000));
+    let publisher = FlakyKeyPackages::new(1);
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint.clone()]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(83)),
+    );
+    runtime
+        .publish_fresh_key_package()
+        .await
+        .expect_err("pending publication is intentionally unacknowledged");
+    let pending = runtime
+        .key_package_maintenance_status()
+        .unwrap()
+        .unwrap()
+        .pending_replacement
+        .unwrap();
+    let pending_event_id = pending.signed_event.unwrap().id;
+    wall.set(pending.not_after.0);
+
+    assert_eq!(
+        runtime
+            .sweep_expired_key_package_private_material()
+            .unwrap(),
+        1
+    );
+    let expired = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert!(expired.pending_replacement.is_none());
+    let retired = expired
+        .retired_publications_pending_deletion
+        .iter()
+        .find(|retired| retired.event_id == pending_event_id)
+        .expect("expired pending signed event remains durably deletable");
+    assert!(retired.delete_without_successor);
+    assert_eq!(retired.package_not_after, Some(pending.not_after));
+    assert_eq!(retired.deletion_targets[0].endpoint, endpoint);
+}
+
+#[tokio::test]
+async fn deleted_current_expiry_prunes_exact_marker_before_fresh_129_endpoint_publication() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot expired deleted current marker key").unwrap();
+    let endpoints = (0..129)
+        .map(|index| TransportEndpoint(format!("wss://fresh-{index}.example")))
+        .collect::<Vec<_>>();
+    let publisher = JournalKeyPackages::default();
+    let wall = Arc::new(TestWallClock::new(150_000));
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(endpoints.clone()),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(101)),
+    );
+
+    runtime.publish_fresh_key_package().await.unwrap();
+    for cycle in 0..3 {
+        let before_delete = runtime.key_package_maintenance_status().unwrap().unwrap();
+        let deleted_event_id = before_delete.authored_event_id.clone().unwrap();
+        let deleted_key_package = before_delete.current_key_package.clone().unwrap();
+        let (deletion, deferred) = runtime
+            .delete_key_package_revision_durably(&deleted_event_id, endpoints.clone())
+            .await
+            .unwrap();
+        let mut expected_deleted_endpoints = endpoints.clone();
+        expected_deleted_endpoints.sort();
+        assert_eq!(deletion.accepted, expected_deleted_endpoints);
+        assert!(deferred.is_empty());
+
+        // Model terminal deletion acknowledgements from all 129 relays. The
+        // exact-id marker still exists until the corresponding live artifact
+        // is expired and removed by the account sweep.
+        let mut marked = runtime.key_package_maintenance_status().unwrap().unwrap();
+        assert_eq!(
+            marked.deleted_live_revision_event_ids,
+            vec![deleted_event_id.clone()]
+        );
+        assert!(marked.publication_targets.iter().all(|target| {
+            target.state == TransportFanoutAttemptState::AttemptedFailed
+                && target.failure_code.as_deref() == Some("confirmed_absent")
+        }));
+        let expires_at = Timestamp(150_001 + cycle);
+        marked.current_not_after = Some(expires_at);
+        runtime
+            .session()
+            .put_key_package_lifecycle(&marked)
+            .unwrap();
+        wall.set(expires_at.0);
+
+        assert_eq!(
+            runtime
+                .sweep_expired_key_package_private_material()
+                .unwrap(),
+            1
+        );
+        let expired = runtime.key_package_maintenance_status().unwrap().unwrap();
+        assert!(expired.current_key_package.is_none());
+        assert!(expired.deleted_live_revision_event_ids.is_empty());
+        assert!(
+            expired
+                .retired_publications_pending_deletion
+                .iter()
+                .all(|retired| retired.event_id != deleted_event_id),
+            "confirmed deletion must not leave a phantom endpoint liability"
+        );
+
+        let fresh = runtime
+            .publish_fresh_key_package()
+            .await
+            .expect("the first genuinely fresh 129-endpoint event must fit below the cap");
+        assert_ne!(fresh, deleted_key_package);
+        let replacement = runtime.key_package_maintenance_status().unwrap().unwrap();
+        assert!(replacement.deleted_live_revision_event_ids.is_empty());
+        assert_eq!(replacement.publication_targets.len(), 129);
+    }
+    assert_eq!(publisher.publications().len(), 4);
+    assert_eq!(publisher.artifacts().len(), 4);
+}
+
+#[tokio::test]
+async fn deleted_current_survives_failed_forced_pending_until_expiry_recovery_publishes_fresh() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot deleted current pending expiry recovery key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let wall = Arc::new(TestWallClock::new(160_000));
+    let accepted = || KeyPackagePublishReceipt {
+        accepted: vec![endpoint.clone()],
+        rejected: Vec::new(),
+        confirmed_absent: Vec::new(),
+        failed: Vec::new(),
+    };
+    let failed = || KeyPackagePublishReceipt {
+        accepted: Vec::new(),
+        rejected: Vec::new(),
+        confirmed_absent: Vec::new(),
+        failed: vec![endpoint.clone()],
+    };
+    let publisher = JournalKeyPackages::default().with_publication_receipts(vec![
+        accepted(),
+        failed(),
+        failed(),
+        accepted(),
+    ]);
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint.clone()]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(103)),
+    );
+
+    let current_key_package = runtime.publish_fresh_key_package().await.unwrap();
+    let current = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let current_event_id = current.authored_event_id.clone().unwrap();
+    runtime
+        .publish_fresh_key_package()
+        .await
+        .expect_err("the pending semantic successor never acknowledges");
+    let mut with_pending = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let pending = with_pending.pending_replacement.as_ref().unwrap();
+    let pending_key_package = pending.key_package.clone();
+    let pending_event_id = pending.signed_event.as_ref().unwrap().id.clone();
+    with_pending.pending_replacement.as_mut().unwrap().not_after = Timestamp(160_060);
+    runtime
+        .session()
+        .put_key_package_lifecycle(&with_pending)
+        .unwrap();
+    let (current_admitted, current_deferred) = runtime
+        .prepare_key_package_deletion_recovery(&current_event_id, vec![endpoint.clone()])
+        .unwrap();
+    let (pending_admitted, pending_deferred) = runtime
+        .prepare_key_package_deletion_recovery(&pending_event_id, vec![endpoint])
+        .unwrap();
+    assert_eq!(current_admitted.len(), 1);
+    assert!(current_deferred.is_empty());
+    assert_eq!(pending_admitted.len(), 1);
+    assert!(pending_deferred.is_empty());
+    let both_deleted = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert!(
+        both_deleted
+            .deleted_live_revision_event_ids
+            .contains(&current_event_id)
+    );
+    assert!(
+        both_deleted
+            .deleted_live_revision_event_ids
+            .contains(&pending_event_id)
+    );
+
+    runtime.run_due_maintenance().await.unwrap();
+    let forced = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let forced_pending = forced.pending_replacement.as_ref().unwrap();
+    let forced_pending_event_id = forced_pending.signed_event.as_ref().unwrap().id.clone();
+    assert_ne!(forced_pending_event_id, pending_event_id);
+    assert_eq!(forced_pending.key_package, pending_key_package);
+    assert!(
+        forced
+            .deleted_live_revision_event_ids
+            .contains(&current_event_id),
+        "forcing the exact pending successor must not erase the deleted-current recovery marker"
+    );
+    assert!(
+        !forced
+            .deleted_live_revision_event_ids
+            .contains(&pending_event_id)
+    );
+    assert_eq!(publisher.publications().len(), 3);
+
+    wall.set(160_060);
+    assert_eq!(
+        runtime
+            .sweep_expired_key_package_private_material()
+            .unwrap(),
+        1
+    );
+    let after_pending_expiry = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert!(after_pending_expiry.pending_replacement.is_none());
+    assert_eq!(
+        after_pending_expiry.current_key_package,
+        Some(current_key_package.clone())
+    );
+    assert!(
+        after_pending_expiry
+            .deleted_live_revision_event_ids
+            .contains(&current_event_id),
+        "pending expiry must retain the independent exact current recovery marker"
+    );
+
+    runtime.run_due_maintenance().await.unwrap();
+    let publications = publisher.publications();
+    let artifacts = publisher.artifacts();
+    assert_eq!(publications.len(), 4);
+    assert_eq!(artifacts.len(), 4);
+    assert_ne!(publications[3].key_package, pending_key_package);
+    assert_ne!(publications[3].key_package, current_key_package);
+    assert!(artifacts[3].created_at > artifacts[2].created_at);
+    let recovered = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert!(recovered.pending_replacement.is_none());
+    assert_eq!(recovered.authored_event_id, Some(artifacts[3].id.clone()));
+    assert!(recovered.deleted_live_revision_event_ids.is_empty());
+}
+
+#[tokio::test]
+async fn legacy_deleted_current_id_without_signed_bytes_restarts_into_fresh_semantic_recovery() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot legacy deleted current recovery key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let wall = Arc::new(TestWallClock::new(170_000));
+    let publisher = JournalKeyPackages::default();
+
+    let original_key_package;
+    let deleted_event_id;
+    {
+        let mut runtime = AccountDeviceRuntime::new(
+            session(&database, &key, b"alice"),
+            RecordingAdapter::default(),
+            StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint.clone()]),
+            publisher.clone(),
+        )
+        .with_maintenance_sources(
+            wall.clone(),
+            Arc::new(TestMonotonicClock::default()),
+            Arc::new(TestRandom::new(107)),
+        );
+        original_key_package = runtime.publish_fresh_key_package().await.unwrap();
+        let mut lifecycle = runtime.key_package_maintenance_status().unwrap().unwrap();
+        deleted_event_id = lifecycle.authored_event_id.clone().unwrap();
+
+        // Model a pre-artifact upgrade row, then exercise the durable deletion
+        // path so its terminal ACK must match the authored-id fallback rather
+        // than signed bytes that this legacy row does not contain.
+        lifecycle.authored_signed_event = None;
+        lifecycle.refresh_at = Some(Timestamp(180_000));
+        lifecycle.upgrade_rotation_recorded = true;
+        runtime
+            .session()
+            .put_key_package_lifecycle(&lifecycle)
+            .unwrap();
+        let (deletion, deferred) = runtime
+            .delete_key_package_revision_durably(&deleted_event_id, vec![endpoint.clone()])
+            .await
+            .unwrap();
+        assert_eq!(deletion.accepted, vec![endpoint.clone()]);
+        assert!(deferred.is_empty());
+        let marked = runtime.key_package_maintenance_status().unwrap().unwrap();
+        assert_eq!(
+            marked.deleted_live_revision_event_ids,
+            vec![deleted_event_id.clone()]
+        );
+        assert_eq!(
+            marked.publication_targets[0].failure_code.as_deref(),
+            Some("confirmed_absent")
+        );
+    }
+
+    let mut reopened = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall,
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(109)),
+    );
+    assert!(
+        reopened.key_package_network_maintenance_due().unwrap(),
+        "authored_event_id must keep a deleted pre-artifact current revision due after restart"
+    );
+    reopened.run_due_maintenance().await.unwrap();
+
+    let publications = publisher.publications();
+    let artifacts = publisher.artifacts();
+    assert_eq!(publications.len(), 2);
+    assert_eq!(artifacts.len(), 2);
+    assert_ne!(publications[1].key_package, original_key_package);
+    assert_ne!(artifacts[1].id, deleted_event_id);
+    let recovered = reopened.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(
+        recovered.current_key_package,
+        Some(publications[1].key_package.clone())
+    );
+    assert_eq!(recovered.authored_event_id, Some(artifacts[1].id.clone()));
+    assert_eq!(
+        recovered
+            .authored_signed_event
+            .as_ref()
+            .map(|artifact| artifact.id.clone()),
+        Some(artifacts[1].id.clone())
+    );
+    assert!(recovered.pending_replacement.is_none());
+    assert!(
+        recovered.deleted_live_revision_event_ids.is_empty(),
+        "successful semantic replacement must clear the deleted-live upgrade marker"
+    );
+}
+
+#[tokio::test]
+async fn key_package_endpoint_liability_limit_blocks_new_signature_without_evicting_deletions() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot key package liability bound key").unwrap();
+    let endpoints = (0..256)
+        .map(|index| TransportEndpoint(format!("wss://liability-{index}.example")))
+        .collect::<Vec<_>>();
+    let publisher =
+        JournalKeyPackages::default().with_deletion_receipts(vec![KeyPackagePublishReceipt {
+            accepted: Vec::new(),
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: vec![endpoints[0].clone()],
+        }]);
+    let session = session(dir.path().join("alice.sqlite"), &key, b"alice");
+    let slot = publisher
+        .legacy_slot_id(&session.self_id())
+        .unwrap()
+        .unwrap();
+    let mut lifecycle = cgka_traits::KeyPackageLifecycleState::slot_only(slot);
+    lifecycle
+        .retired_publications_pending_deletion
+        .push(retired_revision(
+            MessageId::new(vec![0x73; 32]),
+            Timestamp(1),
+            &endpoints,
+        ));
+    session.put_key_package_lifecycle(&lifecycle).unwrap();
+    let mut runtime = AccountDeviceRuntime::new(
+        session,
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]),
+        publisher,
+    );
+    let durable_before = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(
+        durable_before
+            .retired_publications_pending_deletion
+            .iter()
+            .map(|retired| retired.deletion_targets.len())
+            .sum::<usize>(),
+        256
+    );
+
+    let result = runtime
+        .prepare_fresh_key_package(vec![TransportEndpoint("wss://new.example".into())])
+        .await;
+    let blocked = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(
+        blocked
+            .pending_replacement
+            .as_ref()
+            .map(|pending| pending.targets.len()),
+        Some(1)
+    );
+    assert_eq!(
+        blocked
+            .retired_publications_pending_deletion
+            .iter()
+            .map(|retired| retired.deletion_targets.len())
+            .sum::<usize>(),
+        256,
+        "staging must preserve every existing privacy obligation"
+    );
+    let error = result.expect_err("the 257th endpoint liability must not be signed");
+    assert!(
+        error
+            .to_string()
+            .contains("signed-publication endpoint-liability journal is full"),
+        "unexpected capacity error: {error:?}"
+    );
+    assert_eq!(
+        blocked
+            .retired_publications_pending_deletion
+            .iter()
+            .map(|retired| retired.deletion_targets.len())
+            .sum::<usize>(),
+        256,
+        "privacy obligations must never be evicted to make capacity"
+    );
+    assert!(
+        blocked
+            .pending_replacement
+            .as_ref()
+            .is_some_and(|pending| pending.signed_event.is_none()),
+        "capacity is checked before signing the newly staged package"
+    );
+}
+
+#[tokio::test]
+async fn stale_current_reauthor_projects_exact_pair_cap_when_live_targets_are_duplicated() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot duplicate current reauthor cap key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let other_endpoints = (0..255)
+        .map(|index| TransportEndpoint(format!("wss://retired-{index}.example")))
+        .collect::<Vec<_>>();
+    let wall = Arc::new(TestWallClock::new(175_000));
+    let publisher = JournalKeyPackages::default().reauthor_after_secs(600);
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(111)),
+    );
+    runtime.publish_fresh_key_package().await.unwrap();
+    let mut lifecycle = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let old_artifact = lifecycle.authored_signed_event.clone().unwrap();
+    let duplicate = lifecycle.publication_targets[0].clone();
+    lifecycle.publication_targets.push(duplicate);
+    lifecycle
+        .retired_publications_pending_deletion
+        .push(RetiredKeyPackagePublication {
+            event_id: MessageId::new(vec![0x74; 32]),
+            // A current publication at the same timestamp is not a strictly
+            // newer successor, so the pre-reauthor cleanup cannot free one of
+            // these 255 liabilities before the projection check.
+            authored_created_at: old_artifact.created_at,
+            key_package_ref: None,
+            package_not_after: None,
+            delete_without_successor: false,
+            deletion_targets: other_endpoints.iter().map(deletion_target).collect(),
+        });
+    runtime
+        .session()
+        .put_key_package_lifecycle(&lifecycle)
+        .unwrap();
+
+    wall.set(175_600);
+    let error = runtime
+        .republish_key_package()
+        .await
+        .expect_err("retired old(A) plus new(A) would exceed the exact-pair cap");
+    assert!(
+        error
+            .to_string()
+            .contains("signed-publication endpoint-liability journal is full"),
+        "unexpected capacity error: {error:?}"
+    );
+    assert_eq!(
+        publisher.artifacts(),
+        vec![old_artifact.clone()],
+        "capacity must be checked before signing a replacement revision"
+    );
+    let blocked = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(blocked.authored_signed_event, Some(old_artifact));
+    assert_eq!(blocked.publication_targets.len(), 2);
+    assert_eq!(
+        blocked.retired_publications_pending_deletion.len(),
+        1,
+        "the rejected projection must not partially retire the current revision"
+    );
 }
 
 #[tokio::test]
@@ -2142,6 +5986,618 @@ async fn publish_fresh_key_package_retains_bundle_when_publish_fails_after_expos
             .len(),
         2
     );
+}
+
+#[tokio::test]
+async fn consumed_ambiguous_pending_is_swept_across_restart_without_exact_republication() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot consumed ambiguous pending key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let routing = StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint.clone()]);
+    let wall = Arc::new(TestWallClock::new(100_000));
+    let exposed = ExposedThenFailsKeyPackages::default();
+    let mut runtime = AccountDeviceRuntime::new(
+        session(database.clone(), &key, b"alice"),
+        RecordingAdapter::default(),
+        routing.clone(),
+        exposed,
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(89)),
+    );
+
+    runtime
+        .publish_fresh_key_package()
+        .await
+        .expect_err("the pending KeyPackage is exposed before transport returns ambiguously");
+    let pending_before_welcome = runtime
+        .key_package_maintenance_status()
+        .unwrap()
+        .unwrap()
+        .pending_replacement
+        .unwrap();
+    let consumed_ref = pending_before_welcome.key_package_ref.clone();
+    let consumed_key_package = pending_before_welcome.key_package.clone();
+    let consumed_artifact = pending_before_welcome.signed_event.clone().unwrap();
+    let alice_id = runtime.session().self_id();
+    let mut bob = session(dir.path().join("bob.sqlite"), &key, b"bob");
+    let welcome = welcome_for_key_package(
+        &mut bob,
+        &alice_id,
+        consumed_key_package.clone(),
+        "ambiguous pending invite",
+    )
+    .await;
+    runtime
+        .session_mut()
+        .ingest(welcome)
+        .await
+        .expect("the ambiguously published pending private bundle remains joinable");
+    let consumed = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(
+        consumed.consumed_key_package_refs,
+        vec![consumed_ref.clone()]
+    );
+    assert_eq!(
+        consumed.last_consumed_key_package_ref,
+        Some(consumed_ref.clone())
+    );
+    drop(runtime);
+
+    let cleanup =
+        JournalKeyPackages::default().with_deletion_receipts(vec![KeyPackagePublishReceipt {
+            accepted: Vec::new(),
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: vec![endpoint.clone()],
+        }]);
+    let mut restarted = AccountDeviceRuntime::new(
+        session(database.clone(), &key, b"alice"),
+        RecordingAdapter::default(),
+        routing.clone(),
+        cleanup.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(89)),
+    );
+    restarted.pause_maintenance();
+    restarted.run_due_maintenance().await.unwrap();
+
+    assert!(
+        cleanup.publications().is_empty(),
+        "paused cleanup must never republish the exact consumed pending artifact"
+    );
+    let swept = restarted.key_package_maintenance_status().unwrap().unwrap();
+    assert!(swept.pending_replacement.is_none());
+    assert!(swept.current_key_package.is_none());
+    assert_eq!(
+        swept.authored_event_created_at,
+        Some(consumed_artifact.created_at),
+        "the consumed pending revision remains the stable-slot authoring high-water"
+    );
+    assert!(swept.consumed_key_package_refs.is_empty());
+    assert!(swept.last_consumed_key_package_ref.is_none());
+    let retired = swept
+        .retired_publications_pending_deletion
+        .iter()
+        .find(|retired| retired.event_id == consumed_artifact.id)
+        .expect("possible relay exposure remains durably deletable after the bundle is consumed");
+    assert!(retired.delete_without_successor);
+    assert_eq!(retired.key_package_ref, Some(consumed_ref));
+    assert_eq!(retired.deletion_targets.len(), 1);
+    assert!(restarted.durably_owned_key_packages().unwrap().is_empty());
+    drop(restarted);
+
+    let mut reopened = AccountDeviceRuntime::new(
+        session(database, &key, b"alice"),
+        RecordingAdapter::default(),
+        routing,
+        cleanup.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(89)),
+    );
+    reopened.pause_maintenance();
+    reopened.run_due_maintenance().await.unwrap();
+    assert!(
+        cleanup.publications().is_empty(),
+        "restart while paused must not resurrect the consumed exact revision"
+    );
+
+    reopened.resume_maintenance();
+    wall.set(100_030);
+    reopened.run_due_maintenance().await.unwrap();
+    let recovery_publications = cleanup.publications();
+    let recovery_artifacts = cleanup.artifacts();
+    assert_eq!(recovery_publications.len(), 1);
+    assert_ne!(recovery_publications[0].key_package, consumed_key_package);
+    assert_eq!(recovery_artifacts.len(), 1);
+    assert_ne!(recovery_artifacts[0].id, consumed_artifact.id);
+    assert!(recovery_artifacts[0].created_at > consumed_artifact.created_at);
+}
+
+#[tokio::test]
+async fn welcome_without_legacy_lifecycle_row_preserves_consumed_ref_in_synthesized_state() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot legacy lifecycle-less Welcome key").unwrap();
+    let mut alice = session(&database, &key, b"alice");
+    let alice_id = alice.self_id();
+    let key_package = alice.fresh_key_package().await.unwrap();
+    let key_package_ref = hex::decode(
+        alice
+            .key_package_metadata(&key_package)
+            .unwrap()
+            .key_package_ref_hex,
+    )
+    .unwrap();
+    assert!(alice.key_package_lifecycle().unwrap().is_none());
+
+    let mut bob = session(dir.path().join("bob.sqlite"), &key, b"bob");
+    let welcome = welcome_for_key_package(
+        &mut bob,
+        &alice_id,
+        key_package.clone(),
+        "legacy lifecycle-less invite",
+    )
+    .await;
+    alice.ingest(welcome).await.unwrap();
+
+    let lifecycle = alice
+        .key_package_lifecycle()
+        .unwrap()
+        .expect("Welcome ingest synthesizes compatibility lifecycle state");
+    assert!(lifecycle.stable_slot_id.is_empty());
+    assert_eq!(
+        lifecycle.consumed_key_package_refs,
+        vec![key_package_ref.clone()],
+        "newly proven legacy consumption must survive even without a projected current/pending row"
+    );
+    assert_eq!(
+        lifecycle.last_consumed_key_package_ref,
+        Some(key_package_ref.clone())
+    );
+    assert!(
+        alice
+            .durably_owned_key_packages()
+            .unwrap()
+            .contains(&key_package)
+    );
+    drop(alice);
+
+    let mut restarted = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]),
+        JournalKeyPackages::default(),
+    );
+    assert_eq!(
+        restarted
+            .sweep_expired_key_package_private_material()
+            .unwrap(),
+        1,
+        "the lifecycle-less consumed bundle is correlated and deleted after restart"
+    );
+    assert!(restarted.durably_owned_key_packages().unwrap().is_empty());
+    let swept = restarted.key_package_maintenance_status().unwrap().unwrap();
+    assert!(swept.consumed_key_package_refs.is_empty());
+    assert!(swept.last_consumed_key_package_ref.is_none());
+}
+
+#[tokio::test]
+async fn welcome_fails_closed_when_consumed_ref_journal_is_full_without_evicting_evidence() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot full consumed ref journal key").unwrap();
+    let mut alice = session(dir.path().join("alice.sqlite"), &key, b"alice");
+    let alice_id = alice.self_id();
+    let key_package = alice.fresh_key_package().await.unwrap();
+    let key_package_ref = hex::decode(
+        alice
+            .key_package_metadata(&key_package)
+            .unwrap()
+            .key_package_ref_hex,
+    )
+    .unwrap();
+    let mut lifecycle = cgka_traits::KeyPackageLifecycleState::slot_only("stable-slot".into());
+    lifecycle.consumed_key_package_refs = (0
+        ..cgka_traits::maintenance::MAX_CONSUMED_KEY_PACKAGE_REFS_PENDING_CLEANUP)
+        .map(|index| u64::try_from(index).unwrap().to_be_bytes().to_vec())
+        .collect();
+    let evidence_before = lifecycle.consumed_key_package_refs.clone();
+    assert!(!evidence_before.contains(&key_package_ref));
+    alice.put_key_package_lifecycle(&lifecycle).unwrap();
+
+    let mut bob = session(dir.path().join("bob.sqlite"), &key, b"bob");
+    let welcome = welcome_for_key_package(
+        &mut bob,
+        &alice_id,
+        key_package.clone(),
+        "full consumed journal invite",
+    )
+    .await;
+    let error = alice
+        .ingest(welcome)
+        .await
+        .expect_err("the 257th unswept consumption ref must fail the Welcome transaction");
+    assert!(
+        error
+            .to_string()
+            .contains("consumed KeyPackage cleanup journal is full"),
+        "unexpected capacity error: {error:?}"
+    );
+
+    let after = alice.key_package_lifecycle().unwrap().unwrap();
+    assert_eq!(after.consumed_key_package_refs, evidence_before);
+    assert!(
+        alice
+            .durably_owned_key_packages()
+            .unwrap()
+            .contains(&key_package),
+        "transaction rollback must retain the private bundle when consumption evidence cannot commit"
+    );
+}
+
+#[tokio::test]
+async fn legacy_overwritten_consumption_marker_is_swept_before_startup_transport() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot overwritten consumed marker key").unwrap();
+    let relay_a = TransportEndpoint("wss://a.keys.example".into());
+    let relay_b = TransportEndpoint("wss://b.keys.example".into());
+    let routing = StaticTransportRouting::new(vec![])
+        .key_package_endpoints(vec![relay_a.clone(), relay_b.clone()]);
+    let publisher = JournalKeyPackages::default().with_publication_receipts(vec![
+        KeyPackagePublishReceipt {
+            accepted: vec![relay_a.clone(), relay_b.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+        KeyPackagePublishReceipt {
+            accepted: vec![relay_a.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: vec![relay_b.clone()],
+        },
+        KeyPackagePublishReceipt {
+            accepted: vec![relay_a.clone(), relay_b.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+    ]);
+    let wall = Arc::new(TestWallClock::new(130_000));
+    let mut runtime = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        routing.clone(),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(101)),
+    );
+
+    // This package predates lifecycle projection entirely. A schema-51
+    // writer could overwrite its consumption marker with a later Welcome, so
+    // upgrade recovery must not limit conservative retirement to current /
+    // retained lifecycle fields.
+    let unprojected_key_package = runtime.session_mut().fresh_key_package().await.unwrap();
+    let unprojected_ref = hex::decode(
+        runtime
+            .session()
+            .key_package_metadata(&unprojected_key_package)
+            .unwrap()
+            .key_package_ref_hex,
+    )
+    .unwrap();
+    let retained_key_package = runtime.publish_fresh_key_package().await.unwrap();
+    let retained = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let retained_ref = retained.current_key_package_ref.clone().unwrap();
+    let current_key_package = runtime.publish_fresh_key_package().await.unwrap();
+    let current = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let current_ref = current.current_key_package_ref.clone().unwrap();
+    let current_artifact = current.authored_signed_event.clone().unwrap();
+    assert_ne!(retained_ref, current_ref);
+    assert_eq!(current.retained_private_material.len(), 1);
+    assert!(
+        current
+            .publication_targets
+            .iter()
+            .any(|target| target.endpoint == relay_b
+                && target.state == TransportFanoutAttemptState::AttemptedFailed),
+        "the live exact revision must retain a partial-relay retry before consumption"
+    );
+
+    let alice_id = runtime.session().self_id();
+    let mut bob = session(dir.path().join("bob.sqlite"), &key, b"bob");
+    let mut carol = session(dir.path().join("carol.sqlite"), &key, b"carol");
+    let mut dave = session(dir.path().join("dave.sqlite"), &key, b"dave");
+    // This third Welcome is already in flight when the upgraded process starts.
+    // Its pre-lifecycle package is intentionally not consumed yet: startup must
+    // retire it before transport can deliver this message and overwrite the
+    // legacy-only ambiguity sentinel.
+    let startup_welcome = welcome_for_key_package(
+        &mut bob,
+        &alice_id,
+        unprojected_key_package.clone(),
+        "unprojected startup Welcome",
+    )
+    .await;
+    let current_welcome = welcome_for_key_package(
+        &mut carol,
+        &alice_id,
+        current_key_package.clone(),
+        "current consumed first",
+    )
+    .await;
+    let retained_welcome = welcome_for_key_package(
+        &mut dave,
+        &alice_id,
+        retained_key_package.clone(),
+        "retained consumed last",
+    )
+    .await;
+    runtime.session_mut().ingest(current_welcome).await.unwrap();
+    runtime
+        .session_mut()
+        .ingest(retained_welcome)
+        .await
+        .unwrap();
+
+    let mut legacy = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(
+        legacy.consumed_key_package_refs,
+        vec![current_ref.clone(), retained_ref.clone()]
+    );
+    assert_eq!(
+        legacy.last_consumed_key_package_ref,
+        Some(retained_ref.clone())
+    );
+    assert_eq!(
+        runtime.durably_owned_key_packages().unwrap().len(),
+        3,
+        "OpenMLS intentionally retains lifecycle-less and projected last-resort bundles"
+    );
+    // Simulate the pre-journal serialized shape: only the legacy last marker
+    // survives, so the first consumed current ref has been overwritten.
+    legacy.consumed_key_package_refs.clear();
+    runtime
+        .session()
+        .put_key_package_lifecycle(&legacy)
+        .unwrap();
+    drop(runtime);
+
+    let adapter = RecordingAdapter::default();
+    let mut restarted = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        adapter.clone(),
+        routing.clone(),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(101)),
+    );
+    assert!(
+        adapter.activations().is_empty(),
+        "transport must still be unopened at the synchronous startup sweep boundary"
+    );
+    assert!(adapter.publishes().is_empty());
+    let publications_before_sweep = publisher.publications().len();
+    assert_eq!(
+        restarted
+            .sweep_expired_key_package_private_material()
+            .unwrap(),
+        3,
+        "legacy-only evidence conservatively retires every possibly consumed durable bundle"
+    );
+    assert!(
+        adapter.activations().is_empty(),
+        "private-material startup reconciliation performs no transport I/O"
+    );
+    assert!(adapter.publishes().is_empty());
+    assert_eq!(publisher.publications().len(), publications_before_sweep);
+    let swept = restarted.key_package_maintenance_status().unwrap().unwrap();
+    assert!(swept.current_key_package.is_none());
+    assert!(swept.current_key_package_ref.is_none());
+    assert!(swept.authored_event_id.is_none());
+    assert!(swept.authored_signed_event.is_none());
+    assert!(swept.publication_targets.is_empty());
+    assert!(swept.retained_private_material.is_empty());
+    assert!(swept.pending_replacement.is_none());
+    let mut expected_consumed_refs = vec![
+        unprojected_ref.clone(),
+        current_ref.clone(),
+        retained_ref.clone(),
+    ];
+    expected_consumed_refs.sort();
+    assert_eq!(swept.consumed_key_package_refs, expected_consumed_refs);
+    assert_eq!(swept.last_consumed_key_package_ref, Some(retained_ref));
+    assert_eq!(
+        swept.authored_event_created_at,
+        Some(current_artifact.created_at),
+        "the unusable live revision remains the stable-slot authoring high-water"
+    );
+    let retired_current = swept
+        .retired_publications_pending_deletion
+        .iter()
+        .find(|retired| retired.event_id == current_artifact.id)
+        .expect("the exact partially published current revision remains durably deletable");
+    assert!(retired_current.delete_without_successor);
+    assert_eq!(retired_current.key_package_ref, Some(current_ref));
+    assert_eq!(retired_current.deletion_targets.len(), 2);
+    assert_eq!(
+        publisher.publications().len(),
+        2,
+        "the atomic sentinel transition performs no exact network retry"
+    );
+    restarted.activate_transport(None).await.unwrap();
+    assert_eq!(adapter.activations().len(), 1);
+    let rejected = restarted
+        .session_mut()
+        .ingest(startup_welcome)
+        .await
+        .expect("missing private material is a classified rejection");
+    assert!(matches!(
+        rejected.outcome,
+        cgka_traits::IngestOutcome::Ignored {
+            category: cgka_traits::ingest::InputRejectionCategory::InvalidEncoding
+        }
+    ));
+    assert_eq!(
+        restarted.key_package_maintenance_status().unwrap(),
+        Some(swept.clone()),
+        "failed startup Welcome ingest must not overwrite the reconciled lifecycle"
+    );
+    assert!(restarted.durably_owned_key_packages().unwrap().is_empty());
+    restarted
+        .finalize_key_package_cutover_consumption_evidence()
+        .unwrap();
+    let finalized = restarted.key_package_maintenance_status().unwrap().unwrap();
+    assert!(finalized.consumed_key_package_refs.is_empty());
+    assert!(finalized.last_consumed_key_package_ref.is_none());
+    drop(restarted);
+
+    let mut recovered = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        routing,
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall,
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(101)),
+    );
+    let recovered_state = recovered.key_package_maintenance_status().unwrap().unwrap();
+    assert!(recovered_state.last_consumed_key_package_ref.is_none());
+    assert!(recovered_state.current_key_package.is_none());
+    recovered.run_due_maintenance().await.unwrap();
+    let publications = publisher.publications();
+    let artifacts = publisher.artifacts();
+    assert_eq!(publications.len(), 3);
+    assert_eq!(artifacts.len(), 3);
+    assert_ne!(publications[2].key_package, current_key_package);
+    assert_ne!(publications[2].key_package, retained_key_package);
+    assert_ne!(publications[2].key_package, unprojected_key_package);
+    assert_ne!(artifacts[2].id, current_artifact.id);
+    assert!(artifacts[2].created_at > current_artifact.created_at);
+}
+
+#[tokio::test]
+async fn two_welcome_refs_survive_until_one_sweep_and_prune_only_removed_private_material() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot two consumed welcome refs key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let publisher = JournalKeyPackages::default();
+    let wall = Arc::new(TestWallClock::new(120_000));
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall,
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(97)),
+    );
+
+    let first_key_package = runtime.publish_fresh_key_package().await.unwrap();
+    let first = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let first_ref = first.current_key_package_ref.clone().unwrap();
+    let first_event_id = first.authored_event_id.clone().unwrap();
+    let second_key_package = runtime.publish_fresh_key_package().await.unwrap();
+    let mut second = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let second_ref = second.current_key_package_ref.clone().unwrap();
+    let second_event_id = second.authored_event_id.clone().unwrap();
+    assert_ne!(first_ref, second_ref);
+    assert_ne!(first_event_id, second_event_id);
+    assert_eq!(second.retained_private_material.len(), 1);
+    second.authored_signed_event = None;
+    runtime
+        .session()
+        .put_key_package_lifecycle(&second)
+        .unwrap();
+
+    let alice_id = runtime.session().self_id();
+    let mut bob = session(dir.path().join("bob.sqlite"), &key, b"bob");
+    let mut carol = session(dir.path().join("carol.sqlite"), &key, b"carol");
+    let first_welcome =
+        welcome_for_key_package(&mut bob, &alice_id, first_key_package, "first consumed ref").await;
+    let second_welcome = welcome_for_key_package(
+        &mut carol,
+        &alice_id,
+        second_key_package.clone(),
+        "second consumed ref",
+    )
+    .await;
+    runtime.session_mut().ingest(first_welcome).await.unwrap();
+    runtime.session_mut().ingest(second_welcome).await.unwrap();
+
+    let before_sweep = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(
+        before_sweep.consumed_key_package_refs,
+        vec![first_ref.clone(), second_ref.clone()],
+        "a second Welcome must append instead of overwriting unswept evidence"
+    );
+    assert_eq!(
+        before_sweep.last_consumed_key_package_ref,
+        Some(second_ref.clone())
+    );
+
+    assert_eq!(
+        runtime
+            .sweep_expired_key_package_private_material()
+            .unwrap(),
+        1,
+        "the consumed retained package is deleted while the consumed current remains blocked"
+    );
+    let after_sweep = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(
+        after_sweep.current_key_package_ref,
+        Some(second_ref.clone())
+    );
+    assert!(after_sweep.retained_private_material.is_empty());
+    assert_eq!(
+        after_sweep.consumed_key_package_refs,
+        vec![second_ref.clone()]
+    );
+    assert_eq!(
+        after_sweep.last_consumed_key_package_ref,
+        Some(second_ref.clone())
+    );
+    for event_id in [&first_event_id, &second_event_id] {
+        let retired = after_sweep
+            .retired_publications_pending_deletion
+            .iter()
+            .find(|retired| &retired.event_id == event_id)
+            .expect("each consumed signed revision remains durably deletable");
+        assert!(retired.delete_without_successor);
+    }
+    assert!(runtime.key_package_network_maintenance_due().unwrap());
+    assert!(!runtime.key_package_has_pending_fanout().unwrap());
+
+    runtime
+        .republish_key_package()
+        .await
+        .expect("a consumed current reference must force semantic replacement");
+    let replacement = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_ne!(replacement.current_key_package_ref, Some(second_ref));
+    assert!(replacement.consumed_key_package_refs.is_empty());
+    assert!(replacement.last_consumed_key_package_ref.is_none());
+    assert_eq!(publisher.publications().len(), 3);
+    assert_ne!(publisher.publications()[2].key_package, second_key_package);
 }
 
 #[tokio::test]
@@ -3366,6 +7822,134 @@ async fn group_evolution_confirms_commit_when_welcome_publish_fails() {
     assert_eq!(adapter.publishes().len(), 3);
 }
 
+#[tokio::test]
+async fn cancelled_post_confirmation_welcome_publish_replays_nested_session_events() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot nested visibility cancellation key").unwrap();
+    let mut alice = session(
+        dir.path().join("alice.sqlite"),
+        &key,
+        b"alice-nested-visibility",
+    );
+    let mut bob = session(
+        dir.path().join("bob.sqlite"),
+        &key,
+        b"bob-nested-visibility",
+    );
+    let mut carol = session(
+        dir.path().join("carol.sqlite"),
+        &key,
+        b"carol-nested-visibility",
+    );
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let carol_id = carol.self_id();
+
+    let created = alice
+        .create_group(CreateGroupRequest {
+            name: "nested visibility".into(),
+            description: String::new(),
+            members: vec![bob_kp],
+            required_features: Vec::new(),
+            app_components: Vec::new(),
+            initial_admins: Vec::new(),
+        })
+        .await
+        .unwrap();
+    let group_id = created.group_id;
+    let create_pending = match created.effects.publish.as_slice() {
+        [PublishWork::GroupCreated { pending, .. }] => *pending,
+        other => panic!("expected one GroupCreated publish work, got {other:?}"),
+    };
+    alice.confirm_published(create_pending).await.unwrap();
+
+    let adapter = RecordingAdapter::default();
+    let gate = adapter.gate_welcome_publishes();
+    let policy =
+        StaticTransportRouting::new(vec![TransportEndpoint("wss://nested-inbox.example".into())])
+            .with_group_route(
+                group_id.clone(),
+                group_id.as_slice().to_vec(),
+                vec![TransportEndpoint("wss://nested-group.example".into())],
+            )
+            .with_inbox_route(
+                carol_id,
+                vec![TransportEndpoint("wss://nested-carol.example".into())],
+            );
+    let mut runtime = AccountDeviceRuntime::new(
+        alice,
+        adapter.clone(),
+        policy,
+        RecordingKeyPackages::default(),
+    );
+
+    // The group commit publishes first and is confirmed locally. Confirmation
+    // drains EpochChanged into the account output, then the recipient Welcome
+    // crosses the blocking adapter await. Cancelling there used to discard the
+    // only live copy of that newly generated event.
+    let mut cancelled = Box::pin(runtime.send(SendIntent::Invite {
+        group_id: group_id.clone(),
+        key_packages: vec![carol_kp],
+        initial_admins: Vec::new(),
+    }));
+    tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::select! {
+            result = &mut cancelled => {
+                panic!("invite returned before Welcome cancellation boundary: {result:?}")
+            }
+            () = async {
+                while adapter.publishes().len() < 2 {
+                    tokio::task::yield_now().await;
+                }
+            } => {}
+        }
+    })
+    .await
+    .expect("invite reaches the blocking Welcome publish");
+    drop(cancelled);
+    let commit_id = adapter.publishes()[0].message.id.clone();
+
+    gate.release.add_permits(1);
+    let recovered = tokio::time::timeout(Duration::from_secs(5), runtime.drain())
+        .await
+        .expect("retained runtime drain completes")
+        .unwrap();
+    assert!(recovered.events.iter().any(|event| matches!(
+        event,
+        GroupEvent::EpochChanged { group_id: changed, .. } if changed == &group_id
+    )));
+    assert!(
+        recovered
+            .pending
+            .iter()
+            .any(|resolution| matches!(resolution, PendingResolution::Confirmed { .. }))
+    );
+    assert_eq!(
+        recovered
+            .reports
+            .iter()
+            .filter(|report| report.message_id == commit_id)
+            .count(),
+        1,
+        "the completed commit report must survive cancellation inside its Welcome loop"
+    );
+    assert_eq!(
+        adapter
+            .publishes()
+            .iter()
+            .filter(|request| request.message.id == commit_id)
+            .count(),
+        1,
+        "visibility replay must not publish the already-confirmed commit again"
+    );
+
+    let handed_off = runtime.drain().await.unwrap();
+    assert!(!handed_off.events.iter().any(|event| matches!(
+        event,
+        GroupEvent::EpochChanged { group_id: changed, .. } if changed == &group_id
+    )));
+}
+
 // mdk#499 regression: an explicit group-evolution commit that a relay
 // accepted but that missed `required_acks` has already been exposed to peers.
 // Rolling it back locally diverges the sender from recipients; mirror the
@@ -3575,6 +8159,1767 @@ async fn drain_surfaces_hydration_quarantine_without_inbound_delivery() {
     );
 }
 
+#[tokio::test]
+async fn visibility_lease_replays_drain_in_order_through_maintenance_until_acknowledged() {
+    use cgka_traits::GroupStorage;
+    use cgka_traits::engine::GroupHydrationQuarantineReason;
+    use cgka_traits::group::Group;
+
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot leased visibility key").unwrap();
+    let db_path = dir.path().join("alice-leased.sqlite");
+    drop(session(&db_path, &key, b"alice-leased"));
+
+    let broken_groups = [
+        GroupId::new(b"leased-broken-a".to_vec()),
+        GroupId::new(b"leased-broken-b".to_vec()),
+    ];
+    {
+        let storage = SqliteAccountStorage::open_encrypted(&db_path, &key).unwrap();
+        for group_id in &broken_groups {
+            storage
+                .put_group(&Group {
+                    id: group_id.clone(),
+                    name: "broken".into(),
+                    description: String::new(),
+                    members: Vec::new(),
+                    epoch: EpochId(9),
+                    required_capabilities: cgka_traits::GroupCapabilities::default(),
+                    protocol_profile: ProtocolProfile::Legacy,
+                    removed: false,
+                    unrecoverable: false,
+                    disbanded: None,
+                    join_epoch: EpochId(0),
+                })
+                .unwrap();
+        }
+    }
+
+    let reopened = session(&db_path, &key, b"alice-leased");
+    let policy =
+        StaticTransportRouting::new(vec![TransportEndpoint("wss://leased-inbox.example".into())]);
+    let mut runtime = AccountDeviceRuntime::new(
+        reopened,
+        RecordingAdapter::default(),
+        policy,
+        RecordingKeyPackages::default(),
+    );
+    runtime.pause_maintenance();
+
+    let first = runtime.drain_leased().await.unwrap();
+    let quarantine_order = |effects: &marmot_account::AccountDeviceEffects| {
+        effects
+            .events
+            .iter()
+            .filter_map(|event| match event {
+                GroupEvent::GroupHydrationQuarantined {
+                    group_id,
+                    reason: GroupHydrationQuarantineReason::OpenMlsGroupMissing,
+                } => Some(group_id.clone()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+    };
+    let first_order = quarantine_order(&first.effects);
+    assert_eq!(first_order.len(), 2);
+
+    // Maintenance itself has no new work while paused. Older unacknowledged
+    // visibility is source-attributed in `batches`, while the command-local
+    // `effects` remains empty and cannot inherit an old command's failures.
+    let replayed = runtime.run_due_maintenance_leased().await.unwrap();
+    assert!(quarantine_order(&replayed.effects).is_empty());
+    assert_eq!(
+        quarantine_order(&flatten_visibility_batches(&replayed.batches)),
+        first_order
+    );
+    assert!(!runtime.acknowledge_visibility_lease(first.lease));
+    assert!(runtime.acknowledge_visibility_lease(replayed.lease));
+
+    let after_ack = runtime.drain_leased().await.unwrap();
+    assert!(quarantine_order(&after_ack.effects).is_empty());
+    assert!(runtime.acknowledge_visibility_lease(after_ack.lease));
+}
+
+#[tokio::test]
+async fn durably_acknowledged_visibility_lease_advances_after_storage_closes() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot post-commit visibility lease key").unwrap();
+    let database = dir.path().join("alice-post-commit-visibility.sqlite");
+    let account = session(&database, &key, b"alice-post-commit-visibility");
+    let mut runtime = AccountDeviceRuntime::new(
+        account,
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![TransportEndpoint(
+            "wss://post-commit-visibility.example".into(),
+        )]),
+        RecordingKeyPackages::default(),
+    );
+    runtime.pause_maintenance();
+
+    let leased = runtime.drain_leased().await.unwrap();
+    let batch_ids = runtime
+        .visibility_lease_batch_ids(leased.lease)
+        .expect("the returned visibility rows remain leased until app commit");
+    assert!(!batch_ids.is_empty());
+    let storage = runtime.session().storage_handle();
+    assert_eq!(
+        storage
+            .delete_account_visibility_journal_batches(&batch_ids)
+            .unwrap(),
+        batch_ids.len(),
+        "the app-side transaction must delete every leased row before advancing memory",
+    );
+
+    // Terminal shutdown may close the shared handle immediately after the app
+    // projection transaction commits. Lease advancement is therefore a pure
+    // in-memory post-commit step and must not attempt another storage read.
+    storage.close().unwrap();
+    assert!(
+        runtime
+            .forget_durably_acknowledged_visibility_batches(leased.lease, &batch_ids)
+            .unwrap(),
+        "the matching fully acknowledged lease must advance after storage closes",
+    );
+    assert_eq!(runtime.visibility_lease_batch_ids(leased.lease), None);
+}
+
+#[tokio::test]
+async fn rejected_leave_header_replays_without_false_acceptance() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot rejected leave source key").unwrap();
+    let database = dir.path().join("rejected-leave-source.sqlite");
+    let unknown_group = GroupId::new(b"unknown-leave-source".to_vec());
+    let account = session(&database, &key, b"rejected-leave-source");
+    let adapter = RecordingAdapter::default();
+    let mut runtime = AccountDeviceRuntime::new(
+        account,
+        adapter.clone(),
+        StaticTransportRouting::new(vec![TransportEndpoint(
+            "wss://rejected-leave-source.example".into(),
+        )]),
+        RecordingKeyPackages::default(),
+    )
+    .with_maintenance_sources(
+        Arc::new(TestWallClock::new(31337)),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(0)),
+    );
+    runtime.pause_maintenance();
+
+    assert!(
+        runtime
+            .send_leased(SendIntent::Leave {
+                group_id: unknown_group.clone(),
+            })
+            .await
+            .is_err(),
+        "an unknown-group Leave must fail before engine acceptance"
+    );
+    assert!(adapter.publishes().is_empty());
+    drop(runtime);
+
+    let reopened = session(&database, &key, b"rejected-leave-source");
+    let mut restarted = AccountDeviceRuntime::new(
+        reopened,
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![TransportEndpoint(
+            "wss://rejected-leave-source.example".into(),
+        )]),
+        RecordingKeyPackages::default(),
+    );
+    restarted.pause_maintenance();
+    let replayed = restarted
+        .replay_visibility_leased()
+        .unwrap()
+        .expect("the pre-acceptance Header remains crash-visible");
+    assert!(!replayed.batches.is_empty());
+    assert!(replayed.batches.iter().all(|batch| {
+        batch.source
+            == (AccountVisibilitySource::Outbound {
+                group_id: Some(unknown_group.clone()),
+                observed_at: Timestamp(31337),
+                action: Some(AccountVisibilityOutboundAction::Leave),
+                action_message_id: None,
+            })
+    }));
+    assert!(restarted.acknowledge_visibility_lease(replayed.lease));
+}
+
+#[tokio::test]
+async fn leave_visibility_source_survives_restart_until_acknowledged() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot leave visibility source key").unwrap();
+    let alice_path = dir.path().join("alice-leave-source.sqlite");
+    let bob_path = dir.path().join("bob-leave-source.sqlite");
+    let mut alice = session_with_registry(
+        &alice_path,
+        &key,
+        b"alice-leave-source",
+        selfremove_registry(),
+    );
+    let mut bob =
+        session_with_registry(&bob_path, &key, b"bob-leave-source", selfremove_registry());
+    let bob_key_package = bob.fresh_key_package().await.unwrap();
+    let created = alice
+        .create_group(CreateGroupRequest {
+            name: "leave visibility source".into(),
+            description: String::new(),
+            members: vec![bob_key_package],
+            required_features: Vec::new(),
+            app_components: Vec::new(),
+            initial_admins: Vec::new(),
+        })
+        .await
+        .unwrap();
+    let group_id = created.group_id;
+    let (pending, welcome) = match created.effects.publish.as_slice() {
+        [PublishWork::GroupCreated { pending, welcomes }] => (*pending, welcomes[0].clone()),
+        other => panic!("expected one GroupCreated publish work, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    bob.ingest(welcome).await.unwrap();
+
+    let route = || {
+        StaticTransportRouting::new(vec![TransportEndpoint(
+            "wss://leave-source-inbox.example".into(),
+        )])
+        .with_group_route(
+            group_id.clone(),
+            group_id.as_slice().to_vec(),
+            vec![TransportEndpoint("wss://leave-source-group.example".into())],
+        )
+    };
+    let mut runtime = AccountDeviceRuntime::new(
+        bob,
+        RecordingAdapter::default(),
+        route(),
+        RecordingKeyPackages::default(),
+    )
+    .with_maintenance_sources(
+        Arc::new(TestWallClock::new(4242)),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(0)),
+    );
+    runtime.pause_maintenance();
+
+    let leased = runtime
+        .send_leased(SendIntent::Leave {
+            group_id: group_id.clone(),
+        })
+        .await
+        .unwrap();
+    assert!(leased.current_operation_id.is_some());
+    assert!(!leased.batches.is_empty());
+    let action_outcome = leased
+        .effects
+        .action_outcomes
+        .as_slice()
+        .first()
+        .expect("a terminal Leave publish emits its typed action outcome");
+    assert_eq!(leased.effects.action_outcomes.len(), 1);
+    assert_eq!(
+        action_outcome.operation_id,
+        leased.current_operation_id.clone().unwrap()
+    );
+    assert_eq!(action_outcome.group_id, group_id);
+    assert_eq!(
+        action_outcome.action,
+        AccountVisibilityOutboundAction::Leave
+    );
+    assert!(action_outcome.published);
+    let leave_message_id = action_outcome.message_id.clone();
+    assert!(leased.batches.iter().all(|batch| {
+        batch.source
+            == (AccountVisibilitySource::Outbound {
+                group_id: Some(group_id.clone()),
+                observed_at: Timestamp(4242),
+                action: Some(AccountVisibilityOutboundAction::Leave),
+                action_message_id: Some(leave_message_id.clone()),
+            })
+    }));
+    let original_batch_ids = leased
+        .batches
+        .iter()
+        .map(|batch| batch.batch_id.clone())
+        .collect::<Vec<_>>();
+    drop(runtime);
+
+    let restarted_adapter = RecordingAdapter::default();
+    let reopened =
+        session_with_registry(&bob_path, &key, b"bob-leave-source", selfremove_registry());
+    let mut restarted = AccountDeviceRuntime::new(
+        reopened,
+        restarted_adapter.clone(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    restarted.pause_maintenance();
+    let replayed = restarted
+        .replay_visibility_leased()
+        .unwrap()
+        .expect("unacknowledged Leave visibility replays after restart");
+    assert_eq!(replayed.current_operation_id, None);
+    assert_eq!(
+        replayed
+            .batches
+            .iter()
+            .map(|batch| batch.batch_id.clone())
+            .collect::<Vec<_>>(),
+        original_batch_ids
+    );
+    assert!(replayed.batches.iter().all(|batch| {
+        batch.source
+            == (AccountVisibilitySource::Outbound {
+                group_id: Some(group_id.clone()),
+                observed_at: Timestamp(4242),
+                action: Some(AccountVisibilityOutboundAction::Leave),
+                action_message_id: Some(leave_message_id.clone()),
+            })
+    }));
+    assert_eq!(
+        flatten_visibility_batches(&replayed.batches).action_outcomes,
+        vec![action_outcome.clone()]
+    );
+    assert!(
+        restarted_adapter.publishes().is_empty(),
+        "visibility replay must not repeat the already-completed Leave publish"
+    );
+    assert!(restarted.acknowledge_visibility_lease(replayed.lease));
+    assert!(restarted.replay_visibility_leased().unwrap().is_none());
+}
+
+#[tokio::test]
+async fn terminal_leave_publish_failure_is_durable_and_does_not_authorize_left() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot failed leave outcome key").unwrap();
+    let (bob, bob_path, bob_identity, group_id) =
+        joined_selfremove_member(dir.path(), &key, "failed-leave-outcome").await;
+    let adapter = RecordingAdapter::default();
+    let group_endpoint = TransportEndpoint("wss://failed-leave-group.example".into());
+    adapter.fail_endpoints_as(
+        vec![group_endpoint.clone()],
+        TransportEndpointFailureKind::TerminalRejected,
+    );
+    let route = || {
+        StaticTransportRouting::new(vec![TransportEndpoint(
+            "wss://failed-leave-inbox.example".into(),
+        )])
+        .with_group_route(
+            group_id.clone(),
+            group_id.as_slice().to_vec(),
+            vec![group_endpoint.clone()],
+        )
+    };
+    let mut runtime =
+        AccountDeviceRuntime::new(bob, adapter, route(), RecordingKeyPackages::default());
+    runtime.pause_maintenance();
+    let leased = runtime
+        .send_leased(SendIntent::Leave {
+            group_id: group_id.clone(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(leased.effects.action_outcomes.len(), 1);
+    let outcome = leased.effects.action_outcomes[0].clone();
+    assert_eq!(outcome.operation_id, leased.current_operation_id.unwrap());
+    assert_eq!(outcome.group_id, group_id);
+    assert_eq!(outcome.action, AccountVisibilityOutboundAction::Leave);
+    assert!(
+        !outcome.published,
+        "an unmet required-ACK policy must not authorize the app's Left tail"
+    );
+    assert!(!leased.effects.failures.is_empty());
+    drop(runtime);
+
+    let reopened = session_with_registry(&bob_path, &key, &bob_identity, selfremove_registry());
+    let mut restarted = AccountDeviceRuntime::new(
+        reopened,
+        RecordingAdapter::default(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    restarted.pause_maintenance();
+    let replayed = restarted
+        .replay_visibility_leased()
+        .unwrap()
+        .expect("terminal failed Leave outcome survives restart");
+    assert_eq!(
+        flatten_visibility_batches(&replayed.batches).action_outcomes,
+        vec![outcome]
+    );
+    assert!(restarted.acknowledge_visibility_lease(replayed.lease));
+}
+
+#[tokio::test]
+async fn zero_accept_best_effort_leave_does_not_publish_on_restart() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot zero ack leave key").unwrap();
+    let (bob, bob_path, bob_identity, group_id) =
+        joined_selfremove_member(dir.path(), &key, "zero-ack-leave").await;
+    let adapter = RecordingAdapter::default();
+    let group_endpoint = TransportEndpoint("wss://zero-ack-leave-group.example".into());
+    adapter.fail_endpoints_as(
+        vec![group_endpoint.clone()],
+        TransportEndpointFailureKind::TerminalRejected,
+    );
+    let route = || {
+        StaticTransportRouting::new(vec![TransportEndpoint(
+            "wss://zero-ack-leave-inbox.example".into(),
+        )])
+        .required_acks(0)
+        .with_group_route(
+            group_id.clone(),
+            group_id.as_slice().to_vec(),
+            vec![group_endpoint.clone()],
+        )
+    };
+    let mut runtime =
+        AccountDeviceRuntime::new(bob, adapter, route(), RecordingKeyPackages::default());
+    runtime.pause_maintenance();
+    let leased = runtime
+        .send_leased(SendIntent::Leave {
+            group_id: group_id.clone(),
+        })
+        .await
+        .unwrap();
+    assert!(
+        leased
+            .effects
+            .action_outcomes
+            .iter()
+            .all(|outcome| !outcome.published),
+        "required_acks=0 still needs at least one accept"
+    );
+    drop(runtime);
+
+    let reopened = session_with_registry(&bob_path, &key, &bob_identity, selfremove_registry());
+    let mut restarted = AccountDeviceRuntime::new(
+        reopened,
+        RecordingAdapter::default(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    restarted.pause_maintenance();
+    if let Some(replayed) = restarted.replay_visibility_leased().unwrap() {
+        assert!(
+            flatten_visibility_batches(&replayed.batches)
+                .action_outcomes
+                .iter()
+                .all(|outcome| !outcome.published),
+            "restart must not upgrade a zero-accept Leave to published:true"
+        );
+        assert!(restarted.acknowledge_visibility_lease(replayed.lease));
+    }
+    assert!(
+        restarted
+            .session()
+            .outbound_fanouts()
+            .unwrap()
+            .iter()
+            .all(|fanout| {
+                fanout.outcome().accepted_targets < fanout.request().required_acks.max(1)
+            }),
+        "a surviving terminal zero-accept fanout must still miss required_acks.max(1)"
+    );
+    let drained = restarted.drain_leased().await.unwrap();
+    assert!(
+        drained
+            .effects
+            .action_outcomes
+            .iter()
+            .all(|outcome| !outcome.published),
+        "resuming a terminal zero-accept Leave must not authorize Left"
+    );
+    assert!(
+        restarted.session().outbound_fanouts().unwrap().is_empty(),
+        "terminal zero-accept resume must finish the Leave fanout without publishing"
+    );
+}
+
+#[tokio::test]
+async fn leave_m1_to_m2_repair_persists_every_row_so_cleared_request_does_not_split_source() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot torn leave source key").unwrap();
+    let (bob, bob_path, bob_identity, group_id) =
+        joined_selfremove_member(dir.path(), &key, "torn-leave-source").await;
+    let route = || {
+        StaticTransportRouting::new(vec![TransportEndpoint(
+            "wss://torn-leave-inbox.example".into(),
+        )])
+        .with_group_route(
+            group_id.clone(),
+            group_id.as_slice().to_vec(),
+            vec![TransportEndpoint("wss://torn-leave-group.example".into())],
+        )
+    };
+    let mut runtime = AccountDeviceRuntime::new(
+        bob,
+        RecordingAdapter::default(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    runtime.pause_maintenance();
+    let _leased = runtime
+        .send_leased(SendIntent::Leave {
+            group_id: group_id.clone(),
+        })
+        .await
+        .unwrap();
+    let later_id = MessageId::new(b"leave-m2-torn-source".to_vec());
+    let mut request = runtime
+        .session()
+        .storage_handle()
+        .leave_request(&group_id)
+        .unwrap()
+        .expect("accepted Leave writes a durable request");
+    request.last_proposed_message_id = Some(later_id.clone());
+    runtime
+        .session()
+        .storage_handle()
+        .put_leave_request(&request)
+        .unwrap();
+    drop(runtime);
+
+    let reopened = session_with_registry(&bob_path, &key, &bob_identity, selfremove_registry());
+    let mut repaired = AccountDeviceRuntime::new(
+        reopened,
+        RecordingAdapter::default(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    repaired.pause_maintenance();
+    let replayed = repaired
+        .replay_visibility_leased()
+        .unwrap()
+        .expect("unacked Leave remains crash-visible for M1→M2 repair");
+    let leave_sources = replayed
+        .batches
+        .iter()
+        .filter_map(|batch| match &batch.source {
+            AccountVisibilitySource::Outbound {
+                group_id: Some(source_group),
+                action: Some(AccountVisibilityOutboundAction::Leave),
+                action_message_id,
+                ..
+            } if source_group == &group_id => {
+                Some((batch.operation_id.clone(), action_message_id.clone()))
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let mut unique_source_by_operation =
+        std::collections::HashMap::<Vec<u8>, Option<MessageId>>::new();
+    for (operation_id, action_message_id) in &leave_sources {
+        if let Some(existing) = unique_source_by_operation.get(operation_id) {
+            assert_eq!(
+                existing, action_message_id,
+                "M1→M2 repair must persist one source per operation, got {leave_sources:?}"
+            );
+        } else {
+            unique_source_by_operation.insert(operation_id.clone(), action_message_id.clone());
+        }
+    }
+    assert!(
+        unique_source_by_operation
+            .values()
+            .any(|bound| bound.as_ref() == Some(&later_id)),
+        "repaired Leave source must name the live M2 id: {leave_sources:?}"
+    );
+    drop(replayed);
+    drop(repaired);
+
+    let storage_session =
+        session_with_registry(&bob_path, &key, &bob_identity, selfremove_registry());
+    storage_session
+        .storage_handle()
+        .clear_leave_request(&group_id)
+        .unwrap();
+    drop(storage_session);
+
+    let reopened = session_with_registry(&bob_path, &key, &bob_identity, selfremove_registry());
+    let mut restarted = AccountDeviceRuntime::new(
+        reopened,
+        RecordingAdapter::default(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    restarted.pause_maintenance();
+    let replayed = restarted
+        .replay_visibility_leased()
+        .expect("Header+suffix M2 repair must persist every row so reopen cannot split source")
+        .expect("repaired Leave source must survive LeaveRequest clear");
+    let leave_sources = replayed
+        .batches
+        .iter()
+        .filter_map(|batch| match &batch.source {
+            AccountVisibilitySource::Outbound {
+                group_id: Some(source_group),
+                action: Some(AccountVisibilityOutboundAction::Leave),
+                action_message_id,
+                ..
+            } if source_group == &group_id => {
+                Some((batch.operation_id.clone(), action_message_id.clone()))
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let mut unique_source_by_operation =
+        std::collections::HashMap::<Vec<u8>, Option<MessageId>>::new();
+    for (operation_id, action_message_id) in &leave_sources {
+        if let Some(existing) = unique_source_by_operation.get(operation_id) {
+            assert_eq!(
+                existing, action_message_id,
+                "cleared LeaveRequest must not resurrect a split M1/M2 source: {leave_sources:?}"
+            );
+        } else {
+            unique_source_by_operation.insert(operation_id.clone(), action_message_id.clone());
+        }
+    }
+    assert!(
+        !unique_source_by_operation.is_empty()
+            && unique_source_by_operation
+                .values()
+                .all(|bound| bound.is_some()),
+        "cleared LeaveRequest must not resurrect a split or unbound Leave source: {leave_sources:?}"
+    );
+}
+
+#[tokio::test]
+async fn terminal_m1_failure_ack_then_engine_m2_records_published_true() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot m1 ack engine m2 leave key").unwrap();
+    let tag = "engine-m2-leave";
+    let (bob, bob_path, bob_identity, group_id) =
+        joined_selfremove_member(dir.path(), &key, tag).await;
+    let bob_id = bob.self_id();
+    let adapter = RecordingAdapter::default();
+    let group_endpoint = TransportEndpoint("wss://engine-m2-group.example".into());
+    adapter.fail_endpoints_as(
+        vec![group_endpoint.clone()],
+        TransportEndpointFailureKind::TerminalRejected,
+    );
+    let route = || {
+        StaticTransportRouting::new(vec![TransportEndpoint(
+            "wss://engine-m2-inbox.example".into(),
+        )])
+        .with_group_route(
+            group_id.clone(),
+            group_id.as_slice().to_vec(),
+            vec![group_endpoint.clone()],
+        )
+    };
+    let mut runtime =
+        AccountDeviceRuntime::new(bob, adapter, route(), RecordingKeyPackages::default());
+    runtime.pause_maintenance();
+    let leased = runtime
+        .send_leased(SendIntent::Leave {
+            group_id: group_id.clone(),
+        })
+        .await
+        .unwrap();
+    let m1_id = leased
+        .effects
+        .action_outcomes
+        .iter()
+        .find(|outcome| !outcome.published)
+        .map(|outcome| outcome.message_id.clone())
+        .expect("terminal M1 Header failure records unpublished Leave");
+    assert!(
+        leased
+            .effects
+            .action_outcomes
+            .iter()
+            .all(|outcome| !outcome.published)
+    );
+    assert!(runtime.acknowledge_visibility_lease(leased.lease));
+    drop(runtime);
+
+    let alice_identity = format!("alice-{tag}").into_bytes();
+    let alice_path = dir.path().join(format!("alice-{tag}.sqlite"));
+    let alice = session_with_registry(&alice_path, &key, &alice_identity, selfremove_registry());
+    let alice_adapter = RecordingAdapter::default();
+    let mut alice_runtime = AccountDeviceRuntime::new(
+        alice,
+        alice_adapter.clone(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    alice_runtime.pause_maintenance();
+    alice_runtime
+        .send(SendIntent::UpdateGroupData {
+            group_id: group_id.clone(),
+            name: Some("engine m2 epoch".to_owned()),
+            description: None,
+        })
+        .await
+        .expect("alice must advance the epoch so Bob's LeaveRequest can auto-repropose");
+    let commit = alice_adapter
+        .publishes()
+        .into_iter()
+        .map(|publish| publish.message)
+        .find(|message| matches!(message.envelope, TransportEnvelope::GroupMessage { .. }))
+        .expect("alice epoch-advancing commit is published");
+    let commit = TransportMessage {
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+        ..commit
+    };
+    drop(alice_runtime);
+
+    let reopened = session_with_registry(&bob_path, &key, &bob_identity, selfremove_registry());
+    let recovered_adapter = RecordingAdapter::default();
+    let mut restarted = AccountDeviceRuntime::new(
+        reopened,
+        recovered_adapter.clone(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    restarted.pause_maintenance();
+    assert!(
+        restarted.replay_visibility_leased().unwrap().is_none(),
+        "terminal M1 Header ACK must drop Leave provenance from the journal"
+    );
+    let ingested = restarted
+        .ingest_delivery_leased(TransportDelivery {
+            account_id: bob_id,
+            group_id_hint: Some(group_id.clone()),
+            message: commit,
+            received_at: Timestamp(0),
+            source: TransportDeliverySource {
+                transport: TransportSource("marmot-account-test".into()),
+                plane: TransportDeliveryPlane::Group,
+                endpoint: None,
+                subscription_id: None,
+                wire: None,
+            },
+        })
+        .await
+        .expect("bob must ingest alice's epoch-advancing commit");
+    let mut published_outcomes = ingested.effects.action_outcomes.clone();
+    if matches!(
+        ingested.outcome,
+        cgka_traits::ingest::IngestOutcome::Buffered { .. }
+    ) || restarted.has_pending_convergence_inputs(&group_id).unwrap()
+        || ingested
+            .effects
+            .pending_convergence
+            .iter()
+            .any(|pending| pending == &group_id)
+    {
+        tokio::time::sleep(Duration::from_millis(
+            cgka_engine::canonicalization::V1_SETTLEMENT_QUIESCENCE_MS + 50,
+        ))
+        .await;
+        let converged = restarted
+            .advance_convergence_leased(&group_id)
+            .await
+            .expect("buffered epoch-advancing commit must converge");
+        published_outcomes.extend(converged.effects.action_outcomes);
+    }
+    let drained = restarted.drain_leased().await.unwrap();
+    published_outcomes.extend(drained.effects.action_outcomes.clone());
+    let m2 = published_outcomes
+        .into_iter()
+        .find(|outcome| outcome.published)
+        .expect(
+            "engine-driven M2 success must record published:true even with no surviving M1 Header",
+        );
+    assert_ne!(
+        m2.message_id, m1_id,
+        "engine-driven Leave success must bind the new SelfRemove, not the failed M1 Header"
+    );
+    drop(restarted);
+
+    let reopened = session_with_registry(&bob_path, &key, &bob_identity, selfremove_registry());
+    let mut recovered = AccountDeviceRuntime::new(
+        reopened,
+        RecordingAdapter::default(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    recovered.pause_maintenance();
+    let replayed = recovered
+        .replay_visibility_leased()
+        .unwrap()
+        .expect("engine-driven M2 published outcome must survive restart");
+    assert!(
+        flatten_visibility_batches(&replayed.batches)
+            .action_outcomes
+            .iter()
+            .any(|outcome| outcome.published && outcome.message_id == m2.message_id),
+        "restart must replay the exact engine-driven M2 Leave"
+    );
+    assert!(recovered.acknowledge_visibility_lease(replayed.lease));
+}
+
+#[tokio::test]
+async fn mixed_leave_headers_select_one_owner_without_duplicate_bind() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot mixed leave header key").unwrap();
+    let (bob, bob_path, bob_identity, group_id) =
+        joined_selfremove_member(dir.path(), &key, "mixed-leave-header").await;
+    let route = || {
+        StaticTransportRouting::new(vec![TransportEndpoint(
+            "wss://mixed-leave-inbox.example".into(),
+        )])
+        .with_group_route(
+            group_id.clone(),
+            group_id.as_slice().to_vec(),
+            vec![TransportEndpoint("wss://mixed-leave-group.example".into())],
+        )
+    };
+    let mut runtime = AccountDeviceRuntime::new(
+        bob,
+        RecordingAdapter::default(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    runtime.pause_maintenance();
+    let first = runtime
+        .send_leased(SendIntent::Leave {
+            group_id: group_id.clone(),
+        })
+        .await
+        .unwrap();
+    let first_id = first.effects.action_outcomes[0].message_id.clone();
+    let second = runtime
+        .send_leased(SendIntent::Leave {
+            group_id: group_id.clone(),
+        })
+        .await;
+    assert!(
+        second.is_err(),
+        "a second Leave in the same epoch must fail closed as already requested"
+    );
+    drop(runtime);
+
+    let reopened = session_with_registry(&bob_path, &key, &bob_identity, selfremove_registry());
+    let mut restarted = AccountDeviceRuntime::new(
+        reopened,
+        RecordingAdapter::default(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    restarted.pause_maintenance();
+    let replayed = restarted
+        .replay_visibility_leased()
+        .unwrap()
+        .expect("mixed Leave Headers remain crash-visible");
+    let leave_bindings = replayed
+        .batches
+        .iter()
+        .filter_map(|batch| match &batch.source {
+            AccountVisibilitySource::Outbound {
+                group_id: Some(source_group),
+                action: Some(AccountVisibilityOutboundAction::Leave),
+                action_message_id,
+                ..
+            } if source_group == &group_id => {
+                Some((batch.operation_id.clone(), action_message_id.clone()))
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let bound_operations = leave_bindings
+        .iter()
+        .filter(|(_, bound)| bound.as_ref() == Some(&first_id))
+        .map(|(operation_id, _)| operation_id.clone())
+        .collect::<std::collections::HashSet<_>>();
+    assert_eq!(
+        bound_operations.len(),
+        1,
+        "exactly one visibility operation may own the live Leave id; mixed Some(M1)+None must not duplicate: {leave_bindings:?}"
+    );
+    let recovered = restarted
+        .drain_leased()
+        .await
+        .expect("mixed Some(M1)+None Headers must not hard-fail terminal outcome recording");
+    assert!(restarted.acknowledge_visibility_lease(recovered.lease));
+}
+
+#[tokio::test]
+async fn cancelled_leave_fanout_recovery_emits_outcome_for_original_operation() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot cancelled leave outcome key").unwrap();
+    let (bob, bob_path, bob_identity, group_id) =
+        joined_selfremove_member(dir.path(), &key, "cancelled-leave-outcome").await;
+    let adapter = RecordingAdapter::default();
+    let gate = adapter.gate_all_publishes();
+    let route = || {
+        StaticTransportRouting::new(vec![TransportEndpoint(
+            "wss://cancelled-leave-inbox.example".into(),
+        )])
+        .with_group_route(
+            group_id.clone(),
+            group_id.as_slice().to_vec(),
+            vec![TransportEndpoint(
+                "wss://cancelled-leave-group.example".into(),
+            )],
+        )
+    };
+    let mut runtime = AccountDeviceRuntime::new(
+        bob,
+        adapter.clone(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    runtime.pause_maintenance();
+    let mut cancelled = Box::pin(runtime.send_leased(SendIntent::Leave {
+        group_id: group_id.clone(),
+    }));
+    tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::select! {
+            result = &mut cancelled => panic!("Leave returned before cancellation boundary: {result:?}"),
+            () = async {
+                while adapter.publishes().is_empty() {
+                    tokio::task::yield_now().await;
+                }
+            } => {}
+        }
+    })
+    .await
+    .expect("Leave reaches the blocked relay publish");
+    let leave_message_id = adapter.publishes()[0].message.id.clone();
+    drop(cancelled);
+    drop(runtime);
+    gate.release.add_permits(1);
+
+    let reopened = session_with_registry(&bob_path, &key, &bob_identity, selfremove_registry());
+    let recovered_adapter = RecordingAdapter::default();
+    let mut restarted = AccountDeviceRuntime::new(
+        reopened,
+        recovered_adapter.clone(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    restarted.pause_maintenance();
+    let pending = restarted
+        .replay_visibility_leased()
+        .unwrap()
+        .expect("bound original Leave Header survives cancellation");
+    assert!(
+        flatten_visibility_batches(&pending.batches)
+            .action_outcomes
+            .is_empty(),
+        "an unresolved Attempting fanout must not invent a terminal action outcome"
+    );
+    let original_operation_id = pending
+        .batches
+        .iter()
+        .find_map(|batch| match &batch.source {
+            AccountVisibilitySource::Outbound {
+                group_id: Some(source_group),
+                action: Some(AccountVisibilityOutboundAction::Leave),
+                action_message_id: Some(source_message),
+                ..
+            } if source_group == &group_id && source_message == &leave_message_id => {
+                Some(batch.operation_id.clone())
+            }
+            _ => None,
+        })
+        .expect("original Header binds the exact SelfRemove message");
+
+    let recovered = restarted.drain_leased().await.unwrap();
+    assert_eq!(recovered.effects.action_outcomes.len(), 1);
+    assert_eq!(
+        recovered.effects.action_outcomes[0],
+        marmot_account::AccountVisibilityActionOutcome {
+            operation_id: original_operation_id,
+            group_id: group_id.clone(),
+            message_id: leave_message_id,
+            action: AccountVisibilityOutboundAction::Leave,
+            published: true,
+        }
+    );
+    assert_eq!(recovered_adapter.publishes().len(), 1);
+    assert!(
+        !restarted.acknowledge_visibility_lease(pending.lease),
+        "the recovery lease supersedes the pre-recovery generation"
+    );
+    assert!(restarted.acknowledge_visibility_lease(recovered.lease));
+    assert!(restarted.replay_visibility_leased().unwrap().is_none());
+}
+
+#[tokio::test]
+async fn legacy_cancelled_operation_drain_acks_recovered_rows_so_reopen_does_not_redeliver() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot cancelled drain ack key").unwrap();
+    let (bob, bob_path, bob_identity, group_id) =
+        joined_selfremove_member(dir.path(), &key, "cancelled-drain-ack").await;
+    let adapter = RecordingAdapter::default();
+    let gate = adapter.gate_all_publishes();
+    let route = || {
+        StaticTransportRouting::new(vec![TransportEndpoint(
+            "wss://cancelled-drain-inbox.example".into(),
+        )])
+        .with_group_route(
+            group_id.clone(),
+            group_id.as_slice().to_vec(),
+            vec![TransportEndpoint(
+                "wss://cancelled-drain-group.example".into(),
+            )],
+        )
+    };
+    let mut runtime = AccountDeviceRuntime::new(
+        bob,
+        adapter.clone(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    runtime.pause_maintenance();
+    let mut cancelled = Box::pin(runtime.send_leased(SendIntent::Leave {
+        group_id: group_id.clone(),
+    }));
+    tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::select! {
+            result = &mut cancelled => panic!("Leave returned before cancellation boundary: {result:?}"),
+            () = async {
+                while adapter.publishes().is_empty() {
+                    tokio::task::yield_now().await;
+                }
+            } => {}
+        }
+    })
+    .await
+    .expect("Leave reaches the blocked relay publish");
+    drop(cancelled);
+    gate.release.add_permits(1);
+    let drained = runtime.drain().await.unwrap();
+    assert!(
+        !drained.events.is_empty()
+            || !drained.action_outcomes.is_empty()
+            || !drained.reports.is_empty(),
+        "legacy drain must hand off the cancelled Leave effects"
+    );
+    drop(runtime);
+
+    let reopened = session_with_registry(&bob_path, &key, &bob_identity, selfremove_registry());
+    let mut restarted = AccountDeviceRuntime::new(
+        reopened,
+        RecordingAdapter::default(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    restarted.pause_maintenance();
+    assert!(
+        restarted.replay_visibility_leased().unwrap().is_none(),
+        "legacy drain must ACK every handed-off cancelled operation"
+    );
+    let second = restarted.drain().await.unwrap();
+    assert!(
+        second.action_outcomes.is_empty(),
+        "reopen must not redeliver a cancelled Leave already returned by drain"
+    );
+}
+
+#[tokio::test]
+async fn legacy_ingest_delivery_acks_engine_outbox_so_reopen_does_not_redeliver() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot legacy ingest ack key").unwrap();
+    let alice_path = dir.path().join("alice-legacy-ingest.sqlite");
+    let bob_path = dir.path().join("bob-legacy-ingest.sqlite");
+    let mut alice = session_with_registry(
+        &alice_path,
+        &key,
+        b"alice-legacy-ingest",
+        selfremove_registry(),
+    );
+    let mut bob =
+        session_with_registry(&bob_path, &key, b"bob-legacy-ingest", selfremove_registry());
+    let bob_id = bob.self_id();
+    let bob_key_package = bob.fresh_key_package().await.unwrap();
+    let created = alice
+        .create_group(CreateGroupRequest {
+            name: "legacy ingest ack".into(),
+            description: String::new(),
+            members: vec![bob_key_package],
+            required_features: Vec::new(),
+            app_components: Vec::new(),
+            initial_admins: Vec::new(),
+        })
+        .await
+        .unwrap();
+    let (pending, welcome) = match created.effects.publish.as_slice() {
+        [PublishWork::GroupCreated { pending, welcomes }] => (*pending, welcomes[0].clone()),
+        other => panic!("expected one GroupCreated publish work, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+
+    let mut runtime = AccountDeviceRuntime::new(
+        bob,
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![TransportEndpoint(
+            "wss://legacy-ingest-inbox.example".into(),
+        )]),
+        RecordingKeyPackages::default(),
+    );
+    runtime.pause_maintenance();
+    let ingested = runtime
+        .ingest_delivery(TransportDelivery {
+            account_id: bob_id,
+            group_id_hint: None,
+            message: welcome,
+            received_at: Timestamp(0),
+            source: TransportDeliverySource {
+                transport: TransportSource("marmot-account-test".into()),
+                plane: TransportDeliveryPlane::AccountInbox,
+                endpoint: None,
+                subscription_id: None,
+                wire: None,
+            },
+        })
+        .await
+        .unwrap();
+    assert!(
+        ingested
+            .effects
+            .events
+            .iter()
+            .any(|event| matches!(event, GroupEvent::GroupJoined { .. })),
+        "legacy ingest must return the Welcome application event"
+    );
+    assert!(
+        runtime
+            .session()
+            .storage_handle()
+            .list_pending_application_events()
+            .unwrap()
+            .is_empty(),
+        "legacy ingest must ACK engine outbox ids with the visibility discard"
+    );
+    drop(runtime);
+
+    let reopened =
+        session_with_registry(&bob_path, &key, b"bob-legacy-ingest", selfremove_registry());
+    assert!(
+        reopened
+            .storage_handle()
+            .list_pending_application_events()
+            .unwrap()
+            .is_empty(),
+        "reopen must not hydrate a returned Welcome back into the engine outbox"
+    );
+    let mut restarted = AccountDeviceRuntime::new(
+        reopened,
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![TransportEndpoint(
+            "wss://legacy-ingest-inbox.example".into(),
+        )]),
+        RecordingKeyPackages::default(),
+    );
+    restarted.pause_maintenance();
+    let drained = restarted.drain().await.unwrap();
+    assert!(
+        drained
+            .events
+            .iter()
+            .all(|event| !matches!(event, GroupEvent::GroupJoined { .. })),
+        "a returned GroupJoined must not reappear after every reopen"
+    );
+}
+
+#[tokio::test]
+async fn leave_quorum_records_published_true_while_optional_target_stays_retryable() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot leave quorum outcome key").unwrap();
+    let (bob, bob_path, bob_identity, group_id) =
+        joined_selfremove_member(dir.path(), &key, "leave-quorum-outcome").await;
+    let required = TransportEndpoint("wss://leave-quorum-required.example".into());
+    let optional = TransportEndpoint("wss://leave-quorum-optional.example".into());
+    let adapter = RecordingAdapter::default();
+    adapter.fail_endpoints_as(
+        vec![optional.clone()],
+        TransportEndpointFailureKind::RetryableUnavailable,
+    );
+    let route = || {
+        StaticTransportRouting::new(vec![TransportEndpoint(
+            "wss://leave-quorum-inbox.example".into(),
+        )])
+        .required_acks(1)
+        .with_group_route(
+            group_id.clone(),
+            group_id.as_slice().to_vec(),
+            vec![required.clone(), optional.clone()],
+        )
+    };
+    let mut runtime =
+        AccountDeviceRuntime::new(bob, adapter, route(), RecordingKeyPackages::default());
+    runtime.pause_maintenance();
+    let leased = runtime
+        .send_leased(SendIntent::Leave {
+            group_id: group_id.clone(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(leased.effects.action_outcomes.len(), 1);
+    assert!(
+        leased.effects.action_outcomes[0].published,
+        "meeting required ACKs must authorize Left even if an optional target is still retryable"
+    );
+    assert!(
+        leased
+            .effects
+            .fanout
+            .iter()
+            .any(|outcome| outcome.outstanding_targets > 0 && !outcome.fanout_complete),
+        "the optional target must remain outstanding so this is not the complete-fanout path"
+    );
+    drop(runtime);
+
+    let reopened = session_with_registry(&bob_path, &key, &bob_identity, selfremove_registry());
+    let mut restarted = AccountDeviceRuntime::new(
+        reopened,
+        RecordingAdapter::default(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    restarted.pause_maintenance();
+    let replayed = restarted
+        .replay_visibility_leased()
+        .unwrap()
+        .expect("quorum Leave outcome survives restart");
+    assert_eq!(
+        flatten_visibility_batches(&replayed.batches)
+            .action_outcomes
+            .iter()
+            .filter(|outcome| outcome.published)
+            .count(),
+        1
+    );
+    let drained = restarted
+        .drain_leased()
+        .await
+        .expect("optional Leave completion must accept an already-durable published outcome");
+    assert!(
+        drained
+            .effects
+            .action_outcomes
+            .iter()
+            .all(|outcome| outcome.published),
+        "completing the optional target must not rewrite the durable published:true outcome"
+    );
+    if !restarted.acknowledge_visibility_lease(replayed.lease) {
+        assert!(restarted.acknowledge_visibility_lease(drained.lease));
+    }
+}
+
+#[tokio::test]
+async fn leave_reproposal_rebinds_header_to_the_new_self_remove() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot leave reproposal provenance key").unwrap();
+    let (bob, bob_path, bob_identity, group_id) =
+        joined_selfremove_member(dir.path(), &key, "leave-reproposal-provenance").await;
+    let route = || {
+        StaticTransportRouting::new(vec![TransportEndpoint(
+            "wss://leave-reproposal-inbox.example".into(),
+        )])
+        .with_group_route(
+            group_id.clone(),
+            group_id.as_slice().to_vec(),
+            vec![TransportEndpoint(
+                "wss://leave-reproposal-group.example".into(),
+            )],
+        )
+    };
+    let mut runtime = AccountDeviceRuntime::new(
+        bob,
+        RecordingAdapter::default(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    runtime.pause_maintenance();
+    let leased = runtime
+        .send_leased(SendIntent::Leave {
+            group_id: group_id.clone(),
+        })
+        .await
+        .unwrap();
+    let original = leased
+        .effects
+        .action_outcomes
+        .first()
+        .expect("the original Leave binds an exact SelfRemove");
+    let first_id = original.message_id.clone();
+    let later_id = MessageId::new(b"leave-reproposal-m2".to_vec());
+    assert_ne!(first_id, later_id);
+    let mut request = runtime
+        .session()
+        .storage_handle()
+        .leave_request(&group_id)
+        .unwrap()
+        .expect("accepted Leave writes a durable request");
+    request.last_proposed_message_id = Some(later_id.clone());
+    runtime
+        .session()
+        .storage_handle()
+        .put_leave_request(&request)
+        .unwrap();
+    drop(runtime);
+
+    let reopened = session_with_registry(&bob_path, &key, &bob_identity, selfremove_registry());
+    let mut restarted = AccountDeviceRuntime::new(
+        reopened,
+        RecordingAdapter::default(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    restarted.pause_maintenance();
+    let replayed = restarted
+        .replay_visibility_leased()
+        .unwrap()
+        .expect("Leave Header survives the message-id move");
+    assert!(replayed.batches.iter().any(|batch| {
+        matches!(
+            &batch.source,
+            AccountVisibilitySource::Outbound {
+                group_id: Some(source_group),
+                action: Some(AccountVisibilityOutboundAction::Leave),
+                action_message_id: Some(bound),
+                ..
+            } if source_group == &group_id && bound == &later_id
+        )
+    }));
+    assert!(restarted.acknowledge_visibility_lease(replayed.lease));
+}
+
+#[tokio::test]
+async fn older_pre_acceptance_leave_header_does_not_bind_a_later_leave_id() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot stale leave header key").unwrap();
+    let database = dir.path().join("stale-leave-header.sqlite");
+    let mut alice = session_with_registry(
+        &database,
+        &key,
+        b"stale-leave-header",
+        selfremove_registry(),
+    );
+    let created = alice
+        .create_group(CreateGroupRequest {
+            name: "stale leave header".into(),
+            description: String::new(),
+            members: Vec::new(),
+            required_features: Vec::new(),
+            app_components: Vec::new(),
+            initial_admins: Vec::new(),
+        })
+        .await
+        .unwrap();
+    let group_id = created.group_id;
+    let pending = match created.effects.publish.as_slice() {
+        [PublishWork::GroupCreated { pending, .. }] => *pending,
+        other => panic!("expected one GroupCreated publish work, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    let route = || {
+        StaticTransportRouting::new(vec![TransportEndpoint(
+            "wss://stale-leave-header.example".into(),
+        )])
+        .with_group_route(
+            group_id.clone(),
+            group_id.as_slice().to_vec(),
+            vec![TransportEndpoint(
+                "wss://stale-leave-header-group.example".into(),
+            )],
+        )
+    };
+    let mut runtime = AccountDeviceRuntime::new(
+        alice,
+        RecordingAdapter::default(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    runtime.pause_maintenance();
+    assert!(
+        runtime
+            .send_leased(SendIntent::Leave {
+                group_id: group_id.clone(),
+            })
+            .await
+            .is_err(),
+        "an admin SelfRemove must fail before engine acceptance"
+    );
+    assert!(
+        runtime
+            .send_leased(SendIntent::Leave {
+                group_id: group_id.clone(),
+            })
+            .await
+            .is_err(),
+        "a second pre-acceptance Leave must leave a newer Header"
+    );
+    let later_id = MessageId::new(b"later-leave".to_vec());
+    runtime
+        .session()
+        .storage_handle()
+        .put_leave_request(&cgka_traits::storage::LeaveRequest {
+            group_id: group_id.clone(),
+            requested_at_ms: 1,
+            last_proposed_epoch: None,
+            last_proposed_message_id: Some(later_id.clone()),
+        })
+        .unwrap();
+    drop(runtime);
+
+    let reopened = session_with_registry(
+        &database,
+        &key,
+        b"stale-leave-header",
+        selfremove_registry(),
+    );
+    let mut restarted = AccountDeviceRuntime::new(
+        reopened,
+        RecordingAdapter::default(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    restarted.pause_maintenance();
+    let replayed = restarted
+        .replay_visibility_leased()
+        .unwrap()
+        .expect("both pre-acceptance Headers remain crash-visible");
+    let leave_headers = replayed
+        .batches
+        .iter()
+        .filter_map(|batch| match &batch.source {
+            AccountVisibilitySource::Outbound {
+                group_id: Some(source_group),
+                action: Some(AccountVisibilityOutboundAction::Leave),
+                action_message_id,
+                ..
+            } if source_group == &group_id => Some((batch.sequence, action_message_id.clone())),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(leave_headers.len(), 2);
+    let max_seq = leave_headers
+        .iter()
+        .map(|(sequence, _)| *sequence)
+        .max()
+        .unwrap();
+    for (sequence, bound) in &leave_headers {
+        if *sequence == max_seq {
+            assert_eq!(bound.as_ref(), Some(&later_id));
+        } else {
+            assert_eq!(
+                bound, &None,
+                "an older unacknowledged pre-acceptance Header must not inherit a later Leave id"
+            );
+        }
+    }
+    assert!(restarted.acknowledge_visibility_lease(replayed.lease));
+}
+
+// A startup drain can contain both a one-shot hydration/application event and
+// restored durable publish work. Cancelling while that publish is in flight
+// must not require rebuilding the whole AccountDeviceRuntime to see the event
+// again: the retained runtime's following no-inbound drain is the handoff
+// recovery surface.
+#[tokio::test]
+async fn cancelled_drain_replays_visibility_after_restored_publish_blocks() {
+    use cgka_traits::GroupStorage;
+    use cgka_traits::engine::GroupHydrationQuarantineReason;
+    use cgka_traits::group::Group;
+
+    let dir = tempfile::tempdir().unwrap();
+    let key_text = "marmot cancelled drain visibility key";
+    let key = SqlCipherKey::new(key_text).unwrap();
+    let db_path = dir.path().join("alice.sqlite");
+    let mut alice = session(&db_path, &key, b"alice-cancelled-drain");
+
+    let created = alice
+        .create_group(CreateGroupRequest {
+            name: "cancelled drain source".into(),
+            description: String::new(),
+            members: Vec::new(),
+            required_features: Vec::new(),
+            app_components: Vec::new(),
+            initial_admins: Vec::new(),
+        })
+        .await
+        .unwrap();
+    let group_id = created.group_id;
+    let create_pending = match created.effects.publish.as_slice() {
+        [PublishWork::GroupCreated { pending, .. }] => *pending,
+        other => panic!("expected one GroupCreated publish work, got {other:?}"),
+    };
+    alice.confirm_published(create_pending).await.unwrap();
+
+    // Leave an exact signed evolution and its frozen fanout durable but
+    // unpublished. Reopening recovers the pending evolution, and `drain()`
+    // resumes that fanout in the same call as the hydration event below.
+    let staged = alice
+        .send(SendIntent::UpdateGroupData {
+            group_id: group_id.clone(),
+            name: Some("restored publish".into()),
+            description: None,
+        })
+        .await
+        .unwrap();
+    let (message, pending) = match staged.publish.as_slice() {
+        [PublishWork::GroupEvolution { msg, pending, .. }] => (msg.clone(), *pending),
+        other => panic!("expected one GroupEvolution publish work, got {other:?}"),
+    };
+    let transport_group_id = match &message.envelope {
+        TransportEnvelope::GroupMessage { transport_group_id } => transport_group_id.clone(),
+        other => panic!("expected group-message evolution, got {other:?}"),
+    };
+    let group_endpoint = TransportEndpoint("wss://cancelled-drain-group.example".into());
+    let frozen_request = TransportPublishRequest {
+        account_id: alice.self_id().clone(),
+        message,
+        target: TransportPublishTarget::Group {
+            group_id: group_id.clone(),
+            transport_group_id,
+            endpoints: vec![group_endpoint.clone()],
+        },
+        required_acks: 1,
+    };
+    let frozen_fanout =
+        OutboundFanout::stage(frozen_request, Some(pending), Some(group_id.clone()), 0).unwrap();
+    alice.put_outbound_fanout(&frozen_fanout).unwrap();
+    drop(alice);
+
+    let broken_group = GroupId::new(b"cancelled-drain-broken-group".to_vec());
+    {
+        let storage =
+            SqliteAccountStorage::open_encrypted(&db_path, &SqlCipherKey::new(key_text).unwrap())
+                .unwrap();
+        storage
+            .put_group(&Group {
+                id: broken_group.clone(),
+                name: "broken".into(),
+                description: String::new(),
+                members: Vec::new(),
+                epoch: EpochId(9),
+                required_capabilities: cgka_traits::GroupCapabilities::default(),
+                protocol_profile: ProtocolProfile::Legacy,
+                removed: false,
+                unrecoverable: false,
+                disbanded: None,
+                join_epoch: EpochId(0),
+            })
+            .unwrap();
+    }
+
+    let reopened = session(
+        &db_path,
+        &SqlCipherKey::new(key_text).unwrap(),
+        b"alice-cancelled-drain",
+    );
+    let adapter = RecordingAdapter::default();
+    let gate = adapter.gate_all_publishes();
+    let policy = StaticTransportRouting::new(vec![TransportEndpoint(
+        "wss://cancelled-drain-inbox.example".into(),
+    )])
+    .with_group_route(
+        group_id.clone(),
+        group_id.as_slice().to_vec(),
+        vec![group_endpoint],
+    );
+    let mut runtime = AccountDeviceRuntime::new(
+        reopened,
+        adapter.clone(),
+        policy,
+        RecordingKeyPackages::default(),
+    );
+
+    let mut cancelled = Box::pin(runtime.drain());
+    tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::select! {
+            result = &mut cancelled => {
+                panic!("startup publish returned before cancellation boundary: {result:?}")
+            }
+            () = async {
+                while adapter.publishes().is_empty() {
+                    tokio::task::yield_now().await;
+                }
+            } => {}
+        }
+    })
+    .await
+    .expect("restored publish reaches the blocking adapter");
+    drop(cancelled);
+
+    // The first blocked adapter future was dropped with the drain. Let its
+    // durable exact fanout retry complete on the next call.
+    gate.release.add_permits(1);
+    let recovered = tokio::time::timeout(Duration::from_secs(5), runtime.drain())
+        .await
+        .expect("retained runtime drain completes")
+        .unwrap();
+    assert!(recovered.events.iter().any(|event| matches!(
+        event,
+        GroupEvent::GroupHydrationQuarantined {
+            group_id,
+            reason: GroupHydrationQuarantineReason::OpenMlsGroupMissing,
+        } if group_id == &broken_group
+    )));
+
+    let handed_off = runtime.drain().await.unwrap();
+    assert!(!handed_off.events.iter().any(|event| matches!(
+        event,
+        GroupEvent::GroupHydrationQuarantined { group_id, .. } if group_id == &broken_group
+    )));
+}
+
+#[tokio::test]
+async fn cancelled_later_publish_work_replays_completed_application_effects_without_republishing() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot multi-work visibility key").unwrap();
+    let mut alice = session(
+        dir.path().join("alice-multi-work.sqlite"),
+        &key,
+        b"alice-multi-work",
+    );
+    let created = alice
+        .create_group(CreateGroupRequest {
+            name: "multi-work visibility".into(),
+            description: String::new(),
+            members: Vec::new(),
+            required_features: Vec::new(),
+            app_components: Vec::new(),
+            initial_admins: Vec::new(),
+        })
+        .await
+        .unwrap();
+    let group_id = created.group_id;
+    let create_pending = match created.effects.publish.as_slice() {
+        [PublishWork::GroupCreated { pending, .. }] => *pending,
+        other => panic!("expected one GroupCreated publish work, got {other:?}"),
+    };
+    alice.confirm_published(create_pending).await.unwrap();
+
+    let mut combined = alice
+        .send(SendIntent::AppMessage {
+            group_id: group_id.clone(),
+            payload: app_payload_for(&hex::encode(alice.self_id().as_slice()), "first"),
+        })
+        .await
+        .unwrap();
+    let second = alice
+        .send(SendIntent::AppMessage {
+            group_id: group_id.clone(),
+            payload: app_payload_for(&hex::encode(alice.self_id().as_slice()), "second"),
+        })
+        .await
+        .unwrap();
+    combined.events.extend(second.events);
+    combined.publish.extend(second.publish);
+    combined.queued.extend(second.queued);
+    combined
+        .pending_convergence
+        .extend(second.pending_convergence);
+
+    let (first_message_id, first_app_event_id) = match &combined.publish[0] {
+        PublishWork::ApplicationMessage {
+            msg, app_event_id, ..
+        } => (msg.id.clone(), app_event_id.clone()),
+        other => panic!("expected first ApplicationMessage, got {other:?}"),
+    };
+    let second_message_id = match &combined.publish[1] {
+        PublishWork::ApplicationMessage { msg, .. } => msg.id.clone(),
+        other => panic!("expected second ApplicationMessage, got {other:?}"),
+    };
+
+    let adapter = RecordingAdapter::default();
+    let gate = adapter.gate_all_publishes();
+    gate.release.add_permits(1);
+    let endpoint = TransportEndpoint("wss://multi-work-group.example".into());
+    let routing = StaticTransportRouting::new(vec![TransportEndpoint(
+        "wss://multi-work-inbox.example".into(),
+    )])
+    .with_group_route(
+        group_id.clone(),
+        group_id.as_slice().to_vec(),
+        vec![endpoint],
+    );
+    let mut runtime = AccountDeviceRuntime::new(
+        alice,
+        adapter.clone(),
+        routing,
+        RecordingKeyPackages::default(),
+    );
+
+    let mut cancelled = Box::pin(runtime.publish_session_effects(combined));
+    tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::select! {
+            result = &mut cancelled => {
+                panic!("both publish work items completed before cancellation: {result:?}")
+            }
+            () = async {
+                while adapter.publishes().len() < 2 {
+                    tokio::task::yield_now().await;
+                }
+            } => {}
+        }
+    })
+    .await
+    .expect("second application publish reaches its blocking adapter");
+    drop(cancelled);
+
+    // The second exact fanout remains durable and retryable. Completing it may
+    // not re-run the first PublishWork; its report and app-acceptance metadata
+    // must instead come from the runtime visibility journal.
+    gate.release.add_permits(1);
+    let recovered = tokio::time::timeout(Duration::from_secs(5), runtime.drain_leased())
+        .await
+        .expect("durable second fanout retry completes")
+        .unwrap();
+    let recovered_visibility = flatten_visibility_batches(&recovered.batches);
+    assert_eq!(
+        recovered_visibility
+            .reports
+            .iter()
+            .filter(|report| report.message_id == first_message_id)
+            .count(),
+        1
+    );
+    assert_eq!(
+        recovered_visibility
+            .published_app_messages
+            .iter()
+            .filter(|published| published.app_event_id == first_app_event_id)
+            .count(),
+        1
+    );
+    let publishes = adapter.publishes();
+    assert_eq!(
+        publishes
+            .iter()
+            .filter(|request| request.message.id == first_message_id)
+            .count(),
+        1,
+        "replay must not publish the completed first item again"
+    );
+    assert_eq!(
+        publishes
+            .iter()
+            .filter(|request| request.message.id == second_message_id)
+            .count(),
+        2,
+        "only the cancelled second fanout should retry"
+    );
+
+    let replayed = runtime.drain_leased().await.unwrap();
+    let replayed_visibility = flatten_visibility_batches(&replayed.batches);
+    assert_eq!(
+        replayed_visibility
+            .published_app_messages
+            .iter()
+            .filter(|published| published.app_event_id == first_app_event_id)
+            .count(),
+        1,
+        "an unacknowledged full-effects lease must replay without duplication"
+    );
+    assert!(!runtime.acknowledge_visibility_lease(recovered.lease));
+    assert!(runtime.acknowledge_visibility_lease(replayed.lease));
+
+    let after_ack = runtime.drain_leased().await.unwrap();
+    assert!(after_ack.effects.published_app_messages.is_empty());
+    assert!(runtime.acknowledge_visibility_lease(after_ack.lease));
+}
+
 // mdk#483 regression: an auto-published commit (here, the admin's
 // auto-commit of a peer self-remove proposal) that a relay *accepted* but that
 // did not meet `required_acks` must be CONFIRMED, not rolled back. Rolling it
@@ -3677,7 +10022,7 @@ async fn auto_publish_confirms_pending_when_commit_was_partially_exposed() {
         },
     };
 
-    let ingested = runtime.ingest_delivery(delivery).await.unwrap();
+    let ingested = runtime.ingest_delivery_leased(delivery).await.unwrap();
     assert_eq!(ingested.effects.pending_convergence, vec![group_id.clone()]);
     assert!(
         ingested.effects.pending.is_empty(),
@@ -3685,20 +10030,40 @@ async fn auto_publish_confirms_pending_when_commit_was_partially_exposed() {
     );
 
     tokio::time::sleep(std::time::Duration::from_millis(75)).await;
-    let advanced = runtime.advance_convergence(&group_id).await.unwrap();
+    let advanced = runtime.advance_convergence_leased(&group_id).await.unwrap();
+
+    assert_eq!(
+        flatten_visibility_batches(&advanced.batches).pending_convergence,
+        vec![group_id.clone()],
+        "the unacknowledged ingest visibility must precede convergence output"
+    );
+    assert!(
+        !runtime.acknowledge_visibility_lease(ingested.lease),
+        "a later lease supersedes the ingest generation"
+    );
 
     // The auto-published commit was accepted by a relay but missed required_acks
     // — it must be confirmed (kept), not rolled back.
-    assert_eq!(advanced.pending.len(), 1);
+    assert_eq!(advanced.effects.pending.len(), 1);
     assert!(
-        matches!(advanced.pending[0], PendingResolution::Confirmed { .. }),
+        matches!(
+            advanced.effects.pending[0],
+            PendingResolution::Confirmed { .. }
+        ),
         "relay-accepted auto-publish must be confirmed, got {:?}",
-        advanced.pending[0]
+        advanced.effects.pending[0]
     );
     // The commit publish was attempted and reported under-threshold acceptance.
-    assert_eq!(advanced.reports.len(), 1);
-    assert_eq!(advanced.reports[0].accepted_count(), 1);
-    assert!(!advanced.reports[0].met_required_acks());
+    assert_eq!(advanced.effects.reports.len(), 1);
+    assert_eq!(advanced.effects.reports[0].accepted_count(), 1);
+    assert!(!advanced.effects.reports[0].met_required_acks());
+    assert!(runtime.acknowledge_visibility_lease(advanced.lease));
+
+    let after_ack = runtime.drain_leased().await.unwrap();
+    assert!(after_ack.effects.pending_convergence.is_empty());
+    assert!(after_ack.effects.pending.is_empty());
+    assert!(after_ack.effects.reports.is_empty());
+    assert!(runtime.acknowledge_visibility_lease(after_ack.lease));
     // The removal was applied locally: epoch advanced and bob is gone.
     assert_eq!(runtime.session().epoch(&group_id).unwrap().0, 2);
     assert_eq!(runtime.session().members(&group_id).unwrap().len(), 1);

--- a/crates/storage-sqlite/src/account_projection.rs
+++ b/crates/storage-sqlite/src/account_projection.rs
@@ -973,12 +973,36 @@ impl SqliteAccountStorage {
         frontiers_to_clear: &[(String, u64)],
         application_event_ids_to_ack: &[MessageId],
     ) -> StorageResult<()> {
+        self.save_account_projection_state_clearing_local_group_deletion_frontiers_and_acking_application_events_and_visibility_batches(
+            state,
+            max_seen_events,
+            max_future_skew_secs,
+            frontiers_to_clear,
+            application_event_ids_to_ack,
+            &[],
+        )
+    }
+
+    /// Persist the complete account projection and atomically transfer both
+    /// engine application events and lower account-visibility rows into app
+    /// ownership. A crash therefore replays the rows or observes their fully
+    /// committed projection, never an engine state advance with neither.
+    pub fn save_account_projection_state_clearing_local_group_deletion_frontiers_and_acking_application_events_and_visibility_batches(
+        &self,
+        state: &StoredAccountState,
+        max_seen_events: usize,
+        max_future_skew_secs: u64,
+        frontiers_to_clear: &[(String, u64)],
+        application_event_ids_to_ack: &[MessageId],
+        visibility_batch_ids_to_ack: &[Vec<u8>],
+    ) -> StorageResult<()> {
         self.save_account_projection(
             state,
             max_seen_events,
             max_future_skew_secs,
             frontiers_to_clear,
             application_event_ids_to_ack,
+            visibility_batch_ids_to_ack,
             true,
         )
     }
@@ -1001,16 +1025,38 @@ impl SqliteAccountStorage {
         frontiers_to_clear: &[(String, u64)],
         application_event_ids_to_ack: &[MessageId],
     ) -> StorageResult<()> {
+        self.save_account_projection_delta_clearing_local_group_deletion_frontiers_and_acking_application_events_and_visibility_batches(
+            state,
+            max_seen_events,
+            max_future_skew_secs,
+            frontiers_to_clear,
+            application_event_ids_to_ack,
+            &[],
+        )
+    }
+
+    /// Delta counterpart to the full-snapshot visibility transfer above.
+    pub fn save_account_projection_delta_clearing_local_group_deletion_frontiers_and_acking_application_events_and_visibility_batches(
+        &self,
+        state: &StoredAccountState,
+        max_seen_events: usize,
+        max_future_skew_secs: u64,
+        frontiers_to_clear: &[(String, u64)],
+        application_event_ids_to_ack: &[MessageId],
+        visibility_batch_ids_to_ack: &[Vec<u8>],
+    ) -> StorageResult<()> {
         self.save_account_projection(
             state,
             max_seen_events,
             max_future_skew_secs,
             frontiers_to_clear,
             application_event_ids_to_ack,
+            visibility_batch_ids_to_ack,
             false,
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn save_account_projection(
         &self,
         state: &StoredAccountState,
@@ -1018,6 +1064,7 @@ impl SqliteAccountStorage {
         max_future_skew_secs: u64,
         frontiers_to_clear: &[(String, u64)],
         application_event_ids_to_ack: &[MessageId],
+        visibility_batch_ids_to_ack: &[Vec<u8>],
         replace_group_snapshot: bool,
     ) -> StorageResult<()> {
         let now = unix_now_seconds();
@@ -1268,6 +1315,13 @@ impl SqliteAccountStorage {
                     "DELETE FROM pending_application_events WHERE message_id = ?1",
                     params![message_id.as_slice()],
                 )
+                    .storage()?;
+            }
+            for batch_id in visibility_batch_ids_to_ack {
+                conn.execute(
+                    "DELETE FROM account_visibility_journal WHERE batch_id = ?1",
+                    params![batch_id],
+                )
                 .storage()?;
             }
             Ok(())
@@ -1407,6 +1461,13 @@ impl SqliteAccountStorage {
                 deleted = deleted.saturating_add(
                     tx.execute(
                         "DELETE FROM pending_application_events WHERE group_id = ?1",
+                        params![&group_id],
+                    )
+                    .storage()?,
+                );
+                deleted = deleted.saturating_add(
+                    tx.execute(
+                        "DELETE FROM app_epoch_backfill_intents WHERE group_id = ?1",
                         params![&group_id],
                     )
                     .storage()?,

--- a/crates/storage-sqlite/src/account_projection/tests.rs
+++ b/crates/storage-sqlite/src/account_projection/tests.rs
@@ -2855,6 +2855,78 @@ fn failed_resurrection_projection_save_retains_local_deletion_frontier() {
 }
 
 #[test]
+fn visibility_batch_ack_is_atomic_with_projection_delta() {
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    let operation_id = b"visibility-operation";
+    let batch_id = b"visibility-batch".to_vec();
+    store
+        .upsert_account_visibility_journal(operation_id, 1, &batch_id, b"opaque-effects")
+        .unwrap();
+    store
+        .lock()
+        .unwrap()
+        .execute_batch(
+            "CREATE TRIGGER fail_visibility_projection
+             BEFORE INSERT ON account_groups
+             BEGIN
+                 SELECT RAISE(ABORT, 'injected visibility projection failure');
+             END;",
+        )
+        .unwrap();
+    let state = StoredAccountState {
+        label: "alice".to_owned(),
+        seen_events: vec!["visible-event".to_owned()],
+        last_transport_timestamp: None,
+        groups: vec![group("aa", "visible group")],
+    };
+
+    let result = store
+        .save_account_projection_delta_clearing_local_group_deletion_frontiers_and_acking_application_events_and_visibility_batches(
+            &state,
+            16,
+            MAX_FUTURE_SKEW_SECS,
+            &[],
+            &[],
+            std::slice::from_ref(&batch_id),
+        );
+
+    assert!(result.is_err());
+    assert_eq!(store.load_account_visibility_journal().unwrap().len(), 1);
+    assert!(
+        store
+            .load_account_projection_state("alice", 16)
+            .unwrap()
+            .groups
+            .is_empty(),
+        "a failed projection must not expose state while keeping the lower row",
+    );
+
+    store
+        .lock()
+        .unwrap()
+        .execute_batch("DROP TRIGGER fail_visibility_projection")
+        .unwrap();
+    store
+        .save_account_projection_delta_clearing_local_group_deletion_frontiers_and_acking_application_events_and_visibility_batches(
+            &state,
+            16,
+            MAX_FUTURE_SKEW_SECS,
+            &[],
+            &[],
+            std::slice::from_ref(&batch_id),
+        )
+        .unwrap();
+    assert!(store.load_account_visibility_journal().unwrap().is_empty());
+    assert_eq!(
+        store
+            .load_account_projection_state("alice", 16)
+            .unwrap()
+            .groups,
+        state.groups,
+    );
+}
+
+#[test]
 fn repeated_local_group_delete_advances_frontier_past_buffered_messages() {
     let store = SqliteAccountStorage::in_memory().unwrap();
     insert_protocol_group_marker(&store, &[0xaa]);

--- a/crates/storage-sqlite/src/account_visibility_journal.rs
+++ b/crates/storage-sqlite/src/account_visibility_journal.rs
@@ -1,0 +1,294 @@
+use crate::connection::retry_on_busy;
+use crate::{SqliteAccountStorage, SqliteResultExt, i64_to_u64, u64_to_i64};
+use cgka_traits::storage::{StorageError, StorageResult};
+use rusqlite::{OptionalExtension, params};
+
+/// One ordered opaque account-runtime visibility record.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AccountVisibilityJournalRow {
+    pub sequence: u64,
+    pub operation_id: Vec<u8>,
+    pub ordinal: u64,
+    pub batch_id: Vec<u8>,
+    pub record: Vec<u8>,
+}
+
+/// One opaque record to insert or replace as part of an atomic visibility
+/// checkpoint.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AccountVisibilityJournalUpsert {
+    pub operation_id: Vec<u8>,
+    pub ordinal: u64,
+    pub batch_id: Vec<u8>,
+    pub record: Vec<u8>,
+}
+
+impl SqliteAccountStorage {
+    /// Load every unacknowledged visibility record in insertion order.
+    pub fn load_account_visibility_journal(
+        &self,
+    ) -> StorageResult<Vec<AccountVisibilityJournalRow>> {
+        let connection = self.lock()?;
+        let mut statement = connection
+            .prepare(
+                "SELECT sequence, operation_id, ordinal, batch_id, record
+                 FROM account_visibility_journal
+                 ORDER BY sequence",
+            )
+            .storage()?;
+        let rows = statement
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, Vec<u8>>(1)?,
+                    row.get::<_, i64>(2)?,
+                    row.get::<_, Vec<u8>>(3)?,
+                    row.get::<_, Vec<u8>>(4)?,
+                ))
+            })
+            .storage()?
+            .collect::<Result<Vec<_>, _>>()
+            .storage()?;
+        rows.into_iter()
+            .map(|(sequence, operation_id, ordinal, batch_id, record)| {
+                Ok(AccountVisibilityJournalRow {
+                    sequence: i64_to_u64(sequence)?,
+                    operation_id,
+                    ordinal: i64_to_u64(ordinal)?,
+                    batch_id,
+                    record,
+                })
+            })
+            .collect()
+    }
+
+    /// Insert a new stable operation/ordinal record or replace its opaque bytes.
+    /// Existing rows retain their original global `sequence`.
+    pub fn upsert_account_visibility_journal(
+        &self,
+        operation_id: &[u8],
+        ordinal: u64,
+        batch_id: &[u8],
+        record: &[u8],
+    ) -> StorageResult<u64> {
+        let mut sequences =
+            self.upsert_account_visibility_journal_records(&[AccountVisibilityJournalUpsert {
+                operation_id: operation_id.to_vec(),
+                ordinal,
+                batch_id: batch_id.to_vec(),
+                record: record.to_vec(),
+            }])?;
+        Ok(sequences.pop().expect("one input produces one sequence"))
+    }
+
+    /// Atomically insert or replace a complete visibility checkpoint. If any
+    /// entry is invalid or conflicts, none of the rows are changed.
+    pub fn upsert_account_visibility_journal_records(
+        &self,
+        records: &[AccountVisibilityJournalUpsert],
+    ) -> StorageResult<Vec<u64>> {
+        let validated = records
+            .iter()
+            .map(|record| {
+                if record.operation_id.is_empty() || record.batch_id.is_empty() {
+                    return Err(StorageError::Backend(
+                        "account visibility operation and batch ids must be non-empty".into(),
+                    ));
+                }
+                Ok((record, u64_to_i64(record.ordinal)?))
+            })
+            .collect::<StorageResult<Vec<_>>>()?;
+        self.write_account_visibility_journal(|| {
+            self.connection.with_transaction(|| {
+                let connection = self.lock()?;
+                let mut sequences = Vec::with_capacity(validated.len());
+                for (record, ordinal) in &validated {
+                    connection
+                        .execute(
+                            "INSERT INTO account_visibility_journal
+                                (operation_id, ordinal, batch_id, record)
+                             VALUES (?1, ?2, ?3, ?4)
+                             ON CONFLICT(operation_id, ordinal) DO UPDATE SET
+                                record = excluded.record
+                             WHERE account_visibility_journal.batch_id = excluded.batch_id",
+                            params![
+                                &record.operation_id,
+                                ordinal,
+                                &record.batch_id,
+                                &record.record,
+                            ],
+                        )
+                        .storage()?;
+                    let sequence = connection
+                        .query_row(
+                            "SELECT sequence FROM account_visibility_journal
+                             WHERE operation_id = ?1 AND ordinal = ?2 AND batch_id = ?3",
+                            params![&record.operation_id, ordinal, &record.batch_id],
+                            |row| row.get::<_, i64>(0),
+                        )
+                        .optional()
+                        .storage()?
+                        .ok_or_else(|| {
+                            StorageError::Backend(
+                                "account visibility operation/ordinal reused with another batch id"
+                                    .into(),
+                            )
+                        })?;
+                    sequences.push(i64_to_u64(sequence)?);
+                }
+                Ok(sequences)
+            })
+        })
+    }
+
+    /// Atomically delete exactly the acknowledged stable batch ids.
+    pub fn delete_account_visibility_journal_batches(
+        &self,
+        batch_ids: &[Vec<u8>],
+    ) -> StorageResult<usize> {
+        self.write_account_visibility_journal(|| {
+            self.connection.with_transaction(|| {
+                let connection = self.lock()?;
+                let mut deleted = 0_usize;
+                for batch_id in batch_ids {
+                    deleted = deleted.saturating_add(
+                        connection
+                            .execute(
+                                "DELETE FROM account_visibility_journal WHERE batch_id = ?1",
+                                params![batch_id],
+                            )
+                            .storage()?,
+                    );
+                }
+                Ok(deleted)
+            })
+        })
+    }
+
+    fn write_account_visibility_journal<T>(
+        &self,
+        op: impl Fn() -> StorageResult<T>,
+    ) -> StorageResult<T> {
+        if self.connection.is_current_thread_transaction_owner() {
+            op()
+        } else {
+            retry_on_busy(op)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn journal_orders_exact_bytes_upserts_in_place_and_deletes_atomically() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let operation_a = [0_u8, 0xff, 0x80];
+        let operation_b = [2_u8, 0, 3];
+        let batch_a = [4_u8, 0xff, 5];
+        let batch_b = [6_u8, 0, 7];
+        let first = [8_u8, 0xff, 9, 0];
+        let second = [10_u8, 0, 11];
+        let replacement = [12_u8, 0xff, 13, 0];
+
+        let sequence_a = store
+            .upsert_account_visibility_journal(&operation_a, 0, &batch_a, &first)
+            .unwrap();
+        let sequence_b = store
+            .upsert_account_visibility_journal(&operation_b, 9, &batch_b, &second)
+            .unwrap();
+        assert!(sequence_a < sequence_b);
+        assert_eq!(
+            store
+                .upsert_account_visibility_journal(&operation_a, 0, &batch_a, &replacement,)
+                .unwrap(),
+            sequence_a,
+            "upsert must preserve global order"
+        );
+
+        assert_eq!(
+            store.load_account_visibility_journal().unwrap(),
+            vec![
+                AccountVisibilityJournalRow {
+                    sequence: sequence_a,
+                    operation_id: operation_a.to_vec(),
+                    ordinal: 0,
+                    batch_id: batch_a.to_vec(),
+                    record: replacement.to_vec(),
+                },
+                AccountVisibilityJournalRow {
+                    sequence: sequence_b,
+                    operation_id: operation_b.to_vec(),
+                    ordinal: 9,
+                    batch_id: batch_b.to_vec(),
+                    record: second.to_vec(),
+                },
+            ]
+        );
+
+        assert_eq!(
+            store
+                .delete_account_visibility_journal_batches(&[batch_b.to_vec(), batch_a.to_vec(),])
+                .unwrap(),
+            2
+        );
+        assert!(store.load_account_visibility_journal().unwrap().is_empty());
+    }
+
+    #[test]
+    fn upsert_rejects_operation_ordinal_or_batch_id_aba() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        store
+            .upsert_account_visibility_journal(b"operation-a", 3, b"batch-a", b"first")
+            .unwrap();
+        assert!(
+            store
+                .upsert_account_visibility_journal(b"operation-a", 3, b"batch-b", b"other")
+                .is_err()
+        );
+        assert!(
+            store
+                .upsert_account_visibility_journal(b"operation-b", 4, b"batch-a", b"other")
+                .is_err()
+        );
+        assert_eq!(
+            store.load_account_visibility_journal().unwrap()[0].record,
+            b"first"
+        );
+    }
+
+    #[test]
+    fn bulk_upsert_rolls_back_every_row_when_one_entry_conflicts() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        store
+            .upsert_account_visibility_journal(b"operation-a", 1, b"batch-a", b"original")
+            .unwrap();
+
+        let result = store.upsert_account_visibility_journal_records(&[
+            AccountVisibilityJournalUpsert {
+                operation_id: b"operation-b".to_vec(),
+                ordinal: 2,
+                batch_id: b"batch-b".to_vec(),
+                record: vec![0, 0xff, 0x80],
+            },
+            AccountVisibilityJournalUpsert {
+                operation_id: b"operation-a".to_vec(),
+                ordinal: 1,
+                batch_id: b"wrong-batch".to_vec(),
+                record: b"must-not-replace".to_vec(),
+            },
+        ]);
+        assert!(result.is_err());
+        assert_eq!(
+            store.load_account_visibility_journal().unwrap(),
+            vec![AccountVisibilityJournalRow {
+                sequence: 1,
+                operation_id: b"operation-a".to_vec(),
+                ordinal: 1,
+                batch_id: b"batch-a".to_vec(),
+                record: b"original".to_vec(),
+            }]
+        );
+    }
+}

--- a/crates/storage-sqlite/src/chat_list.rs
+++ b/crates/storage-sqlite/src/chat_list.rs
@@ -14,7 +14,7 @@ use cgka_traits::app_event::{
     GROUP_SYSTEM_TYPE_MEMBER_LEFT, GROUP_SYSTEM_TYPE_MEMBER_REMOVED, GROUP_SYSTEM_TYPE_TAG,
     MARMOT_APP_EVENT_KIND_CHAT, MARMOT_APP_EVENT_KIND_GROUP_SYSTEM,
 };
-use cgka_traits::storage::StorageResult;
+use cgka_traits::storage::{StorageError, StorageResult};
 use rusqlite::{Connection, OptionalExtension, Params, params};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -717,24 +717,60 @@ impl SqliteAccountStorage {
         group_id_hex: &str,
         mention_classifier: &MentionClassifier<'_>,
     ) -> StorageResult<Option<ChatListRow>> {
+        self.save_account_projection_delta_and_refresh_chat_list_row_acking_application_events_and_visibility_batches(
+            state,
+            max_seen_events,
+            max_future_skew_secs,
+            frontiers_to_clear,
+            application_event_ids_to_ack,
+            &[],
+            local_account_id_hex,
+            group_id_hex,
+            mention_classifier,
+        )
+    }
+
+    /// Persist an exact account-projection delta, acknowledge both engine
+    /// application events and lower account-visibility batches, and materialize
+    /// one chat-list row in the same SQLCipher transaction.
+    ///
+    /// This is the visibility-aware created-group boundary. A failed row refresh
+    /// rolls back the projection, frontier clears, and both outbox transfers;
+    /// success returns the row committed with all of them.
+    #[allow(clippy::too_many_arguments)]
+    pub fn save_account_projection_delta_and_refresh_chat_list_row_acking_application_events_and_visibility_batches(
+        &self,
+        state: &StoredAccountState,
+        max_seen_events: usize,
+        max_future_skew_secs: u64,
+        frontiers_to_clear: &[(String, u64)],
+        application_event_ids_to_ack: &[cgka_traits::MessageId],
+        visibility_batch_ids_to_ack: &[Vec<u8>],
+        local_account_id_hex: &str,
+        group_id_hex: &str,
+        mention_classifier: &MentionClassifier<'_>,
+    ) -> StorageResult<Option<ChatListRow>> {
         self.connection.with_transaction(|| {
             // `with_transaction` is intentionally nestable on the owning
             // thread, so the projection helper participates in this outer
             // transaction and cannot commit before the chat-list row exists.
-            self.save_account_projection_delta_clearing_local_group_deletion_frontiers_and_acking_application_events(
+            self.save_account_projection_delta_clearing_local_group_deletion_frontiers_and_acking_application_events_and_visibility_batches(
                 state,
                 max_seen_events,
                 max_future_skew_secs,
                 frontiers_to_clear,
                 application_event_ids_to_ack,
+                visibility_batch_ids_to_ack,
             )?;
             let conn = self.lock()?;
-            refresh_chat_list_row_tx(
+            let row = refresh_chat_list_row_tx(
                 &conn,
                 local_account_id_hex,
                 group_id_hex,
                 mention_classifier,
-            )
+            )?
+            .ok_or(StorageError::NotFound)?;
+            Ok(Some(row))
         })
     }
 

--- a/crates/storage-sqlite/src/chat_list/tests.rs
+++ b/crates/storage-sqlite/src/chat_list/tests.rs
@@ -15,7 +15,7 @@ use cgka_traits::app_event::{
     MARMOT_APP_EVENT_KIND_GROUP_SYSTEM, MARMOT_APP_EVENT_KIND_REACTION,
 };
 use cgka_traits::storage::{GroupStorage, LeaveRequest, LeaveRequestStorage};
-use cgka_traits::types::{EpochId, GroupId};
+use cgka_traits::types::{EpochId, GroupId, MessageId};
 
 const LOCAL: &str = "aa";
 const REMOTE: &str = "bb";
@@ -231,6 +231,243 @@ fn created_group_projection_and_chat_list_row_commit_atomically() {
         .unwrap()
         .expect("created chat-list row");
     assert_eq!(store.chat_list_row(GROUP).unwrap(), Some(committed));
+}
+
+#[test]
+fn created_group_visibility_transfer_and_chat_list_row_commit_atomically() {
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    let deletion_frontier = 7_u64;
+    let application_event_id = MessageId::new(vec![0x42; 32]);
+    let operation_id = b"created-chat-visibility-operation";
+    let acknowledged_batch_id = b"created-chat-acknowledged-batch".to_vec();
+    let retained_batch_id = b"created-chat-retained-batch".to_vec();
+    {
+        let connection = store.lock().unwrap();
+        connection
+            .execute(
+                "INSERT INTO local_group_deletion_frontiers
+                    (group_id_hex, message_insert_order, prior_nostr_routes_json)
+                 VALUES (?1, ?2, '[]')",
+                params![GROUP, i64::try_from(deletion_frontier).unwrap()],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO pending_application_events
+                    (message_id, group_id, message_insert_order, record)
+                 VALUES (?1, ?2, ?3, ?4)",
+                params![
+                    application_event_id.as_slice(),
+                    &[0x11_u8],
+                    i64::try_from(deletion_frontier + 1).unwrap(),
+                    b"opaque-pending-application-event",
+                ],
+            )
+            .unwrap();
+    }
+    store
+        .upsert_account_visibility_journal(
+            operation_id,
+            1,
+            &acknowledged_batch_id,
+            b"created-chat-effects",
+        )
+        .unwrap();
+    store
+        .upsert_account_visibility_journal(
+            operation_id,
+            2,
+            &retained_batch_id,
+            b"unrelated-effects",
+        )
+        .unwrap();
+    store
+        .lock()
+        .unwrap()
+        .execute_batch(
+            "CREATE TRIGGER fail_created_chat_list_visibility_row
+             BEFORE INSERT ON chat_list_rows
+             BEGIN
+                 SELECT RAISE(ABORT, 'injected created visibility row failure');
+             END;",
+        )
+        .unwrap();
+    let state = StoredAccountState {
+        label: "alice".to_owned(),
+        groups: vec![group()],
+        ..StoredAccountState::default()
+    };
+    let save = || {
+        store.save_account_projection_delta_and_refresh_chat_list_row_acking_application_events_and_visibility_batches(
+            &state,
+            256,
+            MAX_FUTURE_SKEW_SECS,
+            &[(GROUP.to_owned(), deletion_frontier)],
+            std::slice::from_ref(&application_event_id),
+            std::slice::from_ref(&acknowledged_batch_id),
+            LOCAL,
+            GROUP,
+            &no_mentions,
+        )
+    };
+    let pending_application_event_count = || {
+        store
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT COUNT(*) FROM pending_application_events WHERE message_id = ?1",
+                params![application_event_id.as_slice()],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap()
+    };
+    let visibility_batch_ids = || {
+        store
+            .load_account_visibility_journal()
+            .unwrap()
+            .into_iter()
+            .map(|row| row.batch_id)
+            .collect::<Vec<_>>()
+    };
+
+    save().expect_err("the chat-list failure must roll back the visibility transfer");
+    assert!(
+        store
+            .load_account_projection_state("alice", 256)
+            .unwrap()
+            .groups
+            .is_empty(),
+        "the failed outer transaction must roll back the projection delta",
+    );
+    assert_eq!(store.chat_list_row(GROUP).unwrap(), None);
+    assert_eq!(
+        store.local_group_deletion_frontier(GROUP).unwrap(),
+        Some(deletion_frontier),
+        "the failed row refresh must roll back the frontier clear",
+    );
+    assert_eq!(
+        pending_application_event_count(),
+        1,
+        "the failed row refresh must roll back the application-event acknowledgement",
+    );
+    assert_eq!(
+        visibility_batch_ids(),
+        vec![acknowledged_batch_id.clone(), retained_batch_id.clone()],
+        "the failed row refresh must retain every lower visibility batch",
+    );
+
+    store
+        .lock()
+        .unwrap()
+        .execute_batch("DROP TRIGGER fail_created_chat_list_visibility_row")
+        .unwrap();
+    let committed = save().unwrap().expect("created chat-list row");
+
+    assert_eq!(store.chat_list_row(GROUP).unwrap(), Some(committed));
+    assert_eq!(
+        store
+            .load_account_projection_state("alice", 256)
+            .unwrap()
+            .groups,
+        state.groups,
+    );
+    assert_eq!(store.local_group_deletion_frontier(GROUP).unwrap(), None);
+    assert_eq!(
+        pending_application_event_count(),
+        0,
+        "success must acknowledge the application event with the created row",
+    );
+    assert_eq!(
+        visibility_batch_ids(),
+        vec![retained_batch_id],
+        "success must delete exactly the passed visibility batch",
+    );
+}
+
+#[test]
+fn missing_created_chat_list_row_rolls_back_projection_and_outbox_acks() {
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    let missing_group_id_hex = "22";
+    let application_event_id = MessageId::new(vec![0x43; 32]);
+    let visibility_batch_id = b"missing-created-chat-visibility-batch".to_vec();
+    store
+        .lock()
+        .unwrap()
+        .execute(
+            "INSERT INTO pending_application_events
+                (message_id, group_id, message_insert_order, record)
+             VALUES (?1, ?2, 1, ?3)",
+            params![
+                application_event_id.as_slice(),
+                &[0x22_u8],
+                b"opaque-pending-application-event",
+            ],
+        )
+        .unwrap();
+    store
+        .upsert_account_visibility_journal(
+            b"missing-created-chat-operation",
+            1,
+            &visibility_batch_id,
+            b"missing-created-chat-effects",
+        )
+        .unwrap();
+    let state = StoredAccountState {
+        label: "alice".to_owned(),
+        groups: vec![group()],
+        ..StoredAccountState::default()
+    };
+
+    let error = store
+        .save_account_projection_delta_and_refresh_chat_list_row_acking_application_events_and_visibility_batches(
+            &state,
+            256,
+            MAX_FUTURE_SKEW_SECS,
+            &[],
+            std::slice::from_ref(&application_event_id),
+            std::slice::from_ref(&visibility_batch_id),
+            LOCAL,
+            missing_group_id_hex,
+            &no_mentions,
+        )
+        .expect_err("a missing created-chat row must abort its enclosing transaction");
+
+    assert!(matches!(
+        error,
+        cgka_traits::storage::StorageError::NotFound
+    ));
+    assert!(
+        store
+            .load_account_projection_state("alice", 256)
+            .unwrap()
+            .groups
+            .is_empty(),
+        "the missing-row error must roll back the projection delta",
+    );
+    assert_eq!(store.chat_list_row(GROUP).unwrap(), None);
+    assert_eq!(
+        store
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT COUNT(*) FROM pending_application_events WHERE message_id = ?1",
+                params![application_event_id.as_slice()],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap(),
+        1,
+        "the missing-row error must roll back the application-event acknowledgement",
+    );
+    assert_eq!(
+        store
+            .load_account_visibility_journal()
+            .unwrap()
+            .into_iter()
+            .map(|row| row.batch_id)
+            .collect::<Vec<_>>(),
+        vec![visibility_batch_id],
+        "the missing-row error must roll back the visibility-batch deletion",
+    );
 }
 
 /// Operational mdk#1487 benchmark for the post-canonical app-local tail.
@@ -3519,6 +3756,7 @@ fn chat_list_rows_report_the_durable_leave_request_at_read_time() {
             group_id: group_id.clone(),
             requested_at_ms: 1_700_000_000_123,
             last_proposed_epoch: Some(EpochId(3)),
+            last_proposed_message_id: None,
         })
         .unwrap();
 

--- a/crates/storage-sqlite/src/epoch_backfill_intent_journal.rs
+++ b/crates/storage-sqlite/src/epoch_backfill_intent_journal.rs
@@ -1,0 +1,105 @@
+use crate::connection::retry_on_busy;
+use crate::{SqliteAccountStorage, SqliteResultExt};
+use cgka_traits::storage::StorageResult;
+use rusqlite::{OptionalExtension, params};
+
+impl SqliteAccountStorage {
+    /// Load the opaque, account-wide epoch-backfill intent journal.
+    ///
+    /// Serialization belongs to the app layer so storage-format changes do not
+    /// require this crate to understand the queued intent envelope.
+    pub fn load_epoch_backfill_intent_journal(&self) -> StorageResult<Option<Vec<u8>>> {
+        self.lock()?
+            .query_row(
+                "SELECT record FROM app_epoch_backfill_intent_journal WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .optional()
+            .storage()
+    }
+
+    /// Atomically replace the opaque, account-wide epoch-backfill intent
+    /// journal.
+    pub fn store_epoch_backfill_intent_journal(&self, record: &[u8]) -> StorageResult<()> {
+        self.write_epoch_backfill_intent_journal(|| {
+            self.lock()?
+                .execute(
+                    "INSERT INTO app_epoch_backfill_intent_journal (singleton, record)
+                     VALUES (1, ?1)
+                     ON CONFLICT(singleton) DO UPDATE SET record = excluded.record",
+                    params![record],
+                )
+                .storage()?;
+            Ok(())
+        })
+    }
+
+    /// Clear the account-wide epoch-backfill intent journal, if present.
+    pub fn clear_epoch_backfill_intent_journal(&self) -> StorageResult<()> {
+        self.write_epoch_backfill_intent_journal(|| {
+            self.lock()?
+                .execute(
+                    "DELETE FROM app_epoch_backfill_intent_journal WHERE singleton = 1",
+                    [],
+                )
+                .storage()?;
+            Ok(())
+        })
+    }
+
+    fn write_epoch_backfill_intent_journal<T>(
+        &self,
+        op: impl Fn() -> StorageResult<T>,
+    ) -> StorageResult<T> {
+        if self.connection.is_current_thread_transaction_owner() {
+            op()
+        } else {
+            retry_on_busy(op)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn journal_round_trips_overwrites_and_clears_opaque_bytes() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        assert_eq!(store.load_epoch_backfill_intent_journal().unwrap(), None);
+
+        let first = [0_u8, 0xff, 0x80, 0x00, b'{'];
+        store.store_epoch_backfill_intent_journal(&first).unwrap();
+        assert_eq!(
+            store.load_epoch_backfill_intent_journal().unwrap(),
+            Some(first.to_vec())
+        );
+
+        let replacement = [9_u8, 8, 7];
+        store
+            .store_epoch_backfill_intent_journal(&replacement)
+            .unwrap();
+        assert_eq!(
+            store.load_epoch_backfill_intent_journal().unwrap(),
+            Some(replacement.to_vec()),
+            "the singleton upsert must replace, not append to, the journal"
+        );
+
+        store.clear_epoch_backfill_intent_journal().unwrap();
+        assert_eq!(store.load_epoch_backfill_intent_journal().unwrap(), None);
+        store.clear_epoch_backfill_intent_journal().unwrap();
+    }
+
+    #[test]
+    fn journal_preserves_an_explicit_empty_blob() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        store.store_epoch_backfill_intent_journal(&[]).unwrap();
+
+        assert_eq!(
+            store.load_epoch_backfill_intent_journal().unwrap(),
+            Some(Vec::new()),
+            "an empty opaque record is occupied state, not an absent journal"
+        );
+    }
+}

--- a/crates/storage-sqlite/src/lib.rs
+++ b/crates/storage-sqlite/src/lib.rs
@@ -6,11 +6,13 @@
 //! layers.
 
 mod account_projection;
+mod account_visibility_journal;
 mod agent_stream_sequences;
 mod chat_list;
 mod codec;
 mod connection;
 mod encrypted_media_secrets;
+mod epoch_backfill_intent_journal;
 mod message_drafts;
 mod migrations;
 mod openmls_storage;
@@ -29,6 +31,7 @@ pub use account_projection::{
     StoredAppMessageQuery, StoredAppMessageRecord, StoredEpochBackfillIntent,
     StoredEpochStallEvidence, StoredNostrRoute, clamp_to_max_future_skew,
 };
+pub use account_visibility_journal::{AccountVisibilityJournalRow, AccountVisibilityJournalUpsert};
 pub use chat_list::{
     AccountUnreadTotal, ChatConversationKind, ChatListAttachmentKind, ChatListAvatar,
     ChatListMessageDeliveryState, ChatListMessagePreview, ChatListQuery, ChatListRow, ChatPinError,

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -108,6 +108,12 @@ mod migration_0053_account_delivery_recovery;
 mod migration_0054_transport_reconciliation_items;
 #[path = "migrations/0055_epoch_stall_evidence.rs"]
 mod migration_0055_epoch_stall_evidence;
+#[path = "migrations/0056_key_package_lifecycle_privacy_journal.rs"]
+mod migration_0056_key_package_lifecycle_privacy_journal;
+#[path = "migrations/0057_epoch_backfill_intent_journal.rs"]
+mod migration_0057_epoch_backfill_intent_journal;
+#[path = "migrations/0058_account_visibility_journal.rs"]
+mod migration_0058_account_visibility_journal;
 #[cfg(test)]
 #[path = "migrations/test_support.rs"]
 mod test_support;
@@ -398,6 +404,21 @@ const MIGRATIONS: &[Migration] = &[
         name: "0055_epoch_stall_evidence",
         apply: migration_0055_epoch_stall_evidence::apply,
     },
+    Migration {
+        version: 56,
+        name: "0056_key_package_lifecycle_privacy_journal",
+        apply: migration_0056_key_package_lifecycle_privacy_journal::apply,
+    },
+    Migration {
+        version: 57,
+        name: "0057_epoch_backfill_intent_journal",
+        apply: migration_0057_epoch_backfill_intent_journal::apply,
+    },
+    Migration {
+        version: 58,
+        name: "0058_account_visibility_journal",
+        apply: migration_0058_account_visibility_journal::apply,
+    },
 ];
 
 pub(crate) fn run_all(connection: &mut Connection) -> StorageResult<()> {
@@ -604,8 +625,9 @@ mod tests {
         SqlCipherHardening, SqlCipherKey, SqliteAccountStorage, epoch_to_i64, message_state_to_i64,
         open_hardened_sqlcipher, serialize,
     };
+    use cgka_traits::maintenance::KeyPackageLifecycleState;
     use cgka_traits::message::{MessageRecord, MessageState, StoredMessagePayload};
-    use cgka_traits::storage::{GroupStorage, MessageStorage};
+    use cgka_traits::storage::{GroupStorage, MaintenanceStorage, MessageStorage};
     use cgka_traits::transport::{Timestamp, TransportEnvelope, TransportMessage, TransportSource};
     use std::io::{Read, Write};
     use std::path::Path;
@@ -621,6 +643,10 @@ mod tests {
     const TEST_DATABASE_KEY: &str = "storage format migration crash key";
     const V0_9_12_FIXTURE_KEY: &str = "mdk storage v1 fixture key";
     const V0_9_12_FIXTURE: &[u8] = include_bytes!("../fixtures/storage-v1-v0.9.12.bin");
+    const KEY_PACKAGE_PRIVACY_JOURNAL_TRIGGERS: [&str; 2] = [
+        "cgka_key_package_lifecycle_privacy_journal_insert",
+        "cgka_key_package_lifecycle_privacy_journal_update",
+    ];
 
     fn applied_migrations(store: &SqliteAccountStorage) -> Vec<(i64, String)> {
         let conn = store.lock().unwrap();
@@ -690,6 +716,58 @@ mod tests {
             .collect();
         drop(connection);
         messages
+    }
+
+    fn schema_51_key_package_lifecycle_record() -> Vec<u8> {
+        let mut record =
+            serde_json::to_value(KeyPackageLifecycleState::slot_only("slot".into())).unwrap();
+        let fields = record.as_object_mut().unwrap();
+        fields.remove("cutover_publication_blocked");
+        fields.remove("deleted_live_revision_event_ids");
+        fields.remove("deletion_overflow_owner_event_id");
+        fields.remove("retired_publications_pending_deletion");
+        fields.remove("consumed_key_package_refs");
+        serde_json::to_vec(&record).unwrap()
+    }
+
+    fn seed_file_backed_schema_51_key_package_lifecycle(path: &Path) -> Vec<u8> {
+        let mut connection = keyed_connection(path);
+        run(&mut connection, &MIGRATIONS[..51]).unwrap();
+        let record = schema_51_key_package_lifecycle_record();
+        connection
+            .execute(
+                "INSERT INTO cgka_key_package_lifecycle (singleton, record) VALUES (1, ?1)",
+                params![record.as_slice()],
+            )
+            .unwrap();
+        connection
+            .execute_batch("PRAGMA wal_checkpoint(TRUNCATE)")
+            .unwrap();
+        drop(connection);
+        record
+    }
+
+    fn key_package_privacy_journal_triggers(connection: &rusqlite::Connection) -> Vec<String> {
+        let mut statement = connection
+            .prepare(
+                "SELECT name
+                   FROM sqlite_schema
+                  WHERE type = 'trigger'
+                    AND name IN (?1, ?2)
+                  ORDER BY name",
+            )
+            .unwrap();
+        statement
+            .query_map(
+                params![
+                    KEY_PACKAGE_PRIVACY_JOURNAL_TRIGGERS[0],
+                    KEY_PACKAGE_PRIVACY_JOURNAL_TRIGGERS[1]
+                ],
+                |row| row.get(0),
+            )
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
     }
 
     fn benchmark_message_id(index: usize) -> cgka_traits::MessageId {
@@ -902,6 +980,36 @@ mod tests {
     }
 
     #[test]
+    fn key_package_privacy_journal_migration_refuses_schema_51_writer() {
+        let mut connection = rusqlite::Connection::open_in_memory().unwrap();
+        run(&mut connection, &MIGRATIONS[..56]).unwrap();
+        let privacy_journal = br#"{"stable_slot_id":"slot","cutover_publication_blocked":true,"deleted_live_revision_event_ids":[[1,2,3]],"deletion_overflow_owner_event_id":[4,5,6],"retired_publications_pending_deletion":[{"event_id":[4,5,6]}],"consumed_key_package_refs":[[7,8,9]]}"#;
+        connection
+            .execute(
+                "INSERT INTO cgka_key_package_lifecycle (singleton, record) VALUES (1, ?1)",
+                params![privacy_journal.as_slice()],
+            )
+            .unwrap();
+
+        let error = run(&mut connection, &MIGRATIONS[..55]).unwrap_err();
+        assert!(matches!(
+            error,
+            StorageError::UnsupportedSchemaVersion {
+                found: 56,
+                latest_supported: 55,
+            }
+        ));
+        let retained: Vec<u8> = connection
+            .query_row(
+                "SELECT record FROM cgka_key_package_lifecycle WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(retained, privacy_journal);
+    }
+
+    #[test]
     fn file_backed_v1_database_upgrades_once_and_refuses_downgrade() {
         let directory = tempfile::tempdir().unwrap();
         let database = directory.path().join("v1-upgrade.sqlite3");
@@ -922,13 +1030,19 @@ mod tests {
             .query_row("SELECT count(*) FROM cgka_messages", [], |row| row.get(0))
             .unwrap();
         let error = run(&mut older_connection, &MIGRATIONS[..46]).unwrap_err();
-        assert!(matches!(
-            error,
+        match error {
             StorageError::UnsupportedSchemaVersion {
-                found: 55,
+                found,
                 latest_supported: 46,
-            }
-        ));
+            } => assert_eq!(
+                found,
+                MIGRATIONS
+                    .last()
+                    .expect("migration registry is nonempty")
+                    .version
+            ),
+            other => panic!("expected downgrade refusal, got {other:?}"),
+        }
         let after: i64 = older_connection
             .query_row("SELECT count(*) FROM cgka_messages", [], |row| row.get(0))
             .unwrap();
@@ -978,13 +1092,19 @@ mod tests {
             connection
         };
         let error = run(&mut older_connection, &MIGRATIONS[..46]).unwrap_err();
-        assert!(matches!(
-            error,
+        match error {
             StorageError::UnsupportedSchemaVersion {
-                found: 55,
+                found,
                 latest_supported: 46,
-            }
-        ));
+            } => assert_eq!(
+                found,
+                MIGRATIONS
+                    .last()
+                    .expect("migration registry is nonempty")
+                    .version
+            ),
+            other => panic!("expected downgrade refusal, got {other:?}"),
+        }
     }
 
     #[test]
@@ -1138,6 +1258,114 @@ mod tests {
     }
 
     #[test]
+    fn process_kill_mid_key_package_privacy_migration_retries_fail_closed() {
+        let directory = tempfile::tempdir().unwrap();
+        let database = directory
+            .path()
+            .join("key-package-privacy-migration-kill.sqlite3");
+        let schema_51_record = seed_file_backed_schema_51_key_package_lifecycle(&database);
+
+        kill_child_at(
+            "migrations::tests::storage_format_migration_crash_child",
+            "migration",
+            "MDK_STORAGE_TEST_MIGRATION_CRASH_VERSION",
+            "56",
+            &database,
+            "migration-56",
+        );
+
+        let connection = keyed_connection(&database);
+        assert_eq!(applied_name(&connection, 56).unwrap(), None);
+        let rolled_back_record: Vec<u8> = connection
+            .query_row(
+                "SELECT record FROM cgka_key_package_lifecycle WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(rolled_back_record, schema_51_record);
+        let rolled_back_json: serde_json::Value =
+            serde_json::from_slice(&rolled_back_record).unwrap();
+        for field in [
+            "cutover_publication_blocked",
+            "deleted_live_revision_event_ids",
+            "deletion_overflow_owner_event_id",
+            "retired_publications_pending_deletion",
+            "consumed_key_package_refs",
+        ] {
+            assert!(
+                rolled_back_json.get(field).is_none(),
+                "killed migration must roll back the {field} backfill"
+            );
+        }
+        assert!(key_package_privacy_journal_triggers(&connection).is_empty());
+        drop(connection);
+
+        let key = SqlCipherKey::new(TEST_DATABASE_KEY).unwrap();
+        let store = SqliteAccountStorage::open_encrypted(&database, &key).unwrap();
+        let lifecycle = store.key_package_lifecycle().unwrap().unwrap();
+        assert!(
+            lifecycle.cutover_publication_blocked,
+            "an upgraded schema-51 lifecycle must remain fail-closed until relay cutover completes"
+        );
+        assert!(lifecycle.deleted_live_revision_event_ids.is_empty());
+        assert!(lifecycle.deletion_overflow_owner_event_id.is_none());
+        assert!(lifecycle.retired_publications_pending_deletion.is_empty());
+        assert!(lifecycle.consumed_key_package_refs.is_empty());
+
+        let connection = store.lock().unwrap();
+        assert_eq!(
+            applied_name(&connection, 56).unwrap().as_deref(),
+            Some("0056_key_package_lifecycle_privacy_journal")
+        );
+        let migration_count: i64 = connection
+            .query_row(
+                "SELECT count(*) FROM cgka_schema_migrations WHERE version = 56",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(migration_count, 1);
+        assert_eq!(
+            key_package_privacy_journal_triggers(&connection),
+            KEY_PACKAGE_PRIVACY_JOURNAL_TRIGGERS.map(str::to_owned)
+        );
+        let storage_type: String = connection
+            .query_row(
+                "SELECT typeof(record) FROM cgka_key_package_lifecycle WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(storage_type, "blob");
+        let upgraded_record: Vec<u8> = connection
+            .query_row(
+                "SELECT record FROM cgka_key_package_lifecycle WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let upgraded_json: serde_json::Value = serde_json::from_slice(&upgraded_record).unwrap();
+        assert_eq!(
+            upgraded_json.get("cutover_publication_blocked"),
+            Some(&serde_json::json!(true))
+        );
+        for field in [
+            "deleted_live_revision_event_ids",
+            "deletion_overflow_owner_event_id",
+            "retired_publications_pending_deletion",
+            "consumed_key_package_refs",
+        ] {
+            let expected = if field == "deletion_overflow_owner_event_id" {
+                serde_json::Value::Null
+            } else {
+                serde_json::json!([])
+            };
+            assert_eq!(upgraded_json.get(field), Some(&expected));
+        }
+    }
+
+    #[test]
     fn process_kill_mid_promotion_rolls_back_and_retry_converges() {
         let directory = tempfile::tempdir().unwrap();
         let database = directory.path().join("promotion-kill.sqlite3");
@@ -1282,13 +1510,19 @@ mod tests {
         run(&mut connection, MIGRATIONS).unwrap();
 
         let error = run(&mut connection, &MIGRATIONS[..46]).unwrap_err();
-        assert!(matches!(
-            error,
+        match error {
             StorageError::UnsupportedSchemaVersion {
-                found: 55,
+                found,
                 latest_supported: 46,
-            }
-        ));
+            } => assert_eq!(
+                found,
+                MIGRATIONS
+                    .last()
+                    .expect("migration registry is nonempty")
+                    .version
+            ),
+            other => panic!("expected downgrade refusal, got {other:?}"),
+        }
         assert_eq!(
             applied_migrations_from_connection(&connection),
             expected_migrations(),

--- a/crates/storage-sqlite/src/migrations/0056_key_package_lifecycle_privacy_journal.rs
+++ b/crates/storage-sqlite/src/migrations/0056_key_package_lifecycle_privacy_journal.rs
@@ -1,0 +1,264 @@
+use crate::SqliteResultExt;
+use cgka_traits::storage::StorageResult;
+use rusqlite::Transaction;
+
+/// Compatibility fence for privacy-critical fields added to the serialized
+/// `cgka_key_package_lifecycle.record` value.
+///
+/// Schema-51 readers deserialize that JSON permissively and would discard the
+/// exact deletion, overflow-owner, and multi-consumption journals on their
+/// next write. The
+/// migration-runner version check rejects an older binary that opens after this
+/// migration. These triggers additionally reject a schema-51 writer that was
+/// already connected while a newer process applied the migration.
+pub(crate) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
+    tx.execute_batch(
+        r#"
+UPDATE cgka_key_package_lifecycle
+SET record = CAST(
+    json_set(
+        json_insert(
+            CAST(record AS TEXT),
+            '$.deleted_live_revision_event_ids', json('[]'),
+            '$.deletion_overflow_owner_event_id', json('null'),
+            '$.retired_publications_pending_deletion', json('[]'),
+            '$.consumed_key_package_refs', json('[]')
+        ),
+        -- Every schema-51 row predates the relay cutover proof, including a
+        -- development/backport row that already serialized `false`. Force the
+        -- gate closed while preserving any journals it already carries.
+        '$.cutover_publication_blocked', json('true')
+    ) AS BLOB
+)
+WHERE singleton = 1;
+
+CREATE TRIGGER cgka_key_package_lifecycle_privacy_journal_insert
+BEFORE INSERT ON cgka_key_package_lifecycle
+WHEN CASE
+    WHEN json_valid(CAST(NEW.record AS TEXT)) = 0 THEN 1
+    WHEN json_type(CAST(NEW.record AS TEXT), '$') IS NOT 'object' THEN 1
+    WHEN json_type(CAST(NEW.record AS TEXT), '$.cutover_publication_blocked') IS NOT 'false'
+         AND json_type(CAST(NEW.record AS TEXT), '$.cutover_publication_blocked') IS NOT 'true' THEN 1
+    WHEN json_type(CAST(NEW.record AS TEXT), '$.deleted_live_revision_event_ids') IS NOT 'array' THEN 1
+    WHEN json_type(CAST(NEW.record AS TEXT), '$.deletion_overflow_owner_event_id') IS NOT 'null'
+         AND json_type(CAST(NEW.record AS TEXT), '$.deletion_overflow_owner_event_id') IS NOT 'array' THEN 1
+    WHEN json_type(CAST(NEW.record AS TEXT), '$.retired_publications_pending_deletion') IS NOT 'array' THEN 1
+    WHEN json_type(CAST(NEW.record AS TEXT), '$.consumed_key_package_refs') IS NOT 'array' THEN 1
+    ELSE 0
+END
+BEGIN
+    SELECT RAISE(ABORT, 'key package lifecycle privacy journals are required');
+END;
+
+CREATE TRIGGER cgka_key_package_lifecycle_privacy_journal_update
+BEFORE UPDATE OF record ON cgka_key_package_lifecycle
+WHEN CASE
+    WHEN json_valid(CAST(NEW.record AS TEXT)) = 0 THEN 1
+    WHEN json_type(CAST(NEW.record AS TEXT), '$') IS NOT 'object' THEN 1
+    WHEN json_type(CAST(NEW.record AS TEXT), '$.cutover_publication_blocked') IS NOT 'false'
+         AND json_type(CAST(NEW.record AS TEXT), '$.cutover_publication_blocked') IS NOT 'true' THEN 1
+    WHEN json_type(CAST(NEW.record AS TEXT), '$.deleted_live_revision_event_ids') IS NOT 'array' THEN 1
+    WHEN json_type(CAST(NEW.record AS TEXT), '$.deletion_overflow_owner_event_id') IS NOT 'null'
+         AND json_type(CAST(NEW.record AS TEXT), '$.deletion_overflow_owner_event_id') IS NOT 'array' THEN 1
+    WHEN json_type(CAST(NEW.record AS TEXT), '$.retired_publications_pending_deletion') IS NOT 'array' THEN 1
+    WHEN json_type(CAST(NEW.record AS TEXT), '$.consumed_key_package_refs') IS NOT 'array' THEN 1
+    ELSE 0
+END
+BEGIN
+    SELECT RAISE(ABORT, 'key package lifecycle privacy journals are required');
+END;
+
+-- Validate the upgraded row through the same guard. This is deliberately an
+-- identity update: valid existing bytes stay byte-for-byte unchanged.
+UPDATE cgka_key_package_lifecycle
+SET record = record
+WHERE singleton = 1;
+"#,
+    )
+    .storage()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::migrations::{MIGRATIONS, run};
+    use cgka_traits::{
+        KeyPackageLifecycleState, MessageId, RetiredKeyPackagePublication, Timestamp,
+    };
+    use rusqlite::{Connection, OptionalExtension, params};
+
+    fn schema_51_lifecycle_record() -> Vec<u8> {
+        let mut record = serde_json::to_value(KeyPackageLifecycleState::slot_only("slot".into()))
+            .expect("serialize lifecycle fixture");
+        let fields = record.as_object_mut().expect("lifecycle is an object");
+        fields.remove("cutover_publication_blocked");
+        fields.remove("deleted_live_revision_event_ids");
+        fields.remove("deletion_overflow_owner_event_id");
+        fields.remove("retired_publications_pending_deletion");
+        fields.remove("consumed_key_package_refs");
+        serde_json::to_vec(&record).expect("serialize schema-51 lifecycle fixture")
+    }
+
+    fn privacy_journal_lifecycle_record() -> Vec<u8> {
+        let mut lifecycle = KeyPackageLifecycleState::slot_only("slot".into());
+        lifecycle.cutover_publication_blocked = true;
+        lifecycle
+            .deleted_live_revision_event_ids
+            .push(MessageId::new(vec![1, 2, 3]));
+        lifecycle.deletion_overflow_owner_event_id = Some(MessageId::new(vec![4, 5, 6]));
+        lifecycle
+            .retired_publications_pending_deletion
+            .push(RetiredKeyPackagePublication {
+                event_id: MessageId::new(vec![4, 5, 6]),
+                authored_created_at: Timestamp(7),
+                key_package_ref: Some(vec![8]),
+                package_not_after: Some(Timestamp(9)),
+                delete_without_successor: true,
+                deletion_targets: Vec::new(),
+            });
+        lifecycle.consumed_key_package_refs.push(vec![10, 11]);
+        serde_json::to_vec(&lifecycle).expect("serialize lifecycle privacy journal fixture")
+    }
+
+    #[test]
+    fn migration_forces_an_existing_false_gate_without_replacing_privacy_journals() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        run(&mut connection, &MIGRATIONS[..51]).unwrap();
+        let mut before: serde_json::Value =
+            serde_json::from_slice(&privacy_journal_lifecycle_record()).unwrap();
+        before["cutover_publication_blocked"] = serde_json::json!(false);
+        let before_bytes = serde_json::to_vec(&before).unwrap();
+        connection
+            .execute(
+                "INSERT INTO cgka_key_package_lifecycle (singleton, record) VALUES (1, ?1)",
+                params![before_bytes],
+            )
+            .unwrap();
+
+        run(&mut connection, MIGRATIONS).unwrap();
+        let after: Vec<u8> = connection
+            .query_row(
+                "SELECT record FROM cgka_key_package_lifecycle WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let after: serde_json::Value = serde_json::from_slice(&after).unwrap();
+        assert_eq!(
+            after.get("cutover_publication_blocked"),
+            Some(&serde_json::json!(true))
+        );
+        for field in [
+            "deleted_live_revision_event_ids",
+            "deletion_overflow_owner_event_id",
+            "retired_publications_pending_deletion",
+            "consumed_key_package_refs",
+        ] {
+            assert_eq!(
+                after.get(field),
+                before.get(field),
+                "{field} must be preserved"
+            );
+        }
+    }
+
+    #[test]
+    fn migration_guards_blob_json_from_already_open_schema_51_writer() {
+        let directory = tempfile::tempdir().unwrap();
+        let database = directory.path().join("schema-51-open-writer.sqlite3");
+        let mut old_writer = Connection::open(&database).unwrap();
+        run(&mut old_writer, &MIGRATIONS[..51]).unwrap();
+        old_writer
+            .execute(
+                "INSERT INTO cgka_key_package_lifecycle (singleton, record) VALUES (1, ?1)",
+                params![schema_51_lifecycle_record()],
+            )
+            .unwrap();
+
+        let mut new_writer = Connection::open(&database).unwrap();
+        run(&mut new_writer, MIGRATIONS).unwrap();
+        let upgraded: Vec<u8> = new_writer
+            .query_row(
+                "SELECT record FROM cgka_key_package_lifecycle WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            new_writer
+                .query_row(
+                    "SELECT typeof(record) FROM cgka_key_package_lifecycle WHERE singleton = 1",
+                    [],
+                    |row| row.get::<_, String>(0),
+                )
+                .unwrap(),
+            "blob",
+            "JSON1 backfill must preserve the encrypted table's BLOB representation"
+        );
+        let upgraded: serde_json::Value = serde_json::from_slice(&upgraded).unwrap();
+        for field in [
+            "cutover_publication_blocked",
+            "deleted_live_revision_event_ids",
+            "deletion_overflow_owner_event_id",
+            "retired_publications_pending_deletion",
+            "consumed_key_package_refs",
+        ] {
+            let expected = match field {
+                "cutover_publication_blocked" => serde_json::json!(true),
+                "deletion_overflow_owner_event_id" => serde_json::Value::Null,
+                _ => serde_json::json!([]),
+            };
+            assert_eq!(upgraded.get(field), Some(&expected));
+        }
+
+        let privacy_record = privacy_journal_lifecycle_record();
+        new_writer
+            .execute(
+                "UPDATE cgka_key_package_lifecycle SET record = ?1 WHERE singleton = 1",
+                params![privacy_record.as_slice()],
+            )
+            .unwrap();
+
+        let error = old_writer
+            .execute(
+                "INSERT INTO cgka_key_package_lifecycle (singleton, record) VALUES (1, ?1)
+                 ON CONFLICT(singleton) DO UPDATE SET record = excluded.record",
+                params![schema_51_lifecycle_record()],
+            )
+            .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("key package lifecycle privacy journals are required")
+        );
+        let retained: Vec<u8> = new_writer
+            .query_row(
+                "SELECT record FROM cgka_key_package_lifecycle WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(retained, privacy_record);
+
+        new_writer
+            .execute("DELETE FROM cgka_key_package_lifecycle", [])
+            .unwrap();
+        assert!(
+            old_writer
+                .execute(
+                    "INSERT INTO cgka_key_package_lifecycle (singleton, record) VALUES (1, ?1)",
+                    params![schema_51_lifecycle_record()],
+                )
+                .is_err(),
+            "the insert guard must reject an old-shaped row too"
+        );
+        let absent: Option<Vec<u8>> = new_writer
+            .query_row(
+                "SELECT record FROM cgka_key_package_lifecycle WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .optional()
+            .unwrap();
+        assert!(absent.is_none());
+    }
+}

--- a/crates/storage-sqlite/src/migrations/0057_epoch_backfill_intent_journal.rs
+++ b/crates/storage-sqlite/src/migrations/0057_epoch_backfill_intent_journal.rs
@@ -1,0 +1,111 @@
+//! Migration 0057: durable per-account epoch-backfill intent state.
+
+use crate::SqliteResultExt;
+use cgka_traits::storage::StorageResult;
+use rusqlite::Transaction;
+
+pub(crate) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
+    tx.execute_batch(
+        r#"
+CREATE TABLE app_epoch_backfill_intent_journal (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    record BLOB NOT NULL
+);
+"#,
+    )
+    .storage()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::migrations::{MIGRATIONS, run};
+    use cgka_traits::storage::StorageError;
+    use rusqlite::{Connection, OptionalExtension, params};
+
+    #[test]
+    fn migration_adds_an_empty_singleton_blob_journal_after_schema_56() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        run(&mut connection, &MIGRATIONS[..56]).unwrap();
+        let absent: Option<String> = connection
+            .query_row(
+                "SELECT name FROM sqlite_schema
+                 WHERE type = 'table' AND name = 'app_epoch_backfill_intent_journal'",
+                [],
+                |row| row.get(0),
+            )
+            .optional()
+            .unwrap();
+        assert_eq!(absent, None);
+
+        run(&mut connection, &MIGRATIONS[..57]).unwrap();
+
+        let initial: Option<Vec<u8>> = connection
+            .query_row(
+                "SELECT record FROM app_epoch_backfill_intent_journal WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .optional()
+            .unwrap();
+        assert_eq!(initial, None, "migration must not synthesize an intent");
+
+        let opaque = [0_u8, 0xff, 0x80, 0x00];
+        connection
+            .execute(
+                "INSERT INTO app_epoch_backfill_intent_journal (singleton, record)
+                 VALUES (1, ?1)",
+                params![opaque.as_slice()],
+            )
+            .unwrap();
+        let stored: Vec<u8> = connection
+            .query_row(
+                "SELECT record FROM app_epoch_backfill_intent_journal WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(stored, opaque);
+
+        assert!(
+            connection
+                .execute(
+                    "INSERT INTO app_epoch_backfill_intent_journal (singleton, record)
+                     VALUES (2, ?1)",
+                    params![opaque.as_slice()],
+                )
+                .is_err(),
+            "the per-account journal must admit only its singleton row"
+        );
+    }
+
+    #[test]
+    fn schema_56_runner_refuses_a_journal_database_without_mutating_the_blob() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        run(&mut connection, &MIGRATIONS[..57]).unwrap();
+        let opaque = [0_u8, 0xff, 0x80, 0x00];
+        connection
+            .execute(
+                "INSERT INTO app_epoch_backfill_intent_journal (singleton, record)
+                 VALUES (1, ?1)",
+                params![opaque.as_slice()],
+            )
+            .unwrap();
+
+        let error = run(&mut connection, &MIGRATIONS[..56]).unwrap_err();
+        assert!(matches!(
+            error,
+            StorageError::UnsupportedSchemaVersion {
+                found: 57,
+                latest_supported: 56,
+            }
+        ));
+        let retained: Vec<u8> = connection
+            .query_row(
+                "SELECT record FROM app_epoch_backfill_intent_journal WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(retained, opaque);
+    }
+}

--- a/crates/storage-sqlite/src/migrations/0058_account_visibility_journal.rs
+++ b/crates/storage-sqlite/src/migrations/0058_account_visibility_journal.rs
@@ -1,0 +1,112 @@
+//! Migration 0058: durable ordered account-runtime visibility outbox.
+
+use crate::SqliteResultExt;
+use cgka_traits::storage::StorageResult;
+use rusqlite::Transaction;
+
+pub(crate) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
+    tx.execute_batch(
+        r#"
+CREATE TABLE account_visibility_journal (
+    sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+    operation_id BLOB NOT NULL CHECK (length(operation_id) > 0),
+    ordinal INTEGER NOT NULL CHECK (ordinal >= 0),
+    batch_id BLOB NOT NULL UNIQUE CHECK (length(batch_id) > 0),
+    record BLOB NOT NULL,
+    UNIQUE (operation_id, ordinal)
+);
+"#,
+    )
+    .storage()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::migrations::{MIGRATIONS, run};
+    use cgka_traits::storage::StorageError;
+    use rusqlite::{Connection, OptionalExtension, params};
+
+    #[test]
+    fn migration_adds_an_empty_ordered_visibility_journal_after_schema_57() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        run(&mut connection, &MIGRATIONS[..57]).unwrap();
+        let absent: Option<String> = connection
+            .query_row(
+                "SELECT name FROM sqlite_schema
+                 WHERE type = 'table' AND name = 'account_visibility_journal'",
+                [],
+                |row| row.get(0),
+            )
+            .optional()
+            .unwrap();
+        assert_eq!(absent, None);
+
+        run(&mut connection, MIGRATIONS).unwrap();
+        let initial: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM account_visibility_journal",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(initial, 0, "migration must not synthesize visibility");
+
+        let operation = [0_u8, 0xff, 0x80];
+        let batch = [9_u8, 0, 8];
+        let record = [7_u8, 0xff, 6, 0];
+        connection
+            .execute(
+                "INSERT INTO account_visibility_journal
+                    (operation_id, ordinal, batch_id, record)
+                 VALUES (?1, 0, ?2, ?3)",
+                params![operation.as_slice(), batch.as_slice(), record.as_slice()],
+            )
+            .unwrap();
+        let stored: (Vec<u8>, i64, Vec<u8>, Vec<u8>) = connection
+            .query_row(
+                "SELECT operation_id, ordinal, batch_id, record
+                 FROM account_visibility_journal",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            stored,
+            (operation.to_vec(), 0, batch.to_vec(), record.to_vec())
+        );
+    }
+
+    #[test]
+    fn schema_57_runner_refuses_a_visibility_journal_database_without_mutating_rows() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        run(&mut connection, MIGRATIONS).unwrap();
+        let operation = [1_u8, 2, 3];
+        let batch = [4_u8, 5, 6];
+        let record = [0_u8, 0xff, 0x80, 0x00];
+        connection
+            .execute(
+                "INSERT INTO account_visibility_journal
+                    (operation_id, ordinal, batch_id, record)
+                 VALUES (?1, 0, ?2, ?3)",
+                params![operation.as_slice(), batch.as_slice(), record.as_slice()],
+            )
+            .unwrap();
+
+        let error = run(&mut connection, &MIGRATIONS[..57]).unwrap_err();
+        assert!(matches!(
+            error,
+            StorageError::UnsupportedSchemaVersion {
+                found: 58,
+                latest_supported: 57,
+            }
+        ));
+        let retained: Vec<u8> = connection
+            .query_row(
+                "SELECT record FROM account_visibility_journal WHERE batch_id = ?1",
+                params![batch.as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(retained, record);
+    }
+}

--- a/crates/storage-sqlite/src/shared.rs
+++ b/crates/storage-sqlite/src/shared.rs
@@ -257,6 +257,33 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
         Ok(Some(record))
     }
 
+    /// Remove one exact cached KeyPackage projection without disturbing the
+    /// identity's public profile, relay lists, follow edges, or their generic
+    /// event provenance.
+    ///
+    /// `expected_key_package_json` makes this a compare-and-swap: a sibling
+    /// device may publish under a different NIP-33 `d` slot while a removed
+    /// local slot is being scrubbed, and that newer projection must survive.
+    pub fn clear_public_directory_key_package_if_matches(
+        &self,
+        account_id_hex: &str,
+        expected_key_package_json: &str,
+    ) -> StorageResult<bool> {
+        retry_on_busy(|| {
+            let conn = self.lock()?;
+            let changed = conn
+                .execute(
+                    "UPDATE directory_users
+                     SET key_package_json = NULL
+                     WHERE account_id_hex = ?1
+                       AND key_package_json = ?2",
+                    params![account_id_hex, expected_key_package_json],
+                )
+                .storage()?;
+            Ok(changed != 0)
+        })
+    }
+
     pub fn public_directory_users(&self) -> StorageResult<Vec<PublicDirectoryUserRecord>> {
         self.public_directory_users_capped(PUBLIC_DIRECTORY_USERS_MAX)
     }
@@ -620,6 +647,64 @@ mod tests {
                 .unwrap(),
             record
         );
+    }
+
+    #[test]
+    fn conditional_key_package_clear_preserves_public_identity_projection() {
+        let storage = SqliteSharedStorage::in_memory().unwrap();
+        let record = PublicDirectoryUserRecord {
+            account_id_hex: "aa".repeat(32),
+            npub: "npub1example".to_owned(),
+            profile_json: Some(r#"{"name":"Alice"}"#.to_owned()),
+            relay_lists_json: r#"{"nip65":["wss://relay.example"]}"#.to_owned(),
+            key_package_json: Some(r#"{"key_package_id":"removed-slot"}"#.to_owned()),
+            event_id_hex: Some("bb".repeat(32)),
+            // These columns describe the combined public-directory projection,
+            // not exclusively its KeyPackage. Use profile-like provenance so
+            // this regression catches a scrub that damages profile ordering.
+            event_kind: Some(0),
+            event_created_at: Some(1_700_000_000),
+            follows: vec!["cc".repeat(32)],
+        };
+        storage.put_public_directory_user(&record).unwrap();
+
+        assert!(
+            !storage
+                .clear_public_directory_key_package_if_matches(
+                    &record.account_id_hex,
+                    r#"{"key_package_id":"sibling-slot"}"#,
+                )
+                .unwrap(),
+            "a changed sibling-device projection must win the CAS"
+        );
+        assert_eq!(
+            storage
+                .public_directory_user(&record.account_id_hex)
+                .unwrap()
+                .unwrap(),
+            record
+        );
+
+        assert!(
+            storage
+                .clear_public_directory_key_package_if_matches(
+                    &record.account_id_hex,
+                    record.key_package_json.as_deref().unwrap(),
+                )
+                .unwrap()
+        );
+        let scrubbed = storage
+            .public_directory_user(&record.account_id_hex)
+            .unwrap()
+            .unwrap();
+        assert_eq!(scrubbed.npub, record.npub);
+        assert_eq!(scrubbed.profile_json, record.profile_json);
+        assert_eq!(scrubbed.relay_lists_json, record.relay_lists_json);
+        assert_eq!(scrubbed.follows, record.follows);
+        assert!(scrubbed.key_package_json.is_none());
+        assert_eq!(scrubbed.event_id_hex, record.event_id_hex);
+        assert_eq!(scrubbed.event_kind, record.event_kind);
+        assert_eq!(scrubbed.event_created_at, record.event_created_at);
     }
 
     #[test]

--- a/crates/storage-sqlite/src/storage/leave_requests.rs
+++ b/crates/storage-sqlite/src/storage/leave_requests.rs
@@ -104,6 +104,7 @@ mod tests {
             group_id: group.id.clone(),
             requested_at_ms: 42,
             last_proposed_epoch: Some(EpochId(3)),
+            last_proposed_message_id: None,
         };
         store.put_leave_request(&request).unwrap();
         assert_eq!(store.leave_request(&group.id).unwrap(), Some(request));

--- a/crates/traits/src/lib.rs
+++ b/crates/traits/src/lib.rs
@@ -87,10 +87,11 @@ pub use ingest::{
     ProposalRejectionCategory, StaleReason,
 };
 pub use maintenance::{
-    DurableGroupEvolution, DurableTransportFanout, GroupEvolutionPhase, GroupEvolutionSemantic,
-    GroupMaintenanceState, GroupMaintenanceStatus, KeyPackageLifecycleState, MaintenanceObligation,
-    MaintenancePhase, MaintenanceRandom, MaintenanceRunSummary, MaintenanceTrigger, MonotonicClock,
-    PendingKeyPackageReplacement, PeriodicMaintenancePolicy, RetainedKeyPackagePrivateMaterial,
+    ConsumedKeyPackageRefJournalFull, DurableGroupEvolution, DurableTransportFanout,
+    GroupEvolutionPhase, GroupEvolutionSemantic, GroupMaintenanceState, GroupMaintenanceStatus,
+    KeyPackageLifecycleState, MaintenanceObligation, MaintenancePhase, MaintenanceRandom,
+    MaintenanceRunSummary, MaintenanceTrigger, MonotonicClock, PendingKeyPackageReplacement,
+    PeriodicMaintenancePolicy, RetainedKeyPackagePrivateMaterial, RetiredKeyPackagePublication,
     SendMaintenanceDisposition, SignedPublicationArtifact, TransportFanoutAttemptState,
     TransportFanoutTarget, WallClock,
 };

--- a/crates/traits/src/maintenance.rs
+++ b/crates/traits/src/maintenance.rs
@@ -11,6 +11,36 @@ use crate::transport::{Timestamp, TransportMessage};
 use crate::transport_adapter::{TransportEndpoint, TransportPublishTarget};
 use crate::types::{EpochId, GroupId, MessageId};
 use serde::{Deserialize, Serialize};
+
+/// Maximum durable exact `(signed event id, relay endpoint)` liabilities held
+/// by one account-device KeyPackage lifecycle.
+pub const MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES: usize = 256;
+/// Additional exact endpoint liabilities reserved exclusively for atomically
+/// deleting one explicitly selected KeyPackage revision. An event id that is
+/// not projected as current/pending is still treated as potentially live for
+/// this purpose because the deletion API carries no stable-slot proof. The
+/// app's relay safety boundary caps one publication route at sixteen
+/// endpoints. Keeping the reserve separate means a full ordinary journal
+/// cannot force partial same-slot deletion, while discovery and new
+/// publication remain bound by
+/// [`MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES`].
+pub const MAX_KEY_PACKAGE_LIVE_DELETION_OVERFLOW_LIABILITIES: usize = 16;
+/// Absolute lifecycle bound while a live-revision deletion is in flight.
+pub const MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES_WITH_LIVE_DELETION_OVERFLOW: usize =
+    MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES
+        + MAX_KEY_PACKAGE_LIVE_DELETION_OVERFLOW_LIABILITIES;
+/// Maximum distinct consumed KeyPackage references awaiting account cleanup.
+/// The journal never evicts live evidence; a transaction that would exceed
+/// this cap fails closed before committing the Welcome.
+pub const MAX_CONSUMED_KEY_PACKAGE_REFS_PENDING_CLEANUP: usize = 256;
+
+/// The durable consumed-KeyPackage cleanup journal has no free slot.
+///
+/// Welcome processing must fail closed instead of evicting an older, still
+/// unswept consumption record.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+#[error("consumed KeyPackage cleanup journal is full")]
+pub struct ConsumedKeyPackageRefJournalFull;
 use std::time::Duration;
 
 pub const POST_JOIN_CONTENTION_JITTER_MAX_MS: u64 = 30_000;
@@ -219,8 +249,8 @@ pub struct DurableTransportFanout {
     pub bounded_until: Option<Timestamp>,
 }
 
-/// Transport-neutral exact signed artifact used for account-scoped
-/// replaceable events such as a KeyPackage publication.
+/// One exact signed revision of an account-scoped replaceable event such as a
+/// KeyPackage publication.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SignedPublicationArtifact {
     pub id: MessageId,
@@ -228,13 +258,45 @@ pub struct SignedPublicationArtifact {
     pub bytes: Vec<u8>,
 }
 
+/// A superseded signed KeyPackage revision that still has relay-side deletion
+/// work outstanding.
+///
+/// Reauthoring keeps the same replaceable-event coordinate, but a relay that
+/// accepted (or may ambiguously have accepted) the older event can retain that
+/// exact event id. Each endpoint remains listed until it explicitly
+/// acknowledges a deletion for `event_id`.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RetiredKeyPackagePublication {
+    pub event_id: MessageId,
+    pub authored_created_at: Timestamp,
+    /// Reference of the semantic MLS KeyPackage carried by this signed
+    /// revision. This lets consumption make every older transport revision of
+    /// the same single-use package immediately eligible for deletion.
+    #[serde(default)]
+    pub key_package_ref: Option<Vec<u8>>,
+    /// MLS lifetime boundary for the semantic KeyPackage carried by this
+    /// revision. Once reached, the old event may be deleted even when no newer
+    /// revision reached that endpoint.
+    #[serde(default)]
+    pub package_not_after: Option<Timestamp>,
+    /// The underlying single-use KeyPackage is no longer usable locally (for
+    /// example because a Welcome consumed it), so successor acknowledgement is
+    /// not required before deleting this revision.
+    #[serde(default)]
+    pub delete_without_successor: bool,
+    #[serde(default)]
+    pub deletion_targets: Vec<TransportFanoutTarget>,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PendingKeyPackageReplacement {
     pub key_package: KeyPackage,
     pub key_package_ref: Vec<u8>,
-    /// Transport authoring time selected before signing. The private bundle
-    /// and this enclosing lifecycle intent are persisted atomically; signing
-    /// may therefore resume safely after a crash.
+    /// Transport authoring time of the current pending signed revision. The
+    /// private bundle and this enclosing lifecycle intent are persisted
+    /// atomically; signing may therefore resume safely after a crash. A
+    /// bounded-age transport updates this field and `signed_event` together
+    /// before exposing a newer revision.
     pub authored_created_at: Timestamp,
     pub not_before: Timestamp,
     pub not_after: Timestamp,
@@ -260,17 +322,49 @@ pub struct KeyPackageLifecycleState {
     pub stable_slot_id: String,
     #[serde(default)]
     pub phase: MaintenancePhase,
+    /// Durable fail-closed gate for upgrade cutover discovery. While set, the
+    /// account may prepare local KeyPackage material and retry exact deletion
+    /// obligations, but it must not publish, republish, or fan out a kind
+    /// 30443 revision. The app clears this only after every authoritative
+    /// relay completed its scan and every discovered exact endpoint liability
+    /// was admitted durably.
+    #[serde(default)]
+    pub cutover_publication_blocked: bool,
     pub current_key_package: Option<KeyPackage>,
     pub current_key_package_ref: Option<Vec<u8>>,
     pub current_not_before: Option<Timestamp>,
     pub current_not_after: Option<Timestamp>,
     pub authored_event_id: Option<MessageId>,
+    /// Highest transport authoring time durably selected for this stable
+    /// replaceable-event slot. This normally describes the current artifact,
+    /// but remains above it when a newer pending artifact was consumed before
+    /// acknowledgement so the required fresh replacement sorts after both.
     pub authored_event_created_at: Option<Timestamp>,
-    /// Exact current replaceable event retained until its snapshotted fanout
-    /// finishes. Local lifecycle promotion still occurs on the first accepted
-    /// acknowledgement.
+    /// Current signed revision retained for restart-safe exact retries within
+    /// that revision. A bounded-age transport may atomically replace it with a
+    /// strictly newer revision at the same coordinate and reset every live
+    /// target before fanout continues. Local lifecycle promotion still occurs
+    /// on the first accepted acknowledgement.
     #[serde(default)]
     pub authored_signed_event: Option<SignedPublicationArtifact>,
+    /// Current or pending signed revision ids selected for relay deletion.
+    /// An artifact remains forbidden from exact republication while its id is
+    /// present; the marker follows that exact revision rather than leaking
+    /// onto a newly generated KeyPackage after expiry or promotion.
+    #[serde(default)]
+    pub deleted_live_revision_event_ids: Vec<MessageId>,
+    /// Exact deletion currently entitled to use the bounded liabilities above
+    /// [`MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES`]. The owner remains
+    /// durable until every one of that event's deletion targets has a terminal
+    /// receipt, preventing two atomic exact-deletion sets from sharing the
+    /// overflow reserve across retries or process restarts.
+    #[serde(default)]
+    pub deletion_overflow_owner_event_id: Option<MessageId>,
+    /// Superseded signed revisions whose possible relay copies still require
+    /// explicit deletion acknowledgement. This is independent of MLS private
+    /// material retention and therefore survives package expiry and restart.
+    #[serde(default)]
+    pub retired_publications_pending_deletion: Vec<RetiredKeyPackagePublication>,
     #[serde(default)]
     pub publication_targets: Vec<TransportFanoutTarget>,
     pub refresh_at: Option<Timestamp>,
@@ -282,6 +376,12 @@ pub struct KeyPackageLifecycleState {
     pub last_consumed_key_package_ref: Option<Vec<u8>>,
     #[serde(default)]
     pub last_consumed_at: Option<Timestamp>,
+    /// Durable, deduplicated references of locally owned KeyPackages proven
+    /// consumed by successfully processed Welcomes. Only the account sweep
+    /// may remove evidence after it has handled the matching private material;
+    /// unmatched upgrade-era evidence is retained fail-closed.
+    #[serde(default)]
+    pub consumed_key_package_refs: Vec<Vec<u8>>,
     /// Prior, unconsumed packages remain decryptable until their MLS lifetime
     /// expires so an invite already in flight can still be processed.
     #[serde(default)]
@@ -297,6 +397,7 @@ impl KeyPackageLifecycleState {
         Self {
             stable_slot_id,
             phase: MaintenancePhase::Complete,
+            cutover_publication_blocked: false,
             current_key_package: None,
             current_key_package_ref: None,
             current_not_before: None,
@@ -304,13 +405,80 @@ impl KeyPackageLifecycleState {
             authored_event_id: None,
             authored_event_created_at: None,
             authored_signed_event: None,
+            deleted_live_revision_event_ids: Vec::new(),
+            deletion_overflow_owner_event_id: None,
+            retired_publications_pending_deletion: Vec::new(),
             publication_targets: Vec::new(),
             refresh_at: None,
             upgrade_rotation_recorded: false,
             last_consumed_key_package_ref: None,
             last_consumed_at: None,
+            consumed_key_package_refs: Vec::new(),
             retained_private_material: Vec::new(),
             pending_replacement: None,
+        }
+    }
+
+    /// Record a locally matched Welcome consumption without overwriting an
+    /// earlier still-live reference. The legacy `last_consumed_*` fields remain
+    /// the latest-consumption status projection.
+    pub fn record_consumed_key_package_ref(
+        &mut self,
+        key_package_ref: Vec<u8>,
+        consumed_at: Timestamp,
+    ) -> Result<(), ConsumedKeyPackageRefJournalFull> {
+        if !self.consumed_key_package_refs.contains(&key_package_ref) {
+            if self.consumed_key_package_refs.len() >= MAX_CONSUMED_KEY_PACKAGE_REFS_PENDING_CLEANUP
+            {
+                return Err(ConsumedKeyPackageRefJournalFull);
+            }
+            self.consumed_key_package_refs.push(key_package_ref.clone());
+        }
+        self.last_consumed_key_package_ref = Some(key_package_ref);
+        self.last_consumed_at = Some(consumed_at);
+        Ok(())
+    }
+
+    /// Import the legacy last-consumed marker and deduplicate without pruning.
+    /// Only the account sweep that actually handles matching private/lifecycle
+    /// material may clear consumption evidence; an upgrade row may not yet
+    /// project its still-owned OpenMLS bundle into these lifecycle fields.
+    pub fn reconcile_consumed_key_package_refs(&mut self) {
+        if let Some(last) = self.last_consumed_key_package_ref.as_ref()
+            && !self
+                .consumed_key_package_refs
+                .iter()
+                .any(|candidate| candidate == last)
+            && self.consumed_key_package_refs.len() < MAX_CONSUMED_KEY_PACKAGE_REFS_PENDING_CLEANUP
+        {
+            self.consumed_key_package_refs.push(last.clone());
+        }
+        let mut reconciled = Vec::with_capacity(self.consumed_key_package_refs.len());
+        for consumed in self.consumed_key_package_refs.drain(..) {
+            if !reconciled.iter().any(|candidate| candidate == &consumed) {
+                reconciled.push(consumed);
+            }
+        }
+        self.consumed_key_package_refs = reconciled;
+    }
+
+    /// Whether a still-live/private lifecycle reference has durable Welcome
+    /// consumption evidence. The legacy field is accepted for upgrade safety.
+    pub fn key_package_ref_is_consumed(&self, key_package_ref: &[u8]) -> bool {
+        self.consumed_key_package_refs
+            .iter()
+            .any(|candidate| candidate.as_slice() == key_package_ref)
+            || self.last_consumed_key_package_ref.as_deref() == Some(key_package_ref)
+    }
+
+    /// Clear one consumption marker only after the account sweep has handled
+    /// the matching current/pending/retained private material.
+    pub fn clear_consumed_key_package_ref(&mut self, key_package_ref: &[u8]) {
+        self.consumed_key_package_refs
+            .retain(|candidate| candidate.as_slice() != key_package_ref);
+        if self.last_consumed_key_package_ref.as_deref() == Some(key_package_ref) {
+            self.last_consumed_key_package_ref = self.consumed_key_package_refs.last().cloned();
+            self.last_consumed_at = None;
         }
     }
 }
@@ -359,7 +527,10 @@ pub struct GroupMaintenanceStatus {
 
 #[cfg(test)]
 mod tests {
-    use super::MaintenancePhase;
+    use super::{
+        KeyPackageLifecycleState, MAX_CONSUMED_KEY_PACKAGE_REFS_PENDING_CLEANUP, MaintenancePhase,
+    };
+    use crate::Timestamp;
 
     #[test]
     fn maintenance_phase_names_are_stable_snake_case() {
@@ -374,6 +545,73 @@ mod tests {
         assert_eq!(
             MaintenancePhase::ClockSkewBlocked.as_str(),
             "clock_skew_blocked"
+        );
+    }
+
+    #[test]
+    fn consumed_key_package_ref_journal_is_serde_defaulted_deduplicated_and_reconciled() {
+        let mut legacy_json =
+            serde_json::to_value(KeyPackageLifecycleState::slot_only("stable-slot".into()))
+                .unwrap();
+        legacy_json
+            .as_object_mut()
+            .unwrap()
+            .remove("consumed_key_package_refs");
+        legacy_json
+            .as_object_mut()
+            .unwrap()
+            .remove("cutover_publication_blocked");
+        legacy_json
+            .as_object_mut()
+            .unwrap()
+            .remove("deletion_overflow_owner_event_id");
+        let legacy: KeyPackageLifecycleState = serde_json::from_value(legacy_json).unwrap();
+        assert!(legacy.consumed_key_package_refs.is_empty());
+        assert!(!legacy.cutover_publication_blocked);
+        assert!(legacy.deletion_overflow_owner_event_id.is_none());
+
+        let mut lifecycle = KeyPackageLifecycleState::slot_only("stable-slot".into());
+        lifecycle.current_key_package_ref = Some(vec![1]);
+        lifecycle
+            .record_consumed_key_package_ref(vec![1], Timestamp(10))
+            .unwrap();
+        lifecycle
+            .record_consumed_key_package_ref(vec![1], Timestamp(11))
+            .unwrap();
+        assert_eq!(lifecycle.consumed_key_package_refs, vec![vec![1]]);
+        assert_eq!(lifecycle.last_consumed_at, Some(Timestamp(11)));
+
+        lifecycle.current_key_package_ref = Some(vec![2]);
+        lifecycle
+            .record_consumed_key_package_ref(vec![2], Timestamp(12))
+            .unwrap();
+        assert_eq!(
+            lifecycle.consumed_key_package_refs,
+            vec![vec![1], vec![2]],
+            "only the account sweep may clear older unswept evidence"
+        );
+        lifecycle.clear_consumed_key_package_ref(&[1]);
+        assert_eq!(lifecycle.consumed_key_package_refs, vec![vec![2]]);
+        lifecycle.current_key_package_ref = None;
+        lifecycle.clear_consumed_key_package_ref(&[2]);
+        assert!(lifecycle.consumed_key_package_refs.is_empty());
+        assert!(lifecycle.last_consumed_key_package_ref.is_none());
+        assert!(lifecycle.last_consumed_at.is_none());
+
+        let mut bounded = KeyPackageLifecycleState::slot_only(String::new());
+        for index in 0..MAX_CONSUMED_KEY_PACKAGE_REFS_PENDING_CLEANUP {
+            bounded
+                .record_consumed_key_package_ref(
+                    u64::try_from(index).unwrap().to_be_bytes().to_vec(),
+                    Timestamp(index as u64),
+                )
+                .unwrap();
+        }
+        assert!(
+            bounded
+                .record_consumed_key_package_ref(vec![0xff; 9], Timestamp(u64::MAX))
+                .is_err(),
+            "the journal fails closed rather than evicting unswept evidence"
         );
     }
 }

--- a/crates/traits/src/storage.rs
+++ b/crates/traits/src/storage.rs
@@ -403,6 +403,11 @@ pub struct LeaveRequest {
     pub group_id: GroupId,
     pub requested_at_ms: u64,
     pub last_proposed_epoch: Option<EpochId>,
+    /// Exact engine message id of the most recently accepted SelfRemove.
+    /// Older records predate this attribution and hydrate it from the paired
+    /// durable sent-message row.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_proposed_message_id: Option<MessageId>,
 }
 
 pub trait LeaveRequestStorage {

--- a/crates/traits/src/transport_adapter.rs
+++ b/crates/traits/src/transport_adapter.rs
@@ -849,6 +849,16 @@ pub struct TransportEndpointFailure {
     pub rejection_category: Option<TransportEndpointRejectionCategory>,
 }
 
+impl TransportEndpointFailure {
+    /// Whether the adapter mapped an exact, stable relay response to terminal
+    /// target-absence evidence. The sentinel reason is adapter-authored and
+    /// privacy-safe; arbitrary relay suffix text is never retained here.
+    pub fn confirms_target_absence(&self) -> bool {
+        self.rejection_category == Some(TransportEndpointRejectionCategory::Invalid)
+            && self.reason == "relay rejected event (not-found)"
+    }
+}
+
 /// Publish failure surfaced by transport adapters.
 ///
 /// `summary` is safe for `Display`/logging. Per-endpoint diagnostics live in

--- a/crates/transport-nostr-adapter/src/lib.rs
+++ b/crates/transport-nostr-adapter/src/lib.rs
@@ -92,6 +92,7 @@ pub use telemetry::{
 };
 
 const DELIVERY_BUFFER: usize = 1024;
+const GROUP_MAINTENANCE_SUBSCRIPTION_ID_PREFIX: &str = "marmot:group-maintenance:";
 
 fn unix_now_seconds() -> u64 {
     SystemTime::now()
@@ -672,12 +673,14 @@ impl NostrTransportAdapter {
         subscription: NostrSubscription,
     ) -> Result<(), TransportAdapterError> {
         let _subscription_guard = self.subscription_lock.lock().await;
-        self.relay_client.unsubscribe(subscription.clone()).await?;
+        // Local teardown is authoritative even when relay cleanup fails or is
+        // cancelled: once the caller removes this temporary subscription, a
+        // late raw relay copy must no longer be an account delivery path.
         self.state
             .write()
             .await
             .forget_subscription_starts(std::slice::from_ref(&subscription));
-        Ok(())
+        self.relay_client.unsubscribe(subscription).await
     }
 
     /// Resolve opaque relay indices to relay endpoints for the opt-in export
@@ -722,6 +725,37 @@ impl NostrTransportAdapter {
             .await
     }
 
+    /// Route a raw SDK relay copy only when it belongs to an active temporary
+    /// group-maintenance subscription.
+    ///
+    /// The SDK's database is shared by every local account. When another
+    /// account has already cached an event, a later full-history REQ emits only
+    /// the raw per-subscription copy; the SDK's ordinary deduplicated `Event`
+    /// notification is suppressed. Subscription ownership restores that replay
+    /// for the requesting account without turning ordinary raw copies into a
+    /// second, cross-account delivery path.
+    #[cfg(feature = "sdk")]
+    pub async fn handle_group_maintenance_replay(
+        &self,
+        relay_event: NostrRelayEvent,
+    ) -> Result<usize, TransportAdapterError> {
+        let Some(subscription_id) = relay_event.subscription_id.as_deref() else {
+            return Ok(0);
+        };
+        let account_id = self
+            .state
+            .read()
+            .await
+            .group_maintenance_accounts
+            .get(subscription_id)
+            .cloned();
+        let Some(account_id) = account_id else {
+            return Ok(0);
+        };
+        self.handle_relay_event_scoped(relay_event, Some(&account_id))
+            .await
+    }
+
     async fn handle_relay_event_scoped(
         &self,
         relay_event: NostrRelayEvent,
@@ -734,6 +768,27 @@ impl NostrTransportAdapter {
         let received_at = Timestamp(unix_now_seconds());
         let mut routes = {
             let state = self.state.read().await;
+            if let Some(subscription_id) = relay_event.subscription_id.as_deref()
+                && subscription_id.starts_with(GROUP_MAINTENANCE_SUBSCRIPTION_ID_PREFIX)
+                && state
+                    .group_maintenance_accounts
+                    .get(subscription_id)
+                    .is_none_or(|owner| account_id.is_some_and(|account_id| owner != account_id))
+            {
+                // nostr-relay-pool does not verify subscription existence by
+                // default. A relay can therefore race a queued EVENT behind
+                // CLOSE (or keep sending after failed remote teardown), and
+                // the SDK may surface that stale maintenance copy as its
+                // deduplicated Event. Once local ownership is gone, fail
+                // closed instead of letting the stale temporary REQ re-enter
+                // ordinary group routing.
+                tracing::debug!(
+                    target: "transport_nostr_adapter::adapter",
+                    method = "handle_relay_event_scoped",
+                    "ignored event for inactive maintenance subscription"
+                );
+                return Ok(0);
+            }
             state.routes_for(&message, &relay_event.endpoint)
         };
         if let Some(account_id) = account_id {
@@ -1296,6 +1351,15 @@ struct AdapterState {
     /// sync may append only missing pre-REQ routes while a subscribe batch is in
     /// flight; both success and failure rebuild the index before returning.
     by_transport_group: HashMap<Vec<u8>, Vec<GroupRouteEntry>>,
+    /// Account ownership for active full-history post-join subscriptions.
+    ///
+    /// `nostr-sdk` suppresses its deduplicated `Event` notification when a
+    /// relay replays an event already present in the shared SDK database, but
+    /// still emits the raw per-subscription copy. Keeping this ownership map
+    /// lets that raw maintenance replay use the ordinary signed-routing table
+    /// while remaining scoped to the account that requested it. Ordinary raw
+    /// subscription copies remain telemetry-only.
+    group_maintenance_accounts: HashMap<String, MemberId>,
     /// Unconfirmed relay unsubscribes retained until teardown succeeds.
     /// Routing state (`accounts`/`by_transport_group`) already reflects the
     /// removal; these are relay-side cleanups only, drained on later
@@ -1486,13 +1550,18 @@ impl AdapterState {
 
     fn record_subscription_starts(&mut self, subscriptions: &[NostrSubscription], now_ms: u64) {
         for subscription in subscriptions {
+            let subscription_id = subscription.subscription_id();
+            if let NostrSubscription::GroupMaintenance { account_id, .. } = subscription {
+                self.group_maintenance_accounts
+                    .insert(subscription_id.clone(), account_id.clone());
+            }
             let relays: Vec<RelayIndex> = subscription
                 .endpoints()
                 .iter()
                 .map(|endpoint| self.relay_index.index_for(endpoint))
                 .collect();
             self.sync
-                .record_subscription_start(&subscription.subscription_id(), &relays, now_ms);
+                .record_subscription_start(&subscription_id, &relays, now_ms);
         }
     }
 
@@ -1541,8 +1610,11 @@ impl AdapterState {
     /// telemetry map tracks live subscriptions rather than historical churn.
     fn forget_subscription_starts(&mut self, subscriptions: &[NostrSubscription]) {
         for subscription in subscriptions {
-            self.sync
-                .forget_subscription(&subscription.subscription_id());
+            let subscription_id = subscription.subscription_id();
+            self.sync.forget_subscription(&subscription_id);
+            if matches!(subscription, NostrSubscription::GroupMaintenance { .. }) {
+                self.group_maintenance_accounts.remove(&subscription_id);
+            }
         }
     }
 
@@ -1579,6 +1651,17 @@ impl AdapterState {
     fn forget_account_subscription_starts(&mut self, account_id: &MemberId) {
         for id in self.account_subscription_ids(account_id) {
             self.sync.forget_subscription(&id);
+        }
+        let maintenance_ids = self
+            .group_maintenance_accounts
+            .iter()
+            .filter_map(|(subscription_id, owner)| {
+                (owner == account_id).then_some(subscription_id.clone())
+            })
+            .collect::<Vec<_>>();
+        for subscription_id in maintenance_ids {
+            self.group_maintenance_accounts.remove(&subscription_id);
+            self.sync.forget_subscription(&subscription_id);
         }
     }
 

--- a/crates/transport-nostr-adapter/src/lib.rs
+++ b/crates/transport-nostr-adapter/src/lib.rs
@@ -1037,14 +1037,19 @@ impl TransportAdapter for NostrTransportAdapter {
             subscriptions_removed = removed_count,
             "deactivating transport account"
         );
-        self.relay_client.unsubscribe_account(account_id).await?;
-        let mut state = self.state.write().await;
-        state.forget_account_subscription_starts(account_id);
-        // The blanket `unsubscribe_account` above supersedes any queued
-        // per-subscription unsubscribes for this account.
-        state.clear_pending_unsubscribes_for_account(account_id);
-        state.deactivate(account_id, removed_count);
-        Ok(())
+        // Commit the local teardown before the fallible/cancellable relay I/O.
+        // A signed-out or wiped account cannot remain an active delivery target
+        // merely because a relay is unavailable or this future is cancelled.
+        {
+            let mut state = self.state.write().await;
+            state.forget_account_subscription_starts(account_id);
+            // The blanket `unsubscribe_account` below supersedes queued
+            // per-subscription relay cleanup for this account.
+            state.clear_pending_unsubscribes_for_account(account_id);
+            state.deactivate(account_id, removed_count);
+        }
+
+        self.relay_client.unsubscribe_account(account_id).await
     }
 
     async fn publish(

--- a/crates/transport-nostr-adapter/src/sdk_client.rs
+++ b/crates/transport-nostr-adapter/src/sdk_client.rs
@@ -478,23 +478,31 @@ impl NostrSdkRelayClient {
                                         event,
                                     },
                             } => {
-                                // Raw per-relay copy (not deduplicated): telemetry
-                                // only, so cross-relay spread sees every relay's
-                                // copy. Delivery happens on the deduplicated
-                                // `Event` notification above.
+                                // Raw per-relay copy (not deduplicated): always
+                                // retain it for telemetry, so cross-relay spread
+                                // sees every relay's copy. Normally delivery
+                                // happens on the deduplicated `Event`
+                                // notification above. One exception is an active
+                                // full-history group-maintenance subscription:
+                                // nostr-sdk suppresses `Event` when another local
+                                // account already cached the replayed event in
+                                // the shared database, while this verified raw
+                                // copy is still emitted. The adapter registry
+                                // scopes that replay to the requesting account.
                                 if let Ok(event) = NostrTransportEvent::from_nostr_event(&event) {
                                     tracing::trace!(
                                         target: "transport_nostr_adapter::sdk_client",
                                         method = "spawn_notification_forwarder",
                                         "observing per-relay event copy"
                                     );
-                                    adapter
-                                        .observe_relay_event(NostrRelayEvent {
-                                            endpoint: TransportEndpoint(relay_url.to_string()),
-                                            subscription_id: Some(subscription_id.to_string()),
-                                            event,
-                                        })
-                                        .await;
+                                    let relay_event = NostrRelayEvent {
+                                        endpoint: TransportEndpoint(relay_url.to_string()),
+                                        subscription_id: Some(subscription_id.to_string()),
+                                        event,
+                                    };
+                                    adapter.observe_relay_event(relay_event.clone()).await;
+                                    let _ =
+                                        adapter.handle_group_maintenance_replay(relay_event).await;
                                 }
                                 Ok(false)
                             }
@@ -1577,8 +1585,10 @@ fn relay_rejection_endpoint_failure(
 mod tests {
     use super::*;
     use crate::NostrKeyPackagePublication;
-    use cgka_traits::Timestamp;
     use cgka_traits::engine::KeyPackage;
+    use cgka_traits::{
+        Timestamp, TransportAccountActivation, TransportAdapter, TransportGroupSubscription,
+    };
     use futures::{SinkExt, StreamExt};
     use nostr_relay_builder::MockRelay;
     use nostr_sdk::prelude::{DatabaseEventStatus, EventBuilder, Keys, Kind, Tag};
@@ -1600,6 +1610,204 @@ mod tests {
             .sign_with_keys(&ephemeral)
             .expect("sign ephemeral 445");
         NostrTransportEvent::from_nostr_event(&signed).expect("dto from signed event")
+    }
+
+    #[tokio::test]
+    async fn shared_sdk_cache_replays_group_history_only_to_maintenance_owner() {
+        let relay = timeout(Duration::from_secs(5), MockRelay::run())
+            .await
+            .expect("local relay starts within the test budget")
+            .expect("start relay");
+        let endpoint = TransportEndpoint(relay.url().await.to_string());
+        let sdk = NostrSdkRelayClient::new(Client::builder().build());
+        let adapter = NostrTransportAdapter::new(Arc::new(sdk.clone()));
+        let forwarder = sdk.spawn_notification_forwarder(adapter.clone());
+        // Let the spawned task install its notification receiver before the
+        // first subscription can produce stored-event notifications.
+        tokio::task::yield_now().await;
+
+        let alice = MemberId::new(Keys::generate().public_key().to_bytes().to_vec());
+        let bob = MemberId::new(Keys::generate().public_key().to_bytes().to_vec());
+        let group = TransportGroupSubscription {
+            group_id: cgka_traits::GroupId::new(vec![0xAB; 32]),
+            transport_group_id: vec![0xCC; 32],
+            endpoints: vec![endpoint.clone()],
+        };
+        timeout(
+            Duration::from_secs(5),
+            adapter.activate_account(TransportAccountActivation {
+                account_id: alice.clone(),
+                inbox_endpoints: vec![endpoint.clone()],
+                group_subscriptions: vec![group.clone()],
+                since: None,
+            }),
+        )
+        .await
+        .expect("account A activation finishes within the test budget")
+        .expect("activate account A");
+
+        let event = signed_group_event_dto();
+        // Use a distinct client/database for the remote sender. Publishing
+        // through the recipient client would pre-cache the outgoing event and
+        // suppress A's initial deduplicated Event notification too, which is a
+        // different scenario from A caching a genuinely received event.
+        let publisher = NostrSdkRelayClient::new(Client::builder().build());
+        timeout(
+            Duration::from_secs(5),
+            publisher.publish_event(std::slice::from_ref(&endpoint), &event, 1),
+        )
+        .await
+        .expect("publish finishes within the test budget")
+        .expect("publish event for account A's live subscription");
+        let alice_delivery = timeout(Duration::from_secs(5), adapter.receive())
+            .await
+            .expect("account A receives the live event")
+            .expect("delivery queue remains open")
+            .expect("account A delivery exists");
+        assert_eq!(alice_delivery.account_id, alice);
+
+        // Account B shares the same nostr-sdk client/database. Its ordinary
+        // group REQ gets the relay's raw stored copy, but nostr-sdk suppresses
+        // the deduplicated Event notification because A already cached it.
+        timeout(
+            Duration::from_secs(5),
+            adapter.activate_account(TransportAccountActivation {
+                account_id: bob.clone(),
+                inbox_endpoints: vec![endpoint.clone()],
+                group_subscriptions: vec![group.clone()],
+                since: None,
+            }),
+        )
+        .await
+        .expect("account B activation finishes within the test budget")
+        .expect("activate account B");
+        assert!(
+            timeout(Duration::from_millis(250), adapter.receive())
+                .await
+                .is_err(),
+            "ordinary raw replays must remain telemetry-only"
+        );
+
+        let maintenance_id = timeout(
+            Duration::from_secs(5),
+            adapter.install_group_maintenance_subscription(&bob, &group),
+        )
+        .await
+        .expect("maintenance install finishes within the test budget")
+        .expect("install account B maintenance subscription");
+        let bob_delivery = timeout(Duration::from_secs(5), adapter.receive())
+            .await
+            .expect("maintenance REQ recovers the shared-cache event")
+            .expect("delivery queue remains open")
+            .expect("account B delivery exists");
+        assert_eq!(bob_delivery.account_id, bob);
+        assert_eq!(bob_delivery.group_id_hint, Some(group.group_id.clone()));
+        assert_eq!(
+            bob_delivery.source.subscription_id.as_deref(),
+            Some(maintenance_id.as_str())
+        );
+        assert!(
+            timeout(Duration::from_millis(250), adapter.receive())
+                .await
+                .is_err(),
+            "account B's maintenance replay must not fan out to account A"
+        );
+
+        let maintenance = NostrSubscription::GroupMaintenance {
+            account_id: bob.clone(),
+            group_id: group.group_id.clone(),
+            transport_group_id: group.transport_group_id.clone(),
+            endpoints: group.endpoints.clone(),
+        };
+        timeout(
+            Duration::from_secs(5),
+            adapter.remove_group_maintenance_subscription(maintenance.clone()),
+        )
+        .await
+        .expect("maintenance removal finishes within the test budget")
+        .expect("remove maintenance subscription");
+        let replay_after_remove = adapter
+            .handle_group_maintenance_replay(NostrRelayEvent {
+                endpoint: endpoint.clone(),
+                subscription_id: Some(maintenance_id.clone()),
+                event: event.clone(),
+            })
+            .await
+            .expect("removed replay is ignored");
+        assert_eq!(replay_after_remove, 0);
+
+        // Account teardown is also authoritative for an otherwise-live
+        // maintenance registration.
+        timeout(
+            Duration::from_secs(5),
+            adapter.install_group_maintenance_subscription(&bob, &group),
+        )
+        .await
+        .expect("maintenance reinstall finishes within the test budget")
+        .expect("reinstall maintenance subscription");
+        assert_eq!(
+            adapter
+                .state
+                .read()
+                .await
+                .group_maintenance_accounts
+                .get(&maintenance_id),
+            Some(&bob)
+        );
+        timeout(Duration::from_secs(5), adapter.deactivate_account(&bob))
+            .await
+            .expect("account B teardown finishes within the test budget")
+            .expect("deactivate account B");
+        assert!(
+            !adapter
+                .state
+                .read()
+                .await
+                .group_maintenance_accounts
+                .contains_key(&maintenance_id),
+            "account teardown must remove raw-replay ownership"
+        );
+
+        publisher.client().shutdown().await;
+        sdk.client().shutdown().await;
+        timeout(Duration::from_secs(5), forwarder)
+            .await
+            .expect("notification forwarder shuts down")
+            .expect("notification forwarder does not panic");
+    }
+
+    #[tokio::test]
+    async fn failed_maintenance_subscribe_rolls_back_raw_replay_scope() {
+        let sdk = NostrSdkRelayClient::new(Client::builder().build());
+        let adapter = NostrTransportAdapter::new(Arc::new(sdk));
+        let account_id = MemberId::new(Keys::generate().public_key().to_bytes().to_vec());
+        let group = TransportGroupSubscription {
+            group_id: cgka_traits::GroupId::new(vec![0x11; 32]),
+            transport_group_id: vec![0x22; 32],
+            endpoints: vec![TransportEndpoint("not a relay URL".into())],
+        };
+        let maintenance_id = NostrSubscription::GroupMaintenance {
+            account_id: account_id.clone(),
+            group_id: group.group_id.clone(),
+            transport_group_id: group.transport_group_id.clone(),
+            endpoints: group.endpoints.clone(),
+        }
+        .subscription_id();
+
+        adapter
+            .install_group_maintenance_subscription(&account_id, &group)
+            .await
+            .expect_err("invalid endpoint rejects the maintenance REQ");
+
+        assert!(
+            !adapter
+                .state
+                .read()
+                .await
+                .group_maintenance_accounts
+                .contains_key(&maintenance_id),
+            "failed subscribe must not leave raw-replay ownership active"
+        );
     }
 
     #[test]

--- a/crates/transport-nostr-adapter/src/sdk_client.rs
+++ b/crates/transport-nostr-adapter/src/sdk_client.rs
@@ -1520,6 +1520,17 @@ fn relay_rejection_endpoint_failure(
     endpoint: TransportEndpoint,
     relay_message: &str,
 ) -> TransportEndpointFailure {
+    // Buzz relays currently expose deletion target absence through this exact
+    // stable rejection. Do not generalize the free-text suffix across other
+    // NIP-01 prefixes: only the observed full response is terminal evidence.
+    if relay_message == "invalid: target event not found" {
+        return TransportEndpointFailure {
+            endpoint,
+            reason: "relay rejected event (not-found)".to_owned(),
+            kind: TransportEndpointFailureKind::TerminalRejected,
+            rejection_category: Some(TransportEndpointRejectionCategory::Invalid),
+        };
+    }
     if let Some(prefix) = nostr::message::MachineReadablePrefix::parse(relay_message) {
         let category = map_relay_rejection_category(prefix);
         // nostr-sdk also uses the generic `error:` prefix for local SDK/send
@@ -1638,6 +1649,12 @@ mod tests {
                 "relay rejected event (invalid)",
             ),
             (
+                "invalid: target event not found",
+                TransportEndpointRejectionCategory::Invalid,
+                TransportEndpointFailureKind::TerminalRejected,
+                "relay rejected event (not-found)",
+            ),
+            (
                 "unsupported: kind 5",
                 TransportEndpointRejectionCategory::Unsupported,
                 TransportEndpointFailureKind::TerminalRejected,
@@ -1653,6 +1670,32 @@ mod tests {
             assert_eq!(failure.reason, summary);
             assert!(!failure.reason.contains("evil.example"));
             assert!(!failure.reason.contains("leaked event payload"));
+        }
+        assert!(
+            relay_rejection_endpoint_failure(
+                TransportEndpoint("wss://relay.example".into()),
+                "invalid: target event not found",
+            )
+            .confirms_target_absence()
+        );
+    }
+
+    #[test]
+    fn target_absence_requires_the_exact_known_relay_response() {
+        for message in [
+            "error: target event not found",
+            "blocked: target event not found",
+            "invalid: target event not found elsewhere",
+            "invalid: Target event not found",
+        ] {
+            let failure = relay_rejection_endpoint_failure(
+                TransportEndpoint("wss://relay.example".into()),
+                message,
+            );
+            assert!(
+                !failure.confirms_target_absence(),
+                "unrecognized free text must remain retryable: {message}"
+            );
         }
     }
 

--- a/crates/transport-nostr-adapter/tests/inbound_routing.rs
+++ b/crates/transport-nostr-adapter/tests/inbound_routing.rs
@@ -342,6 +342,9 @@ struct FlakyUnsubscribeRelayClient {
     unsubscribed: Mutex<Vec<transport_nostr_adapter::NostrSubscription>>,
     unsubscribed_accounts: Mutex<Vec<MemberId>>,
     fail_next_unsubscribes: AtomicUsize,
+    fail_next_account_unsubscribes: AtomicUsize,
+    block_account_unsubscribes: AtomicBool,
+    account_unsubscribe_entered: AtomicUsize,
 }
 
 #[async_trait]
@@ -377,6 +380,22 @@ impl NostrRelayClient for FlakyUnsubscribeRelayClient {
         &self,
         account_id: &MemberId,
     ) -> Result<(), cgka_traits::TransportAdapterError> {
+        if self.block_account_unsubscribes.load(Ordering::SeqCst) {
+            self.account_unsubscribe_entered
+                .fetch_add(1, Ordering::SeqCst);
+            std::future::pending::<()>().await;
+        }
+        if self
+            .fail_next_account_unsubscribes
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |armed| {
+                armed.checked_sub(1)
+            })
+            .is_ok()
+        {
+            return Err(cgka_traits::TransportAdapterError::Subscription(
+                "injected account unsubscribe failure".into(),
+            ));
+        }
         self.unsubscribed_accounts
             .lock()
             .unwrap()
@@ -2381,6 +2400,111 @@ async fn deactivate_account_clears_pending_unsubscribes() {
         std::slice::from_ref(&account_id)
     );
     assert_eq!(adapter.metrics().await.unsubscribe_retries_pending, 0);
+}
+
+#[tokio::test]
+async fn failed_account_unsubscribe_still_clears_local_account_routes() {
+    let relay = Arc::new(FlakyUnsubscribeRelayClient::default());
+    let adapter = NostrTransportAdapter::new(relay.clone());
+    let account_id = MemberId::new(vec![0xA1; 32]);
+
+    adapter
+        .activate_account(TransportAccountActivation {
+            account_id: account_id.clone(),
+            inbox_endpoints: vec![TransportEndpoint("wss://inbox.example".into())],
+            group_subscriptions: vec![],
+            since: None,
+        })
+        .await
+        .expect("activation succeeds");
+    assert_eq!(adapter.metrics().await.active_accounts, 1);
+
+    relay
+        .fail_next_account_unsubscribes
+        .store(1, Ordering::SeqCst);
+    adapter
+        .deactivate_account(&account_id)
+        .await
+        .expect_err("relay-side account unsubscribe is injected to fail");
+
+    assert_eq!(
+        adapter.metrics().await.active_accounts,
+        0,
+        "local routing must be inactive even when relay unsubscribe fails"
+    );
+    assert!(
+        relay.unsubscribed_accounts.lock().unwrap().is_empty(),
+        "the injected failure must not be recorded as a relay acknowledgement"
+    );
+}
+
+#[tokio::test]
+async fn cancelled_pending_account_unsubscribe_keeps_local_account_deactivated() {
+    let relay = Arc::new(FlakyUnsubscribeRelayClient::default());
+    let adapter = NostrTransportAdapter::new(relay.clone());
+    let account_id = MemberId::new(vec![0xA1; 32]);
+    let group = TransportGroupSubscription {
+        group_id: cgka_traits::GroupId::new(vec![0xB2; 32]),
+        transport_group_id: vec![0xC3; 32],
+        endpoints: vec![TransportEndpoint("wss://group.example".into())],
+    };
+
+    adapter
+        .activate_account(TransportAccountActivation {
+            account_id: account_id.clone(),
+            inbox_endpoints: vec![TransportEndpoint("wss://inbox.example".into())],
+            group_subscriptions: vec![group],
+            since: None,
+        })
+        .await
+        .expect("activation succeeds");
+    relay.fail_next_unsubscribes.store(1, Ordering::SeqCst);
+    adapter
+        .sync_account_groups(TransportGroupSync {
+            account_id: account_id.clone(),
+            group_subscriptions: vec![],
+            since: None,
+        })
+        .await
+        .expect("group removal commits despite failed relay cleanup");
+    assert_eq!(adapter.metrics().await.unsubscribe_retries_pending, 1);
+
+    relay
+        .block_account_unsubscribes
+        .store(true, Ordering::SeqCst);
+    let adapter_for_deactivation = adapter.clone();
+    let account_for_deactivation = account_id.clone();
+    let deactivation = tokio::spawn(async move {
+        adapter_for_deactivation
+            .deactivate_account(&account_for_deactivation)
+            .await
+    });
+    tokio::time::timeout(concurrent_subscribe_timeout(), async {
+        while relay.account_unsubscribe_entered.load(Ordering::SeqCst) == 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("deactivation must reach the pending relay unsubscribe");
+
+    let metrics = adapter.metrics().await;
+    assert_eq!(metrics.active_accounts, 0);
+    assert_eq!(metrics.active_group_subscriptions, 0);
+    assert_eq!(
+        metrics.unsubscribe_retries_pending, 0,
+        "blanket account teardown must clear queued relay cleanup before awaiting"
+    );
+    assert_eq!(adapter.relay_sync().await.tracked_subscriptions, 0);
+
+    deactivation.abort();
+    let join_error = deactivation
+        .await
+        .expect_err("pending deactivation must be cancellable");
+    assert!(join_error.is_cancelled());
+
+    let metrics = adapter.metrics().await;
+    assert_eq!(metrics.active_accounts, 0);
+    assert_eq!(metrics.unsubscribe_retries_pending, 0);
 }
 
 #[tokio::test]

--- a/crates/transport-nostr-adapter/tests/inbound_routing.rs
+++ b/crates/transport-nostr-adapter/tests/inbound_routing.rs
@@ -704,6 +704,95 @@ async fn group_subscription_id_fans_out_to_matching_accounts_and_replays_route_a
 }
 
 #[tokio::test]
+async fn failed_maintenance_unsubscribe_blocks_late_deduplicated_event() {
+    let relay = Arc::new(FlakyUnsubscribeRelayClient::default());
+    let adapter = NostrTransportAdapter::new(relay.clone());
+    let account_id = MemberId::new(vec![0xA1; 32]);
+    let group_id = cgka_traits::GroupId::new(vec![0xB2; 32]);
+    let transport_group_id = vec![0xC3; 32];
+    let endpoint = TransportEndpoint("wss://group.example".into());
+    let group = TransportGroupSubscription {
+        group_id: group_id.clone(),
+        transport_group_id: transport_group_id.clone(),
+        endpoints: vec![endpoint.clone()],
+    };
+    adapter
+        .activate_account(TransportAccountActivation {
+            account_id: account_id.clone(),
+            inbox_endpoints: vec![TransportEndpoint("wss://inbox.example".into())],
+            group_subscriptions: vec![group.clone()],
+            since: None,
+        })
+        .await
+        .expect("activate account");
+
+    let maintenance_id = adapter
+        .install_group_maintenance_subscription(&account_id, &group)
+        .await
+        .expect("install maintenance subscription");
+    let maintenance = NostrSubscription::GroupMaintenance {
+        account_id: account_id.clone(),
+        group_id: group_id.clone(),
+        transport_group_id: transport_group_id.clone(),
+        endpoints: vec![endpoint.clone()],
+    };
+    let delivered = adapter
+        .handle_relay_event(NostrRelayEvent {
+            endpoint: endpoint.clone(),
+            subscription_id: Some(maintenance_id.clone()),
+            event: group_event("active-maintenance", &transport_group_id),
+        })
+        .await
+        .expect("active maintenance event remains routable");
+    assert_eq!(delivered, 1);
+    assert_eq!(
+        adapter.receive().await.unwrap().unwrap().account_id,
+        account_id
+    );
+
+    relay.fail_next_unsubscribes.store(1, Ordering::SeqCst);
+    adapter
+        .remove_group_maintenance_subscription(maintenance)
+        .await
+        .expect_err("inject relay-side unsubscribe failure");
+
+    let delivered = adapter
+        .handle_relay_event(NostrRelayEvent {
+            endpoint: endpoint.clone(),
+            subscription_id: Some(maintenance_id),
+            event: group_event("retired-maintenance", &transport_group_id),
+        })
+        .await
+        .expect("late maintenance event is handled fail-closed");
+    assert_eq!(
+        delivered, 0,
+        "a retired maintenance REQ must not re-enter ordinary group routing"
+    );
+
+    let ordinary_id = NostrSubscription::Group {
+        account_id: account_id.clone(),
+        group_id,
+        transport_group_id: transport_group_id.clone(),
+        endpoints: vec![endpoint.clone()],
+        since: None,
+    }
+    .subscription_id();
+    let delivered = adapter
+        .handle_relay_event(NostrRelayEvent {
+            endpoint,
+            subscription_id: Some(ordinary_id),
+            event: group_event("ordinary-live", &transport_group_id),
+        })
+        .await
+        .expect("ordinary group event remains routable");
+    assert_eq!(delivered, 1);
+    assert_eq!(
+        adapter.receive().await.unwrap().unwrap().account_id,
+        account_id
+    );
+}
+
+#[tokio::test]
 async fn reconciled_group_event_routes_only_to_the_compared_account() {
     let relay = Arc::new(FakeRelayClient::default());
     let adapter = NostrTransportAdapter::new(relay);

--- a/crates/transport-quic-broker/src/tests.rs
+++ b/crates/transport-quic-broker/src/tests.rs
@@ -3,6 +3,7 @@
 
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use cgka_traits::agent_text_stream::{
@@ -18,7 +19,8 @@ use tokio::sync::oneshot;
 use tokio::time::{sleep, timeout};
 use transport_quic_stream::{
     AgentTextStreamCrypto, AgentTextStreamReceiveLimitError, AgentTextStreamReceiveLimits,
-    EphemeralPublisherSequenceStore, stream_record_text,
+    EphemeralPublisherSequenceStore, PublisherSequenceReservation, PublisherSequenceSnapshot,
+    PublisherSequenceStore, prepare_text_stream_crypto_for_network_handoff, stream_record_text,
 };
 
 use crate::client::{
@@ -55,6 +57,55 @@ fn test_state(max_backlog: usize) -> BrokerState {
         DEFAULT_BROKER_MAX_BACKLOG_BYTES,
         MAX_BROKER_REPLAY_TTL,
     )
+}
+
+struct ClosablePublisherSequenceStore {
+    inner: EphemeralPublisherSequenceStore,
+    closed: AtomicBool,
+}
+
+impl ClosablePublisherSequenceStore {
+    fn new() -> Self {
+        Self {
+            inner: EphemeralPublisherSequenceStore::default(),
+            closed: AtomicBool::new(false),
+        }
+    }
+
+    fn close(&self) {
+        self.closed.store(true, Ordering::SeqCst);
+    }
+
+    fn ensure_open(&self) -> Result<(), String> {
+        if self.closed.load(Ordering::SeqCst) {
+            Err("publisher sequence backend is closed".to_owned())
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl PublisherSequenceStore for ClosablePublisherSequenceStore {
+    fn load(&self, context_id: &[u8; 32]) -> Result<Option<PublisherSequenceSnapshot>, String> {
+        self.ensure_open()?;
+        self.inner.load(context_id)
+    }
+
+    fn reserve(
+        &self,
+        context_id: &[u8; 32],
+        initial_transcript_hash: &[u8; 32],
+        reservation: &PublisherSequenceReservation,
+    ) -> Result<(), String> {
+        self.ensure_open()?;
+        self.inner
+            .reserve(context_id, initial_transcript_hash, reservation)
+    }
+
+    fn confirm(&self, context_id: &[u8; 32], token: &[u8; 16]) -> Result<(), String> {
+        self.ensure_open()?;
+        self.inner.confirm(context_id, token)
+    }
 }
 
 #[tokio::test]
@@ -110,6 +161,84 @@ async fn broker_forwards_live_records_to_subscriber_with_same_transcript() {
     assert_eq!(received.chunk_count, 4);
     assert_eq!(sent.chunk_count, received.chunk_count);
     assert_eq!(sent.transcript_hash, received.transcript_hash);
+
+    let _ = shutdown_tx.send(());
+    broker_task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn broker_publishes_preconfirmed_range_after_sequence_backend_closes() {
+    let server = QuicBrokerServer::bind(QuicBrokerConfig {
+        bind_addr: LOCAL_SERVER_BIND,
+        ..QuicBrokerConfig::default()
+    })
+    .unwrap();
+    let broker_addr = server.local_addr().unwrap();
+    let server_cert = server.server_cert_der().to_vec();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let broker_task = tokio::spawn(server.run_until(async {
+        let _ = shutdown_rx.await;
+    }));
+
+    let stream_id = vec![0xa8; 32];
+    let start_event_id = MessageId::new(vec![0x18; 32]);
+    let stream_secret = SecretBytes::new(vec![0x28; 32]);
+    let context = AgentTextStreamKeyContextV1::new(
+        GroupId::new(vec![0x38; 32]),
+        stream_id.clone(),
+        EpochId(4),
+        MemberId::new(vec![0x48; 32]),
+        start_event_id.clone(),
+    );
+    let sequence_backend = Arc::new(ClosablePublisherSequenceStore::new());
+    let durable_crypto = AgentTextStreamCrypto::new(stream_secret.clone(), context.clone())
+        .with_publisher_sequence_store(sequence_backend.clone());
+    let text = "publish after root shutdown";
+    let detached_crypto = prepare_text_stream_crypto_for_network_handoff(
+        durable_crypto,
+        &stream_id,
+        &start_event_id,
+        text,
+        7,
+        None,
+    )
+    .expect("reserve and confirm the exact range before shutdown");
+    sequence_backend.close();
+
+    let receiver_crypto = AgentTextStreamCrypto::new(stream_secret, context);
+    let subscriber = tokio::spawn(subscribe_text_from_broker(SubscribeTextFromBroker {
+        broker_addr,
+        server_name: "localhost".to_owned(),
+        trust: BrokerServerTrust::CertificateDer(server_cert.clone()),
+        stream_id: stream_id.clone(),
+        start_event_id: start_event_id.clone(),
+        crypto: Some(receiver_crypto),
+    }));
+    sleep(Duration::from_millis(100)).await;
+
+    let sent = publish_text_to_broker(PublishTextToBroker {
+        broker_addr,
+        server_name: "localhost".to_owned(),
+        trust: BrokerServerTrust::CertificateDer(server_cert),
+        stream_id: stream_id.clone(),
+        start_event_id,
+        text: text.to_owned(),
+        max_chunk_bytes: 7,
+        chunk_delay: Duration::ZERO,
+        crypto: Some(detached_crypto),
+        max_plaintext_frame_len: None,
+    })
+    .await
+    .expect("publish must use only the detached one-shot capability");
+    let received = timeout(Duration::from_secs(5), subscriber)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(received.text, text);
+    assert_eq!(received.transcript_hash, sent.transcript_hash);
+    assert_eq!(received.chunk_count, sent.chunk_count);
 
     let _ = shutdown_tx.send(());
     broker_task.await.unwrap().unwrap();

--- a/crates/transport-quic-stream/src/lib.rs
+++ b/crates/transport-quic-stream/src/lib.rs
@@ -50,5 +50,6 @@ pub use receive::{
     QuicTextStreamReceiver, ReceivedTextChunk, ReceivedTextStream, ServerTrust, stream_record_text,
 };
 pub use send::{
-    SendTextStream, SentTextStream, random_stream_id, send_text_stream, split_text_deltas,
+    SendTextStream, SentTextStream, prepare_text_stream_crypto_for_network_handoff,
+    random_stream_id, send_text_stream, split_text_deltas,
 };

--- a/crates/transport-quic-stream/src/publisher_sequence.rs
+++ b/crates/transport-quic-stream/src/publisher_sequence.rs
@@ -42,15 +42,110 @@ pub struct ReservedPublisherRecords {
     pub transcript_hash: [u8; 32],
     pub chunk_count: u64,
     context_id: [u8; 32],
-    token: [u8; 16],
+    initial_transcript_hash: [u8; 32],
+    reservation: PublisherSequenceReservation,
     store: Arc<dyn PublisherSequenceStore>,
 }
 
 impl ReservedPublisherRecords {
     pub fn confirm(self) -> Result<(), QuicTextStreamError> {
         self.store
-            .confirm(&self.context_id, &self.token)
+            .confirm(&self.context_id, &self.reservation.token)
             .map_err(QuicTextStreamError::PublisherSequence)
+    }
+
+    pub(crate) fn confirm_and_detach_store(
+        self,
+    ) -> Result<Arc<dyn PublisherSequenceStore>, QuicTextStreamError> {
+        self.store
+            .confirm(&self.context_id, &self.reservation.token)
+            .map_err(QuicTextStreamError::PublisherSequence)?;
+        Ok(Arc::new(DetachedPublisherSequenceStore {
+            context_id: self.context_id,
+            initial_transcript_hash: self.initial_transcript_hash,
+            expected: self.reservation.expected,
+            resulting: self.reservation.resulting,
+            state: Mutex::new(DetachedPublisherSequenceState::Ready),
+        }))
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DetachedPublisherSequenceState {
+    Ready,
+    Reserved([u8; 16]),
+    Exhausted,
+}
+
+/// One-shot capability for replaying one already-durable reservation after
+/// its SQLCipher store has been closed for a root-ownership handoff.
+struct DetachedPublisherSequenceStore {
+    context_id: [u8; 32],
+    initial_transcript_hash: [u8; 32],
+    expected: PublisherSequenceSnapshot,
+    resulting: PublisherSequenceSnapshot,
+    state: Mutex<DetachedPublisherSequenceState>,
+}
+
+impl PublisherSequenceStore for DetachedPublisherSequenceStore {
+    fn load(&self, context_id: &[u8; 32]) -> Result<Option<PublisherSequenceSnapshot>, String> {
+        if context_id != &self.context_id {
+            return Err("detached publisher context does not match".to_owned());
+        }
+        match *self
+            .state
+            .lock()
+            .map_err(|_| "detached publisher state lock poisoned")?
+        {
+            DetachedPublisherSequenceState::Ready => Ok(Some(self.expected)),
+            DetachedPublisherSequenceState::Reserved(_) => {
+                Err("publisher continuity is ambiguous".to_owned())
+            }
+            DetachedPublisherSequenceState::Exhausted => {
+                Err("detached publisher sequence capability is exhausted".to_owned())
+            }
+        }
+    }
+
+    fn reserve(
+        &self,
+        context_id: &[u8; 32],
+        initial_transcript_hash: &[u8; 32],
+        reservation: &PublisherSequenceReservation,
+    ) -> Result<(), String> {
+        if context_id != &self.context_id
+            || initial_transcript_hash != &self.initial_transcript_hash
+            || reservation.expected != self.expected
+            || reservation.resulting != self.resulting
+        {
+            return Err("detached publisher reservation does not match".to_owned());
+        }
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| "detached publisher state lock poisoned")?;
+        if *state != DetachedPublisherSequenceState::Ready {
+            return Err("detached publisher sequence capability is not available".to_owned());
+        }
+        *state = DetachedPublisherSequenceState::Reserved(reservation.token);
+        Ok(())
+    }
+
+    fn confirm(&self, context_id: &[u8; 32], token: &[u8; 16]) -> Result<(), String> {
+        if context_id != &self.context_id {
+            return Err("detached publisher context does not match".to_owned());
+        }
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| "detached publisher state lock poisoned")?;
+        match *state {
+            DetachedPublisherSequenceState::Reserved(current) if &current == token => {
+                *state = DetachedPublisherSequenceState::Exhausted;
+                Ok(())
+            }
+            _ => Err("detached publisher reservation is not current".to_owned()),
+        }
     }
 }
 
@@ -110,23 +205,21 @@ pub fn reserve_publisher_records(
         transcript_hash: transcript.hash(),
         chunk_count: transcript.chunk_count(),
     };
+    let reservation = PublisherSequenceReservation {
+        expected,
+        resulting,
+        token,
+    };
     store
-        .reserve(
-            &context_id,
-            &initial,
-            &PublisherSequenceReservation {
-                expected,
-                resulting,
-                token,
-            },
-        )
+        .reserve(&context_id, &initial, &reservation)
         .map_err(QuicTextStreamError::PublisherSequence)?;
     Ok(ReservedPublisherRecords {
         records,
         transcript_hash: resulting.transcript_hash,
         chunk_count: resulting.chunk_count,
         context_id,
-        token,
+        initial_transcript_hash: initial,
+        reservation,
         store,
     })
 }
@@ -260,6 +353,69 @@ mod tests {
                 &stream_id,
                 &start,
                 &[(AGENT_TEXT_STREAM_RECORD_TEXT_DELTA, b"retry".to_vec())],
+            ),
+            Err(QuicTextStreamError::PublisherSequence(_))
+        ));
+    }
+
+    #[test]
+    fn confirmed_detached_capability_replays_exact_durable_range_once() {
+        let store = Arc::new(EphemeralPublisherSequenceStore::default());
+        let durable_crypto = crypto(store);
+        let stream_id = durable_crypto.context.stream_id.clone();
+        let start = durable_crypto.context.start_event_id.clone();
+        let detached_crypto = crate::prepare_text_stream_crypto_for_network_handoff(
+            durable_crypto.clone(),
+            &stream_id,
+            &start,
+            "detached",
+            1024,
+            None,
+        )
+        .unwrap();
+
+        let frames = vec![(AGENT_TEXT_STREAM_RECORD_TEXT_DELTA, b"detached".to_vec())];
+        let detached = reserve_publisher_records(&detached_crypto, &stream_id, &start, &frames)
+            .expect("the exact preconfirmed range remains usable after storage closes");
+        assert_eq!(detached.records[0].seq, 1);
+        detached.confirm().unwrap();
+        assert!(matches!(
+            reserve_publisher_records(&detached_crypto, &stream_id, &start, &frames),
+            Err(QuicTextStreamError::PublisherSequence(_))
+        ));
+
+        let next = reserve_publisher_records(
+            &durable_crypto,
+            &stream_id,
+            &start,
+            &[(AGENT_TEXT_STREAM_RECORD_TEXT_DELTA, b"next".to_vec())],
+        )
+        .expect("durable state advanced before the detached send");
+        assert_eq!(next.records[0].seq, 2);
+        next.confirm().unwrap();
+    }
+
+    #[test]
+    fn detached_capability_rejects_a_different_frame_set() {
+        let durable_crypto = crypto(Arc::new(EphemeralPublisherSequenceStore::default()));
+        let stream_id = durable_crypto.context.stream_id.clone();
+        let start = durable_crypto.context.start_event_id.clone();
+        let detached_crypto = crate::prepare_text_stream_crypto_for_network_handoff(
+            durable_crypto,
+            &stream_id,
+            &start,
+            "authorized",
+            1024,
+            None,
+        )
+        .unwrap();
+
+        assert!(matches!(
+            reserve_publisher_records(
+                &detached_crypto,
+                &stream_id,
+                &start,
+                &[(AGENT_TEXT_STREAM_RECORD_TEXT_DELTA, b"different".to_vec())],
             ),
             Err(QuicTextStreamError::PublisherSequence(_))
         ));

--- a/crates/transport-quic-stream/src/send.rs
+++ b/crates/transport-quic-stream/src/send.rs
@@ -47,20 +47,11 @@ pub struct SentTextStream {
 pub async fn send_text_stream(
     config: SendTextStream,
 ) -> Result<SentTextStream, QuicTextStreamError> {
-    if config.max_chunk_bytes == 0 {
-        return Err(QuicTextStreamError::EmptyChunkSize);
-    }
-    if config.max_chunk_bytes > AGENT_TEXT_STREAM_MAX_PLAINTEXT_FRAME_LEN as usize {
-        return Err(QuicTextStreamError::ChunkSizeTooLarge(
-            config.max_chunk_bytes,
-        ));
-    }
-    // Clamp the chunk size to the group policy cap when the caller supplied
-    // one. A plaintext within the cap always encrypts to a ciphertext within
-    // the record's `ciphertext<0..2^16-1>` field bound (cap + 16 <= 65535).
-    let max_chunk_bytes = config
-        .max_chunk_bytes
-        .min(effective_plaintext_cap(config.max_plaintext_frame_len));
+    let frames = text_delta_frames(
+        &config.text,
+        config.max_chunk_bytes,
+        config.max_plaintext_frame_len,
+    )?;
 
     let endpoint = client_endpoint(config.trust, config.server_addr)?;
     let connection = connect_with_timeout(
@@ -71,15 +62,6 @@ pub async fn send_text_stream(
     )
     .await?;
     let mut send = connection.open_uni().await?;
-    let frames = split_text_deltas(&config.text, max_chunk_bytes)
-        .into_iter()
-        .map(|chunk| {
-            (
-                cgka_traits::agent_text_stream::AGENT_TEXT_STREAM_RECORD_TEXT_DELTA,
-                chunk,
-            )
-        })
-        .collect::<Vec<_>>();
     let mut transcript =
         AgentTextStreamTranscriptV1::new(config.stream_id.clone(), config.start_event_id.clone());
     let reservation = config
@@ -138,6 +120,57 @@ pub async fn send_text_stream(
         transcript_hash,
         chunk_count,
     })
+}
+
+/// Persist and confirm exactly one bounded text-record range, then replace the
+/// crypto's SQL-backed sequence store with a one-shot in-memory capability for
+/// that same range. This is for hosts that must terminally close storage before
+/// network I/O to transfer exclusive root ownership.
+///
+/// A later network failure burns the confirmed range rather than risking nonce
+/// reuse. The returned capability rejects any different frame set and cannot be
+/// reused for another send.
+pub fn prepare_text_stream_crypto_for_network_handoff(
+    crypto: AgentTextStreamCrypto,
+    stream_id: &[u8],
+    start_event_id: &MessageId,
+    text: &str,
+    max_chunk_bytes: usize,
+    max_plaintext_frame_len: Option<u32>,
+) -> Result<AgentTextStreamCrypto, QuicTextStreamError> {
+    let frames = text_delta_frames(text, max_chunk_bytes, max_plaintext_frame_len)?;
+    if frames.is_empty() {
+        return Ok(crypto);
+    }
+    let detached_store = reserve_publisher_records(&crypto, stream_id, start_event_id, &frames)?
+        .confirm_and_detach_store()?;
+    Ok(crypto.with_publisher_sequence_store(detached_store))
+}
+
+fn text_delta_frames(
+    text: &str,
+    max_chunk_bytes: usize,
+    max_plaintext_frame_len: Option<u32>,
+) -> Result<Vec<(u8, Vec<u8>)>, QuicTextStreamError> {
+    if max_chunk_bytes == 0 {
+        return Err(QuicTextStreamError::EmptyChunkSize);
+    }
+    if max_chunk_bytes > AGENT_TEXT_STREAM_MAX_PLAINTEXT_FRAME_LEN as usize {
+        return Err(QuicTextStreamError::ChunkSizeTooLarge(max_chunk_bytes));
+    }
+    // Clamp the chunk size to the group policy cap when the caller supplied
+    // one. A plaintext within the cap always encrypts to a ciphertext within
+    // the record's `ciphertext<0..2^16-1>` field bound (cap + 16 <= 65535).
+    let max_chunk_bytes = max_chunk_bytes.min(effective_plaintext_cap(max_plaintext_frame_len));
+    Ok(split_text_deltas(text, max_chunk_bytes)
+        .into_iter()
+        .map(|chunk| {
+            (
+                cgka_traits::agent_text_stream::AGENT_TEXT_STREAM_RECORD_TEXT_DELTA,
+                chunk,
+            )
+        })
+        .collect())
 }
 
 pub fn random_stream_id() -> Vec<u8> {


### PR DESCRIPTION
## Split of #1594 (3/6)

Account runtime journals source-attributed effects, records Leave published outcomes, and retries the exact persisted KeyPackage revision.

Targets `master` because fork stack branches cannot be used as bases on this repo. **Files changed vs `master` includes slices 1–2.** Review the latest commit, or the incremental compare:

https://github.com/marmot-protocol/mdk/compare/romainPellerin:split/1594-engine-transport...romainPellerin:split/1594-account-runtime

**Incremental diff vs slice 2:** 7 files, +16055 / −4787

Depends on the engine/transport slice.

**Stack on this repo (review latest commit / incremental compare, merge in this order):**
1. storage/journals — https://github.com/marmot-protocol/mdk/pull/1595
2. engine/transport exact-retry — https://github.com/marmot-protocol/mdk/pull/1596
3. account visibility + KeyPackage persist — https://github.com/marmot-protocol/mdk/pull/1597
4. app projection / Leave / tombstones / backfill — https://github.com/marmot-protocol/mdk/pull/1598
5. app tests — https://github.com/marmot-protocol/mdk/pull/1599
6. CLI / UniFFI / docs — https://github.com/marmot-protocol/mdk/pull/1600
